### PR TITLE
Sync `directionality` related UA changes from web specification

### DIFF
--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -1423,11 +1423,18 @@ iframe {
     border: 2px inset;
 }
 
+/* https://html.spec.whatwg.org/multipage/rendering.html#bidi-rendering */
 bdi, output {
     unicode-bidi: isolate;
 }
 
-input[type=tel i]:dir(ltr) { direction: ltr; }
+[dir]:dir(ltr), bdi:dir(ltr), input[type=tel i]:dir(ltr) {
+    direction: ltr;
+}
+
+[dir]:dir(rtl), bdi:dir(rtl) {
+    direction: rtl;
+}
 
 bdo, bdo[dir] {
     unicode-bidi: isolate-override;


### PR DESCRIPTION
#### 6cbac97b50c5ea5ae9444ff37abe3a1abe4543fe
<pre>
Sync `directionality` related UA changes from web specification
<a href="https://bugs.webkit.org/show_bug.cgi?id=283843">https://bugs.webkit.org/show_bug.cgi?id=283843</a>
<a href="https://rdar.apple.com/140710298">rdar://140710298</a>

Reviewed by NOBODY (OOPS!).

This patch syncs our current UA stylesheet with web specification [1]:

[1] <a href="https://html.spec.whatwg.org/multipage/rendering.html#bidi-rendering">https://html.spec.whatwg.org/multipage/rendering.html#bidi-rendering</a>

We already had it partially synced for input type `tel` (telephone) and
our implementation is already working because of HTMLElement::collectPresentationalHintsForAttribute.

We are passing relevant WPT tests as well (e.g., dir-pseudo-on-bdi-element.html).

* Source/WebCore/css/html.css:
([dir]:dir(ltr), bdi:dir(ltr), input[type=tel i]:dir(ltr)):
([dir]:dir(rtl), bdi:dir(rtl)):
(input[type=tel i]:dir(ltr)): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6cbac97b50c5ea5ae9444ff37abe3a1abe4543fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57708 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32045 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83324 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29925 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80796 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66859 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5989 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61611 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19532 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81730 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51636 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/70445 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41920 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48982 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25570 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28266 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70086 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25947 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84692 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6028 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4151 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69838 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6189 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67613 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69092 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13127 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11651 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5975 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/11903 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5961 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9397 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7750 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->