### PR TITLE
CanvasRenderingContext2DBase output bitmap using CanvasPixelFormat

### DIFF
--- a/LayoutTests/fast/canvas/imagedata-storageformat-enabled.html
+++ b/LayoutTests/fast/canvas/imagedata-storageformat-enabled.html
@@ -57,6 +57,16 @@ verifyImageData('created_imageData_float16', 'Float16Array', float16_bytes_per_e
 var gotten_imageData_float16 = context.getImageData(0, 0, 1, 1, { storageFormat: "float16" });
 verifyImageData('gotten_imageData_float16', 'Float16Array', float16_bytes_per_element, r / 255, g / 255, b / 255, a / 255, float16_nonzero_tolerance);
 
+context.clearRect(0, 0, 1, 1);
+context.putImageData(gotten_imageData_uint8, 0, 0);
+var gotten_imageData_uint8_from_uint8 = context.getImageData(0, 0, 1, 1);
+verifyImageData('gotten_imageData_uint8_from_uint8', 'Uint8ClampedArray', uint8_bytes_per_element, r, g, b, a);
+
+context.clearRect(0, 0, 1, 1);
+context.putImageData(gotten_imageData_float16, 0, 0);
+var gotten_imageData_float16_from_float16 = context.getImageData(0, 0, 1, 1, { storageFormat: "float16" });
+verifyImageData('gotten_imageData_float16_from_float16', 'Float16Array', float16_bytes_per_element, r / 255, g / 255, b / 255, a / 255, float16_nonzero_tolerance);
+
 // Put the float16 ImageData back into the (uint8-backed) canvas, and get a default (uint8) ImageData.
 // This verifies the basic uint8->float16 conversion:
 context.clearRect(0, 0, 1, 1);

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -31,6 +31,7 @@
 #include "BitmapImage.h"
 #include "Blob.h"
 #include "BlobCallback.h"
+#include "ByteArrayPixelBuffer.h"
 #include "CSSParserContext.h"
 #include "CanvasGradient.h"
 #include "CanvasPattern.h"
@@ -805,7 +806,7 @@ RefPtr<ImageData> HTMLCanvasElement::getImageData()
         return nullptr;
 
     postProcessPixelBufferResults(*pixelBuffer);
-    return ImageData::create(pixelBuffer.releaseNonNull());
+    return ImageData::create(Ref<PixelBuffer>(pixelBuffer.releaseNonNull()));
 #else
     return nullptr;
 #endif

--- a/Source/WebCore/html/ImageData.cpp
+++ b/Source/WebCore/html/ImageData.cpp
@@ -30,6 +30,8 @@
 #include "config.h"
 #include "ImageData.h"
 
+#include "ByteArrayPixelBuffer.h"
+#include "Float16ArrayPixelBuffer.h"
 #include <JavaScriptCore/GenericTypedArrayViewInlines.h>
 #include <JavaScriptCore/JSCInlines.h>
 #include <wtf/text/TextStream.h>
@@ -53,13 +55,24 @@ static ImageDataStorageFormat computeStorageFormat(std::optional<ImageDataSettin
     return settings ? settings->storageFormat : defaultStorageFormat;
 }
 
-Ref<ImageData> ImageData::create(Ref<ByteArrayPixelBuffer>&& pixelBuffer, std::optional<ImageDataStorageFormat> overridingStorageFormat)
+static ImageDataArray takeArrayBufferView(Ref<PixelBuffer>&& pixelBuffer)
 {
-    auto colorSpace = toPredefinedColorSpace(pixelBuffer->format().colorSpace);
-    return adoptRef(*new ImageData(pixelBuffer->size(), pixelBuffer->takeData(), *colorSpace, overridingStorageFormat));
+    if (auto* buffer = WTF::dynamicDowncast<ByteArrayPixelBuffer>(pixelBuffer.get()))
+        return buffer->takeData();
+    if (auto* buffer = WTF::dynamicDowncast<Float16ArrayPixelBuffer>(pixelBuffer.get()))
+        return buffer->takeData();
+    ASSERT(!PixelBuffer::supportedPixelFormat(pixelBuffer->format().pixelFormat));
+    RELEASE_ASSERT_NOT_REACHED();
 }
 
-RefPtr<ImageData> ImageData::create(RefPtr<ByteArrayPixelBuffer>&& pixelBuffer, std::optional<ImageDataStorageFormat> overridingStorageFormat)
+Ref<ImageData> ImageData::create(Ref<PixelBuffer>&& pixelBuffer, std::optional<ImageDataStorageFormat> overridingStorageFormat)
+{
+    auto size = pixelBuffer->size();
+    auto colorSpace = toPredefinedColorSpace(pixelBuffer->format().colorSpace);
+    return adoptRef(*new ImageData(size, takeArrayBufferView(WTFMove(pixelBuffer)), *colorSpace, overridingStorageFormat));
+}
+
+RefPtr<ImageData> ImageData::create(RefPtr<PixelBuffer>&& pixelBuffer, std::optional<ImageDataStorageFormat> overridingStorageFormat)
 {
     if (!pixelBuffer)
         return nullptr;
@@ -154,11 +167,24 @@ ImageData::ImageData(const IntSize& size, ImageDataArray&& data, PredefinedColor
 
 ImageData::~ImageData() = default;
 
-Ref<ByteArrayPixelBuffer> ImageData::pixelBuffer() const
+Ref<PixelBuffer> ImageData::pixelBuffer() const
 {
-    Ref uint8Data = m_data.asUint8ClampedArray();
+    Ref arrayBufferView = m_data.arrayBufferView();
+    if (auto* array = dynamicDowncast<JSC::Uint8ClampedArray>(arrayBufferView.get())) {
+        PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, toDestinationColorSpace(m_colorSpace) };
+        return ByteArrayPixelBuffer::create(format, m_size, *array);
+    }
+
+#if HAVE(HDR_SUPPORT)
+    if (auto* array = dynamicDowncast<JSC::Float16Array>(arrayBufferView.get())) {
+        PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA16F, toDestinationColorSpace(m_colorSpace) };
+        return Float16ArrayPixelBuffer::create(format, m_size, *array);
+    }
+#endif
+
     PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, toDestinationColorSpace(m_colorSpace) };
-    return ByteArrayPixelBuffer::create(format, m_size, uint8Data.get());
+    Ref uint8Array = m_data.asUint8ClampedArray();
+    return ByteArrayPixelBuffer::create(format, m_size, uint8Array.get());
 }
 
 TextStream& operator<<(TextStream& ts, const ImageData& imageData)

--- a/Source/WebCore/html/ImageData.h
+++ b/Source/WebCore/html/ImageData.h
@@ -28,11 +28,11 @@
 
 #pragma once
 
-#include "ByteArrayPixelBuffer.h"
 #include "ExceptionOr.h"
 #include "ImageDataArray.h"
 #include "ImageDataSettings.h"
 #include "IntSize.h"
+#include "PixelBuffer.h"
 #include "PredefinedColorSpace.h"
 #include <JavaScriptCore/Forward.h>
 #include <wtf/Forward.h>
@@ -41,8 +41,8 @@ namespace WebCore {
 
 class ImageData : public RefCounted<ImageData> {
 public:
-    WEBCORE_EXPORT static Ref<ImageData> create(Ref<ByteArrayPixelBuffer>&&, std::optional<ImageDataStorageFormat> = { });
-    WEBCORE_EXPORT static RefPtr<ImageData> create(RefPtr<ByteArrayPixelBuffer>&&, std::optional<ImageDataStorageFormat> = { });
+    WEBCORE_EXPORT static Ref<ImageData> create(Ref<PixelBuffer>&&, std::optional<ImageDataStorageFormat> = { });
+    WEBCORE_EXPORT static RefPtr<ImageData> create(RefPtr<PixelBuffer>&&, std::optional<ImageDataStorageFormat> = { });
     WEBCORE_EXPORT static RefPtr<ImageData> create(const IntSize&, PredefinedColorSpace, ImageDataStorageFormat = ImageDataStorageFormat::Uint8);
     WEBCORE_EXPORT static RefPtr<ImageData> create(const IntSize&, ImageDataArray&&, PredefinedColorSpace);
 
@@ -62,7 +62,7 @@ public:
     PredefinedColorSpace colorSpace() const { return m_colorSpace; }
     ImageDataStorageFormat storageFormat() const { return m_data.storageFormat(); }
 
-    Ref<ByteArrayPixelBuffer> pixelBuffer() const;
+    Ref<PixelBuffer> pixelBuffer() const;
 
 private:
     explicit ImageData(const IntSize&, ImageDataArray&&, PredefinedColorSpace);

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -34,6 +34,7 @@
 #include "CanvasRenderingContext2DBase.h"
 
 #include "BitmapImage.h"
+#include "ByteArrayPixelBuffer.h"
 #include "CSSFontSelector.h"
 #include "CSSMarkup.h"
 #include "CSSParser.h"
@@ -231,11 +232,24 @@ static TextBaseline fromCanvasTextBaseline(CanvasTextBaseline canvasTextBaseline
     return TopTextBaseline;
 }
 
+static CanvasRenderingContext2DSettings&& tweakSettings(CanvasRenderingContext2DSettings&& settings)
+{
+#if !HAVE(HDR_SUPPORT)
+    // On platforms with no HDR_SUPPORT, the output bitmap ImageBufferPixelFormat::RGBA16F is not available so we cannot store these pixel values.
+    // Fallback to uint8 ~ BGRA8, and change the settings accordingly; webdevs can notice by reading back getContextAttributes().pixelFormat.
+    // FIXME: Should the getContext() call throw an exception instead? Could be done by simply removing "float16" from CanvasPixelFormat
+    //        in CanvasRenderingContext2DSettings.idl (and related changes, includind removing this tweak here).
+    if (settings.pixelFormat == CanvasRenderingContext2DSettings::PixelFormat::Float16)
+        settings.pixelFormat = CanvasRenderingContext2DSettings::PixelFormat::Uint8;
+#endif
+    return settings;
+}
+
 CanvasRenderingContext2DBase::CanvasRenderingContext2DBase(CanvasBase& canvas, CanvasRenderingContext::Type type, CanvasRenderingContext2DSettings&& settings, bool usesCSSCompatibilityParseMode)
     : CanvasRenderingContext(canvas, type)
     , m_stateStack(1)
     , m_usesCSSCompatibilityParseMode(usesCSSCompatibilityParseMode)
-    , m_settings(WTFMove(settings))
+    , m_settings(tweakSettings(WTFMove(settings)))
 {
     ASSERT(is2dBase());
 }
@@ -2487,6 +2501,9 @@ RefPtr<ByteArrayPixelBuffer> CanvasRenderingContext2DBase::cacheImageDataIfPossi
     if (imageData.colorSpace() != m_settings.colorSpace)
         return nullptr;
 
+    if (imageData.storageFormat() != ImageDataStorageFormat::Uint8)
+        return nullptr;
+
     // Consider:
     //   * Real putImageData needs premultiply step.
     //   * Retrieve from cache needs to ensure premultiply + unpremultiply was made to simulate the real putImageData.
@@ -2537,20 +2554,19 @@ RefPtr<ImageData> CanvasRenderingContext2DBase::makeImageDataIfContentsCached(co
         return nullptr;
 
     auto size = pixelBuffer->size();
-    auto data = pixelBuffer->takeData();
     unsigned bytesPerRow = static_cast<unsigned>(size.width()) * 4u;
     ConstPixelBufferConversionView source {
         .format = pixelBuffer->format(),
         .bytesPerRow = bytesPerRow,
-        .rows = data->span(),
+        .rows = pixelBuffer->bytes(),
     };
     PixelBufferConversionView destination {
-        .format = { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, pixelBuffer->format().colorSpace },
+        .format = { AlphaPremultiplication::Unpremultiplied, pixelBuffer->format().pixelFormat, pixelBuffer->format().colorSpace },
         .bytesPerRow = bytesPerRow,
-        .rows = data->mutableSpan(),
+        .rows = pixelBuffer->bytes(),
     };
     convertImagePixels(source, destination, size);
-    return ImageData::create(size, WTFMove(data), m_settings.colorSpace);
+    return ImageData::create(WTFMove(pixelBuffer));
 }
 
 ExceptionOr<Ref<ImageData>> CanvasRenderingContext2DBase::getImageData(int sx, int sy, int sw, int sh, std::optional<ImageDataSettings> settings) const
@@ -2583,7 +2599,7 @@ ExceptionOr<Ref<ImageData>> CanvasRenderingContext2DBase::getImageData(int sx, i
             return Exception { ExceptionCode::InvalidStateError };
 
         auto format = PixelBufferFormat { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, buffer->colorSpace() };
-        RefPtr pixelBuffer = dynamicDowncast<ByteArrayPixelBuffer>(buffer->getPixelBuffer(format, imageDataRect));
+        RefPtr pixelBuffer = buffer->getPixelBuffer(format, imageDataRect);
         if (!pixelBuffer)
             return Exception { ExceptionCode::InvalidStateError };
 
@@ -2602,7 +2618,7 @@ ExceptionOr<Ref<ImageData>> CanvasRenderingContext2DBase::getImageData(int sx, i
         return ImageData::create(imageDataRect.width(), imageDataRect.height(), m_settings.colorSpace, settings);
 
     PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, toDestinationColorSpace(computedColorSpace) };
-    RefPtr pixelBuffer = dynamicDowncast<ByteArrayPixelBuffer>(buffer->getPixelBuffer(format, imageDataRect));
+    RefPtr pixelBuffer = buffer->getPixelBuffer(format, imageDataRect);
     if (!pixelBuffer) {
         scriptContext->addConsoleMessage(MessageSource::Rendering, MessageLevel::Error,
             makeString("Unable to get image data from canvas. Requested size was "_s, imageDataRect.width(), " x "_s, imageDataRect.height()));
@@ -3021,6 +3037,18 @@ FloatPoint CanvasRenderingContext2DBase::textOffset(float width, TextDirection d
 
 ImageBufferPixelFormat CanvasRenderingContext2DBase::pixelFormat() const
 {
+    switch (m_settings.pixelFormat) {
+    case CanvasRenderingContext2DSettings::PixelFormat::Uint8:
+        break;
+    case CanvasRenderingContext2DSettings::PixelFormat::Float16:
+#if HAVE(HDR_SUPPORT)
+        return ImageBufferPixelFormat::RGBA16F;
+#else
+        break;
+#endif
+    default:
+        RELEASE_ASSERT_NOT_REACHED("Unexpected ImageDataStorageFormat value");
+    }
     // FIXME: Take m_settings.alpha into account here and add PixelFormat::BGRX8.
     return ImageBufferPixelFormat::BGRA8;
 }

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -505,7 +505,7 @@ private:
     unsigned m_unrealizedSaveCount { 0 };
     bool m_usesCSSCompatibilityParseMode;
     mutable std::variant<CachedContentsTransparent, CachedContentsUnknown, CachedContentsImageData> m_cachedContents;
-    CanvasRenderingContext2DSettings m_settings;
+    const CanvasRenderingContext2DSettings m_settings;
     bool m_hasDeferredOperations { false };
 };
 

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -30,6 +30,7 @@
 
 #include "ANGLEInstancedArrays.h"
 #include "BitmapImage.h"
+#include "ByteArrayPixelBuffer.h"
 #include "CachedImage.h"
 #include "Chrome.h"
 #include "DiagnosticLoggingClient.h"

--- a/Source/WebCore/platform/graphics/Float16ArrayPixelBuffer.cpp
+++ b/Source/WebCore/platform/graphics/Float16ArrayPixelBuffer.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "Float16ArrayPixelBuffer.h"
+#include <wtf/StdLibExtras.h>
 
 #if HAVE(HDR_SUPPORT)
 
@@ -63,6 +64,15 @@ std::optional<Ref<Float16ArrayPixelBuffer>> Float16ArrayPixelBuffer::create(cons
     }
 
     return Float16ArrayPixelBuffer::create(format, size, buffer.releaseNonNull());
+}
+
+std::optional<Ref<Float16ArrayPixelBuffer>> Float16ArrayPixelBuffer::create(const PixelBufferFormat& format, const IntSize& size, std::span<const uint8_t> data)
+{
+    if (data.size_bytes() % sizeof(Float16))
+        return { };
+    if (uintptr_t(data.data()) % alignof(Float16))
+        return { };
+    return create(format, size, spanReinterpretCast<const Float16>(data));
 }
 
 RefPtr<Float16ArrayPixelBuffer> Float16ArrayPixelBuffer::tryCreate(const PixelBufferFormat& format, const IntSize& size)

--- a/Source/WebCore/platform/graphics/Float16ArrayPixelBuffer.h
+++ b/Source/WebCore/platform/graphics/Float16ArrayPixelBuffer.h
@@ -36,6 +36,7 @@ class Float16ArrayPixelBuffer : public PixelBuffer {
 public:
     WEBCORE_EXPORT static Ref<Float16ArrayPixelBuffer> create(const PixelBufferFormat&, const IntSize&, JSC::Float16Array&);
     WEBCORE_EXPORT static std::optional<Ref<Float16ArrayPixelBuffer>> create(const PixelBufferFormat&, const IntSize&, std::span<const Float16> data);
+    WEBCORE_EXPORT static std::optional<Ref<Float16ArrayPixelBuffer>> create(const PixelBufferFormat&, const IntSize&, std::span<const uint8_t> data);
 
     WEBCORE_EXPORT static RefPtr<Float16ArrayPixelBuffer> tryCreate(const PixelBufferFormat&, const IntSize&);
     WEBCORE_EXPORT static RefPtr<Float16ArrayPixelBuffer> tryCreate(const PixelBufferFormat&, const IntSize&, Ref<JSC::ArrayBuffer>&&);

--- a/Source/WebCore/platform/graphics/PixelBuffer.cpp
+++ b/Source/WebCore/platform/graphics/PixelBuffer.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "PixelBuffer.h"
 
+#include "ByteArrayPixelBuffer.h"
+#include "Float16ArrayPixelBuffer.h"
 #include <JavaScriptCore/TypedArrayInlines.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/text/TextStream.h>
@@ -52,6 +54,27 @@ bool PixelBuffer::supportedPixelFormat(PixelFormat pixelFormat)
 
     ASSERT_NOT_REACHED();
     return false;
+}
+
+RefPtr<PixelBuffer> PixelBuffer::tryCreate(const PixelBufferFormat& format, const IntSize& size)
+{
+    if (!supportedPixelFormat(format.pixelFormat))
+        return nullptr;
+
+    switch (format.pixelFormat) {
+    case PixelFormat::RGBA8:
+    case PixelFormat::BGRA8:
+        ASSERT(supportedPixelFormat(format.pixelFormat));
+        return ByteArrayPixelBuffer::tryCreate(format, size);
+#if HAVE(HDR_SUPPORT)
+    case PixelFormat::RGBA16F:
+        ASSERT(supportedPixelFormat(format.pixelFormat));
+        return Float16ArrayPixelBuffer::tryCreate(format, size);
+#endif
+    default:
+        ASSERT(!supportedPixelFormat(format.pixelFormat));
+    }
+    return nullptr;
 }
 
 static CheckedUint32 mustFitInInt32(CheckedUint32 uint32)

--- a/Source/WebCore/platform/graphics/PixelBuffer.h
+++ b/Source/WebCore/platform/graphics/PixelBuffer.h
@@ -44,6 +44,8 @@ public:
 
     WEBCORE_EXPORT static bool supportedPixelFormat(PixelFormat);
 
+    static RefPtr<PixelBuffer> tryCreate(const PixelBufferFormat&, const IntSize&);
+
     WEBCORE_EXPORT virtual ~PixelBuffer();
 
     const PixelBufferFormat& format() const { return m_format; }

--- a/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
+++ b/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
@@ -296,6 +296,7 @@ static void convertImagePixelsUnaccelerated(const ConstPixelBufferConversionView
     }
 }
 
+<<<<<<< HEAD
 #if !(USE(ACCELERATE) && USE(CG))
 static void copyImagePixels(const ConstPixelBufferConversionView& source, const PixelBufferConversionView& destination, const IntSize& destinationSize)
 {
@@ -313,11 +314,96 @@ static void copyImagePixels(const ConstPixelBufferConversionView& source, const 
     }
 }
 #endif
+=======
+static void convertImagePixelsToFloatUnaccelerated(const ConstPixelBufferConversionView& source, const PixelBufferConversionView& destination, const IntSize& destinationSize)
+{
+    ASSERT(source.format.pixelFormat == PixelFormat::RGBA8 || source.format.pixelFormat == PixelFormat::BGRA8 || source.format.pixelFormat == PixelFormat::BGRX8);
+    ASSERT(destination.format.pixelFormat == PixelFormat::RGBA16F);
+
+    RELEASE_ASSERT(!(destination.bytesPerRow % sizeof(Float16)));
+    auto intermediateBytesPerRow = destination.bytesPerRow / unsigned(sizeof(Float16));
+    Vector<uint8_t> intermediateBuffer(intermediateBytesPerRow * destinationSize.height());
+    auto intermediateRowsSpan = intermediateBuffer.mutableSpan();
+
+    PixelBufferConversionView intermediate {
+        .format = PixelBufferFormat {
+            .alphaFormat = destination.format.alphaFormat,
+            .pixelFormat = PixelFormat::RGBA8,
+            .colorSpace = destination.format.colorSpace
+        },
+        .bytesPerRow = intermediateBytesPerRow,
+        .rows = intermediateRowsSpan
+    };
+
+    convertImagePixels(source, intermediate, destinationSize);
+
+    auto pixelComponentsPerRow = intermediateBytesPerRow;
+
+    size_t intermediateRowsByteIndex = 0;
+    size_t destinationRowsFloat16Index = 0;
+    for (int y = 0; y < destinationSize.height(); ++y) {
+        for (size_t i = 0; i < pixelComponentsPerRow; ++i) {
+            Float16 f16 = double(intermediateRowsSpan[intermediateRowsByteIndex + i]) / 255.0;
+            uint8_t u[sizeof(Float16)];
+            memcpy(u, &f16, sizeof(Float16));
+            destination.rows[destinationRowsFloat16Index * sizeof(Float16) + i + 0] = u[0];
+            destination.rows[destinationRowsFloat16Index * sizeof(Float16) + i + 1] = u[1];
+        }
+        intermediateRowsByteIndex += pixelComponentsPerRow;
+        destinationRowsFloat16Index += pixelComponentsPerRow;
+    }
+}
+
+static void convertImagePixelsFromFloatUnaccelerated(const ConstPixelBufferConversionView& source, const PixelBufferConversionView& destination, const IntSize& destinationSize)
+{
+    ASSERT(source.format.pixelFormat == PixelFormat::RGBA16F);
+
+    RELEASE_ASSERT(!(source.bytesPerRow % sizeof(Float16)));
+    auto sourcePixelComponentsPerRow = source.bytesPerRow / unsigned(sizeof(Float16));
+
+    auto newSourceBytesPerRow = sourcePixelComponentsPerRow * unsigned(sizeof(uint8_t));
+    Vector<uint8_t> newSourceBuffer(newSourceBytesPerRow * destinationSize.height());
+
+    size_t sourceRowsFloat16Index = 0;
+    size_t newSourceRowsByteIndex = 0;
+    for (int y = 0; y < destinationSize.height(); ++y) {
+        for (size_t i = 0; i < sourcePixelComponentsPerRow; ++i) {
+            uint8_t u[sizeof(Float16)];
+            u[0] = source.rows[sourceRowsFloat16Index * sizeof(Float16) + i + 0];
+            u[1] = source.rows[sourceRowsFloat16Index * sizeof(Float16) + i + 1];
+            Float16 f16;
+            memcpy(&f16, u, sizeof(Float16));
+            newSourceBuffer[newSourceRowsByteIndex + i] = std::clamp(double(f16), 0.0, 1.0) * 255.0;
+        }
+        sourceRowsFloat16Index += sourcePixelComponentsPerRow;
+        newSourceRowsByteIndex += sourcePixelComponentsPerRow;
+    }
+
+    ConstPixelBufferConversionView newSource {
+        .format = PixelBufferFormat {
+            .alphaFormat = source.format.alphaFormat,
+            .pixelFormat = PixelFormat::RGBA8,
+            .colorSpace = source.format.colorSpace
+        },
+        .bytesPerRow = newSourceBytesPerRow,
+        .rows = newSourceBuffer.span()
+    };
+
+    convertImagePixels(newSource, destination, destinationSize);
+}
+>>>>>>> ed4d067b4e4f (CanvasRenderingContext2DBase output bitmap using CanvasPixelFormat)
 
 void convertImagePixels(const ConstPixelBufferConversionView& source, const PixelBufferConversionView& destination, const IntSize& destinationSize)
 {
-    // We currently only support converting between RGBA8, BGRA8, and BGRX8.
+    // We currently only support converting between RGBA8, BGRA8, BGRX8, and RGBA16F.
+    if (source.format.pixelFormat == PixelFormat::RGBA16F)
+        return convertImagePixelsFromFloatUnaccelerated(source, destination, destinationSize);
+
     ASSERT(source.format.pixelFormat == PixelFormat::RGBA8 || source.format.pixelFormat == PixelFormat::BGRA8 || source.format.pixelFormat == PixelFormat::BGRX8);
+
+    if (destination.format.pixelFormat == PixelFormat::RGBA16F)
+        return convertImagePixelsToFloatUnaccelerated(source, destination, destinationSize);
+
     ASSERT(destination.format.pixelFormat == PixelFormat::RGBA8 || destination.format.pixelFormat == PixelFormat::BGRA8 || destination.format.pixelFormat == PixelFormat::BGRX8);
 
 #if USE(ACCELERATE) && USE(CG)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -393,6 +393,15 @@ public:
 #endif
     }
 
+    ExceptionOr<bool> haveHDRSupport()
+    {
+#if HAVE(HDR_SUPPORT)
+        return true;
+#else
+        return false;
+#endif
+    }
+
     ExceptionOr<void> setPagination(const String& mode, int gap, int pageLength);
     ExceptionOr<uint64_t> lineIndexAfterPageBreak(Element&);
     ExceptionOr<String> configurationForViewport(float devicePixelRatio, int deviceWidth, int deviceHeight, int availableWidth, int availableHeight);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -598,6 +598,7 @@ enum RenderingMode {
     DOMString documentBackgroundColor();
 
     boolean displayP3Available();
+    boolean haveHDRSupport();
 
     undefined setPagination(DOMString mode, long gap, optional long pageLength = 0);
     unsigned long long lineIndexAfterPageBreak(Element element);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3390,7 +3390,8 @@ using WebCore::Style::RaySize = std::variant<WebCore::CSS::Keyword::ClosestCorne
 using WebCore::Style::BasicShape = std::variant<WebCore::Style::CircleFunction, WebCore::Style::EllipseFunction, WebCore::Style::InsetFunction, WebCore::Style::PathFunction, WebCore::Style::PolygonFunction, WebCore::Style::ShapeFunction>;
 
 [AdditionalEncoder=StreamConnectionEncoder, RefCounted] class WebCore::PixelBuffer subclasses {
-    WebCore::ByteArrayPixelBuffer
+    WebCore::ByteArrayPixelBuffer,
+    WebCore::Float16ArrayPixelBuffer
 }
 
 header: <WebCore/RenderStyleConstants.h>
@@ -7711,6 +7712,12 @@ enum class WebCore::RepaintRectCalculation : bool;
 };
 
 [RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::ByteArrayPixelBuffer {
+    WebCore::PixelBufferFormat format();
+    WebCore::IntSize size();
+    std::span<const uint8_t> span();
+}
+
+[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::Float16ArrayPixelBuffer {
     WebCore::PixelBufferFormat format();
     WebCore::IntSize size();
     std::span<const uint8_t> span();


### PR DESCRIPTION
#### 35dc1e40069f82629730e4f6d6facba6d23d66cf
<pre>
CanvasRenderingContext2DBase output bitmap using CanvasPixelFormat
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* LayoutTests/fast/canvas/imagedata-storageformat-enabled.html:
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::getImageData):
* Source/WebCore/html/ImageData.cpp:
(WebCore::takeArrayBufferView):
(WebCore::ImageData::create):
(WebCore::ImageData::pixelBuffer const):
* Source/WebCore/html/ImageData.h:
(WebCore::ImageData::create):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::tweakSettings):
(WebCore::CanvasRenderingContext2DBase::CanvasRenderingContext2DBase):
(WebCore::CanvasRenderingContext2DBase::CachedContentsImageData::CachedContentsImageData):
(WebCore::toPixelFormat):
(WebCore::CanvasRenderingContext2DBase::cacheImageDataIfPossible):
(WebCore::CanvasRenderingContext2DBase::makeImageDataIfContentsCached const):
(WebCore::CanvasRenderingContext2DBase::getImageData const):
(WebCore::CanvasRenderingContext2DBase::pixelFormat const):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
* Source/WebCore/platform/graphics/Float16ArrayPixelBuffer.cpp:
(WebCore::Float16ArrayPixelBuffer::create):
* Source/WebCore/platform/graphics/Float16ArrayPixelBuffer.h:
* Source/WebCore/platform/graphics/PixelBuffer.cpp:
(WebCore::PixelBuffer::tryCreate):
* Source/WebCore/platform/graphics/PixelBuffer.h:
* Source/WebCore/platform/graphics/PixelBufferConversion.cpp:
(WebCore::convertImagePixelsToFloatUnaccelerated):
(WebCore::convertImagePixelsFromFloatUnaccelerated):
(WebCore::convertImagePixels):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35dc1e40069f82629730e4f6d6facba6d23d66cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/87958 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/7474 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/42350 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/92861 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/38708 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/90009 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/7855 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/15650 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/92861 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/38708 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/90960 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/7855 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/42350 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/92861 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/7855 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/42350 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/37815 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/7855 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/42350 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/94723 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/15126 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/15650 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/94723 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/15381 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/42350 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/94723 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/42350 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/8130 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/15144 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20445 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/14886 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/18331 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/16668 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->