### PR TITLE
[Text] Add support for capitalizing content with characters outside of BMP

### DIFF
--- a/LayoutTests/fast/text/capitalize-content-with-outside-bmp-characters-expected.html
+++ b/LayoutTests/fast/text/capitalize-content-with-outside-bmp-characters-expected.html
@@ -1,0 +1,2 @@
+<meta charset="utf-8">
+<div>𐐐𐐮𐐭𐑋𐐰𐑌 𐐐𐐮𐐭𐑋𐐰𐑌 Firﬆ Œuf Æsthetics</div>

--- a/LayoutTests/fast/text/capitalize-content-with-outside-bmp-characters.html
+++ b/LayoutTests/fast/text/capitalize-content-with-outside-bmp-characters.html
@@ -1,0 +1,7 @@
+<meta charset="utf-8">
+<style>
+div {
+  text-transform: capitalize;
+}
+</style>
+<div>𐐸𐐮𐐭𐑋𐐰𐑌 <span>𐐸𐐮𐐭𐑋𐐰𐑌</span> ﬁrﬆ œuf æsthetics</div>

--- a/LayoutTests/platform/ios/css1/text_properties/text_transform-expected.txt
+++ b/LayoutTests/platform/ios/css1/text_properties/text_transform-expected.txt
@@ -22,10 +22,10 @@ layer at (0,0) size 800x775
           text run at (0,0) width 733: "This page tests the 'text-transform' property of CSS1. This paragraph has no text transformation and should appear"
           text run at (0,20) width 50: "normal."
       RenderBlock {P} at (0,193) size 784x60
-        RenderText {#text} at (0,0) size 780x59
+        RenderText {#text} at (0,0) size 758x59
           text run at (0,0) width 758: "This Paragraph Is Capitalized And The First Letter In Each Word Should Therefore Appear In Uppercase. Words That"
-          text run at (0,20) width 780: "Are In Uppercase In The Source (E.g. USA) Should Remain So. There Should Be A Capital Letter After A Non-Breaking"
-          text run at (0,40) width 482: "Space (&Nbsp;). Both Those Characters Appear In The Previous Sentence."
+          text run at (0,20) width 721: "Are In Uppercase In The Source (E.g. USA) Should Remain So. There Should Be A Capital Letter After A Non-"
+          text run at (0,40) width 544: "Breaking Space (&Nbsp;). Both Those Characters Appear In The Previous Sentence."
       RenderBlock {P} at (0,269) size 784x40
         RenderText {#text} at (0,0) size 771x39
           text run at (0,0) width 771: "Words with inline elements inside them should only capitalize the first letter of the word. Therefore, the last word in this"


### PR DESCRIPTION
#### eef844b64baefafc66b443e8cf12e2aa545e22c1
<pre>
[Text] Add support for capitalizing content with characters outside of BMP
<a href="https://bugs.webkit.org/show_bug.cgi?id=283779">https://bugs.webkit.org/show_bug.cgi?id=283779</a>
&lt;<a href="https://rdar.apple.com/problem/140673480">rdar://problem/140673480</a>&gt;

Reviewed by Antti Koivisto.

Let&apos;s use SurrogatePairAwareTextIterator to figure out the actual length of capitalized content.

(titlecasing code is the same except now we can pass in multi-character content to capitalize.
In practice it&apos;s only 16bit content that may have this property)

* Source/WebCore/rendering/RenderText.cpp:
(WebCore::capitalizeCharacter):
(WebCore::capitalize):

Canonical link: <a href="https://commits.webkit.org/287169@main">https://commits.webkit.org/287169@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e9ab06d9f41a5f5d9822a2bcdbf8059023cce4d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78620 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57665 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32002 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83281 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29884 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80753 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66816 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5946 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61579 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19502 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81687 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51600 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/70209 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41889 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48946 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25498 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28223 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70049 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25874 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84649 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5985 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4117 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69805 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6146 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67577 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69059 "Found 9 new API test failures: /TestWebKit:WebKit.DownloadDecideDestinationCrash, /TestWebKit:WebKit.LoadAlternateHTMLStringWithEmptyBaseURL, /TestWebKit:WebKit2.ProvisionalURLAfterWillSendRequestCallback, /TestWebKit:WebKit.CanHandleRequest, /TestWebKit:WebKit.HitTestResultNodeHandle, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/test-page-list, /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginShouldNotBeDispatchedForAlreadyFocusedField, /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginAndEndEditingEvents, /TestWebKit:WebKit.Find (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17204 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13090 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11586 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5932 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/11873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5919 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9354 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7707 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->