### PR TITLE
[SwiftUI] Introduce the NavigationDeciding protocol

### DIFF
--- a/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationDeciding.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationDeciding.swift
@@ -1,0 +1,141 @@
+// Copyright (C) 2024 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE_SWIFTUI && compiler(>=6.0)
+
+import Foundation
+public import SwiftUI
+
+// MARK: Supporting types
+
+extension WebPage_v0 {
+    @MainActor
+    @_spi(Private)
+    public struct NavigationAction: Sendable {
+        init(_ wrapped: WKNavigationAction) {
+            self.wrapped = wrapped
+        }
+
+        public var source: FrameInfo { .init(wrapped.sourceFrame) }
+
+        public var target: FrameInfo? { wrapped.targetFrame.map(FrameInfo.init(_:)) }
+
+        public var navigationType: WKNavigationType { wrapped.navigationType }
+
+        public var request: URLRequest { wrapped.request }
+
+        public var shouldPerformDownload: Bool { wrapped.shouldPerformDownload }
+
+#if canImport(UIKit)
+        public var buttonNumber: UIEvent.ButtonMask { wrapped.buttonNumber }
+#else
+        public var buttonNumber: Int { wrapped.buttonNumber }
+#endif
+
+        public var modifierFlags: EventModifiers { EventModifiers(wrapped.modifierFlags) }
+
+        var wrapped: WKNavigationAction
+    }
+
+    @MainActor
+    @_spi(Private)
+    public struct NavigationResponse: Sendable {
+        init(_ wrapped: WKNavigationResponse) {
+            self.wrapped = wrapped
+        }
+
+        public var isForMainFrame: Bool { wrapped.isForMainFrame }
+
+        public var response: URLResponse { wrapped.response }
+
+        public var canShowMimeType: Bool { wrapped.canShowMIMEType }
+
+        var wrapped: WKNavigationResponse
+    }
+}
+
+// MARK: Adapters
+
+fileprivate extension EventModifiers {
+#if canImport(UIKit)
+    init(_ wrapped: UIKeyModifierFlags) {
+        self = switch wrapped {
+        case .alphaShift: .capsLock
+        case .command: .command
+        case .control: .control
+        case .numericPad: .numericPad
+        case .alternate: .option
+        case .shift: .shift
+        default: []
+        }
+    }
+#else
+    init(_ wrapped: NSEvent.ModifierFlags) {
+        self = switch wrapped {
+        case .capsLock: .capsLock
+        case .command: .command
+        case .control: .control
+        case .numericPad: .numericPad
+        case .option: .option
+        case .shift: .shift
+        default: []
+        }
+    }
+#endif
+}
+
+// MARK: NavigationDeciding protocol
+
+@_spi(Private)
+public protocol NavigationDeciding {
+    @MainActor
+    func decidePolicy(for action: WebPage_v0.NavigationAction, preferences: inout WebPage_v0.NavigationPreferences) async -> WKNavigationActionPolicy
+
+    @MainActor
+    func decidePolicy(for response: WebPage_v0.NavigationResponse) async -> WKNavigationResponsePolicy
+
+    @MainActor
+    func decideAuthenticationChallengeDisposition(for challenge: URLAuthenticationChallenge) async -> (URLSession.AuthChallengeDisposition, URLCredential?)
+}
+
+// MARK: Default implementation
+
+@_spi(Private)
+public extension NavigationDeciding {
+    @MainActor
+    func decidePolicy(for action: WebPage_v0.NavigationAction, preferences: inout WebPage_v0.NavigationPreferences) async -> WKNavigationActionPolicy {
+        .allow
+    }
+
+    @MainActor
+    func decidePolicy(for response: WebPage_v0.NavigationResponse) async -> WKNavigationResponsePolicy {
+        .allow
+    }
+
+    @MainActor
+    func decideAuthenticationChallengeDisposition(for challenge: URLAuthenticationChallenge) async -> (URLSession.AuthChallengeDisposition, URLCredential?) {
+        (.performDefaultHandling, nil)
+    }
+}
+
+ #endif

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift
@@ -36,12 +36,21 @@ extension WebPage_v0 {
             case desktop
         }
 
+        public enum UpgradeToHTTPSPolicy: Sendable {
+            case keepAsRequested
+            case automaticFallbackToHTTP
+            case userMediatedFallbackToHTTP
+            case errorOnFailure
+        }
+
         public init() {
         }
 
         public var preferredContentMode: ContentMode = .recommended
 
         public var allowsContentJavaScript: Bool = true
+
+        public var preferredHTTPSNavigationPolicy: UpgradeToHTTPSPolicy = .keepAsRequested
 
         fileprivate var _isLockdownModeEnabled: Bool? = nil
         public var isLockdownModeEnabled: Bool {
@@ -53,11 +62,33 @@ extension WebPage_v0 {
 
 // MARK: Adapters
 
+extension WKWebpagePreferences.ContentMode {
+    init(_ wrapped: WebPage_v0.NavigationPreferences.ContentMode) {
+        self = switch wrapped {
+        case .recommended: .recommended
+        case .mobile: .mobile
+        case .desktop: .desktop
+        }
+    }
+}
+
+extension WKWebpagePreferences.UpgradeToHTTPSPolicy {
+    init(_ wrapped: WebPage_v0.NavigationPreferences.UpgradeToHTTPSPolicy) {
+        self = switch wrapped {
+        case .keepAsRequested: .keepAsRequested
+        case .automaticFallbackToHTTP: .automaticFallbackToHTTP
+        case .userMediatedFallbackToHTTP: .userMediatedFallbackToHTTP
+        case .errorOnFailure: .errorOnFailure
+        }
+    }
+}
+
 extension WKWebpagePreferences {
     convenience init(_ wrapped: WebPage_v0.NavigationPreferences) {
         self.init()
 
         self.preferredContentMode = .init(wrapped.preferredContentMode)
+        self.preferredHTTPSNavigationPolicy = .init(wrapped.preferredHTTPSNavigationPolicy)
         self.allowsContentJavaScript = wrapped.allowsContentJavaScript
 
         if let isLockdownModeEnabled = wrapped._isLockdownModeEnabled {
@@ -66,13 +97,40 @@ extension WKWebpagePreferences {
     }
 }
 
-extension WKWebpagePreferences.ContentMode {
-    init(_ wrapped: WebPage_v0.NavigationPreferences.ContentMode) {
+extension WebPage_v0.NavigationPreferences.ContentMode {
+    init(_ wrapped: WKWebpagePreferences.ContentMode) {
         self = switch wrapped {
         case .recommended: .recommended
         case .mobile: .mobile
         case .desktop: .desktop
+        @unknown default:
+            fatalError()
         }
+    }
+}
+
+extension WebPage_v0.NavigationPreferences.UpgradeToHTTPSPolicy {
+    init(_ wrapped: WKWebpagePreferences.UpgradeToHTTPSPolicy) {
+        self = switch wrapped {
+        case .keepAsRequested: .keepAsRequested
+        case .automaticFallbackToHTTP: .automaticFallbackToHTTP
+        case .userMediatedFallbackToHTTP: .userMediatedFallbackToHTTP
+        case .errorOnFailure: .errorOnFailure
+        @unknown default:
+            fatalError()
+        }
+    }
+}
+
+extension WebPage_v0.NavigationPreferences {
+    init(_ wrapped: WKWebpagePreferences) {
+        self.init()
+
+        self.preferredContentMode = .init(wrapped.preferredContentMode)
+        self.preferredHTTPSNavigationPolicy = .init(wrapped.preferredHTTPSNavigationPolicy)
+
+        self.allowsContentJavaScript = wrapped.allowsContentJavaScript
+        self.isLockdownModeEnabled = wrapped.isLockdownModeEnabled
     }
 }
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -146,6 +146,9 @@
 		0744DA552CE05FE400AACC81 /* WebKitInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 0744DA542CE05FE400AACC81 /* WebKitInternal.h */; };
 		074879B92373A90900F5678E /* AppKitSoftLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 074879B72373A90900F5678E /* AppKitSoftLink.h */; };
 		074E75FE1DF2211900D318EC /* UserMediaProcessManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 074E75FB1DF1FD1300D318EC /* UserMediaProcessManager.h */; };
+		074E87DF2CF8E9F30059E469 /* WebPage+FrameInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074E87DE2CF8E9F30059E469 /* WebPage+FrameInfo.swift */; };
+		074E87E12CF8EA3D0059E469 /* WebPage+NavigationDeciding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074E87E02CF8EA3D0059E469 /* WebPage+NavigationDeciding.swift */; };
+		074E87E32CF8EABE0059E469 /* WebPage+NavigationPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074E87E22CF8EABE0059E469 /* WebPage+NavigationPreferences.swift */; };
 		074F34812CC5F7D500CA5301 /* WKIntelligenceTextEffectCoordinator.h in Headers */ = {isa = PBXBuildFile; fileRef = 074F34802CC5F7D500CA5301 /* WKIntelligenceTextEffectCoordinator.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		075A9CF326169BAB006DFA3A /* MediaSessionCoordinatorProxyPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 077BA570260E8F630072F19F /* MediaSessionCoordinatorProxyPrivate.h */; };
 		076CEF0C2CEEE79900E4ABD6 /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 076CEF0B2CEEE79900E4ABD6 /* WebView.swift */; };
@@ -3170,6 +3173,9 @@
 		074E75FC1DF2002400D318EC /* UserMediaProcessManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UserMediaProcessManager.cpp; sourceTree = "<group>"; };
 		074E76001DF7075D00D318EC /* MediaDeviceSandboxExtensions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MediaDeviceSandboxExtensions.cpp; sourceTree = "<group>"; };
 		074E76011DF7075D00D318EC /* MediaDeviceSandboxExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MediaDeviceSandboxExtensions.h; sourceTree = "<group>"; };
+		074E87DE2CF8E9F30059E469 /* WebPage+FrameInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebPage+FrameInfo.swift"; sourceTree = "<group>"; };
+		074E87E02CF8EA3D0059E469 /* WebPage+NavigationDeciding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebPage+NavigationDeciding.swift"; sourceTree = "<group>"; };
+		074E87E22CF8EABE0059E469 /* WebPage+NavigationPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebPage+NavigationPreferences.swift"; sourceTree = "<group>"; };
 		074F34802CC5F7D500CA5301 /* WKIntelligenceTextEffectCoordinator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKIntelligenceTextEffectCoordinator.h; sourceTree = "<group>"; };
 		076CEF0B2CEEE79900E4ABD6 /* WebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebView.swift; sourceTree = "<group>"; };
 		076E884D1A13CADF005E90FC /* APIContextMenuClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APIContextMenuClient.h; sourceTree = "<group>"; };
@@ -8795,6 +8801,7 @@
 				078B04452CF1154B00B453A6 /* WebPage+Configuration.swift */,
 				078B04B32CF1A27F00B453A6 /* WebPage+FrameInfo.swift */,
 				07FAA74A2CE947AA00128360 /* WebPage+Navigation.swift */,
+				074E87E02CF8EA3D0059E469 /* WebPage+NavigationDeciding.swift */,
 				078B049F2CF18EAB00B453A6 /* WebPage+NavigationPreferences.swift */,
 				07CB79952CE9435700199C49 /* WebPage.swift */,
 				076CEF0B2CEEE79900E4ABD6 /* WebView.swift */,
@@ -20158,6 +20165,7 @@
 				078B04462CF1154B00B453A6 /* WebPage+Configuration.swift in Sources */,
 				078B04B42CF1A27F00B453A6 /* WebPage+FrameInfo.swift in Sources */,
 				07FAA74B2CE947AA00128360 /* WebPage+Navigation.swift in Sources */,
+				074E87E12CF8EA3D0059E469 /* WebPage+NavigationDeciding.swift in Sources */,
 				078B04A02CF18EAB00B453A6 /* WebPage+NavigationPreferences.swift in Sources */,
 				07CB79962CE9435700199C49 /* WebPage.swift in Sources */,
 				C0CE72A01247E71D00BC0EC4 /* WebPageMessageReceiver.cpp in Sources */,

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		041A1E34216FFDBC00789E0A /* PublicSuffix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 041A1E33216FFDBC00789E0A /* PublicSuffix.cpp */; };
 		04DB2396235E43EC00328F17 /* BumpPointerAllocator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0451A5A6235E438E009DF945 /* BumpPointerAllocator.cpp */; };
 		07492B3B1DF8B14C00633DE1 /* EnumerateMediaDevices.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 07492B3A1DF8AE2D00633DE1 /* EnumerateMediaDevices.cpp */; };
+		074E87E52CF920A20059E469 /* Bundle+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074E87E42CF920A20059E469 /* Bundle+Extras.swift */; };
 		075A9CF526177218006DFA3A /* MediaSessionCoordinatorTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 075A9CF426177217006DFA3A /* MediaSessionCoordinatorTest.mm */; };
 		076E507F1F4513D6006E9F5A /* Logging.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 076E507E1F45031E006E9F5A /* Logging.cpp */; };
 		077489CC2CE4061A00133938 /* WKWebViewSwiftOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 070721142CE2F5F6004D9EC8 /* WKWebViewSwiftOverlay.swift */; };
@@ -2135,6 +2136,7 @@
 		07492B391DF8ADA400633DQ1 /* playable-audio.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "playable-audio.html"; sourceTree = "<group>"; };
 		07492B3A1DF8AE2D00633DE1 /* EnumerateMediaDevices.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EnumerateMediaDevices.cpp; sourceTree = "<group>"; };
 		074AD7092B604E7600FFA67B /* WritingTools.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WritingTools.mm; sourceTree = "<group>"; };
+		074E87E42CF920A20059E469 /* Bundle+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Extras.swift"; sourceTree = "<group>"; };
 		075A9CF426177217006DFA3A /* MediaSessionCoordinatorTest.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MediaSessionCoordinatorTest.mm; sourceTree = "<group>"; };
 		0766DD1F1A5AD5200023E3BB /* PendingAPIRequestURL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PendingAPIRequestURL.cpp; sourceTree = "<group>"; };
 		076E507E1F45031E006E9F5A /* Logging.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Logging.cpp; sourceTree = "<group>"; };
@@ -4010,6 +4012,7 @@
 		0707210D2CE2F3A0004D9EC8 /* WebKit Swift */ = {
 			isa = PBXGroup;
 			children = (
+				074E87E42CF920A20059E469 /* Bundle+Extras.swift */,
 				078B04492CF139BF00B453A6 /* Foundation+Extras.swift */,
 				070721102CE2F4B8004D9EC8 /* TestWebKitAPIBundle-Bridging-Header.h */,
 				078B04472CF118BD00B453A6 /* URLSchemeHandler.swift */,
@@ -7440,6 +7443,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				078B044A2CF139BF00B453A6 /* Foundation+Extras.swift in Sources */,
+				074E87E52CF920A20059E469 /* Bundle+Extras.swift in Sources */,
 				A17C58472C9BF524009DD0B5 /* GoogleTests.mm in Sources */,
 				078B04482CF118BD00B453A6 /* URLSchemeHandler.swift in Sources */,
 				07FAA74D2CE95E3200128360 /* WebPage.swift in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/Bundle+Extras.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/Bundle+Extras.swift
@@ -18,34 +18,20 @@
 // SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
 // CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
-// THE POSSIBILITY OF SUCH DAMAGE.
+// ARISING IN ANY WAY OUT OF THE USE
 
-#if canImport(Testing) && compiler(>=6.0)
+import Foundation
 
-import Testing
-import WebKit
+extension Bundle {
+    static var testResources: Bundle {
+        guard let url = Bundle.main.url(forResource: "TestWebKitAPIResources", withExtension: "bundle") else {
+            fatalError()
+        }
 
-@MainActor
-struct WKWebViewSwiftOverlayTests {
-    @Test
-    func evaluateJavaScriptYieldsExpectedResponse() async throws {
-        let webView = WKWebView()
+        guard let bundle = Bundle(url: url) else {
+            fatalError()
+        }
 
-        let response = try await webView.evaluateJavaScript("1 + 2") as! Int
-        #expect(response == 3)
-    }
-
-    @Test(
-        .disabled("This test currently crashes due to the associated bug."),
-        .bug("https://bugs.webkit.org/show_bug.cgi?id=282918")
-    )
-    func evaluateJavaScriptWithNilResponse() async throws {
-        let webView = WKWebView()
-        
-        let response: Any? = try await webView.evaluateJavaScript("console.log('hello')")
-        #expect(response == nil)
+        return bundle
     }
 }
-
-#endif

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPage.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPage.swift
@@ -1,25 +1,25 @@
 // Copyright (C) 2024 Apple Inc. All rights reserved.
- //
- // Redistribution and use in source and binary forms, with or without
- // modification, are permitted provided that the following conditions
- // are met:
- // 1. Redistributions of source code must retain the above copyright
- //    notice, this list of conditions and the following disclaimer.
- // 2. Redistributions in binary form must reproduce the above copyright
- //    notice, this list of conditions and the following disclaimer in the
- //    documentation and/or other materials provided with the distribution.
- //
- // THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
- // AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
- // THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
- // PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
- // BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- // CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- // SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- // CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
- // THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
 
 #if ENABLE_SWIFTUI && canImport(Testing) && compiler(>=6.0)
 
@@ -51,6 +51,36 @@ extension WebPage_v0.NavigationEvent.Kind: @retroactive Equatable {
 extension WebPage_v0.NavigationEvent: @retroactive Equatable {
     public static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.kind == rhs.kind && lhs.navigationID == rhs.navigationID
+    }
+}
+
+// MARK: Supporting test types
+
+@MainActor
+fileprivate class TestNavigationDecider: NavigationDeciding {
+    init() {
+        (self.navigationActionStream, self.navigationActionContinuation) = AsyncStream.makeStream(of: WebPage_v0.NavigationAction.self)
+        (self.navigationResponseStream, self.navigationResponseContinuation) = AsyncStream.makeStream(of: WebPage_v0.NavigationResponse.self)
+    }
+
+    let navigationActionStream: AsyncStream<WebPage_v0.NavigationAction>
+    private let navigationActionContinuation: AsyncStream<WebPage_v0.NavigationAction>.Continuation
+
+    let navigationResponseStream: AsyncStream<WebPage_v0.NavigationResponse>
+    private let navigationResponseContinuation: AsyncStream<WebPage_v0.NavigationResponse>.Continuation
+
+    var preferencesMutation: (inout WebPage_v0.NavigationPreferences) -> Void = { _ in }
+
+    func decidePolicy(for action: WebPage_v0.NavigationAction, preferences: inout WebPage_v0.NavigationPreferences) async -> WKNavigationActionPolicy {
+        preferencesMutation(&preferences)
+
+        navigationActionContinuation.yield(action)
+        return .allow
+    }
+
+    func decidePolicy(for response: WebPage_v0.NavigationResponse) async -> WKNavigationResponsePolicy {
+        navigationResponseContinuation.yield(response)
+        return .allow
     }
 }
 
@@ -195,6 +225,52 @@ struct WebPageTests {
     }
 
     @Test
+    func decidePolicyForNavigationActionFragment() async throws {
+        let decider = TestNavigationDecider()
+        let page = WebPage_v0(navigationDecider: decider)
+
+        let html = "<script>window.location.href='#fragment';</script>"
+
+        let baseURL = URL(string: "http://webkit.org")!
+        page.load(htmlString: html, baseURL: baseURL)
+
+        let actions = await Array(decider.navigationActionStream.prefix(2))
+
+        #expect(actions[0].request.url!.absoluteString == "http://webkit.org/")
+        #expect(actions[1].request.url!.absoluteString == "http://webkit.org/#fragment")
+    }
+
+    @Test
+    func navigationPreferencesMutationDuringNavigation() async throws {
+        let decider = TestNavigationDecider()
+        let page = WebPage_v0(navigationDecider: decider)
+
+        let html = "<script>var foo = 'bar'</script>"
+
+        decider.preferencesMutation = {
+            $0.allowsContentJavaScript = false
+        }
+
+        let id = page.load(htmlString: html, baseURL: .aboutBlank)!
+
+        let actions = await Array(decider.navigationActionStream.prefix(1))
+        #expect(actions[0].request.url == .aboutBlank)
+
+        for await event in page.navigations where event.navigationID == id {
+            if case .finished = event.kind {
+                break
+            }
+        }
+
+        do {
+            _ = try await page.callAsyncJavaScript("return foo;", contentWorld: .page)
+            Issue.record()
+        } catch {
+            #expect(error.localizedDescription == "A JavaScript exception occurred")
+        }
+    }
+
+    @Test
     func javaScriptEvaluation() async throws {
         let page = WebPage_v0()
 
@@ -208,6 +284,21 @@ struct WebPageTests {
 
         let nilResult = try await page.callAsyncJavaScript("console.log('hi')")
         #expect(nilResult == nil)
+    }
+
+    @Test
+    func decidePolicyForNavigationResponse() async throws {
+        let decider = TestNavigationDecider()
+        let page = WebPage_v0(navigationDecider: decider)
+
+        let simpleURL = Bundle.testResources.url(forResource: "simple", withExtension: "html")!
+        let request = URLRequest(url: simpleURL)
+
+        page.load(request)
+
+        let responses = await Array(decider.navigationResponseStream.prefix(1))
+
+        #expect(responses[0].response.url!.absoluteString == simpleURL.absoluteString)
     }
 }
 


### PR DESCRIPTION
#### 7d88a900b0d51f0d827e99ffa15d6b729d0446b7
<pre>
[SwiftUI] Introduce the NavigationDeciding protocol
<a href="https://bugs.webkit.org/show_bug.cgi?id=283805">https://bugs.webkit.org/show_bug.cgi?id=283805</a>
<a href="https://rdar.apple.com/140672055">rdar://140672055</a>

Reviewed by Wenson Hsieh.

This protocol is designed to provide the subset of functionality of WKNavigationDelegate for making navigation
decisions and responding to authentication challenges.

The exception is `webView(_:authenticationChallenge:shouldAllowDeprecatedTLS:)`, which is intentionally excluded
as its functionality is effectively deprecated.

* Source/WebKit/UIProcess/API/Swift/WKNavigationDelegateAdapter.swift:
(WKNavigationDelegateAdapter.webView(_:decidePolicyFor:preferences:WKWebpagePreferences:)):
(WKNavigationDelegateAdapter.webView(_:decidePolicyFor:)):
(WKNavigationDelegateAdapter.webView(_:respondTo:URLCredential:)):
* Source/WebKit/UIProcess/API/Swift/WebPage+FrameInfo.swift: Added.
(FrameInfo.isMainFrame):
(FrameInfo.request):
(FrameInfo.securityOrigin):
(FrameInfo.wrapped):
* Source/WebKit/UIProcess/API/Swift/WebPage+NavigationDeciding.swift: Added.
(NavigationAction.source):
(NavigationAction.target):
(NavigationAction.navigationType):
(NavigationAction.request):
(NavigationAction.shouldPerformDownload):
(NavigationAction.buttonNumber):
(NavigationAction.modifierFlags):
(NavigationAction.wrapped):
(NavigationResponse.isForMainFrame):
(NavigationResponse.response):
(NavigationResponse.canShowMimeType):
(NavigationResponse.wrapped):
(NavigationDeciding.decidePolicy(for:preferences:)):
(NavigationDeciding.decidePolicy(for:)):
(NavigationDeciding.decideAuthenticationChallengeDisposition(for:URLCredential:)):
* Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift: Added.
(preferredContentMode):
(allowsContentJavaScript):
(preferredHTTPSNavigationPolicy):
(isLockdownModeEnabled):
* Source/WebKit/UIProcess/API/Swift/WebPage.swift:
(WebPage_v0.callAsyncJavaScript(_:arguments:in:contentWorld:)):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit Swift/Bundle+Extras.swift: Added.
(Bundle.testResources):
* Tools/TestWebKitAPI/Tests/WebKit Swift/WKWebViewSwiftOverlay.swift:
* Tools/TestWebKitAPI/Tests/WebKit Swift/WebPage.swift:
(TestNavigationDecider.preferencesMutation):
(TestNavigationDecider.decidePolicy(for:preferences:)):
(TestNavigationDecider.decidePolicy(for:)):
(WebPageTests.decidePolicyForNavigationActionFragment):
(WebPageTests.navigationPreferencesMutationDuringNavigation):
(WebPageTests.decidePolicyForNavigationResponse):

Canonical link: <a href="https://commits.webkit.org/287483@main">https://commits.webkit.org/287483@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/254baebe854a7ed1a64a4cff439cfe949e1b6a47

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79861 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58861 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33259 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/84379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/30851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81970 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67929 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7151 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/84379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/30851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82929 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/52473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/72730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/84379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/49813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/26879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/29304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/70938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/27354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85809 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7086 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/70682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/7260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/68570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/69925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/12852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12346 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7047 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/6901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/10413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/8707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->