### PR TITLE
Convert AXLoadingEvent to an enum class

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -262,6 +262,13 @@ WEBCORE_AXNOTIFICATION_KEYS(WEBCORE_DEFINE_AXNOTIFICATION_ENUM)
 #undef WEBCORE_DEFINE_AXNOTIFICATION_ENUM
 };
 
+enum class AXLoadingEvent : uint8_t {
+    Started,
+    Reloaded,
+    Failed,
+    Finished
+};
+
 #if !PLATFORM(COCOA)
 enum AXTextChange { AXTextInserted, AXTextDeleted, AXTextAttributesChanged };
 #endif
@@ -537,13 +544,6 @@ public:
     void postTextStateChangeNotification(Node*, const AXTextStateChangeIntent&, const VisibleSelection&);
     void postTextStateChangeNotification(const Position&, const AXTextStateChangeIntent&, const VisibleSelection&);
     void postLiveRegionChangeNotification(AccessibilityObject&);
-
-    enum AXLoadingEvent {
-        AXLoadingStarted,
-        AXLoadingReloaded,
-        AXLoadingFailed,
-        AXLoadingFinished
-    };
 
     void frameLoadingEventNotification(LocalFrame*, AXLoadingEvent);
 

--- a/Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp
@@ -244,18 +244,18 @@ void AXObjectCache::frameLoadingEventPlatformNotification(AccessibilityObject* c
         return;
 
     switch (loadingEvent) {
-    case AXObjectCache::AXLoadingStarted:
+    case AXLoadingEvent::Started:
         wrapper->stateChanged("busy", true);
         break;
-    case AXObjectCache::AXLoadingReloaded:
+    case AXLoadingEvent::Reloaded:
         wrapper->stateChanged("busy", true);
         wrapper->loadEvent("Reload");
         break;
-    case AXObjectCache::AXLoadingFailed:
+    case AXLoadingEvent::Failed:
         wrapper->stateChanged("busy", false);
         wrapper->loadEvent("LoadStopped");
         break;
-    case AXObjectCache::AXLoadingFinished:
+    case AXLoadingEvent::Finished:
         wrapper->stateChanged("busy", false);
         wrapper->loadEvent("LoadComplete");
         break;

--- a/Source/WebCore/accessibility/ios/AXObjectCacheIOS.mm
+++ b/Source/WebCore/accessibility/ios/AXObjectCacheIOS.mm
@@ -155,7 +155,7 @@ void AXObjectCache::frameLoadingEventPlatformNotification(AccessibilityObject* a
     if (!axFrameObject)
         return;
 
-    if (loadingEvent == AXLoadingFinished && axFrameObject->document() == axFrameObject->topDocument())
+    if (loadingEvent == AXLoadingEvent::Finished && axFrameObject->document() == axFrameObject->topDocument())
         postPlatformNotification(*axFrameObject, AXNotification::LoadComplete);
 }
 

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -711,7 +711,7 @@ void AXObjectCache::frameLoadingEventPlatformNotification(AccessibilityObject* a
     if (!axFrameObject)
         return;
 
-    if (loadingEvent == AXLoadingFinished) {
+    if (loadingEvent == AXLoadingEvent::Finished) {
         if (axFrameObject->document() == axFrameObject->topDocument())
             postNotification(axFrameObject, axFrameObject->document(), AXNotification::LoadComplete);
         else

--- a/Source/WebCore/accessibility/win/AXObjectCacheWin.cpp
+++ b/Source/WebCore/accessibility/win/AXObjectCacheWin.cpp
@@ -139,9 +139,9 @@ void AXObjectCache::frameLoadingEventPlatformNotification(AccessibilityObject* o
     if (!page)
         return;
 
-    if (notification == AXLoadingStarted)
+    if (notification == AXLoadingEvent::Started)
         page->chrome().client().AXStartFrameLoad();
-    else if (notification == AXLoadingFinished)
+    else if (notification == AXLoadingEvent::Finished)
         page->chrome().client().AXFinishFrameLoad();
 }
 

--- a/Source/WebCore/loader/EmptyClients.h
+++ b/Source/WebCore/loader/EmptyClients.h
@@ -182,7 +182,7 @@ class EmptyChromeClient : public ChromeClient {
 #if PLATFORM(PLAYSTATION)
     void postAccessibilityNotification(AccessibilityObject&, AXNotification) final { }
     void postAccessibilityNodeTextChangeNotification(AccessibilityObject*, AXTextChange, unsigned, const String&) final { }
-    void postAccessibilityFrameLoadingEventNotification(AccessibilityObject*, AXObjectCache::AXLoadingEvent) final { }
+    void postAccessibilityFrameLoadingEventNotification(AccessibilityObject*, AXLoadingEvent) final { }
 #endif
 
 #if ENABLE(IOS_TOUCH_EVENTS)

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1379,7 +1379,7 @@ void FrameLoader::prepareForLoadStart()
 
     if (AXObjectCache::accessibilityEnabled()) {
         if (CheckedPtr cache = m_frame->document()->existingAXObjectCache()) {
-            AXObjectCache::AXLoadingEvent loadingEvent = loadType() == FrameLoadType::Reload ? AXObjectCache::AXLoadingReloaded : AXObjectCache::AXLoadingStarted;
+            auto loadingEvent = loadType() == FrameLoadType::Reload ? AXLoadingEvent::Reloaded : AXLoadingEvent::Started;
             cache->frameLoadingEventNotification(protectedFrame().ptr(), loadingEvent);
         }
     }
@@ -2908,11 +2908,11 @@ void FrameLoader::checkLoadCompleteForThisFrame(LoadWillContinueInAnotherProcess
         Ref documentLoader = *m_documentLoader;
         auto& error = documentLoader->mainDocumentError();
 
-        auto loadingEvent = AXObjectCache::AXLoadingFailed;
+        auto loadingEvent = AXLoadingEvent::Failed;
         if (!error.isNull()) {
             FRAMELOADER_RELEASE_LOG(ResourceLoading, "checkLoadCompleteForThisFrame: Finished frame load with error (isTimeout = %d, isCancellation = %d, errorCode = %d)", error.isTimeout(), error.isCancellation(), error.errorCode());
             m_client->dispatchDidFailLoad(error);
-            loadingEvent = AXObjectCache::AXLoadingFailed;
+            loadingEvent = AXLoadingEvent::Failed;
             m_errorOccurredInLoading = true;
         } else {
             FRAMELOADER_RELEASE_LOG(ResourceLoading, "checkLoadCompleteForThisFrame: Finished frame load");
@@ -2934,7 +2934,7 @@ void FrameLoader::checkLoadCompleteForThisFrame(LoadWillContinueInAnotherProcess
             }
 #endif
             m_client->dispatchDidFinishLoad();
-            loadingEvent = AXObjectCache::AXLoadingFinished;
+            loadingEvent = AXLoadingEvent::Finished;
         }
 
         // Notify accessibility.

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -514,7 +514,7 @@ public:
 #if PLATFORM(PLAYSTATION)
     virtual void postAccessibilityNotification(AccessibilityObject&, AXNotification) = 0;
     virtual void postAccessibilityNodeTextChangeNotification(AccessibilityObject*, AXTextChange, unsigned, const String&) = 0;
-    virtual void postAccessibilityFrameLoadingEventNotification(AccessibilityObject*, AXObjectCache::AXLoadingEvent) = 0;
+    virtual void postAccessibilityFrameLoadingEventNotification(AccessibilityObject*, AXLoadingEvent) = 0;
 #endif
 
     virtual bool selectItemWritingDirectionIsNatural() = 0;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1772,7 +1772,7 @@ void WebChromeClient::postAccessibilityNodeTextChangeNotification(WebCore::Acces
     notImplemented();
 }
 
-void WebChromeClient::postAccessibilityFrameLoadingEventNotification(WebCore::AccessibilityObject*, WebCore::AXObjectCache::AXLoadingEvent)
+void WebChromeClient::postAccessibilityFrameLoadingEventNotification(WebCore::AccessibilityObject*, WebCore::AXLoadingEvent)
 {
     notImplemented();
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -252,7 +252,7 @@ private:
 #if PLATFORM(PLAYSTATION)
     void postAccessibilityNotification(WebCore::AccessibilityObject&, WebCore::AXNotification) final;
     void postAccessibilityNodeTextChangeNotification(WebCore::AccessibilityObject*, WebCore::AXTextChange, unsigned, const String&) final;
-    void postAccessibilityFrameLoadingEventNotification(WebCore::AccessibilityObject*, WebCore::AXObjectCache::AXLoadingEvent) final;
+    void postAccessibilityFrameLoadingEventNotification(WebCore::AccessibilityObject*, WebCore::AXLoadingEvent) final;
 #endif
 
     void animationDidFinishForElement(const WebCore::Element&) final;


### PR DESCRIPTION
#### cb69234f3d98ec60cc76a75ca7770edaf91fba99
<pre>
Convert AXLoadingEvent to an enum class
<a href="https://bugs.webkit.org/show_bug.cgi?id=283835">https://bugs.webkit.org/show_bug.cgi?id=283835</a>
<a href="https://rdar.apple.com/140705448">rdar://140705448</a>

Reviewed by Tyler Wilcock and Wenson Hsieh.

Convert AXLoadingEvent to an enum class, and move it out of AXObjectCache so we can
forward declare it (for future ChromeClient.h cleanup).

* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp:
(WebCore::AXObjectCache::frameLoadingEventPlatformNotification):
* Source/WebCore/accessibility/ios/AXObjectCacheIOS.mm:
(WebCore::AXObjectCache::frameLoadingEventPlatformNotification):
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(WebCore::AXObjectCache::frameLoadingEventPlatformNotification):
* Source/WebCore/accessibility/win/AXObjectCacheWin.cpp:
(WebCore::AXObjectCache::frameLoadingEventPlatformNotification):
* Source/WebCore/loader/EmptyClients.h:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::prepareForLoadStart):
(WebCore::FrameLoader::checkLoadCompleteForThisFrame):
* Source/WebCore/page/ChromeClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::postAccessibilityFrameLoadingEventNotification):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:

Canonical link: <a href="https://commits.webkit.org/287176@main">https://commits.webkit.org/287176@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/933f1ff13b2407ba8e8750a14eec07201c6cb4a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78648 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57693 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32030 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83309 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29910 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80781 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66844 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5974 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61599 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19519 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81715 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51625 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/70368 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41908 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48971 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25547 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28251 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70075 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25924 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84677 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6013 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4141 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69826 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6174 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67602 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69080 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17206 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13114 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11630 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5960 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/11891 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5946 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9382 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7735 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->