### PR TITLE
Add virtual destructor to StyleRuleBase

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/RefCntblBaseVirtualDtorExpectations
+++ b/Source/WebCore/SaferCPPExpectations/RefCntblBaseVirtualDtorExpectations
@@ -9,7 +9,6 @@ css/CSSBorderImageWidthValue.h
 css/CSSCanvasValue.h
 css/CSSColorSchemeValue.h
 css/CSSContentDistributionValue.h
-css/CSSCounterStyleRule.h
 css/CSSCounterValue.h
 css/CSSCrossfadeValue.h
 css/CSSCursorImageValue.h
@@ -33,8 +32,6 @@ css/CSSGridTemplateAreasValue.h
 css/CSSImageSetOptionValue.h
 css/CSSImageSetValue.h
 css/CSSImageValue.h
-css/CSSKeyframeRule.h
-css/CSSKeyframesRule.h
 css/CSSLineBoxContainValue.h
 css/CSSNamedImageValue.h
 css/CSSOffsetRotateValue.h
@@ -55,14 +52,11 @@ css/CSSUnicodeRangeValue.h
 css/CSSValueList.h
 css/CSSValuePair.h
 css/CSSVariableReferenceValue.h
-css/CSSViewTransitionRule.h
 css/CSSViewValue.h
 css/DOMMatrix.h
 css/DeprecatedCSSOMPrimitiveValue.h
 css/DeprecatedCSSOMValue.h
 css/DeprecatedCSSOMValueList.h
-css/StyleRule.h
-css/StyleRuleImport.h
 css/calc/CSSCalcValue.h
 dom/DOMPoint.h
 dom/DOMRect.h

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -53,7 +53,8 @@
 namespace WebCore {
 
 struct SameSizeAsStyleRuleBase : public WTF::RefCountedBase {
-    unsigned bitfields : 5;
+    unsigned bitfields : 6;
+    void* vptr;
 };
 
 static_assert(sizeof(StyleRuleBase) == sizeof(SameSizeAsStyleRuleBase), "StyleRuleBase should stay small");

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -55,6 +55,8 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleRuleBase);
 class StyleRuleBase : public RefCounted<StyleRuleBase> {
     WTF_MAKE_STRUCT_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(StyleRuleBase);
 public:
+    virtual ~StyleRuleBase() = default;
+
     StyleRuleType type() const { return static_cast<StyleRuleType>(m_type); }
     
     bool isCharsetRule() const { return type() == StyleRuleType::Charset; }


### PR DESCRIPTION
#### 2dc2d4729ca6cc0aa7887b613482a31d427761f3
<pre>
Add virtual destructor to StyleRuleBase
<a href="https://rdar.apple.com/140739786">rdar://140739786</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=283864">https://bugs.webkit.org/show_bug.cgi?id=283864</a>

Reviewed by NOBODY (OOPS!).

Safer C++ check points out that StyleRuleBase is a base class, yet its
destructor is not virtual.

* Source/WebCore/SaferCPPExpectations/RefCntblBaseVirtualDtorExpectations:
  remove Safer C++ exception.
* Source/WebCore/css/StyleRule.cpp: increase maximum size of StyleRuleBase to
  16 bytes, now that it has to accomodate a pointer to the vtable.
* Source/WebCore/css/StyleRule.h: add virtual destructor to StyleRuleBase.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2dc2d4729ca6cc0aa7887b613482a31d427761f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78755 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57799 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32137 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83415 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30017 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80888 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66951 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6080 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61679 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19601 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81822 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51714 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/71223 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41986 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49060 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25780 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28357 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70170 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26181 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84784 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6120 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4239 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69904 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6282 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67699 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69157 "Found 1 new API test failure: /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/test-page-list (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13199 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11850 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6065 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/11968 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6050 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9487 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7839 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->