### PR TITLE
Add padding: 1px to <td> and <th> for make spec-compliant

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/html-to-css-mapping-1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/html-to-css-mapping-1-expected.txt
@@ -16,7 +16,7 @@ The table has the background but is empty; it does not apply border-spacing in t
 
 
 PASS HTML -> CSS Mapping is applied correctly on proper table markup (border-spacing, padding)
-FAIL HTML -> CSS Mapping is applied correctly on improper table markup (no table => no border-spacing, but padding) assert_equals: expected 10 but got 0
+PASS HTML -> CSS Mapping is applied correctly on improper table markup (no table => no border-spacing, but padding)
 PASS HTML -> CSS Mapping is applied correctly on improper table markup (no td => border-spacing, but no padding)
 PASS HTML -> CSS Mapping is applied correctly on empty table markup (no content => no border-spacing, no padding)
 

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -323,6 +323,7 @@ tr {
 td, th {
     display: table-cell;
     vertical-align: inherit;
+    padding: 1px;
 }
 
 th {


### PR DESCRIPTION
#### 83eaa21149af78ac78da917d3fc421dda3282f8c
<pre>
Add padding:1px to &lt;td&gt; and &lt;th&gt; for make spec-compliant
<a href="https://bugs.webkit.org/show_bug.cgi?id=255844">https://bugs.webkit.org/show_bug.cgi?id=255844</a>

Reviewed by NOBODY (OOPS!).

Add padding:1px to &lt;td&gt; and &lt;th&gt; to html.css.
Fix wpt test that was failing because of the missing padding.

* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/html-to-css-mapping-1-expected.txt:
* Source/WebCore/css/html.css:
(td, th):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83eaa21149af78ac78da917d3fc421dda3282f8c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78678 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57722 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32060 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83338 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29940 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80811 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66874 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6003 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61618 "Found 223 new test failures: css1/box_properties/float_elements_in_series.html css2.1/t0905-c5525-fltmult-00-d-g.html css2.1/tables/table-anonymous-objects-091.xht css2.1/tables/table-anonymous-objects-092.xht css2.1/tables/table-anonymous-objects-099.xht css2.1/tables/table-anonymous-objects-100.xht css2.1/tables/table-anonymous-objects-103.xht css2.1/tables/table-anonymous-objects-104.xht css2.1/tables/table-anonymous-objects-105.xht css2.1/tables/table-anonymous-objects-106.xht ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19541 "Found 3 new test failures: fast/css-grid-layout/grid-item-overflow-paint.html fast/dom/HTMLTableElement/cellpadding-attribute.html fast/forms/005.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81745 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51649 "Found 60 new test failures: compositing/contents-format/deep-color-backing-store.html css1/box_properties/float_elements_in_series.html css2.1/t0905-c5525-fltmult-00-d-g.html css2.1/tables/table-anonymous-objects-091.xht css2.1/tables/table-anonymous-objects-092.xht css2.1/tables/table-anonymous-objects-099.xht css2.1/tables/table-anonymous-objects-100.xht css2.1/tables/table-anonymous-objects-103.xht css2.1/tables/table-anonymous-objects-104.xht css2.1/tables/table-anonymous-objects-105.xht ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/70504 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41927 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48995 "Found 15 new test failures: imported/w3c/web-platform-tests/css/css-break/table/table-rowspan-001.html imported/w3c/web-platform-tests/css/css-tables/colspan-001.html imported/w3c/web-platform-tests/css/css-tables/colspan-002.html imported/w3c/web-platform-tests/css/css-tables/colspan-003.html imported/w3c/web-platform-tests/css/css-tables/colspan-004.html imported/w3c/web-platform-tests/css/css-tables/height-distribution/computing-row-measure-0.html imported/w3c/web-platform-tests/css/css-tables/height-distribution/computing-row-measure-1.html imported/w3c/web-platform-tests/css/css-tables/percent-width-ignored-001.tentative.html imported/w3c/web-platform-tests/css/css-tables/percent-width-ignored-002.tentative.html imported/w3c/web-platform-tests/css/css-tables/percent-width-ignored-003.tentative.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25589 "Found 60 new test failures: css1/box_properties/float_elements_in_series.html css2.1/t0905-c5525-fltmult-00-d-g.html css2.1/tables/table-anonymous-objects-091.xht css2.1/tables/table-anonymous-objects-092.xht css2.1/tables/table-anonymous-objects-099.xht css2.1/tables/table-anonymous-objects-100.xht css2.1/tables/table-anonymous-objects-103.xht css2.1/tables/table-anonymous-objects-104.xht css2.1/tables/table-anonymous-objects-105.xht css2.1/tables/table-anonymous-objects-106.xht ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28280 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70100 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25967 "Found 60 new test failures: css1/box_properties/float_elements_in_series.html css2.1/t0905-c5525-fltmult-00-d-g.html css2.1/tables/table-anonymous-objects-091.xht css2.1/tables/table-anonymous-objects-092.xht css2.1/tables/table-anonymous-objects-099.xht css2.1/tables/table-anonymous-objects-100.xht css2.1/tables/table-anonymous-objects-103.xht css2.1/tables/table-anonymous-objects-104.xht css2.1/tables/table-anonymous-objects-105.xht css2.1/tables/table-anonymous-objects-106.xht ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84707 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6043 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4162 "Found 60 new test failures: css1/box_properties/float_elements_in_series.html css2.1/t0905-c5525-fltmult-00-d-g.html css2.1/tables/table-anonymous-objects-091.xht css2.1/tables/table-anonymous-objects-092.xht css2.1/tables/table-anonymous-objects-099.xht css2.1/tables/table-anonymous-objects-100.xht css2.1/tables/table-anonymous-objects-103.xht css2.1/tables/table-anonymous-objects-104.xht css2.1/tables/table-anonymous-objects-105.xht css2.1/tables/table-anonymous-objects-106.xht ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69844 "Failure limit exceed. At least found 214 new test failures: css1/box_properties/float_elements_in_series.html css2.1/t0905-c5525-fltmult-00-d-g.html css2.1/tables/table-anonymous-objects-091.xht css2.1/tables/table-anonymous-objects-092.xht css2.1/tables/table-anonymous-objects-099.xht css2.1/tables/table-anonymous-objects-100.xht css2.1/tables/table-anonymous-objects-103.xht css2.1/tables/table-anonymous-objects-104.xht css2.1/tables/table-anonymous-objects-105.xht css2.1/tables/table-anonymous-objects-106.xht ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6205 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67624 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69099 "Found 3 new API test failures: /TestWebKit:WebKit.HitTestResultNodeHandle, /TestWebKit:WebKit.FrameMIMETypePNG, /TestWebKit:WebKit.WillSendSubmitEvent (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13136 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11669 "Found 60 new test failures: compositing/overflow/overflow-scroll-to-visible.html css1/box_properties/float_elements_in_series.html css2.1/t0905-c5525-fltmult-00-d-g.html css2.1/tables/table-anonymous-objects-091.xht css2.1/tables/table-anonymous-objects-092.xht css2.1/tables/table-anonymous-objects-099.xht css2.1/tables/table-anonymous-objects-100.xht css2.1/tables/table-anonymous-objects-103.xht css2.1/tables/table-anonymous-objects-104.xht css2.1/tables/table-anonymous-objects-105.xht ... (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5988 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/11910 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5974 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9410 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7762 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->