### PR TITLE
[iOS] [SelectionHonorsOverflowScrolling] Overflow containers are unscrollable when text outside of the container is selected

### DIFF
--- a/LayoutTests/editing/selection/ios/scroll-overflow-container-with-selection-expected.txt
+++ b/LayoutTests/editing/selection/ios/scroll-overflow-container-with-selection-expected.txt
@@ -1,0 +1,19 @@
+1. Select this text
+
+2. Scroll down in this container
+Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes. The ones who see things differently. They’re not fond of rules. And they have no respect for the status quo.
+
+You can quote them, disagree with them, glorify or vilify them. About the only thing you can’t do is ignore them.
+
+Because they change things. They push the human race forward. And while some may see them as the crazy ones, we see genius. Because the people who are crazy enough to think they can change the world, are the ones who do.
+
+Verifies that a text selection on text outside of an overflow scrolling container does not prevent the user from scrolling the container
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS Selected text
+PASS Scrolled overflow container
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/scroll-overflow-container-with-selection.html
+++ b/LayoutTests/editing/selection/ios/scroll-overflow-container-with-selection.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true SelectionHonorsOverflowScrolling=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+body, html {
+    font-size: 20px;
+    font-family: system-ui;
+}
+
+.textToSelect {
+    border: 1px solid tomato;
+    padding: 3px;
+}
+
+.scrollable {
+    width: 300px;
+    height: 300px;
+    border: solid 1px lightgray;
+    border-radius: 4px;
+    box-sizing: border-box;
+    overflow-y: scroll;
+    line-height: 1.5em;
+    outline: none;
+    padding: 1em;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    const textToSelect = document.querySelector(".textToSelect");
+    const scroller = document.querySelector(".scrollable");
+
+    description("Verifies that a text selection on text outside of an overflow scrolling container does not prevent the user from scrolling the container");
+
+    await UIHelper.longPressElement(textToSelect);
+    await UIHelper.waitForSelectionToAppear();
+    testPassed("Selected text");
+
+    const scrollerRect = scroller.getBoundingClientRect();
+    const swipeLocation = {
+        x : scrollerRect.left + scrollerRect.width / 2,
+        y : scrollerRect.top + scrollerRect.height - 50,
+    };
+
+    const maxNumberOfAttempts = 3;
+    let numberOfAttemptsRemaining = maxNumberOfAttempts;
+    while (true) {
+        await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+            .begin(swipeLocation.x, swipeLocation.y)
+            .move(swipeLocation.x, swipeLocation.y - 200, 0.25)
+            .end()
+            .takeResult());
+        await UIHelper.waitForZoomingOrScrollingToEnd();
+
+        if (scroller.scrollTop >= 200) {
+            testPassed("Scrolled overflow container");
+            break;
+        }
+
+        if (!--numberOfAttemptsRemaining) {
+            testFailed(`Failed to scroll after ${maxNumberOfAttempts} swipes`);
+            break;
+        }
+    }
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <p>1. <span class="textToSelect">Select</span> this text</p>
+    <div class="scrollable">
+        <strong>2. Scroll down in this container</strong>
+        <p>Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes. The ones who see things differently. They’re not fond of rules. And they have no respect for the status quo.</p>
+        <p>You can quote them, disagree with them, glorify or vilify them. About the only thing you can’t do is ignore them.</p>
+        <p>Because they change things. They push the human race forward. And while some may see them as the crazy ones, we see genius. Because the people who are crazy enough to think they can change the world, are the ones who do.</p>
+    </div>
+    <div id="description"></div>
+    <div id="console"></div>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -78,6 +78,7 @@
 #import <wtf/HashSet.h>
 #import <wtf/ObjectIdentifier.h>
 #import <wtf/OptionSet.h>
+#import <wtf/Scope.h>
 #import <wtf/Vector.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/text/WTFString.h>
@@ -914,6 +915,8 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 
 - (BOOL)_shouldIgnoreTouchEvent:(UIEvent *)event;
 - (void)_touchEventsRecognized;
+
+- (ScopeExit<Function<void()>>)makeTextSelectionViewsNonInteractiveForScope;
 
 @property (nonatomic, readonly) BOOL shouldUseAsyncInteractions;
 @property (nonatomic, readonly) BOOL selectionHonorsOverflowScrolling;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -1206,6 +1206,23 @@ static WKDragSessionContext *ensureLocalDragSessionContext(id <UIDragSession> se
     return _page->preferences().selectionHonorsOverflowScrolling();
 }
 
+- (ScopeExit<Function<void()>>)makeTextSelectionViewsNonInteractiveForScope
+{
+    Vector<RetainPtr<UIView>> viewsToRestore;
+    for (UIView *view in [_textInteractionWrapper managedTextSelectionViews]) {
+        if (!view.userInteractionEnabled)
+            continue;
+
+        viewsToRestore.append(view);
+        view.userInteractionEnabled = NO;
+    }
+
+    return makeScopeExit(Function<void()> { [viewsToRestore = WTFMove(viewsToRestore)] {
+        for (RetainPtr view : viewsToRestore)
+            [view setUserInteractionEnabled:YES];
+    } });
+}
+
 - (BOOL)_shouldUseUIContextMenuAsyncConfiguration
 {
 #if USE(BROWSERENGINEKIT)

--- a/Source/WebKit/UIProcess/ios/WKScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKScrollView.mm
@@ -32,6 +32,7 @@
 #import "UIKitSPI.h"
 #import "UIKitUtilities.h"
 #import "WKBrowserEngineDefinitions.h"
+#import "WKContentViewInteraction.h"
 #import "WKDeferringGestureRecognizer.h"
 #import "WKWebViewIOS.h"
 #import "WebPage.h"
@@ -547,6 +548,13 @@ static inline bool valuesAreWithinOnePixel(CGFloat a, CGFloat b)
 #endif // PLATFORM(WATCHOS)
     else
         ASSERT_NOT_REACHED();
+}
+
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+{
+    auto scope = [_internalDelegate->_contentView makeTextSelectionViewsNonInteractiveForScope];
+
+    return [super hitTest:point withEvent:event];
 }
 
 #if HAVE(PEPPER_UI_CORE)

--- a/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.h
+++ b/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.h
@@ -62,6 +62,7 @@
 @property (nonatomic, strong, readonly) UIContextMenuInteraction *contextMenuInteraction;
 #endif
 
+@property (nonatomic, readonly) NSArray<UIView *> *managedTextSelectionViews;
 @property (nonatomic, readonly) UIWKTextInteractionAssistant *textInteractionAssistant;
 
 @end


### PR DESCRIPTION
#### 3df5437fcea8f1902bf5728215ee7309d4a4db6d
<pre>
[iOS] [SelectionHonorsOverflowScrolling] Overflow containers are unscrollable when text outside of the container is selected
<a href="https://bugs.webkit.org/show_bug.cgi?id=283804">https://bugs.webkit.org/show_bug.cgi?id=283804</a>
<a href="https://rdar.apple.com/140308383">rdar://140308383</a>

Reviewed by Richard Robinson.

On iOS, when `SelectionHonorsOverflowScrolling` is enabled, the text selection display interaction
can be installed under arbitrary compositing views in the UI-side layer tree/compositing view
hierarchy. However, this exposes a bug in which the text selection display interaction&apos;s managed
selection views (i.e. native container views that encapsulate the selection highlight view, range
adjustment handles, and other UI affordances managed by the interaction) will block hit-testing
underneath the `WKScrollView`, if the compositing view that contains the selection contains child
scroll views. This prevents UIKit from routing `UITouchEvent`s to the proper child scroll view under
the gesture location (and therefore prevents scrolling), if the text selection display interaction
is installed on anything that covers the child scroller.

From manual testing, it seems generally safe to mark these selection display interaction containers
with `userInteractionEnabled := NO`, since their child views (e.g. range adjustment handles) have
user interaction enabled, and the only other gesture relevant to this interaction is tapping to
toggle edit menu visibility, which isn&apos;t affected by whether or not these container views are
interactive due to the fact that the text tap gesture is installed over the content view. To limit
unnecessary bincompat risk (and because this probably uniquely affects WebKit&apos;s integration of the
selection display interaction), we mitigate this by overriding `-[WKScrollView hitTest:withEvent:]`
and forcing `userInteractionEnabled` to be `NO` for these managed container views over the scope of
hit-testing.

* LayoutTests/editing/selection/ios/scroll-overflow-container-with-selection-expected.txt: Added.
* LayoutTests/editing/selection/ios/scroll-overflow-container-with-selection.html: Added.

Add a layout test to exercise the bug, by selecting text in the mainframe and then attempting to
scroll an overflow container below it via pan gesture.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView makeTextSelectionViewsNonInteractiveForScope]):

Add a helper method that returns a RAII object (`ScopeExit`), which callers can use to temporarily
make selection container views non-interactive. See above for more details.

* Source/WebKit/UIProcess/ios/WKScrollView.mm:
(-[WKScrollView hitTest:withEvent:]):

Call `-makeTextSelectionViewsNonInteractiveForScope` when hit-testing.

* Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.h:
* Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm:
(-[WKTextInteractionWrapper managedTextSelectionViews]):
(-[WKTextInteractionWrapper prepareToMoveSelectionContainer:]):

Add logic to keep track of all the managed views of the text selection display interaction, by
observing which views were introduced to the target container view as a result of invoking
`-didMoveToView:`.

Canonical link: <a href="https://commits.webkit.org/287294@main">https://commits.webkit.org/287294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c40e987f9bfeae005fd85818ac7a99004c48410d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79057 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58093 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32434 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83697 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30272 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67202 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6363 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61876 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19796 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82124 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51918 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72059 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42179 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49269 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26158 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28636 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70384 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26576 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85083 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6382 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4412 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70116 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6546 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67931 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69365 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17290 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13410 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12190 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6333 "Built successfully") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6293 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9745 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8086 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->