### PR TITLE
Further reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/platform

### DIFF
--- a/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp
@@ -41,8 +41,6 @@
 #include <wtf/NativePromise.h>
 #include <wtf/StringPrintStream.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 class MockMediaSample final : public MediaSample {
@@ -176,8 +174,7 @@ void MockSourceBufferPrivate::didReceiveInitializationSegment(const MockInitiali
     SourceBufferPrivateClient::InitializationSegment segment;
     segment.duration = initBox.duration();
 
-    for (auto it = initBox.tracks().begin(); it != initBox.tracks().end(); ++it) {
-        const MockTrackBox& trackBox = *it;
+    for (auto& trackBox : initBox.tracks()) {
         if (trackBox.kind() == MockTrackBox::Video) {
             SourceBufferPrivateClient::InitializationSegment::VideoTrackInformation info;
             info.track = MockVideoTrackPrivate::create(trackBox);
@@ -279,8 +276,6 @@ WTFLogChannel& MockSourceBufferPrivate::logChannel() const
 #endif
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif
 

--- a/Source/WebCore/platform/network/DNS.cpp
+++ b/Source/WebCore/platform/network/DNS.cpp
@@ -31,6 +31,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/MainThread.h>
 #include <wtf/RuntimeApplicationChecks.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/URL.h>
 
 #if PLATFORM(IOS_FAMILY)
@@ -44,8 +45,6 @@
 #if OS(QNX)
 #include <sys/socket.h>
 #endif
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 
@@ -148,17 +147,17 @@ IPAddress IPAddress::isolatedCopy() const
 
 unsigned IPAddress::matchingNetMaskLength(const IPAddress& other) const
 {
-    const unsigned char* addressData = nullptr;
-    const unsigned char* otherAddressData = nullptr;
+    std::span<const uint8_t> addressData;
+    std::span<const uint8_t> otherAddressData;
     size_t addressLengthInBytes = 0;
     if (isIPv4() && other.isIPv4()) {
         addressLengthInBytes = sizeof(struct in_addr);
-        addressData = reinterpret_cast<const unsigned char*>(&ipv4Address());
-        otherAddressData = reinterpret_cast<const unsigned char*>(&other.ipv4Address());
+        addressData = asByteSpan(ipv4Address());
+        otherAddressData = asByteSpan(other.ipv4Address());
     } else if (isIPv6() && other.isIPv6()) {
         addressLengthInBytes = sizeof(struct in6_addr);
-        addressData = reinterpret_cast<const unsigned char*>(&ipv6Address());
-        otherAddressData = reinterpret_cast<const unsigned char*>(&other.ipv6Address());
+        addressData = asByteSpan(ipv6Address());
+        otherAddressData = asByteSpan(other.ipv6Address());
     } else
         return 0;
 
@@ -182,5 +181,3 @@ unsigned IPAddress::matchingNetMaskLength(const IPAddress& other) const
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/network/FormDataBuilder.cpp
+++ b/Source/WebCore/platform/network/FormDataBuilder.cpp
@@ -34,8 +34,6 @@
 #include <wtf/text/CString.h>
 #include <wtf/text/StringView.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 namespace FormDataBuilder {
@@ -130,7 +128,7 @@ Vector<uint8_t> generateUniqueBoundaryString()
     // Note that our algorithm makes it twice as much likely for 'A' or 'B'
     // to appear in the boundary string, because 0x41 and 0x42 are present in
     // the below array twice.
-    static const char alphaNumericEncodingMap[64] = {
+    static constexpr std::array<char, 64> alphaNumericEncodingMap {
         0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48,
         0x49, 0x4A, 0x4B, 0x4C, 0x4D, 0x4E, 0x4F, 0x50,
         0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58,
@@ -221,5 +219,3 @@ void encodeStringAsFormData(Vector<uint8_t>& buffer, const CString& string)
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/network/HTTPHeaderMap.cpp
+++ b/Source/WebCore/platform/network/HTTPHeaderMap.cpp
@@ -37,13 +37,9 @@
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringView.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
-HTTPHeaderMap::HTTPHeaderMap()
-{
-}
+HTTPHeaderMap::HTTPHeaderMap() = default;
 
 HTTPHeaderMap::HTTPHeaderMap(CommonHeadersVector&& commonHeaders, UncommonHeadersVector&& uncommonHeaders)
     : m_commonHeaders(WTFMove(commonHeaders))
@@ -90,12 +86,12 @@ void HTTPHeaderMap::set(CFStringRef name, const String& value)
 {
     // Fast path: avoid constructing a temporary String in the common header case.
     if (auto* nameCharacters = CFStringGetCStringPtr(name, kCFStringEncodingASCII)) {
-        unsigned length = CFStringGetLength(name);
+        auto asciiCharacters = unsafeMakeSpan(nameCharacters, CFStringGetLength(name));
         HTTPHeaderName headerName;
-        if (findHTTPHeaderName(StringView(std::span { nameCharacters, length }), headerName))
+        if (findHTTPHeaderName(StringView(asciiCharacters), headerName))
             set(headerName, value);
         else
-            setUncommonHeader(String({ nameCharacters, length }), value);
+            setUncommonHeader(String(asciiCharacters), value);
 
         return;
     }
@@ -245,5 +241,3 @@ void HTTPHeaderMap::add(HTTPHeaderName name, const String& value)
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/network/HTTPHeaderMap.h
+++ b/Source/WebCore/platform/network/HTTPHeaderMap.h
@@ -30,8 +30,6 @@
 #include <utility>
 #include <wtf/text/WTFString.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 // FIXME: Not every header fits into a map. Notably, multiple Set-Cookie header fields are needed to set multiple cookies.
@@ -91,6 +89,7 @@ public:
         const KeyValue& operator*() const { return *get(); }
         const KeyValue* operator->() const { return get(); }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         HTTPHeaderMapConstIterator& operator++()
         {
             if (m_commonHeadersIt != m_table.m_commonHeaders.end()) {
@@ -102,6 +101,7 @@ public:
             updateKeyValue(m_uncommonHeadersIt);
             return *this;
         }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
         bool operator==(const HTTPHeaderMapConstIterator& other) const
         {
@@ -217,5 +217,3 @@ private:
 };
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/network/RFC8941.cpp
+++ b/Source/WebCore/platform/network/RFC8941.cpp
@@ -33,8 +33,6 @@
 #include <wtf/text/StringParsingBuffer.h>
 #include <wtf/text/StringView.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace RFC8941 {
 
 using namespace WebCore;
@@ -54,10 +52,10 @@ template<typename CharType> static StringView parseKey(StringParsingBuffer<CharT
 {
     if (buffer.atEnd() || !isASCIILower(*buffer))
         return { };
-    auto keyStart = buffer.position();
+    auto keyStart = buffer.span();
     ++buffer;
     skipUntil<isEndOfKey>(buffer);
-    return std::span(keyStart, buffer.position() - keyStart);
+    return keyStart.first(buffer.position() - keyStart.data());
 }
 
 // Parsing a String (https://datatracker.ietf.org/doc/html/rfc8941#section-4.2.5).
@@ -92,9 +90,9 @@ template<typename CharType> static std::optional<Token> parseToken(StringParsing
 {
     if (buffer.atEnd() || (!isASCIIAlpha(*buffer) && *buffer != '*'))
         return std::nullopt;
-    auto tokenStart = buffer.position();
+    auto tokenStart = buffer.span();
     skipUntil<isEndOfToken>(buffer);
-    return Token { String({ tokenStart, buffer.position() }) };
+    return Token { String(tokenStart.first(buffer.position() - tokenStart.data())) };
 }
 
 // Parsing a Boolean (https://datatracker.ietf.org/doc/html/rfc8941#section-4.2.8).
@@ -276,5 +274,3 @@ std::optional<HashMap<String, std::pair<ItemOrInnerList, Parameters>>> parseDict
 }
 
 } // namespace RFC8941
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### 832b877945ec8bcddd235de47f3a1c6d50efaf4d
<pre>
Further reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/platform
<a href="https://bugs.webkit.org/show_bug.cgi?id=283865">https://bugs.webkit.org/show_bug.cgi?id=283865</a>

Reviewed by Darin Adler.

* Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp:
(WebCore::MockSourceBufferPrivate::didReceiveInitializationSegment):
* Source/WebCore/platform/network/BlobRegistryImpl.cpp:
(WebCore::BlobRegistryImpl::appendStorageItems):
* Source/WebCore/platform/network/DNS.cpp:
(WebCore::IPAddress::matchingNetMaskLength const):
* Source/WebCore/platform/network/FormDataBuilder.cpp:
(WebCore::FormDataBuilder::generateUniqueBoundaryString):
* Source/WebCore/platform/network/HTTPHeaderMap.cpp:
(WebCore::HTTPHeaderMap::set):
* Source/WebCore/platform/network/HTTPHeaderMap.h:
* Source/WebCore/platform/network/HTTPParsers.cpp:
(WebCore::parseHTTPHeader):
* Source/WebCore/platform/network/RFC8941.cpp:
(RFC8941::parseKey):
(RFC8941::parseToken):

Canonical link: <a href="https://commits.webkit.org/287191@main">https://commits.webkit.org/287191@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/732f6222bd588ce77bb89947f39bf0784ccefa6a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78737 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57781 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32119 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83397 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29999 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80870 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66933 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6062 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61669 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19590 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81804 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51699 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/71007 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41977 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49045 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25727 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28339 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70153 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26110 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84766 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6102 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4219 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69895 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6264 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67683 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69148 "Found 1 new API test failure: /TestWebKit:WebKit.WillSendSubmitEvent (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13183 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11791 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12153 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6047 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/11956 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6033 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9469 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7821 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->