### PR TITLE
[macOS] open.spotify.com: unnecessary text selection when dragging various sliders

### DIFF
--- a/LayoutTests/fast/events/mac/mouse-down-can-start-selection-quirk-expected.txt
+++ b/LayoutTests/fast/events/mac/mouse-down-can-start-selection-quirk-expected.txt
@@ -1,0 +1,7 @@
+PASS getSelection().toString() is ""
+PASS sliderPosition is 180
+PASS isDraggingSlider is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+ Hello world

--- a/LayoutTests/fast/events/mac/mouse-down-can-start-selection-quirk.html
+++ b/LayoutTests/fast/events/mac/mouse-down-can-start-selection-quirk.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+body, html {
+    font-family: system-ui;
+    font-size: 18px;
+}
+
+.slider {
+    width: 200px;
+    height: 40px;
+    touch-action: none;
+    background: #efefef;
+    border-radius: 4px;
+    padding: 4px;
+    display: inline-block;
+}
+
+.track {
+    width: 200px;
+    height: 2px;
+    background: lightgray;
+    top: 21px;
+    position: relative;
+    border-radius: 2px;
+}
+
+.grabber {
+    width: 20px;
+    height: 20px;
+    background: white;
+    border: 2px solid green;
+    border-radius: 20px;
+    top: 10px;
+    left: 0;
+    position: relative;
+    box-sizing: border-box;
+    cursor: pointer;
+}
+
+.text {
+    display: inline-block;
+    height: 24px;
+    margin-top: -34px;
+    vertical-align: middle;
+
+}
+</style>
+<script>
+addEventListener("load", () => {
+    window.internals?.setTopDocumentURLForQuirks("https://open.spotify.com");
+
+    sliderPosition = 0;
+    isDraggingSlider = false;
+    const grabber = document.querySelector(".grabber");
+    grabber.addEventListener("mousedown", () => {
+        isDraggingSlider = true;
+    });
+
+    addEventListener("mousemove", (event) => {
+        if (!isDraggingSlider)
+            return;
+
+        sliderPosition = Math.min(180, Math.max(0, event.clientX - 20));
+        grabber.style.left = `${sliderPosition}px`;
+    });
+
+    addEventListener("mouseup", () => {
+        isDraggingSlider = false;
+    });
+
+    const rect = grabber.getBoundingClientRect();
+    eventSender.mouseMoveTo(rect.left + 10, rect.top + 10);
+    eventSender.mouseDown();
+    eventSender.mouseMoveTo(rect.left + 250, rect.top + 10);
+    eventSender.mouseUp();
+
+    shouldBeEqualToString("getSelection().toString()", "");
+    shouldBe("sliderPosition", "180");
+    shouldBeFalse("isDraggingSlider");
+});
+</script>
+</head>
+<body>
+    <div class="slider">
+        <div class="track"></div>
+        <div class="grabber"></div>
+    </div>
+    <div class="text">Hello world</div>
+</body>
+</html>

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -796,6 +796,9 @@ bool EventHandler::canMouseDownStartSelect(const MouseEventWithHitTestResults& e
     if (!node || !node->renderer())
         return true;
 
+    if (node->protectedDocument()->quirks().shouldAvoidStartingSelectionOnMouseDown(*node))
+        return false;
+
     if (ImageOverlay::isOverlayText(*node))
         return node->renderer()->style().usedUserSelect() != UserSelect::None;
 

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -232,6 +232,8 @@ public:
 
     bool needsBingGestureEventQuirk(EventTarget*) const;
 
+    bool shouldAvoidStartingSelectionOnMouseDown(const Node&) const;
+
 #if PLATFORM(IOS)
     bool hideForbesVolumeSlider() const;
     bool hideIGNVolumeSlider() const;
@@ -244,6 +246,7 @@ private:
     bool isEmbedDomain(const String&) const;
     bool isYoutubeEmbedDomain() const;
     bool isYahooMail() const;
+    bool isSpotifyPlayer() const;
 
     bool isAmazon() const;
     bool isESPN() const;

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -33,13 +33,13 @@ struct WEBCORE_EXPORT QuirksData {
     std::optional<bool> isGoogleMaps;
     std::optional<bool> isNetflix;
     std::optional<bool> isSoundCloud;
+    std::optional<bool> isSpotify;
     std::optional<bool> isVimeo;
     std::optional<bool> isYouTube;
     std::optional<bool> isZoom;
 
     std::optional<bool> implicitMuteWhenVolumeSetToZero;
     std::optional<bool> needsBingGestureEventQuirk;
-    std::optional<bool> needsBodyScrollbarWidthNoneDisabledQuirk;
     std::optional<bool> needsCanPlayAfterSeekedQuirk;
     std::optional<bool> needsChromeMediaControlsPseudoElementQuirk;
     std::optional<bool> needsDisableDOMPasteAccessQuirk;


### PR DESCRIPTION
#### 40abe11810765b73c18b0873553852baf83de3fb
<pre>
[macOS] open.spotify.com: unnecessary text selection when dragging various sliders
<a href="https://bugs.webkit.org/show_bug.cgi?id=283837">https://bugs.webkit.org/show_bug.cgi?id=283837</a>
<a href="https://rdar.apple.com/138916062">rdar://138916062</a>

Reviewed by Abrar Rahman Protyasha.

Add a quirk to prevent mousedown from triggering text selection on Spotify, when clicking and
dragging over various progress sliders. While these widgets lack any accessibility roles which would
suggest that they&apos;re sliders or interactive progress-related DOM elements of some kind, they do
contain both `touch-action: none;` and `pointer: cursor;` which serve as a strong hint that they are
clickable (or at least interactive in some way), and the web app intends to process the interaction
using some custom logic.

* LayoutTests/fast/events/mac/mouse-down-can-start-selection-quirk-expected.txt: Added.
* LayoutTests/fast/events/mac/mouse-down-can-start-selection-quirk.html: Added.

Add a layout test to exercise this change.

* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::canMouseDownStartSelect):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::isSpotifyPlayer const):

Factor this out into a separate helper method, so we can use it in both places below.

(WebCore::Quirks::needsBodyScrollbarWidthNoneDisabledQuirk const):
(WebCore::Quirks::shouldAvoidStartingSelectionOnMouseDown const):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:

Add a cached bit `isSpotifyPlayer` flag, and use it to replace an existing cached quirks state flag.

Canonical link: <a href="https://commits.webkit.org/287194@main">https://commits.webkit.org/287194@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7a4036bc373ad261a685588bf0f072ef1810a76

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78658 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57703 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32040 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83319 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29920 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80791 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66854 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5984 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61608 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19526 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81725 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51632 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/70419 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41917 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48978 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25560 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28261 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70082 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25937 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84687 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6023 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4147 "Found 4 new test failures: http/tests/workers/service/shownotification-allowed.html http/wpt/html/cross-origin-embedder-policy/require-corp.https.html imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html imported/w3c/web-platform-tests/html/semantics/links/links-created-by-a-and-area-elements/target_blank_implicit_noopener.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69835 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6184 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67607 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69089 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17213 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13120 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11642 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5970 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/11899 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5956 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9392 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7745 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->