### PR TITLE
Add Float16ArrayPixelBuffer

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2002,6 +2002,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/DisplayRefreshMonitorManager.h
     platform/graphics/DisplayUpdate.h
     platform/graphics/DrawGlyphsRecorder.h
+    platform/graphics/Float16ArrayPixelBuffer.h
     platform/graphics/FloatLine.h
     platform/graphics/FloatPoint.h
     platform/graphics/FloatPoint3D.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1563,7 +1563,6 @@ platform/graphics/BitmapImage.cpp
 platform/graphics/BitmapImage.h
 platform/graphics/BitmapImageDescriptor.cpp
 platform/graphics/BitmapImageSource.cpp
-platform/graphics/ByteArrayPixelBuffer.cpp
 platform/graphics/Color.cpp
 platform/graphics/Color.h
 platform/graphics/ComplexTextController.cpp

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2438,6 +2438,7 @@ platform/graphics/DisplayRefreshMonitor.cpp
 platform/graphics/DisplayRefreshMonitorClient.cpp
 platform/graphics/DisplayRefreshMonitorManager.cpp
 platform/graphics/DisplayUpdate.cpp
+platform/graphics/Float16ArrayPixelBuffer.cpp
 platform/graphics/FloatLine.cpp
 platform/graphics/FloatPoint.cpp
 platform/graphics/FloatPoint3D.cpp

--- a/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.cpp
@@ -32,12 +32,12 @@ namespace WebCore {
 
 Ref<ByteArrayPixelBuffer> ByteArrayPixelBuffer::create(const PixelBufferFormat& format, const IntSize& size, JSC::Uint8ClampedArray& data)
 {
+    ASSERT(format.pixelFormat == PixelFormat::RGBA8 || format.pixelFormat == PixelFormat::BGRA8);
     return adoptRef(*new ByteArrayPixelBuffer(format, size, { data }));
 }
 
 std::optional<Ref<ByteArrayPixelBuffer>> ByteArrayPixelBuffer::create(const PixelBufferFormat& format, const IntSize& size, std::span<const uint8_t> data)
 {
-    // FIXME: Support non-8 bit formats.
     if (!(format.pixelFormat == PixelFormat::RGBA8 || format.pixelFormat == PixelFormat::BGRA8)) {
         ASSERT_NOT_REACHED();
         return std::nullopt;
@@ -67,6 +67,11 @@ RefPtr<ByteArrayPixelBuffer> ByteArrayPixelBuffer::tryCreate(const PixelBufferFo
 {
     ASSERT(supportedPixelFormat(format.pixelFormat));
 
+    if (!(format.pixelFormat == PixelFormat::RGBA8 || format.pixelFormat == PixelFormat::BGRA8)) {
+        ASSERT_NOT_REACHED();
+        return nullptr;
+    }
+
     auto bufferSize = computeBufferSize(format.pixelFormat, size);
     if (bufferSize.hasOverflowed())
         return nullptr;
@@ -81,6 +86,11 @@ RefPtr<ByteArrayPixelBuffer> ByteArrayPixelBuffer::tryCreate(const PixelBufferFo
 RefPtr<ByteArrayPixelBuffer> ByteArrayPixelBuffer::tryCreate(const PixelBufferFormat& format, const IntSize& size, Ref<JSC::ArrayBuffer>&& arrayBuffer)
 {
     ASSERT(supportedPixelFormat(format.pixelFormat));
+
+    if (!(format.pixelFormat == PixelFormat::RGBA8 || format.pixelFormat == PixelFormat::BGRA8)) {
+        ASSERT_NOT_REACHED();
+        return nullptr;
+    }
 
     auto bufferSize = computeBufferSize(format.pixelFormat, size);
     if (bufferSize.hasOverflowed())
@@ -105,8 +115,9 @@ RefPtr<PixelBuffer> ByteArrayPixelBuffer::createScratchPixelBuffer(const IntSize
 
 std::span<const uint8_t> ByteArrayPixelBuffer::span() const
 {
-    ASSERT(m_data->byteLength() == (m_size.area() * 4));
-    return m_data->span();
+    Ref data = m_data;
+    ASSERT(data->byteLength() == (m_size.area() * 4));
+    return data->span();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.h
+++ b/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.h
@@ -42,12 +42,11 @@ public:
     Ref<JSC::Uint8ClampedArray>&& takeData() { return WTFMove(m_data); }
     WEBCORE_EXPORT std::span<const uint8_t> span() const;
 
+    Type type() const override { return Type::ByteArray; }
     RefPtr<PixelBuffer> createScratchPixelBuffer(const IntSize&) const override;
 
 private:
     ByteArrayPixelBuffer(const PixelBufferFormat&, const IntSize&, Ref<JSC::Uint8ClampedArray>&&);
-
-    bool isByteArrayPixelBuffer() const override { return true; }
 
     Ref<JSC::Uint8ClampedArray> m_data;
 };
@@ -55,5 +54,5 @@ private:
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ByteArrayPixelBuffer)
-    static bool isType(const WebCore::PixelBuffer& pixelBuffer) { return pixelBuffer.isByteArrayPixelBuffer(); }
+    static bool isType(const WebCore::PixelBuffer& pixelBuffer) { return pixelBuffer.type() == WebCore::PixelBuffer::Type::ByteArray; }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/platform/graphics/Float16ArrayPixelBuffer.cpp
+++ b/Source/WebCore/platform/graphics/Float16ArrayPixelBuffer.cpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2022-2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "Float16ArrayPixelBuffer.h"
+
+#if HAVE(HDR_SUPPORT)
+
+#include <JavaScriptCore/TypedArrayInlines.h>
+
+namespace WebCore {
+
+Ref<Float16ArrayPixelBuffer> Float16ArrayPixelBuffer::create(const PixelBufferFormat& format, const IntSize& size, JSC::Float16Array& data)
+{
+    ASSERT(format.pixelFormat == PixelFormat::RGBA16F);
+    return adoptRef(*new Float16ArrayPixelBuffer(format, size, { data }));
+}
+
+std::optional<Ref<Float16ArrayPixelBuffer>> Float16ArrayPixelBuffer::create(const PixelBufferFormat& format, const IntSize& size, std::span<const Float16> data)
+{
+    if (format.pixelFormat != PixelFormat::RGBA16F) {
+        ASSERT_NOT_REACHED();
+        return std::nullopt;
+    }
+
+    auto computedBufferSize = PixelBuffer::computeBufferSize(format.pixelFormat, size);
+    if (computedBufferSize.hasOverflowed()) {
+        ASSERT_NOT_REACHED();
+        return std::nullopt;
+    }
+
+    if (data.size_bytes() != computedBufferSize.value()) {
+        ASSERT_NOT_REACHED();
+        return std::nullopt;
+    }
+
+    auto buffer = JSC::Float16Array::tryCreate(data);
+    if (!buffer) {
+        ASSERT_NOT_REACHED();
+        return std::nullopt;
+    }
+
+    return Float16ArrayPixelBuffer::create(format, size, buffer.releaseNonNull());
+}
+
+RefPtr<Float16ArrayPixelBuffer> Float16ArrayPixelBuffer::tryCreate(const PixelBufferFormat& format, const IntSize& size)
+{
+    ASSERT(supportedPixelFormat(format.pixelFormat));
+
+    if (format.pixelFormat != PixelFormat::RGBA16F) {
+        ASSERT_NOT_REACHED();
+        return nullptr;
+    }
+
+    auto bufferSize = computeBufferSize(format.pixelFormat, size);
+    if (bufferSize.hasOverflowed())
+        return nullptr;
+
+    auto data = JSC::Float16Array::tryCreateUninitialized(bufferSize / sizeof(Float16));
+    if (!data)
+        return nullptr;
+
+    return create(format, size, data.releaseNonNull());
+}
+
+RefPtr<Float16ArrayPixelBuffer> Float16ArrayPixelBuffer::tryCreate(const PixelBufferFormat& format, const IntSize& size, Ref<JSC::ArrayBuffer>&& arrayBuffer)
+{
+    ASSERT(supportedPixelFormat(format.pixelFormat));
+
+    if (format.pixelFormat != PixelFormat::RGBA16F) {
+        ASSERT_NOT_REACHED();
+        return nullptr;
+    }
+
+    auto bufferSize = computeBufferSize(format.pixelFormat, size);
+    if (bufferSize.hasOverflowed())
+        return nullptr;
+    if (bufferSize != arrayBuffer->byteLength())
+        return nullptr;
+
+    Ref data = JSC::Float16Array::create(WTFMove(arrayBuffer));
+    return create(format, size, WTFMove(data));
+}
+
+Float16ArrayPixelBuffer::Float16ArrayPixelBuffer(const PixelBufferFormat& format, const IntSize& size, Ref<JSC::Float16Array>&& data)
+    : PixelBuffer(format, size, data->mutableSpan())
+    , m_data(WTFMove(data))
+{
+}
+
+RefPtr<PixelBuffer> Float16ArrayPixelBuffer::createScratchPixelBuffer(const IntSize& size) const
+{
+    return Float16ArrayPixelBuffer::tryCreate(m_format, size);
+}
+
+std::span<const uint8_t> Float16ArrayPixelBuffer::span() const
+{
+    Ref data = m_data;
+    ASSERT(data->byteLength() == (m_size.area() * 4 * sizeof(Float16)));
+    return data->span();
+}
+
+} // namespace WebCore
+
+#endif // HAVE(HDR_SUPPORT)

--- a/Source/WebCore/platform/graphics/Float16ArrayPixelBuffer.h
+++ b/Source/WebCore/platform/graphics/Float16ArrayPixelBuffer.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2024 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if HAVE(HDR_SUPPORT)
+
+#include "PixelBuffer.h"
+#include <JavaScriptCore/Float16Array.h>
+
+namespace WebCore {
+
+class Float16ArrayPixelBuffer : public PixelBuffer {
+public:
+    WEBCORE_EXPORT static Ref<Float16ArrayPixelBuffer> create(const PixelBufferFormat&, const IntSize&, JSC::Float16Array&);
+    WEBCORE_EXPORT static std::optional<Ref<Float16ArrayPixelBuffer>> create(const PixelBufferFormat&, const IntSize&, std::span<const Float16> data);
+
+    WEBCORE_EXPORT static RefPtr<Float16ArrayPixelBuffer> tryCreate(const PixelBufferFormat&, const IntSize&);
+    WEBCORE_EXPORT static RefPtr<Float16ArrayPixelBuffer> tryCreate(const PixelBufferFormat&, const IntSize&, Ref<JSC::ArrayBuffer>&&);
+
+    JSC::Float16Array& data() const { return m_data.get(); }
+    Ref<JSC::Float16Array>&& takeData() { return WTFMove(m_data); }
+    WEBCORE_EXPORT std::span<const uint8_t> span() const;
+
+    Type type() const override { return Type::Float16Array; }
+    RefPtr<PixelBuffer> createScratchPixelBuffer(const IntSize&) const override;
+
+private:
+    Float16ArrayPixelBuffer(const PixelBufferFormat&, const IntSize&, Ref<JSC::Float16Array>&&);
+
+    Ref<JSC::Float16Array> m_data;
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::Float16ArrayPixelBuffer)
+    static bool isType(const WebCore::PixelBuffer& pixelBuffer) { return pixelBuffer.type() == WebCore::PixelBuffer::Type::Float16Array; }
+SPECIALIZE_TYPE_TRAITS_END()
+
+#endif // HAVE(HDR_SUPPORT)

--- a/Source/WebCore/platform/graphics/PixelBuffer.cpp
+++ b/Source/WebCore/platform/graphics/PixelBuffer.cpp
@@ -38,14 +38,14 @@ bool PixelBuffer::supportedPixelFormat(PixelFormat pixelFormat)
     switch (pixelFormat) {
     case PixelFormat::RGBA8:
     case PixelFormat::BGRA8:
+#if HAVE(HDR_SUPPORT)
+    case PixelFormat::RGBA16F:
+#endif
         return true;
 
     case PixelFormat::BGRX8:
     case PixelFormat::RGB10:
     case PixelFormat::RGB10A8:
-#if HAVE(HDR_SUPPORT)
-    case PixelFormat::RGBA16F:
-#endif
         return false;
     }
 
@@ -53,15 +53,44 @@ bool PixelBuffer::supportedPixelFormat(PixelFormat pixelFormat)
     return false;
 }
 
+static CheckedUint32 mustFitInInt32(CheckedUint32 uint32)
+{
+    if (!uint32.hasOverflowed() && !isInBounds<int32_t>(uint32.value()))
+        uint32.overflowed();
+    return uint32;
+}
+
+static CheckedUint32 computeRawPixelCount(const IntSize& size)
+{
+    return CheckedUint32 { size.width() } * size.height();
+}
+
+static CheckedUint32 computeRawPixelComponentCount(PixelFormat pixelFormat, const IntSize& size)
+{
+    ASSERT_UNUSED(pixelFormat, PixelBuffer::supportedPixelFormat(pixelFormat));
+    constexpr unsigned componentsPerPixel = 4;
+    return computeRawPixelCount(size) * componentsPerPixel;
+}
+
+CheckedUint32 PixelBuffer::computePixelCount(const IntSize& size)
+{
+    return mustFitInInt32(computeRawPixelCount(size));
+}
+
+CheckedUint32 PixelBuffer::computePixelComponentCount(PixelFormat pixelFormat, const IntSize& size)
+{
+    return mustFitInInt32(computeRawPixelComponentCount(pixelFormat, size));
+}
+
 CheckedUint32 PixelBuffer::computeBufferSize(PixelFormat pixelFormat, const IntSize& size)
 {
-    ASSERT_UNUSED(pixelFormat, supportedPixelFormat(pixelFormat));
-    constexpr unsigned bytesPerPixel = 4;
-    auto bufferSize = CheckedUint32 { size.width() } * size.height() * bytesPerPixel;
-    if (!bufferSize.hasOverflowed() && bufferSize.value() > std::numeric_limits<int32_t>::max())
-        bufferSize.overflowed();
-    return bufferSize;
-
+    // FIXME: Implement a better way to deal with sizes of diffferent formats.
+    unsigned bytesPerPixelComponent =
+#if HAVE(HDR_SUPPORT)
+        (pixelFormat == PixelFormat::RGBA16F) ? 2 :
+#endif
+        1;
+    return mustFitInInt32(computeRawPixelComponentCount(pixelFormat, size) * bytesPerPixelComponent);
 }
 
 PixelBuffer::PixelBuffer(const PixelBufferFormat& format, const IntSize& size, std::span<uint8_t> bytes)

--- a/Source/WebCore/platform/graphics/PixelBuffer.h
+++ b/Source/WebCore/platform/graphics/PixelBuffer.h
@@ -38,6 +38,8 @@ namespace WebCore {
 class PixelBuffer : public RefCounted<PixelBuffer> {
     WTF_MAKE_NONCOPYABLE(PixelBuffer);
 public:
+    static CheckedUint32 computePixelCount(const IntSize&);
+    static CheckedUint32 computePixelComponentCount(PixelFormat, const IntSize&);
     WEBCORE_EXPORT static CheckedUint32 computeBufferSize(PixelFormat, const IntSize&);
 
     WEBCORE_EXPORT static bool supportedPixelFormat(PixelFormat);
@@ -49,7 +51,14 @@ public:
 
     std::span<uint8_t> bytes() const { return m_bytes; }
 
-    virtual bool isByteArrayPixelBuffer() const { return false; }
+    enum class Type {
+        ByteArray,
+#if HAVE(HDR_SUPPORT)
+        Float16Array,
+#endif
+        Other
+    };
+    virtual Type type() const { return Type::Other; }
     virtual RefPtr<PixelBuffer> createScratchPixelBuffer(const IntSize&) const = 0;
 
     bool setRange(std::span<const uint8_t> data, size_t byteOffset);


### PR DESCRIPTION
#### 7857fde428154dcf9de6646518a5ae5f897df36e
<pre>
Add Float16ArrayPixelBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=283878">https://bugs.webkit.org/show_bug.cgi?id=283878</a>
<a href="https://rdar.apple.com/problem/140761117">rdar://problem/140761117</a>

Reviewed by Cameron McCormack.

Float16ArrayPixelBuffer is pretty much the same as
ByteArrayPixelBuffer, but obviously handling Float16Array data
instead.
Note: These types could eventually be reimplemented through
a single template, to be done later after they&apos;ve been used a
bit more...

At this time, Float16ArrayPixelBuffer is not actually used yet,
this will come in upcoming patches, with relevant tests.

Accompanying changes:
- Changed bool isByteArrayPixelBuffer() to a more flexible type()
  function, to be used by isType().
- Fixed safer-cpp warning in ByteArrayPixelBuffer::span().
- Made PixelFormat::RGBA16F officially supported in PixelBuffer.
- Updated PixelBuffer::computeBufferSize to handle more formats.
- Added PixelBuffer::computePixelComponentCount to distinguish
  which value (array size in bytes or color components) is needed
  in callers, since these two can now be different.
  Note: All callers have *not* been checked/updated yet! To be
  done in upcoming patches touching ImageData and 2d context...
  Related note for the future: It would be good to have strong
  types to help distinguish counts of pixels/components/bytes
  everywhere.
- Also added PixelBuffer::computePixelCount.

* Source/WebCore/Headers.cmake:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/ByteArrayPixelBuffer.cpp:
(WebCore::ByteArrayPixelBuffer::create):
(WebCore::ByteArrayPixelBuffer::tryCreate):
(WebCore::ByteArrayPixelBuffer::span const):
* Source/WebCore/platform/graphics/ByteArrayPixelBuffer.h:
(isType):
* Source/WebCore/platform/graphics/Float16ArrayPixelBuffer.cpp: Copied from Source/WebCore/platform/graphics/ByteArrayPixelBuffer.cpp.
(WebCore::Float16ArrayPixelBuffer::create):
(WebCore::Float16ArrayPixelBuffer::tryCreate):
(WebCore::Float16ArrayPixelBuffer::Float16ArrayPixelBuffer):
(WebCore::Float16ArrayPixelBuffer::createScratchPixelBuffer const):
(WebCore::Float16ArrayPixelBuffer::span const):
* Source/WebCore/platform/graphics/Float16ArrayPixelBuffer.h: Copied from Source/WebCore/platform/graphics/ByteArrayPixelBuffer.h.
(WebCore::Float16ArrayPixelBuffer::data const):
(WebCore::Float16ArrayPixelBuffer::takeData):
(isType):
* Source/WebCore/platform/graphics/PixelBuffer.cpp:
(WebCore::PixelBuffer::supportedPixelFormat):
(WebCore::mustFitInInt32):
(WebCore::computeRawPixelCount):
(WebCore::computeRawPixelComponentCount):
(WebCore::PixelBuffer::computePixelCount):
(WebCore::PixelBuffer::computePixelComponentCount):
(WebCore::PixelBuffer::computeBufferSize):
* Source/WebCore/platform/graphics/PixelBuffer.h:
(WebCore::PixelBuffer::type const):
(WebCore::PixelBuffer::isByteArrayPixelBuffer const): Deleted.

Canonical link: <a href="https://commits.webkit.org/287230@main">https://commits.webkit.org/287230@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90fae450d9203e6af16f7a54765ad1f972eb5461

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78805 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57849 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32187 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83465 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30067 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80938 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67000 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6130 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61716 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19644 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81872 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51751 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/71562 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42023 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49097 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25876 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28407 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70209 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26282 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84834 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6170 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4265 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69939 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6332 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67741 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69193 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17237 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13236 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11951 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6115 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12009 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6099 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9536 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7889 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->