### PR TITLE
[macOS] Pressing Shift + Up should not cause the page to scroll

### DIFF
--- a/LayoutTests/fast/scrolling/mac/no-keyboard-scrolling-when-holding-shift-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/no-keyboard-scrolling-when-holding-shift-expected.txt
@@ -1,0 +1,10 @@
+Verifies that pressing Shift + Up modifies an extant selection, and does not begin keyboard scrolling after the selection is completely cleared. To manually run the test, press Shift + Up until the selection disappears, and then keep pressing Shift + Up — the page should not scroll
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.scrollingElement.scrollTop is scrollTopBeforeKeyPresses
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes. The ones who see things differently. They’re not fond of rules. And they have no respect for the status quo.

--- a/LayoutTests/fast/scrolling/mac/no-keyboard-scrolling-when-holding-shift.html
+++ b/LayoutTests/fast/scrolling/mac/no-keyboard-scrolling-when-holding-shift.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ScrollAnimatorEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+body {
+    font-family: system-ui;
+}
+
+#scroller {
+    width: 20%;
+    height: 20%;
+    overflow: scroll;
+    border: 1px solid black;
+    padding: 10px;
+}
+
+.tall {
+    background-image: linear-gradient(blue, red);
+    height: 3000px;
+    width: 100px;
+    z-index: -1;
+}
+
+.text {
+    width: 300px;
+    height: 300px;
+}
+</style>
+<meta charset="utf-8">
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async function() {
+    description("Verifies that pressing Shift + Up modifies an extant selection, and does not begin keyboard scrolling after the selection is completely cleared. To manually run the test, press Shift + Up until the selection disappears, and then keep pressing Shift + Up — the page should not scroll")
+    getSelection().selectAllChildren(document.querySelector("p.text"));
+    await UIHelper.ensurePresentationUpdate();
+    scrollTo(0, 5000);
+
+    if (!window.testRunner || !testRunner.runUIScript)
+        return;
+
+    scrollTopBeforeKeyPresses = document.scrollingElement.scrollTop;
+
+    // Verify that pressing Shift + Up modifies the selection until it's no longer visible.
+    while (getSelection().type === "Range") {
+        await UIHelper.keyDown("upArrow", ["shiftKey"]);
+    }
+
+    // Verify that pressing Shift + Up afterwards does not trigger keyboard scrolling.
+    await UIHelper.rawKeyDown("upArrow", ["shiftKey"]);
+    await UIHelper.delayFor(250);
+    await UIHelper.rawKeyUp("upArrow", ["shiftKey"]);
+    shouldBe("document.scrollingElement.scrollTop", "scrollTopBeforeKeyPresses");
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div class="tall"></div>
+    <p class="text">Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes. The ones who see things differently. They’re not fond of rules. And they have no respect for the status quo.</p>
+</body>
+</html>

--- a/Source/WebCore/platform/KeyboardScrollingAnimator.cpp
+++ b/Source/WebCore/platform/KeyboardScrollingAnimator.cpp
@@ -122,6 +122,8 @@ const std::optional<ScrollGranularity> scrollGranularityForKeyboardEvent(const K
         return ScrollGranularity::Line;
     case KeyboardScrollingKey::UpArrow:
     case KeyboardScrollingKey::DownArrow:
+        if (event.shiftKey())
+            return { };
         if (event.metaKey())
             return ScrollGranularity::Document;
         if (event.altKey())


### PR DESCRIPTION
#### 35b3fc5d9015f3b089d0aa090b07ed7840c666f8
<pre>
[macOS] Pressing Shift + Up should not cause the page to scroll
<a href="https://bugs.webkit.org/show_bug.cgi?id=283806">https://bugs.webkit.org/show_bug.cgi?id=283806</a>
<a href="https://rdar.apple.com/137983379">rdar://137983379</a>

Reviewed by Richard Robinson.

Currently, pressing Shift + Up (or Shift + Alt|Command + Up) triggers keyboard scrolling; this
behavior is inconsistent with Firefox and Chrome on macOS, as well as Safari on iPadOS. This also
leads to unintuitive behaviors after pressing Shift + Up to modify the selection, since keyboard
scrolling will immediately start once the selection is collapsed.

Fix this by returning early in the case where the shift key is held, when pressing up or down on the
keyboard.

* LayoutTests/fast/scrolling/mac/no-keyboard-scrolling-when-holding-shift-expected.txt: Added.
* LayoutTests/fast/scrolling/mac/no-keyboard-scrolling-when-holding-shift.html: Added.
* Source/WebCore/platform/KeyboardScrollingAnimator.cpp:
(WebCore::scrollGranularityForKeyboardEvent):

Canonical link: <a href="https://commits.webkit.org/287161@main">https://commits.webkit.org/287161@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/725235b8a12a403f41152e033e9bb9d9f6b0221e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78569 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57614 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31951 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83230 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29834 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80702 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66765 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5895 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61544 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19461 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81636 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51555 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/69926 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41854 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48901 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25410 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28171 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70002 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25784 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84596 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5934 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4069 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69767 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6095 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67532 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69021 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17199 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13042 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11506 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5881 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/11838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5869 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9303 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7656 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->