### PR TITLE
Update spec links for File System API

### DIFF
--- a/Source/WebCore/Modules/filesystemaccess/FileSystemFileHandle.idl
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemFileHandle.idl
@@ -23,7 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// https://wicg.github.io/file-system-access/#api-filesystemhandle
+// https://fs.spec.whatwg.org/#api-filesystemhandle
 
 [
     EnabledBySetting=FileSystemAccessEnabled,

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
@@ -103,7 +103,7 @@ bool FileSystemStorageHandle::isSameEntry(WebCore::FileSystemHandleIdentifier id
 
 static bool isValidFileName(const String& directory, const String& name)
 {
-    // https://wicg.github.io/file-system-access/#valid-file-name
+    // https://fs.spec.whatwg.org/#valid-file-name
     if (name.isEmpty() || (name == "."_s) || (name == ".."_s) || name.contains(pathSeparator))
         return false;
 


### PR DESCRIPTION
#### c10e7d3bdde79e0f9d296f64a6662b659dbbd81a
<pre>
Update spec links for File System API
<a href="https://bugs.webkit.org/show_bug.cgi?id=283850">https://bugs.webkit.org/show_bug.cgi?id=283850</a>
<a href="https://rdar.apple.com/140728743">rdar://140728743</a>

Reviewed by Sam Weinig.

The specification has been moved to WHATWG, and old links are no longer valid.

* Source/WebCore/Modules/filesystemaccess/FileSystemFileHandle.idl:
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp:
(WebKit::isValidFileName):

Canonical link: <a href="https://commits.webkit.org/287193@main">https://commits.webkit.org/287193@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eea15e587c706e478d7bf00813217fea65ac802b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78703 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57747 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32085 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83363 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29965 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80836 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66899 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6028 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61637 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19563 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81770 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51669 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/70784 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41945 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49015 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25662 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28305 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70122 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26043 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84732 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6068 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4188 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69864 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6230 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67651 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69118 "Found 7 new API test failures: /TestWebKit:WebKit.PreventEmptyUserAgent, /TestWebKit:WebKit.FrameMIMETypeHTML, /TestWebKit:WebKit.PageLoadBasic, /TestWebKit:WebKit.InjectedBundleFrameHitTest, /TestWebKit:WebKit.FrameMIMETypePNG, /TestWebKit:WebKit2UserMessageRoundTripTest.WKURLRequestRef, /TestWebKit:WebKit.InjectedBundleBasic (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17212 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13157 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11733 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6013 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/11930 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5999 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9435 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7787 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->