### PR TITLE
Make more MessageReceiver objects ref-counted in the WebProcess

### DIFF
--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
@@ -242,7 +242,7 @@ bool GPUProcessConnection::dispatchMessage(IPC::Connection& connection, IPC::Dec
 
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
     if (decoder.messageReceiverName() == Messages::UserMediaCaptureManager::messageReceiverName()) {
-        if (auto* captureManager = WebProcess::singleton().supplement<UserMediaCaptureManager>())
+        if (RefPtr captureManager = WebProcess::singleton().supplement<UserMediaCaptureManager>())
             captureManager->didReceiveMessageFromGPUProcess(connection, decoder);
         return true;
     }

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorInterruptDispatcher.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorInterruptDispatcher.cpp
@@ -28,20 +28,32 @@
 
 #include "Connection.h"
 #include "WebInspectorInterruptDispatcherMessages.h"
+#include "WebProcess.h"
 #include <JavaScriptCore/VM.h>
 #include <WebCore/CommonVM.h>
 #include <wtf/WorkQueue.h>
 
 namespace WebKit {
 
-WebInspectorInterruptDispatcher::WebInspectorInterruptDispatcher()
-    : m_queue(WorkQueue::create("com.apple.WebKit.WebInspectorInterruptDispatcher"_s))
+WebInspectorInterruptDispatcher::WebInspectorInterruptDispatcher(WebProcess& process)
+    : m_process(process)
+    , m_queue(WorkQueue::create("com.apple.WebKit.WebInspectorInterruptDispatcher"_s))
 {
 }
 
 WebInspectorInterruptDispatcher::~WebInspectorInterruptDispatcher()
 {
     ASSERT_NOT_REACHED();
+}
+
+void WebInspectorInterruptDispatcher::ref() const
+{
+    m_process->ref();
+}
+
+void WebInspectorInterruptDispatcher::deref() const
+{
+    m_process->deref();
 }
 
 void WebInspectorInterruptDispatcher::initializeConnection(IPC::Connection& connection)

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorInterruptDispatcher.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorInterruptDispatcher.h
@@ -27,6 +27,7 @@
 
 #include "MessageReceiver.h"
 #include <wtf/Ref.h>
+#include <wtf/WeakRef.h>
 
 namespace WTF {
 class WorkQueue;
@@ -34,12 +35,17 @@ class WorkQueue;
 
 namespace WebKit {
 
+class WebProcess;
+
 class WebInspectorInterruptDispatcher final : private IPC::MessageReceiver {
 public:
-    WebInspectorInterruptDispatcher();
+    explicit WebInspectorInterruptDispatcher(WebProcess&);
     ~WebInspectorInterruptDispatcher();
     
     void initializeConnection(IPC::Connection&);
+
+    void ref() const;
+    void deref() const;
     
 private:
     // IPC::MessageReceiver overrides.
@@ -47,6 +53,7 @@ private:
     
     void notifyNeedDebuggerBreak();
     
+    WeakRef<WebProcess> m_process;
     Ref<WTF::WorkQueue> m_queue;
 };
 

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorInterruptDispatcher.messages.in
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorInterruptDispatcher.messages.in
@@ -20,6 +20,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> WebInspectorInterruptDispatcher NotRefCounted {
+messages -> WebInspectorInterruptDispatcher {
     NotifyNeedDebuggerBreak()
 }

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
@@ -346,7 +346,7 @@ void NetworkProcessConnection::loadCancelledDownloadRedirectRequestInFrame(WebCo
 #if ENABLE(WEB_RTC)
 void NetworkProcessConnection::connectToRTCDataChannelRemoteSource(WebCore::RTCDataChannelIdentifier localIdentifier, WebCore::RTCDataChannelIdentifier remoteIdentifier, CompletionHandler<void(std::optional<bool>)>&& callback)
 {
-    callback(RTCDataChannelRemoteManager::sharedManager().connectToRemoteSource(localIdentifier, remoteIdentifier));
+    callback(RTCDataChannelRemoteManager::singleton().connectToRemoteSource(localIdentifier, remoteIdentifier));
 }
 #endif
 

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.cpp
@@ -40,6 +40,9 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(LibWebRTCNetwork);
 
 LibWebRTCNetwork::LibWebRTCNetwork(WebProcess& webProcess)
     : m_webProcess(webProcess)
+#if USE(LIBWEBRTC)
+    , m_webNetworkMonitor(*this)
+#endif
 #if ENABLE(WEB_RTC)
     , m_mdnsRegister(*this)
 #endif

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.h
@@ -32,10 +32,10 @@
 #include "WebRTCMonitor.h"
 #include "WebRTCResolver.h"
 #include <WebCore/LibWebRTCSocketIdentifier.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/FunctionDispatcher.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
-#include <wtf/WeakRef.h>
 
 namespace WebKit {
 class WebProcess;
@@ -58,6 +58,7 @@ public:
 
 #if USE(LIBWEBRTC)
     WebRTCMonitor& monitor() { return m_webNetworkMonitor; }
+    Ref<WebRTCMonitor> protectedMonitor() { return m_webNetworkMonitor; }
     LibWebRTCSocketFactory& socketFactory() { return m_socketFactory; }
 
     void disableNonLocalhostConnections() { socketFactory().disableNonLocalhostConnections(); }
@@ -92,7 +93,7 @@ private:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 #endif
 
-    WeakRef<WebProcess> m_webProcess;
+    CheckedRef<WebProcess> m_webProcess;
 
 #if USE(LIBWEBRTC)
     LibWebRTCSocketFactory m_socketFactory;

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.messages.in
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.messages.in
@@ -22,7 +22,7 @@
 
 #if USE(LIBWEBRTC)
 
-messages -> LibWebRTCNetwork NotRefCounted {
+messages -> LibWebRTCNetwork {
     SignalReadPacket(WebCore::LibWebRTCSocketIdentifier socketIdentifier, std::span<const uint8_t> data, WebKit::RTC::Network::IPAddress address, uint16_t port, int64_t timestamp, WebKit::RTC::Network::EcnMarking ecn)
     SignalSentPacket(WebCore::LibWebRTCSocketIdentifier socketIdentifier, int64_t rtcPacketID, int64_t timestamp)
     SignalAddressReady(WebCore::LibWebRTCSocketIdentifier socketIdentifier, WebKit::RTC::Network::SocketAddress address)

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
@@ -56,7 +56,7 @@ RefPtr<LibWebRTCNetworkManager> LibWebRTCNetworkManager::getOrCreate(WebCore::Sc
         auto newNetworkManager = adoptRef(*new LibWebRTCNetworkManager(identifier));
         networkManager = newNetworkManager.ptr();
         document->setRTCNetworkManager(WTFMove(newNetworkManager));
-        WebProcess::singleton().libWebRTCNetwork().monitor().addObserver(*networkManager);
+        WebProcess::singleton().libWebRTCNetwork().protectedMonitor()->addObserver(*networkManager);
     }
 
     return networkManager;
@@ -85,7 +85,7 @@ void LibWebRTCNetworkManager::close()
 #if ASSERT_ENABLED
     m_isClosed = true;
 #endif
-    WebProcess::singleton().libWebRTCNetwork().monitor().removeObserver(*this);
+    WebProcess::singleton().libWebRTCNetwork().protectedMonitor()->removeObserver(*this);
 }
 
 void LibWebRTCNetworkManager::unregisterMDNSNames()
@@ -125,7 +125,7 @@ void LibWebRTCNetworkManager::StopUpdating()
     callOnMainRunLoop([weakThis = WeakPtr { *this }] {
         if (!weakThis)
             return;
-        WebProcess::singleton().libWebRTCNetwork().monitor().stopUpdating();
+        WebProcess::singleton().libWebRTCNetwork().protectedMonitor()->stopUpdating();
     });
 }
 

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp
@@ -189,7 +189,7 @@ std::unique_ptr<LibWebRTCProvider::SuspendableSocketFactory> LibWebRTCProvider::
 
 RefPtr<RTCDataChannelRemoteHandlerConnection> LibWebRTCProvider::createRTCDataChannelRemoteHandlerConnection()
 {
-    return &RTCDataChannelRemoteManager::sharedManager().remoteHandlerConnection();
+    return &RTCDataChannelRemoteManager::singleton().remoteHandlerConnection();
 }
 
 void LibWebRTCProvider::setLoggingLevel(WTFLogLevel level)

--- a/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp
@@ -39,14 +39,14 @@
 
 namespace WebKit {
 
-RTCDataChannelRemoteManager& RTCDataChannelRemoteManager::sharedManager()
+RTCDataChannelRemoteManager& RTCDataChannelRemoteManager::singleton()
 {
-    static RTCDataChannelRemoteManager* sharedManager = [] {
-        auto instance = new RTCDataChannelRemoteManager;
+    static NeverDestroyed<Ref<RTCDataChannelRemoteManager>> sharedManager = [] {
+        Ref instance = adoptRef(*new RTCDataChannelRemoteManager);
         instance->initialize();
         return instance;
     }();
-    return *sharedManager;
+    return sharedManager.get();
 }
 
 RTCDataChannelRemoteManager::RTCDataChannelRemoteManager()
@@ -184,10 +184,10 @@ RTCDataChannelRemoteManager::RemoteHandlerConnection::RemoteHandlerConnection(Re
 void RTCDataChannelRemoteManager::RemoteHandlerConnection::connectToSource(WebCore::RTCDataChannelRemoteHandler& handler, std::optional<WebCore::ScriptExecutionContextIdentifier> contextIdentifier, WebCore::RTCDataChannelIdentifier localIdentifier, WebCore::RTCDataChannelIdentifier remoteIdentifier)
 {
     m_queue->dispatch([handler = WeakPtr { handler }, contextIdentifier, localIdentifier]() mutable {
-        RTCDataChannelRemoteManager::sharedManager().m_handlers.add(localIdentifier.object(), RemoteHandler { WTFMove(handler), *contextIdentifier });
+        RTCDataChannelRemoteManager::singleton().m_handlers.add(localIdentifier.object(), RemoteHandler { WTFMove(handler), *contextIdentifier });
     });
     m_connection->sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::ConnectToRTCDataChannelRemoteSource { localIdentifier, remoteIdentifier }, [localIdentifier](auto&& result) {
-        RTCDataChannelRemoteManager::sharedManager().postTaskToHandler(localIdentifier, [result](auto& handler) {
+        RTCDataChannelRemoteManager::singleton().postTaskToHandler(localIdentifier, [result](auto& handler) {
             if (!result || !*result) {
                 handler.didDetectError(WebCore::RTCError::create(WebCore::RTCErrorDetailType::DataChannelFailure, "Unable to find data channel"_s));
                 return;

--- a/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.h
@@ -38,7 +38,11 @@ namespace WebKit {
 
 class RTCDataChannelRemoteManager final : private IPC::MessageReceiver {
 public:
-    static RTCDataChannelRemoteManager& sharedManager();
+    static RTCDataChannelRemoteManager& singleton();
+
+    // Do nothing since this is a singleton.
+    void ref() const { }
+    void deref() const { }
 
     WebCore::RTCDataChannelRemoteHandlerConnection& remoteHandlerConnection();
     bool connectToRemoteSource(WebCore::RTCDataChannelIdentifier source, WebCore::RTCDataChannelIdentifier handler);

--- a/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.messages.in
+++ b/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.messages.in
@@ -22,7 +22,7 @@
 
 #if ENABLE(WEB_RTC)
 
-messages -> RTCDataChannelRemoteManager NotRefCounted {
+messages -> RTCDataChannelRemoteManager {
     // To source
     SendData(struct WebCore::RTCDataChannelIdentifier source, bool isRaw, std::span<const uint8_t> text);
     Close(struct WebCore::RTCDataChannelIdentifier source);

--- a/Source/WebKit/WebProcess/Network/webrtc/WebRTCMonitor.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebRTCMonitor.cpp
@@ -39,6 +39,21 @@ namespace WebKit {
 
 #define WEBRTC_RELEASE_LOG(fmt, ...) RELEASE_LOG(Network, "%p - WebRTCMonitor::" fmt, this, ##__VA_ARGS__)
 
+WebRTCMonitor::WebRTCMonitor(LibWebRTCNetwork& libWebRTCNetwork)
+    : m_libWebRTCNetwork(libWebRTCNetwork)
+{
+}
+
+void WebRTCMonitor::ref() const
+{
+    m_libWebRTCNetwork->ref();
+}
+
+void WebRTCMonitor::deref() const
+{
+    m_libWebRTCNetwork->deref();
+}
+
 void WebRTCMonitor::startUpdating()
 {
     WEBRTC_RELEASE_LOG("StartUpdating - Asking network process to start updating");

--- a/Source/WebKit/WebProcess/Network/webrtc/WebRTCMonitor.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebRTCMonitor.h
@@ -40,6 +40,7 @@ class Decoder;
 
 namespace WebKit {
 
+class LibWebRTCNetwork;
 struct NetworksChangedData;
 
 class WebRTCMonitorObserver : public AbstractRefCountedAndCanMakeWeakPtr<WebRTCMonitorObserver> {
@@ -52,7 +53,10 @@ public:
 
 class WebRTCMonitor {
 public:
-    WebRTCMonitor() = default;
+    explicit WebRTCMonitor(LibWebRTCNetwork&);
+
+    void ref() const;
+    void deref() const;
 
     void addObserver(WebRTCMonitorObserver& observer) { m_observers.add(observer); }
     void removeObserver(WebRTCMonitorObserver& observer) { m_observers.remove(observer); }
@@ -70,6 +74,7 @@ public:
 private:
     void networksChanged(Vector<RTCNetwork>&&, RTCNetwork::IPAddress&&, RTCNetwork::IPAddress&&);
 
+    WeakRef<LibWebRTCNetwork> m_libWebRTCNetwork;
     unsigned m_clientCount { 0 };
     WeakHashSet<WebRTCMonitorObserver> m_observers;
     bool m_didReceiveNetworkList { false };

--- a/Source/WebKit/WebProcess/Network/webrtc/WebRTCMonitor.messages.in
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebRTCMonitor.messages.in
@@ -22,7 +22,7 @@
 
 #if USE(LIBWEBRTC)
 
-messages -> WebRTCMonitor NotRefCounted {
+messages -> WebRTCMonitor {
     void NetworksChanged(Vector<WebKit::RTCNetwork> networks, WebKit::RTC::Network::IPAddress defaultIPV4Address, WebKit::RTC::Network::IPAddress defaultIPV6Address)
 }
 

--- a/Source/WebKit/WebProcess/Notifications/NotificationPermissionRequestManager.cpp
+++ b/Source/WebKit/WebProcess/Notifications/NotificationPermissionRequestManager.cpp
@@ -86,7 +86,7 @@ void NotificationPermissionRequestManager::startRequest(const SecurityOriginData
     m_page->sendWithAsyncReply(Messages::WebPageProxy::RequestNotificationPermission(securityOrigin.toString()), [this, protectedThis = Ref { *this }, securityOrigin, permissionHandler = WTFMove(permissionHandler)](bool allowed) mutable {
 
         auto innerPermissionHandler = [this, protectedThis = Ref { *this }, securityOrigin, permissionHandler = WTFMove(permissionHandler)] (bool allowed) mutable {
-            WebProcess::singleton().supplement<WebNotificationManager>()->didUpdateNotificationDecision(securityOrigin.toString(), allowed);
+            WebProcess::singleton().protectedNotificationManager()->didUpdateNotificationDecision(securityOrigin.toString(), allowed);
 
             auto permissionHandlers = m_requestsPerOrigin.take(securityOrigin);
             callPermissionHandlersWith(permissionHandlers, allowed ? Permission::Granted : Permission::Denied);
@@ -109,7 +109,7 @@ auto NotificationPermissionRequestManager::permissionLevel(const SecurityOriginD
     if (!m_page->corePage()->settings().notificationsEnabled())
         return Permission::Denied;
     
-    return WebProcess::singleton().supplement<WebNotificationManager>()->policyForOrigin(securityOrigin.toString());
+    return WebProcess::singleton().protectedNotificationManager()->policyForOrigin(securityOrigin.toString());
 #else
     UNUSED_PARAM(securityOrigin);
     return Permission::Denied;
@@ -119,7 +119,7 @@ auto NotificationPermissionRequestManager::permissionLevel(const SecurityOriginD
 void NotificationPermissionRequestManager::setPermissionLevelForTesting(const String& originString, bool allowed)
 {
 #if ENABLE(NOTIFICATIONS)
-    WebProcess::singleton().supplement<WebNotificationManager>()->didUpdateNotificationDecision(originString, allowed);
+    WebProcess::singleton().protectedNotificationManager()->didUpdateNotificationDecision(originString, allowed);
 #else
     UNUSED_PARAM(originString);
     UNUSED_PARAM(allowed);
@@ -129,7 +129,7 @@ void NotificationPermissionRequestManager::setPermissionLevelForTesting(const St
 void NotificationPermissionRequestManager::removeAllPermissionsForTesting()
 {
 #if ENABLE(NOTIFICATIONS)
-    WebProcess::singleton().supplement<WebNotificationManager>()->removeAllPermissionsForTesting();
+    WebProcess::singleton().protectedNotificationManager()->removeAllPermissionsForTesting();
 #endif
 }
 

--- a/Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp
+++ b/Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp
@@ -104,14 +104,23 @@ ASCIILiteral WebNotificationManager::supplementName()
 }
 
 WebNotificationManager::WebNotificationManager(WebProcess& process)
+    : m_process(process)
 {
 #if ENABLE(NOTIFICATIONS)
     process.addMessageReceiver(Messages::WebNotificationManager::messageReceiverName(), *this);
 #endif
 }
 
-WebNotificationManager::~WebNotificationManager()
+WebNotificationManager::~WebNotificationManager() = default;
+
+void WebNotificationManager::ref() const
 {
+    m_process->ref();
+}
+
+void WebNotificationManager::deref() const
+{
+    m_process->deref();
 }
 
 void WebNotificationManager::initialize(const WebProcessCreationParameters& parameters)

--- a/Source/WebKit/WebProcess/Notifications/WebNotificationManager.h
+++ b/Source/WebKit/WebProcess/Notifications/WebNotificationManager.h
@@ -37,6 +37,7 @@
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UUID.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/StringHash.h>
 
 namespace WebCore {
@@ -57,6 +58,9 @@ class WebNotificationManager : public WebProcessSupplement, public IPC::MessageR
 public:
     explicit WebNotificationManager(WebProcess&);
     ~WebNotificationManager();
+
+    void ref() const;
+    void deref() const;
 
     static ASCIILiteral supplementName();
     
@@ -88,6 +92,7 @@ private:
     void didCloseNotifications(const Vector<WTF::UUID>& notificationIDs);
     void didRemoveNotificationDecisions(const Vector<String>& originStrings);
 
+    WeakRef<WebProcess> m_process;
 #if ENABLE(NOTIFICATIONS)
     HashMap<WTF::UUID, WebCore::ScriptExecutionContextIdentifier> m_nonPersistentNotificationsContexts;
     HashMap<String, bool> m_permissionsMap;

--- a/Source/WebKit/WebProcess/Notifications/WebNotificationManager.messages.in
+++ b/Source/WebKit/WebProcess/Notifications/WebNotificationManager.messages.in
@@ -20,7 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> WebNotificationManager NotRefCounted {
+messages -> WebNotificationManager {
     DidShowNotification(WTF::UUID notificationID);
     DidClickNotification(WTF::UUID notificationID);
     DidCloseNotifications(Vector<WTF::UUID> notificationIDs);

--- a/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.h
+++ b/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.h
@@ -40,11 +40,16 @@ class CaptureDevice;
 
 namespace WebKit {
 
+class WebProcess;
+
 class SpeechRecognitionRealtimeMediaSourceManager final : public IPC::MessageReceiver, private IPC::MessageSender {
     WTF_MAKE_TZONE_ALLOCATED(SpeechRecognitionRealtimeMediaSourceManager);
 public:
-    explicit SpeechRecognitionRealtimeMediaSourceManager(Ref<IPC::Connection>&&);
+    explicit SpeechRecognitionRealtimeMediaSourceManager(WebProcess&);
     ~SpeechRecognitionRealtimeMediaSourceManager();
+
+    void ref() const;
+    void deref() const;
 
 private:
     // Messages::SpeechRecognitionRealtimeMediaSourceManager
@@ -60,7 +65,10 @@ private:
     IPC::Connection* messageSenderConnection() const final;
     uint64_t messageSenderDestinationID() const final;
 
-    Ref<IPC::Connection> m_connection;
+    IPC::Connection& connection() const;
+    Ref<IPC::Connection> protectedConnection() const;
+
+    WeakRef<WebProcess> m_process;
 
     class Source;
     friend class Source;

--- a/Source/WebKit/WebProcess/Storage/RemoteWorkerLibWebRTCProvider.h
+++ b/Source/WebKit/WebProcess/Storage/RemoteWorkerLibWebRTCProvider.h
@@ -48,7 +48,7 @@ public:
     RemoteWorkerLibWebRTCProvider() = default;
 
 private:
-    RefPtr<WebCore::RTCDataChannelRemoteHandlerConnection> createRTCDataChannelRemoteHandlerConnection() final { return &RTCDataChannelRemoteManager::sharedManager().remoteHandlerConnection(); }
+    RefPtr<WebCore::RTCDataChannelRemoteHandlerConnection> createRTCDataChannelRemoteHandlerConnection() final { return &RTCDataChannelRemoteManager::singleton().remoteHandlerConnection(); }
 };
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.h
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.h
@@ -55,6 +55,9 @@ public:
     TextCheckingControllerProxy(WebPage&);
     ~TextCheckingControllerProxy();
 
+    void ref() const;
+    void deref() const;
+
     static WebCore::AttributedString annotatedSubstringBetweenPositions(const WebCore::VisiblePosition&, const WebCore::VisiblePosition&);
 
 private:

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.messages.in
@@ -22,7 +22,7 @@
 
 #if ENABLE(PLATFORM_DRIVEN_TEXT_CHECKING)
 
-messages -> TextCheckingControllerProxy NotRefCounted {
+messages -> TextCheckingControllerProxy {
     ReplaceRelativeToSelection(struct WebCore::AttributedString annotatedString, int64_t selectionOffset, uint64_t length, uint64_t relativeReplacementLocation, uint64_t relativeReplacementLength)
 
     RemoveAnnotationRelativeToSelection(String annotationName, int64_t selectionOffset, uint64_t length)

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.mm
@@ -69,6 +69,16 @@ TextCheckingControllerProxy::~TextCheckingControllerProxy()
     WebProcess::singleton().removeMessageReceiver(Messages::TextCheckingControllerProxy::messageReceiverName(), m_page->identifier());
 }
 
+void TextCheckingControllerProxy::ref() const
+{
+    m_page->ref();
+}
+
+void TextCheckingControllerProxy::deref() const
+{
+    m_page->deref();
+}
+
 static OptionSet<DocumentMarkerType> relevantMarkerTypes()
 {
     return { DocumentMarkerType::PlatformTextChecking, DocumentMarkerType::Spelling, DocumentMarkerType::Grammar };

--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp
@@ -62,8 +62,9 @@
 namespace WebKit {
 using namespace WebCore;
 
-EventDispatcher::EventDispatcher()
-    : m_queue(WorkQueue::create("com.apple.WebKit.EventDispatcher"_s, WorkQueue::QOS::UserInteractive))
+EventDispatcher::EventDispatcher(WebProcess& process)
+    : m_process(process)
+    , m_queue(WorkQueue::create("com.apple.WebKit.EventDispatcher"_s, WorkQueue::QOS::UserInteractive))
     , m_recentWheelEventDeltaFilter(WheelEventDeltaFilter::create())
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER)
     , m_momentumEventDispatcher(WTF::makeUnique<MomentumEventDispatcher>(*this))
@@ -75,6 +76,16 @@ EventDispatcher::EventDispatcher()
 EventDispatcher::~EventDispatcher()
 {
     ASSERT_NOT_REACHED();
+}
+
+void EventDispatcher::ref() const
+{
+    m_process->ref();
+}
+
+void EventDispatcher::deref() const
+{
+    m_process->deref();
 }
 
 #if ENABLE(ASYNC_SCROLLING) && ENABLE(SCROLLING_THREAD)

--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.h
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.h
@@ -41,6 +41,7 @@
 #include <wtf/Noncopyable.h>
 #include <wtf/RefPtr.h>
 #include <wtf/ThreadingPrimitives.h>
+#include <wtf/WeakRef.h>
 #include <wtf/WorkQueue.h>
 
 #if ENABLE(MAC_GESTURE_EVENTS)
@@ -64,6 +65,7 @@ namespace WebKit {
 class MomentumEventDispatcher;
 class ScrollingAccelerationCurve;
 class WebPage;
+class WebProcess;
 class WebWheelEvent;
 
 class EventDispatcher final :
@@ -76,8 +78,11 @@ class EventDispatcher final :
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(EventDispatcher);
 #endif
 public:
-    EventDispatcher();
+    explicit EventDispatcher(WebProcess&);
     ~EventDispatcher();
+
+    void ref() const;
+    void deref() const;
 
     enum class WheelEventOrigin : bool { UIProcess, MomentumEventDispatcher };
 
@@ -154,6 +159,7 @@ private:
 
     void pageScreenDidChange(WebCore::PageIdentifier, WebCore::PlatformDisplayID, std::optional<unsigned> nominalFramesPerSecond);
 
+    WeakRef<WebProcess> m_process;
     Ref<WorkQueue> m_queue;
 
 #if ENABLE(ASYNC_SCROLLING) && ENABLE(SCROLLING_THREAD)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2489,7 +2489,7 @@ private:
 #endif
 
 #if ENABLE(PLATFORM_DRIVEN_TEXT_CHECKING)
-    UniqueRef<TextCheckingControllerProxy> m_textCheckingControllerProxy;
+    const UniqueRef<TextCheckingControllerProxy> m_textCheckingControllerProxy;
 #endif
 
 #if PLATFORM(COCOA) || PLATFORM(GTK)

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -286,7 +286,9 @@ WebProcess& WebProcess::singleton()
 }
 
 WebProcess::WebProcess()
-    : m_webLoaderStrategy(makeUniqueRefWithoutRefCountedCheck<WebLoaderStrategy>(*this))
+    : m_eventDispatcher(*this)
+    , m_webInspectorInterruptDispatcher(*this)
+    , m_webLoaderStrategy(makeUniqueRefWithoutRefCountedCheck<WebLoaderStrategy>(*this))
 #if PLATFORM(COCOA) && USE(LIBWEBRTC) && ENABLE(WEB_CODECS)
     , m_remoteVideoCodecFactory(*this)
 #endif
@@ -2350,7 +2352,7 @@ bool WebProcess::shouldUseRemoteRenderingForWebGL() const
 SpeechRecognitionRealtimeMediaSourceManager& WebProcess::ensureSpeechRecognitionRealtimeMediaSourceManager()
 {
     if (!m_speechRecognitionRealtimeMediaSourceManager)
-        m_speechRecognitionRealtimeMediaSourceManager = makeUnique<SpeechRecognitionRealtimeMediaSourceManager>(Ref { *parentProcessConnection() });
+        m_speechRecognitionRealtimeMediaSourceManager = makeUniqueWithoutRefCountedCheck<SpeechRecognitionRealtimeMediaSourceManager>(*this);
 
     return *m_speechRecognitionRealtimeMediaSourceManager;
 }
@@ -2386,6 +2388,11 @@ RemoteMediaEngineConfigurationFactory& WebProcess::mediaEngineConfigurationFacto
     return *supplement<RemoteMediaEngineConfigurationFactory>();
 }
 #endif
+
+Ref<WebNotificationManager> WebProcess::protectedNotificationManager()
+{
+    return *supplement<WebNotificationManager>();
+}
 
 WebTransportSession* WebProcess::webTransportSession(WebTransportSessionIdentifier identifier)
 {

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -147,6 +147,7 @@ class WebCookieJar;
 class WebFileSystemStorageConnection;
 class WebFrame;
 class WebLoaderStrategy;
+class WebNotificationManager;
 class WebPage;
 class WebPageGroupProxy;
 class WebProcessSupplement;
@@ -177,9 +178,9 @@ class LayerHostingContext;
 class SpeechRecognitionRealtimeMediaSourceManager;
 #endif
 
-class WebProcess final : public AuxiliaryProcess
-{
+class WebProcess final : public AuxiliaryProcess {
     WTF_MAKE_TZONE_ALLOCATED(WebProcess);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebProcess);
 public:
     using TopFrameDomain = WebCore::RegistrableDomain;
     using SubResourceDomain = WebCore::RegistrableDomain;
@@ -371,6 +372,8 @@ public:
     WebCookieJar& cookieJar() { return m_cookieJar.get(); }
     Ref<WebCookieJar> protectedCookieJar();
     WebSocketChannelManager& webSocketChannelManager() { return m_webSocketChannelManager; }
+
+    Ref<WebNotificationManager> protectedNotificationManager();
 
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(MACCATALYST)
     float backlightLevel() const { return m_backlightLevel; }

--- a/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.cpp
+++ b/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.cpp
@@ -50,7 +50,8 @@ using namespace WebCore;
 WTF_MAKE_TZONE_ALLOCATED_IMPL(UserMediaCaptureManager);
 
 UserMediaCaptureManager::UserMediaCaptureManager(WebProcess& process)
-    : m_audioFactory(*this)
+    : m_process(process)
+    , m_audioFactory(*this)
     , m_videoFactory(*this)
     , m_displayFactory(*this)
 {
@@ -62,8 +63,18 @@ UserMediaCaptureManager::~UserMediaCaptureManager()
     RealtimeMediaSourceCenter::singleton().unsetAudioCaptureFactory(m_audioFactory);
     RealtimeMediaSourceCenter::singleton().unsetDisplayCaptureFactory(m_displayFactory);
     RealtimeMediaSourceCenter::singleton().unsetVideoCaptureFactory(m_videoFactory);
-    WebProcess::singleton().removeMessageReceiver(Messages::UserMediaCaptureManager::messageReceiverName());
+    m_process->removeMessageReceiver(Messages::UserMediaCaptureManager::messageReceiverName());
     m_remoteCaptureSampleManager.stopListeningForIPC();
+}
+
+void UserMediaCaptureManager::ref() const
+{
+    m_process->ref();
+}
+
+void UserMediaCaptureManager::deref() const
+{
+    m_process->deref();
 }
 
 ASCIILiteral UserMediaCaptureManager::supplementName()

--- a/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.h
+++ b/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.h
@@ -55,6 +55,9 @@ public:
     explicit UserMediaCaptureManager(WebProcess&);
     ~UserMediaCaptureManager();
 
+    void ref() const;
+    void deref() const;
+
     static ASCIILiteral supplementName();
 
     void didReceiveMessageFromGPUProcess(IPC::Connection& connection, IPC::Decoder& decoder) { didReceiveMessage(connection, decoder); }
@@ -134,6 +137,7 @@ private:
     void applyConstraintsSucceeded(WebCore::RealtimeMediaSourceIdentifier, WebCore::RealtimeMediaSourceSettings&&);
     void applyConstraintsFailed(WebCore::RealtimeMediaSourceIdentifier, WebCore::MediaConstraintType, String&&);
 
+    WeakRef<WebProcess> m_process;
     using Source = std::variant<std::nullptr_t, Ref<RemoteRealtimeAudioSource>, Ref<RemoteRealtimeVideoSource>>;
     HashMap<WebCore::RealtimeMediaSourceIdentifier, Source> m_sources;
     NoOpCaptureDeviceManager m_noOpCaptureDeviceManager;

--- a/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.messages.in
+++ b/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.messages.in
@@ -23,7 +23,7 @@
 
 #if ENABLE(MEDIA_STREAM)
 
-messages -> UserMediaCaptureManager NotRefCounted {
+messages -> UserMediaCaptureManager {
     SourceStopped(WebCore::RealtimeMediaSourceIdentifier id, bool didFail)
     SourceMutedChanged(WebCore::RealtimeMediaSourceIdentifier id, bool muted, bool interrupted)
     SourceSettingsChanged(WebCore::RealtimeMediaSourceIdentifier id, WebCore::RealtimeMediaSourceSettings settings)


### PR DESCRIPTION
#### b2cc9692034c128c2bf7fbadc94aa28eaa9caf6f
<pre>
Make more MessageReceiver objects ref-counted in the WebProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=283807">https://bugs.webkit.org/show_bug.cgi?id=283807</a>

Reviewed by Geoffrey Garen.

* Source/WebKit/WebProcess/Inspector/WebInspectorInterruptDispatcher.cpp:
(WebKit::WebInspectorInterruptDispatcher::WebInspectorInterruptDispatcher):
(WebKit::WebInspectorInterruptDispatcher::ref const):
(WebKit::WebInspectorInterruptDispatcher::deref const):
* Source/WebKit/WebProcess/Inspector/WebInspectorInterruptDispatcher.h:
* Source/WebKit/WebProcess/Inspector/WebInspectorInterruptDispatcher.messages.in:
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp:
(WebKit::NetworkProcessConnection::connectToRTCDataChannelRemoteSource):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.cpp:
(WebKit::LibWebRTCNetwork::LibWebRTCNetwork):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.messages.in:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp:
(WebKit::LibWebRTCProvider::createRTCDataChannelRemoteHandlerConnection):
* Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp:
(WebKit::RTCDataChannelRemoteManager::singleton):
(WebKit::RTCDataChannelRemoteManager::RemoteHandlerConnection::connectToSource):
(WebKit::RTCDataChannelRemoteManager::sharedManager): Deleted.
* Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.h:
* Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.messages.in:
* Source/WebKit/WebProcess/Network/webrtc/WebRTCMonitor.cpp:
(WebKit::WebRTCMonitor::WebRTCMonitor):
(WebKit::WebRTCMonitor::ref const):
(WebKit::WebRTCMonitor::deref const):
* Source/WebKit/WebProcess/Network/webrtc/WebRTCMonitor.h:
* Source/WebKit/WebProcess/Network/webrtc/WebRTCMonitor.messages.in:
* Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp:
(WebKit::WebNotificationManager::WebNotificationManager):
(WebKit::WebNotificationManager::ref const):
(WebKit::WebNotificationManager::deref const):
(WebKit::WebNotificationManager::~WebNotificationManager): Deleted.
* Source/WebKit/WebProcess/Notifications/WebNotificationManager.h:
* Source/WebKit/WebProcess/Notifications/WebNotificationManager.messages.in:
* Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp:
(WebKit::SpeechRecognitionRealtimeMediaSourceManager::SpeechRecognitionRealtimeMediaSourceManager):
(WebKit::SpeechRecognitionRealtimeMediaSourceManager::~SpeechRecognitionRealtimeMediaSourceManager):
(WebKit::SpeechRecognitionRealtimeMediaSourceManager::connection const):
(WebKit::SpeechRecognitionRealtimeMediaSourceManager::protectedConnection const):
(WebKit::SpeechRecognitionRealtimeMediaSourceManager::ref const):
(WebKit::SpeechRecognitionRealtimeMediaSourceManager::deref const):
(WebKit::SpeechRecognitionRealtimeMediaSourceManager::createSource):
(WebKit::SpeechRecognitionRealtimeMediaSourceManager::messageSenderConnection const):
* Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.h:
* Source/WebKit/WebProcess/Storage/RemoteWorkerLibWebRTCProvider.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.messages.in:
* Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.mm:
(WebKit::TextCheckingControllerProxy::ref const):
(WebKit::TextCheckingControllerProxy::deref const):
* Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp:
(WebKit::EventDispatcher::EventDispatcher):
(WebKit::EventDispatcher::ref const):
(WebKit::EventDispatcher::deref const):
* Source/WebKit/WebProcess/WebPage/EventDispatcher.h:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::WebProcess):
(WebKit::WebProcess::ensureSpeechRecognitionRealtimeMediaSourceManager):
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.cpp:
(WebKit::UserMediaCaptureManager::UserMediaCaptureManager):
(WebKit::UserMediaCaptureManager::~UserMediaCaptureManager):
(WebKit::UserMediaCaptureManager::ref const):
(WebKit::UserMediaCaptureManager::deref const):
* Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.h:
* Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.messages.in:

Canonical link: <a href="https://commits.webkit.org/287171@main">https://commits.webkit.org/287171@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bce99a1e41b87e2b0ea73dbd2aa8e9bcc093bc2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78597 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57642 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31979 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83258 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29862 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66793 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5923 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61563 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19488 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81664 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51579 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/70080 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41873 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48925 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28200 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70027 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25832 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84626 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5962 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4097 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69788 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6123 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67556 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69042 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13069 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11549 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12139 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5909 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/11858 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5897 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9331 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7684 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->