### PR TITLE
Deploy smart pointer in ScrollingTreeScrollingNodeDelegate

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -60,7 +60,6 @@ page/WheelEventTestMonitor.h
 page/scrolling/ScrollLatchingController.h
 page/scrolling/ScrollingCoordinator.h
 page/scrolling/ScrollingTreeGestureState.h
-page/scrolling/ScrollingTreeScrollingNodeDelegate.h
 page/scrolling/mac/ScrollerMac.h
 platform/PODInterval.h
 platform/encryptedmedia/CDMProxy.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -966,7 +966,6 @@ page/scrolling/ScrollingThread.cpp
 page/scrolling/ScrollingTree.cpp
 page/scrolling/ScrollingTree.h
 page/scrolling/ScrollingTreeGestureState.cpp
-page/scrolling/ScrollingTreeScrollingNodeDelegate.h
 page/scrolling/ThreadedScrollingCoordinator.cpp
 page/scrolling/mac/ScrollerMac.mm
 page/scrolling/mac/ScrollingCoordinatorMac.mm

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.cpp
@@ -50,22 +50,22 @@ RefPtr<ScrollingTree> ScrollingTreeScrollingNodeDelegate::scrollingTree() const
 
 FloatPoint ScrollingTreeScrollingNodeDelegate::lastCommittedScrollPosition() const
 {
-    return m_scrollingNode.lastCommittedScrollPosition();
+    return protectedScrollingNode()->lastCommittedScrollPosition();
 }
 
 FloatSize ScrollingTreeScrollingNodeDelegate::totalContentsSize()
 {
-    return m_scrollingNode.totalContentsSize();
+    return protectedScrollingNode()->totalContentsSize();
 }
 
 FloatSize ScrollingTreeScrollingNodeDelegate::reachableContentsSize()
 {
-    return m_scrollingNode.reachableContentsSize();
+    return protectedScrollingNode()->reachableContentsSize();
 }
 
 IntPoint ScrollingTreeScrollingNodeDelegate::scrollOrigin() const
 {
-    return m_scrollingNode.scrollOrigin();
+    return protectedScrollingNode()->scrollOrigin();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
@@ -39,9 +39,9 @@ public:
     WEBCORE_EXPORT explicit ScrollingTreeScrollingNodeDelegate(ScrollingTreeScrollingNode&);
     WEBCORE_EXPORT virtual ~ScrollingTreeScrollingNodeDelegate();
 
-    ScrollingTreeScrollingNode& scrollingNode() { return m_scrollingNode; }
-    const ScrollingTreeScrollingNode& scrollingNode() const { return m_scrollingNode; }
-    Ref<ScrollingTreeScrollingNode> protectedScrollingNode() const { return m_scrollingNode; }
+    RefPtr<ScrollingTreeScrollingNode> protectedScrollingNode() const { return m_scrollingNode.get(); }
+    ScrollingTreeScrollingNode& scrollingNode() { return  *protectedScrollingNode().get(); }
+    const ScrollingTreeScrollingNode& scrollingNode() const { return  *protectedScrollingNode().get(); }
     
     virtual bool startAnimatedScrollToPosition(FloatPoint) = 0;
     virtual void stopAnimatedScroll() = 0;
@@ -72,21 +72,21 @@ protected:
     WEBCORE_EXPORT FloatSize reachableContentsSize();
     WEBCORE_EXPORT IntPoint scrollOrigin() const;
 
-    FloatPoint currentScrollPosition() const { return m_scrollingNode.currentScrollPosition(); }
-    FloatPoint minimumScrollPosition() const { return m_scrollingNode.minimumScrollPosition(); }
-    FloatPoint maximumScrollPosition() const { return m_scrollingNode.maximumScrollPosition(); }
+    FloatPoint currentScrollPosition() const { return protectedScrollingNode()->currentScrollPosition(); }
+    FloatPoint minimumScrollPosition() const { return protectedScrollingNode()->minimumScrollPosition(); }
+    FloatPoint maximumScrollPosition() const { return protectedScrollingNode()->maximumScrollPosition(); }
 
-    FloatSize scrollableAreaSize() const { return m_scrollingNode.scrollableAreaSize(); }
-    FloatSize totalContentsSize() const { return m_scrollingNode.totalContentsSize(); }
+    FloatSize scrollableAreaSize() const { return protectedScrollingNode()->scrollableAreaSize(); }
+    FloatSize totalContentsSize() const { return protectedScrollingNode()->totalContentsSize(); }
 
-    bool allowsHorizontalScrolling() const { return m_scrollingNode.allowsHorizontalScrolling(); }
-    bool allowsVerticalScrolling() const { return m_scrollingNode.allowsVerticalScrolling(); }
+    bool allowsHorizontalScrolling() const { return protectedScrollingNode()->allowsHorizontalScrolling(); }
+    bool allowsVerticalScrolling() const { return protectedScrollingNode()->allowsVerticalScrolling(); }
 
-    ScrollElasticity horizontalScrollElasticity() const { return m_scrollingNode.horizontalScrollElasticity(); }
-    ScrollElasticity verticalScrollElasticity() const { return m_scrollingNode.verticalScrollElasticity(); }
+    ScrollElasticity horizontalScrollElasticity() const { return protectedScrollingNode()->horizontalScrollElasticity(); }
+    ScrollElasticity verticalScrollElasticity() const { return protectedScrollingNode()->verticalScrollElasticity(); }
 
 private:
-    ScrollingTreeScrollingNode& m_scrollingNode; // FIXME : Should use a smart pointer.
+    ThreadSafeWeakPtr<ScrollingTreeScrollingNode> m_scrollingNode; // m_scrollingNode is expected never be null
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 3dfccb26ff7f0e04cc9ce362331e805eff58d171
<pre>
Deploy smart pointer in ScrollingTreeScrollingNodeDelegate
<a href="https://bugs.webkit.org/show_bug.cgi?id=283868">https://bugs.webkit.org/show_bug.cgi?id=283868</a>

Reviewed by Chris Dumez.

Deploy smart pointer in ScrollingTreeScrollingNodeDelegate

* Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.cpp:
(WebCore::ScrollingTreeScrollingNodeDelegate::lastCommittedScrollPosition const):
(WebCore::ScrollingTreeScrollingNodeDelegate::totalContentsSize):
(WebCore::ScrollingTreeScrollingNodeDelegate::reachableContentsSize):
(WebCore::ScrollingTreeScrollingNodeDelegate::scrollOrigin const):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h:
(WebCore::ScrollingTreeScrollingNodeDelegate::currentScrollPosition const):
(WebCore::ScrollingTreeScrollingNodeDelegate::minimumScrollPosition const):
(WebCore::ScrollingTreeScrollingNodeDelegate::maximumScrollPosition const):
(WebCore::ScrollingTreeScrollingNodeDelegate::scrollableAreaSize const):
(WebCore::ScrollingTreeScrollingNodeDelegate::totalContentsSize const):
(WebCore::ScrollingTreeScrollingNodeDelegate::allowsHorizontalScrolling const):
(WebCore::ScrollingTreeScrollingNodeDelegate::allowsVerticalScrolling const):
(WebCore::ScrollingTreeScrollingNodeDelegate::horizontalScrollElasticity const):
(WebCore::ScrollingTreeScrollingNodeDelegate::verticalScrollElasticity const):
* Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/292555@main">https://commits.webkit.org/292555@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8bdd7fb5192beccceb88cd262cf5a51b9066e8a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96415 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16029 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6042 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101483 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46934 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98460 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16325 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24462 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73493 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30723 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99418 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12262 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87129 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53830 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12018 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4899 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46262 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82127 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4995 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103510 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23482 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17104 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82540 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23733 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83155 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81913 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20553 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26551 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4016 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16909 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23445 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28600 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23104 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26584 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24845 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->