### PR TITLE
[Text] Add support for

### DIFF
--- a/LayoutTests/fast/text/capitalize-content-with-outside-bmp-characters-expected.html
+++ b/LayoutTests/fast/text/capitalize-content-with-outside-bmp-characters-expected.html
@@ -1,0 +1,2 @@
+<meta charset="utf-8">
+<div>𐐐𐐮𐐭𐑋𐐰𐑌 𐐐𐐮𐐭𐑋𐐰𐑌 Firﬆ Œuf Æsthetics</div>

--- a/LayoutTests/fast/text/capitalize-content-with-outside-bmp-characters.html
+++ b/LayoutTests/fast/text/capitalize-content-with-outside-bmp-characters.html
@@ -1,0 +1,7 @@
+<meta charset="utf-8">
+<style>
+div {
+  text-transform: capitalize;
+}
+</style>
+<div>𐐸𐐮𐐭𐑋𐐰𐑌 <span>𐐸𐐮𐐭𐑋𐐰𐑌</span> ﬁrﬆ œuf æsthetics</div>

--- a/LayoutTests/fast/text/capitalize-content-with-outside-bmp-previous-characters-expected.html
+++ b/LayoutTests/fast/text/capitalize-content-with-outside-bmp-previous-characters-expected.html
@@ -1,0 +1,3 @@
+<meta charset="utf-8">
+<div>Actual: 𐐸𐐮𐐭𐑋𐐰𐑌 𐐐𐐮𐐭𐑋𐐰𐑌 Firﬆ Œuf Æsthetics</div>
+<div>Expected: 𐐸𐐮𐐭𐑋𐐰𐑌 𐐐𐐮𐐭𐑋𐐰𐑌 Firﬆ Œuf Æsthetics</div>

--- a/LayoutTests/fast/text/capitalize-content-with-outside-bmp-previous-characters.html
+++ b/LayoutTests/fast/text/capitalize-content-with-outside-bmp-previous-characters.html
@@ -1,0 +1,8 @@
+<meta charset="utf-8">
+<style>
+span {
+  text-transform: capitalize;
+}
+</style>
+<div>Actual: 𐐸<span>𐐮𐐭𐑋𐐰𐑌 𐐸𐐮𐐭𐑋𐐰𐑌 ﬁrﬆ œuf æsthetics</span><div>
+<div>Expected: 𐐸𐐮𐐭𐑋𐐰𐑌 𐐐𐐮𐐭𐑋𐐰𐑌 Firﬆ Œuf Æsthetics</div>

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -1112,7 +1112,7 @@ Vector<String> AccessibilityObject::performTextOperation(const AccessibilityText
         bool replaceSelection = false;
         switch (operation.type) {
         case AccessibilityTextOperationType::Capitalize:
-            replacementString = capitalize(text, ' '); // FIXME: Needs to take locale into account to work correctly.
+            replacementString = capitalize(text); // FIXME: Needs to take locale into account to work correctly.
             replaceSelection = true;
             break;
         case AccessibilityTextOperationType::Uppercase:
@@ -1131,7 +1131,7 @@ Vector<String> AccessibilityObject::performTextOperation(const AccessibilityText
                 && replacementString.length() > 2
                 && replacementString != replacementString.convertToUppercaseWithoutLocale()) {
                 if (text[0] == u_toupper(text[0]))
-                    replacementString = capitalize(replacementString, ' '); // FIXME: Needs to take locale into account to work correctly.
+                    replacementString = capitalize(replacementString); // FIXME: Needs to take locale into account to work correctly.
                 else
                     replacementString = replacementString.convertToLowercaseWithoutLocale(); // FIXME: Needs locale to work correctly.
             }

--- a/Source/WebCore/editing/cocoa/HTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/HTMLConverter.mm
@@ -2152,7 +2152,7 @@ void HTMLConverter::_processText(Text& text)
     if (outputString.length()) {
         String textTransform = _caches->propertyValueForNode(text, CSSPropertyTextTransform);
         if (textTransform == "capitalize"_s)
-            outputString = capitalize(outputString, ' '); // FIXME: Needs to take locale into account to work correctly.
+            outputString = capitalize(outputString); // FIXME: Needs to take locale into account to work correctly.
         else if (textTransform == "uppercase"_s)
             outputString = outputString.convertToUppercaseWithoutLocale(); // FIXME: Needs locale to work correctly.
         else if (textTransform == "lowercase"_s)

--- a/Source/WebCore/rendering/RenderListBox.cpp
+++ b/Source/WebCore/rendering/RenderListBox.cpp
@@ -142,7 +142,7 @@ void RenderListBox::updateFromElement()
             }
             if (text.isEmpty())
                 continue;
-            text = applyTextTransform(style(), text, ' ');
+            text = applyTextTransform(style(), text);
             auto textRun = constructTextRun(text, style(), ExpansionBehavior::allowRightOnly());
             logicalWidth = std::max(logicalWidth, selectFont().width(textRun));
         }
@@ -508,7 +508,7 @@ void RenderListBox::paintItemForeground(PaintInfo& paintInfo, const LayoutPoint&
         itemText = optionElement->textIndentedToRespectGroupLabel();
     else if (optGroupElement)
         itemText = optGroupElement->groupLabelText();
-    itemText = applyTextTransform(style(), itemText, ' ');
+    itemText = applyTextTransform(style(), itemText);
 
     if (itemText.isNull())
         return;

--- a/Source/WebCore/rendering/RenderMenuList.cpp
+++ b/Source/WebCore/rendering/RenderMenuList.cpp
@@ -223,7 +223,7 @@ void RenderMenuList::updateOptionsWidth()
             continue;
 
         String text = option->textIndentedToRespectGroupLabel();
-        text = applyTextTransform(style(), text, ' ');
+        text = applyTextTransform(style(), text);
         if (theme().popupOptionSupportsTextIndent()) {
             // Add in the option's text indent.  We can't calculate percentage values for now.
             float optionWidth = 0;
@@ -470,7 +470,7 @@ String RenderMenuList::itemText(unsigned listIndex) const
     else if (auto* option = dynamicDowncast<HTMLOptionElement>(element))
         itemString = option->textIndentedToRespectGroupLabel();
 
-    return applyTextTransform(style(), itemString, ' ');
+    return applyTextTransform(style(), itemString);
 }
 
 String RenderMenuList::itemLabel(unsigned) const

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -55,6 +55,7 @@
 #include "SVGElementTypeHelpers.h"
 #include "SVGInlineTextBox.h"
 #include "Settings.h"
+#include "SurrogatePairAwareTextIterator.h"
 #include "Text.h"
 #include "TextResourceDecoder.h"
 #include "TextTransform.h"
@@ -163,27 +164,49 @@ static constexpr UChar convertNoBreakSpaceToSpace(UChar character)
     return character == noBreakSpace ? ' ' : character;
 }
 
-static inline bool capitalizeCharacter(UChar characterToCapitalize, StringBuilder& output)
+static inline size_t capitalizeCharacter(String textContent, unsigned startCharacterOffset, StringBuilder& output)
 {
-    // FIXME: Add support for non-BMP content.
-    UChar capitalizedCharacter;
-    UErrorCode status = U_ZERO_ERROR;
-    auto realLength = u_strToTitle(&capitalizedCharacter, 1, &characterToCapitalize, 1, nullptr, "", &status);
-    if (U_SUCCESS(status) && realLength == 1) {
-        output.append(capitalizedCharacter);
-        return true;
+    if (startCharacterOffset >= textContent.length()) {
+        ASSERT_NOT_REACHED();
+        return 0;
     }
 
-    // Decomposed ligatures may need more space.
-    std::span<UChar> capitalizedStringData;
-    auto capitalizedString = String::createUninitialized(realLength, capitalizedStringData);
-    status = U_ZERO_ERROR;
-    u_strToTitle(capitalizedStringData.data(), capitalizedStringData.size(), &characterToCapitalize, 1, nullptr, "", &status);
-    if (U_SUCCESS(status)) {
-        output.append(capitalizedString);
-        return true;
+    auto capitalize = [&](const UChar* contentToCapitalize, size_t length) -> size_t {
+        UChar capitalizedCharacter;
+        UErrorCode status = U_ZERO_ERROR;
+        auto realLength = u_strToTitle(&capitalizedCharacter, 1, contentToCapitalize, length, nullptr, "", &status);
+        if (U_SUCCESS(status) && realLength == 1) {
+            output.append(capitalizedCharacter);
+            return realLength;
+        }
+
+        // Decomposed ligatures may need more space.
+        std::span<UChar> capitalizedStringData;
+        auto capitalizedString = String::createUninitialized(realLength, capitalizedStringData);
+        status = U_ZERO_ERROR;
+        u_strToTitle(capitalizedStringData.data(), capitalizedStringData.size(), contentToCapitalize, length, nullptr, "", &status);
+        if (U_SUCCESS(status)) {
+            output.append(capitalizedString);
+            return length;
+        }
+        return 0;
+    };
+
+    if (textContent.is8Bit()) {
+        auto characterToCapitalize = textContent[startCharacterOffset];
+        return capitalize(&characterToCapitalize, 1);
     }
-    return false;
+
+    auto content = textContent.span16().subspan(startCharacterOffset);
+    auto contentIterator = SurrogatePairAwareTextIterator { content, startCharacterOffset, textContent.length() };
+    unsigned capitalizedContentLength = 0;
+    char32_t currentCharacter = 0;
+    contentIterator.consume(currentCharacter, capitalizedContentLength);
+    if (startCharacterOffset + capitalizedContentLength > textContent.length()) {
+        ASSERT_NOT_REACHED();
+        return 0;
+    }
+    return capitalize(content.data(), capitalizedContentLength);
 }
 
 String capitalize(const String& string, UChar previousCharacter)
@@ -212,12 +235,15 @@ String capitalize(const String& string, UChar previousCharacter)
     int32_t endOfWord;
     for (endOfWord = ubrk_next(breakIterator); endOfWord != UBRK_DONE; startOfWord = endOfWord, endOfWord = ubrk_next(breakIterator)) {
         // Do not append the first character, since it's the previous character, not from this string.
+        size_t capitalizedContentLength = 1;
         if (startOfWord) {
-            auto characterToCapitalize = stringWithPrevious[startOfWord];
-            if (!capitalizeCharacter(characterToCapitalize, result))
-                result.append(characterToCapitalize);
+            capitalizedContentLength = capitalizeCharacter(string, startOfWord - 1, result);
+            if (!capitalizedContentLength) {
+                result.append(stringWithPrevious[startOfWord]);
+                capitalizedContentLength = 1;
+            }
         }
-        for (int i = startOfWord + 1; i < endOfWord; i++)
+        for (int i = startOfWord + capitalizedContentLength; i < endOfWord; i++)
             result.append(stringImpl[i - 1]);
     }
 

--- a/Source/WebCore/rendering/RenderText.h
+++ b/Source/WebCore/rendering/RenderText.h
@@ -211,7 +211,7 @@ protected:
     void willBeDestroyed() override;
 
     virtual void setRenderedText(const String&);
-    virtual UChar previousCharacter() const;
+    virtual Vector<UChar> previousCharacter() const;
 
     virtual void setTextInternal(const String&, bool force);
 
@@ -287,8 +287,10 @@ private:
     unsigned m_hasSecureTextTimer : 1 { false };
 };
 
-String applyTextTransform(const RenderStyle&, const String&, UChar previousCharacter);
-String capitalize(const String&, UChar previousCharacter);
+String applyTextTransform(const RenderStyle&, const String&, Vector<UChar> previousCharacter);
+String applyTextTransform(const RenderStyle&, const String&);
+String capitalize(const String&, Vector<UChar> previousCharacter);
+String capitalize(const String&);
 TextBreakIterator::LineMode::Behavior mapLineBreakToIteratorMode(LineBreak);
 TextBreakIterator::ContentAnalysis mapWordBreakToContentAnalysis(WordBreak);
 

--- a/Source/WebCore/rendering/RenderTextFragment.cpp
+++ b/Source/WebCore/rendering/RenderTextFragment.cpp
@@ -86,14 +86,16 @@ void RenderTextFragment::setTextInternal(const String& newText, bool force)
     ASSERT(!textNode() || textNode()->renderer() == this);
 }
 
-UChar RenderTextFragment::previousCharacter() const
+Vector<UChar> RenderTextFragment::previousCharacter() const
 {
     if (start()) {
         String original = textNode() ? textNode()->data() : contentString();
-        if (!original.isNull() && start() <= original.length())
-            return original[start() - 1];
+        if (!original.isNull() && start() <= original.length()) {
+            Vector<UChar> previous;
+            previous.append(original[start() - 1]);
+            return previous;
+        }
     }
-
     return RenderText::previousCharacter();
 }
 

--- a/Source/WebCore/rendering/RenderTextFragment.h
+++ b/Source/WebCore/rendering/RenderTextFragment.h
@@ -60,7 +60,7 @@ public:
 private:
     void setTextInternal(const String&, bool force) override;
 
-    UChar previousCharacter() const override;
+    Vector<UChar> previousCharacter() const override;
 
     unsigned m_start;
     unsigned m_end;


### PR DESCRIPTION
#### 49adbd216430fcbc40fbd65de90f8cb5c23b1cb6
<pre>
[Text] Add support for skipping previous non-bmp content when capitalizing
<a href="https://bugs.webkit.org/show_bug.cgi?id=283814">https://bugs.webkit.org/show_bug.cgi?id=283814</a>
&lt;<a href="https://rdar.apple.com/problem/140681383">rdar://problem/140681383</a>&gt;

Reviewed by NOBODY (OOPS!).

Previous content may be a grapheme cluster with series of codepoints.

* LayoutTests/fast/text/capitalize-content-with-outside-bmp-previous-characters-expected.html: Added.
* LayoutTests/fast/text/capitalize-content-with-outside-bmp-previous-characters.html: Added.
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::performTextOperation):
* Source/WebCore/editing/cocoa/HTMLConverter.mm:
(HTMLConverter::_processText):
* Source/WebCore/rendering/RenderListBox.cpp:
(WebCore::RenderListBox::updateFromElement):
(WebCore::RenderListBox::paintItemForeground):
* Source/WebCore/rendering/RenderMenuList.cpp:
(RenderMenuList::updateOptionsWidth):
(RenderMenuList::itemText const):
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::capitalize):
(WebCore::RenderText::previousCharacter const):
(WebCore::applyTextTransform):
* Source/WebCore/rendering/RenderText.h:
* Source/WebCore/rendering/RenderTextFragment.cpp:
(WebCore::RenderTextFragment::previousCharacter const):
* Source/WebCore/rendering/RenderTextFragment.h:
</pre>
----------------------------------------------------------------------
#### 4e957291c8be66060d5f42f10f7a3c6b9eb82e41
<pre>
[Text] Add support for capitalizing content with characters outside of BMP
<a href="https://bugs.webkit.org/show_bug.cgi?id=283779">https://bugs.webkit.org/show_bug.cgi?id=283779</a>

Reviewed by Antti Koivisto.

Let&apos;s use SurrogatePairAwareTextIterator to figure out the actual length of capitalized content.

(titlecasing code is the same except now we can pass in multi-character content to capitalize.
In practice it&apos;s only 16bit content that may have this property)

* Source/WebCore/rendering/RenderText.cpp:
(WebCore::capitalizeCharacter):
(WebCore::capitalize):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49adbd216430fcbc40fbd65de90f8cb5c23b1cb6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78591 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57636 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31973 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83252 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29856 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80724 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66787 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5917 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61560 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19483 "Found 1 new test failure: fast/text/capitalize-content-with-outside-bmp-previous-characters.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81658 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51574 "Found 1 new test failure: css1/text_properties/text_transform.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/70017 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41870 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48920 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25442 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28194 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70022 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25816 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84620 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5956 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4092 "Found 2 new test failures: http/wpt/html/browsers/the-window-object/window-open-noopener-webkit.html imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69784 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6117 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67551 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69038 "Found 4 new API test failures: /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginAndEndEditingEvents, /TestWebKit:WebKit.EvaluateJavaScriptThatThrowsAnException, /TestWebKit:WebKit.LoadCanceledNoServerRedirectCallback, /TestWebKit:WebKit.WillSendSubmitEvent (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13064 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11535 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5903 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/11854 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5891 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9325 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7678 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->