### PR TITLE
Generate aliases for Constant<CSSValueIDs> type used by CSS/Style values

### DIFF
--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+ColorAdjust.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+ColorAdjust.cpp
@@ -61,7 +61,7 @@ std::optional<CSS::ColorScheme> consumeUnresolvedColorScheme(CSSParserTokenRange
     if (range.peek().id() == CSSValueOnly) {
         range.consumeIncludingWhitespace();
 
-        result->only = CSS::Only { };
+        result->only = CSS::Keyword::Only { };
     }
 
     while (!range.atEnd()) {
@@ -83,7 +83,7 @@ std::optional<CSS::ColorScheme> consumeUnresolvedColorScheme(CSSParserTokenRange
             if (result->only)
                 return { };
             range.consumeIncludingWhitespace();
-            result->only = CSS::Only { };
+            result->only = CSS::Keyword::Only { };
 
             if (!range.atEnd())
                 return { };

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp
@@ -385,14 +385,14 @@ template<CSSValueID Name> static RefPtr<CSSValue> consumePrefixedLinearGradient(
     // see https://www.w3.org/TR/2011/WD-css3-images-20110217/#linear-gradients.
 
     static constexpr std::pair<CSSValueID, CSS::Vertical> verticalMappings[] {
-        { CSSValueTop, CSS::Vertical { CSS::Top { } } },
-        { CSSValueBottom, CSS::Vertical { CSS::Bottom { } } },
+        { CSSValueTop, CSS::Vertical { CSS::Keyword::Top { } } },
+        { CSSValueBottom, CSS::Vertical { CSS::Keyword::Bottom { } } },
     };
     static constexpr SortedArrayMap verticalMap { verticalMappings };
 
     static constexpr std::pair<CSSValueID, CSS::Horizontal> horizontalMappings[] {
-        { CSSValueLeft, CSS::Horizontal { CSS::Left { } } },
-        { CSSValueRight, CSS::Horizontal { CSS::Right { } } },
+        { CSSValueLeft, CSS::Horizontal { CSS::Keyword::Left { } } },
+        { CSSValueRight, CSS::Horizontal { CSS::Keyword::Right { } } },
     };
     static constexpr SortedArrayMap horizontalMap { horizontalMappings };
 
@@ -412,16 +412,16 @@ template<CSSValueID Name> static RefPtr<CSSValue> consumePrefixedLinearGradient(
         switch (range.peek().id()) {
         case CSSValueLeft:
             range.consumeIncludingWhitespace();
-            return consumeKeywordGradientLineKnownHorizontal(range, CSS::Horizontal { CSS::Left { } });
+            return consumeKeywordGradientLineKnownHorizontal(range, CSS::Horizontal { CSS::Keyword::Left { } });
         case CSSValueRight:
             range.consumeIncludingWhitespace();
-            return consumeKeywordGradientLineKnownHorizontal(range, CSS::Horizontal { CSS::Right { } });
+            return consumeKeywordGradientLineKnownHorizontal(range, CSS::Horizontal { CSS::Keyword::Right { } });
         case CSSValueTop:
             range.consumeIncludingWhitespace();
-            return consumeKeywordGradientLineKnownVertical(range, CSS::Vertical { CSS::Top { } });
+            return consumeKeywordGradientLineKnownVertical(range, CSS::Vertical { CSS::Keyword::Top { } });
         case CSSValueBottom:
             range.consumeIncludingWhitespace();
-            return consumeKeywordGradientLineKnownVertical(range, CSS::Vertical { CSS::Bottom { } });
+            return consumeKeywordGradientLineKnownVertical(range, CSS::Vertical { CSS::Keyword::Bottom { } });
         default:
             return { };
         }
@@ -453,7 +453,7 @@ template<CSSValueID Name> static RefPtr<CSSValue> consumePrefixedLinearGradient(
         CSS::FunctionNotation<Name, CSS::PrefixedLinearGradient> {
             .parameters = {
                 .colorInterpolationMethod = CSS::GradientColorInterpolationMethod::legacyMethod(AlphaPremultiplication::Premultiplied),
-                .gradientLine = gradientLine.value_or(CSS::Vertical { CSS::Top { } }),
+                .gradientLine = gradientLine.value_or(CSS::Vertical { CSS::Keyword::Top { } }),
                 .stops = WTFMove(*stops)
             }
         }
@@ -484,12 +484,12 @@ template<CSSValueID Name> static RefPtr<CSSValue> consumePrefixedRadialGradient(
     static constexpr SortedArrayMap shapeMap { shapeMappings };
 
     static constexpr std::pair<CSSValueID, CSS::PrefixedRadialGradient::Extent> extentMappings[] {
-        { CSSValueContain, CSS::PrefixedRadialGradient::Extent { CSS::Contain { } } },
-        { CSSValueCover, CSS::PrefixedRadialGradient::Extent { CSS::Cover { } } },
-        { CSSValueClosestSide, CSS::PrefixedRadialGradient::Extent { CSS::ClosestSide { } } },
-        { CSSValueClosestCorner, CSS::PrefixedRadialGradient::Extent { CSS::ClosestCorner { } } },
-        { CSSValueFarthestSide, CSS::PrefixedRadialGradient::Extent { CSS::FarthestSide { } } },
-        { CSSValueFarthestCorner, CSS::PrefixedRadialGradient::Extent { CSS::FarthestCorner { } } },
+        { CSSValueContain, CSS::PrefixedRadialGradient::Extent { CSS::Keyword::Contain { } } },
+        { CSSValueCover, CSS::PrefixedRadialGradient::Extent { CSS::Keyword::Cover { } } },
+        { CSSValueClosestSide, CSS::PrefixedRadialGradient::Extent { CSS::Keyword::ClosestSide { } } },
+        { CSSValueClosestCorner, CSS::PrefixedRadialGradient::Extent { CSS::Keyword::ClosestCorner { } } },
+        { CSSValueFarthestSide, CSS::PrefixedRadialGradient::Extent { CSS::Keyword::FarthestSide { } } },
+        { CSSValueFarthestCorner, CSS::PrefixedRadialGradient::Extent { CSS::Keyword::FarthestCorner { } } },
     };
     static constexpr SortedArrayMap extentMap { extentMappings };
 
@@ -609,14 +609,14 @@ template<CSSValueID Name> static RefPtr<CSSValue> consumeLinearGradient(CSSParse
     // )
 
     static constexpr std::pair<CSSValueID, CSS::Vertical> verticalMappings[] {
-        { CSSValueTop, CSS::Vertical { CSS::Top { } } },
-        { CSSValueBottom, CSS::Vertical { CSS::Bottom { } } },
+        { CSSValueTop, CSS::Vertical { CSS::Keyword::Top { } } },
+        { CSSValueBottom, CSS::Vertical { CSS::Keyword::Bottom { } } },
     };
     static constexpr SortedArrayMap verticalMap { verticalMappings };
 
     static constexpr std::pair<CSSValueID, CSS::Horizontal> horizontalMappings[] {
-        { CSSValueLeft, CSS::Horizontal { CSS::Left { } } },
-        { CSSValueRight, CSS::Horizontal { CSS::Right { } } },
+        { CSSValueLeft, CSS::Horizontal { CSS::Keyword::Left { } } },
+        { CSSValueRight, CSS::Horizontal { CSS::Keyword::Right { } } },
     };
     static constexpr SortedArrayMap horizontalMap { horizontalMappings };
 
@@ -639,16 +639,16 @@ template<CSSValueID Name> static RefPtr<CSSValue> consumeLinearGradient(CSSParse
         switch (range.peek().id()) {
         case CSSValueLeft:
             range.consumeIncludingWhitespace();
-            return consumeKeywordGradientLineKnownHorizontal(range, CSS::Horizontal { CSS::Left { } });
+            return consumeKeywordGradientLineKnownHorizontal(range, CSS::Horizontal { CSS::Keyword::Left { } });
         case CSSValueRight:
             range.consumeIncludingWhitespace();
-            return consumeKeywordGradientLineKnownHorizontal(range, CSS::Horizontal { CSS::Right { } });
+            return consumeKeywordGradientLineKnownHorizontal(range, CSS::Horizontal { CSS::Keyword::Right { } });
         case CSSValueTop:
             range.consumeIncludingWhitespace();
-            return consumeKeywordGradientLineKnownVertical(range, CSS::Vertical { CSS::Top { } });
+            return consumeKeywordGradientLineKnownVertical(range, CSS::Vertical { CSS::Keyword::Top { } });
         case CSSValueBottom:
             range.consumeIncludingWhitespace();
-            return consumeKeywordGradientLineKnownVertical(range, CSS::Vertical { CSS::Bottom { } });
+            return consumeKeywordGradientLineKnownVertical(range, CSS::Vertical { CSS::Keyword::Bottom { } });
         default:
             return { };
         }
@@ -700,7 +700,7 @@ template<CSSValueID Name> static RefPtr<CSSValue> consumeLinearGradient(CSSParse
         CSS::FunctionNotation<Name, CSS::LinearGradient> {
             .parameters = {
                 .colorInterpolationMethod = computedColorInterpolationMethod,
-                .gradientLine = gradientLine.value_or(CSS::Vertical { CSS::Bottom { } }),
+                .gradientLine = gradientLine.value_or(CSS::Vertical { CSS::Keyword::Bottom { } }),
                 .stops = WTFMove(*stops)
             }
         }
@@ -724,14 +724,14 @@ template<CSSValueID Name> static RefPtr<CSSValue> consumeRadialGradient(CSSParse
     static constexpr SortedArrayMap shapeMap { shapeMappings };
 
     static constexpr std::pair<CSSValueID, CSS::RadialGradient::Extent> extentMappings[] {
-        { CSSValueClosestSide, CSS::RadialGradient::Extent { CSS::ClosestSide { } } },
-        { CSSValueClosestCorner, CSS::RadialGradient::Extent { CSS::ClosestCorner { } } },
-        { CSSValueFarthestSide, CSS::RadialGradient::Extent { CSS::FarthestSide { } } },
-        { CSSValueFarthestCorner, CSS::RadialGradient::Extent { CSS::FarthestCorner { } } },
+        { CSSValueClosestSide, CSS::RadialGradient::Extent { CSS::Keyword::ClosestSide { } } },
+        { CSSValueClosestCorner, CSS::RadialGradient::Extent { CSS::Keyword::ClosestCorner { } } },
+        { CSSValueFarthestSide, CSS::RadialGradient::Extent { CSS::Keyword::FarthestSide { } } },
+        { CSSValueFarthestCorner, CSS::RadialGradient::Extent { CSS::Keyword::FarthestCorner { } } },
     };
     static constexpr SortedArrayMap extentMap { extentMappings };
 
-    static constexpr auto defaultExtent = CSS::RadialGradient::Extent { CSS::FarthestCorner { } };
+    static constexpr auto defaultExtent = CSS::RadialGradient::Extent { CSS::Keyword::FarthestCorner { } };
 
     std::optional<ColorInterpolationMethod> colorInterpolationMethod;
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Motion.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Motion.cpp
@@ -54,11 +54,11 @@ static RefPtr<CSSValue> consumeRayFunction(CSSParserTokenRange& range, const CSS
     // https://drafts.fxtf.org/motion-1/#ray-function
 
     static constexpr std::pair<CSSValueID, CSS::RaySize> sizeMappings[] {
-        { CSSValueClosestSide, CSS::RaySize { CSS::ClosestSide { } } },
-        { CSSValueClosestCorner, CSS::RaySize { CSS::ClosestCorner { } } },
-        { CSSValueFarthestSide, CSS::RaySize { CSS::FarthestSide { } } },
-        { CSSValueFarthestCorner, CSS::RaySize { CSS::FarthestCorner { } } },
-        { CSSValueSides, CSS::RaySize { CSS::Sides { } } },
+        { CSSValueClosestSide, CSS::RaySize { CSS::Keyword::ClosestSide { } } },
+        { CSSValueClosestCorner, CSS::RaySize { CSS::Keyword::ClosestCorner { } } },
+        { CSSValueFarthestSide, CSS::RaySize { CSS::Keyword::FarthestSide { } } },
+        { CSSValueFarthestCorner, CSS::RaySize { CSS::Keyword::FarthestCorner { } } },
+        { CSSValueSides, CSS::RaySize { CSS::Keyword::Sides { } } },
     };
     static constexpr SortedArrayMap sizeMap { sizeMappings };
 
@@ -69,7 +69,7 @@ static RefPtr<CSSValue> consumeRayFunction(CSSParserTokenRange& range, const CSS
 
     std::optional<CSS::Angle<>> angle;
     std::optional<CSS::RaySize> size;
-    std::optional<CSS::Contain> contain;
+    std::optional<CSS::Keyword::Contain> contain;
     std::optional<CSS::Position> position;
 
     auto consumeAngle = [&] -> bool {
@@ -87,7 +87,7 @@ static RefPtr<CSSValue> consumeRayFunction(CSSParserTokenRange& range, const CSS
     auto consumeContain = [&] -> bool {
         if (contain || !consumeIdentRaw<CSSValueContain>(args).has_value())
             return false;
-        contain = CSS::Contain { };
+        contain = CSS::Keyword::Contain { };
         return contain.has_value();
     };
     auto consumeAtPosition = [&] -> bool {
@@ -111,7 +111,7 @@ static RefPtr<CSSValue> consumeRayFunction(CSSParserTokenRange& range, const CSS
         CSS::RayFunction {
             .parameters = CSS::Ray {
                 WTFMove(*angle),
-                size.value_or(CSS::RaySize { CSS::ClosestSide { } }),
+                size.value_or(CSS::RaySize { CSS::Keyword::ClosestSide { } }),
                 WTFMove(contain),
                 WTFMove(position)
             }

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Position.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Position.cpp
@@ -282,7 +282,7 @@ RefPtr<CSSValue> consumePositionY(CSSParserTokenRange& range, const CSSParserCon
 
 // MARK: Unresolved Position
 
-using PositionUnresolvedComponent = std::variant<CSS::Left, CSS::Right, CSS::Top, CSS::Bottom, CSS::Center, CSS::LengthPercentage<>>;
+using PositionUnresolvedComponent = std::variant<CSS::Keyword::Left, CSS::Keyword::Right, CSS::Keyword::Top, CSS::Keyword::Bottom, CSS::Keyword::Center, CSS::LengthPercentage<>>;
 
 static std::optional<PositionUnresolvedComponent> consumePositionUnresolvedComponent(CSSParserTokenRange& range, const CSSParserContext& context)
 {
@@ -290,19 +290,19 @@ static std::optional<PositionUnresolvedComponent> consumePositionUnresolvedCompo
         switch (range.peek().id()) {
         case CSSValueLeft:
             range.consumeIncludingWhitespace();
-            return PositionUnresolvedComponent { CSS::Left { } };
+            return PositionUnresolvedComponent { CSS::Keyword::Left { } };
         case CSSValueRight:
             range.consumeIncludingWhitespace();
-            return PositionUnresolvedComponent { CSS::Right { } };
+            return PositionUnresolvedComponent { CSS::Keyword::Right { } };
         case CSSValueBottom:
             range.consumeIncludingWhitespace();
-            return PositionUnresolvedComponent { CSS::Bottom { } };
+            return PositionUnresolvedComponent { CSS::Keyword::Bottom { } };
         case CSSValueTop:
             range.consumeIncludingWhitespace();
-            return PositionUnresolvedComponent { CSS::Top { } };
+            return PositionUnresolvedComponent { CSS::Keyword::Top { } };
         case CSSValueCenter:
             range.consumeIncludingWhitespace();
-            return PositionUnresolvedComponent { CSS::Center { } };
+            return PositionUnresolvedComponent { CSS::Keyword::Center { } };
         default:
             return std::nullopt;
         }
@@ -323,13 +323,13 @@ std::optional<CSS::TwoComponentPositionHorizontal> consumeTwoComponentPositionHo
         switch (range.peek().id()) {
         case CSSValueLeft:
             range.consumeIncludingWhitespace();
-            return CSS::TwoComponentPositionHorizontal { CSS::Left { } };
+            return CSS::TwoComponentPositionHorizontal { CSS::Keyword::Left { } };
         case CSSValueRight:
             range.consumeIncludingWhitespace();
-            return CSS::TwoComponentPositionHorizontal { CSS::Right { } };
+            return CSS::TwoComponentPositionHorizontal { CSS::Keyword::Right { } };
         case CSSValueCenter:
             range.consumeIncludingWhitespace();
-            return CSS::TwoComponentPositionHorizontal { CSS::Center { } };
+            return CSS::TwoComponentPositionHorizontal { CSS::Keyword::Center { } };
         default:
             return std::nullopt;
         }
@@ -350,13 +350,13 @@ std::optional<CSS::TwoComponentPositionVertical> consumeTwoComponentPositionVert
         switch (range.peek().id()) {
         case CSSValueBottom:
             range.consumeIncludingWhitespace();
-            return CSS::TwoComponentPositionVertical { CSS::Bottom { } };
+            return CSS::TwoComponentPositionVertical { CSS::Keyword::Bottom { } };
         case CSSValueTop:
             range.consumeIncludingWhitespace();
-            return CSS::TwoComponentPositionVertical { CSS::Top { } };
+            return CSS::TwoComponentPositionVertical { CSS::Keyword::Top { } };
         case CSSValueCenter:
             range.consumeIncludingWhitespace();
-            return CSS::TwoComponentPositionVertical { CSS::Center { } };
+            return CSS::TwoComponentPositionVertical { CSS::Keyword::Center { } };
         default:
             return std::nullopt;
         }
@@ -373,34 +373,34 @@ std::optional<CSS::TwoComponentPositionVertical> consumeTwoComponentPositionVert
 
 static bool isHorizontalPositionKeywordOnly(const PositionUnresolvedComponent& component)
 {
-    return std::holds_alternative<CSS::Left>(component) || std::holds_alternative<CSS::Right>(component);
+    return std::holds_alternative<CSS::Keyword::Left>(component) || std::holds_alternative<CSS::Keyword::Right>(component);
 }
 
 static bool isVerticalPositionKeywordOnly(const PositionUnresolvedComponent& component)
 {
-    return std::holds_alternative<CSS::Top>(component) || std::holds_alternative<CSS::Bottom>(component);
+    return std::holds_alternative<CSS::Keyword::Top>(component) || std::holds_alternative<CSS::Keyword::Bottom>(component);
 }
 
 static CSS::Position positionUnresolvedFromOneComponent(PositionUnresolvedComponent&& component)
 {
     return WTF::switchOn(WTFMove(component),
-        [](CSS::Left&& component) {
-            return CSS::TwoComponentPosition { { WTFMove(component) }, { CSS::Center { } } };
+        [](CSS::Keyword::Left&& component) {
+            return CSS::TwoComponentPosition { { WTFMove(component) }, { CSS::Keyword::Center { } } };
         },
-        [](CSS::Right&& component) {
-            return CSS::TwoComponentPosition { { WTFMove(component) }, { CSS::Center { } } };
+        [](CSS::Keyword::Right&& component) {
+            return CSS::TwoComponentPosition { { WTFMove(component) }, { CSS::Keyword::Center { } } };
         },
-        [](CSS::Top&& component) {
-            return CSS::TwoComponentPosition { { CSS::Center { } }, { WTFMove(component) } };
+        [](CSS::Keyword::Top&& component) {
+            return CSS::TwoComponentPosition { { CSS::Keyword::Center { } }, { WTFMove(component) } };
         },
-        [](CSS::Bottom&& component) {
-            return CSS::TwoComponentPosition { { CSS::Center { } }, { WTFMove(component) } };
+        [](CSS::Keyword::Bottom&& component) {
+            return CSS::TwoComponentPosition { { CSS::Keyword::Center { } }, { WTFMove(component) } };
         },
-        [](CSS::Center&&) {
-            return CSS::TwoComponentPosition { { CSS::Center { } }, { CSS::Center { } } };
+        [](CSS::Keyword::Center&&) {
+            return CSS::TwoComponentPosition { { CSS::Keyword::Center { } }, { CSS::Keyword::Center { } } };
         },
         [](CSS::LengthPercentage<>&& component) {
-            return CSS::TwoComponentPosition { { WTFMove(component) }, { CSS::Center { } } };
+            return CSS::TwoComponentPosition { { WTFMove(component) }, { CSS::Keyword::Center { } } };
         }
     );
 }
@@ -408,13 +408,13 @@ static CSS::Position positionUnresolvedFromOneComponent(PositionUnresolvedCompon
 static CSS::TwoComponentPositionHorizontal toTwoComponentPositionHorizontal(PositionUnresolvedComponent&& component)
 {
     return WTF::switchOn(WTFMove(component),
-        [](CSS::Top&&) {
+        [](CSS::Keyword::Top&&) {
             ASSERT_NOT_REACHED();
-            return CSS::TwoComponentPositionHorizontal { CSS::Center { } };
+            return CSS::TwoComponentPositionHorizontal { CSS::Keyword::Center { } };
         },
-        [](CSS::Bottom&&) {
+        [](CSS::Keyword::Bottom&&) {
             ASSERT_NOT_REACHED();
-            return CSS::TwoComponentPositionHorizontal { CSS::Center { } };
+            return CSS::TwoComponentPositionHorizontal { CSS::Keyword::Center { } };
         },
         [](auto&& component) {
             return CSS::TwoComponentPositionHorizontal { WTFMove(component) };
@@ -425,13 +425,13 @@ static CSS::TwoComponentPositionHorizontal toTwoComponentPositionHorizontal(Posi
 static CSS::TwoComponentPositionVertical toTwoComponentPositionVertical(PositionUnresolvedComponent&& component)
 {
     return WTF::switchOn(WTFMove(component),
-        [](CSS::Left&&) {
+        [](CSS::Keyword::Left&&) {
             ASSERT_NOT_REACHED();
-            return CSS::TwoComponentPositionVertical { CSS::Center { } };
+            return CSS::TwoComponentPositionVertical { CSS::Keyword::Center { } };
         },
-        [](CSS::Right&&) {
+        [](CSS::Keyword::Right&&) {
             ASSERT_NOT_REACHED();
-            return CSS::TwoComponentPositionVertical { CSS::Center { } };
+            return CSS::TwoComponentPositionVertical { CSS::Keyword::Center { } };
         },
         [](auto&& component) {
             return CSS::TwoComponentPositionVertical { WTFMove(component) };
@@ -456,27 +456,27 @@ static std::optional<CSS::Position> positionUnresolvedFromFourComponents(Positio
     std::optional<CSS::FourComponentPositionVertical> vertical;
 
     WTF::switchOn(WTFMove(component1),
-        [&](CSS::Left&& component) {
+        [&](CSS::Keyword::Left&& component) {
             if (!std::holds_alternative<CSS::LengthPercentage<>>(component2))
                 return;
             horizontal = CSS::FourComponentPositionHorizontal { component, std::get<CSS::LengthPercentage<>>(component2) };
         },
-        [&](CSS::Right&& component) {
+        [&](CSS::Keyword::Right&& component) {
             if (!std::holds_alternative<CSS::LengthPercentage<>>(component2))
                 return;
             horizontal = CSS::FourComponentPositionHorizontal { component, std::get<CSS::LengthPercentage<>>(component2) };
         },
-        [&](CSS::Top&& component) {
+        [&](CSS::Keyword::Top&& component) {
             if (!std::holds_alternative<CSS::LengthPercentage<>>(component2))
                 return;
             vertical = CSS::FourComponentPositionVertical { component, std::get<CSS::LengthPercentage<>>(component2) };
         },
-        [&](CSS::Bottom&& component) {
+        [&](CSS::Keyword::Bottom&& component) {
             if (!std::holds_alternative<CSS::LengthPercentage<>>(component2))
                 return;
             vertical = CSS::FourComponentPositionVertical { component, std::get<CSS::LengthPercentage<>>(component2) };
         },
-        [&](CSS::Center&&) { },
+        [&](CSS::Keyword::Center&&) { },
         [&](CSS::LengthPercentage<>&&) { }
     );
 
@@ -484,27 +484,27 @@ static std::optional<CSS::Position> positionUnresolvedFromFourComponents(Positio
         return std::nullopt;
 
     WTF::switchOn(WTFMove(component3),
-        [&](CSS::Left&& component) {
+        [&](CSS::Keyword::Left&& component) {
             if (horizontal || !std::holds_alternative<CSS::LengthPercentage<>>(component4))
                 return;
             horizontal = CSS::FourComponentPositionHorizontal { component, std::get<CSS::LengthPercentage<>>(component4) };
         },
-        [&](CSS::Right&& component) {
+        [&](CSS::Keyword::Right&& component) {
             if (horizontal || !std::holds_alternative<CSS::LengthPercentage<>>(component4))
                 return;
             horizontal = CSS::FourComponentPositionHorizontal { component, std::get<CSS::LengthPercentage<>>(component4) };
         },
-        [&](CSS::Top&& component) {
+        [&](CSS::Keyword::Top&& component) {
             if (vertical || !std::holds_alternative<CSS::LengthPercentage<>>(component4))
                 return;
             vertical = CSS::FourComponentPositionVertical { component, std::get<CSS::LengthPercentage<>>(component4) };
         },
-        [&](CSS::Bottom&& component) {
+        [&](CSS::Keyword::Bottom&& component) {
             if (vertical || !std::holds_alternative<CSS::LengthPercentage<>>(component4))
                 return;
             vertical = CSS::FourComponentPositionVertical { component, std::get<CSS::LengthPercentage<>>(component4) };
         },
-        [&](CSS::Center&&) { },
+        [&](CSS::Keyword::Center&&) { },
         [&](CSS::LengthPercentage<>&&) { }
     );
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Shapes.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Shapes.cpp
@@ -65,8 +65,8 @@ static std::optional<CSS::FillRule> peekFillRule(CSSParserTokenRange& range)
     // https://svgwg.org/svg2-draft/painting.html#FillRuleProperty
 
     static constexpr std::pair<CSSValueID, CSS::FillRule> fillRuleMappings[] {
-        { CSSValueNonzero, CSS::FillRule { CSS::Nonzero { } } },
-        { CSSValueEvenodd, CSS::FillRule { CSS::Evenodd { } } },
+        { CSSValueNonzero, CSS::FillRule { CSS::Keyword::Nonzero { } } },
+        { CSSValueEvenodd, CSS::FillRule { CSS::Keyword::Evenodd { } } },
     };
     static constexpr SortedArrayMap fillRuleMap { fillRuleMappings };
 
@@ -117,9 +117,9 @@ static std::optional<CSS::RelativeControlPoint> consumeRelativeControlPoint(CSSP
     using Anchor = CSS::RelativeControlPoint::Anchor;
 
     static constexpr std::pair<CSSValueID, Anchor> anchorMappings[] {
-        { CSSValueStart, Anchor { CSS::Start { } } },
-        { CSSValueEnd, Anchor { CSS::End { } } },
-        { CSSValueOrigin, Anchor { CSS::Origin { } } },
+        { CSSValueStart, Anchor { CSS::Keyword::Start { } } },
+        { CSSValueEnd, Anchor { CSS::Keyword::End { } } },
+        { CSSValueOrigin, Anchor { CSS::Keyword::Origin { } } },
     };
     static constexpr SortedArrayMap anchorMap { anchorMappings };
 
@@ -186,17 +186,17 @@ static CSS::Circle::RadialSize consumeCircleRadialSize(CSSParserTokenRange& rang
     // Default to `closest-side` if no radial-size is provided.
 
     static constexpr std::pair<CSSValueID, CSS::Circle::Extent> extentMappings[] {
-        { CSSValueClosestSide, CSS::Circle::Extent { CSS::ClosestSide { } } },
-        { CSSValueClosestCorner, CSS::Circle::Extent { CSS::ClosestCorner { } } },
-        { CSSValueFarthestSide, CSS::Circle::Extent { CSS::FarthestSide { } } },
-        { CSSValueFarthestCorner, CSS::Circle::Extent { CSS::FarthestCorner { } } },
+        { CSSValueClosestSide, CSS::Circle::Extent { CSS::Keyword::ClosestSide { } } },
+        { CSSValueClosestCorner, CSS::Circle::Extent { CSS::Keyword::ClosestCorner { } } },
+        { CSSValueFarthestSide, CSS::Circle::Extent { CSS::Keyword::FarthestSide { } } },
+        { CSSValueFarthestCorner, CSS::Circle::Extent { CSS::Keyword::FarthestCorner { } } },
     };
     static constexpr SortedArrayMap extentMap { extentMappings };
 
     // Default to `closest-side` if no radial-size is provided.
     // FIXME: The spec says that `farthest-corner` should be the default, but this does not match the tests.
     auto defaultValue = [] {
-        return CSS::Circle::RadialSize { CSS::Circle::Extent { CSS::ClosestSide { } } };
+        return CSS::Circle::RadialSize { CSS::Circle::Extent { CSS::Keyword::ClosestSide { } } };
     };
 
     if (range.peek().type() == IdentToken) {
@@ -249,10 +249,10 @@ static std::optional<CSS::Ellipse::RadialSize> consumeEllipseRadialSize(CSSParse
     // Default to `closest-side` if no radial-size is provided.
 
     static constexpr std::pair<CSSValueID, CSS::Ellipse::Extent> extentMappings[] {
-        { CSSValueClosestSide, CSS::Ellipse::Extent { CSS::ClosestSide { } } },
-        { CSSValueClosestCorner, CSS::Ellipse::Extent { CSS::ClosestCorner { } } },
-        { CSSValueFarthestSide, CSS::Ellipse::Extent { CSS::FarthestSide { } } },
-        { CSSValueFarthestCorner, CSS::Ellipse::Extent { CSS::FarthestCorner { } } },
+        { CSSValueClosestSide, CSS::Ellipse::Extent { CSS::Keyword::ClosestSide { } } },
+        { CSSValueClosestCorner, CSS::Ellipse::Extent { CSS::Keyword::ClosestCorner { } } },
+        { CSSValueFarthestSide, CSS::Ellipse::Extent { CSS::Keyword::FarthestSide { } } },
+        { CSSValueFarthestCorner, CSS::Ellipse::Extent { CSS::Keyword::FarthestCorner { } } },
     };
     static constexpr SortedArrayMap extentMap { extentMappings };
 
@@ -297,8 +297,8 @@ static std::optional<CSS::Ellipse> consumeBasicShapeEllipseFunctionParameters(CS
         }
 
         return CSS::SpaceSeparatedPair<CSS::Ellipse::RadialSize> {
-            CSS::Ellipse::RadialSize { CSS::Ellipse::Extent { CSS::ClosestSide { } } },
-            CSS::Ellipse::RadialSize { CSS::Ellipse::Extent { CSS::ClosestSide { } } }
+            CSS::Ellipse::RadialSize { CSS::Ellipse::Extent { CSS::Keyword::ClosestSide { } } },
+            CSS::Ellipse::RadialSize { CSS::Ellipse::Extent { CSS::Keyword::ClosestSide { } } }
         };
     };
     auto radii = consumeRadialSizePair();
@@ -390,8 +390,8 @@ static std::optional<CSS::CommandAffinity> consumeShapeCommandAffinity(CSSParser
     // https://drafts.csswg.org/css-shapes-2/#typedef-shape-by-to
 
     static constexpr std::pair<CSSValueID, CSS::CommandAffinity> affinityMappings[] {
-        { CSSValueTo, CSS::CommandAffinity { CSS::To { } } },
-        { CSSValueBy, CSS::CommandAffinity { CSS::By { } } },
+        { CSSValueTo, CSS::CommandAffinity { CSS::Keyword::To { } } },
+        { CSSValueBy, CSS::CommandAffinity { CSS::Keyword::By { } } },
     };
     static constexpr SortedArrayMap affinityMap { affinityMappings };
 
@@ -409,7 +409,7 @@ static std::optional<CSS::MoveCommand> consumeShapeMoveCommand(CSSParserTokenRan
         return { };
 
     return WTF::switchOn(*affinity,
-        [&](CSS::To) -> std::optional<CSS::MoveCommand> {
+        [&](CSS::Keyword::To) -> std::optional<CSS::MoveCommand> {
             auto position = consumePositionUnresolved(range, context);
             if (!position)
                 return std::nullopt;
@@ -417,7 +417,7 @@ static std::optional<CSS::MoveCommand> consumeShapeMoveCommand(CSSParserTokenRan
                 .toBy = CSS::MoveCommand::To { .offset = WTFMove(*position) }
             };
         },
-        [&](CSS::By) -> std::optional<CSS::MoveCommand> {
+        [&](CSS::Keyword::By) -> std::optional<CSS::MoveCommand> {
             auto coordinatePair = consumeCoordinatePair(range, context);
             if (!coordinatePair)
                 return std::nullopt;
@@ -439,7 +439,7 @@ static std::optional<CSS::LineCommand> consumeShapeLineCommand(CSSParserTokenRan
         return { };
 
     return WTF::switchOn(*affinity,
-        [&](CSS::To) -> std::optional<CSS::LineCommand> {
+        [&](CSS::Keyword::To) -> std::optional<CSS::LineCommand> {
             auto position = consumePositionUnresolved(range, context);
             if (!position)
                 return { };
@@ -447,7 +447,7 @@ static std::optional<CSS::LineCommand> consumeShapeLineCommand(CSSParserTokenRan
                 .toBy = CSS::LineCommand::To { .offset = WTFMove(*position) }
             };
         },
-        [&](CSS::By) -> std::optional<CSS::LineCommand> {
+        [&](CSS::Keyword::By) -> std::optional<CSS::LineCommand> {
             auto coordinatePair = consumeCoordinatePair(range, context);
             if (!coordinatePair)
                 return { };
@@ -468,7 +468,7 @@ static std::optional<CSS::HLineCommand> consumeShapeHLineCommand(CSSParserTokenR
         return { };
 
     return WTF::switchOn(*affinity,
-        [&](CSS::To) -> std::optional<CSS::HLineCommand> {
+        [&](CSS::Keyword::To) -> std::optional<CSS::HLineCommand> {
             auto offset = consumeTwoComponentPositionHorizontalUnresolved(range, context);
             if (!offset)
                 return { };
@@ -476,7 +476,7 @@ static std::optional<CSS::HLineCommand> consumeShapeHLineCommand(CSSParserTokenR
                 .toBy = CSS::HLineCommand::To { .offset = WTFMove(*offset) }
             };
         },
-        [&](CSS::By) -> std::optional<CSS::HLineCommand> {
+        [&](CSS::Keyword::By) -> std::optional<CSS::HLineCommand> {
             const auto options = CSSPropertyParserOptions {
                 .parserMode = context.mode,
                 .unitlessZero = UnitlessZeroQuirk::Allow
@@ -501,7 +501,7 @@ static std::optional<CSS::VLineCommand> consumeShapeVLineCommand(CSSParserTokenR
         return { };
 
     return WTF::switchOn(*affinity,
-        [&](CSS::To) -> std::optional<CSS::VLineCommand> {
+        [&](CSS::Keyword::To) -> std::optional<CSS::VLineCommand> {
             auto offset = consumeTwoComponentPositionVerticalUnresolved(range, context);
             if (!offset)
                 return { };
@@ -509,7 +509,7 @@ static std::optional<CSS::VLineCommand> consumeShapeVLineCommand(CSSParserTokenR
                 .toBy = CSS::VLineCommand::To { .offset = WTFMove(*offset) }
             };
         },
-        [&](CSS::By) -> std::optional<CSS::VLineCommand> {
+        [&](CSS::Keyword::By) -> std::optional<CSS::VLineCommand> {
             const auto options = CSSPropertyParserOptions {
                 .parserMode = context.mode,
                 .unitlessZero = UnitlessZeroQuirk::Allow
@@ -536,7 +536,7 @@ static std::optional<CSS::CurveCommand> consumeShapeCurveCommand(CSSParserTokenR
         return { };
 
     return WTF::switchOn(*affinity,
-        [&](CSS::To) -> std::optional<CSS::CurveCommand> {
+        [&](CSS::Keyword::To) -> std::optional<CSS::CurveCommand> {
             auto position = consumePositionUnresolved(range, context);
             if (!position)
                 return { };
@@ -570,7 +570,7 @@ static std::optional<CSS::CurveCommand> consumeShapeCurveCommand(CSSParserTokenR
                 };
             }
         },
-        [&](CSS::By) -> std::optional<CSS::CurveCommand> {
+        [&](CSS::Keyword::By) -> std::optional<CSS::CurveCommand> {
             auto coordinatePair = consumeCoordinatePair(range, context);
             if (!coordinatePair)
                 return { };
@@ -619,7 +619,7 @@ static std::optional<CSS::SmoothCommand> consumeShapeSmoothCommand(CSSParserToke
         return { };
 
     return WTF::switchOn(*affinity,
-        [&](CSS::To) -> std::optional<CSS::SmoothCommand> {
+        [&](CSS::Keyword::To) -> std::optional<CSS::SmoothCommand> {
             auto position = consumePositionUnresolved(range, context);
             if (!position)
                 return { };
@@ -644,7 +644,7 @@ static std::optional<CSS::SmoothCommand> consumeShapeSmoothCommand(CSSParserToke
                 };
             }
         },
-        [&](CSS::By) -> std::optional<CSS::SmoothCommand> {
+        [&](CSS::Keyword::By) -> std::optional<CSS::SmoothCommand> {
             auto coordinatePair = consumeCoordinatePair(range, context);
             if (!coordinatePair)
                 return { };
@@ -684,13 +684,13 @@ static std::optional<CSS::ArcCommand> consumeShapeArcCommand(CSSParserTokenRange
 
     using ToBy = std::variant<CSS::ArcCommand::To, CSS::ArcCommand::By>;
     auto toBy = WTF::switchOn(*affinity,
-        [&](CSS::To) -> std::optional<ToBy> {
+        [&](CSS::Keyword::To) -> std::optional<ToBy> {
             auto position = consumePositionUnresolved(range, context);
             if (!position)
                 return { };
             return ToBy { CSS::ArcCommand::To { WTFMove(*position) } };
         },
-        [&](CSS::By) -> std::optional<ToBy> {
+        [&](CSS::Keyword::By) -> std::optional<ToBy> {
             auto coordinatePair = consumeCoordinatePair(range, context);
             if (!coordinatePair)
                 return { };
@@ -731,24 +731,24 @@ static std::optional<CSS::ArcCommand> consumeShapeArcCommand(CSSParserTokenRange
         case CSSValueCw:
             if (arcSweep)
                 return { };
-            arcSweep = CSS::Cw { };
+            arcSweep = CSS::Keyword::Cw { };
             break;
         case CSSValueCcw:
             if (arcSweep)
                 return { };
-            arcSweep = CSS::Ccw { };
+            arcSweep = CSS::Keyword::Ccw { };
             break;
 
         case CSSValueLarge:
             if (arcSize)
                 return { };
-            arcSize = CSS::Large { };
+            arcSize = CSS::Keyword::Large { };
             break;
 
         case CSSValueSmall:
             if (arcSize)
                 return { };
-            arcSize = CSS::Small { };
+            arcSize = CSS::Keyword::Small { };
             break;
 
         case CSSValueRotate:
@@ -768,8 +768,8 @@ static std::optional<CSS::ArcCommand> consumeShapeArcCommand(CSSParserTokenRange
     return CSS::ArcCommand {
         .toBy = WTFMove(*toBy),
         .size = { WTFMove(*length1), WTFMove(*length2) },
-        .arcSweep = arcSweep.value_or(CSS::ArcSweep { CSS::Ccw { } }),
-        .arcSize = arcSize.value_or(CSS::ArcSize { CSS::Small { } }),
+        .arcSweep = arcSweep.value_or(CSS::ArcSweep { CSS::Keyword::Ccw { } }),
+        .arcSize = arcSize.value_or(CSS::ArcSize { CSS::Keyword::Small { } }),
         .rotation = angle.value_or(CSS::Angle<> { CSS::AngleRaw<> { CSSUnitType::CSS_DEG, 0 } })
     };
 }
@@ -872,7 +872,7 @@ static std::optional<CSS::Rect::Edge> consumeBasicShapeRectEdge(CSSParserTokenRa
     if (args.peek().type() == IdentToken) {
         if (args.peek().id() == CSSValueAuto) {
             args.consumeIncludingWhitespace();
-            return { CSS::Auto { } };
+            return { CSS::Keyword::Auto { } };
         }
         return { };
     }

--- a/Source/WebCore/css/process-css-values.py
+++ b/Source/WebCore/css/process-css-values.py
@@ -358,8 +358,21 @@ class GenerationContext:
             };
             constexpr AllCSSValueKeywordsRange allCSSValueKeywords() { return { }; }
 
-            } // namespace WebCore
             """))
+
+    def _generate_css_value_keywords_h_constant_aliases(self, *, to):
+        to.write(f"template<CSSValueID C> struct Constant {{\n")
+        to.write(f"    static constexpr auto value = C;\n")
+        to.write(f"    constexpr bool operator==(const Constant<C>&) const = default;\n")
+        to.write(f"}};\n\n")
+
+        to.write(f"namespace CSS::Keyword {{\n\n")
+
+        for value in self.values:
+            to.write(f"using {value.id_without_prefix} = Constant<{value.id_without_scope}>;\n")
+
+        to.write(f"\n}} // namespace CSS::Keyword\n")
+        to.write(f"}} // namespace WebCore\n\n")
 
     def _generate_css_value_keywords_h_hash_traits(self, *, to):
         to.write(textwrap.dedent("""
@@ -395,6 +408,10 @@ class GenerationContext:
             )
 
             self._generate_css_value_keywords_h_forward_declarations(
+                to=output_file
+            )
+
+            self._generate_css_value_keywords_h_constant_aliases(
                 to=output_file
             )
 

--- a/Source/WebCore/css/values/CSSValueTypes.h
+++ b/Source/WebCore/css/values/CSSValueTypes.h
@@ -57,13 +57,6 @@ template<class> inline constexpr bool TreatAsTypeWrapper = false;
     template<> inline constexpr bool TreatAsTypeWrapper<t> = true; \
     template<size_t> const auto& get(const t& value) { return value.name; }
 
-// Helper type used to represent a known constant identifier.
-template<CSSValueID C> struct Constant {
-    static constexpr auto value = C;
-
-    constexpr bool operator==(const Constant<C>&) const = default;
-};
-
 // Helper type used to represent an arbitrary constant identifier.
 struct CustomIdentifier {
     AtomString value;

--- a/Source/WebCore/css/values/color-adjust/CSSColorScheme.cpp
+++ b/Source/WebCore/css/values/color-adjust/CSSColorScheme.cpp
@@ -37,7 +37,7 @@ namespace CSS {
 void Serialize<ColorScheme>::operator()(StringBuilder& builder, const ColorScheme& value)
 {
     if (value.isNormal()) {
-        serializationForCSS(builder, Constant<CSSValueNormal> { });
+        serializationForCSS(builder, Keyword::Normal { });
         return;
     }
 

--- a/Source/WebCore/css/values/color-adjust/CSSColorScheme.h
+++ b/Source/WebCore/css/values/color-adjust/CSSColorScheme.h
@@ -35,13 +35,11 @@
 namespace WebCore {
 namespace CSS {
 
-using Only = Constant<CSSValueOnly>;
-
 // <'color-scheme'> = normal | [ light | dark | <custom-ident> ]+ && only?
 // https://drafts.csswg.org/css-color-adjust/#propdef-color-scheme
 struct ColorScheme {
     SpaceSeparatedVector<CustomIdentifier> schemes;
-    std::optional<Only> only;
+    std::optional<Keyword::Only> only;
 
     // As an optimization, if `schemes` is empty, that indicates the
     // entire value should be considered `normal`.

--- a/Source/WebCore/css/values/images/CSSGradient.cpp
+++ b/Source/WebCore/css/values/images/CSSGradient.cpp
@@ -172,7 +172,7 @@ static bool appendColorInterpolationMethod(StringBuilder& builder, CSS::Gradient
             }
             return false;
         },
-        [&]<typename MethodColorSpace> (const MethodColorSpace& methodColorSpace) {
+        [&]<typename MethodColorSpace>(const MethodColorSpace& methodColorSpace) {
             builder.append(needsLeadingSpace ? " "_s : ""_s, "in "_s, serializationForCSS(methodColorSpace.interpolationColorSpace));
             if constexpr (hasHueInterpolationMethod<MethodColorSpace>)
                 serializationForCSS(builder, methodColorSpace.hueInterpolationMethod);
@@ -209,7 +209,7 @@ void Serialize<LinearGradient>::operator()(StringBuilder& builder, const LinearG
             wroteSomething = true;
         },
         [&](const Vertical& vertical) {
-            if (std::holds_alternative<Bottom>(vertical))
+            if (std::holds_alternative<Keyword::Bottom>(vertical))
                 return;
 
             builder.append("to "_s);
@@ -266,7 +266,7 @@ void Serialize<RadialGradient::Ellipse>::operator()(StringBuilder& builder, cons
             serializationForCSS(builder, size);
         },
         [&](const RadialGradient::Extent& extent) {
-            if (!std::holds_alternative<FarthestCorner>(extent))
+            if (!std::holds_alternative<Keyword::FarthestCorner>(extent))
                 serializationForCSS(builder, extent);
         }
     );
@@ -290,7 +290,7 @@ void Serialize<RadialGradient::Circle>::operator()(StringBuilder& builder, const
             serializationForCSS(builder, length);
         },
         [&](const RadialGradient::Extent& extent) {
-            if (!std::holds_alternative<FarthestCorner>(extent)) {
+            if (!std::holds_alternative<Keyword::FarthestCorner>(extent)) {
                 builder.append("circle "_s);
                 serializationForCSS(builder, extent);
             } else
@@ -352,7 +352,7 @@ void Serialize<PrefixedRadialGradient::Circle>::operator()(StringBuilder& builde
         builder.append("center"_s);
 
     builder.append(", circle "_s);
-    serializationForCSS(builder, circle.size.value_or(PrefixedRadialGradient::Extent { CSS::Cover { } }));
+    serializationForCSS(builder, circle.size.value_or(PrefixedRadialGradient::Extent { CSS::Keyword::Cover { } }));
 }
 
 void Serialize<PrefixedRadialGradient>::operator()(StringBuilder& builder, const PrefixedRadialGradient& gradient)

--- a/Source/WebCore/css/values/images/CSSGradient.h
+++ b/Source/WebCore/css/values/images/CSSGradient.h
@@ -38,18 +38,11 @@ namespace CSS {
 
 using DeprecatedGradientPosition = SpaceSeparatedArray<NumberOrPercentage<>, 2>;
 
-using Horizontal     = std::variant<Left, Right>;
-using Vertical       = std::variant<Top, Bottom>;
+using Horizontal = std::variant<Keyword::Left, Keyword::Right>;
+using Vertical   = std::variant<Keyword::Top, Keyword::Bottom>;
 
-using ClosestCorner  = Constant<CSSValueClosestCorner>;
-using ClosestSide    = Constant<CSSValueClosestSide>;
-using FarthestCorner = Constant<CSSValueFarthestCorner>;
-using FarthestSide   = Constant<CSSValueFarthestSide>;
-using Contain        = Constant<CSSValueContain>;
-using Cover          = Constant<CSSValueCover>;
-
-using RadialGradientExtent         = std::variant<ClosestCorner, ClosestSide, FarthestCorner, FarthestSide>;
-using PrefixedRadialGradientExtent = std::variant<ClosestCorner, ClosestSide, FarthestCorner, FarthestSide, Contain, Cover>;
+using RadialGradientExtent         = std::variant<Keyword::ClosestCorner, Keyword::ClosestSide, Keyword::FarthestCorner, Keyword::FarthestSide>;
+using PrefixedRadialGradientExtent = std::variant<Keyword::ClosestCorner, Keyword::ClosestSide, Keyword::FarthestCorner, Keyword::FarthestSide, Keyword::Contain, Keyword::Cover>;
 
 // MARK: - Gradient Color Interpolation Definitions.
 

--- a/Source/WebCore/css/values/motion/CSSRayFunction.cpp
+++ b/Source/WebCore/css/values/motion/CSSRayFunction.cpp
@@ -28,8 +28,6 @@
 #include "CSSPrimitiveNumericTypes+CSSValueVisitation.h"
 #include "CSSPrimitiveNumericTypes+ComputedStyleDependencies.h"
 #include "CSSPrimitiveNumericTypes+Serialization.h"
-#include "CSSValueKeywords.h"
-#include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
 namespace CSS {
@@ -41,7 +39,7 @@ void Serialize<Ray>::operator()(StringBuilder& builder, const Ray& value)
 
     serializationForCSS(builder, value.angle);
 
-    if (!std::holds_alternative<ClosestSide>(value.size)) {
+    if (!std::holds_alternative<Keyword::ClosestSide>(value.size)) {
         builder.append(' ');
         serializationForCSS(builder, value.size);
     }

--- a/Source/WebCore/css/values/motion/CSSRayFunction.h
+++ b/Source/WebCore/css/values/motion/CSSRayFunction.h
@@ -30,15 +30,7 @@
 namespace WebCore {
 namespace CSS {
 
-using Contain        = Constant<CSSValueContain>;
-
-using ClosestCorner  = Constant<CSSValueClosestCorner>;
-using ClosestSide    = Constant<CSSValueClosestSide>;
-using FarthestCorner = Constant<CSSValueFarthestCorner>;
-using FarthestSide   = Constant<CSSValueFarthestSide>;
-using Sides          = Constant<CSSValueSides>;
-
-using RaySize        = std::variant<ClosestCorner, ClosestSide, FarthestCorner, FarthestSide, Sides>;
+using RaySize = std::variant<Keyword::ClosestCorner, Keyword::ClosestSide, Keyword::FarthestCorner, Keyword::FarthestSide, Keyword::Sides>;
 
 // ray() = ray( <angle> && <ray-size>? && contain? && [at <position>]? )
 // <ray-size> = closest-side | closest-corner | farthest-side | farthest-corner | sides
@@ -46,7 +38,7 @@ using RaySize        = std::variant<ClosestCorner, ClosestSide, FarthestCorner, 
 struct Ray {
     Angle<> angle;
     RaySize size;
-    std::optional<Contain> contain;
+    std::optional<Keyword::Contain> contain;
     std::optional<Position> position;
 
     bool operator==(const Ray&) const = default;

--- a/Source/WebCore/css/values/primitives/CSSPosition.cpp
+++ b/Source/WebCore/css/values/primitives/CSSPosition.cpp
@@ -32,8 +32,8 @@ bool isCenterPosition(const Position& position)
 {
     auto isCenter = [](const auto& component) {
         return WTF::switchOn(component.offset,
-            [](auto)   { return false; },
-            [](Center) { return true;  },
+            [](auto)            { return false; },
+            [](Keyword::Center) { return true;  },
             [](const LengthPercentage<>& value) {
                 return WTF::switchOn(value,
                     [](const LengthPercentageRaw<>& raw) { return raw.type == CSSUnitType::CSS_PERCENTAGE && raw.value == 50.0; },

--- a/Source/WebCore/css/values/primitives/CSSPosition.h
+++ b/Source/WebCore/css/values/primitives/CSSPosition.h
@@ -29,21 +29,15 @@
 namespace WebCore {
 namespace CSS {
 
-using Left   = Constant<CSSValueLeft>;
-using Right  = Constant<CSSValueRight>;
-using Top    = Constant<CSSValueTop>;
-using Bottom = Constant<CSSValueBottom>;
-using Center = Constant<CSSValueCenter>;
-
 struct TwoComponentPositionHorizontal {
-    std::variant<Left, Right, Center, LengthPercentage<>> offset;
+    std::variant<Keyword::Left, Keyword::Right, Keyword::Center, LengthPercentage<>> offset;
 
     bool operator==(const TwoComponentPositionHorizontal&) const = default;
 };
 DEFINE_CSS_TYPE_WRAPPER(TwoComponentPositionHorizontal, offset);
 
 struct TwoComponentPositionVertical {
-    std::variant<Top, Bottom, Center, LengthPercentage<>> offset;
+    std::variant<Keyword::Top, Keyword::Bottom, Keyword::Center, LengthPercentage<>> offset;
 
     bool operator==(const TwoComponentPositionVertical&) const = default;
 };
@@ -51,8 +45,8 @@ DEFINE_CSS_TYPE_WRAPPER(TwoComponentPositionVertical, offset);
 
 using TwoComponentPosition              = SpaceSeparatedTuple<TwoComponentPositionHorizontal, TwoComponentPositionVertical>;
 
-using FourComponentPositionHorizontal   = SpaceSeparatedTuple<std::variant<Left, Right>, LengthPercentage<>>;
-using FourComponentPositionVertical     = SpaceSeparatedTuple<std::variant<Top, Bottom>, LengthPercentage<>>;
+using FourComponentPositionHorizontal   = SpaceSeparatedTuple<std::variant<Keyword::Left, Keyword::Right>, LengthPercentage<>>;
+using FourComponentPositionVertical     = SpaceSeparatedTuple<std::variant<Keyword::Top, Keyword::Bottom>, LengthPercentage<>>;
 using FourComponentPosition             = SpaceSeparatedTuple<FourComponentPositionHorizontal, FourComponentPositionVertical>;
 
 struct Position {

--- a/Source/WebCore/css/values/shapes/CSSCircleFunction.cpp
+++ b/Source/WebCore/css/values/shapes/CSSCircleFunction.cpp
@@ -36,7 +36,7 @@ static bool hasDefaultValueForCircleRadius(Circle::RadialSize radius)
     return WTF::switchOn(radius,
         [](Circle::Extent extent) {
             // FIXME: The spec says that `farthest-corner` should be the default, but this does not match the tests.
-            return std::holds_alternative<ClosestSide>(extent);
+            return std::holds_alternative<Keyword::ClosestSide>(extent);
         },
         [](const auto&) {
             return false;

--- a/Source/WebCore/css/values/shapes/CSSCircleFunction.h
+++ b/Source/WebCore/css/values/shapes/CSSCircleFunction.h
@@ -34,7 +34,7 @@ namespace CSS {
 // <circle()> = circle( <radial-size>? [ at <position> ]? )
 // https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-circle
 struct Circle {
-    using Extent = std::variant<ClosestCorner, ClosestSide, FarthestCorner, FarthestSide>;
+    using Extent = std::variant<Keyword::ClosestCorner, Keyword::ClosestSide, Keyword::FarthestCorner, Keyword::FarthestSide>;
     // FIXME: The spec says that this should take Length, not a LengthPercentage, but this does not match the tests.
     using Length = CSS::LengthPercentage<Nonnegative>;
     using RadialSize = std::variant<Length, Extent>;

--- a/Source/WebCore/css/values/shapes/CSSEllipseFunction.cpp
+++ b/Source/WebCore/css/values/shapes/CSSEllipseFunction.cpp
@@ -36,7 +36,7 @@ static bool hasDefaultValueForEllipseRadius(Ellipse::RadialSize radius)
     return WTF::switchOn(radius,
         [](Ellipse::Extent extent) {
             // FIXME: The spec says that `farthest-corner` should be the default, but this does not match the tests.
-            return std::holds_alternative<ClosestSide>(extent);
+            return std::holds_alternative<Keyword::ClosestSide>(extent);
         },
         [](const auto&) {
             return false;

--- a/Source/WebCore/css/values/shapes/CSSEllipseFunction.h
+++ b/Source/WebCore/css/values/shapes/CSSEllipseFunction.h
@@ -34,7 +34,7 @@ namespace CSS {
 // <ellipse()> = ellipse( <radial-size>? [ at <position> ]? )
 // https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-ellipse
 struct Ellipse {
-    using Extent = std::variant<ClosestCorner, ClosestSide, FarthestCorner, FarthestSide>;
+    using Extent = std::variant<Keyword::ClosestCorner, Keyword::ClosestSide, Keyword::FarthestCorner, Keyword::FarthestSide>;
     using Length = CSS::LengthPercentage<Nonnegative>;
     using RadialSize = std::variant<Length, Extent>;
 

--- a/Source/WebCore/css/values/shapes/CSSFillRule.h
+++ b/Source/WebCore/css/values/shapes/CSSFillRule.h
@@ -29,10 +29,7 @@
 namespace WebCore {
 namespace CSS {
 
-using Nonzero = Constant<CSSValueNonzero>;
-using Evenodd = Constant<CSSValueEvenodd>;
-
-using FillRule = std::variant<Nonzero, Evenodd>;
+using FillRule = std::variant<Keyword::Nonzero, Keyword::Evenodd>;
 
 } // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/css/values/shapes/CSSPathFunction.cpp
+++ b/Source/WebCore/css/values/shapes/CSSPathFunction.cpp
@@ -38,7 +38,7 @@ void Serialize<Path>::operator()(StringBuilder& builder, const Path& value)
 {
     // <path()> = path( <'fill-rule'>? , <string> )
 
-    if (value.fillRule && !std::holds_alternative<Nonzero>(*value.fillRule)) {
+    if (value.fillRule && !std::holds_alternative<Keyword::Nonzero>(*value.fillRule)) {
         serializationForCSS(builder, *value.fillRule);
         builder.append(", "_s);
     }

--- a/Source/WebCore/css/values/shapes/CSSPolygonFunction.cpp
+++ b/Source/WebCore/css/values/shapes/CSSPolygonFunction.cpp
@@ -37,7 +37,7 @@ void Serialize<Polygon>::operator()(StringBuilder& builder, const Polygon& value
 
     // FIXME: Add support the "round" clause.
 
-    if (value.fillRule && std::holds_alternative<Evenodd>(*value.fillRule)) {
+    if (value.fillRule && std::holds_alternative<CSS::Keyword::Evenodd>(*value.fillRule)) {
         serializationForCSS(builder, *value.fillRule);
         builder.append(", "_s);
     }

--- a/Source/WebCore/css/values/shapes/CSSRectFunction.h
+++ b/Source/WebCore/css/values/shapes/CSSRectFunction.h
@@ -31,12 +31,10 @@
 namespace WebCore {
 namespace CSS {
 
-using Auto = Constant<CSSValueAuto>;
-
 // <rect()> = rect( [ <length-percentage> | auto ]{4} [ round <'border-radius'> ]? )
 // https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-rect
 struct Rect {
-    using Edge = std::variant<LengthPercentage<>, Auto>;
+    using Edge = std::variant<LengthPercentage<>, Keyword::Auto>;
 
     RectEdges<Edge> edges;
     BorderRadius radii;

--- a/Source/WebCore/css/values/shapes/CSSShapeFunction.cpp
+++ b/Source/WebCore/css/values/shapes/CSSShapeFunction.cpp
@@ -224,12 +224,12 @@ void Serialize<ArcCommand>::operator()(StringBuilder& builder, const ArcCommand&
     else
         serializationForCSS(builder, value.size);
 
-    if (!std::holds_alternative<Ccw>(value.arcSweep)) {
+    if (!std::holds_alternative<CSS::Keyword::Ccw>(value.arcSweep)) {
         builder.append(' ');
         serializationForCSS(builder, value.arcSweep);
     }
 
-    if (!std::holds_alternative<Small>(value.arcSize)) {
+    if (!std::holds_alternative<CSS::Keyword::Small>(value.arcSize)) {
         builder.append(' ');
         serializationForCSS(builder, value.arcSize);
     }
@@ -244,7 +244,7 @@ void Serialize<Shape>::operator()(StringBuilder& builder, const Shape& value)
 {
     // shape() = shape( <'fill-rule'>? from <coordinate-pair>, <shape-command>#)
 
-    if (value.fillRule && !std::holds_alternative<Nonzero>(*value.fillRule)) {
+    if (value.fillRule && !std::holds_alternative<Keyword::Nonzero>(*value.fillRule)) {
         serializationForCSS(builder, *value.fillRule);
         builder.append(' ');
     }

--- a/Source/WebCore/css/values/shapes/CSSShapeFunction.h
+++ b/Source/WebCore/css/values/shapes/CSSShapeFunction.h
@@ -37,29 +37,20 @@ using CoordinatePair = Point<LengthPercentage<>>;
 // <by-to> = by | to
 // https://drafts.csswg.org/css-shapes-2/#typedef-shape-by-to
 // Indicates if a command is relative or absolute.
-using By              = Constant<CSSValueBy>;
-using To              = Constant<CSSValueTo>;
-using CommandAffinity = std::variant<By, To>;
+using CommandAffinity = std::variant<Keyword::By, Keyword::To>;
 
 // <arc-sweep> = cw | ccw
-using Cw              = Constant<CSSValueCw>;
-using Ccw             = Constant<CSSValueCcw>;
-using ArcSweep        = std::variant<Cw, Ccw>;
+using ArcSweep        = std::variant<Keyword::Cw, Keyword::Ccw>;
 
 // <arc-size> = large | small
-using Large           = Constant<CSSValueLarge>;
-using Small           = Constant<CSSValueSmall>;
-using ArcSize         = std::variant<Large, Small>;
+using ArcSize         = std::variant<Keyword::Large, Keyword::Small>;
 
 // <control-point-anchor> = start | end | origin
-using Start           = Constant<CSSValueStart>;
-using End             = Constant<CSSValueEnd>;
-using Origin          = Constant<CSSValueOrigin>;
-using ControlPointAnchor = std::variant<CSS::Start, CSS::End, CSS::Origin>;
+using ControlPointAnchor = std::variant<Keyword::Start, Keyword::End, Keyword::Origin>;
 
 // <to-position> = to <position>
 struct ToPosition {
-    static constexpr auto affinity = CSS::To { };
+    static constexpr auto affinity = Keyword::To { };
 
     Position offset;
 
@@ -71,7 +62,7 @@ template<> struct Serialize<ToPosition> { void operator()(StringBuilder&, const 
 
 // <by-coordinate-pair> = by <coordinate-pair>
 struct ByCoordinatePair {
-    static constexpr auto affinity = CSS::By { };
+    static constexpr auto affinity = Keyword::By { };
 
     CoordinatePair offset;
 
@@ -156,14 +147,14 @@ struct HLineCommand {
     static constexpr auto name = CSSValueHline;
 
     struct To {
-        static constexpr auto affinity = CSS::To { };
+        static constexpr auto affinity = Keyword::To { };
 
         TwoComponentPositionHorizontal offset;
 
         bool operator==(const To&) const = default;
     };
     struct By {
-        static constexpr auto affinity = CSS::By { };
+        static constexpr auto affinity = Keyword::By { };
 
         LengthPercentage<> offset;
 
@@ -187,14 +178,14 @@ template<> struct Serialize<HLineCommand> { void operator()(StringBuilder&, cons
 struct VLineCommand {
     static constexpr auto name = CSSValueVline;
     struct To {
-        static constexpr auto affinity = CSS::To { };
+        static constexpr auto affinity = Keyword::To { };
 
         TwoComponentPositionVertical offset;
 
         bool operator==(const To&) const = default;
     };
     struct By {
-        static constexpr auto affinity = CSS::By { };
+        static constexpr auto affinity = Keyword::By { };
 
         LengthPercentage<> offset;
 
@@ -219,7 +210,7 @@ template<> struct Serialize<VLineCommand> { void operator()(StringBuilder&, cons
 struct CurveCommand {
     static constexpr auto name = CSSValueCurve;
     struct To {
-        static constexpr auto affinity = CSS::To { };
+        static constexpr auto affinity = Keyword::To { };
 
         Position offset;
         AbsoluteControlPoint controlPoint1;
@@ -228,7 +219,7 @@ struct CurveCommand {
         bool operator==(const To&) const = default;
     };
     struct By {
-        static constexpr auto affinity = CSS::By { };
+        static constexpr auto affinity = Keyword::By { };
 
         CoordinatePair offset;
         RelativeControlPoint controlPoint1;
@@ -271,7 +262,7 @@ template<> struct Serialize<CurveCommand> { void operator()(StringBuilder&, cons
 struct SmoothCommand {
     static constexpr auto name = CSSValueSmooth;
     struct To {
-        static constexpr auto affinity = CSS::To { };
+        static constexpr auto affinity = Keyword::To { };
 
         Position offset;
         std::optional<AbsoluteControlPoint> controlPoint;
@@ -279,7 +270,7 @@ struct SmoothCommand {
         bool operator==(const To&) const = default;
     };
     struct By {
-        static constexpr auto affinity = CSS::By { };
+        static constexpr auto affinity = Keyword::By { };
 
         CoordinatePair offset;
         std::optional<RelativeControlPoint> controlPoint;
@@ -345,7 +336,7 @@ template<> struct Serialize<ArcCommand> { void operator()(StringBuilder&, const 
 
 // <close> = close
 // https://drafts.csswg.org/css-shapes-2/#valdef-shape-close
-using CloseCommand = Constant<CSSValueClose>;
+using CloseCommand = Keyword::Close;
 
 // <shape-command> = <move-command> | <line-command> | <hv-line-command> | <curve-command> | <smooth-command> | <arc-command> | close
 // https://drafts.csswg.org/css-shapes-2/#typedef-shape-command

--- a/Source/WebCore/rendering/MotionPath.cpp
+++ b/Source/WebCore/rendering/MotionPath.cpp
@@ -178,19 +178,19 @@ static double lengthForRayPath(const Style::Ray& ray, const MotionPathData& data
     auto distances = distanceOfPointToSidesOfRect(boundingBox, data.usedStartingPosition);
 
     return WTF::switchOn(ray.size,
-        [&](Style::ClosestSide) {
+        [&](CSS::Keyword::ClosestSide) {
             return std::min( { distances.top(), distances.bottom(), distances.left(), distances.right() } );
         },
-        [&](Style::FarthestSide) {
+        [&](CSS::Keyword::FarthestSide) {
             return std::max( { distances.top(), distances.bottom(), distances.left(), distances.right() } );
         },
-        [&](Style::FarthestCorner) {
+        [&](CSS::Keyword::FarthestCorner) {
             return std::hypot(std::max(distances.left(), distances.right()), std::max(distances.top(), distances.bottom()));
         },
-        [&](Style::ClosestCorner) {
+        [&](CSS::Keyword::ClosestCorner) {
             return std::hypot(std::min(distances.left(), distances.right()), std::min(distances.top(), distances.bottom()));
         },
-        [&](Style::Sides) {
+        [&](CSS::Keyword::Sides) {
             return lengthOfRayIntersectionWithBoundingBox(boundingBox, std::make_pair(data.usedStartingPosition, ray.angle.value));
         }
     );

--- a/Source/WebCore/style/values/StyleValueTypes.h
+++ b/Source/WebCore/style/values/StyleValueTypes.h
@@ -100,9 +100,6 @@ template<typename CSSType> using PrimaryCSSType = typename ToPrimaryCSSTypeMappi
 
 // MARK: Common Types.
 
-// Helper type used to represent a known constant identifier.
-template<CSSValueID C> using Constant = CSS::Constant<C>;
-
 // Specialize `TreatAsNonConverting` for `Constant<C>`, to indicate that its type does not change from the CSS representation.
 template<CSSValueID C> inline constexpr bool TreatAsNonConverting<Constant<C>> = true;
 

--- a/Source/WebCore/style/values/color-adjust/StyleColorScheme.h
+++ b/Source/WebCore/style/values/color-adjust/StyleColorScheme.h
@@ -37,11 +37,9 @@
 namespace WebCore {
 namespace Style {
 
-using Only = CSS::Only;
-
 struct ColorScheme {
     SpaceSeparatedVector<CustomIdentifier> schemes;
-    std::optional<Only> only;
+    std::optional<CSS::Keyword::Only> only;
 
     // As an optimization, if `schemes` is empty, that indicates the
     // entire value should be considered `normal`.

--- a/Source/WebCore/style/values/images/StyleGradient.cpp
+++ b/Source/WebCore/style/values/images/StyleGradient.cpp
@@ -851,20 +851,20 @@ template<CSSValueID Name> static Ref<WebCore::Gradient> createPlatformGradient(c
         },
         [&](const Horizontal& horizontal) -> std::pair<FloatPoint, FloatPoint> {
             return WTF::switchOn(horizontal,
-                [&](Left) -> std::pair<FloatPoint, FloatPoint> {
+                [&](CSS::Keyword::Left) -> std::pair<FloatPoint, FloatPoint> {
                     return { { size.width(), 0 }, { 0, 0 } };
                 },
-                [&](Right) -> std::pair<FloatPoint, FloatPoint> {
+                [&](CSS::Keyword::Right) -> std::pair<FloatPoint, FloatPoint> {
                     return { { 0, 0 }, { size.width(), 0 } };
                 }
             );
         },
         [&](const Vertical& vertical) -> std::pair<FloatPoint, FloatPoint> {
             return WTF::switchOn(vertical,
-                [&](Top) -> std::pair<FloatPoint, FloatPoint> {
+                [&](CSS::Keyword::Top) -> std::pair<FloatPoint, FloatPoint> {
                     return { { 0, size.height() }, { 0, 0 } };
                 },
-                [&](Bottom) -> std::pair<FloatPoint, FloatPoint> {
+                [&](CSS::Keyword::Bottom) -> std::pair<FloatPoint, FloatPoint> {
                     return { { 0, 0 }, { 0, size.height() } };
                 }
             );
@@ -872,9 +872,9 @@ template<CSSValueID Name> static Ref<WebCore::Gradient> createPlatformGradient(c
         [&](const SpaceSeparatedTuple<Horizontal, Vertical>& pair) -> std::pair<FloatPoint, FloatPoint> {
             float rise = size.width();
             float run = size.height();
-            if (std::holds_alternative<Left>(get<0>(pair)))
+            if (std::holds_alternative<CSS::Keyword::Left>(get<0>(pair)))
                 run *= -1;
-            if (std::holds_alternative<Bottom>(get<1>(pair)))
+            if (std::holds_alternative<CSS::Keyword::Bottom>(get<1>(pair)))
                 rise *= -1;
             // Compute angle, and flip it back to "bearing angle" degrees.
             float angle = 90 - rad2deg(atan2(rise, run));
@@ -901,36 +901,36 @@ template<CSSValueID Name> static Ref<WebCore::Gradient> createPlatformGradient(c
         },
         [&](const Horizontal& horizontal) -> std::pair<FloatPoint, FloatPoint> {
             return WTF::switchOn(horizontal,
-                [&](Left) -> std::pair<FloatPoint, FloatPoint> {
+                [&](CSS::Keyword::Left) -> std::pair<FloatPoint, FloatPoint> {
                     return { { 0, 0 }, { size.width(), 0 } };
                 },
-                [&](Right) -> std::pair<FloatPoint, FloatPoint> {
+                [&](CSS::Keyword::Right) -> std::pair<FloatPoint, FloatPoint> {
                     return { { size.width(), 0 }, { 0, 0 } };
                 }
             );
         },
         [&](const Vertical vertical) -> std::pair<FloatPoint, FloatPoint> {
             return WTF::switchOn(vertical,
-                [&](Top) -> std::pair<FloatPoint, FloatPoint> {
+                [&](CSS::Keyword::Top) -> std::pair<FloatPoint, FloatPoint> {
                     return { { 0, 0 }, { 0, size.height() } };
                 },
-                [&](Bottom) -> std::pair<FloatPoint, FloatPoint> {
+                [&](CSS::Keyword::Bottom) -> std::pair<FloatPoint, FloatPoint> {
                     return { { 0, size.height() }, { 0, 0 } };
                 }
             );
         },
         [&](const SpaceSeparatedTuple<Horizontal, Vertical>& pair) -> std::pair<FloatPoint, FloatPoint> {
             return std::visit(WTF::makeVisitor(
-                [&](Left, Top) -> std::pair<FloatPoint, FloatPoint> {
+                [&](CSS::Keyword::Left, CSS::Keyword::Top) -> std::pair<FloatPoint, FloatPoint> {
                     return { { 0, 0 }, { size.width(), size.height() } };
                 },
-                [&](Left, Bottom) -> std::pair<FloatPoint, FloatPoint> {
+                [&](CSS::Keyword::Left, CSS::Keyword::Bottom) -> std::pair<FloatPoint, FloatPoint> {
                     return { { 0, size.height() }, { size.width(), 0 } };
                 },
-                [&](Right, Top) -> std::pair<FloatPoint, FloatPoint> {
+                [&](CSS::Keyword::Right, CSS::Keyword::Top) -> std::pair<FloatPoint, FloatPoint> {
                     return { { size.width(), 0 }, { 0, size.height() } };
                 },
-                [&](Right, Bottom) -> std::pair<FloatPoint, FloatPoint> {
+                [&](CSS::Keyword::Right, CSS::Keyword::Bottom) -> std::pair<FloatPoint, FloatPoint> {
                     return { { size.width(), size.height() }, { 0, 0 } };
                 }
             ), get<0>(pair), get<1>(pair));
@@ -977,16 +977,16 @@ template<CSSValueID Name> static Ref<WebCore::Gradient> createPlatformGradient(c
             },
             [&](const RadialGradient::Extent& extent) -> std::pair<float, float> {
                 return WTF::switchOn(extent,
-                    [&](ClosestSide) -> std::pair<float, float> {
+                    [&](CSS::Keyword::ClosestSide) -> std::pair<float, float> {
                         return { distanceToClosestSide(centerPoint, size), 1 };
                     },
-                    [&](FarthestSide) -> std::pair<float, float> {
+                    [&](CSS::Keyword::FarthestSide) -> std::pair<float, float> {
                         return { distanceToFarthestSide(centerPoint, size), 1 };
                     },
-                    [&](ClosestCorner) -> std::pair<float, float> {
+                    [&](CSS::Keyword::ClosestCorner) -> std::pair<float, float> {
                         return { distanceToClosestCorner(centerPoint, size), 1 };
                     },
-                    [&](FarthestCorner) -> std::pair<float, float> {
+                    [&](CSS::Keyword::FarthestCorner) -> std::pair<float, float> {
                         return { distanceToFarthestCorner(centerPoint, size), 1 };
                     }
                 );
@@ -1003,17 +1003,17 @@ template<CSSValueID Name> static Ref<WebCore::Gradient> createPlatformGradient(c
             },
             [&](const RadialGradient::Extent& extent) -> std::pair<float, float> {
                 return WTF::switchOn(extent,
-                    [&](ClosestSide) -> std::pair<float, float> {
+                    [&](CSS::Keyword::ClosestSide) -> std::pair<float, float> {
                         float xDist = std::min(centerPoint.x(), size.width() - centerPoint.x());
                         float yDist = std::min(centerPoint.y(), size.height() - centerPoint.y());
                         return { xDist, xDist / yDist };
                     },
-                    [&](FarthestSide) -> std::pair<float, float> {
+                    [&](CSS::Keyword::FarthestSide) -> std::pair<float, float> {
                         float xDist = std::max(centerPoint.x(), size.width() - centerPoint.x());
                         float yDist = std::max(centerPoint.y(), size.height() - centerPoint.y());
                         return { xDist, xDist / yDist };
                     },
-                    [&](ClosestCorner) -> std::pair<float, float> {
+                    [&](CSS::Keyword::ClosestCorner) -> std::pair<float, float> {
                         auto [distance, corner] = findDistanceToClosestCorner(centerPoint, size);
                         // If <shape> is ellipse, the gradient-shape has the same ratio of width to height
                         // that it would if closest-side or farthest-side were specified, as appropriate.
@@ -1021,7 +1021,7 @@ template<CSSValueID Name> static Ref<WebCore::Gradient> createPlatformGradient(c
                         float yDist = std::min(centerPoint.y(), size.height() - centerPoint.y());
                         return { horizontalEllipseRadius(corner - centerPoint, xDist / yDist), xDist / yDist };
                     },
-                    [&](FarthestCorner) -> std::pair<float, float> {
+                    [&](CSS::Keyword::FarthestCorner) -> std::pair<float, float> {
                         auto [distance, corner] = findDistanceToFarthestCorner(centerPoint, size);
                         // If <shape> is ellipse, the gradient-shape has the same ratio of width to height
                         // that it would if closest-side or farthest-side were specified, as appropriate.
@@ -1074,22 +1074,22 @@ template<CSSValueID Name> static Ref<WebCore::Gradient> createPlatformGradient(c
             },
             [&](const PrefixedRadialGradient::Extent& extent) -> std::pair<float, float> {
                 return WTF::switchOn(extent,
-                    [&](ClosestSide) -> std::pair<float, float> {
+                    [&](CSS::Keyword::ClosestSide) -> std::pair<float, float> {
                         float xDist = std::min(centerPoint.x(), size.width() - centerPoint.x());
                         float yDist = std::min(centerPoint.y(), size.height() - centerPoint.y());
                         return { xDist, xDist / yDist };
                     },
-                    [&](Contain) -> std::pair<float, float> {
+                    [&](CSS::Keyword::Contain) -> std::pair<float, float> {
                         float xDist = std::min(centerPoint.x(), size.width() - centerPoint.x());
                         float yDist = std::min(centerPoint.y(), size.height() - centerPoint.y());
                         return { xDist, xDist / yDist };
                     },
-                    [&](FarthestSide) -> std::pair<float, float> {
+                    [&](CSS::Keyword::FarthestSide) -> std::pair<float, float> {
                         float xDist = std::max(centerPoint.x(), size.width() - centerPoint.x());
                         float yDist = std::max(centerPoint.y(), size.height() - centerPoint.y());
                         return { xDist, xDist / yDist };
                     },
-                    [&](ClosestCorner) -> std::pair<float, float> {
+                    [&](CSS::Keyword::ClosestCorner) -> std::pair<float, float> {
                         auto [distance, corner] = findDistanceToClosestCorner(centerPoint, size);
                         // If <shape> is ellipse, the gradient-shape has the same ratio of width to height
                         // that it would if closest-side or farthest-side were specified, as appropriate.
@@ -1097,7 +1097,7 @@ template<CSSValueID Name> static Ref<WebCore::Gradient> createPlatformGradient(c
                         float yDist = std::min(centerPoint.y(), size.height() - centerPoint.y());
                         return { horizontalEllipseRadius(corner - centerPoint, xDist / yDist), xDist / yDist };
                     },
-                    [&](FarthestCorner) -> std::pair<float, float> {
+                    [&](CSS::Keyword::FarthestCorner) -> std::pair<float, float> {
                         auto [distance, corner] = findDistanceToFarthestCorner(centerPoint, size);
                         // If <shape> is ellipse, the gradient-shape has the same ratio of width to height
                         // that it would if closest-side or farthest-side were specified, as appropriate.
@@ -1105,7 +1105,7 @@ template<CSSValueID Name> static Ref<WebCore::Gradient> createPlatformGradient(c
                         float yDist = std::max(centerPoint.y(), size.height() - centerPoint.y());
                         return { horizontalEllipseRadius(corner - centerPoint, xDist / yDist), xDist / yDist };
                     },
-                    [&](Cover) -> std::pair<float, float> {
+                    [&](CSS::Keyword::Cover) -> std::pair<float, float> {
                         auto [distance, corner] = findDistanceToFarthestCorner(centerPoint, size);
                         // If <shape> is ellipse, the gradient-shape has the same ratio of width to height
                         // that it would if closest-side or farthest-side were specified, as appropriate.
@@ -1120,22 +1120,22 @@ template<CSSValueID Name> static Ref<WebCore::Gradient> createPlatformGradient(c
 
     auto computeCircleRadius = [&](const PrefixedRadialGradient::Extent& extent, FloatPoint centerPoint) -> std::pair<float, float> {
         return WTF::switchOn(extent,
-            [&](ClosestSide) -> std::pair<float, float> {
+            [&](CSS::Keyword::ClosestSide) -> std::pair<float, float> {
                 return { std::min({ centerPoint.x(), size.width() - centerPoint.x(), centerPoint.y(), size.height() - centerPoint.y() }), 1 };
             },
-            [&](Contain) -> std::pair<float, float> {
+            [&](CSS::Keyword::Contain) -> std::pair<float, float> {
                 return { std::min({ centerPoint.x(), size.width() - centerPoint.x(), centerPoint.y(), size.height() - centerPoint.y() }), 1 };
             },
-            [&](FarthestSide) -> std::pair<float, float> {
+            [&](CSS::Keyword::FarthestSide) -> std::pair<float, float> {
                 return { std::max({ centerPoint.x(), size.width() - centerPoint.x(), centerPoint.y(), size.height() - centerPoint.y() }), 1 };
             },
-            [&](ClosestCorner) -> std::pair<float, float> {
+            [&](CSS::Keyword::ClosestCorner) -> std::pair<float, float> {
                 return { distanceToClosestCorner(centerPoint, size), 1 };
             },
-            [&](FarthestCorner) -> std::pair<float, float> {
+            [&](CSS::Keyword::FarthestCorner) -> std::pair<float, float> {
                 return { distanceToFarthestCorner(centerPoint, size), 1 };
             },
-            [&](Cover) -> std::pair<float, float> {
+            [&](CSS::Keyword::Cover) -> std::pair<float, float> {
                 return { distanceToFarthestCorner(centerPoint, size), 1 };
             }
         );
@@ -1144,13 +1144,13 @@ template<CSSValueID Name> static Ref<WebCore::Gradient> createPlatformGradient(c
     auto data = WTF::switchOn(radial.parameters.gradientBox,
         [&](const PrefixedRadialGradient::Ellipse& ellipse) {
             auto centerPoint = computeCenterPoint(ellipse.position);
-            auto [endRadius, aspectRatio] = computeEllipseRadii(ellipse.size.value_or(PrefixedRadialGradient::Extent { CSS::Cover { } }), centerPoint);
+            auto [endRadius, aspectRatio] = computeEllipseRadii(ellipse.size.value_or(PrefixedRadialGradient::Extent { CSS::Keyword::Cover { } }), centerPoint);
 
             return WebCore::Gradient::RadialData { centerPoint, centerPoint, 0, endRadius, aspectRatio };
         },
         [&](const PrefixedRadialGradient::Circle& circle) {
             auto centerPoint = computeCenterPoint(circle.position);
-            auto [endRadius, aspectRatio] = computeCircleRadius(circle.size.value_or(PrefixedRadialGradient::Extent { CSS::Cover { } }), centerPoint);
+            auto [endRadius, aspectRatio] = computeCircleRadius(circle.size.value_or(PrefixedRadialGradient::Extent { CSS::Keyword::Cover { } }), centerPoint);
 
             return WebCore::Gradient::RadialData { centerPoint, centerPoint, 0, endRadius, aspectRatio };
         }

--- a/Source/WebCore/style/values/images/StyleGradient.h
+++ b/Source/WebCore/style/values/images/StyleGradient.h
@@ -40,17 +40,10 @@ namespace Style {
 
 // MARK: - Common Types
 
-using DeprecatedGradientPosition = SpaceSeparatedArray<NumberOrPercentage<>, 2>;
+using DeprecatedGradientPosition   = SpaceSeparatedArray<NumberOrPercentage<>, 2>;
 
-using Horizontal     = CSS::Horizontal;
-using Vertical       = CSS::Vertical;
-
-using ClosestCorner  = CSS::ClosestCorner;
-using ClosestSide    = CSS::ClosestSide;
-using FarthestCorner = CSS::FarthestCorner;
-using FarthestSide   = CSS::FarthestSide;
-using Contain        = CSS::Contain;
-using Cover          = CSS::Cover;
+using Horizontal                   = CSS::Horizontal;
+using Vertical                     = CSS::Vertical;
 
 using RadialGradientExtent         = CSS::RadialGradientExtent;
 using PrefixedRadialGradientExtent = CSS::PrefixedRadialGradientExtent;

--- a/Source/WebCore/style/values/motion/StyleRayFunction.h
+++ b/Source/WebCore/style/values/motion/StyleRayFunction.h
@@ -34,15 +34,7 @@
 namespace WebCore {
 namespace Style {
 
-using Contain        = CSS::Contain;
-
-using ClosestCorner  = CSS::ClosestCorner;
-using ClosestSide    = CSS::ClosestSide;
-using FarthestCorner = CSS::FarthestCorner;
-using FarthestSide   = CSS::FarthestSide;
-using Sides          = CSS::Sides;
-
-using RaySize        = std::variant<ClosestCorner, ClosestSide, FarthestCorner, FarthestSide, Sides>;
+using RaySize = CSS::RaySize;
 
 // ray() = ray( <angle> && <ray-size>? && contain? && [at <position>]? )
 // <ray-size> = closest-side | closest-corner | farthest-side | farthest-corner | sides
@@ -50,7 +42,7 @@ using RaySize        = std::variant<ClosestCorner, ClosestSide, FarthestCorner, 
 struct Ray {
     Angle<> angle;
     RaySize size;
-    std::optional<Contain> contain;
+    std::optional<CSS::Keyword::Contain> contain;
     std::optional<Position> position;
 
     bool operator==(const Ray&) const = default;

--- a/Source/WebCore/style/values/primitives/StylePosition.cpp
+++ b/Source/WebCore/style/values/primitives/StylePosition.cpp
@@ -37,13 +37,13 @@ namespace Style {
 auto ToStyle<CSS::TwoComponentPositionHorizontal>::operator()(const CSS::TwoComponentPositionHorizontal& value, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> TwoComponentPositionHorizontal
 {
     return WTF::switchOn(value.offset,
-        [&](CSS::Left) {
+        [&](CSS::Keyword::Left) {
             return TwoComponentPositionHorizontal { .offset = LengthPercentage<> { Percentage<> { 0 } } };
         },
-        [&](CSS::Right)  {
+        [&](CSS::Keyword::Right)  {
             return TwoComponentPositionHorizontal { .offset = LengthPercentage<> { Percentage<> { 100 } } };
         },
-        [&](CSS::Center)  {
+        [&](CSS::Keyword::Center)  {
             return TwoComponentPositionHorizontal { .offset = LengthPercentage<> { Percentage<> { 50 } } };
         },
         [&](const CSS::LengthPercentage<>& value) {
@@ -55,13 +55,13 @@ auto ToStyle<CSS::TwoComponentPositionHorizontal>::operator()(const CSS::TwoComp
 auto ToStyle<CSS::TwoComponentPositionVertical>::operator()(const CSS::TwoComponentPositionVertical& value, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> TwoComponentPositionVertical
 {
     return WTF::switchOn(value.offset,
-        [&](CSS::Top) {
+        [&](CSS::Keyword::Top) {
             return TwoComponentPositionVertical { .offset = LengthPercentage<> { Percentage<> { 0 } } };
         },
-        [&](CSS::Bottom) {
+        [&](CSS::Keyword::Bottom) {
             return TwoComponentPositionVertical { .offset = LengthPercentage<> { Percentage<> { 100 } } };
         },
-        [&](CSS::Center) {
+        [&](CSS::Keyword::Center) {
             return TwoComponentPositionVertical { .offset = LengthPercentage<> { Percentage<> { 50 } } };
         },
         [&](const CSS::LengthPercentage<>& value) {
@@ -86,18 +86,18 @@ auto ToStyle<CSS::Position>::operator()(const CSS::Position& position, const Bui
         },
         [&](const CSS::FourComponentPosition& fourComponent) {
             auto horizontal = WTF::switchOn(get<0>(get<0>(fourComponent)),
-                [&](CSS::Left) {
+                [&](CSS::Keyword::Left) {
                     return toStyle(get<1>(get<0>(fourComponent)), state, symbolTable);
                 },
-                [&](CSS::Right) {
+                [&](CSS::Keyword::Right) {
                     return reflect(toStyle(get<1>(get<0>(fourComponent)), state, symbolTable));
                 }
             );
             auto vertical = WTF::switchOn(get<0>(get<1>(fourComponent)),
-                [&](CSS::Top) {
+                [&](CSS::Keyword::Top) {
                     return toStyle(get<1>(get<1>(fourComponent)), state, symbolTable);
                 },
-                [&](CSS::Bottom) {
+                [&](CSS::Keyword::Bottom) {
                     return reflect(toStyle(get<1>(get<1>(fourComponent)), state, symbolTable));
                 }
             );

--- a/Source/WebCore/style/values/primitives/StylePosition.h
+++ b/Source/WebCore/style/values/primitives/StylePosition.h
@@ -30,12 +30,6 @@
 namespace WebCore {
 namespace Style {
 
-using Left   = CSS::Left;
-using Right  = CSS::Right;
-using Top    = CSS::Top;
-using Bottom = CSS::Bottom;
-using Center = CSS::Center;
-
 struct TwoComponentPositionHorizontal {
     LengthPercentage<> offset;
 

--- a/Source/WebCore/style/values/shapes/StyleCircleFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleCircleFunction.cpp
@@ -73,16 +73,16 @@ float resolveRadius(const Circle& value, FloatSize boxSize, FloatPoint center)
         },
         [&](const Circle::Extent& extent) -> float {
             return WTF::switchOn(extent,
-                [&](CSS::ClosestSide) -> float {
+                [&](CSS::Keyword::ClosestSide) -> float {
                     return distanceToClosestSide(center, boxSize);
                 },
-                [&](CSS::FarthestSide) -> float {
+                [&](CSS::Keyword::FarthestSide) -> float {
                     return distanceToFarthestSide(center, boxSize);
                 },
-                [&](CSS::ClosestCorner) -> float {
+                [&](CSS::Keyword::ClosestCorner) -> float {
                     return distanceToClosestCorner(center, boxSize);
                 },
-                [&](CSS::FarthestCorner) -> float {
+                [&](CSS::Keyword::FarthestCorner) -> float {
                     return distanceToFarthestCorner(center, boxSize);
                 }
             );

--- a/Source/WebCore/style/values/shapes/StyleEllipseFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleEllipseFunction.cpp
@@ -75,16 +75,16 @@ FloatSize resolveRadii(const Ellipse& value, FloatSize boxSize, FloatPoint cente
             },
             [&](const Ellipse::Extent& extent) -> float {
                 return WTF::switchOn(extent,
-                    [&](CSS::ClosestSide) -> float {
+                    [&](CSS::Keyword::ClosestSide) -> float {
                         return std::min(std::abs(centerValue), std::abs(dimensionSize - centerValue));
                     },
-                    [&](CSS::FarthestSide) -> float {
+                    [&](CSS::Keyword::FarthestSide) -> float {
                         return std::max(std::abs(centerValue), std::abs(dimensionSize - centerValue));
                     },
-                    [&](CSS::ClosestCorner) -> float {
+                    [&](CSS::Keyword::ClosestCorner) -> float {
                         return distanceToClosestCorner(center, boxSize);
                     },
-                    [&](CSS::FarthestCorner) -> float {
+                    [&](CSS::Keyword::FarthestCorner) -> float {
                         return distanceToFarthestCorner(center, boxSize);
                     }
                 );

--- a/Source/WebCore/style/values/shapes/StyleFillRule.h
+++ b/Source/WebCore/style/values/shapes/StyleFillRule.h
@@ -29,9 +29,6 @@
 namespace WebCore {
 namespace Style {
 
-using Nonzero = CSS::Nonzero;
-using Evenodd = CSS::Evenodd;
-
 using FillRule = CSS::FillRule;
 
 } // namespace Style

--- a/Source/WebCore/style/values/shapes/StylePathFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StylePathFunction.cpp
@@ -153,7 +153,7 @@ WebCore::Path PathComputation<Path>::operator()(const Path& value, const FloatRe
 
 WebCore::WindRule WindRuleComputation<Path>::operator()(const Path& value)
 {
-    return (!value.fillRule || std::holds_alternative<Nonzero>(*value.fillRule)) ? WindRule::NonZero : WindRule::EvenOdd;
+    return (!value.fillRule || std::holds_alternative<CSS::Keyword::Nonzero>(*value.fillRule)) ? WindRule::NonZero : WindRule::EvenOdd;
 }
 
 // MARK: - Blending

--- a/Source/WebCore/style/values/shapes/StylePolygonFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StylePolygonFunction.cpp
@@ -72,7 +72,7 @@ WebCore::Path PathComputation<Polygon>::operator()(const Polygon& value, const F
 
 WebCore::WindRule WindRuleComputation<Polygon>::operator()(const Polygon& value)
 {
-    return (!value.fillRule || std::holds_alternative<Nonzero>(*value.fillRule)) ? WindRule::NonZero : WindRule::EvenOdd;
+    return (!value.fillRule || std::holds_alternative<CSS::Keyword::Nonzero>(*value.fillRule)) ? WindRule::NonZero : WindRule::EvenOdd;
 }
 
 // MARK: - Blending

--- a/Source/WebCore/style/values/shapes/StyleRectFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleRectFunction.cpp
@@ -43,23 +43,23 @@ auto ToStyle<CSS::Rect>::operator()(const CSS::Rect& value, const BuilderState& 
     // Conversion applies reflection to the trailing (right/bottom) edges to convert from rect()
     // form to inset() form. This means that all the `auto` values are converted to 0%.
 
-    auto convertLeadingEdge = [&](const std::variant<CSS::LengthPercentage<>, CSS::Auto>& edge) -> LengthPercentage<> {
+    auto convertLeadingEdge = [&](const std::variant<CSS::LengthPercentage<>, CSS::Keyword::Auto>& edge) -> LengthPercentage<> {
         return WTF::switchOn(edge,
             [&](const CSS::LengthPercentage<>& value) -> LengthPercentage<> {
                 return toStyle(value, state, symbolTable);
             },
-            [&](const CSS::Auto&) -> LengthPercentage<> {
+            [&](const CSS::Keyword::Auto&) -> LengthPercentage<> {
                 return { Percentage<> { 0 } };
             }
         );
     };
 
-    auto convertTrailingEdge = [&](const std::variant<CSS::LengthPercentage<>, CSS::Auto>& edge) -> LengthPercentage<> {
+    auto convertTrailingEdge = [&](const std::variant<CSS::LengthPercentage<>, CSS::Keyword::Auto>& edge) -> LengthPercentage<> {
         return WTF::switchOn(edge,
             [&](const CSS::LengthPercentage<>& value) -> LengthPercentage<> {
                 return reflect(toStyle(value, state, symbolTable));
             },
-            [&](const CSS::Auto&) -> LengthPercentage<> {
+            [&](const CSS::Keyword::Auto&) -> LengthPercentage<> {
                 return { Percentage<> { 0 } };
             }
         );

--- a/Source/WebCore/style/values/shapes/StyleShapeFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleShapeFunction.cpp
@@ -85,24 +85,24 @@ template<typename ControlPoint> static FloatPoint resolveControlPoint(CommandAff
 {
     auto controlPointOffset = evaluateControlPointOffset(controlPoint, boxSize);
 
-    auto defaultAnchor = (std::holds_alternative<By>(affinity)) ? RelativeControlPoint::defaultAnchor : AbsoluteControlPoint::defaultAnchor;
+    auto defaultAnchor = (std::holds_alternative<CSS::Keyword::By>(affinity)) ? RelativeControlPoint::defaultAnchor : AbsoluteControlPoint::defaultAnchor;
     auto controlPointAnchoring = evaluateControlPointAnchoring(controlPoint, defaultAnchor);
 
     auto absoluteControlPoint = WTF::switchOn(controlPointAnchoring,
-        [&](Style::Start) {
+        [&](CSS::Keyword::Start) {
             auto absoluteStartPoint = currentPosition;
             return absoluteStartPoint + controlPointOffset;
         },
-        [&](Style::End) {
-            auto absoluteEndPoint = (std::holds_alternative<By>(affinity)) ? currentPosition + toFloatSize(segmentOffset) : segmentOffset;
+        [&](CSS::Keyword::End) {
+            auto absoluteEndPoint = (std::holds_alternative<CSS::Keyword::By>(affinity)) ? currentPosition + toFloatSize(segmentOffset) : segmentOffset;
             return absoluteEndPoint + controlPointOffset;
         },
-        [&](Style::Origin) {
+        [&](CSS::Keyword::Origin) {
             return controlPointOffset;
         }
     );
 
-    if (std::holds_alternative<By>(affinity))
+    if (std::holds_alternative<CSS::Keyword::By>(affinity))
         return absoluteControlPoint - toFloatSize(currentPosition);
     return absoluteControlPoint;
 }
@@ -241,8 +241,8 @@ private:
             .rx = radius.width(),
             .ry = radius.height(),
             .angle = narrowPrecisionToFloat(arcCommand.rotation.value),
-            .largeArc = std::holds_alternative<Large>(arcCommand.arcSize),
-            .sweep = std::holds_alternative<Cw>(arcCommand.arcSweep),
+            .largeArc = std::holds_alternative<CSS::Keyword::Large>(arcCommand.arcSize),
+            .sweep = std::holds_alternative<CSS::Keyword::Cw>(arcCommand.arcSweep),
             .targetPoint = evaluate(arcCommand.toBy, m_boxSize)
         };
     }
@@ -269,8 +269,8 @@ private:
                 return WTF::switchOn(command.toBy,
                     [](const auto& value) {
                         if (value.controlPoint2)
-                            return std::holds_alternative<To>(value.affinity) ? SVGPathSegType::CurveToCubicAbs : SVGPathSegType::CurveToCubicRel;
-                        return std::holds_alternative<To>(value.affinity) ? SVGPathSegType::CurveToQuadraticAbs : SVGPathSegType::CurveToQuadraticRel;
+                            return std::holds_alternative<CSS::Keyword::To>(value.affinity) ? SVGPathSegType::CurveToCubicAbs : SVGPathSegType::CurveToCubicRel;
+                        return std::holds_alternative<CSS::Keyword::To>(value.affinity) ? SVGPathSegType::CurveToQuadraticAbs : SVGPathSegType::CurveToQuadraticRel;
                     }
                 );
             },
@@ -278,8 +278,8 @@ private:
                 return WTF::switchOn(command.toBy,
                     [](const auto& value) {
                         if (value.controlPoint)
-                            return std::holds_alternative<To>(value.affinity) ? SVGPathSegType::CurveToCubicSmoothAbs : SVGPathSegType::CurveToCubicSmoothRel;
-                        return std::holds_alternative<To>(value.affinity) ? SVGPathSegType::CurveToQuadraticSmoothAbs : SVGPathSegType::CurveToQuadraticSmoothRel;
+                            return std::holds_alternative<CSS::Keyword::To>(value.affinity) ? SVGPathSegType::CurveToCubicSmoothAbs : SVGPathSegType::CurveToCubicSmoothRel;
+                        return std::holds_alternative<CSS::Keyword::To>(value.affinity) ? SVGPathSegType::CurveToQuadraticSmoothAbs : SVGPathSegType::CurveToQuadraticSmoothRel;
                     }
                 );
             },
@@ -535,8 +535,8 @@ private:
             ArcCommand {
                 .toBy = fromOffsetPoint(offsetPoint, mode),
                 .size = { Length<> { r1 }, Length<> { r2 } },
-                .arcSweep = sweepFlag ? ArcSweep { Cw { } } : ArcSweep { Ccw { } },
-                .arcSize = largeArcFlag ? ArcSize { Large { } } : ArcSize { Small { } },
+                .arcSweep = sweepFlag ? ArcSweep { CSS::Keyword::Cw { } } : ArcSweep { CSS::Keyword::Ccw { } },
+                .arcSize = largeArcFlag ? ArcSize { CSS::Keyword::Large { } } : ArcSize { CSS::Keyword::Small { } },
                 .rotation = { angle },
             }
         );
@@ -609,8 +609,8 @@ auto Blending<ArcCommand>::blend(const ArcCommand& a, const ArcCommand& b, const
     return {
         .toBy = WebCore::Style::blend(a.toBy, b.toBy, context),
         .size = WebCore::Style::blend(a.size, b.size, context),
-        .arcSweep = blendWithPreferredValue(a.arcSweep, b.arcSweep, ArcSweep { Cw { } }, context),
-        .arcSize = blendWithPreferredValue(a.arcSize, b.arcSize, ArcSize { Large { } }, context),
+        .arcSweep = blendWithPreferredValue(a.arcSweep, b.arcSweep, ArcSweep { CSS::Keyword::Cw { } }, context),
+        .arcSize = blendWithPreferredValue(a.arcSize, b.arcSize, ArcSize { CSS::Keyword::Large { } }, context),
         .rotation = WebCore::Style::blend(a.rotation, b.rotation, context),
     };
 }
@@ -635,7 +635,7 @@ WebCore::Path PathComputation<Shape>::operator()(const Shape& value, const Float
 
 WebCore::WindRule WindRuleComputation<Shape>::operator()(const Shape& value)
 {
-    return (!value.fillRule || std::holds_alternative<Nonzero>(*value.fillRule)) ? WindRule::NonZero : WindRule::EvenOdd;
+    return (!value.fillRule || std::holds_alternative<CSS::Keyword::Nonzero>(*value.fillRule)) ? WindRule::NonZero : WindRule::EvenOdd;
 }
 
 // MARK: - Shape (blending)

--- a/Source/WebCore/style/values/shapes/StyleShapeFunction.h
+++ b/Source/WebCore/style/values/shapes/StyleShapeFunction.h
@@ -39,27 +39,16 @@ struct Path;
 // <coordinate-pair> = <length-percentage>{2}
 using CoordinatePair  = Point<LengthPercentage<>>;
 
-using By              = CSS::By;
-using To              = CSS::To;
 using CommandAffinity = CSS::CommandAffinity;
-
-using Cw              = CSS::Cw;
-using Ccw             = CSS::Ccw;
 using ArcSweep        = CSS::ArcSweep;
-
-using Large           = CSS::Large;
-using Small           = CSS::Small;
 using ArcSize         = CSS::ArcSize;
 
 // <control-point-anchor> = start | end | origin
-using Start           = CSS::Start;
-using End             = CSS::End;
-using Origin          = CSS::Origin;
 using ControlPointAnchor = CSS::ControlPointAnchor;
 
 // <to-position> = to <position>
 struct ToPosition {
-    static constexpr CommandAffinity affinity = Style::To { };
+    static constexpr CommandAffinity affinity = CSS::Keyword::To { };
 
     Position offset;
 
@@ -70,7 +59,7 @@ DEFINE_CSS_STYLE_MAPPING(CSS::ToPosition, ToPosition)
 
 // <by-coordinate-pair> = by <coordinate-pair>
 struct ByCoordinatePair {
-    static constexpr CommandAffinity affinity = Style::By { };
+    static constexpr CommandAffinity affinity = CSS::Keyword::By { };
 
     CoordinatePair offset;
 
@@ -83,7 +72,7 @@ DEFINE_CSS_STYLE_MAPPING(CSS::ByCoordinatePair, ByCoordinatePair)
 // Specified https://github.com/w3c/csswg-drafts/issues/10649#issuecomment-2412816773
 struct RelativeControlPoint {
     using Anchor = ControlPointAnchor;
-    static constexpr auto defaultAnchor = Anchor { Start { } };
+    static constexpr auto defaultAnchor = Anchor { CSS::Keyword::Start { } };
 
     CoordinatePair offset;
     std::optional<Anchor> anchor;
@@ -108,7 +97,7 @@ template<> struct Blending<RelativeControlPoint> {
 // Specified https://github.com/w3c/csswg-drafts/issues/10649#issuecomment-2412816773
 struct AbsoluteControlPoint {
     using Anchor = ControlPointAnchor;
-    static constexpr auto defaultAnchor = Anchor { Origin { } };
+    static constexpr auto defaultAnchor = Anchor { CSS::Keyword::Origin { } };
 
     Position offset;
     std::optional<Anchor> anchor;
@@ -169,14 +158,14 @@ DEFINE_CSS_STYLE_MAPPING(CSS::LineCommand, LineCommand)
 struct HLineCommand {
     static constexpr auto name = CSSValueHline;
     struct To {
-        static constexpr CommandAffinity affinity = Style::To { };
+        static constexpr CommandAffinity affinity = CSS::Keyword::To { };
 
         TwoComponentPositionHorizontal offset;
 
         bool operator==(const To&) const = default;
     };
     struct By {
-        static constexpr CommandAffinity affinity = Style::By { };
+        static constexpr CommandAffinity affinity = CSS::Keyword::By { };
 
         LengthPercentage<> offset;
 
@@ -201,14 +190,14 @@ DEFINE_CSS_STYLE_MAPPING(CSS::HLineCommand, HLineCommand)
 struct VLineCommand {
     static constexpr auto name = CSSValueVline;
     struct To {
-        static constexpr CommandAffinity affinity = Style::To { };
+        static constexpr CommandAffinity affinity = CSS::Keyword::To { };
 
         TwoComponentPositionVertical offset;
 
         bool operator==(const To&) const = default;
     };
     struct By {
-        static constexpr CommandAffinity affinity = Style::By { };
+        static constexpr CommandAffinity affinity = CSS::Keyword::By { };
 
         LengthPercentage<> offset;
 
@@ -234,7 +223,7 @@ DEFINE_CSS_STYLE_MAPPING(CSS::VLineCommand, VLineCommand)
 struct CurveCommand {
     static constexpr auto name = CSSValueCurve;
     struct To {
-        static constexpr CommandAffinity affinity = Style::To { };
+        static constexpr CommandAffinity affinity = CSS::Keyword::To { };
 
         Position offset;
         AbsoluteControlPoint controlPoint1;
@@ -243,7 +232,7 @@ struct CurveCommand {
         bool operator==(const To&) const = default;
     };
     struct By {
-        static constexpr CommandAffinity affinity = Style::By { };
+        static constexpr CommandAffinity affinity = CSS::Keyword::By { };
 
         CoordinatePair offset;
         RelativeControlPoint controlPoint1;
@@ -288,7 +277,7 @@ DEFINE_CSS_STYLE_MAPPING(CSS::CurveCommand::By, CurveCommand::By)
 struct SmoothCommand {
     static constexpr auto name = CSSValueSmooth;
     struct To {
-        static constexpr CommandAffinity affinity = Style::To { };
+        static constexpr CommandAffinity affinity = CSS::Keyword::To { };
 
         Position offset;
         std::optional<AbsoluteControlPoint> controlPoint;
@@ -296,7 +285,7 @@ struct SmoothCommand {
         bool operator==(const To&) const = default;
     };
     struct By {
-        static constexpr CommandAffinity affinity = Style::By { };
+        static constexpr CommandAffinity affinity = CSS::Keyword::By { };
 
         CoordinatePair offset;
         std::optional<RelativeControlPoint> controlPoint;
@@ -372,7 +361,7 @@ template<> struct Blending<ArcCommand> {
 
 // <close> = close
 // https://drafts.csswg.org/css-shapes-2/#valdef-shape-close
-using CloseCommand = Constant<CSSValueClose>;
+using CloseCommand = CSS::Keyword::Close;
 
 // MARK: - Shape Command (variant)
 

--- a/Source/WebCore/svg/SVGPathElement.cpp
+++ b/Source/WebCore/svg/SVGPathElement.cpp
@@ -281,7 +281,7 @@ void SVGPathElement::collectDPresentationalHint(MutableStyleProperties& style)
     // the path data to be parsed again and path data can be unwieldy.
     auto property = cssPropertyIdForSVGAttributeName(SVGNames::dAttr, document().protectedSettings());
     // The fill rule value passed here is not relevant for the `d` property.
-    auto cssPathValue = CSSPathValue::create(CSS::PathFunction { CSS::Nonzero { }, CSS::Path::Data { Ref { m_pathSegList }->currentPathByteStream() } });
+    auto cssPathValue = CSSPathValue::create(CSS::PathFunction { CSS::Keyword::Nonzero { }, CSS::Path::Data { Ref { m_pathSegList }->currentPathByteStream() } });
     addPropertyToPresentationalHintStyle(style, property, WTFMove(cssPathValue));
 }
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3136,21 +3136,21 @@ header: <WebCore/StylePosition.h>
 };
 
 header: <WebCore/StyleGradient.h>
-using WebCore::Style::ClosestCorner = WebCore::Style::Constant<WebCore::CSSValueClosestCorner>;
-[CustomHeader, Nested] struct WebCore::Style::Constant<WebCore::CSSValueClosestCorner> {
+using WebCore::CSS::Keyword::ClosestCorner = WebCore::Constant<WebCore::CSSValueClosestCorner>;
+[CustomHeader, Nested] struct WebCore::Constant<WebCore::CSSValueClosestCorner> {
 };
-using WebCore::Style::ClosestSide = WebCore::Style::Constant<WebCore::CSSValueClosestSide>;
-[CustomHeader, Nested] struct WebCore::Style::Constant<WebCore::CSSValueClosestSide> {
+using WebCore::CSS::Keyword::ClosestSide = WebCore::Constant<WebCore::CSSValueClosestSide>;
+[CustomHeader, Nested] struct WebCore::Constant<WebCore::CSSValueClosestSide> {
 };
-using WebCore::Style::FarthestCorner = WebCore::Style::Constant<WebCore::CSSValueFarthestCorner>;
-[CustomHeader, Nested] struct WebCore::Style::Constant<WebCore::CSSValueFarthestCorner> {
+using WebCore::CSS::Keyword::FarthestCorner = WebCore::Constant<WebCore::CSSValueFarthestCorner>;
+[CustomHeader, Nested] struct WebCore::Constant<WebCore::CSSValueFarthestCorner> {
 };
-using WebCore::Style::FarthestSide = WebCore::Style::Constant<WebCore::CSSValueFarthestSide>;
-[CustomHeader, Nested] struct WebCore::Style::Constant<WebCore::CSSValueFarthestSide> {
+using WebCore::CSS::Keyword::FarthestSide = WebCore::Constant<WebCore::CSSValueFarthestSide>;
+[CustomHeader, Nested] struct WebCore::Constant<WebCore::CSSValueFarthestSide> {
 };
 
 header: <WebCore/StyleCircleFunction.h>
-using WebCore::Style::Circle::Extent = std::variant<WebCore::Style::ClosestCorner, WebCore::Style::ClosestSide, WebCore::Style::FarthestCorner, WebCore::Style::FarthestSide>;
+using WebCore::Style::Circle::Extent = std::variant<WebCore::CSS::Keyword::ClosestCorner, WebCore::CSS::Keyword::ClosestSide, WebCore::CSS::Keyword::FarthestCorner, WebCore::CSS::Keyword::FarthestSide>;
 using WebCore::Style::Circle::RadialSize = std::variant<WebCore::Style::LengthPercentage<WebCore::CSS::Nonnegative>, WebCore::Style::Circle::Extent>;
 
 [CustomHeader, Nested] struct WebCore::Style::CircleFunction {
@@ -3163,7 +3163,7 @@ using WebCore::Style::Circle::RadialSize = std::variant<WebCore::Style::LengthPe
 
 header: <WebCore/StyleEllipseFunction.h>
 
-using WebCore::Style::Ellipse::Extent = std::variant<WebCore::Style::ClosestCorner, WebCore::Style::ClosestSide, WebCore::Style::FarthestCorner, WebCore::Style::FarthestSide>;
+using WebCore::Style::Ellipse::Extent = std::variant<WebCore::CSS::Keyword::ClosestCorner, WebCore::CSS::Keyword::ClosestSide, WebCore::CSS::Keyword::FarthestCorner, WebCore::CSS::Keyword::FarthestSide>;
 using WebCore::Style::Ellipse::RadialSize = std::variant<WebCore::Style::LengthPercentage<WebCore::CSS::Nonnegative>, WebCore::Style::Ellipse::Extent>;
 [CustomHeader, Nested] struct WebCore::Style::SpaceSeparatedPair<WebCore::Style::Ellipse::RadialSize> {
     std::array<WebCore::Style::Ellipse::RadialSize, 2> value;
@@ -3209,48 +3209,48 @@ header: <WebCore/StylePolygonFunction.h>
 };
 
 header: <WebCore/StyleFillRule.h>
-using WebCore::Style::Nonzero = WebCore::Style::Constant<WebCore::CSSValueNonzero>;
-using WebCore::Style::Evenodd = WebCore::Style::Constant<WebCore::CSSValueEvenodd>;
-[CustomHeader, Nested] struct WebCore::Style::Constant<WebCore::CSSValueNonzero> {
+using WebCore::CSS::Keyword::Nonzero = WebCore::Constant<WebCore::CSSValueNonzero>;
+using WebCore::CSS::Keyword::Evenodd = WebCore::Constant<WebCore::CSSValueEvenodd>;
+[CustomHeader, Nested] struct WebCore::Constant<WebCore::CSSValueNonzero> {
 };
-[CustomHeader, Nested] struct WebCore::Style::Constant<WebCore::CSSValueEvenodd> {
+[CustomHeader, Nested] struct WebCore::Constant<WebCore::CSSValueEvenodd> {
 };
-using WebCore::Style::FillRule = std::variant<WebCore::Style::Nonzero, WebCore::Style::Evenodd>;
+using WebCore::Style::FillRule = std::variant<WebCore::CSS::Keyword::Nonzero, WebCore::CSS::Keyword::Evenodd>;
 
 header: <WebCore/StyleShapeFunction.h>
 using WebCore::Style::CoordinatePair = WebCore::Style::Point<WebCore::Style::LengthPercentageAll>;
-using WebCore::Style::CommandAffinity = std::variant<WebCore::Style::By, WebCore::Style::To>;
-using WebCore::Style::By = WebCore::Style::Constant<WebCore::CSSValueBy>;
-using WebCore::Style::To = WebCore::Style::Constant<WebCore::CSSValueTo>;
-using WebCore::Style::Ccw = WebCore::Style::Constant<WebCore::CSSValueCcw>;
-using WebCore::Style::Cw = WebCore::Style::Constant<WebCore::CSSValueCw>;
-using WebCore::Style::Large = WebCore::Style::Constant<WebCore::CSSValueLarge>;
-using WebCore::Style::Small = WebCore::Style::Constant<WebCore::CSSValueSmall>;
-using WebCore::Style::Start = WebCore::Style::Constant<WebCore::CSSValueStart>;
-using WebCore::Style::End = WebCore::Style::Constant<WebCore::CSSValueEnd>;
-using WebCore::Style::Origin = WebCore::Style::Constant<WebCore::CSSValueOrigin>;
-using WebCore::Style::ControlPointAnchor = std::variant<WebCore::Style::Start, WebCore::Style::End, WebCore::Style::Origin>;
-using WebCore::Style::CloseCommand = WebCore::Style::Constant<WebCore::CSSValueClose>;
+using WebCore::Style::CommandAffinity = std::variant<WebCore::CSS::Keyword::By, WebCore::CSS::Keyword::To>;
+using WebCore::CSS::Keyword::By = WebCore::Constant<WebCore::CSSValueBy>;
+using WebCore::CSS::Keyword::To = WebCore::Constant<WebCore::CSSValueTo>;
+using WebCore::CSS::Keyword::Ccw = WebCore::Constant<WebCore::CSSValueCcw>;
+using WebCore::CSS::Keyword::Cw = WebCore::Constant<WebCore::CSSValueCw>;
+using WebCore::CSS::Keyword::Large = WebCore::Constant<WebCore::CSSValueLarge>;
+using WebCore::CSS::Keyword::Small = WebCore::Constant<WebCore::CSSValueSmall>;
+using WebCore::CSS::Keyword::Start = WebCore::Constant<WebCore::CSSValueStart>;
+using WebCore::CSS::Keyword::End = WebCore::Constant<WebCore::CSSValueEnd>;
+using WebCore::CSS::Keyword::Origin = WebCore::Constant<WebCore::CSSValueOrigin>;
+using WebCore::Style::ControlPointAnchor = std::variant<WebCore::CSS::Keyword::Start, WebCore::CSS::Keyword::End, WebCore::CSS::Keyword::Origin>;
+using WebCore::Style::CloseCommand = WebCore::Constant<WebCore::CSSValueClose>;
 
-[CustomHeader, Nested] struct WebCore::Style::Constant<WebCore::CSSValueBy> {
+[CustomHeader, Nested] struct WebCore::Constant<WebCore::CSSValueBy> {
 };
-[CustomHeader, Nested] struct WebCore::Style::Constant<WebCore::CSSValueTo> {
+[CustomHeader, Nested] struct WebCore::Constant<WebCore::CSSValueTo> {
 };
-[CustomHeader, Nested] struct WebCore::Style::Constant<WebCore::CSSValueCcw> {
+[CustomHeader, Nested] struct WebCore::Constant<WebCore::CSSValueCcw> {
 };
-[CustomHeader, Nested] struct WebCore::Style::Constant<WebCore::CSSValueCw> {
+[CustomHeader, Nested] struct WebCore::Constant<WebCore::CSSValueCw> {
 };
-[CustomHeader, Nested] struct WebCore::Style::Constant<WebCore::CSSValueLarge> {
+[CustomHeader, Nested] struct WebCore::Constant<WebCore::CSSValueLarge> {
 };
-[CustomHeader, Nested] struct WebCore::Style::Constant<WebCore::CSSValueSmall> {
+[CustomHeader, Nested] struct WebCore::Constant<WebCore::CSSValueSmall> {
 };
-[CustomHeader, Nested] struct WebCore::Style::Constant<WebCore::CSSValueStart> {
+[CustomHeader, Nested] struct WebCore::Constant<WebCore::CSSValueStart> {
 };
-[CustomHeader, Nested] struct WebCore::Style::Constant<WebCore::CSSValueEnd> {
+[CustomHeader, Nested] struct WebCore::Constant<WebCore::CSSValueEnd> {
 };
-[CustomHeader, Nested] struct WebCore::Style::Constant<WebCore::CSSValueOrigin> {
+[CustomHeader, Nested] struct WebCore::Constant<WebCore::CSSValueOrigin> {
 };
-[CustomHeader, Nested] struct WebCore::Style::Constant<WebCore::CSSValueClose> {
+[CustomHeader, Nested] struct WebCore::Constant<WebCore::CSSValueClose> {
 };
 
 [CustomHeader, Nested] struct WebCore::Style::ToPosition {
@@ -3327,8 +3327,8 @@ using WebCore::Style::CloseCommand = WebCore::Style::Constant<WebCore::CSSValueC
 [CustomHeader, Nested] struct WebCore::Style::ArcCommand {
     std::variant<WebCore::Style::ToPosition, WebCore::Style::ByCoordinatePair> toBy;
     WebCore::Style::LengthPercentageSizeAll size;
-    std::variant<WebCore::Style::Cw, WebCore::Style::Ccw> arcSweep;
-    std::variant<WebCore::Style::Large, WebCore::Style::Small> arcSize;
+    std::variant<WebCore::CSS::Keyword::Cw, WebCore::CSS::Keyword::Ccw> arcSweep;
+    std::variant<WebCore::CSS::Keyword::Large, WebCore::CSS::Keyword::Small> arcSize;
     WebCore::Style::Angle<WebCore::CSS::All> rotation;
 };
 using WebCore::Style::LengthPercentageSizeAll = WebCore::Style::Size<WebCore::Style::LengthPercentageAll>
@@ -3354,20 +3354,20 @@ header: <WebCore/StyleMinimallySerializingRectEdges.h>
 
 header: <WebCore/StyleRayFunction.h>
 
-using WebCore::Style::Sides = WebCore::Style::Constant<WebCore::CSSValueSides>;
-[CustomHeader, Nested] struct WebCore::Style::Constant<WebCore::CSSValueSides> {
+using WebCore::CSS::Keyword::Sides = WebCore::Constant<WebCore::CSSValueSides>;
+[CustomHeader, Nested] struct WebCore::Constant<WebCore::CSSValueSides> {
 };
-using WebCore::Style::Contain = WebCore::Style::Constant<WebCore::CSSValueContain>;
-[CustomHeader, Nested] struct WebCore::Style::Constant<WebCore::CSSValueContain> {
+using WebCore::CSS::Keyword::Contain = WebCore::Constant<WebCore::CSSValueContain>;
+[CustomHeader, Nested] struct WebCore::Constant<WebCore::CSSValueContain> {
 };
-using WebCore::Style::RaySize = std::variant<WebCore::Style::ClosestCorner, WebCore::Style::ClosestSide, WebCore::Style::FarthestCorner, WebCore::Style::FarthestSide, WebCore::Style::Sides>;
+using WebCore::Style::RaySize = std::variant<WebCore::CSS::Keyword::ClosestCorner, WebCore::CSS::Keyword::ClosestSide, WebCore::CSS::Keyword::FarthestCorner, WebCore::CSS::Keyword::FarthestSide, WebCore::CSS::Keyword::Sides>;
 [CustomHeader, Nested] struct WebCore::Style::RayFunction {
     WebCore::Style::Ray parameters;
 };
 [CustomHeader, Nested] struct WebCore::Style::Ray {
     WebCore::Style::Angle<WebCore::CSS::All> angle;
     WebCore::Style::RaySize size;
-    std::optional<WebCore::Style::Contain> contain;
+    std::optional<WebCore::CSS::Keyword::Contain> contain;
     std::optional<WebCore::Style::Position> position;
 };
 


### PR DESCRIPTION
#### 108f857f2d9bb0e1adad624af656be4c2737545f
<pre>
Generate aliases for Constant&lt;CSSValueIDs&gt; type used by CSS/Style values
<a href="https://bugs.webkit.org/show_bug.cgi?id=283873">https://bugs.webkit.org/show_bug.cgi?id=283873</a>

Reviewed by Tim Nguyen.

Generates a type alias in the namespace CSS::Keyword, of the form:

    using Foo = Constant&lt;CSSValueFoo&gt;;

for every CSSValueID at compile time.

These replace the adhoc definitions used, and standardizes on the
CSS::Keyword namespace for them.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+ColorAdjust.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Motion.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Position.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Shapes.cpp:
* Source/WebCore/css/process-css-values.py:
* Source/WebCore/css/values/CSSValueTypes.h:
* Source/WebCore/css/values/color-adjust/CSSColorScheme.cpp:
* Source/WebCore/css/values/color-adjust/CSSColorScheme.h:
* Source/WebCore/css/values/images/CSSGradient.cpp:
* Source/WebCore/css/values/images/CSSGradient.h:
* Source/WebCore/css/values/motion/CSSRayFunction.cpp:
* Source/WebCore/css/values/motion/CSSRayFunction.h:
* Source/WebCore/css/values/primitives/CSSPosition.cpp:
* Source/WebCore/css/values/primitives/CSSPosition.h:
* Source/WebCore/css/values/shapes/CSSCircleFunction.cpp:
* Source/WebCore/css/values/shapes/CSSCircleFunction.h:
* Source/WebCore/css/values/shapes/CSSEllipseFunction.cpp:
* Source/WebCore/css/values/shapes/CSSEllipseFunction.h:
* Source/WebCore/css/values/shapes/CSSFillRule.h:
* Source/WebCore/css/values/shapes/CSSPathFunction.cpp:
* Source/WebCore/css/values/shapes/CSSPolygonFunction.cpp:
* Source/WebCore/css/values/shapes/CSSRectFunction.h:
* Source/WebCore/css/values/shapes/CSSShapeFunction.cpp:
* Source/WebCore/css/values/shapes/CSSShapeFunction.h:
* Source/WebCore/rendering/MotionPath.cpp:
* Source/WebCore/style/values/color-adjust/StyleColorScheme.h:
* Source/WebCore/style/values/images/StyleGradient.cpp:
* Source/WebCore/style/values/images/StyleGradient.h:
* Source/WebCore/style/values/motion/StyleRayFunction.h:
* Source/WebCore/style/values/primitives/StylePosition.cpp:
* Source/WebCore/style/values/primitives/StylePosition.h:
* Source/WebCore/style/values/shapes/StyleCircleFunction.cpp:
* Source/WebCore/style/values/shapes/StyleEllipseFunction.cpp:
* Source/WebCore/style/values/shapes/StyleFillRule.h:
* Source/WebCore/style/values/shapes/StylePathFunction.cpp:
* Source/WebCore/style/values/shapes/StylePolygonFunction.cpp:
* Source/WebCore/style/values/shapes/StyleRectFunction.cpp:
* Source/WebCore/style/values/shapes/StyleShapeFunction.cpp:
* Source/WebCore/style/values/shapes/StyleShapeFunction.h:
* Source/WebCore/svg/SVGPathElement.cpp:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/287219@main">https://commits.webkit.org/287219@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84c18c220b6b6e211d06717a27f999e0d3f7a6dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78760 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57804 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32142 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83420 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30022 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80893 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66956 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6085 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61683 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19605 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81827 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51719 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/71259 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41990 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49065 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25790 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28362 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70175 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26192 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84789 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6125 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69909 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6287 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67703 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69162 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17226 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13203 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11866 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6070 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/11973 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6055 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9492 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7844 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->