### PR TITLE
[iOS] Entering full screen may not work in web views even when `isElementFullscreenEnabled` is enabled

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/FullscreenClient.h
+++ b/Source/WebKit/UIProcess/Cocoa/FullscreenClient.h
@@ -63,21 +63,21 @@ private:
 
     struct {
 #if PLATFORM(MAC)
-        bool webViewWillEnterFullscreen : 1;
-        bool webViewDidEnterFullscreen : 1;
-        bool webViewWillExitFullscreen : 1;
-        bool webViewDidExitFullscreen : 1;
+        bool webViewWillEnterFullscreen : 1 { false };
+        bool webViewDidEnterFullscreen : 1 { false };
+        bool webViewWillExitFullscreen : 1 { false };
+        bool webViewDidExitFullscreen : 1 { false };
 #else
-        bool webViewWillEnterElementFullscreen : 1;
-        bool webViewDidEnterElementFullscreen : 1;
-        bool webViewWillExitElementFullscreen : 1;
-        bool webViewDidExitElementFullscreen : 1;
+        bool webViewWillEnterElementFullscreen : 1 { false };
+        bool webViewDidEnterElementFullscreen : 1 { false };
+        bool webViewWillExitElementFullscreen : 1 { false };
+        bool webViewDidExitElementFullscreen : 1 { false };
 #endif
 #if ENABLE(QUICKLOOK_FULLSCREEN)
-        bool webViewDidFullscreenImageWithQuickLook : 1;
+        bool webViewDidFullscreenImageWithQuickLook : 1 { false };
 #endif
 #if PLATFORM(IOS_FAMILY)
-        bool webViewRequestPresentingViewController : 1;
+        bool webViewRequestPresentingViewController : 1 { false };
 #endif
     } m_delegateMethods;
 };


### PR DESCRIPTION
#### 99271c3ed9de09126848bc18c277da8144c2b07e
<pre>
[iOS] Entering full screen may not work in web views even when `isElementFullscreenEnabled` is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=283853">https://bugs.webkit.org/show_bug.cgi?id=283853</a>
<a href="https://rdar.apple.com/138336212">rdar://138336212</a>

Reviewed by Wenson Hsieh.

The bit-field bool values in the `m_delegateMethods` struct in `FullscreenClient.h` are not guaranteed to be
initialized to `false`. As a result, if there is no fullscreen delegate, these values are undefined.

Particularly in the case of `webViewRequestPresentingViewController` being `true`, this causes entering fullscreen
to fail, since the completion handler in `FullscreenClient::requestPresentingViewController` won&apos;t actually ever
be invoked.

Fix by default-initializing all the bit-field values in this class to `false`.

* Source/WebKit/UIProcess/Cocoa/FullscreenClient.h:

Canonical link: <a href="https://commits.webkit.org/287216@main">https://commits.webkit.org/287216@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6fcf25e96d718e6574f263605fc48e36750c81e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78712 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57756 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32094 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83372 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29974 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66908 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6037 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61645 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19568 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81779 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51676 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/70835 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41953 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49022 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28314 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70129 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26059 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84741 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6077 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4196 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69871 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6239 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67659 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69125 "Found 1 new API test failure: /TestWebKit:WebKit2.ProvisionalURLAfterWillSendRequestCallback (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13163 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11747 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12166 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6022 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/11936 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6008 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9444 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7796 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->