### PR TITLE
Deploy smart pointer in Page.h

### DIFF
--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -798,7 +798,7 @@ public:
 #endif
 
     void setDebugger(JSC::Debugger*);
-    JSC::Debugger* debugger() const { return m_debugger; }
+    JSC::Debugger* debugger() const { return m_debugger.get(); }
 
     WEBCORE_EXPORT void invalidateStylesForAllLinks();
     WEBCORE_EXPORT void invalidateStylesForLink(SharedStringHash);
@@ -1423,8 +1423,7 @@ private:
     std::unique_ptr<PageGroup> m_singlePageGroup;
     WeakPtr<PageGroup> m_group;
 
-    JSC::Debugger* m_debugger { nullptr }; // FIXME: Use a smart pointer.
-
+    RefPtr<JSC::Debugger> m_debugger;
     bool m_canStartMedia { true };
     bool m_imageAnimationEnabled { true };
     // Elements containing animations that are individually playing (potentially overriding the page-wide m_imageAnimationEnabled state).


### PR DESCRIPTION
#### 285e99c6286e7a0e7c3dd3c04c3f11fefc35eaf2
<pre>
Deploy smart pointer in Page.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=283869">https://bugs.webkit.org/show_bug.cgi?id=283869</a>

Reviewed by NOBODY (OOPS!).

Deploy smart pointer in Page.h

* Source/WebCore/page/Page.h:
(WebCore::Page::debugger const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/285e99c6286e7a0e7c3dd3c04c3f11fefc35eaf2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78747 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57791 "Hash 285e99c6 for PR 37289 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32129 "Hash 285e99c6 for PR 37289 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83407 "Hash 285e99c6 for PR 37289 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30009 "Hash 285e99c6 for PR 37289 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80880 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66943 "Hash 285e99c6 for PR 37289 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6072 "Hash 285e99c6 for PR 37289 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/83407 "Hash 285e99c6 for PR 37289 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/30009 "Hash 285e99c6 for PR 37289 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81814 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/66943 "Hash 285e99c6 for PR 37289 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/32129 "Hash 285e99c6 for PR 37289 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/83407 "Hash 285e99c6 for PR 37289 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/66943 "Hash 285e99c6 for PR 37289 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/32129 "Hash 285e99c6 for PR 37289 does not build (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28349 "Hash 285e99c6 for PR 37289 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/66943 "Hash 285e99c6 for PR 37289 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/32129 "Hash 285e99c6 for PR 37289 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84776 "Hash 285e99c6 for PR 37289 does not build (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6112 "Hash 285e99c6 for PR 37289 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/6072 "Hash 285e99c6 for PR 37289 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/84776 "Hash 285e99c6 for PR 37289 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6274 "Hash 285e99c6 for PR 37289 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/32129 "Hash 285e99c6 for PR 37289 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/84776 "Hash 285e99c6 for PR 37289 does not build (failure)") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/32129 "Hash 285e99c6 for PR 37289 does not build (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6057 "Hash 285e99c6 for PR 37289 does not build (failure)") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/11963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6043 "Hash 285e99c6 for PR 37289 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9479 "Hash 285e99c6 for PR 37289 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7831 "Hash 285e99c6 for PR 37289 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->