### PR TITLE
Add support for MiniBrowser to run-benchmark

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_minibrowser_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_minibrowser_driver.py
@@ -1,0 +1,87 @@
+import logging
+import os
+import sys
+import re
+import subprocess
+import time
+
+from webkitpy.benchmark_runner.browser_driver.osx_browser_driver import OSXBrowserDriver
+from webkitpy.common.host import Host
+from webkitpy.common.webkit_finder import WebKitFinder
+
+
+_log = logging.getLogger(__name__)
+
+
+class OSXMiniDriver(OSXBrowserDriver):
+    process_name = 'MiniBrowser'
+    browser_name = 'minibrowser'
+    bundle_id = 'org.webkit.MiniBrowser'
+
+    def __init__(self, browser_args):
+        OSXBrowserDriver.__init__(self, browser_args)
+        self._webkit_finder = WebKitFinder(Host().filesystem)
+        _log.warning("It looks like you're running benchmarks on MiniBrowser which has different performance characteristics than Safari... Don't assume they are the same!")
+
+    def prepare_env(self, config):
+        self._process = None
+        super(OSXMiniDriver, self).prepare_env(config)
+        self._enable_signposts = config["enable_signposts"]
+        self._maximize_window()
+
+    def launch_url(self, url, options, browser_build_path, browser_path):
+        env = {}
+        for key, value in os.environ.items():
+            if re.match(r'^__XPC_', key):
+                env[key] = value
+        if self._enable_signposts:
+            env['WEBKIT_SIGNPOSTS_ENABLED'] = '1'
+            env['__XPC_WEBKIT_SIGNPOSTS_ENABLED'] = '1'
+            env['__XPC_JSC_exposeProfilersOnGlobalObject'] = '1'
+        if browser_build_path or browser_path:
+            self._launch_url_with_custom_path(url, options, browser_build_path, browser_path, env)
+            return
+        self._process = subprocess.Popen([self._webkit_finder.path_to_script('run-minibrowser'), '--url', url], env=env)
+
+    def _launch_url_with_custom_path(self, url, options, browser_build_path, browser_path, env):
+        browser_build_absolute_path = None
+        app_path = None
+        if browser_build_path:
+            browser_build_absolute_path = os.path.abspath(browser_build_path)
+            app_path = os.path.join(browser_build_absolute_path, 'MiniBrowser.app')
+        elif browser_path:
+            app_path = os.path.abspath(browser_path)
+            browser_build_absolute_path = os.path.dirname(app_path)
+        else:
+            assert False  # self.launch_url should have dealt with this case
+
+        contains_frameworks = any(map(lambda entry: entry.endswith('.framework'), os.listdir(browser_build_absolute_path)))
+        if contains_frameworks:
+            env['DYLD_FRAMEWORK_PATH'] = browser_build_absolute_path
+            env['DYLD_LIBRARY_PATH'] = browser_build_absolute_path
+            env['__XPC_DYLD_FRAMEWORK_PATH'] = browser_build_absolute_path
+            env['__XPC_DYLD_LIBRARY_PATH'] = browser_build_absolute_path
+        else:
+            raise Exception('Could not find any framework "{}"'.format(browser_build_absolute_path))
+
+        binary_path = os.path.join(app_path, 'Contents/MacOS/MiniBrowser')
+        has_binary = os.path.exists(binary_path)
+        if not has_binary:
+            raise Exception('No binary at "{}"'.format(binary_path))
+
+        try:
+            process = subprocess.Popen([binary_path, '--url', url], env=env)
+        except Exception as error:
+            _log.error('Popen failed: {error}'.format(error=error))
+
+    def close_browsers(self):
+        super(OSXMiniDriver, self).close_browsers()
+        if self._process and self._process.returncode:
+            sys.exit('Browser crashed with exitcode %d' % self._process.returncode)
+
+    @classmethod
+    def _maximize_window(cls):
+        try:
+            subprocess.check_call(['/usr/bin/defaults', 'write', 'com.apple.MiniBrowser', 'NSWindow Frame BrowserWindowFrame', ' '.join(['0', '0', str(cls._screen_size().width), str(cls._screen_size().height)] * 2)])
+        except Exception as error:
+            _log.error('Reset window size failed - Error: {}'.format(error))


### PR DESCRIPTION
#### 6839441f456d8b6d2e5d553f300fa26653cd9307
<pre>
Add support for MiniBrowser to run-benchmark
<a href="https://bugs.webkit.org/show_bug.cgi?id=283830">https://bugs.webkit.org/show_bug.cgi?id=283830</a>
<a href="https://rdar.apple.com/140702535">rdar://140702535</a>

Reviewed by Simon Fraser.

Add new osx_minibrowser_driver.py to &apos;run-benchmark&apos; command.

* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_minibrowser_driver.py: Added.
(OSXMiniDriver):
(OSXMiniDriver.__init__):
(OSXMiniDriver.prepare_env):
(OSXMiniDriver.launch_url):
(OSXMiniDriver._launch_url_with_custom_path):
(OSXMiniDriver.close_browsers):
(OSXMiniDriver._maximize_window):

Canonical link: <a href="https://commits.webkit.org/287556@main">https://commits.webkit.org/287556@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/460ed40d93c5697b1440509ccca8f25189d296fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79781 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58782 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33180 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84306 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30788 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81890 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67856 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7073 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62358 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20200 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82849 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52414 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72660 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42662 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/79236 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49756 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26808 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29231 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70885 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27279 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85732 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7016 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4913 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70616 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7189 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68499 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69855 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17458 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13865 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12785 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6973 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6837 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10345 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8644 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->