### PR TITLE
Clear floats even when they are not tracked by a previous sibling

### DIFF
--- a/LayoutTests/fast/block/float/block-with-negative-margin-clears-float-expected.txt
+++ b/LayoutTests/fast/block/float/block-with-negative-margin-clears-float-expected.txt
@@ -1,0 +1,3 @@
+crbug.com/591243: Clear floats when we have negative margin and are separated from the float by a div that doesn't track it.
+
+ PASS

--- a/LayoutTests/fast/block/float/block-with-negative-margin-clears-float.html
+++ b/LayoutTests/fast/block/float/block-with-negative-margin-clears-float.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<style>
+    #container {
+        width: 100px;
+    }
+
+    .float {
+        float: right;
+        height: 50px;
+        width: 100%;
+        background: green;
+    }
+
+    #clear {
+        clear: both;
+        height: 1px;
+    }
+
+    #next {
+        margin-top: -50px;
+        line-height: 0;
+    }
+
+    span {
+        display: inline-block;
+        width: 100%;
+        height: 50px;
+        background: green;
+    }
+</style>
+<p>crbug.com/591243: Clear floats when we have negative margin and are separated from the float by a div that doesn't track it.</p>
+<div id="container" data-expected-height=100>
+    <div class="float"></div>
+    <div id="clear"></div>
+    <div id="next">
+        <span></span>
+    </div>
+</div>
+<script src="../../../resources/check-layout.js"></script>
+<script>
+    checkLayout("#container");
+</script>

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -2,8 +2,8 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2007 David Smith (catfish.man@gmail.com)
- * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
- * Copyright (C) 2014-2015 Google Inc. All rights reserved.
+ * Copyright (C) 2003-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2016 Google Inc. All rights reserved.
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -237,11 +237,12 @@ void RenderBlockFlow::rebuildFloatingObjectSetFromIntrudingFloats()
         return;
 
     // First add in floats from the parent. Self-collapsing blocks let their parent track any floats that intrude into
-    // them (as opposed to floats they contain themselves) so check for those here too.
+    // them (as opposed to floats they contain themselves) so check for those here too. If margin collapsing has moved
+    // us up past the top a previous sibling then we need to check for floats from the parent too.
     bool parentHasFloats = false;
     RenderBlockFlow* previousBlock = previousSiblingWithOverhangingFloats(parentHasFloats);
     LayoutUnit logicalTopOffset = logicalTop();
-    bool parentHasIntrudingFloats = !parentHasFloats && (!previousBlock  || (previousBlock->isSelfCollapsingBlock() && parentBlock->lowestFloatLogicalBottom() > logicalTopOffset));
+    bool parentHasIntrudingFloats = !parentHasFloats && (!previousBlock  || previousBlock->isSelfCollapsingBlock() || previousBlock->logicalTop() > logicalTopOffset) && parentBlock->lowestFloatLogicalBottom() > logicalTopOffset;
     if (parentHasFloats || parentHasIntrudingFloats)
         addIntrudingFloats(parentBlock.get(), parentBlock.get(), parentBlock->logicalLeftOffsetForContent(), logicalTopOffset);
 


### PR DESCRIPTION
#### 7b4f87a05484315326f8da61f3d1a22b9c7415e2
<pre>
Clear floats even when they are not tracked by a previous sibling

<a href="https://bugs.webkit.org/show_bug.cgi?id=283858">https://bugs.webkit.org/show_bug.cgi?id=283858</a>
<a href="https://rdar.apple.com/140733421">rdar://140733421</a>

Reviewed by Alan Baradlay.

Merge: <a href="https://source.chromium.org/chromium/chromium/src/+/24bc38bac8c8f2ca1ee61b8872829fcdde521fa3">https://source.chromium.org/chromium/chromium/src/+/24bc38bac8c8f2ca1ee61b8872829fcdde521fa3</a>

This patch fixes up case where the margin collapsing has moved us up to past the top
a previous sibling than we need to check for floats from the parent too and clear floats.

* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::rebuildFloatingObjectSetFromIntrudingFloats):
* LayoutTests/fast/block/float/block-with-negative-margin-clears-float.html: Add Test Case
* LayoutTests/fast/block/float/block-with-negative-margin-clears-float-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/287185@main">https://commits.webkit.org/287185@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78f9f8dcef6ea8a2ee9af38386ec6f3257472484

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78720 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57764 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32102 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83380 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29982 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80853 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66916 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6045 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61649 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19573 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81787 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51682 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/70865 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41957 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49028 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25687 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28322 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70135 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26069 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84749 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6085 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4202 "Found 2 new test failures: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html imported/w3c/web-platform-tests/html/semantics/links/links-created-by-a-and-area-elements/target_blank_implicit_noopener.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69876 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6247 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67664 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69130 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17210 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13169 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11756 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6030 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/11943 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6016 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9452 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7804 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->