### PR TITLE
[IFC][SVG text] Use iterator in RenderSVGText::layoutCharactersInTextBoxes

### DIFF
--- a/Source/WebCore/layout/integration/inline/InlineIteratorInlineBox.cpp
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorInlineBox.cpp
@@ -81,6 +81,17 @@ LeafBoxIterator InlineBox::endLeafBox() const
     return { };
 }
 
+IteratorRange<BoxIterator> InlineBox::descendants() const
+{
+    BoxIterator begin(*this);
+    begin.traverseNextOnLine();
+
+    BoxIterator end(*this);
+    end.traverseNextOnLineSkippingChildren();
+
+    return { begin, end };
+}
+
 InlineBoxIterator::InlineBoxIterator(Box::PathVariant&& pathVariant)
     : BoxIterator(WTFMove(pathVariant))
 {

--- a/Source/WebCore/layout/integration/inline/InlineIteratorInlineBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorInlineBox.h
@@ -51,6 +51,8 @@ public:
     LeafBoxIterator firstLeafBox() const;
     LeafBoxIterator lastLeafBox() const;
     LeafBoxIterator endLeafBox() const;
+
+    IteratorRange<BoxIterator> descendants() const;
 };
 
 class InlineBoxIterator : public BoxIterator {

--- a/Source/WebCore/rendering/svg/RenderSVGText.h
+++ b/Source/WebCore/rendering/svg/RenderSVGText.h
@@ -29,6 +29,10 @@
 
 namespace WebCore {
 
+namespace InlineIterator {
+class InlineBoxIterator;
+}
+
 class RenderSVGInlineText;
 class SVGRootInlineBox;
 class SVGTextElement;
@@ -97,7 +101,7 @@ private:
     void layout() override;
 
     void computePerCharacterLayoutInformation();
-    void layoutCharactersInTextBoxes(LegacyInlineFlowBox*, SVGTextLayoutEngine&);
+    void layoutCharactersInTextBoxes(const InlineIterator::InlineBoxIterator&, SVGTextLayoutEngine&);
     FloatRect layoutChildBoxes(LegacyInlineFlowBox*, SVGTextFragmentMap&);
     void layoutRootBox(const FloatRect&);
     void reorderValueListsToLogicalOrder();

--- a/Source/WebCore/rendering/svg/SVGTextChunkBuilder.h
+++ b/Source/WebCore/rendering/svg/SVGTextChunkBuilder.h
@@ -36,9 +36,10 @@ struct SVGTextFragment;
 // Phase three performs all modifications that have to be applied to each individual text chunk (text-anchor & textLength).
 
 class SVGTextChunkBuilder {
-    WTF_MAKE_NONCOPYABLE(SVGTextChunkBuilder);
 public:
     SVGTextChunkBuilder();
+    SVGTextChunkBuilder(SVGTextChunkBuilder&&) = default;
+    SVGTextChunkBuilder(const SVGTextChunkBuilder&) = delete;
 
     const Vector<SVGTextChunk>& textChunks() const { return m_textChunks; }
     unsigned totalCharacters() const;

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp
@@ -155,7 +155,7 @@ bool SVGTextLayoutEngine::parentDefinesTextLength(RenderObject* parent) const
     return false;
 }
 
-void SVGTextLayoutEngine::beginTextPathLayout(RenderSVGTextPath& textPath, SVGTextLayoutEngine& lineLayout)
+void SVGTextLayoutEngine::beginTextPathLayout(const RenderSVGTextPath& textPath, SVGTextLayoutEngine& lineLayout)
 {
     m_inPathLayout = true;
 

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngine.h
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngine.h
@@ -44,13 +44,14 @@ class SVGRenderStyle;
 // which are stored in the SVGInlineTextBox objects.
 
 class SVGTextLayoutEngine {
-    WTF_MAKE_NONCOPYABLE(SVGTextLayoutEngine);
 public:
     SVGTextLayoutEngine(Vector<SVGTextLayoutAttributes*>&);
+    SVGTextLayoutEngine(SVGTextLayoutEngine&&) = default;
+    SVGTextLayoutEngine(const SVGTextLayoutEngine&) = delete;
 
     Vector<SVGTextLayoutAttributes*>& layoutAttributes() { return m_layoutAttributes; }
 
-    void beginTextPathLayout(RenderSVGTextPath&, SVGTextLayoutEngine& lineLayout);
+    void beginTextPathLayout(const RenderSVGTextPath&, SVGTextLayoutEngine& lineLayout);
     void endTextPathLayout();
 
     void layoutInlineTextBox(InlineIterator::SVGTextBoxIterator);


### PR DESCRIPTION
#### c2bb73ebb9059264a8683c9213a9db79ef249ed0
<pre>
[IFC][SVG text] Use iterator in RenderSVGText::layoutCharactersInTextBoxes
<a href="https://bugs.webkit.org/show_bug.cgi?id=283823">https://bugs.webkit.org/show_bug.cgi?id=283823</a>
<a href="https://rdar.apple.com/140693481">rdar://140693481</a>

Reviewed by Alan Baradlay.

* Source/WebCore/layout/integration/inline/InlineIteratorInlineBox.cpp:
(WebCore::InlineIterator::InlineBox::descendants const):
* Source/WebCore/layout/integration/inline/InlineIteratorInlineBox.h:
* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::RenderSVGText::computePerCharacterLayoutInformation):
(WebCore::RenderSVGText::layoutCharactersInTextBoxes):
* Source/WebCore/rendering/svg/RenderSVGText.h:
* Source/WebCore/rendering/svg/SVGTextChunkBuilder.h:
* Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp:
(WebCore::SVGTextLayoutEngine::beginTextPathLayout):
* Source/WebCore/rendering/svg/SVGTextLayoutEngine.h:

Canonical link: <a href="https://commits.webkit.org/287211@main">https://commits.webkit.org/287211@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f77c528d4bb7c950e2455050a62953f21c9d0a33

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78614 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57659 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31996 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83275 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29878 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80747 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66810 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5940 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61574 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19498 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81681 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51597 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/70182 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41884 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48943 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25490 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28217 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70046 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25866 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84643 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5979 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4111 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69800 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6140 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67573 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69054 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17221 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13086 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11579 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5926 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/11868 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5913 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9348 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7701 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->