### PR TITLE
Fix dynamic update of "transform" attribute

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/svgtransformlist-replaceitem-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/svgtransformlist-replaceitem-expected.txt
@@ -1,5 +1,5 @@
 123
 123
 
-FAIL Dynamic update of transform; replaceItem() assert_equals: expected 185.59375 but got 186
+PASS Dynamic update of transform; replaceItem()
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/coordinate-systems/svgtransformlist-replaceitem-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/coordinate-systems/svgtransformlist-replaceitem-expected.txt
@@ -1,5 +1,0 @@
-123
-123
-
-FAIL Dynamic update of transform; replaceItem() assert_equals: expected 185.78125 but got 186
-

--- a/LayoutTests/platform/glib/svg/repaint/text-repainting-after-modifying-transform-repaint-rects-expected.txt
+++ b/LayoutTests/platform/glib/svg/repaint/text-repainting-after-modifying-transform-repaint-rects-expected.txt
@@ -1,2 +1,6 @@
 PASS
+(repaint rects
+  (rect 50 14 92 45)
+  (rect 50 14 92 45)
+)
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/svg/coordinate-systems/svgtransformlist-replaceitem-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/svg/coordinate-systems/svgtransformlist-replaceitem-expected.txt
@@ -1,5 +1,0 @@
-123
-123
-
-FAIL Dynamic update of transform; replaceItem() assert_equals: expected 185.703125 but got 185.5
-

--- a/LayoutTests/platform/ios/svg/repaint/text-repainting-after-modifying-transform-repaint-rects-expected.txt
+++ b/LayoutTests/platform/ios/svg/repaint/text-repainting-after-modifying-transform-repaint-rects-expected.txt
@@ -1,8 +1,8 @@
 PASS
 (repaint rects
   (rect 0 0 1 1)
-  (rect 50 0 96 200)
+  (rect 50 14 96 45)
   (rect 0 0 1 1)
-  (rect 50 0 96 200)
+  (rect 50 14 96 45)
 )
 

--- a/LayoutTests/svg/repaint/text-repainting-after-modifying-transform-repaint-rects-expected.txt
+++ b/LayoutTests/svg/repaint/text-repainting-after-modifying-transform-repaint-rects-expected.txt
@@ -1,8 +1,8 @@
 PASS
 (repaint rects
   (rect 0 0 1 1)
-  (rect 50 20 96 40)
+  (rect 50 14 96 46)
   (rect 0 0 1 1)
-  (rect 50 20 96 40)
+  (rect 50 14 96 46)
 )
 

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -365,7 +365,7 @@ void RenderSVGText::layout()
         else if (auto* rootObject = lineageOfType<RenderSVGRoot>(*this).first())
             isLayoutSizeChanged = rootObject->isLayoutSizeChanged();
 
-        if (m_needsTextMetricsUpdate || isLayoutSizeChanged) {
+        if (m_needsTextMetricsUpdate || isLayoutSizeChanged || m_needsTransformUpdate) {
             // If the root layout size changed (eg. window size changes) or the transform to the root
             // context has changed then recompute the on-screen font size.
             updateFontInAllDescendants(*this);


### PR DESCRIPTION
#### 7d6ca91cb9844bf88afede3feee4c66d68348e17
<pre>
Fix dynamic update of &quot;transform&quot; attribute

<a href="https://bugs.webkit.org/show_bug.cgi?id=283879">https://bugs.webkit.org/show_bug.cgi?id=283879</a>
<a href="https://rdar.apple.com/problem/140761655">rdar://problem/140761655</a>

Reviewed by Simon Fraser.

Merge: <a href="https://chromium-review.googlesource.com/c/chromium/src/+/3260056">https://chromium-review.googlesource.com/c/chromium/src/+/3260056</a>

If RenderSVGText::m_needsTransformUpdate is true, we should update
font too.

* LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/svgtransformlist-replaceitem-expected.txt:
* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::RenderSVGText::layout):
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/coordinate-systems/svgtransformlist-replaceitem-expected.txt: Removed
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/svg/coordinate-systems/svgtransformlist-replaceitem-expected.txt: Removed
* LayoutTests/platform/glib/svg/repaint/text-repainting-after-modifying-transform-repaint-rects-expected.txt: Rebaselined
* LayoutTests/platform/ios/svg/repaint/text-repainting-after-modifying-transform-repaint-rects-expected.txt: Rebaselined
* LayoutTests/svg/repaint/text-repainting-after-modifying-transform-repaint-rects-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/289022@main">https://commits.webkit.org/289022@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4e0847c50204d1068d0cae1ea66b6afaeb6ed88

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84371 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3996 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38676 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89450 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35381 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86456 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4081 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11973 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65610 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23452 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87417 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3069 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76658 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45904 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3020 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30889 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34429 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73910 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31657 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90831 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11638 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8462 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74061 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11865 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72482 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73261 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18267 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17600 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16044 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3021 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11590 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17066 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11439 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14915 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13212 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->