### PR TITLE
Debug assertion triggered when running TestWebKitAPI tests via XC Test Plan

### DIFF
--- a/Tools/TestWebKitAPI/TestBundle/GoogleTests.mm
+++ b/Tools/TestWebKitAPI/TestBundle/GoogleTests.mm
@@ -233,7 +233,15 @@ static void RunTest(id self, SEL _cmd)
 
             SEL selector = sel_registerName([methodName UTF8String]);
             BOOL added = class_addMethod(testClass, selector, (IMP)RunTest, "v@:");
-            NSAssert1(added, @"Failed to add Goole Test method \"%@\", this method may already exist in the class.", methodName);
+
+            // FIXME: (283036) PrintWithJSExecutionOptionTests API tests are duplicated in the testing system
+            NSSet<NSString *> *testsExcludedFromAssertion = [NSSet setWithArray:@[
+                @"UnifiedPDF/PrintWithJSExecutionOptionTests",
+                @"Printing/PrintWithJSExecutionOptionTests",
+            ]];
+
+            NSAssert([testsExcludedFromAssertion containsObject:testCaseName] || added, @"Failed to add Google Test method \"%@\", this method may already exist in the class.", methodName);
+
             hasMethods = YES;
         }
 


### PR DESCRIPTION
#### 58c200a073247603acb2b2839f8d997abe121658
<pre>
Debug assertion triggered when running TestWebKitAPI tests via XC Test Plan
<a href="https://bugs.webkit.org/show_bug.cgi?id=283839">https://bugs.webkit.org/show_bug.cgi?id=283839</a>
<a href="https://rdar.apple.com/140708780">rdar://140708780</a>

Reviewed by Abrar Rahman Protyasha.

Recent changes to the PrintWithJSExecutionOptionTests tests resulted in a debug assertion getting triggered
when running API tests via XC test plans.

Temporarily work around this by creating an allow list for these specific tests to avoid the assertion.

* Tools/TestWebKitAPI/TestBundle/GoogleTests.mm:
(+[GoogleTestLoader registerTestClasses]):

Canonical link: <a href="https://commits.webkit.org/287214@main">https://commits.webkit.org/287214@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef5c18a5602dd6a23b96b495bcc5d8ff6f99555b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78657 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57702 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32039 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83318 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29919 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80790 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66853 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5983 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61606 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19527 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81724 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51630 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/70421 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41915 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48976 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25561 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28260 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70080 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25939 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84686 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6022 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4146 "Found 2 new test failures: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html imported/w3c/web-platform-tests/html/semantics/links/links-created-by-a-and-area-elements/target_blank_implicit_noopener.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69834 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6183 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67608 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69088 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13119 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11643 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12165 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5969 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5955 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9391 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7744 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->