### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/platform

### DIFF
--- a/Source/WebCore/platform/sql/SQLiteStatement.cpp
+++ b/Source/WebCore/platform/sql/SQLiteStatement.cpp
@@ -36,8 +36,6 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringView.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 // SQLite 3.6.16 makes sqlite3_prepare_v2 automatically retry preparing the statement
 // once if the database scheme has changed. We rely on this behavior.
 #if SQLITE_VERSION_NUMBER < 3006016
@@ -113,13 +111,13 @@ int SQLiteStatement::bindBlob(int index, const String& text)
     // treats as a null, so we supply a non-null pointer for that case.
     auto upconvertedCharacters = StringView(text).upconvertedCharacters();
     UChar anyCharacter = 0;
-    const UChar* characters;
+    std::span<const UChar> characters;
     if (text.isEmpty() && !text.isNull())
-        characters = &anyCharacter;
+        characters = unsafeMakeSpan(&anyCharacter, 0);
     else
-        characters = upconvertedCharacters;
+        characters = upconvertedCharacters.span();
 
-    return bindBlob(index, std::span(reinterpret_cast<const uint8_t*>(characters), text.length() * sizeof(UChar)));
+    return bindBlob(index, spanReinterpretCast<const uint8_t>(characters));
 }
 
 int SQLiteStatement::bindText(int index, StringView text)
@@ -220,7 +218,7 @@ SQLValue SQLiteStatement::columnValue(int col)
         return sqlite3_value_double(value);
     case SQLITE_BLOB: // SQLValue and JS don't represent blobs, so use TEXT -case
     case SQLITE_TEXT:
-        return String::fromUTF8(std::span(sqlite3_value_text(value), sqlite3_value_bytes(value)));
+        return String::fromUTF8(unsafeMakeSpan(sqlite3_value_text(value), sqlite3_value_bytes(value)));
     case SQLITE_NULL:
         return nullptr;
     default:
@@ -238,7 +236,7 @@ String SQLiteStatement::columnText(int col)
         return String();
     if (columnCount() <= col)
         return String();
-    return String::fromUTF8(std::span(sqlite3_column_text(m_statement, col), sqlite3_column_bytes(m_statement, col)));
+    return String::fromUTF8(unsafeMakeSpan(sqlite3_column_text(m_statement, col), sqlite3_column_bytes(m_statement, col)));
 }
     
 double SQLiteStatement::columnDouble(int col)
@@ -281,7 +279,7 @@ String SQLiteStatement::columnBlobAsString(int col)
     if (columnCount() <= col)
         return String();
 
-    const void* blob = sqlite3_column_blob(m_statement, col);
+    auto* blob = static_cast<const UChar*>(sqlite3_column_blob(m_statement, col));
     if (!blob)
         return emptyString();
 
@@ -290,7 +288,7 @@ String SQLiteStatement::columnBlobAsString(int col)
         return String();
 
     ASSERT(!(size % sizeof(UChar)));
-    return StringImpl::create8BitIfPossible({ static_cast<const UChar*>(blob), size / sizeof(UChar) });
+    return StringImpl::create8BitIfPossible(unsafeMakeSpan(blob, size / sizeof(UChar)));
 }
 
 Vector<uint8_t> SQLiteStatement::columnBlob(int col)
@@ -308,7 +306,7 @@ std::span<const uint8_t> SQLiteStatement::columnBlobAsSpan(int col)
     if (columnCount() <= col)
         return { };
 
-    const void* blob = sqlite3_column_blob(m_statement, col);
+    auto* blob = static_cast<const uint8_t*>(sqlite3_column_blob(m_statement, col));
     if (!blob)
         return { };
 
@@ -316,7 +314,7 @@ std::span<const uint8_t> SQLiteStatement::columnBlobAsSpan(int col)
     if (blobSize <= 0)
         return { };
 
-    return { static_cast<const uint8_t*>(blob), static_cast<size_t>(blobSize) };
+    return unsafeMakeSpan(blob, blobSize);
 }
 
 bool SQLiteStatement::hasStartedStepping()
@@ -330,5 +328,3 @@ bool SQLiteStatement::isReadOnly()
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/text/DateTimeFormat.cpp
+++ b/Source/WebCore/platform/text/DateTimeFormat.cpp
@@ -30,11 +30,9 @@
 #include <wtf/ASCIICType.h>
 #include <wtf/text/StringBuilder.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
-static const DateTimeFormat::FieldType lowerCaseToFieldTypeMap[26] = {
+static constexpr std::array lowerCaseToFieldTypeMap {
     DateTimeFormat::FieldTypePeriod, // a
     DateTimeFormat::FieldTypeInvalid, // b
     DateTimeFormat::FieldTypeLocalDayOfWeekStandAlon, // c
@@ -63,7 +61,7 @@ static const DateTimeFormat::FieldType lowerCaseToFieldTypeMap[26] = {
     DateTimeFormat::FieldTypeZone, // z
 };
 
-static const DateTimeFormat::FieldType upperCaseToFieldTypeMap[26] = {
+static constexpr std::array upperCaseToFieldTypeMap {
     DateTimeFormat::FieldTypeMillisecondsInDay, // A
     DateTimeFormat::FieldTypeInvalid, // B
     DateTimeFormat::FieldTypeInvalid, // C
@@ -274,7 +272,5 @@ void DateTimeFormat::quoteAndAppendLiteral(const String& literal, StringBuilder&
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif

--- a/Source/WebCore/platform/text/PlatformLocale.cpp
+++ b/Source/WebCore/platform/text/PlatformLocale.cpp
@@ -37,8 +37,6 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringBuilder.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Locale);
@@ -376,5 +374,3 @@ String Locale::localizedDecimalSeparator()
 #endif
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/text/PlatformLocale.h
+++ b/Source/WebCore/platform/text/PlatformLocale.h
@@ -153,7 +153,7 @@ private:
     bool detectSignAndGetDigitRange(const String& input, bool& isNegative, unsigned& startIndex, unsigned& endIndex);
     unsigned matchedDecimalSymbolIndex(const String& input, unsigned& position);
 
-    String m_decimalSymbols[DecimalSymbolsSize];
+    std::array<String, DecimalSymbolsSize> m_decimalSymbols;
     String m_positivePrefix;
     String m_positiveSuffix;
     String m_negativePrefix;


### PR DESCRIPTION
#### 5dc8660948b7bc86ff19b9b09e55687fcc533aff
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/platform
<a href="https://bugs.webkit.org/show_bug.cgi?id=283863">https://bugs.webkit.org/show_bug.cgi?id=283863</a>

Reviewed by Sam Weinig.

* Source/WebCore/platform/sql/SQLiteStatement.cpp:
(WebCore::SQLiteStatement::bindBlob):
(WebCore::SQLiteStatement::columnValue):
(WebCore::SQLiteStatement::columnText):
(WebCore::SQLiteStatement::columnBlobAsString):
(WebCore::SQLiteStatement::columnBlobAsSpan):
* Source/WebCore/platform/text/DateTimeFormat.cpp:
* Source/WebCore/platform/text/PlatformLocale.cpp:
* Source/WebCore/platform/text/PlatformLocale.h:
* Source/WebCore/platform/text/cocoa/LocalizedDateCache.mm:

Canonical link: <a href="https://commits.webkit.org/287199@main">https://commits.webkit.org/287199@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14df8d80056b54914ce5ec50a9cafab3003d6f1a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78763 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32145 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83423 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30025 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80896 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66959 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6088 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61686 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19608 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81830 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51722 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/71322 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41993 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49068 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25804 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28365 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70179 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26207 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84792 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6128 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69912 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6290 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67706 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69167 "Found 9 new API test failures: /TestWebKit:WebKit.DownloadDecideDestinationCrash, /TestWebKit:WebKit.PageLoadDidChangeLocationWithinPage, /TestWebKit:WebKit2UserMessageRoundTripTest.WKURLRequestRef, /TestWebKit:WebKit.InjectedBundleFrameHitTest, /TestWebKit:WebKit.HitTestResultNodeHandle, /TestWebKit:WebKit.GeolocationBasicWithHighAccuracy, /TestWebKit:WebKit.InjectedBundleBasic, /TestWebKit:WebKit.ParentFrame, /TestWebKit:WebKit.GeolocationBasic (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13206 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11889 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12156 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6073 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/11976 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6058 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9495 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7847 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->