### PR TITLE
Update FileSystemSyncAccessHandle::truncate() to match spec

### DIFF
--- a/LayoutTests/storage/filesystemaccess/resources/sync-access-handle-truncate.js
+++ b/LayoutTests/storage/filesystemaccess/resources/sync-access-handle-truncate.js
@@ -1,0 +1,86 @@
+if (this.importScripts) {
+    importScripts('../../../resources/js-test.js');
+    importScripts('shared.js');
+}
+
+description("This test checks truncate() method of FileSystemSyncAccessHandle");
+
+var accessHandle, fileSize, writeBuffer, writeSize, readBuffer, readSize, readText;
+
+function arrayBufferToString(buffer)
+{
+    const decoder = new TextDecoder();
+    var view = new Uint8Array(buffer);
+    return decoder.decode(view);
+}
+
+function stringToArrayBuffer(string)
+{
+    const encoder = new TextEncoder();
+    return encoder.encode(string);
+}
+
+function write(accessHandle, text)
+{
+    writeBuffer = stringToArrayBuffer(text);
+    writeSize = accessHandle.write(writeBuffer);
+    shouldBe("writeSize", "writeBuffer.byteLength");
+    return writeSize;
+}
+
+function read(accessHandle, offset, size, expectedString)
+{
+    readBuffer = new ArrayBuffer(size);
+    if (offset == null)
+        readSize = accessHandle.read(readBuffer);
+    else
+        readSize = accessHandle.read(readBuffer, { "at": offset });
+    shouldBe("readSize", "readBuffer.byteLength");
+    if (expectedString) {
+        readText = arrayBufferToString(readBuffer);
+        shouldBeEqualToString("readText", expectedString);
+    }
+    return readSize;
+}
+
+async function test() 
+{
+    try {
+        var rootHandle = await navigator.storage.getDirectory();
+        // Create a new file for this test.
+        await rootHandle.removeEntry("sync-access-handle-truncate.txt").then(() => { }, () => { });
+        var fileHandle = await rootHandle.getFileHandle("sync-access-handle-truncate.txt", { "create" : true  });
+        accessHandle = await fileHandle.createSyncAccessHandle();
+        fileSize = accessHandle.getSize();
+        shouldBe("fileSize", "0");
+
+        debug("Test: truncate size smaller than file size");
+        write(accessHandle, "abcdefghi");
+        accessHandle.truncate(4); // Write offset is updated to 4.
+        write(accessHandle, "xyz");
+        accessHandle.flush();
+        fileSize = accessHandle.getSize();
+        shouldBe("fileSize", "7");
+        read(accessHandle, 0, fileSize, "abcdxyz");
+
+        debug("Test: truncate size bigger than file size");
+        write(accessHandle, "?");  // Write offset is 8.
+        accessHandle.truncate(12); // Write offset should not be updated.
+        write(accessHandle, "!");
+        accessHandle.flush();
+        fileSize = accessHandle.getSize();
+        shouldBe("fileSize", "12");
+        read(accessHandle, 0, fileSize, "abcdxyz?!\0\0\0");
+
+        debug("Test: truncate size bigger than quota (1MB)");
+        shouldThrow("accessHandle.truncate(1024 * 1024 + 1)");
+
+        accessHandle.close();
+        finishTest();
+    } catch (error) {
+        finishTest(error);
+    }
+}
+
+console.log('error');
+test();

--- a/LayoutTests/storage/filesystemaccess/sync-access-handle-truncate-worker-expected.txt
+++ b/LayoutTests/storage/filesystemaccess/sync-access-handle-truncate-worker-expected.txt
@@ -1,0 +1,25 @@
+[Worker] This test checks truncate() method of FileSystemSyncAccessHandle
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Starting worker: resources/sync-access-handle-truncate.js
+PASS [Worker] fileSize is 0
+[Worker] Test: truncate size smaller than file size
+PASS [Worker] writeSize is writeBuffer.byteLength
+PASS [Worker] writeSize is writeBuffer.byteLength
+PASS [Worker] fileSize is 7
+PASS [Worker] readSize is readBuffer.byteLength
+PASS [Worker] readText is "abcdxyz"
+[Worker] Test: truncate size bigger than file size
+PASS [Worker] writeSize is writeBuffer.byteLength
+PASS [Worker] writeSize is writeBuffer.byteLength
+PASS [Worker] fileSize is 12
+PASS [Worker] readSize is readBuffer.byteLength
+PASS [Worker] readText is "abcdxyz?!\u0000\u0000\u0000"
+[Worker] Test: truncate size bigger than quota (1MB)
+PASS [Worker] accessHandle.truncate(1024 * 1024 + 1) threw exception QuotaExceededError: The quota has been exceeded..
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/storage/filesystemaccess/sync-access-handle-truncate-worker.html
+++ b/LayoutTests/storage/filesystemaccess/sync-access-handle-truncate-worker.html
@@ -1,0 +1,14 @@
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+if (window.testRunner) {
+	testRunner.setOriginQuotaRatioEnabled(false); // Use fixed quota instead of quota based on disk space.
+	testRunner.setQuota(1024 * 1024); // 1 MB
+	testRunner.setAllowStorageQuotaIncrease(false);
+}
+worker = startWorker('resources/sync-access-handle-truncate.js');</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.h
@@ -66,6 +66,7 @@ private:
     using CloseCallback = CompletionHandler<void(ExceptionOr<void>&&)>;
     enum class ShouldNotifyBackend : bool { No, Yes };
     void closeInternal(ShouldNotifyBackend);
+    bool requestSpaceForNewSize(uint64_t newSize);
     bool requestSpaceForWrite(uint64_t writeOffset, uint64_t writeLength);
 
     // ActiveDOMObject.


### PR DESCRIPTION
#### 50dfdfae2f6c87a6a2ce83a9a9d4318956f5c974
<pre>
Update FileSystemSyncAccessHandle::truncate() to match spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=283857">https://bugs.webkit.org/show_bug.cgi?id=283857</a>
<a href="https://rdar.apple.com/140732908">rdar://140732908</a>

Reviewed by Youenn Fablet.

Perform quota check and update file cursor position in truncate().

New test: storage/filesystemaccess/sync-access-handle-truncate-worker.html

* LayoutTests/storage/filesystemaccess/resources/sync-access-handle-truncate.js: Added.
(arrayBufferToString):
(stringToArrayBuffer):
(write):
(read):
(async test):
* LayoutTests/storage/filesystemaccess/sync-access-handle-truncate-worker-expected.txt: Added.
* LayoutTests/storage/filesystemaccess/sync-access-handle-truncate-worker.html: Added.
* Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.cpp:
(WebCore::FileSystemSyncAccessHandle::truncate):
(WebCore::FileSystemSyncAccessHandle::requestSpaceForNewSize):
(WebCore::FileSystemSyncAccessHandle::requestSpaceForWrite):
* Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.h:

Canonical link: <a href="https://commits.webkit.org/287244@main">https://commits.webkit.org/287244@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/441b64c29fd3fc6fdbea771062bad8b968613752

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78931 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57970 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32311 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83578 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30167 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81064 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67101 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6250 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61799 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19722 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81998 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51835 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/71818 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42103 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49185 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26017 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28523 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70299 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26426 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84957 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6279 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70028 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6442 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67841 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69279 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17256 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13323 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12067 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6228 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6194 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9645 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7985 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->