### PR TITLE
bdo element uses bidi-override instead of isolate-override

### DIFF
--- a/LayoutTests/fast/css/default-bidi-css-rules-expected.txt
+++ b/LayoutTests/fast/css/default-bidi-css-rules-expected.txt
@@ -41,15 +41,15 @@ PASS styleOf("output", {"dir":"auto"}).unicodeBidi is "isolate"
 PASS styleOf("output", {"dir":""}).direction is "ltr"
 PASS styleOf("output", {"dir":""}).unicodeBidi is "isolate"
 PASS styleOf("bdo", {}).direction is "ltr"
-PASS styleOf("bdo", {}).unicodeBidi is "bidi-override"
+PASS styleOf("bdo", {}).unicodeBidi is "isolate-override"
 PASS styleOf("bdo", {"dir":"ltr"}).direction is "ltr"
-PASS styleOf("bdo", {"dir":"ltr"}).unicodeBidi is "bidi-override"
+PASS styleOf("bdo", {"dir":"ltr"}).unicodeBidi is "isolate-override"
 PASS styleOf("bdo", {"dir":"rtl"}).direction is "rtl"
-PASS styleOf("bdo", {"dir":"rtl"}).unicodeBidi is "bidi-override"
+PASS styleOf("bdo", {"dir":"rtl"}).unicodeBidi is "isolate-override"
 PASS styleOf("bdo", {"dir":"auto"}).direction is "ltr"
-FAIL styleOf("bdo", {"dir":"auto"}).unicodeBidi should be bidi-override isolate. Was isolate.
+FAIL styleOf("bdo", {"dir":"auto"}).unicodeBidi should be isolate-override. Was isolate.
 PASS styleOf("bdo", {"dir":""}).direction is "ltr"
-PASS styleOf("bdo", {"dir":""}).unicodeBidi is "bidi-override"
+PASS styleOf("bdo", {"dir":""}).unicodeBidi is "isolate-override"
 PASS styleOf("textarea", {}).direction is "ltr"
 PASS styleOf("textarea", {}).unicodeBidi is "normal"
 PASS styleOf("textarea", {"dir":"ltr"}).direction is "ltr"
@@ -71,6 +71,7 @@ PASS styleOf("pre", {"dir":"auto"}).unicodeBidi is "plaintext"
 PASS styleOf("pre", {"dir":""}).direction is "ltr"
 PASS styleOf("pre", {"dir":""}).unicodeBidi is "normal"
 PASS successfullyParsed is true
+Some tests failed.
 
 TEST COMPLETE
 

--- a/LayoutTests/fast/css/default-bidi-css-rules.html
+++ b/LayoutTests/fast/css/default-bidi-css-rules.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <body>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 <p>This test checks <a href="http://dev.w3.org/html5/spec/Overview.html#bidirectional-text">the default rules for direction and unicode-bidi CSS properties</a>.</p>
 <div id="container"></div>
 <div id="console"></div>
@@ -44,11 +44,11 @@ var tests = [
     ['output', {'dir': 'auto'}, 'ltr', 'isolate'],
     ['output', {'dir': ''}, 'ltr', 'isolate'],
 
-    ['bdo', {}, 'ltr', 'bidi-override'],
-    ['bdo', {'dir': 'ltr'}, 'ltr', 'bidi-override'],
-    ['bdo', {'dir': 'rtl'}, 'rtl', 'bidi-override'],
-    ['bdo', {'dir': 'auto'}, 'ltr', 'bidi-override isolate'],
-    ['bdo', {'dir': ''}, 'ltr', 'bidi-override'],
+    ['bdo', {}, 'ltr', 'isolate-override'],
+    ['bdo', {'dir': 'ltr'}, 'ltr', 'isolate-override'],
+    ['bdo', {'dir': 'rtl'}, 'rtl', 'isolate-override'],
+    ['bdo', {'dir': 'auto'}, 'ltr', 'isolate-override'],
+    ['bdo', {'dir': ''}, 'ltr', 'isolate-override'],
 
     ['textarea', {}, 'ltr', 'normal'],
     ['textarea', {'dir': 'ltr'}, 'ltr', 'isolate'],
@@ -69,6 +69,5 @@ var tests = [
 });
 
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/text/international/bidi-LDB-2-HTML.html
+++ b/LayoutTests/fast/text/international/bidi-LDB-2-HTML.html
@@ -30,6 +30,8 @@ p.pair { margin: 0; }
 
 div.box { border:1px green solid; display:inline-block; padding:3px; margin:3px; vertical-align:middle; }
 
+/* simulate old behavior for the <bdo> element that this test is based on */
+bdo { unicode-bidi: bidi-override; }
 </STYLE>
 </HEAD>
 <BODY>

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -2,7 +2,7 @@
  * The default style sheet used to render HTML.
  *
  * Copyright (C) 2000 Lars Knoll (knoll@kde.org)
- * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -1429,8 +1429,8 @@ bdi, output {
 
 input[type=tel i]:dir(ltr) { direction: ltr; }
 
-bdo {
-    unicode-bidi: bidi-override;
+bdo, bdo[dir] {
+    unicode-bidi: isolate-override;
 }
 
 slot {

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -81,7 +81,7 @@ InlineLayoutUnit TextUtil::width(const InlineTextBox& inlineTextBox, const FontC
             width = fontCascade.widthForTextUsingSimplifiedMeasuring(view);
     } else {
         auto& style = inlineTextBox.style();
-        auto directionalOverride = style.unicodeBidi() == UnicodeBidi::Override;
+        auto directionalOverride = isOverride(style.unicodeBidi());
         auto run = WebCore::TextRun { StringView(text).substring(from, to - from), contentLogicalLeft, { }, ExpansionBehavior::defaultBehavior(), directionalOverride ? style.writingMode().bidiDirection() : TextDirection::LTR, directionalOverride };
         if (!style.collapseWhiteSpace() && style.tabSize())
             run.setTabSize(true, style.tabSize());


### PR DESCRIPTION
#### 1bf83c07887e3a653a605cf08600e1774247a3c9
<pre>
bdo element uses bidi-override instead of isolate-override

<a href="https://bugs.webkit.org/show_bug.cgi?id=283765">https://bugs.webkit.org/show_bug.cgi?id=283765</a>
<a href="https://rdar.apple.com/problem/140662417">rdar://problem/140662417</a>

Reviewed by Alan Baradlay.

This patch aligns WebKit with web specification [1]:

<a href="https://html.spec.whatwg.org/multipage/rendering.html#bidi-rendering">https://html.spec.whatwg.org/multipage/rendering.html#bidi-rendering</a>

As per web specification, `bdo` should be `unicode-bidi: isolate-override`
instead of `bidi-override`. This also align us with Gecko / Firefox and
Blink / Chromium.

It is covered by existing imported WPT test case below:
&gt; html/rendering/bidi-rendering/unicode-bidi-ua-rules.html

Since we haven&apos;t aligned with web specification fully, we progress only few more
sub-tests pass for `UA stylesheet rule for unicode-bidi, for &lt;bdo&gt;`.

In 259172@main , WebKit fixed bug to handle bidirectional override and corresponding
glyph content width but it failed to account for `isolate-override`, this fixes it as well.

* Source/WebCore/css/html.css:
(bdo, bdo[dir]):
(bdo): Deleted.
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
(TextUtil::width):
* LayoutTests/fast/css/default-bidi-css-rules-expected.txt:
* LayoutTests/fast/css/default-bidi-css-rules.html:
* LayoutTests/fast/text/international/bidi-LDB-2-HTML.html:

Canonical link: <a href="https://commits.webkit.org/287175@main">https://commits.webkit.org/287175@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32f7afed1e84034cf4539367e2750fd57ac55215

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78646 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57691 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32028 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83307 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29908 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80779 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66842 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5972 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61597 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19516 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81713 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51624 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/70342 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41906 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48970 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25538 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28249 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70074 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25915 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84675 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6011 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4136 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69824 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6172 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67597 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69078 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17205 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13109 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11622 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5958 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/11889 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5944 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9380 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7733 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->