### PR TITLE
Make MessageReceiver AbstractRefCounted

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -135,6 +135,9 @@ public:
     static Ref<GPUConnectionToWebProcess> create(GPUProcess&, WebCore::ProcessIdentifier, PAL::SessionID, IPC::Connection::Handle&&, GPUProcessConnectionParameters&&);
     virtual ~GPUConnectionToWebProcess();
 
+    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
+    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
+
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_sharedPreferencesForWebProcess; }
     const SharedPreferencesForWebProcess& sharedPreferencesForWebProcessValue() const { return m_sharedPreferencesForWebProcess; }
     void updateSharedPreferencesForWebProcess(SharedPreferencesForWebProcess&&);

--- a/Source/WebKit/GPUProcess/RemoteSharedResourceCache.h
+++ b/Source/WebKit/GPUProcess/RemoteSharedResourceCache.h
@@ -54,6 +54,9 @@ public:
     static Ref<RemoteSharedResourceCache> create(GPUConnectionToWebProcess&);
     virtual ~RemoteSharedResourceCache();
 
+    void ref() const final { ThreadSafeRefCounted::ref(); }
+    void deref() const final { ThreadSafeRefCounted::deref(); }
+
     void addSerializedImageBuffer(WebCore::RenderingResourceIdentifier, Ref<WebCore::ImageBuffer>);
     RefPtr<WebCore::ImageBuffer> takeSerializedImageBuffer(WebCore::RenderingResourceIdentifier);
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
@@ -106,7 +106,7 @@ protected:
     virtual void platformWorkQueueInitialize(WebCore::GraphicsContextGLAttributes&&) { };
     void workQueueUninitialize();
     template<typename T>
-    IPC::Error send(T&& message) const { return m_streamConnection->send(std::forward<T>(message), m_graphicsContextGLIdentifier); }
+    IPC::Error send(T&& message) const { return Ref { *m_streamConnection }->send(std::forward<T>(message), m_graphicsContextGLIdentifier); }
 
     // GraphicsContextGL::Client overrides.
     void forceContextLost() final;

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
@@ -75,14 +75,14 @@ RemoteImageBuffer::~RemoteImageBuffer()
 
 void RemoteImageBuffer::startListeningForIPC()
 {
-    m_backend->streamConnection().startReceivingMessages(*this, Messages::RemoteImageBuffer::messageReceiverName(), identifier().toUInt64());
+    m_backend->protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteImageBuffer::messageReceiverName(), identifier().toUInt64());
 }
 
 void RemoteImageBuffer::stopListeningForIPC()
 {
     if (auto backend = std::exchange(m_backend, { })) {
         backend->protectedSharedResourceCache()->didReleaseImageBuffer(m_imageBuffer->renderingPurpose(), m_imageBuffer->renderingMode());
-        backend->streamConnection().stopReceivingMessages(Messages::RemoteImageBuffer::messageReceiverName(), identifier().toUInt64());
+        backend->protectedStreamConnection()->stopReceivingMessages(Messages::RemoteImageBuffer::messageReceiverName(), identifier().toUInt64());
     }
 }
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
@@ -72,13 +72,13 @@ RemoteImageBufferSet::~RemoteImageBufferSet()
 
 void RemoteImageBufferSet::startListeningForIPC()
 {
-    m_backend->streamConnection().startReceivingMessages(*this, Messages::RemoteImageBufferSet::messageReceiverName(), m_identifier.toUInt64());
+    m_backend->protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteImageBufferSet::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteImageBufferSet::stopListeningForIPC()
 {
     if (auto backend = std::exchange(m_backend, { }))
-        backend->streamConnection().stopReceivingMessages(Messages::RemoteImageBufferSet::messageReceiverName(), m_identifier.toUInt64());
+        backend->protectedStreamConnection()->stopReceivingMessages(Messages::RemoteImageBufferSet::messageReceiverName(), m_identifier.toUInt64());
 }
 
 IPC::StreamConnectionWorkQueue& RemoteImageBufferSet::workQueue() const
@@ -122,7 +122,7 @@ void RemoteImageBufferSet::endPrepareForDisplay(RenderingUpdateID renderingUpdat
     }
 
     outputData.bufferCacheIdentifiers = BufferIdentifierSet { bufferIdentifier(frontBuffer), bufferIdentifier(m_backBuffer), bufferIdentifier(m_secondaryBackBuffer) };
-    backend->streamConnection().send(Messages::RemoteImageBufferSetProxy::DidPrepareForDisplay(WTFMove(outputData), renderingUpdateID), m_identifier);
+    backend->protectedStreamConnection()->send(Messages::RemoteImageBufferSetProxy::DidPrepareForDisplay(WTFMove(outputData), renderingUpdateID), m_identifier);
 #endif
 }
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -523,7 +523,7 @@ void RemoteRenderingBackend::createRemoteBarcodeDetector(ShapeDetectionIdentifie
     auto inner = WebCore::ShapeDetection::BarcodeDetectorImpl::create(barcodeDetectorOptions);
     auto remoteBarcodeDetector = RemoteBarcodeDetector::create(WTFMove(inner), m_shapeDetectionObjectHeap, *this, identifier, gpuConnectionToWebProcess().webProcessIdentifier());
     protectedShapeDetectionObjectHeap()->addObject(identifier, remoteBarcodeDetector);
-    streamConnection().startReceivingMessages(remoteBarcodeDetector, Messages::RemoteBarcodeDetector::messageReceiverName(), identifier.toUInt64());
+    protectedStreamConnection()->startReceivingMessages(remoteBarcodeDetector, Messages::RemoteBarcodeDetector::messageReceiverName(), identifier.toUInt64());
 #else
     UNUSED_PARAM(identifier);
     UNUSED_PARAM(barcodeDetectorOptions);
@@ -532,7 +532,7 @@ void RemoteRenderingBackend::createRemoteBarcodeDetector(ShapeDetectionIdentifie
 
 void RemoteRenderingBackend::releaseRemoteBarcodeDetector(ShapeDetectionIdentifier identifier)
 {
-    streamConnection().stopReceivingMessages(Messages::RemoteBarcodeDetector::messageReceiverName(), identifier.toUInt64());
+    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteBarcodeDetector::messageReceiverName(), identifier.toUInt64());
     protectedShapeDetectionObjectHeap()->removeObject(identifier);
 }
 
@@ -551,7 +551,7 @@ void RemoteRenderingBackend::createRemoteFaceDetector(ShapeDetectionIdentifier i
     auto inner = WebCore::ShapeDetection::FaceDetectorImpl::create(faceDetectorOptions);
     auto remoteFaceDetector = RemoteFaceDetector::create(WTFMove(inner), m_shapeDetectionObjectHeap, *this, identifier, gpuConnectionToWebProcess().webProcessIdentifier());
     protectedShapeDetectionObjectHeap()->addObject(identifier, remoteFaceDetector);
-    streamConnection().startReceivingMessages(remoteFaceDetector, Messages::RemoteFaceDetector::messageReceiverName(), identifier.toUInt64());
+    protectedStreamConnection()->startReceivingMessages(remoteFaceDetector, Messages::RemoteFaceDetector::messageReceiverName(), identifier.toUInt64());
 #else
     UNUSED_PARAM(identifier);
     UNUSED_PARAM(faceDetectorOptions);
@@ -560,7 +560,7 @@ void RemoteRenderingBackend::createRemoteFaceDetector(ShapeDetectionIdentifier i
 
 void RemoteRenderingBackend::releaseRemoteFaceDetector(ShapeDetectionIdentifier identifier)
 {
-    streamConnection().stopReceivingMessages(Messages::RemoteFaceDetector::messageReceiverName(), identifier.toUInt64());
+    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteFaceDetector::messageReceiverName(), identifier.toUInt64());
     protectedShapeDetectionObjectHeap()->removeObject(identifier);
 }
 
@@ -570,7 +570,7 @@ void RemoteRenderingBackend::createRemoteTextDetector(ShapeDetectionIdentifier i
     auto inner = WebCore::ShapeDetection::TextDetectorImpl::create();
     auto remoteTextDetector = RemoteTextDetector::create(WTFMove(inner), m_shapeDetectionObjectHeap, *this, identifier, gpuConnectionToWebProcess().webProcessIdentifier());
     protectedShapeDetectionObjectHeap()->addObject(identifier, remoteTextDetector);
-    streamConnection().startReceivingMessages(remoteTextDetector, Messages::RemoteTextDetector::messageReceiverName(), identifier.toUInt64());
+    protectedStreamConnection()->startReceivingMessages(remoteTextDetector, Messages::RemoteTextDetector::messageReceiverName(), identifier.toUInt64());
 #else
     UNUSED_PARAM(identifier);
 #endif
@@ -578,7 +578,7 @@ void RemoteRenderingBackend::createRemoteTextDetector(ShapeDetectionIdentifier i
 
 void RemoteRenderingBackend::releaseRemoteTextDetector(ShapeDetectionIdentifier identifier)
 {
-    streamConnection().stopReceivingMessages(Messages::RemoteTextDetector::messageReceiverName(), identifier.toUInt64());
+    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteTextDetector::messageReceiverName(), identifier.toUInt64());
     protectedShapeDetectionObjectHeap()->removeObject(identifier);
 }
 
@@ -605,14 +605,15 @@ RefPtr<ImageBuffer> RemoteRenderingBackend::takeImageBuffer(RenderingResourceIde
 
 void RemoteRenderingBackend::terminateWebProcess(ASCIILiteral message)
 {
+    Ref gpuConnectionToWebProcess = m_gpuConnectionToWebProcess;
 #if ENABLE(IPC_TESTING_API)
-    bool shouldTerminate = !m_gpuConnectionToWebProcess->connection().ignoreInvalidMessageForTesting();
+    bool shouldTerminate = !gpuConnectionToWebProcess->connection().ignoreInvalidMessageForTesting();
 #else
     bool shouldTerminate = true;
 #endif
     if (shouldTerminate) {
         RELEASE_LOG_FAULT(IPC, "Requesting termination of web process %" PRIu64 " for reason: %" PUBLIC_LOG_STRING, m_gpuConnectionToWebProcess->webProcessIdentifier().toUInt64(), message.characters());
-        m_gpuConnectionToWebProcess->terminateWebProcess();
+        gpuConnectionToWebProcess->terminateWebProcess();
     }
 }
 
@@ -636,6 +637,11 @@ void RemoteRenderingBackend::getImageBufferResourceLimitsForTesting(CompletionHa
 Ref<ShapeDetection::ObjectHeap> RemoteRenderingBackend::protectedShapeDetectionObjectHeap() const
 {
     return m_shapeDetectionObjectHeap;
+}
+
+Ref<GPUConnectionToWebProcess> RemoteRenderingBackend::protectedGPUConnectionToWebProcess()
+{
+    return m_gpuConnectionToWebProcess.get();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -106,8 +106,10 @@ public:
     void dispatch(Function<void()>&&);
 
     IPC::StreamServerConnection& streamConnection() const { return m_streamConnection.get(); }
+    Ref<IPC::StreamServerConnection> protectedStreamConnection() const { return m_streamConnection; }
 
     GPUConnectionToWebProcess& gpuConnectionToWebProcess() { return m_gpuConnectionToWebProcess.get(); }
+    Ref<GPUConnectionToWebProcess> protectedGPUConnectionToWebProcess();
 
     void setSharedMemoryForGetPixelBuffer(RefPtr<WebCore::SharedMemory> memory) { m_getPixelBufferSharedMemory = WTFMove(memory); }
     RefPtr<WebCore::SharedMemory> sharedMemoryForGetPixelBuffer() const { return m_getPixelBufferSharedMemory; }
@@ -190,9 +192,9 @@ private:
 
     void getImageBufferResourceLimitsForTesting(CompletionHandler<void(WebCore::ImageBufferResourceLimits)>&&);
 
-    Ref<IPC::StreamConnectionWorkQueue> m_workQueue;
-    Ref<IPC::StreamServerConnection> m_streamConnection;
-    Ref<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;
+    const Ref<IPC::StreamConnectionWorkQueue> m_workQueue;
+    const Ref<IPC::StreamServerConnection> m_streamConnection;
+    const Ref<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;
     Ref<RemoteSharedResourceCache> m_sharedResourceCache;
     RemoteResourceCache m_remoteResourceCache;
     WebCore::ProcessIdentity m_resourceOwner;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.cpp
@@ -52,7 +52,7 @@ RemoteAdapter::RemoteAdapter(GPUConnectionToWebProcess& gpuConnectionToWebProces
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
-    m_streamConnection->startReceivingMessages(*this, Messages::RemoteAdapter::messageReceiverName(), m_identifier.toUInt64());
+    Ref { m_streamConnection }->startReceivingMessages(*this, Messages::RemoteAdapter::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteAdapter::~RemoteAdapter() = default;
@@ -64,7 +64,7 @@ void RemoteAdapter::destruct()
 
 void RemoteAdapter::stopListeningForIPC()
 {
-    m_streamConnection->stopReceivingMessages(Messages::RemoteAdapter::messageReceiverName(), m_identifier.toUInt64());
+    Ref { m_streamConnection }->stopReceivingMessages(Messages::RemoteAdapter::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteAdapter::requestDevice(const WebGPU::DeviceDescriptor& descriptor, WebGPUIdentifier identifier, WebGPUIdentifier queueIdentifier, CompletionHandler<void(WebGPU::SupportedFeatures&&, WebGPU::SupportedLimits&&)>&& callback)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.h
@@ -89,7 +89,7 @@ private:
 
     Ref<WebCore::WebGPU::Adapter> m_backing;
     WeakRef<WebGPU::ObjectHeap> m_objectHeap;
-    Ref<IPC::StreamServerConnection> m_streamConnection;
+    const Ref<IPC::StreamServerConnection> m_streamConnection;
     ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;
     WeakRef<RemoteGPU> m_gpu;
     WebGPUIdentifier m_identifier;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.cpp
@@ -55,7 +55,7 @@ RemoteCommandEncoder::RemoteCommandEncoder(GPUConnectionToWebProcess& gpuConnect
     , m_gpuConnectionToWebProcess(gpuConnectionToWebProcess)
     , m_gpu(gpu)
 {
-    m_streamConnection->startReceivingMessages(*this, Messages::RemoteCommandEncoder::messageReceiverName(), m_identifier.toUInt64());
+    Ref { m_streamConnection }->startReceivingMessages(*this, Messages::RemoteCommandEncoder::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteCommandEncoder::~RemoteCommandEncoder() = default;
@@ -75,7 +75,7 @@ void RemoteCommandEncoder::destruct()
 
 void RemoteCommandEncoder::stopListeningForIPC()
 {
-    m_streamConnection->stopReceivingMessages(Messages::RemoteCommandEncoder::messageReceiverName(), m_identifier.toUInt64());
+    Ref { m_streamConnection }->stopReceivingMessages(Messages::RemoteCommandEncoder::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteCommandEncoder::beginRenderPass(const WebGPU::RenderPassDescriptor& descriptor, WebGPUIdentifier identifier)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.h
@@ -144,7 +144,7 @@ private:
 
     Ref<WebCore::WebGPU::CommandEncoder> m_backing;
     WeakRef<WebGPU::ObjectHeap> m_objectHeap;
-    Ref<IPC::StreamServerConnection> m_streamConnection;
+    const Ref<IPC::StreamServerConnection> m_streamConnection;
     WebGPUIdentifier m_identifier;
     ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;
     WeakRef<RemoteGPU> m_gpu;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
@@ -101,8 +101,9 @@ void RemoteGPU::workQueueInitialize()
 {
     assertIsCurrent(workQueue());
     Ref workQueue = m_workQueue;
-    m_streamConnection->open(workQueue);
-    m_streamConnection->startReceivingMessages(*this, Messages::RemoteGPU::messageReceiverName(), m_identifier.toUInt64());
+    RefPtr streamConnection = m_streamConnection;
+    streamConnection->open(workQueue);
+    streamConnection->startReceivingMessages(*this, Messages::RemoteGPU::messageReceiverName(), m_identifier.toUInt64());
 
 #if HAVE(WEBGPU_IMPLEMENTATION)
     // BEWARE: This is a retain cycle.
@@ -119,7 +120,7 @@ void RemoteGPU::workQueueInitialize()
 #endif
     if (backing) {
         m_backing = backing.releaseNonNull();
-        send(Messages::RemoteGPUProxy::WasCreated(true, workQueue->wakeUpSemaphore(), m_streamConnection->clientWaitSemaphore()));
+        send(Messages::RemoteGPUProxy::WasCreated(true, workQueue->wakeUpSemaphore(), streamConnection->clientWaitSemaphore()));
     } else
         send(Messages::RemoteGPUProxy::WasCreated(false, { }, { }));
 }
@@ -127,8 +128,9 @@ void RemoteGPU::workQueueInitialize()
 void RemoteGPU::workQueueUninitialize()
 {
     assertIsCurrent(workQueue());
-    m_streamConnection->stopReceivingMessages(Messages::RemoteGPU::messageReceiverName(), m_identifier.toUInt64());
-    m_streamConnection->invalidate();
+    RefPtr streamConnection = m_streamConnection;
+    streamConnection->stopReceivingMessages(Messages::RemoteGPU::messageReceiverName(), m_identifier.toUInt64());
+    streamConnection->invalidate();
     m_streamConnection = nullptr;
     Ref { m_objectHeap }->clear();
     m_backing = nullptr;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h
@@ -113,7 +113,7 @@ private:
     template<typename T>
     IPC::Error send(T&& message) const
     {
-        return m_streamConnection->send(std::forward<T>(message), m_identifier);
+        return Ref { *m_streamConnection }->send(std::forward<T>(message), m_identifier);
     }
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.cpp
@@ -47,7 +47,7 @@ RemoteQueue::RemoteQueue(WebCore::WebGPU::Queue& queue, WebGPU::ObjectHeap& obje
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
-    m_streamConnection->startReceivingMessages(*this, Messages::RemoteQueue::messageReceiverName(), m_identifier.toUInt64());
+    Ref { m_streamConnection }->startReceivingMessages(*this, Messages::RemoteQueue::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteQueue::~RemoteQueue() = default;
@@ -59,7 +59,7 @@ void RemoteQueue::destruct()
 
 void RemoteQueue::stopListeningForIPC()
 {
-    m_streamConnection->stopReceivingMessages(Messages::RemoteQueue::messageReceiverName(), m_identifier.toUInt64());
+    Ref { m_streamConnection }->stopReceivingMessages(Messages::RemoteQueue::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteQueue::submit(Vector<WebGPUIdentifier>&& commandBuffers)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.h
@@ -121,7 +121,7 @@ private:
 
     Ref<WebCore::WebGPU::Queue> m_backing;
     WeakRef<WebGPU::ObjectHeap> m_objectHeap;
-    Ref<IPC::StreamServerConnection> m_streamConnection;
+    const Ref<IPC::StreamServerConnection> m_streamConnection;
     WeakRef<RemoteGPU> m_gpu;
     WebGPUIdentifier m_identifier;
 };

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.cpp
@@ -49,7 +49,7 @@ RemoteRenderPassEncoder::RemoteRenderPassEncoder(WebCore::WebGPU::RenderPassEnco
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
-    m_streamConnection->startReceivingMessages(*this, Messages::RemoteRenderPassEncoder::messageReceiverName(), m_identifier.toUInt64());
+    Ref { m_streamConnection }->startReceivingMessages(*this, Messages::RemoteRenderPassEncoder::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteRenderPassEncoder::~RemoteRenderPassEncoder() = default;
@@ -61,7 +61,7 @@ void RemoteRenderPassEncoder::destruct()
 
 void RemoteRenderPassEncoder::stopListeningForIPC()
 {
-    m_streamConnection->stopReceivingMessages(Messages::RemoteRenderPassEncoder::messageReceiverName(), m_identifier.toUInt64());
+    Ref { m_streamConnection }->stopReceivingMessages(Messages::RemoteRenderPassEncoder::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteRenderPassEncoder::setPipeline(WebGPUIdentifier renderPipeline)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.h
@@ -129,7 +129,7 @@ private:
 
     Ref<WebCore::WebGPU::RenderPassEncoder> m_backing;
     WeakRef<WebGPU::ObjectHeap> m_objectHeap;
-    Ref<IPC::StreamServerConnection> m_streamConnection;
+    const Ref<IPC::StreamServerConnection> m_streamConnection;
     WeakRef<RemoteGPU> m_gpu;
     WebGPUIdentifier m_identifier;
 };

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.cpp
@@ -54,7 +54,7 @@ RemoteTexture::RemoteTexture(GPUConnectionToWebProcess& gpuConnectionToWebProces
     , m_gpuConnectionToWebProcess(gpuConnectionToWebProcess)
     , m_gpu(gpu)
 {
-    m_streamConnection->startReceivingMessages(*this, Messages::RemoteTexture::messageReceiverName(), m_identifier.toUInt64());
+    Ref { m_streamConnection }->startReceivingMessages(*this, Messages::RemoteTexture::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteTexture::~RemoteTexture() = default;
@@ -69,7 +69,7 @@ RefPtr<IPC::Connection> RemoteTexture::connection() const
 
 void RemoteTexture::stopListeningForIPC()
 {
-    m_streamConnection->stopReceivingMessages(Messages::RemoteTexture::messageReceiverName(), m_identifier.toUInt64());
+    Ref { m_streamConnection }->stopReceivingMessages(Messages::RemoteTexture::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteTexture::createView(const std::optional<WebGPU::TextureViewDescriptor>& descriptor, WebGPUIdentifier identifier)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.h
@@ -95,7 +95,7 @@ private:
 
     Ref<WebCore::WebGPU::Texture> m_backing;
     WeakRef<WebGPU::ObjectHeap> m_objectHeap;
-    Ref<IPC::StreamServerConnection> m_streamConnection;
+    const Ref<IPC::StreamServerConnection> m_streamConnection;
     WebGPUIdentifier m_identifier;
     ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;
     WeakRef<RemoteGPU> m_gpu;

--- a/Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.h
+++ b/Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.h
@@ -54,6 +54,9 @@ public:
     // message handlers
     void update(WCUpdateInfo&&, CompletionHandler<void(std::optional<WebKit::UpdateInfo>)>&&);
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
 private:
     RemoteWCLayerTreeHost(GPUConnectionToWebProcess&, WebKit::WCLayerTreeHostIdentifier, uint64_t nativeWindow, bool usesOffscreenRendering);
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.h
@@ -62,8 +62,8 @@ public:
     RemoteAudioDestinationManager(GPUConnectionToWebProcess&);
     ~RemoteAudioDestinationManager();
 
-    void ref() const;
-    void deref() const;
+    void ref() const final;
+    void deref() const final;
 
     void didReceiveMessageFromWebProcess(IPC::Connection& connection, IPC::Decoder& decoder) { didReceiveMessage(connection, decoder); }
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h
@@ -55,6 +55,9 @@ public:
         return adoptRef(*new RemoteAudioSessionProxy(gpuConnection));
     }
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual ~RemoteAudioSessionProxy();
 
     WebCore::ProcessIdentifier processIdentifier();

--- a/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.h
@@ -55,6 +55,9 @@ public:
     }
     virtual ~RemoteCDMFactoryProxy();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     void clear();
 
     void didReceiveMessageFromWebProcess(IPC::Connection& connection, IPC::Decoder& decoder) { didReceiveMessage(connection, decoder); }

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.h
@@ -48,6 +48,9 @@ public:
     virtual ~RemoteCDMInstanceSessionProxy();
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
 private:
     friend class RemoteCDMFactoryProxy;
     RemoteCDMInstanceSessionProxy(WeakPtr<RemoteCDMProxy>&&, Ref<WebCore::CDMInstanceSession>&&, uint64_t logIdentifier, RemoteCDMInstanceSessionIdentifier);

--- a/Source/WebKit/GPUProcess/media/RemoteCDMProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMProxy.h
@@ -55,6 +55,9 @@ public:
     static RefPtr<RemoteCDMProxy> create(RemoteCDMFactoryProxy&, std::unique_ptr<WebCore::CDMPrivate>&&);
     ~RemoteCDMProxy();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     const RemoteCDMConfiguration& configuration() const { return m_configuration.get(); }
 
     RemoteCDMFactoryProxy* factory() const { return m_factory.get(); }

--- a/Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.h
@@ -58,8 +58,8 @@ public:
 
     bool allowsExitUnderMemoryPressure() const;
 
-    void ref() const;
-    void deref() const;
+    void ref() const final;
+    void deref() const final;
 
 private:
     void createDecoder(const IPC::SharedBufferReference&, const String& mimeType, CompletionHandler<void(std::optional<WebCore::ImageDecoderIdentifier>&&)>&&);

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.h
@@ -53,6 +53,9 @@ public:
 
     virtual ~RemoteLegacyCDMFactoryProxy();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     void clear();
 
     void didReceiveMessageFromWebProcess(IPC::Connection& connection, IPC::Decoder& decoder) { didReceiveMessage(connection, decoder); }

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.h
@@ -45,6 +45,9 @@ public:
     static Ref<RemoteLegacyCDMProxy> create(WeakPtr<RemoteLegacyCDMFactoryProxy>, std::optional<WebCore::MediaPlayerIdentifier>, Ref<WebCore::LegacyCDM>&&);
     ~RemoteLegacyCDMProxy();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     RemoteLegacyCDMFactoryProxy* factory() const { return m_factory.get(); }
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h
@@ -52,6 +52,9 @@ public:
     static Ref<RemoteLegacyCDMSessionProxy> create(RemoteLegacyCDMFactoryProxy&, uint64_t logIdentifier, RemoteLegacyCDMSessionIdentifier, WebCore::LegacyCDM&);
     ~RemoteLegacyCDMSessionProxy();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     void invalidate();
 
     RemoteLegacyCDMFactoryProxy* factory() const { return m_factory.get(); }

--- a/Source/WebKit/GPUProcess/media/RemoteMediaEngineConfigurationFactoryProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaEngineConfigurationFactoryProxy.h
@@ -46,8 +46,8 @@ public:
 
     void didReceiveMessageFromWebProcess(IPC::Connection& connection, IPC::Decoder& decoder) { didReceiveMessage(connection, decoder); }
 
-    void ref() const;
-    void deref() const;
+    void ref() const final;
+    void deref() const final;
 
 private:
     friend class GPUProcessConnection;

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.h
@@ -73,6 +73,9 @@ public:
 
     ~RemoteMediaPlayerManagerProxy();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     RefPtr<GPUConnectionToWebProcess> gpuConnectionToWebProcess() { return m_gpuConnectionToWebProcess.get(); }
     void clear();
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -117,6 +117,9 @@ public:
     static Ref<RemoteMediaPlayerProxy> create(RemoteMediaPlayerManagerProxy&, WebCore::MediaPlayerIdentifier, WebCore::MediaPlayerClientIdentifier, Ref<IPC::Connection>&&, WebCore::MediaPlayerEnums::MediaEngineIdentifier, RemoteMediaPlayerProxyConfiguration&&, RemoteVideoFrameObjectHeap&, const WebCore::ProcessIdentity&);
     ~RemoteMediaPlayerProxy();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     WebCore::MediaPlayerIdentifier identifier() const { return m_id; }
     void invalidate();
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.h
@@ -59,6 +59,9 @@ public:
     static Ref<RemoteMediaResourceManager> create() { return adoptRef(*new RemoteMediaResourceManager()); }
     ~RemoteMediaResourceManager();
 
+    void ref() const final { IPC::WorkQueueMessageReceiver::ref(); }
+    void deref() const final { IPC::WorkQueueMessageReceiver::deref(); }
+
     void initializeConnection(IPC::Connection*);
     void stopListeningForIPC();
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
@@ -61,6 +61,9 @@ public:
     RemoteMediaSourceProxy(RemoteMediaPlayerManagerProxy&, RemoteMediaSourceIdentifier, bool webMParserEnabled, RemoteMediaPlayerProxy&);
     virtual ~RemoteMediaSourceProxy();
 
+    void ref() const final { WebCore::MediaSourcePrivateClient::ref(); }
+    void deref() const final { WebCore::MediaSourcePrivateClient::deref(); }
+
     void setMediaPlayers(RemoteMediaPlayerProxy&, WebCore::MediaPlayerPrivateInterface*);
 
     // MediaSourcePrivateClient overrides

--- a/Source/WebKit/GPUProcess/media/RemoteRemoteCommandListenerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteRemoteCommandListenerProxy.h
@@ -54,6 +54,9 @@ public:
 
     virtual ~RemoteRemoteCommandListenerProxy();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     bool supportsSeeking() const { return m_supportsSeeking; }
     const WebCore::RemoteCommandListener::RemoteCommandsSet& supportedCommands() const { return m_supportedCommands; }
 

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
@@ -63,6 +63,9 @@ public:
     static Ref<RemoteSourceBufferProxy> create(GPUConnectionToWebProcess&, RemoteSourceBufferIdentifier, Ref<WebCore::SourceBufferPrivate>&&, RemoteMediaPlayerProxy&);
     virtual ~RemoteSourceBufferProxy();
 
+    void ref() const final { WebCore::SourceBufferPrivateClient::ref(); }
+    void deref() const final { WebCore::SourceBufferPrivateClient::deref(); }
+
     void setMediaPlayer(RemoteMediaPlayerProxy&);
 
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;

--- a/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.h
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.h
@@ -49,6 +49,9 @@ public:
     static Ref<RemoteVideoFrameObjectHeap> create(Ref<IPC::Connection>&&);
     ~RemoteVideoFrameObjectHeap();
 
+    void ref() const final { IPC::WorkQueueMessageReceiver::ref(); }
+    void deref() const final { IPC::WorkQueueMessageReceiver::deref(); }
+
     void close();
     RemoteVideoFrameProxy::Properties add(Ref<WebCore::VideoFrame>&&);
     RefPtr<WebCore::VideoFrame> get(RemoteVideoFrameReadReference&&);

--- a/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.h
+++ b/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.h
@@ -50,8 +50,8 @@ public:
     void overridePresentingApplicationPIDIfNeeded();
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
-    void ref() const;
-    void deref() const;
+    void ref() const final;
+    void deref() const final;
 
 private:
     // IPC::MessageReceiver

--- a/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h
+++ b/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h
@@ -70,6 +70,10 @@ class LibWebRTCCodecsProxy final : public IPC::WorkQueueMessageReceiver {
 public:
     static Ref<LibWebRTCCodecsProxy> create(GPUConnectionToWebProcess&, SharedPreferencesForWebProcess&);
     ~LibWebRTCCodecsProxy();
+
+    void ref() const final { IPC::WorkQueueMessageReceiver::ref(); }
+    void deref() const final { IPC::WorkQueueMessageReceiver::deref(); }
+
     void stopListeningForIPC(Ref<LibWebRTCCodecsProxy>&& refFromConnection);
     bool allowsExitUnderMemoryPressure() const;
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_sharedPreferencesForWebProcess; }

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.h
@@ -62,8 +62,8 @@ public:
 
     void notifyLastToCaptureAudioChanged();
 
-    void ref() const;
-    void deref() const;
+    void ref() const final;
+    void deref() const final;
 
 private:
     // Messages

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.h
@@ -62,6 +62,9 @@ public:
     }
     ~RemoteSampleBufferDisplayLayerManager();
 
+    void ref() const final { IPC::WorkQueueMessageReceiver::ref(); }
+    void deref() const final { IPC::WorkQueueMessageReceiver::deref(); }
+
     void close();
 
     bool allowsExitUnderMemoryPressure() const;

--- a/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.h
+++ b/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.h
@@ -74,6 +74,9 @@ public:
     static Ref<ModelConnectionToWebProcess> create(ModelProcess&, WebCore::ProcessIdentifier, PAL::SessionID, IPC::Connection::Handle&&, ModelProcessConnectionParameters&&);
     virtual ~ModelConnectionToWebProcess();
 
+    void ref() const final { ThreadSafeRefCounted::ref(); }
+    void deref() const final { ThreadSafeRefCounted::deref(); }
+
     USING_CAN_MAKE_WEAKPTR(CanMakeWeakPtr<ModelConnectionToWebProcess>);
 
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_sharedPreferencesForWebProcess; }

--- a/Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.h
+++ b/Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.h
@@ -51,6 +51,9 @@ public:
 
     ~ModelProcessModelPlayerManagerProxy();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
     ModelConnectionToWebProcess* modelConnectionToWebProcess() { return m_modelConnectionToWebProcess.get(); }

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
@@ -68,6 +68,9 @@ public:
     static Ref<ModelProcessModelPlayerProxy> create(ModelProcessModelPlayerManagerProxy&, WebCore::ModelPlayerIdentifier, Ref<IPC::Connection>&&);
     ~ModelProcessModelPlayerProxy();
 
+    void ref() const final { WebCore::ModelPlayer::ref(); }
+    void deref() const final { WebCore::ModelPlayer::deref(); }
+
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
     static bool transformSupported(const simd_float4x4& transform);

--- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h
+++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h
@@ -57,8 +57,8 @@ public:
     WebCookieManager(NetworkProcess&);
     ~WebCookieManager();
 
-    void ref() const;
-    void deref() const;
+    void ref() const final;
+    void deref() const final;
 
     static ASCIILiteral supplementName();
 

--- a/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.h
+++ b/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.h
@@ -66,8 +66,8 @@ public:
     void unregisterScheme(const String&);
     bool supportsScheme(const String&);
 
-    void ref() const;
-    void deref() const;
+    void ref() const final;
+    void deref() const final;
 
 #if PLATFORM(COCOA)
     typedef RetainPtr<WKCustomProtocol> CustomProtocol;

--- a/Source/WebKit/NetworkProcess/EarlyHintsResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/EarlyHintsResourceLoader.cpp
@@ -129,7 +129,7 @@ void EarlyHintsResourceLoader::startPreconnectTask(const URL& baseURL, const Lin
     if (!contentSecurityPolicy.allowConnectToSource(url, ContentSecurityPolicy::RedirectResponseReceived::No, originalRequest.url()))
         return;
 
-    auto* networkSession = m_loader->connectionToWebProcess().networkSession();
+    auto* networkSession = m_loader->protectedConnectionToWebProcess()->networkSession();
     if (!networkSession)
         return;
 

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -292,7 +292,7 @@ bool NetworkConnectionToWebProcess::dispatchMessage(IPC::Connection& connection,
 
     if (decoder.messageReceiverName() == Messages::NetworkTransportSession::messageReceiverName()) {
         MESSAGE_CHECK_WITH_RETURN_VALUE(WebTransportSessionIdentifier::isValidIdentifier(decoder.destinationID()), false);
-        if (auto* networkTransportSession = m_networkTransportSessions.get(WebTransportSessionIdentifier(decoder.destinationID())))
+        if (RefPtr networkTransportSession = m_networkTransportSessions.get(WebTransportSessionIdentifier(decoder.destinationID())))
             networkTransportSession->didReceiveMessage(connection, decoder);
         return true;
     }

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -154,6 +154,9 @@ public:
     using IPC::Connection::Client::incrementCheckedPtrCount;
     using IPC::Connection::Client::decrementCheckedPtrCount;
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_sharedPreferencesForWebProcess; }
     void updateSharedPreferencesForWebProcess(SharedPreferencesForWebProcess&& sharedPreferencesForWebProcess) { m_sharedPreferencesForWebProcess = WTFMove(sharedPreferencesForWebProcess); }
 

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -3043,7 +3043,7 @@ void NetworkProcess::countNonDefaultSessionSets(PAL::SessionID sessionID, Comple
 
 void NetworkProcess::allowFilesAccessFromWebProcess(WebCore::ProcessIdentifier processID, const Vector<String>& paths, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* connection = webProcessConnection(processID)) {
+    if (RefPtr connection = webProcessConnection(processID)) {
         for (auto& path : paths)
             connection->allowAccessToFile(path);
     }
@@ -3052,7 +3052,7 @@ void NetworkProcess::allowFilesAccessFromWebProcess(WebCore::ProcessIdentifier p
 
 void NetworkProcess::allowFileAccessFromWebProcess(WebCore::ProcessIdentifier processID, const String& path, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* connection = webProcessConnection(processID))
+    if (RefPtr connection = webProcessConnection(processID))
         connection->allowAccessToFile(path);
     completionHandler();
 }

--- a/Source/WebKit/NetworkProcess/NetworkSocketChannel.h
+++ b/Source/WebKit/NetworkProcess/NetworkSocketChannel.h
@@ -64,6 +64,9 @@ public:
     static RefPtr<NetworkSocketChannel> create(NetworkConnectionToWebProcess&, PAL::SessionID, const WebCore::ResourceRequest&, const String& protocol, WebCore::WebSocketIdentifier, WebPageProxyIdentifier, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::PageIdentifier>, const WebCore::ClientOrigin&, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<WebCore::AdvancedPrivacyProtections>, WebCore::ShouldRelaxThirdPartyCookieBlocking, WebCore::StoredCredentialsPolicy);
     ~NetworkSocketChannel();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
 
     friend class WebSocketTask;

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.h
@@ -57,6 +57,9 @@ public:
     }
     ~ServiceWorkerDownloadTask();
 
+    void ref() const final { NetworkDataTask::ref(); }
+    void deref() const final { NetworkDataTask::deref(); }
+
     WebCore::FetchIdentifier fetchIdentifier() const { return m_fetchIdentifier; }
     void contextClosed() { cancel(); }
     void start();

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
@@ -138,10 +138,11 @@ ServiceWorkerFetchTask::~ServiceWorkerFetchTask()
 
 template<typename Message> bool ServiceWorkerFetchTask::sendToServiceWorker(Message&& message)
 {
-    if (!m_serviceWorkerConnection)
+    RefPtr serviceWorkerConnection = m_serviceWorkerConnection.get();
+    if (!serviceWorkerConnection)
         return false;
 
-    return m_serviceWorkerConnection->protectedIPCConnection()->send(std::forward<Message>(message), 0) == IPC::Error::NoError;
+    return serviceWorkerConnection->protectedIPCConnection()->send(std::forward<Message>(message), 0) == IPC::Error::NoError;
 }
 
 template<typename Message> bool ServiceWorkerFetchTask::sendToClient(Message&& message)
@@ -462,7 +463,7 @@ void ServiceWorkerFetchTask::softUpdateIfNeeded()
     if (!m_shouldSoftUpdate)
         return;
     Ref loader = *m_loader;
-    RefPtr swConnection = loader->connectionToWebProcess().swConnection();
+    RefPtr swConnection = loader->protectedConnectionToWebProcess()->swConnection();
     if (!swConnection)
         return;
     RefPtr server = swConnection->server();
@@ -572,7 +573,11 @@ bool ServiceWorkerFetchTask::convertToDownload(DownloadManager& manager, Downloa
         return m_preloader->convertToDownload(manager, downloadID, request, response);
 
     CheckedPtr session = this->session();
-    if (!session || !m_serviceWorkerConnection)
+    if (!session)
+        return false;
+
+    RefPtr serviceWorkerConnection = m_serviceWorkerConnection.get();
+    if (!serviceWorkerConnection)
         return false;
 
     m_isDone = true;
@@ -580,7 +585,7 @@ bool ServiceWorkerFetchTask::convertToDownload(DownloadManager& manager, Downloa
     // FIXME: We might want to keep the service worker alive until the download ends.
     RefPtr<ServiceWorkerDownloadTask> serviceWorkerDownloadTask;
     auto serviceWorkerDownloadLoad = NetworkLoad::create(*protectedLoader(), *session, [&](auto& client) {
-        serviceWorkerDownloadTask =  ServiceWorkerDownloadTask::create(*session, client, *m_serviceWorkerConnection, *m_serviceWorkerIdentifier, *m_serverConnectionIdentifier, m_fetchIdentifier, request, response, downloadID);
+        serviceWorkerDownloadTask =  ServiceWorkerDownloadTask::create(*session, client, *serviceWorkerConnection, *m_serviceWorkerIdentifier, *m_serverConnectionIdentifier, m_fetchIdentifier, request, response, downloadID);
         return serviceWorkerDownloadTask.copyRef();
     });
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
@@ -78,6 +78,9 @@ public:
     WebSWServerConnection(const WebSWServerConnection&) = delete;
     ~WebSWServerConnection() final;
 
+    void ref() const final { WebCore::SWServer::Connection::ref(); }
+    void deref() const final { WebCore::SWServer::Connection::deref(); }
+
     USING_CAN_MAKE_WEAKPTR(WebCore::SWServer::Connection);
 
     IPC::Connection& ipcConnection() const { return m_contentConnection.get(); }

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
@@ -204,7 +204,7 @@ void WebSWServerToContextConnection::fireNotificationEvent(ServiceWorkerIdentifi
         if (!protectedThis || !protectedThis->m_connection)
             return callback(wasProcessed);
 
-        CheckedPtr session = protectedThis->m_connection->networkSession();
+        CheckedPtr session = protectedThis->protectedConnection()->networkSession();
         if (auto* resourceLoadStatistics = session ? session->resourceLoadStatistics() : nullptr; resourceLoadStatistics && wasProcessed && eventType == NotificationEventType::Click) {
             return resourceLoadStatistics->setMostRecentWebPushInteractionTime(RegistrableDomain(protectedThis->registrableDomain()), [callback = WTFMove(callback), wasProcessed] () mutable {
                 callback(wasProcessed);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
@@ -66,6 +66,9 @@ public:
     static Ref<WebSWServerToContextConnection> create(NetworkConnectionToWebProcess&, WebPageProxyIdentifier, WebCore::Site&&, std::optional<WebCore::ScriptExecutionContextIdentifier>, WebCore::SWServer&);
     ~WebSWServerToContextConnection();
 
+    void ref() const final { WebCore::SWServerToContextConnection::ref(); }
+    void deref() const final { WebCore::SWServerToContextConnection::deref(); }
+
     void stop();
 
     RefPtr<IPC::Connection> protectedIPCConnection() const;

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.h
@@ -61,6 +61,9 @@ public:
 
     ~WebSharedWorkerServerConnection();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     WebSharedWorkerServer* server();
     const WebSharedWorkerServer* server() const;
 

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h
@@ -61,6 +61,9 @@ public:
 
     ~WebSharedWorkerServerToContextConnection();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     std::optional<WebCore::ProcessIdentifier> webProcessIdentifier() const;
     const WebCore::RegistrableDomain& registrableDomain() const { return m_site.domain(); }
     const WebCore::Site& site() const { return m_site; }

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp
@@ -238,8 +238,8 @@ const String& NetworkRTCProvider::attributedBundleIdentifierFromPageIdentifier(W
     return m_attributedBundleIdentifiers.ensure(pageIdentifier, [&]() -> String {
         String value;
         callOnMainRunLoopAndWait([&] {
-            auto* session = m_connection ? m_connection->networkSession() : nullptr;
-            if (session)
+            RefPtr connection = m_connection.get();
+            if (auto* session = connection ? connection->networkSession() : nullptr)
                 value = session->attributedBundleIdentifierFromPageIdentifier(pageIdentifier).isolatedCopy();
         });
         return value;

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h
@@ -89,6 +89,9 @@ public:
     }
     ~NetworkRTCProvider();
 
+    void ref() const final { ThreadSafeRefCounted::ref(); }
+    void deref() const final { ThreadSafeRefCounted::deref(); }
+
     void didReceiveNetworkRTCMonitorMessage(IPC::Connection& connection, IPC::Decoder& decoder) { protectedRTCMonitor()->didReceiveMessage(connection, decoder); }
 
     class Socket {

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
@@ -58,6 +58,9 @@ public:
 
     ~NetworkTransportSession();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     void sendDatagram(std::span<const uint8_t>, CompletionHandler<void()>&&);
     void createOutgoingUnidirectionalStream(CompletionHandler<void(std::optional<WebTransportStreamIdentifier>)>&&);
     void createBidirectionalStream(CompletionHandler<void(std::optional<WebTransportStreamIdentifier>)>&&);

--- a/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportReceiveStreamCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportReceiveStreamCocoa.mm
@@ -60,8 +60,8 @@ void NetworkTransportReceiveStream::receiveLoop()
             return;
         if (error)
             return; // FIXME: Pipe this error to JS.
-        if (strongThis->m_session)
-            strongThis->m_session->streamReceiveBytes(strongThis->m_identifier, vectorFromData(content).span(), withFin);
+        if (RefPtr session = strongThis->m_session.get())
+            session->streamReceiveBytes(strongThis->m_identifier, vectorFromData(content).span(), withFin);
         strongThis->receiveLoop();
     }).get());
 }

--- a/Source/WebKit/Platform/IPC/MessageReceiveQueues.h
+++ b/Source/WebKit/Platform/IPC/MessageReceiveQueues.h
@@ -29,6 +29,7 @@
 #include "MessageReceiveQueue.h"
 #include "WorkQueueMessageReceiver.h"
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/WeakRef.h>
 
 namespace IPC {
 
@@ -44,13 +45,13 @@ public:
 
     void enqueueMessage(Connection& connection, UniqueRef<Decoder>&& message) final
     {
-        m_dispatcher.dispatch([connection = Ref { connection }, message = WTFMove(message), &receiver = m_receiver]() mutable {
+        m_dispatcher.dispatch([connection = Ref { connection }, message = WTFMove(message), receiver = Ref { m_receiver.get() }]() mutable {
             connection->dispatchMessageReceiverMessage(receiver, WTFMove(message));
         });
     }
 private:
     FunctionDispatcher& m_dispatcher;
-    MessageReceiver& m_receiver;
+    WeakRef<MessageReceiver> m_receiver;
 };
 
 class WorkQueueMessageReceiverQueue final : public MessageReceiveQueue {

--- a/Source/WebKit/Platform/IPC/MessageReceiver.h
+++ b/Source/WebKit/Platform/IPC/MessageReceiver.h
@@ -25,17 +25,9 @@
 
 #pragma once
 
+#include <wtf/AbstractRefCounted.h>
 #include <wtf/Assertions.h>
 #include <wtf/WeakPtr.h>
-
-namespace IPC {
-class MessageReceiver;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<IPC::MessageReceiver> : std::true_type { };
-}
 
 namespace IPC {
 
@@ -43,7 +35,7 @@ class Connection;
 class Decoder;
 class Encoder;
 
-class MessageReceiver : public CanMakeWeakPtr<MessageReceiver> {
+class MessageReceiver : public CanMakeWeakPtr<MessageReceiver>, public AbstractRefCounted {
 public:
     virtual ~MessageReceiver()
     {

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
@@ -33,8 +33,9 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(StreamClientConnection);
 
 // FIXME(http://webkit.org/b/238986): Workaround for not being able to deliver messages from the dedicated connection to the work queue the client uses.
 
-StreamClientConnection::DedicatedConnectionClient::DedicatedConnectionClient(Connection::Client& receiver)
-    : m_receiver(receiver)
+StreamClientConnection::DedicatedConnectionClient::DedicatedConnectionClient(StreamClientConnection& owner, Connection::Client& receiver)
+    : m_owner(owner)
+    , m_receiver(receiver)
 {
 }
 
@@ -112,7 +113,7 @@ void StreamClientConnection::setMaxBatchSize(unsigned size)
 
 void StreamClientConnection::open(Connection::Client& receiver, SerialFunctionDispatcher& dispatcher)
 {
-    m_dedicatedConnectionClient.emplace(receiver);
+    m_dedicatedConnectionClient.emplace(*this, receiver);
     protectedConnection()->open(*m_dedicatedConnectionClient, dispatcher);
 }
 

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.h
@@ -79,6 +79,9 @@ public:
     static RefPtr<StreamServerConnection> tryCreate(Handle&&, const StreamServerConnectionParameters&);
     ~StreamServerConnection() final;
 
+    void ref() const final { ThreadSafeRefCounted::ref(); }
+    void deref() const final { ThreadSafeRefCounted::deref(); }
+
     void startReceivingMessages(StreamMessageReceiver&, ReceiverName, uint64_t destinationID);
     // Stops the message receipt. Note: already received messages might still be delivered.
     void stopReceivingMessages(ReceiverName, uint64_t destinationID);

--- a/Source/WebKit/Platform/IPC/WorkQueueMessageReceiver.h
+++ b/Source/WebKit/Platform/IPC/WorkQueueMessageReceiver.h
@@ -31,7 +31,9 @@
 namespace IPC {
 
 class WorkQueueMessageReceiver : public MessageReceiver, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WorkQueueMessageReceiver> {
-
+public:
+    void ref() const override { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
+    void deref() const override { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
 };
 
 }

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -371,11 +371,8 @@ WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsEventCocoa.mm
 WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm
 WebProcess/FileAPI/BlobRegistryProxy.cpp
 WebProcess/FullScreen/WebFullScreenManager.cpp
-WebProcess/GPU/ShapeDetection/RemoteBarcodeDetectorProxy.cpp
-WebProcess/GPU/ShapeDetection/RemoteTextDetectorProxy.cpp
 WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
 WebProcess/GPU/graphics/RemoteNativeImageBackendProxy.cpp
-WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
 WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
 WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.cpp
 WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.cpp

--- a/Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.h
+++ b/Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.h
@@ -47,9 +47,6 @@ class RemoteObjectRegistry : public IPC::MessageReceiver {
 public:
     virtual ~RemoteObjectRegistry();
 
-    virtual void ref() const = 0;
-    virtual void deref() const = 0;
-
     virtual void sendInvocation(const RemoteObjectInvocation&);
     void sendReplyBlock(uint64_t replyID, const UserData& blockInvocation);
     void sendUnusedReply(uint64_t replyID);

--- a/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h
+++ b/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h
@@ -119,6 +119,9 @@ public:
     friend class NetworkConnectionToWebProcess;
     ~WebPaymentCoordinatorProxy();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     void webProcessExited();
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const
     {

--- a/Source/WebKit/Shared/Authentication/AuthenticationManager.h
+++ b/Source/WebKit/Shared/Authentication/AuthenticationManager.h
@@ -71,8 +71,8 @@ public:
     explicit AuthenticationManager(NetworkProcess&);
     ~AuthenticationManager();
 
-    void ref() const;
-    void deref() const;
+    void ref() const final;
+    void deref() const final;
 
     static ASCIILiteral supplementName();
 

--- a/Source/WebKit/Shared/AuxiliaryProcess.h
+++ b/Source/WebKit/Shared/AuxiliaryProcess.h
@@ -55,7 +55,7 @@ class SandboxInitializationParameters;
 struct AuxiliaryProcessInitializationParameters;
 struct AuxiliaryProcessCreationParameters;
 
-class AuxiliaryProcess : public IPC::Connection::Client, public IPC::MessageSender, public AbstractRefCounted {
+class AuxiliaryProcess : public IPC::Connection::Client, public IPC::MessageSender {
     WTF_MAKE_NONCOPYABLE(AuxiliaryProcess);
     WTF_MAKE_FAST_ALLOCATED;
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AuxiliaryProcess);

--- a/Source/WebKit/Shared/IPCConnectionTester.h
+++ b/Source/WebKit/Shared/IPCConnectionTester.h
@@ -48,6 +48,9 @@ public:
     static Ref<IPCConnectionTester> create(IPC::Connection&, IPCConnectionTesterIdentifier, IPC::Connection::Handle&&);
     void stopListeningForIPC(Ref<IPCConnectionTester>&& refFromConnection);
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     void sendAsyncMessages(uint32_t messageCount);
 private:
     IPCConnectionTester(Ref<IPC::Connection>&&, IPCConnectionTesterIdentifier, IPC::Connection::Handle&&);

--- a/Source/WebKit/Shared/IPCStreamTesterProxy.h
+++ b/Source/WebKit/Shared/IPCStreamTesterProxy.h
@@ -45,6 +45,9 @@ class IPCStreamTesterProxy final : public IPC::MessageReceiver, public RefCounte
 public:
     ~IPCStreamTesterProxy() = default;
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     // IPC::MessageReceiver overrides.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
 

--- a/Source/WebKit/Shared/IPCTester.h
+++ b/Source/WebKit/Shared/IPCTester.h
@@ -56,6 +56,9 @@ public:
     static Ref<IPCTester> create();
     ~IPCTester();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     // IPC::MessageReceiver overrides.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
     bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;

--- a/Source/WebKit/Shared/IPCTesterReceiver.h
+++ b/Source/WebKit/Shared/IPCTesterReceiver.h
@@ -41,6 +41,9 @@ public:
     static Ref<IPCTesterReceiver> create();
     ~IPCTesterReceiver() = default;
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 private:

--- a/Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.h
+++ b/Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.h
@@ -40,7 +40,7 @@ struct NotificationData;
 
 namespace WebKit {
 
-class NotificationManagerMessageHandler : public IPC::MessageReceiver, public AbstractRefCounted {
+class NotificationManagerMessageHandler : public IPC::MessageReceiver {
 public:
     virtual ~NotificationManagerMessageHandler() = default;
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
@@ -74,7 +74,7 @@ void RemoteLayerBackingStoreCollection::prepareBackingStoresForDisplay(RemoteLay
     Vector<WeakPtr<RemoteLayerWithRemoteRenderingBackingStore>> backingStoreList;
     backingStoreList.reserveInitialCapacity(m_backingStoresNeedingDisplay.computeSize());
 
-    auto& remoteRenderingBackend = layerTreeContext().ensureRemoteRenderingBackendProxy();
+    Ref remoteRenderingBackend = layerTreeContext().ensureRemoteRenderingBackendProxy();
 
     for (CheckedRef backingStore : m_backingStoresNeedingDisplay) {
         backingStore->layer().properties().notePropertiesChanged(LayerChange::BackingStoreChanged);
@@ -106,7 +106,7 @@ void RemoteLayerBackingStoreCollection::prepareBackingStoresForDisplay(RemoteLay
     }
 
     if (prepareBuffersData.size()) {
-        auto swapResult = remoteRenderingBackend.prepareImageBufferSetsForDisplay(WTFMove(prepareBuffersData));
+        auto swapResult = remoteRenderingBackend->prepareImageBufferSetsForDisplay(WTFMove(prepareBuffersData));
         RELEASE_ASSERT(swapResult.size() == backingStoreList.size() || swapResult.isEmpty());
         for (unsigned i = 0; i < swapResult.size(); ++i) {
             auto& backingStoreSwapResult = swapResult[i];
@@ -483,9 +483,9 @@ bool RemoteLayerBackingStoreCollection::collectAllRemoteRenderingBufferIdentifie
 
 void RemoteLayerBackingStoreCollection::sendMarkBuffersVolatile(Vector<std::pair<Ref<RemoteImageBufferSetProxy>, OptionSet<BufferInSetType>>>&& identifiers, CompletionHandler<void(bool)>&& completionHandler, bool forcePurge)
 {
-    auto& remoteRenderingBackend = m_layerTreeContext->ensureRemoteRenderingBackendProxy();
+    Ref remoteRenderingBackend = m_layerTreeContext->ensureRemoteRenderingBackendProxy();
 
-    remoteRenderingBackend.markSurfacesVolatile(WTFMove(identifiers), [completionHandler = WTFMove(completionHandler)](bool markedAllVolatile) mutable {
+    remoteRenderingBackend->markSurfacesVolatile(WTFMove(identifiers), [completionHandler = WTFMove(completionHandler)](bool markedAllVolatile) mutable {
         LOG_WITH_STREAM(RemoteLayerBuffers, stream << "RemoteLayerBackingStoreCollection::sendMarkBuffersVolatile: marked all volatile " << markedAllVolatile);
         completionHandler(markedAllVolatile);
     }, forcePurge);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionAction.mm
@@ -64,7 +64,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionAction, WebExtensionAction, 
 
 - (WKWebExtensionContext *)webExtensionContext
 {
-    if (auto *context = self._protectedWebExtensionAction->extensionContext())
+    if (RefPtr context = self._protectedWebExtensionAction->extensionContext())
         return context->wrapper();
     return nil;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommand.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommand.mm
@@ -77,7 +77,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionCommand, WebExtensionCommand
 
 - (WKWebExtensionContext *)webExtensionContext
 {
-    if (auto *context = self._protectedWebExtensionCommand->extensionContext())
+    if (RefPtr context = self._protectedWebExtensionCommand->extensionContext())
         return context->wrapper();
     return nil;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm
@@ -72,7 +72,7 @@ using CocoaMenuItem = UIMenuElement;
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
-WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionContext, WebExtensionContext, _webExtensionContext);
+WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionContext, WebExtensionContext, Ref { *_webExtensionContext });
 
 + (instancetype)contextForExtension:(WKWebExtension *)extension
 {
@@ -95,27 +95,27 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionContext, WebExtensionContext
 
 - (WKWebExtension *)webExtension
 {
-    return wrapper(_webExtensionContext->protectedExtension().get());
+    return wrapper(Ref { *_webExtensionContext }->protectedExtension().get());
 }
 
 - (WKWebExtensionController *)webExtensionController
 {
-    return wrapper(_webExtensionContext->extensionController());
+    return wrapper(Ref { *_webExtensionContext }->protectedExtensionController().get());
 }
 
 - (BOOL)isLoaded
 {
-    return _webExtensionContext->isLoaded();
+    return Ref { *_webExtensionContext }->isLoaded();
 }
 
 -(NSArray<NSError *> *)errors
 {
-    return _webExtensionContext->errors();
+    return Ref { *_webExtensionContext }->errors();
 }
 
 - (NSURL *)baseURL
 {
-    return _webExtensionContext->baseURL();
+    return Ref { *_webExtensionContext }->baseURL();
 }
 
 - (void)setBaseURL:(NSURL *)baseURL
@@ -126,66 +126,66 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionContext, WebExtensionContext
     NSAssert1(WebKit::WebExtensionMatchPattern::extensionSchemes().contains(baseURL.scheme), @"Invalid parameter: '%@' is not a registered custom scheme with WKWebExtensionMatchPattern", baseURL.scheme);
     NSAssert(!baseURL.path.length || [baseURL.path isEqualToString:@"/"], @"Invalid parameter: a URL with a path cannot be used");
 
-    _webExtensionContext->setBaseURL(baseURL);
+    Ref { *_webExtensionContext }->setBaseURL(baseURL);
 }
 
 - (NSString *)uniqueIdentifier
 {
-    return _webExtensionContext->uniqueIdentifier();
+    return Ref { *_webExtensionContext }->uniqueIdentifier();
 }
 
 - (void)setUniqueIdentifier:(NSString *)uniqueIdentifier
 {
     NSParameterAssert([uniqueIdentifier isKindOfClass:NSString.class]);
 
-    _webExtensionContext->setUniqueIdentifier(uniqueIdentifier);
+    Ref { *_webExtensionContext }->setUniqueIdentifier(uniqueIdentifier);
 }
 
 - (BOOL)isInspectable
 {
-    return _webExtensionContext->isInspectable();
+    return Ref { *_webExtensionContext }->isInspectable();
 }
 
 - (void)setInspectable:(BOOL)inspectable
 {
-    _webExtensionContext->setInspectable(inspectable);
+    Ref { *_webExtensionContext }->setInspectable(inspectable);
 }
 
 - (NSString *)inspectionName
 {
-    return _webExtensionContext->backgroundWebViewInspectionName();
+    return Ref { *_webExtensionContext }->backgroundWebViewInspectionName();
 }
 
 - (void)setInspectionName:(NSString *)name
 {
-    _webExtensionContext->setBackgroundWebViewInspectionName(name);
+    Ref { *_webExtensionContext }->setBackgroundWebViewInspectionName(name);
 }
 
 - (NSSet<NSString *> *)unsupportedAPIs
 {
-    return WebKit::toAPI(_webExtensionContext->unsupportedAPIs());
+    return WebKit::toAPI(Ref { *_webExtensionContext }->unsupportedAPIs());
 }
 
 - (void)setUnsupportedAPIs:(NSSet<NSString *> *)unsupportedAPIs
 {
     NSParameterAssert(!unsupportedAPIs || [unsupportedAPIs isKindOfClass:NSSet.class]);
 
-    _webExtensionContext->setUnsupportedAPIs(WebKit::toImpl(unsupportedAPIs));
+    Ref { *_webExtensionContext }->setUnsupportedAPIs(WebKit::toImpl(unsupportedAPIs));
 }
 
 - (WKWebViewConfiguration *)webViewConfiguration
 {
-    return _webExtensionContext->webViewConfiguration(WebKit::WebExtensionContext::WebViewPurpose::Tab);
+    return Ref { *_webExtensionContext }->webViewConfiguration(WebKit::WebExtensionContext::WebViewPurpose::Tab);
 }
 
 - (NSURL *)optionsPageURL
 {
-    return _webExtensionContext->optionsPageURL();
+    return Ref { *_webExtensionContext }->optionsPageURL();
 }
 
 - (NSURL *)overrideNewTabPageURL
 {
-    return _webExtensionContext->overrideNewTabPageURL();
+    return Ref { *_webExtensionContext }->overrideNewTabPageURL();
 }
 
 static inline WallTime toImpl(NSDate *date)
@@ -244,70 +244,70 @@ static inline WebKit::WebExtensionContext::PermissionMatchPatternsMap toImpl(NSD
 
 - (NSDictionary<WKWebExtensionPermission, NSDate *> *)grantedPermissions
 {
-    return toAPI(_webExtensionContext->grantedPermissions());
+    return toAPI(Ref { *_webExtensionContext }->grantedPermissions());
 }
 
 - (void)setGrantedPermissions:(NSDictionary<WKWebExtensionPermission, NSDate *> *)grantedPermissions
 {
     NSParameterAssert([grantedPermissions isKindOfClass:NSDictionary.class]);
 
-    _webExtensionContext->setGrantedPermissions(toImpl(grantedPermissions));
+    Ref { *_webExtensionContext }->setGrantedPermissions(toImpl(grantedPermissions));
 }
 
 - (NSDictionary<WKWebExtensionMatchPattern *, NSDate *> *)grantedPermissionMatchPatterns
 {
-    return toAPI(_webExtensionContext->grantedPermissionMatchPatterns());
+    return toAPI(Ref { *_webExtensionContext }->grantedPermissionMatchPatterns());
 }
 
 - (void)setGrantedPermissionMatchPatterns:(NSDictionary<WKWebExtensionMatchPattern *, NSDate *> *)grantedPermissionMatchPatterns
 {
     NSParameterAssert([grantedPermissionMatchPatterns isKindOfClass:NSDictionary.class]);
 
-    _webExtensionContext->setGrantedPermissionMatchPatterns(toImpl(grantedPermissionMatchPatterns));
+    Ref { *_webExtensionContext }->setGrantedPermissionMatchPatterns(toImpl(grantedPermissionMatchPatterns));
 }
 
 - (NSDictionary<WKWebExtensionPermission, NSDate *> *)deniedPermissions
 {
-    return toAPI(_webExtensionContext->deniedPermissions());
+    return toAPI(Ref { *_webExtensionContext }->deniedPermissions());
 }
 
 - (void)setDeniedPermissions:(NSDictionary<WKWebExtensionPermission, NSDate *> *)deniedPermissions
 {
     NSParameterAssert([deniedPermissions isKindOfClass:NSDictionary.class]);
 
-    _webExtensionContext->setDeniedPermissions(toImpl(deniedPermissions));
+    Ref { *_webExtensionContext }->setDeniedPermissions(toImpl(deniedPermissions));
 }
 
 - (NSDictionary<WKWebExtensionMatchPattern *, NSDate *> *)deniedPermissionMatchPatterns
 {
-    return toAPI(_webExtensionContext->deniedPermissionMatchPatterns());
+    return toAPI(Ref { *_webExtensionContext }->deniedPermissionMatchPatterns());
 }
 
 - (void)setDeniedPermissionMatchPatterns:(NSDictionary<WKWebExtensionMatchPattern *, NSDate *> *)deniedPermissionMatchPatterns
 {
     NSParameterAssert([deniedPermissionMatchPatterns isKindOfClass:NSDictionary.class]);
 
-    _webExtensionContext->setDeniedPermissionMatchPatterns(toImpl(deniedPermissionMatchPatterns));
+    Ref { *_webExtensionContext }->setDeniedPermissionMatchPatterns(toImpl(deniedPermissionMatchPatterns));
 }
 
 - (BOOL)hasRequestedOptionalAccessToAllHosts
 {
-    return _webExtensionContext->requestedOptionalAccessToAllHosts();
+    return Ref { *_webExtensionContext }->requestedOptionalAccessToAllHosts();
 }
 
 - (void)setHasRequestedOptionalAccessToAllHosts:(BOOL)requested
 {
-    return _webExtensionContext->setRequestedOptionalAccessToAllHosts(requested);
+    return Ref { *_webExtensionContext }->setRequestedOptionalAccessToAllHosts(requested);
 }
 
 - (BOOL)hasAccessToPrivateData
 {
-    return _webExtensionContext->hasAccessToPrivateData();
+    return Ref { *_webExtensionContext }->hasAccessToPrivateData();
 }
 
 - (void)setHasAccessToPrivateData:(BOOL)hasAccess
 {
-    return _webExtensionContext->setHasAccessToPrivateData(hasAccess);
+    return Ref { *_webExtensionContext }->setHasAccessToPrivateData(hasAccess);
 }
 
 static inline NSSet<WKWebExtensionPermission> *toAPI(const WebKit::WebExtensionContext::PermissionsMap::KeysConstIteratorRange& permissions)
@@ -338,12 +338,12 @@ static inline NSSet<WKWebExtensionMatchPattern *> *toAPI(const WebKit::WebExtens
 
 - (NSSet<WKWebExtensionPermission> *)currentPermissions
 {
-    return toAPI(_webExtensionContext->currentPermissions());
+    return toAPI(Ref { *_webExtensionContext }->currentPermissions());
 }
 
 - (NSSet<WKWebExtensionMatchPattern *> *)currentPermissionMatchPatterns
 {
-    return toAPI(_webExtensionContext->currentPermissionMatchPatterns());
+    return toAPI(Ref { *_webExtensionContext }->currentPermissionMatchPatterns());
 }
 
 - (BOOL)hasPermission:(WKWebExtensionPermission)permission
@@ -357,7 +357,8 @@ static inline NSSet<WKWebExtensionMatchPattern *> *toAPI(const WebKit::WebExtens
 {
     NSParameterAssert([permission isKindOfClass:NSString.class]);
 
-    return _webExtensionContext->hasPermission(permission, toImplNullable(tab, *_webExtensionContext).get());
+    Ref extensionContext { *_webExtensionContext };
+    return extensionContext->hasPermission(permission, toImplNullable(tab, extensionContext.get()).get());
 }
 
 - (BOOL)hasAccessToURL:(NSURL *)url
@@ -371,7 +372,8 @@ static inline NSSet<WKWebExtensionMatchPattern *> *toAPI(const WebKit::WebExtens
 {
     NSParameterAssert([url isKindOfClass:NSURL.class]);
 
-    return _webExtensionContext->hasPermission(url, toImplNullable(tab, *_webExtensionContext).get());
+    Ref extensionContext { *_webExtensionContext };
+    return extensionContext->hasPermission(url, toImplNullable(tab, extensionContext.get()).get());
 }
 
 static inline WKWebExtensionContextPermissionStatus toAPI(WebKit::WebExtensionContext::PermissionState status)
@@ -428,7 +430,8 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(WKWebExtension
 {
     NSParameterAssert([permission isKindOfClass:NSString.class]);
 
-    return toAPI(_webExtensionContext->permissionState(permission, toImplNullable(tab, *_webExtensionContext).get()));
+    Ref extensionContext { *_webExtensionContext };
+    return toAPI(extensionContext->permissionState(permission, toImplNullable(tab, extensionContext.get()).get()));
 }
 
 - (void)setPermissionStatus:(WKWebExtensionContextPermissionStatus)status forPermission:(WKWebExtensionPermission)permission
@@ -444,7 +447,7 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(WKWebExtension
     NSParameterAssert(status == WKWebExtensionContextPermissionStatusDeniedExplicitly || status == WKWebExtensionContextPermissionStatusUnknown || status == WKWebExtensionContextPermissionStatusGrantedExplicitly);
     NSParameterAssert([permission isKindOfClass:NSString.class]);
 
-    _webExtensionContext->setPermissionState(toImpl(status), permission, toImpl(expirationDate));
+    Ref { *_webExtensionContext }->setPermissionState(toImpl(status), permission, toImpl(expirationDate));
 }
 
 - (WKWebExtensionContextPermissionStatus)permissionStatusForURL:(NSURL *)url
@@ -458,7 +461,8 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(WKWebExtension
 {
     NSParameterAssert([url isKindOfClass:NSURL.class]);
 
-    return toAPI(_webExtensionContext->permissionState(url, toImplNullable(tab, *_webExtensionContext).get()));
+    Ref extensionContext { *_webExtensionContext };
+    return toAPI(extensionContext->permissionState(url, toImplNullable(tab, extensionContext.get()).get()));
 }
 
 - (void)setPermissionStatus:(WKWebExtensionContextPermissionStatus)status forURL:(NSURL *)url
@@ -474,7 +478,7 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(WKWebExtension
     NSParameterAssert(status == WKWebExtensionContextPermissionStatusDeniedExplicitly || status == WKWebExtensionContextPermissionStatusUnknown || status == WKWebExtensionContextPermissionStatusGrantedExplicitly);
     NSParameterAssert([url isKindOfClass:NSURL.class]);
 
-    _webExtensionContext->setPermissionState(toImpl(status), url, toImpl(expirationDate));
+    Ref { *_webExtensionContext }->setPermissionState(toImpl(status), url, toImpl(expirationDate));
 }
 
 - (WKWebExtensionContextPermissionStatus)permissionStatusForMatchPattern:(WKWebExtensionMatchPattern *)pattern
@@ -488,7 +492,8 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(WKWebExtension
 {
     NSParameterAssert([pattern isKindOfClass:WKWebExtensionMatchPattern.class]);
 
-    return toAPI(_webExtensionContext->permissionState(pattern._protectedWebExtensionMatchPattern, toImplNullable(tab, *_webExtensionContext).get()));
+    Ref extensionContext { *_webExtensionContext };
+    return toAPI(extensionContext->permissionState(pattern._protectedWebExtensionMatchPattern, toImplNullable(tab, extensionContext.get()).get()));
 }
 
 - (void)setPermissionStatus:(WKWebExtensionContextPermissionStatus)status forMatchPattern:(WKWebExtensionMatchPattern *)pattern
@@ -504,54 +509,56 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(WKWebExtension
     NSParameterAssert(status == WKWebExtensionContextPermissionStatusDeniedExplicitly || status == WKWebExtensionContextPermissionStatusUnknown || status == WKWebExtensionContextPermissionStatusGrantedExplicitly);
     NSParameterAssert([pattern isKindOfClass:WKWebExtensionMatchPattern.class]);
 
-    _webExtensionContext->setPermissionState(toImpl(status), pattern._protectedWebExtensionMatchPattern, toImpl(expirationDate));
+    Ref { *_webExtensionContext }->setPermissionState(toImpl(status), pattern._protectedWebExtensionMatchPattern, toImpl(expirationDate));
 }
 
 - (BOOL)hasAccessToAllURLs
 {
-    return _webExtensionContext->hasAccessToAllURLs();
+    return Ref { *_webExtensionContext }->hasAccessToAllURLs();
 }
 
 - (BOOL)hasAccessToAllHosts
 {
-    return _webExtensionContext->hasAccessToAllHosts();
+    return Ref { *_webExtensionContext }->hasAccessToAllHosts();
 }
 
 - (BOOL)hasInjectedContent
 {
-    return _webExtensionContext->hasInjectedContent();
+    return Ref { *_webExtensionContext }->hasInjectedContent();
 }
 
 - (BOOL)hasInjectedContentForURL:(NSURL *)url
 {
     NSParameterAssert([url isKindOfClass:NSURL.class]);
 
-    return _webExtensionContext->hasInjectedContentForURL(url);
+    return Ref { *_webExtensionContext }->hasInjectedContentForURL(url);
 }
 
 - (BOOL)hasContentModificationRules
 {
-    return _webExtensionContext->hasContentModificationRules();
+    return Ref { *_webExtensionContext }->hasContentModificationRules();
 }
 
 - (void)loadBackgroundContentWithCompletionHandler:(void (^)(NSError *error))completionHandler
 {
-    _webExtensionContext->loadBackgroundContent(makeBlockPtr(completionHandler));
+    Ref { *_webExtensionContext }->loadBackgroundContent(makeBlockPtr(completionHandler));
 }
 
 - (WKWebExtensionAction *)actionForTab:(id<WKWebExtensionTab>)tab
 {
-    return _webExtensionContext->getOrCreateAction(toImplNullable(tab, *_webExtensionContext).get())->wrapper();
+    Ref extensionContext { *_webExtensionContext };
+    return extensionContext->getOrCreateAction(toImplNullable(tab, extensionContext.get()).get())->wrapper();
 }
 
 - (void)performActionForTab:(id<WKWebExtensionTab>)tab
 {
-    _webExtensionContext->performAction(toImplNullable(tab, *_webExtensionContext).get(), WebKit::WebExtensionContext::UserTriggered::Yes);
+    Ref extensionContext { *_webExtensionContext };
+    extensionContext->performAction(toImplNullable(tab, extensionContext.get()).get(), WebKit::WebExtensionContext::UserTriggered::Yes);
 }
 
 - (NSArray<WKWebExtensionCommand *> *)commands
 {
-    return createNSArray(_webExtensionContext->commands(), [](auto& command) {
+    return createNSArray(Ref { *_webExtensionContext }->commands(), [](auto& command) {
         return command->wrapper();
     }).get();
 }
@@ -560,7 +567,7 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(WKWebExtension
 {
     NSParameterAssert([command isKindOfClass:WKWebExtensionCommand.class]);
 
-    _webExtensionContext->performCommand([command _protectedWebExtensionCommand].get(), WebKit::WebExtensionContext::UserTriggered::Yes);
+    Ref { *_webExtensionContext }->performCommand([command _protectedWebExtensionCommand].get(), WebKit::WebExtensionContext::UserTriggered::Yes);
 }
 
 #if TARGET_OS_IPHONE
@@ -568,7 +575,7 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(WKWebExtension
 {
     NSParameterAssert([keyCommand isKindOfClass:UIKeyCommand.class]);
 
-    return _webExtensionContext->performCommand(keyCommand);
+    return Ref { *_webExtensionContext }->performCommand(keyCommand);
 }
 #endif
 
@@ -577,14 +584,14 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(WKWebExtension
 {
     NSParameterAssert([event isKindOfClass:NSEvent.class]);
 
-    return _webExtensionContext->performCommand(event);
+    return Ref { *_webExtensionContext }->performCommand(event);
 }
 
 - (WKWebExtensionCommand *)commandForEvent:(NSEvent *)event
 {
     NSParameterAssert([event isKindOfClass:NSEvent.class]);
 
-    if (RefPtr result = _webExtensionContext->command(event))
+    if (RefPtr result = Ref { *_webExtensionContext }->command(event))
         return result->wrapper();
     return nil;
 }
@@ -594,28 +601,32 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(WKWebExtension
 {
     NSParameterAssert(tab != nil);
 
-    return _webExtensionContext->platformMenuItems(toImpl(tab, *_webExtensionContext));
+    Ref extensionContext { *_webExtensionContext };
+    return extensionContext->platformMenuItems(toImpl(tab, extensionContext.get()));
 }
 
 - (void)userGesturePerformedInTab:(id<WKWebExtensionTab>)tab
 {
     NSParameterAssert(tab != nil);
 
-    _webExtensionContext->userGesturePerformed(toImpl(tab, *_webExtensionContext));
+    Ref extensionContext { *_webExtensionContext };
+    extensionContext->userGesturePerformed(toImpl(tab, extensionContext.get()));
 }
 
 - (BOOL)hasActiveUserGestureInTab:(id<WKWebExtensionTab>)tab
 {
     NSParameterAssert(tab != nil);
 
-    return _webExtensionContext->hasActiveUserGesture(toImpl(tab, *_webExtensionContext));
+    Ref extensionContext { *_webExtensionContext };
+    return extensionContext->hasActiveUserGesture(toImpl(tab, extensionContext.get()));
 }
 
 - (void)clearUserGestureInTab:(id<WKWebExtensionTab>)tab
 {
     NSParameterAssert(tab != nil);
 
-    _webExtensionContext->clearUserGesture(toImpl(tab, *_webExtensionContext));
+    Ref extensionContext { *_webExtensionContext };
+    extensionContext->clearUserGesture(toImpl(tab, extensionContext.get()));
 }
 
 static inline id<WKWebExtensionWindow> toAPI(const RefPtr<WebKit::WebExtensionWindow>& window)
@@ -640,12 +651,12 @@ static inline NSArray *toAPI(const WebKit::WebExtensionContext::WindowVector& wi
 
 - (NSArray<id<WKWebExtensionWindow>> *)openWindows
 {
-    return toAPI(_webExtensionContext->openWindows(WebKit::WebExtensionContext::IgnoreExtensionAccess::Yes));
+    return toAPI(Ref { *_webExtensionContext }->openWindows(WebKit::WebExtensionContext::IgnoreExtensionAccess::Yes));
 }
 
 - (id<WKWebExtensionWindow>)focusedWindow
 {
-    return toAPI(_webExtensionContext->focusedWindow(WebKit::WebExtensionContext::IgnoreExtensionAccess::Yes));
+    return toAPI(Ref { *_webExtensionContext }->focusedWindow(WebKit::WebExtensionContext::IgnoreExtensionAccess::Yes));
 }
 
 static inline NSSet *toAPI(const WebKit::WebExtensionContext::TabVector& tabs)
@@ -665,7 +676,7 @@ static inline NSSet *toAPI(const WebKit::WebExtensionContext::TabVector& tabs)
 
 - (NSSet<id<WKWebExtensionTab>> *)openTabs
 {
-    return toAPI(_webExtensionContext->openTabs(WebKit::WebExtensionContext::IgnoreExtensionAccess::Yes));
+    return toAPI(Ref { *_webExtensionContext }->openTabs(WebKit::WebExtensionContext::IgnoreExtensionAccess::Yes));
 }
 
 static inline Ref<WebKit::WebExtensionWindow> toImpl(id<WKWebExtensionWindow> window, WebKit::WebExtensionContext& context)
@@ -677,19 +688,22 @@ static inline Ref<WebKit::WebExtensionWindow> toImpl(id<WKWebExtensionWindow> wi
 {
     NSParameterAssert(newWindow != nil);
 
-    _webExtensionContext->didOpenWindow(toImpl(newWindow, *_webExtensionContext));
+    Ref extensionContext { *_webExtensionContext };
+    extensionContext->didOpenWindow(toImpl(newWindow, extensionContext.get()));
 }
 
 - (void)didCloseWindow:(id<WKWebExtensionWindow>)closedWindow
 {
     NSParameterAssert(closedWindow != nil);
 
-    _webExtensionContext->didCloseWindow(toImpl(closedWindow, *_webExtensionContext));
+    Ref extensionContext { *_webExtensionContext };
+    extensionContext->didCloseWindow(toImpl(closedWindow, extensionContext.get()));
 }
 
 - (void)didFocusWindow:(id<WKWebExtensionWindow>)focusedWindow
 {
-    _webExtensionContext->didFocusWindow(focusedWindow ? toImpl(focusedWindow, *_webExtensionContext).ptr() : nullptr);
+    Ref extensionContext { *_webExtensionContext };
+    extensionContext->didFocusWindow(focusedWindow ? toImpl(focusedWindow, extensionContext.get()).ptr() : nullptr);
 }
 
 static inline Ref<WebKit::WebExtensionTab> toImpl(id<WKWebExtensionTab> tab, WebKit::WebExtensionContext& context)
@@ -717,42 +731,48 @@ static inline WebKit::WebExtensionContext::TabSet toImpl(NSArray<id<WKWebExtensi
 {
     NSParameterAssert(newTab != nil);
 
-    _webExtensionContext->didOpenTab(toImpl(newTab, *_webExtensionContext));
+    Ref extensionContext { *_webExtensionContext };
+    extensionContext->didOpenTab(toImpl(newTab, extensionContext.get()));
 }
 
 - (void)didCloseTab:(id<WKWebExtensionTab>)closedTab windowIsClosing:(BOOL)windowIsClosing
 {
     NSParameterAssert(closedTab != nil);
 
-    _webExtensionContext->didCloseTab(toImpl(closedTab, *_webExtensionContext), windowIsClosing ? WebKit::WebExtensionContext::WindowIsClosing::Yes : WebKit::WebExtensionContext::WindowIsClosing::No);
+    Ref extensionContext { *_webExtensionContext };
+    extensionContext->didCloseTab(toImpl(closedTab, extensionContext.get()), windowIsClosing ? WebKit::WebExtensionContext::WindowIsClosing::Yes : WebKit::WebExtensionContext::WindowIsClosing::No);
 }
 
 - (void)didActivateTab:(id<WKWebExtensionTab>)activatedTab previousActiveTab:(id<WKWebExtensionTab>)previousTab
 {
     NSParameterAssert(activatedTab != nil);
 
-    _webExtensionContext->didActivateTab(toImpl(activatedTab, *_webExtensionContext), toImplNullable(previousTab, *_webExtensionContext).get());
+    Ref extensionContext { *_webExtensionContext };
+    extensionContext->didActivateTab(toImpl(activatedTab, extensionContext.get()), toImplNullable(previousTab, extensionContext.get()).get());
 }
 
 - (void)didSelectTabs:(NSArray<id<WKWebExtensionTab>> *)selectedTabs
 {
     NSParameterAssert([selectedTabs isKindOfClass:NSArray.class]);
 
-    _webExtensionContext->didSelectOrDeselectTabs(toImpl(selectedTabs, *_webExtensionContext));
+    Ref extensionContext { *_webExtensionContext };
+    extensionContext->didSelectOrDeselectTabs(toImpl(selectedTabs, extensionContext.get()));
 }
 
 - (void)didDeselectTabs:(NSArray<id<WKWebExtensionTab>> *)deselectedTabs
 {
     NSParameterAssert([deselectedTabs isKindOfClass:NSArray.class]);
 
-    _webExtensionContext->didSelectOrDeselectTabs(toImpl(deselectedTabs, *_webExtensionContext));
+    Ref extensionContext { *_webExtensionContext };
+    extensionContext->didSelectOrDeselectTabs(toImpl(deselectedTabs, extensionContext.get()));
 }
 
 - (void)didMoveTab:(id<WKWebExtensionTab>)movedTab fromIndex:(NSUInteger)index inWindow:(id<WKWebExtensionWindow>)oldWindow
 {
     NSParameterAssert(movedTab != nil);
 
-    _webExtensionContext->didMoveTab(toImpl(movedTab, *_webExtensionContext), index != NSNotFound ? index : notFound, oldWindow ? toImpl(oldWindow, *_webExtensionContext).ptr() : nullptr);
+    Ref extensionContext { *_webExtensionContext };
+    extensionContext->didMoveTab(toImpl(movedTab, extensionContext.get()), index != NSNotFound ? index : notFound, oldWindow ? toImpl(oldWindow, extensionContext.get()).ptr() : nullptr);
 }
 
 - (void)didReplaceTab:(id<WKWebExtensionTab>)oldTab withTab:(id<WKWebExtensionTab>)newTab
@@ -760,7 +780,8 @@ static inline WebKit::WebExtensionContext::TabSet toImpl(NSArray<id<WKWebExtensi
     NSParameterAssert(oldTab != nil);
     NSParameterAssert(newTab != nil);
 
-    _webExtensionContext->didReplaceTab(toImpl(oldTab, *_webExtensionContext), toImpl(newTab, *_webExtensionContext));
+    Ref extensionContext { *_webExtensionContext };
+    extensionContext->didReplaceTab(toImpl(oldTab, extensionContext.get()), toImpl(newTab, extensionContext.get()));
 }
 
 static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(WKWebExtensionTabChangedProperties properties)
@@ -804,23 +825,25 @@ static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(WKWeb
 {
     NSParameterAssert(changedTab != nil);
 
-    _webExtensionContext->didChangeTabProperties(toImpl(changedTab, *_webExtensionContext), toImpl(properties));
+    Ref extensionContext { *_webExtensionContext };
+    extensionContext->didChangeTabProperties(toImpl(changedTab, extensionContext.get()), toImpl(properties));
 }
 
 - (WKWebView *)_backgroundWebView
 {
-    return _webExtensionContext->backgroundWebView();
+    return Ref { *_webExtensionContext }->backgroundWebView();
 }
 
 - (NSURL *)_backgroundContentURL
 {
-    return _webExtensionContext->backgroundContentURL();
+    return Ref { *_webExtensionContext }->backgroundContentURL();
 }
 
 #if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
 - (nullable _WKWebExtensionSidebar *)sidebarForTab:(id<WKWebExtensionTab>)tab
 {
-    if (RefPtr maybeSidebar = _webExtensionContext->getOrCreateSidebar(toImplNullable(tab, *_webExtensionContext)))
+    Ref extensionContext { *_webExtensionContext };
+    if (RefPtr maybeSidebar = extensionContext->getOrCreateSidebar(toImplNullable(tab, extensionContext.get())))
         return maybeSidebar->wrapper();
     return nil;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionController.mm
@@ -46,7 +46,7 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
-WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionController, WebExtensionController, _webExtensionController);
+WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionController, WebExtensionController, Ref { *_webExtensionController });
 
 - (instancetype)init
 {
@@ -72,28 +72,28 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionController, WebExtensionCont
 
 - (WKWebExtensionControllerConfiguration *)configuration
 {
-    return _webExtensionController->protectedConfiguration()->copy()->wrapper();
+    return Ref { *_webExtensionController }->protectedConfiguration()->copy()->wrapper();
 }
 
 - (BOOL)loadExtensionContext:(WKWebExtensionContext *)extensionContext error:(NSError **)outError
 {
     NSParameterAssert([extensionContext isKindOfClass:WKWebExtensionContext.class]);
 
-    return _webExtensionController->load(extensionContext._webExtensionContext, outError);
+    return Ref { *_webExtensionController }->load(Ref { extensionContext._webExtensionContext }, outError);
 }
 
 - (BOOL)unloadExtensionContext:(WKWebExtensionContext *)extensionContext error:(NSError **)outError
 {
     NSParameterAssert([extensionContext isKindOfClass:WKWebExtensionContext.class]);
 
-    return _webExtensionController->unload(extensionContext._webExtensionContext, outError);
+    return Ref { *_webExtensionController }->unload(Ref { extensionContext._webExtensionContext }, outError);
 }
 
 - (WKWebExtensionContext *)extensionContextForExtension:(WKWebExtension *)extension
 {
     NSParameterAssert([extension isKindOfClass:WKWebExtension.class]);
 
-    if (auto extensionContext = _webExtensionController->extensionContext(extension._protectedWebExtension))
+    if (auto extensionContext = Ref { *_webExtensionController }->extensionContext(extension._protectedWebExtension))
         return extensionContext->wrapper();
     return nil;
 }
@@ -102,7 +102,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionController, WebExtensionCont
 {
     NSParameterAssert([url isKindOfClass:NSURL.class]);
 
-    if (auto extensionContext = _webExtensionController->extensionContext(url))
+    if (auto extensionContext = Ref { *_webExtensionController }->extensionContext(url))
         return extensionContext->wrapper();
     return nil;
 }
@@ -123,12 +123,12 @@ static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
 
 - (NSSet<WKWebExtension *> *)extensions
 {
-    return toAPI(_webExtensionController->extensions());
+    return toAPI(Ref { *_webExtensionController }->extensions());
 }
 
 - (NSSet<WKWebExtensionContext *> *)extensionContexts
 {
-    return toAPI(_webExtensionController->extensionContexts());
+    return toAPI(Ref { *_webExtensionController }->extensionContexts());
 }
 
 + (NSSet<WKWebExtensionDataType> *)allExtensionDataTypes
@@ -141,7 +141,7 @@ static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
     NSParameterAssert([dataTypes isKindOfClass:NSSet.class]);
     NSParameterAssert(completionHandler);
 
-    _webExtensionController->getDataRecords(WebKit::toWebExtensionDataTypes(dataTypes), [completionHandler = makeBlockPtr(completionHandler)](Vector<Ref<WebKit::WebExtensionDataRecord>> records) {
+    Ref { *_webExtensionController }->getDataRecords(WebKit::toWebExtensionDataTypes(dataTypes), [completionHandler = makeBlockPtr(completionHandler)](Vector<Ref<WebKit::WebExtensionDataRecord>> records) {
         completionHandler(toAPI(records));
     });
 }
@@ -152,7 +152,7 @@ static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
     NSParameterAssert([extensionContext isKindOfClass:WKWebExtensionContext.class]);
     NSParameterAssert(completionHandler);
 
-    _webExtensionController->getDataRecord(WebKit::toWebExtensionDataTypes(dataTypes), extensionContext._webExtensionContext, [completionHandler = makeBlockPtr(completionHandler)](RefPtr<WebKit::WebExtensionDataRecord> record) {
+    Ref { *_webExtensionController }->getDataRecord(WebKit::toWebExtensionDataTypes(dataTypes), Ref { extensionContext._webExtensionContext }, [completionHandler = makeBlockPtr(completionHandler)](RefPtr<WebKit::WebExtensionDataRecord> record) {
         if (record)
             completionHandler(record->wrapper());
         else
@@ -166,7 +166,7 @@ static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
     NSParameterAssert([dataRecords isKindOfClass:NSArray.class]);
     NSParameterAssert(completionHandler);
 
-    _webExtensionController->removeData(WebKit::toWebExtensionDataTypes(dataTypes), WebKit::toWebExtensionDataRecords(dataRecords), [completionHandler = makeBlockPtr(completionHandler)] {
+    Ref { *_webExtensionController }->removeData(WebKit::toWebExtensionDataTypes(dataTypes), WebKit::toWebExtensionDataRecords(dataRecords), [completionHandler = makeBlockPtr(completionHandler)] {
         completionHandler();
     });
 }
@@ -175,7 +175,7 @@ static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
 {
     NSParameterAssert(newWindow != nil);
 
-    for (auto& context : _webExtensionController->extensionContexts())
+    for (auto& context : Ref { *_webExtensionController }->extensionContexts())
         [context->wrapper() didOpenWindow:newWindow];
 }
 
@@ -183,13 +183,13 @@ static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
 {
     NSParameterAssert(closedWindow != nil);
 
-    for (auto& context : _webExtensionController->extensionContexts())
+    for (auto& context : Ref { *_webExtensionController }->extensionContexts())
         [context->wrapper() didCloseWindow:closedWindow];
 }
 
 - (void)didFocusWindow:(id<WKWebExtensionWindow>)focusedWindow
 {
-    for (auto& context : _webExtensionController->extensionContexts())
+    for (auto& context : Ref { *_webExtensionController }->extensionContexts())
         [context->wrapper() didFocusWindow:focusedWindow];
 }
 
@@ -197,7 +197,7 @@ static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
 {
     NSParameterAssert(newTab != nil);
 
-    for (auto& context : _webExtensionController->extensionContexts())
+    for (auto& context : Ref { *_webExtensionController }->extensionContexts())
         [context->wrapper() didOpenTab:newTab];
 }
 
@@ -205,7 +205,7 @@ static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
 {
     NSParameterAssert(closedTab != nil);
 
-    for (auto& context : _webExtensionController->extensionContexts())
+    for (auto& context : Ref { *_webExtensionController }->extensionContexts())
         [context->wrapper() didCloseTab:closedTab windowIsClosing:windowIsClosing];
 }
 
@@ -213,7 +213,7 @@ static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
 {
     NSParameterAssert(activatedTab != nil);
 
-    for (auto& context : _webExtensionController->extensionContexts())
+    for (auto& context : Ref { *_webExtensionController }->extensionContexts())
         [context->wrapper() didActivateTab:activatedTab previousActiveTab:previousTab];
 }
 
@@ -221,7 +221,7 @@ static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
 {
     NSParameterAssert([selectedTabs isKindOfClass:NSArray.class]);
 
-    for (auto& context : _webExtensionController->extensionContexts())
+    for (auto& context : Ref { *_webExtensionController }->extensionContexts())
         [context->wrapper() didSelectTabs:selectedTabs];
 }
 
@@ -229,7 +229,7 @@ static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
 {
     NSParameterAssert([deselectedTabs isKindOfClass:NSArray.class]);
 
-    for (auto& context : _webExtensionController->extensionContexts())
+    for (auto& context : Ref { *_webExtensionController }->extensionContexts())
         [context->wrapper() didDeselectTabs:deselectedTabs];
 }
 
@@ -237,7 +237,7 @@ static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
 {
     NSParameterAssert(movedTab != nil);
 
-    for (auto& context : _webExtensionController->extensionContexts())
+    for (auto& context : Ref { *_webExtensionController }->extensionContexts())
         [context->wrapper() didMoveTab:movedTab fromIndex:index inWindow:oldWindow];
 }
 
@@ -246,7 +246,7 @@ static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
     NSParameterAssert(oldTab != nil);
     NSParameterAssert(newTab != nil);
 
-    for (auto& context : _webExtensionController->extensionContexts())
+    for (auto& context : Ref { *_webExtensionController }->extensionContexts())
         [context->wrapper() didReplaceTab:oldTab withTab:newTab];
 }
 
@@ -254,7 +254,7 @@ static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
 {
     NSParameterAssert(changedTab != nil);
 
-    for (auto& context : _webExtensionController->extensionContexts())
+    for (auto& context : Ref { *_webExtensionController }->extensionContexts())
         [context->wrapper() didChangeTabProperties:properties forTab:changedTab];
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKVisitedLinkStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKVisitedLinkStore.mm
@@ -47,7 +47,7 @@
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(_WKVisitedLinkStore.class, self))
         return;
 
-    _visitedLinkStore->~VisitedLinkStore();
+    Ref { *_visitedLinkStore }->~VisitedLinkStore();
 
     [super dealloc];
 }
@@ -56,31 +56,31 @@
 {
     auto linkHash = WebCore::computeSharedStringHash(URL.absoluteString);
 
-    _visitedLinkStore->addVisitedLinkHash(linkHash);
+    Ref { *_visitedLinkStore }->addVisitedLinkHash(linkHash);
 }
 
 - (void)addVisitedLinkWithString:(NSString *)string
 {
-    _visitedLinkStore->addVisitedLinkHash(WebCore::computeSharedStringHash(string));
+    Ref { *_visitedLinkStore }->addVisitedLinkHash(WebCore::computeSharedStringHash(string));
 }
 
 - (void)removeAll
 {
-    _visitedLinkStore->removeAll();
+    Ref { *_visitedLinkStore }->removeAll();
 }
 
 - (BOOL)containsVisitedLinkWithURL:(NSURL *)URL
 {
     auto linkHash = WebCore::computeSharedStringHash(URL.absoluteString);
 
-    return _visitedLinkStore->containsVisitedLinkHash(linkHash);
+    return Ref { *_visitedLinkStore }->containsVisitedLinkHash(linkHash);
 }
 
 - (void)removeVisitedLinkWithURL:(NSURL *)URL
 {
     auto linkHash = WebCore::computeSharedStringHash(URL.absoluteString);
 
-    _visitedLinkStore->removeVisitedLinkHash(linkHash);
+    Ref { *_visitedLinkStore }->removeVisitedLinkHash(linkHash);
 }
 
 #pragma mark WKObject protocol implementation

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -677,7 +677,8 @@ void WebAutomationSession::exitFullscreenWindowForPage(WebPageProxy& page, WTF::
 {
 #if ENABLE(FULLSCREEN_API)
     ASSERT(!m_windowStateTransitionCallback);
-    if (!page.fullScreenManager() || !page.fullScreenManager()->isFullScreen()) {
+    RefPtr fullScreenManager = page.fullScreenManager();
+    if (!fullScreenManager || !fullScreenManager->isFullScreen()) {
         completionHandler();
         return;
     }
@@ -692,7 +693,7 @@ void WebAutomationSession::exitFullscreenWindowForPage(WebPageProxy& page, WTF::
         completionHandler();
     } };
     
-    page.fullScreenManager()->requestExitFullScreen();
+    fullScreenManager->requestExitFullScreen();
 #else
     completionHandler();
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -234,6 +234,9 @@ public:
     static Ref<PlaybackSessionManagerProxy> create(WebPageProxy&);
     virtual ~PlaybackSessionManagerProxy();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     void invalidate();
 
     bool canEnterVideoFullscreen() const { return !!m_controlsManagerContextId && m_controlsManagerContextIsVideo; }

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h
@@ -86,6 +86,9 @@ public:
     static Ref<UserMediaCaptureManagerProxy> create(UniqueRef<ConnectionProxy>&&);
     ~UserMediaCaptureManagerProxy();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     void close();
     void clear();
 

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
@@ -167,6 +167,9 @@ public:
     static Ref<VideoPresentationManagerProxy> create(WebPageProxy&, PlaybackSessionManagerProxy&);
     virtual ~VideoPresentationManagerProxy();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     void invalidate();
 
     void requestHideAndExitFullscreen();

--- a/Source/WebKit/UIProcess/DigitalCredentials/DigitalCredentialsCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/DigitalCredentials/DigitalCredentialsCoordinatorProxy.h
@@ -56,6 +56,9 @@ public:
     static Ref<DigitalCredentialsCoordinatorProxy> create(WebPageProxy&);
     ~DigitalCredentialsCoordinatorProxy();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
 private:

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
@@ -72,6 +72,9 @@ public:
     }
     ~DownloadProxy();
 
+    void ref() const final { API::ObjectImpl<API::Object::Type::Download>::ref(); }
+    void deref() const final { API::ObjectImpl<API::Object::Type::Download>::deref(); }
+
     DownloadID downloadID() const { return m_downloadID; }
     const WebCore::ResourceRequest& request() const { return m_request; }
     API::Data* legacyResumeData() const { return m_legacyResumeData.get(); }

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.h
@@ -66,7 +66,7 @@ class WebProcessProxy;
 struct UpdateInfo;
 #endif
 
-class DrawingAreaProxy : public IPC::MessageReceiver, public IPC::MessageSender, public Identified<DrawingAreaIdentifier>, public AbstractRefCounted, public CanMakeCheckedPtr<DrawingAreaProxy> {
+class DrawingAreaProxy : public IPC::MessageReceiver, public IPC::MessageSender, public Identified<DrawingAreaIdentifier>, public CanMakeCheckedPtr<DrawingAreaProxy> {
     WTF_MAKE_TZONE_ALLOCATED(DrawingAreaProxy);
     WTF_MAKE_NONCOPYABLE(DrawingAreaProxy);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DrawingAreaProxy);

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm
@@ -100,7 +100,12 @@ void WebExtensionContext::windowsCreate(const WebExtensionWindowParameters& crea
     configuration.tabURLs = [urls copy];
     configuration.tabs = [tabs copy];
 
-    [extensionController()->delegate() webExtensionController:extensionController()->wrapper() openNewWindowUsingConfiguration:configuration forExtensionContext:wrapper() completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](id<WKWebExtensionWindow> newWindow, NSError *error) mutable {
+    RefPtr extensionController = this->extensionController();
+    if (!extensionController) {
+        completionHandler(toWebExtensionError(apiName, nil, @"No extensionController"));
+        return;
+    }
+    [extensionController->delegate() webExtensionController:extensionController->wrapper() openNewWindowUsingConfiguration:configuration forExtensionContext:wrapper() completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](id<WKWebExtensionWindow> newWindow, NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for open new window: %{public}@", privacyPreservingDescription(error));
             completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
@@ -179,8 +179,8 @@ void injectStyleSheets(const SourcePairs& styleSheetPairs, WKWebView *webView, A
     for (auto& styleSheet : styleSheetPairs) {
         auto userStyleSheet = API::UserStyleSheet::create(WebCore::UserStyleSheet { styleSheet.first, styleSheet.second, Vector<String> { }, Vector<String> { }, injectedFrames, styleLevel, pageID }, executionWorld);
 
-        auto& controller = page.get()->userContentController();
-        controller.addUserStyleSheet(userStyleSheet);
+        Ref controller = page.get()->userContentController();
+        controller->addUserStyleSheet(userStyleSheet);
 
         context.dynamicallyInjectedUserStyleSheets().append(userStyleSheet);
     }
@@ -195,8 +195,8 @@ void removeStyleSheets(const SourcePairs& styleSheetPairs, WKWebView *webView,  
         for (auto& userStyleSheet : dynamicallyInjectedUserStyleSheets) {
             if (userStyleSheetMatchesContent(userStyleSheet, styleSheetContent, injectedFrames)) {
                 styleSheetsToRemove.append(userStyleSheet);
-                auto& controller = webView._page.get()->userContentController();
-                controller.removeUserStyleSheet(userStyleSheet);
+                Ref controller = webView._page.get()->userContentController();
+                controller->removeUserStyleSheet(userStyleSheet);
             }
         }
 
@@ -285,8 +285,8 @@ void WebExtensionRegisteredScript::removeUserScripts(const String& identifier)
     auto allUserContentControllers = m_extensionContext->extensionController()->allUserContentControllers();
 
     for (auto& userScript : userScripts) {
-        for (auto& userContentController : allUserContentControllers)
-            userContentController.removeUserScript(userScript);
+        for (Ref userContentController : allUserContentControllers)
+            userContentController->removeUserScript(userScript);
     }
 }
 
@@ -296,8 +296,8 @@ void WebExtensionRegisteredScript::removeUserStyleSheets(const String& identifie
     auto allUserContentControllers = m_extensionContext->extensionController()->allUserContentControllers();
 
     for (auto& userStyleSheet : userStyleSheets) {
-        for (auto& userContentController : allUserContentControllers)
-            userContentController.removeUserStyleSheet(userStyleSheet);
+        for (Ref userContentController : allUserContentControllers)
+            userContentController->removeUserStyleSheet(userStyleSheet);
     }
 }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMenuItemCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMenuItemCocoa.mm
@@ -103,7 +103,7 @@ WebExtensionMenuItem::WebExtensionMenuItem(WebExtensionContext& extensionContext
     relaxAdoptionRequirement();
 
     if (parameters.parentIdentifier) {
-        if (RefPtr parentMenuItem = m_extensionContext->menuItem(parameters.parentIdentifier.value()))
+        if (RefPtr parentMenuItem = extensionContext.menuItem(parameters.parentIdentifier.value()))
             parentMenuItem->addSubmenuItem(*this);
     }
 
@@ -163,7 +163,8 @@ WebExtensionMenuItemParameters WebExtensionMenuItem::minimalParameters() const
 
 void WebExtensionMenuItem::update(const WebExtensionMenuItemParameters& parameters)
 {
-    ASSERT(extensionContext());
+    RefPtr extensionContext = this->extensionContext();
+    ASSERT(extensionContext);
 
     if (parameters.type)
         m_type = parameters.type.value();
@@ -172,7 +173,7 @@ void WebExtensionMenuItem::update(const WebExtensionMenuItemParameters& paramete
         m_identifier = parameters.identifier;
 
     if (parameters.parentIdentifier) {
-        RefPtr updatedParentMenuItem = m_extensionContext->menuItem(parameters.parentIdentifier.value());
+        RefPtr updatedParentMenuItem = extensionContext->menuItem(parameters.parentIdentifier.value());
         if (updatedParentMenuItem.get() != m_parentMenuItem) {
             if (RefPtr parentMenuItem = m_parentMenuItem.get())
                 parentMenuItem->removeSubmenuItem(*this);
@@ -186,7 +187,7 @@ void WebExtensionMenuItem::update(const WebExtensionMenuItemParameters& paramete
         m_title = removeAmpersands(parameters.title);
 
     if (!parameters.command.isNull())
-        m_command = extensionContext()->command(parameters.command);
+        m_command = extensionContext->command(parameters.command);
 
     if (!parameters.iconsJSON.isNull()) {
         RefPtr parsedIcons = JSON::Value::parseJSON(parameters.iconsJSON);
@@ -349,7 +350,8 @@ CocoaMenuItem *WebExtensionMenuItem::platformMenuItem(const WebExtensionMenuItem
 
 RefPtr<WebCore::Icon> WebExtensionMenuItem::icon(WebCore::FloatSize idealSize) const
 {
-    ASSERT(extensionContext());
+    RefPtr extensionContext = this->extensionContext();
+    ASSERT(extensionContext);
 
 #if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
     if (!m_iconVariants && !m_icons)
@@ -370,14 +372,14 @@ RefPtr<WebCore::Icon> WebExtensionMenuItem::icon(WebCore::FloatSize idealSize) c
 
 #if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
     if (m_iconVariants) {
-        result = extensionContext()->protectedExtension()->bestIconVariant(m_iconVariants, WebCore::FloatSize(idealSize), [&](Ref<API::Error> error) {
-            extensionContext()->recordError(wrapper(error.get()));
+        result = extensionContext->protectedExtension()->bestIconVariant(m_iconVariants, WebCore::FloatSize(idealSize), [&](Ref<API::Error> error) {
+            extensionContext->recordError(wrapper(error.get()));
         });
     } else
 #endif // ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
     if (m_icons) {
-        result = extensionContext()->protectedExtension()->bestIcon(m_icons, WebCore::FloatSize(idealSize), [&](Ref<API::Error> error) {
-            extensionContext()->recordError(wrapper(error.get()));
+        result = extensionContext->protectedExtension()->bestIcon(m_icons, WebCore::FloatSize(idealSize), [&](Ref<API::Error> error) {
+            extensionContext->recordError(wrapper(error.get()));
         });
     }
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -151,6 +151,9 @@ public:
         return adoptRef(*new WebExtensionContext(std::forward<Args>(args)...));
     }
 
+    void ref() const final { API::ObjectImpl<API::Object::Type::WebExtensionContext>::ref(); }
+    void deref() const final { API::ObjectImpl<API::Object::Type::WebExtensionContext>::deref(); }
+
     static String plistFileName() { return "State.plist"_s; };
     static NSMutableDictionary *readStateFromPath(const String&);
     static bool readLastBaseURLFromState(const String& filePath, URL& outLastBaseURL);
@@ -309,6 +312,7 @@ public:
     WebExtension& extension() const { return *m_extension; }
     Ref<WebExtension> protectedExtension() const { return extension(); }
     WebExtensionController* extensionController() const { return m_extensionController.get(); }
+    RefPtr<WebExtensionController> protectedExtensionController() const { return m_extensionController.get(); }
 
     const URL& baseURL() const { return m_baseURL; }
     void setBaseURL(URL&&);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -85,6 +85,9 @@ public:
     static Ref<WebExtensionController> create(Ref<WebExtensionControllerConfiguration> configuration) { return adoptRef(*new WebExtensionController(configuration)); }
     static WebExtensionController* get(WebExtensionControllerIdentifier);
 
+    void ref() const final { API::ObjectImpl<API::Object::Type::WebExtensionController>::ref(); }
+    void deref() const final { API::ObjectImpl<API::Object::Type::WebExtensionController>::deref(); }
+
     explicit WebExtensionController(Ref<WebExtensionControllerConfiguration>);
     ~WebExtensionController();
 

--- a/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h
@@ -85,6 +85,9 @@ public:
 
     ~RemoteWebInspectorUIProxy();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     void setClient(RemoteWebInspectorUIProxyClient* client) { m_client = client; }
 
     bool isUnderTest() const { return false; }

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.h
@@ -53,6 +53,9 @@ public:
     static Ref<WebInspectorUIExtensionControllerProxy> create(WebPageProxy& inspectorPage);
     virtual ~WebInspectorUIExtensionControllerProxy();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     // Implemented in generated WebInspectorUIExtensionControllerProxyMessageReceiver.cpp
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
@@ -107,6 +107,9 @@ public:
     explicit WebInspectorUIProxy(WebPageProxy&);
     virtual ~WebInspectorUIProxy();
 
+    void ref() const final { API::ObjectImpl<API::Object::Type::Inspector>::ref(); }
+    void deref() const final { API::ObjectImpl<API::Object::Type::Inspector>::deref(); }
+
     void invalidate();
 
     API::InspectorClient& inspectorClient() { return *m_inspectorClient; }

--- a/Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.h
+++ b/Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.h
@@ -69,8 +69,8 @@ public:
     WallTime arbitrationUpdateTime() const { return m_arbitrationUpdateTime; }
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
-    void ref() const;
-    void deref() const;
+    void ref() const final;
+    void deref() const final;
 
 protected:
     Logger& logger();

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.h
@@ -51,6 +51,9 @@ public:
     static Ref<RemoteMediaSessionCoordinatorProxy> create(WebPageProxy&, Ref<MediaSessionCoordinatorProxyPrivate>&&);
     ~RemoteMediaSessionCoordinatorProxy();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
     void seekTo(double, CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.h
+++ b/Source/WebKit/UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.h
@@ -63,8 +63,8 @@ public:
     void didFailWithError(LegacyCustomProtocolID, const WebCore::ResourceError&);
     void didFinishLoading(LegacyCustomProtocolID);
 
-    void ref() const;
-    void deref() const;
+    void ref() const final;
+    void deref() const final;
 
 private:
     Ref<NetworkProcessProxy> protectedProcess();

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -1415,7 +1415,7 @@ WebsiteDataStore* NetworkProcessProxy::websiteDataStoreFromSessionID(PAL::Sessio
 #if ENABLE(CONTENT_EXTENSIONS)
 void NetworkProcessProxy::contentExtensionRules(UserContentControllerIdentifier identifier)
 {
-    if (auto* webUserContentControllerProxy = WebUserContentControllerProxy::get(identifier)) {
+    if (RefPtr webUserContentControllerProxy = WebUserContentControllerProxy::get(identifier)) {
         m_webUserContentControllerProxies.add(*webUserContentControllerProxy);
         webUserContentControllerProxy->addNetworkProcess(*this);
 

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -72,7 +72,7 @@ using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ProvisionalPageProxy);
 
-ProvisionalPageProxy::ProvisionalPageProxy(WebPageProxy& page, Ref<FrameProcess>&& frameProcess, BrowsingContextGroup& group, std::unique_ptr<SuspendedPageProxy> suspendedPage, API::Navigation& navigation, bool isServerRedirect, const WebCore::ResourceRequest& request, ProcessSwapRequestedByClient processSwapRequestedByClient, bool isProcessSwappingOnNavigationResponse, API::WebsitePolicies* websitePolicies, WebsiteDataStore* replacedDataStoreForWebArchiveLoad)
+ProvisionalPageProxy::ProvisionalPageProxy(WebPageProxy& page, Ref<FrameProcess>&& frameProcess, BrowsingContextGroup& group, RefPtr<SuspendedPageProxy>&& suspendedPage, API::Navigation& navigation, bool isServerRedirect, const WebCore::ResourceRequest& request, ProcessSwapRequestedByClient processSwapRequestedByClient, bool isProcessSwappingOnNavigationResponse, API::WebsitePolicies* websitePolicies, WebsiteDataStore* replacedDataStoreForWebArchiveLoad)
     : m_page(page)
     , m_webPageID(suspendedPage ? suspendedPage->webPageID() : PageIdentifier::generate())
     , m_frameProcess(WTFMove(frameProcess))

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.h
@@ -93,6 +93,9 @@ public:
     }
     ~ProvisionalPageProxy();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     WebPageProxy* page() { return m_page.get(); }
     const WebPageProxy* page() const { return m_page.get(); }
     RefPtr<WebPageProxy> protectedPage() const;
@@ -149,7 +152,7 @@ public:
     WebPageProxyMessageReceiverRegistration& messageReceiverRegistration() { return m_messageReceiverRegistration; }
 
 private:
-    ProvisionalPageProxy(WebPageProxy&, Ref<FrameProcess>&&, BrowsingContextGroup&, std::unique_ptr<SuspendedPageProxy>, API::Navigation&, bool isServerRedirect, const WebCore::ResourceRequest&, ProcessSwapRequestedByClient, bool isProcessSwappingOnNavigationResponse, API::WebsitePolicies*, WebsiteDataStore* replacedDataStoreForWebArchiveLoad = nullptr);
+    ProvisionalPageProxy(WebPageProxy&, Ref<FrameProcess>&&, BrowsingContextGroup&, RefPtr<SuspendedPageProxy>&&, API::Navigation&, bool isServerRedirect, const WebCore::ResourceRequest&, ProcessSwapRequestedByClient, bool isProcessSwappingOnNavigationResponse, API::WebsitePolicies*, WebsiteDataStore* replacedDataStoreForWebArchiveLoad = nullptr);
 
     RefPtr<WebFrameProxy> protectedMainFrame() const;
 

--- a/Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.h
@@ -42,6 +42,9 @@ public:
 
     ~RemotePageDrawingAreaProxy();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     WebProcessProxy& process() { return m_process; }
     Ref<WebProcessProxy> protectedProcess();
 

--- a/Source/WebKit/UIProcess/RemotePageProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageProxy.h
@@ -77,6 +77,9 @@ public:
     static Ref<RemotePageProxy> create(WebPageProxy&, WebProcessProxy&, const WebCore::Site&, WebPageProxyMessageReceiverRegistration* = nullptr);
     ~RemotePageProxy();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     WebPageProxy* page() const;
     RefPtr<WebPageProxy> protectedPage() const;
 

--- a/Source/WebKit/UIProcess/RemotePageVisitedLinkStoreRegistration.h
+++ b/Source/WebKit/UIProcess/RemotePageVisitedLinkStoreRegistration.h
@@ -38,12 +38,12 @@ public:
         : m_page(page)
         , m_process(process)
     {
-        protectedProcess()->addVisitedLinkStoreUser(page.visitedLinkStore(), page.identifier());
+        protectedProcess()->addVisitedLinkStoreUser(page.protectedVisitedLinkStore(), page.identifier());
     }
     ~RemotePageVisitedLinkStoreRegistration()
     {
         if (RefPtr page = m_page.get())
-            protectedProcess()->removeVisitedLinkStoreUser(page->visitedLinkStore(), page->identifier());
+            protectedProcess()->removeVisitedLinkStoreUser(page->protectedVisitedLinkStore(), page->identifier());
     }
 
 private:

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.h
@@ -56,8 +56,8 @@ class SpeechRecognitionRemoteRealtimeMediaSourceManager final : public IPC::Mess
 public:
     explicit SpeechRecognitionRemoteRealtimeMediaSourceManager(const WebProcessProxy&);
 
-    void ref() const;
-    void deref() const;
+    void ref() const final;
+    void deref() const final;
 
     void addSource(SpeechRecognitionRemoteRealtimeMediaSource&, const WebCore::CaptureDevice&);
     void removeSource(SpeechRecognitionRemoteRealtimeMediaSource&);

--- a/Source/WebKit/UIProcess/SpeechRecognitionServer.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionServer.h
@@ -63,6 +63,9 @@ public:
 #endif
         );
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
     void start(WebCore::SpeechRecognitionConnectionClientIdentifier, String&& lang, bool continuous, bool interimResults, uint64_t maxAlternatives, WebCore::ClientOrigin&&, WebCore::FrameIdentifier);

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -60,8 +60,8 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(SuspendedPageProxy);
 
 RefPtr<WebProcessProxy> SuspendedPageProxy::findReusableSuspendedPageProcess(WebProcessPool& processPool, const RegistrableDomain& registrableDomain, WebsiteDataStore& dataStore, WebProcessProxy::LockdownMode lockdownMode, const API::PageConfiguration& pageConfiguration)
 {
-    for (auto& suspendedPage : allSuspendedPages()) {
-        Ref process = suspendedPage.process();
+    for (Ref suspendedPage : allSuspendedPages()) {
+        Ref process = suspendedPage->process();
         if (&process->processPool() == &processPool
             && process->registrableDomain() == registrableDomain
             && process->websiteDataStore() == &dataStore
@@ -106,6 +106,11 @@ static const MessageNameSet& messageNamesToIgnoreWhileSuspended()
     return messageNames;
 }
 #endif
+
+Ref<SuspendedPageProxy> SuspendedPageProxy::create(WebPageProxy& page, Ref<WebProcessProxy>&& process, Ref<WebFrameProxy>&& mainFrame, Ref<BrowsingContextGroup>&& browsingContextGroup, ShouldDelayClosingUntilFirstLayerFlush shouldDelayClosingUntilFirstLayerFlush)
+{
+    return adoptRef(*new SuspendedPageProxy(page, WTFMove(process), WTFMove(mainFrame), WTFMove(browsingContextGroup), shouldDelayClosingUntilFirstLayerFlush));
+}
 
 SuspendedPageProxy::SuspendedPageProxy(WebPageProxy& page, Ref<WebProcessProxy>&& process, Ref<WebFrameProxy>&& mainFrame, Ref<BrowsingContextGroup>&& browsingContextGroup, ShouldDelayClosingUntilFirstLayerFlush shouldDelayClosingUntilFirstLayerFlush)
     : m_page(page)
@@ -158,14 +163,10 @@ SuspendedPageProxy::~SuspendedPageProxy()
     m_process->removeSuspendedPageProxy(*this);
 }
 
-Ref<WebPageProxy> SuspendedPageProxy::protectedPage() const
-{
-    return m_page.get();
-}
-
 void SuspendedPageProxy::didDestroyNavigation(WebCore::NavigationIdentifier navigationID)
 {
-    protectedPage()->didDestroyNavigationShared(m_process.copyRef(), navigationID);
+    if (RefPtr page = m_page.get())
+        page->didDestroyNavigationShared(m_process.copyRef(), navigationID);
 }
 
 WebBackForwardCache& SuspendedPageProxy::backForwardCache() const
@@ -269,7 +270,7 @@ void SuspendedPageProxy::suspensionTimedOut()
     backForwardCache().removeEntry(*this); // Will destroy |this|.
 }
 
-WebPageProxy& SuspendedPageProxy::page() const
+WebPageProxy* SuspendedPageProxy::page() const
 {
     return m_page.get();
 }

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
@@ -82,6 +82,9 @@ public:
     WebUserContentControllerProxy();
     ~WebUserContentControllerProxy();
 
+    void ref() const final { API::ObjectImpl<API::Object::Type::UserContentController>::ref(); }
+    void deref() const final { API::ObjectImpl<API::Object::Type::UserContentController>::deref(); }
+
     static WebUserContentControllerProxy* get(UserContentControllerIdentifier);
 
     UserContentControllerParameters parameters() const;

--- a/Source/WebKit/UIProcess/ViewGestureController.cpp
+++ b/Source/WebKit/UIProcess/ViewGestureController.cpp
@@ -186,7 +186,8 @@ bool ViewGestureController::canSwipeInDirection(SwipeDirection direction) const
         return false;
 
 #if ENABLE(FULLSCREEN_API)
-    if (page->fullScreenManager() && page->fullScreenManager()->isFullScreen())
+    RefPtr fullScreenManager = page->fullScreenManager();
+    if (fullScreenManager && fullScreenManager->isFullScreen())
         return false;
 #endif
 

--- a/Source/WebKit/UIProcess/ViewGestureController.h
+++ b/Source/WebKit/UIProcess/ViewGestureController.h
@@ -108,6 +108,10 @@ public:
 
     static Ref<ViewGestureController> create(WebPageProxy&);
     ~ViewGestureController();
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     void platformTeardown();
 
     void disconnectFromProcess();

--- a/Source/WebKit/UIProcess/VisitedLinkStore.h
+++ b/Source/WebKit/UIProcess/VisitedLinkStore.h
@@ -46,6 +46,9 @@ public:
 
     virtual ~VisitedLinkStore();
 
+    void ref() const final { API::ObjectImpl<API::Object::Type::VisitedLinkStore>::ref(); }
+    void deref() const final { API::ObjectImpl<API::Object::Type::VisitedLinkStore>::deref(); }
+
     void addProcess(WebProcessProxy&);
     void removeProcess(WebProcessProxy&);
 

--- a/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.h
@@ -79,6 +79,9 @@ public:
     static Ref<WebAuthenticatorCoordinatorProxy> create(WebPageProxy&);
     ~WebAuthenticatorCoordinatorProxy();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
 #if HAVE(WEB_AUTHN_AS_MODERN)

--- a/Source/WebKit/UIProcess/WebBackForwardCache.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardCache.cpp
@@ -99,9 +99,10 @@ void WebBackForwardCache::addEntry(WebBackForwardListItem& item, Ref<WebBackForw
     RELEASE_LOG(BackForwardCache, "WebBackForwardCache::addEntry: item=%s, hasSuspendedPage=%d, size=%u/%u", item.itemID().toString().utf8().data(), !!item.suspendedPage(), size(), capacity());
 }
 
-void WebBackForwardCache::addEntry(WebBackForwardListItem& item, std::unique_ptr<SuspendedPageProxy>&& suspendedPage)
+void WebBackForwardCache::addEntry(WebBackForwardListItem& item, Ref<SuspendedPageProxy>&& suspendedPage)
 {
-    addEntry(item, WebBackForwardCacheEntry::create(*this, item.itemID(), suspendedPage->process().coreProcessIdentifier(), WTFMove(suspendedPage)));
+    auto coreProcessIdentifier = suspendedPage->process().coreProcessIdentifier();
+    addEntry(item, WebBackForwardCacheEntry::create(*this, item.itemID(), coreProcessIdentifier, WTFMove(suspendedPage)));
 }
 
 void WebBackForwardCache::addEntry(WebBackForwardListItem& item, WebCore::ProcessIdentifier processIdentifier)
@@ -124,14 +125,13 @@ void WebBackForwardCache::removeEntry(SuspendedPageProxy& suspendedPage)
     });
 }
 
-std::unique_ptr<SuspendedPageProxy> WebBackForwardCache::takeSuspendedPage(WebBackForwardListItem& item)
+Ref<SuspendedPageProxy> WebBackForwardCache::takeSuspendedPage(WebBackForwardListItem& item)
 {
     RELEASE_LOG(BackForwardCache, "WebBackForwardCache::takeSuspendedPage: item=%s", item.itemID().toString().utf8().data());
 
     ASSERT(m_itemsWithCachedPage.contains(item));
     ASSERT(item.backForwardCacheEntry());
-    auto suspendedPage = item.protectedBackForwardCacheEntry()->takeSuspendedPage();
-    ASSERT(suspendedPage);
+    Ref suspendedPage = item.protectedBackForwardCacheEntry()->takeSuspendedPage();
     removeEntry(item);
     return suspendedPage;
 }

--- a/Source/WebKit/UIProcess/WebBackForwardCache.h
+++ b/Source/WebKit/UIProcess/WebBackForwardCache.h
@@ -61,11 +61,11 @@ public:
     void removeEntriesForPageAndProcess(WebPageProxy&, WebProcessProxy&);
     void removeEntriesForSession(PAL::SessionID);
 
-    void addEntry(WebBackForwardListItem&, std::unique_ptr<SuspendedPageProxy>&&);
+    void addEntry(WebBackForwardListItem&, Ref<SuspendedPageProxy>&&);
     void addEntry(WebBackForwardListItem&, WebCore::ProcessIdentifier);
     void removeEntry(WebBackForwardListItem&);
     void removeEntry(SuspendedPageProxy&);
-    std::unique_ptr<SuspendedPageProxy> takeSuspendedPage(WebBackForwardListItem&);
+    Ref<SuspendedPageProxy> takeSuspendedPage(WebBackForwardListItem&);
 
 private:
     Ref<WebProcessPool> protectedProcessPool() const;

--- a/Source/WebKit/UIProcess/WebBackForwardCacheEntry.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardCacheEntry.cpp
@@ -39,12 +39,12 @@ static const Seconds expirationDelay { 30_min };
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebBackForwardCacheEntry);
 
-Ref<WebBackForwardCacheEntry> WebBackForwardCacheEntry::create(WebBackForwardCache& backForwardCache, WebCore::BackForwardItemIdentifier backForwardItemID, WebCore::ProcessIdentifier processIdentifier, std::unique_ptr<SuspendedPageProxy>&& suspendedPage)
+Ref<WebBackForwardCacheEntry> WebBackForwardCacheEntry::create(WebBackForwardCache& backForwardCache, WebCore::BackForwardItemIdentifier backForwardItemID, WebCore::ProcessIdentifier processIdentifier, RefPtr<SuspendedPageProxy>&& suspendedPage)
 {
     return adoptRef(*new WebBackForwardCacheEntry(backForwardCache, backForwardItemID, processIdentifier, WTFMove(suspendedPage)));
 }
 
-WebBackForwardCacheEntry::WebBackForwardCacheEntry(WebBackForwardCache& backForwardCache, WebCore::BackForwardItemIdentifier backForwardItemID, WebCore::ProcessIdentifier processIdentifier, std::unique_ptr<SuspendedPageProxy>&& suspendedPage)
+WebBackForwardCacheEntry::WebBackForwardCacheEntry(WebBackForwardCache& backForwardCache, WebCore::BackForwardItemIdentifier backForwardItemID, WebCore::ProcessIdentifier processIdentifier, RefPtr<SuspendedPageProxy>&& suspendedPage)
     : m_backForwardCache(backForwardCache)
     , m_processIdentifier(processIdentifier)
     , m_backForwardItemID(backForwardItemID)
@@ -67,12 +67,12 @@ WebBackForwardCache* WebBackForwardCacheEntry::backForwardCache() const
     return m_backForwardCache.get();
 }
 
-std::unique_ptr<SuspendedPageProxy> WebBackForwardCacheEntry::takeSuspendedPage()
+Ref<SuspendedPageProxy> WebBackForwardCacheEntry::takeSuspendedPage()
 {
     ASSERT(m_suspendedPage);
     m_backForwardItemID = std::nullopt;
     m_expirationTimer.stop();
-    return std::exchange(m_suspendedPage, nullptr);
+    return std::exchange(m_suspendedPage, nullptr).releaseNonNull();
 }
 
 RefPtr<WebProcessProxy> WebBackForwardCacheEntry::process() const

--- a/Source/WebKit/UIProcess/WebBackForwardCacheEntry.h
+++ b/Source/WebKit/UIProcess/WebBackForwardCacheEntry.h
@@ -42,25 +42,25 @@ class WebProcessProxy;
 class WebBackForwardCacheEntry : public RefCounted<WebBackForwardCacheEntry> {
     WTF_MAKE_TZONE_ALLOCATED(WebBackForwardCacheEntry);
 public:
-    static Ref<WebBackForwardCacheEntry> create(WebBackForwardCache&, WebCore::BackForwardItemIdentifier, WebCore::ProcessIdentifier, std::unique_ptr<SuspendedPageProxy>&&);
+    static Ref<WebBackForwardCacheEntry> create(WebBackForwardCache&, WebCore::BackForwardItemIdentifier, WebCore::ProcessIdentifier, RefPtr<SuspendedPageProxy>&&);
     ~WebBackForwardCacheEntry();
 
     WebBackForwardCache* backForwardCache() const;
 
     SuspendedPageProxy* suspendedPage() const { return m_suspendedPage.get(); }
-    std::unique_ptr<SuspendedPageProxy> takeSuspendedPage();
+    Ref<SuspendedPageProxy> takeSuspendedPage();
     WebCore::ProcessIdentifier processIdentifier() const { return m_processIdentifier; }
     RefPtr<WebProcessProxy> process() const;
 
 private:
-    WebBackForwardCacheEntry(WebBackForwardCache&, WebCore::BackForwardItemIdentifier, WebCore::ProcessIdentifier, std::unique_ptr<SuspendedPageProxy>&&);
+    WebBackForwardCacheEntry(WebBackForwardCache&, WebCore::BackForwardItemIdentifier, WebCore::ProcessIdentifier, RefPtr<SuspendedPageProxy>&&);
 
     void expirationTimerFired();
 
     WeakPtr<WebBackForwardCache> m_backForwardCache;
     WebCore::ProcessIdentifier m_processIdentifier;
     Markable<WebCore::BackForwardItemIdentifier> m_backForwardItemID;
-    std::unique_ptr<SuspendedPageProxy> m_suspendedPage;
+    RefPtr<SuspendedPageProxy> m_suspendedPage;
     RunLoop::Timer m_expirationTimer;
 };
 

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -89,6 +89,9 @@ public:
     static Ref<WebFullScreenManagerProxy> create(WebPageProxy&, WebFullScreenManagerProxyClient&);
     virtual ~WebFullScreenManagerProxy();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
     bool isFullScreen();

--- a/Source/WebKit/UIProcess/WebGeolocationManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebGeolocationManagerProxy.h
@@ -60,6 +60,9 @@ public:
     static Ref<WebGeolocationManagerProxy> create(WebProcessPool*);
     ~WebGeolocationManagerProxy();
 
+    void ref() const final { API::ObjectImpl<API::Object::Type::GeolocationManager>::ref(); }
+    void deref() const final { API::ObjectImpl<API::Object::Type::GeolocationManager>::deref(); }
+
     void setProvider(std::unique_ptr<API::GeolocationProvider>&&);
 
     void providerDidChangePosition(WebGeolocationPosition*);

--- a/Source/WebKit/UIProcess/WebLockRegistryProxy.h
+++ b/Source/WebKit/UIProcess/WebLockRegistryProxy.h
@@ -47,8 +47,8 @@ public:
     explicit WebLockRegistryProxy(WebProcessProxy&);
     ~WebLockRegistryProxy();
 
-    void ref() const { m_process->ref(); }
-    void deref() const { m_process->deref(); }
+    void ref() const final { m_process->ref(); }
+    void deref() const final { m_process->deref(); }
 
     // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
     SUPPRESS_UNCOUNTED_ARG std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() { return m_process->sharedPreferencesForWebProcess(); }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -605,6 +605,9 @@ public:
     static Ref<WebPageProxy> create(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);
     virtual ~WebPageProxy();
 
+    void ref() const final { API::ObjectImpl<API::Object::Type::Page>::ref(); }
+    void deref() const final { API::ObjectImpl<API::Object::Type::Page>::deref(); }
+
     USING_CAN_MAKE_WEAKPTR(IPC::MessageReceiver);
 
     static void forMostVisibleWebPageIfAny(PAL::SessionID, const WebCore::SecurityOriginData&, CompletionHandler<void(WebPageProxy*)>&&);
@@ -3110,7 +3113,7 @@ private:
 
     void reportPageLoadResult(const WebCore::ResourceError&);
 
-    void continueNavigationInNewProcess(API::Navigation&, WebFrameProxy&, std::unique_ptr<SuspendedPageProxy>&&, Ref<WebProcessProxy>&&, ProcessSwapRequestedByClient, WebCore::ShouldTreatAsContinuingLoad, std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume, LoadedWebArchive, WebCore::IsPerformingHTTPFallback, WebsiteDataStore* replacedDataStoreForWebArchiveLoad = nullptr);
+    void continueNavigationInNewProcess(API::Navigation&, WebFrameProxy&, RefPtr<SuspendedPageProxy>&&, Ref<WebProcessProxy>&&, ProcessSwapRequestedByClient, WebCore::ShouldTreatAsContinuingLoad, std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume, LoadedWebArchive, WebCore::IsPerformingHTTPFallback, WebsiteDataStore* replacedDataStoreForWebArchiveLoad = nullptr);
 
     void setNeedsFontAttributes(bool);
     void updateFontAttributesAfterEditorStateChange();
@@ -3656,7 +3659,7 @@ private:
     bool m_isServiceWorkerPage { false };
 
     RefPtr<ProvisionalPageProxy> m_provisionalPage;
-    std::unique_ptr<SuspendedPageProxy> m_suspendedPageKeptToPreventFlashing;
+    RefPtr<SuspendedPageProxy> m_suspendedPageKeptToPreventFlashing;
     WeakPtr<SuspendedPageProxy> m_lastSuspendedPage;
 
     TextManipulationItemCallback m_textManipulationItemCallback;

--- a/Source/WebKit/UIProcess/WebPasteboardProxy.h
+++ b/Source/WebKit/UIProcess/WebPasteboardProxy.h
@@ -67,8 +67,8 @@ public:
     void removeWebProcessProxy(WebProcessProxy&);
 
     // Do nothing since this is a singleton.
-    void ref() const { }
-    void deref() const { }
+    void ref() const final { }
+    void deref() const final { }
 
 #if PLATFORM(COCOA)
     void revokeAccess(WebProcessProxy&);

--- a/Source/WebKit/UIProcess/WebPermissionControllerProxy.h
+++ b/Source/WebKit/UIProcess/WebPermissionControllerProxy.h
@@ -52,8 +52,8 @@ public:
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 
-    void ref() const;
-    void deref() const;
+    void ref() const final;
+    void deref() const final;
 
 private:
     RefPtr<WebPageProxy> mostReasonableWebPageProxy(const WebCore::SecurityOriginData&, WebCore::PermissionQuerySource) const;

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -167,6 +167,9 @@ public:
     explicit WebProcessPool(API::ProcessPoolConfiguration&);        
     virtual ~WebProcessPool();
 
+    void ref() const final { API::ObjectImpl<API::Object::Type::ProcessPool>::ref(); }
+    void deref() const final { API::ObjectImpl<API::Object::Type::ProcessPool>::deref(); }
+
     API::ProcessPoolConfiguration& configuration() { return m_configuration.get(); }
     Ref<API::ProcessPoolConfiguration> protectedConfiguration() { return m_configuration; }
 
@@ -582,9 +585,6 @@ public:
     ExtensionCapabilityGranter& extensionCapabilityGranter();
     RefPtr<GPUProcessProxy> gpuProcessForCapabilityGranter(const ExtensionCapabilityGranter&) final;
     RefPtr<WebProcessProxy> webProcessForCapabilityGranter(const ExtensionCapabilityGranter&, const String& environmentIdentifier) final;
-
-    void ref() const final { API::ObjectImpl<API::Object::Type::ProcessPool>::ref(); }
-    void deref() const final { API::ObjectImpl<API::Object::Type::ProcessPool>::deref(); }
 #endif
 
     bool usesSingleWebProcess() const { return m_configuration->usesSingleWebProcess(); }
@@ -619,7 +619,7 @@ private:
     void platformInitializeWebProcess(const WebProcessProxy&, WebProcessCreationParameters&);
     void platformInvalidateContext();
 
-    std::tuple<Ref<WebProcessProxy>, SuspendedPageProxy*, ASCIILiteral> processForNavigationInternal(WebPageProxy&, const API::Navigation&, Ref<WebProcessProxy>&& sourceProcess, const URL& sourceURL, ProcessSwapRequestedByClient, WebProcessProxy::LockdownMode, const FrameInfoData&, Ref<WebsiteDataStore>&&);
+    std::tuple<Ref<WebProcessProxy>, RefPtr<SuspendedPageProxy>, ASCIILiteral> processForNavigationInternal(WebPageProxy&, const API::Navigation&, Ref<WebProcessProxy>&& sourceProcess, const URL& sourceURL, ProcessSwapRequestedByClient, WebProcessProxy::LockdownMode, const FrameInfoData&, Ref<WebsiteDataStore>&&);
     void prepareProcessForNavigation(Ref<WebProcessProxy>&&, WebPageProxy&, SuspendedPageProxy*, ASCIILiteral reason, const WebCore::Site&, const API::Navigation&, WebProcessProxy::LockdownMode, Ref<WebsiteDataStore>&&, CompletionHandler<void(Ref<WebProcessProxy>&&, SuspendedPageProxy*, ASCIILiteral)>&&, unsigned previousAttemptsCount = 0);
 
     RefPtr<WebProcessProxy> tryTakePrewarmedProcess(WebsiteDataStore&, WebProcessProxy::LockdownMode, const API::PageConfiguration&);

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -464,6 +464,7 @@ public:
 #if ENABLE(MEDIA_STREAM)
     static void muteCaptureInPagesExcept(WebCore::PageIdentifier);
     SpeechRecognitionRemoteRealtimeMediaSourceManager& ensureSpeechRecognitionRemoteRealtimeMediaSourceManager();
+    RefPtr<SpeechRecognitionRemoteRealtimeMediaSourceManager> protectedSpeechRecognitionRemoteRealtimeMediaSourceManager();
 #endif
     void pageMutedStateChanged(WebCore::PageIdentifier, WebCore::MediaProducerMutedStateFlags);
     void pageIsBecomingInvisible(WebCore::PageIdentifier);

--- a/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h
@@ -45,6 +45,10 @@ class WebScreenOrientationManagerProxy final : public IPC::MessageReceiver, publ
 public:
     static Ref<WebScreenOrientationManagerProxy> create(WebPageProxy&, WebCore::ScreenOrientationType);
     ~WebScreenOrientationManagerProxy();
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
     // IPC::MessageReceiver

--- a/Source/WebKit/UIProcess/ios/SmartMagnificationController.h
+++ b/Source/WebKit/UIProcess/ios/SmartMagnificationController.h
@@ -46,6 +46,9 @@ public:
     static Ref<SmartMagnificationController> create(WKContentView *);
     ~SmartMagnificationController();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     void handleSmartMagnificationGesture(WebCore::FloatPoint origin);
     void handleResetMagnificationGesture(WebCore::FloatPoint origin);
 

--- a/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.h
+++ b/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.h
@@ -41,6 +41,9 @@ public:
     static Ref<WebDeviceOrientationUpdateProviderProxy> create(WebPageProxy&);
     ~WebDeviceOrientationUpdateProviderProxy();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     void startUpdatingDeviceOrientation();
     void stopUpdatingDeviceOrientation();
 

--- a/Source/WebKit/UIProcess/mac/SecItemShimProxy.h
+++ b/Source/WebKit/UIProcess/mac/SecItemShimProxy.h
@@ -43,8 +43,8 @@ public:
     void initializeConnection(IPC::Connection&);
 
     // Do nothing since this is a singleton.
-    void ref() const { }
-    void deref() const { }
+    void ref() const final { }
+    void deref() const final { }
 
 private:
     SecItemShimProxy();

--- a/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.h
+++ b/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.h
@@ -61,6 +61,9 @@ public:
     static Ref<AcceleratedBackingStoreDMABuf> create(WebPageProxy&, WPEView*);
     ~AcceleratedBackingStoreDMABuf();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     void updateSurfaceID(uint64_t);
 
     RendererBufferFormat bufferFormat() const;

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.h
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.h
@@ -54,6 +54,9 @@ public:
     static Ref<WebAutomationSessionProxy> create(const String& sessionIdentifier);
     ~WebAutomationSessionProxy();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     String sessionIdentifier() const { return m_sessionIdentifier; }
 
     void didClearWindowObjectForFrame(WebFrame&);

--- a/Source/WebKit/WebProcess/Databases/WebDatabaseProvider.cpp
+++ b/Source/WebKit/WebProcess/Databases/WebDatabaseProvider.cpp
@@ -67,7 +67,7 @@ WebDatabaseProvider::~WebDatabaseProvider()
 
 WebCore::IDBClient::IDBConnectionToServer& WebDatabaseProvider::idbConnectionToServerForSession(PAL::SessionID)
 {
-    return WebProcess::singleton().ensureNetworkProcessConnection().idbConnectionToServer().coreConnectionToServer();
+    return WebProcess::singleton().ensureProtectedNetworkProcessConnection()->idbConnectionToServer().coreConnectionToServer();
 }
 
 }

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -63,6 +63,9 @@ public:
 
     ~WebExtensionContextProxy();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     using WeakFrameSet = WeakHashSet<WebFrame>;
     using TabWindowIdentifierPair = std::pair<std::optional<WebExtensionTabIdentifier>, std::optional<WebExtensionWindowIdentifier>>;
     using WeakPageTabWindowMap = WeakHashMap<WebPage, TabWindowIdentifierPair>;

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h
@@ -53,6 +53,9 @@ public:
 
     ~WebExtensionControllerProxy();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     using WebExtensionContextProxySet = HashSet<Ref<WebExtensionContextProxy>>;
     using WebExtensionContextProxyBaseURLMap = HashMap<String, Ref<WebExtensionContextProxy>>;
 

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
@@ -174,8 +174,8 @@ void GPUProcessConnection::didClose(IPC::Connection&)
         arbitrator->leaveRoutingAbritration();
 #endif
 
-    m_clients.forEach([this] (auto& client) {
-        client.gpuProcessConnectionDidClose(*this);
+    m_clients.forEach([protectedThis = Ref { *this }] (auto& client) {
+        client.gpuProcessConnectionDidClose(protectedThis);
     });
     m_clients.clear();
 }

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.h
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.h
@@ -78,6 +78,9 @@ public:
     ~GPUProcessConnection();
     GPUProcessConnectionIdentifier identifier() const { return m_identifier; }
 
+    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
+    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
+
     IPC::Connection& connection() { return m_connection.get(); }
     Ref<IPC::Connection> protectedConnection() { return m_connection; }
     IPC::MessageReceiverMap& messageReceiverMap() { return m_messageReceiverMap; }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
@@ -93,7 +93,7 @@ ALWAYS_INLINE void RemoteDisplayListRecorderProxy::send(T&& message)
 
 ALWAYS_INLINE RefPtr<IPC::StreamClientConnection> RemoteDisplayListRecorderProxy::connection() const
 {
-    auto* backend = m_renderingBackend.get();
+    RefPtr backend = m_renderingBackend.get();
     if (UNLIKELY(!backend))
         return nullptr;
     return backend->connection();
@@ -101,7 +101,7 @@ ALWAYS_INLINE RefPtr<IPC::StreamClientConnection> RemoteDisplayListRecorderProxy
 
 void RemoteDisplayListRecorderProxy::didBecomeUnresponsive() const
 {
-    auto* backend = m_renderingBackend.get();
+    RefPtr backend = m_renderingBackend.get();
     if (UNLIKELY(!backend))
         return;
     backend->didBecomeUnresponsive();
@@ -572,15 +572,16 @@ bool RemoteDisplayListRecorderProxy::recordResourceUse(NativeImage& image)
 
 bool RemoteDisplayListRecorderProxy::recordResourceUse(ImageBuffer& imageBuffer)
 {
-    if (UNLIKELY(!m_renderingBackend)) {
+    RefPtr renderingBackend = m_renderingBackend.get();
+    if (UNLIKELY(!renderingBackend)) {
         ASSERT_NOT_REACHED();
         return false;
     }
 
-    if (!m_renderingBackend->isCached(imageBuffer))
+    if (!renderingBackend->isCached(imageBuffer))
         return false;
 
-    m_renderingBackend->remoteResourceCacheProxy().recordImageBufferUse(imageBuffer);
+    renderingBackend->remoteResourceCacheProxy().recordImageBufferUse(imageBuffer);
     return true;
 }
 
@@ -641,7 +642,8 @@ bool RemoteDisplayListRecorderProxy::recordResourceUse(Filter& filter)
 
 RefPtr<ImageBuffer> RemoteDisplayListRecorderProxy::createImageBuffer(const FloatSize& size, float resolutionScale, const DestinationColorSpace& colorSpace, std::optional<RenderingMode> renderingMode, std::optional<RenderingMethod> renderingMethod) const
 {
-    if (UNLIKELY(!m_renderingBackend)) {
+    RefPtr renderingBackend = m_renderingBackend.get();
+    if (UNLIKELY(!renderingBackend)) {
         ASSERT_NOT_REACHED();
         return nullptr;
     }
@@ -655,7 +657,7 @@ RefPtr<ImageBuffer> RemoteDisplayListRecorderProxy::createImageBuffer(const Floa
     OptionSet<ImageBufferOptions> options;
     if (renderingMode.value_or(this->renderingMode()) == RenderingMode::Accelerated)
         options.add(ImageBufferOptions::Accelerated);
-    return m_renderingBackend->createImageBuffer(size, purpose, resolutionScale, colorSpace, ImageBufferPixelFormat::BGRA8, options);
+    return renderingBackend->createImageBuffer(size, purpose, resolutionScale, colorSpace, ImageBufferPixelFormat::BGRA8, options);
 }
 
 RefPtr<ImageBuffer> RemoteDisplayListRecorderProxy::createAlignedImageBuffer(const FloatSize& size, const DestinationColorSpace& colorSpace, std::optional<RenderingMethod> renderingMethod) const

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -64,6 +64,9 @@ public:
     static RefPtr<RemoteGraphicsContextGLProxy> create(const WebCore::GraphicsContextGLAttributes&, WebPage&);
     static RefPtr<RemoteGraphicsContextGLProxy> create(const WebCore::GraphicsContextGLAttributes&, RemoteRenderingBackendProxy&, SerialFunctionDispatcher&);
 
+    void ref() const final { WebCore::GraphicsContextGL::ref(); }
+    void deref() const final { WebCore::GraphicsContextGL::deref(); }
+
     ~RemoteGraphicsContextGLProxy();
 
     // IPC::Connection::Client overrides.

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
@@ -150,7 +150,7 @@ ALWAYS_INLINE auto RemoteImageBufferSetProxy::sendSync(T&& message)
 
 ALWAYS_INLINE RefPtr<IPC::StreamClientConnection> RemoteImageBufferSetProxy::connection() const
 {
-    auto* backend = m_remoteRenderingBackendProxy.get();
+    RefPtr backend = m_remoteRenderingBackendProxy.get();
     if (UNLIKELY(!backend))
         return nullptr;
     return backend->connection();
@@ -158,7 +158,7 @@ ALWAYS_INLINE RefPtr<IPC::StreamClientConnection> RemoteImageBufferSetProxy::con
 
 void RemoteImageBufferSetProxy::didBecomeUnresponsive() const
 {
-    auto* backend = m_remoteRenderingBackendProxy.get();
+    RefPtr backend = m_remoteRenderingBackendProxy.get();
     if (UNLIKELY(!backend))
         return;
     backend->didBecomeUnresponsive();
@@ -235,8 +235,8 @@ void RemoteImageBufferSetProxy::close()
         streamConnection->removeWorkQueueMessageReceiver(Messages::RemoteImageBufferSetProxy::messageReceiverName(), identifier().toUInt64());
         m_streamConnection = nullptr;
     }
-    if (m_remoteRenderingBackendProxy)
-        m_remoteRenderingBackendProxy->releaseRemoteImageBufferSet(*this);
+    if (RefPtr remoteRenderingBackendProxy = m_remoteRenderingBackendProxy.get())
+        remoteRenderingBackendProxy->releaseRemoteImageBufferSet(*this);
 }
 
 void RemoteImageBufferSetProxy::setConfiguration(WebCore::FloatSize size, float scale, const WebCore::DestinationColorSpace& colorSpace, WebCore::ImageBufferPixelFormat pixelFormat, WebCore::RenderingMode renderingMode, WebCore::RenderingPurpose renderingPurpose)
@@ -279,7 +279,7 @@ void RemoteImageBufferSetProxy::willPrepareForDisplay()
         if (m_renderingMode == RenderingMode::Accelerated)
             options.add(WebCore::ImageBufferOptions::Accelerated);
 
-        m_displayListRecorder = m_remoteRenderingBackendProxy->createDisplayListRecorder(m_displayListIdentifier, m_size, m_renderingPurpose, m_scale, m_colorSpace, m_pixelFormat, options);
+        m_displayListRecorder = Ref { *m_remoteRenderingBackendProxy }->createDisplayListRecorder(m_displayListIdentifier, m_size, m_renderingPurpose, m_scale, m_colorSpace, m_pixelFormat, options);
     }
     m_remoteNeedsConfigurationUpdate = false;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -113,10 +113,10 @@ void RemoteRenderingBackendProxy::ensureGPUProcessConnection()
     streamConnection->open(*this, *this);
     m_isResponsive = true;
     callOnMainRunLoopAndWait([&, serverHandle = WTFMove(serverHandle)]() mutable {
-        auto& gpuProcessConnection = WebProcess::singleton().ensureGPUProcessConnection();
-        gpuProcessConnection.createRenderingBackend(m_identifier, WTFMove(serverHandle));
-        m_gpuProcessConnection = gpuProcessConnection;
-        m_sharedResourceCache = gpuProcessConnection.sharedResourceCache();
+        Ref gpuProcessConnection = WebProcess::singleton().ensureGPUProcessConnection();
+        gpuProcessConnection->createRenderingBackend(m_identifier, WTFMove(serverHandle));
+        m_gpuProcessConnection = gpuProcessConnection.get();
+        m_sharedResourceCache = gpuProcessConnection->sharedResourceCache();
     });
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -84,10 +84,10 @@ public:
     static Ref<RemoteRenderingBackendProxy> create(WebPage&);
     static Ref<RemoteRenderingBackendProxy> create(SerialFunctionDispatcher&);
 
-    ~RemoteRenderingBackendProxy();
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
-    using RefCounted::ref;
-    using RefCounted::deref;
+    ~RemoteRenderingBackendProxy();
 
     static bool canMapRemoteImageBufferBackendBackingStore();
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
@@ -51,7 +51,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteGPUProxy);
 
 RefPtr<RemoteGPUProxy> RemoteGPUProxy::create(WebGPU::ConvertToBackingContext& convertToBackingContext, WebPage& page)
 {
-    return RemoteGPUProxy::create(convertToBackingContext, page.ensureRemoteRenderingBackendProxy(), RunLoop::protectedMain().get());
+    return RemoteGPUProxy::create(convertToBackingContext, page.ensureProtectedRemoteRenderingBackendProxy(), RunLoop::protectedMain().get());
 }
 
 RefPtr<RemoteGPUProxy> RemoteGPUProxy::create(WebGPU::ConvertToBackingContext& convertToBackingContext, RemoteRenderingBackendProxy& renderingBackend, SerialFunctionDispatcher& dispatcher)
@@ -86,9 +86,9 @@ void RemoteGPUProxy::initializeIPC(Ref<IPC::StreamClientConnection>&& streamConn
     m_streamConnection = WTFMove(streamConnection);
     protectedStreamConnection()->open(*this, *this);
     callOnMainRunLoopAndWait([&]() {
-        auto& gpuProcessConnection = WebProcess::singleton().ensureGPUProcessConnection();
-        gpuProcessConnection.createGPU(m_backing, renderingBackend, WTFMove(serverHandle));
-        m_gpuProcessConnection = gpuProcessConnection;
+        Ref gpuProcessConnection = WebProcess::singleton().ensureGPUProcessConnection();
+        gpuProcessConnection->createGPU(m_backing, renderingBackend, WTFMove(serverHandle));
+        m_gpuProcessConnection = gpuProcessConnection.get();
     });
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -479,7 +479,7 @@ private:
 #if PLATFORM(COCOA)
     void pushVideoFrameMetadata(WebCore::VideoFrameMetadata&&, RemoteVideoFrameProxy::Properties&&);
 #endif
-    RemoteVideoFrameObjectHeapProxy& videoFrameObjectHeapProxy() const { return protectedManager()->gpuProcessConnection().videoFrameObjectHeapProxy(); }
+    RemoteVideoFrameObjectHeapProxy& videoFrameObjectHeapProxy() const { return protectedManager()->protectedGPUProcessConnection()->videoFrameObjectHeapProxy(); }
 
     Ref<RemoteMediaPlayerManager> protectedManager() const;
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstance.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstance.h
@@ -40,6 +40,9 @@ public:
     virtual ~RemoteCDMInstance();
     static Ref<RemoteCDMInstance> create(WeakPtr<RemoteCDMFactory>&&, RemoteCDMInstanceIdentifier&&, RemoteCDMInstanceConfiguration&&);
 
+    void ref() const final { WebCore::CDMInstance::ref(); }
+    void deref() const final { WebCore::CDMInstance::deref(); }
+
     const RemoteCDMInstanceIdentifier& identifier() const { return m_identifier; }
 
 private:

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.h
@@ -44,6 +44,9 @@ public:
     static Ref<RemoteCDMInstanceSession> create(WeakPtr<RemoteCDMFactory>&&, RemoteCDMInstanceSessionIdentifier&&);
     virtual ~RemoteCDMInstanceSession();
 
+    void ref() const final { WebCore::CDMInstanceSession::ref(); }
+    void deref() const final { WebCore::CDMInstanceSession::deref(); }
+
     RemoteCDMInstanceSessionIdentifier identifier() const { return m_identifier; }
 
 private:

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
@@ -281,6 +281,11 @@ GPUProcessConnection& RemoteMediaPlayerManager::gpuProcessConnection()
     return *gpuProcessConnection;
 }
 
+Ref<GPUProcessConnection> RemoteMediaPlayerManager::protectedGPUProcessConnection()
+{
+    return gpuProcessConnection();
+}
+
 void RemoteMediaPlayerManager::gpuProcessConnectionDidClose(GPUProcessConnection& connection)
 {
     ASSERT(m_gpuProcessConnection.get() == &connection);

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h
@@ -57,6 +57,7 @@ public:
     void setUseGPUProcess(bool);
 
     GPUProcessConnection& gpuProcessConnection();
+    Ref<GPUProcessConnection> protectedGPUProcessConnection();
 
     void didReceivePlayerMessage(IPC::Connection&, IPC::Decoder&);
 

--- a/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
@@ -74,7 +74,7 @@ std::unique_ptr<WebCore::NowPlayingManager> WebMediaStrategy::createNowPlayingMa
         class NowPlayingInfoForGPUManager : public WebCore::NowPlayingManager {
             void clearNowPlayingInfoPrivate() final
             {
-                if (auto* connection = WebProcess::singleton().existingGPUProcessConnection())
+                if (RefPtr connection = WebProcess::singleton().existingGPUProcessConnection())
                     connection->connection().send(Messages::GPUConnectionToWebProcess::ClearNowPlayingInfo { }, 0);
             }
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.h
@@ -64,9 +64,10 @@ public:
     void getVideoFrameBuffer(const RemoteVideoFrameProxy&, bool canUseIOSurfce, Callback&&);
     RefPtr<WebCore::NativeImage> getNativeImage(const WebCore::VideoFrame&);
 
-    void ref() const final { return IPC::WorkQueueMessageReceiver::ref(); }
-    void deref() const final { return IPC::WorkQueueMessageReceiver::deref(); }
     ThreadSafeWeakPtrControlBlock& controlBlock() const final { return IPC::WorkQueueMessageReceiver::controlBlock(); }
+
+    void ref() const final { IPC::WorkQueueMessageReceiver::ref(); }
+    void deref() const final { IPC::WorkQueueMessageReceiver::deref(); }
 
 private:
     explicit RemoteVideoFrameObjectHeapProxyProcessor(GPUProcessConnection&);

--- a/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.h
+++ b/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.h
@@ -53,8 +53,8 @@ public:
     explicit WebGeolocationManager(WebProcess&);
     ~WebGeolocationManager();
 
-    void ref() const;
-    void deref() const;
+    void ref() const final;
+    void deref() const final;
 
     static ASCIILiteral supplementName();
 

--- a/Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.h
+++ b/Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.h
@@ -59,6 +59,9 @@ public:
     static Ref<RemoteWebInspectorUI> create(WebPage&);
     ~RemoteWebInspectorUI();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     // Implemented in generated RemoteWebInspectorUIMessageReceiver.cpp
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorInternal.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorInternal.h
@@ -44,6 +44,9 @@ public:
     static Ref<WebInspector> create(WebPage&);
     ~WebInspector();
 
+    void ref() const final { ThreadSafeRefCounted::ref(); }
+    void deref() const final { ThreadSafeRefCounted::deref(); }
+
     WebPage* page() const;
 
     void updateDockingAvailability();

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorInterruptDispatcher.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorInterruptDispatcher.h
@@ -44,8 +44,8 @@ public:
     
     void initializeConnection(IPC::Connection&);
 
-    void ref() const;
-    void deref() const;
+    void ref() const final;
+    void deref() const final;
     
 private:
     // IPC::MessageReceiver overrides.

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUI.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUI.h
@@ -62,6 +62,9 @@ public:
     static Ref<WebInspectorUI> create(WebPage&);
     virtual ~WebInspectorUI();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     // Implemented in generated WebInspectorUIMessageReceiver.cpp
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.h
@@ -66,6 +66,9 @@ public:
 
     ~WebInspectorUIExtensionController();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     // Implemented in generated WebInspectorUIExtensionControllerMessageReceiver.cpp
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 

--- a/Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.h
+++ b/Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.h
@@ -43,11 +43,14 @@ namespace WebKit {
 
 class WebPage;
 
-class RemoteMediaSessionCoordinator final : public WebCore::MediaSessionCoordinatorPrivate , public IPC::MessageReceiver {
+class RemoteMediaSessionCoordinator final : public WebCore::MediaSessionCoordinatorPrivate, public IPC::MessageReceiver {
     WTF_MAKE_TZONE_ALLOCATED(RemoteMediaSessionCoordinator);
 public:
     static Ref<RemoteMediaSessionCoordinator> create(WebPage&, const String&);
     ~RemoteMediaSessionCoordinator();
+
+    void ref() const final { WebCore::MediaSessionCoordinatorPrivate::ref(); }
+    void deref() const final { WebCore::MediaSessionCoordinatorPrivate::deref(); }
 
 private:
     explicit RemoteMediaSessionCoordinator(WebPage&, const String&);

--- a/Source/WebKit/WebProcess/Model/ModelProcessConnection.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessConnection.h
@@ -51,6 +51,9 @@ public:
     static RefPtr<ModelProcessConnection> create(IPC::Connection& parentConnection);
     ~ModelProcessConnection();
 
+    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
+    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
+
     IPC::Connection& connection() { return m_connection.get(); }
     IPC::MessageReceiverMap& messageReceiverMap() { return m_messageReceiverMap; }
 

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
@@ -44,6 +44,9 @@ public:
     static Ref<ModelProcessModelPlayer> create(WebCore::ModelPlayerIdentifier, WebPage&, WebCore::ModelPlayerClient&);
     virtual ~ModelProcessModelPlayer();
 
+    void ref() const final { WebCore::ModelPlayer::ref(); }
+    void deref() const final { WebCore::ModelPlayer::deref(); }
+
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 
     std::optional<WebCore::LayerHostingContextIdentifier> layerHostingContextIdentifier() { return m_layerHostingContextIdentifier; };

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.h
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.h
@@ -67,6 +67,9 @@ public:
         return adoptRef(*new NetworkProcessConnection(connectionIdentifier, httpCookieAcceptPolicy));
     }
     ~NetworkProcessConnection();
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
     
     Ref<IPC::Connection> protectedConnection() { return m_connection; }
     IPC::Connection& connection() { return m_connection.get(); }

--- a/Source/WebKit/WebProcess/Network/WebMockContentFilterManager.cpp
+++ b/Source/WebKit/WebProcess/Network/WebMockContentFilterManager.cpp
@@ -51,7 +51,7 @@ void WebMockContentFilterManager::startObservingSettings()
 
 void WebMockContentFilterManager::mockContentFilterSettingsChanged(WebCore::MockContentFilterSettings& settings)
 {
-    if (auto connection = WebProcess::singleton().existingNetworkProcessConnection())
+    if (RefPtr connection = WebProcess::singleton().existingNetworkProcessConnection())
         connection->connection().send(Messages::NetworkConnectionToWebProcess::InstallMockContentFilter(settings), 0);
 }
 

--- a/Source/WebKit/WebProcess/Network/WebSocketChannel.h
+++ b/Source/WebKit/WebProcess/Network/WebSocketChannel.h
@@ -52,6 +52,9 @@ public:
     static Ref<WebSocketChannel> create(WebPageProxyIdentifier, WebCore::Document&, WebCore::WebSocketChannelClient&);
     ~WebSocketChannel();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
 
     void networkProcessCrashed();

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.h
@@ -46,8 +46,8 @@ public:
     explicit LibWebRTCNetwork(WebProcess&);
     ~LibWebRTCNetwork();
 
-    void ref() const;
-    void deref() const;
+    void ref() const final;
+    void deref() const final;
 
     IPC::Connection* connection() { return m_connection.get(); }
     void setConnection(RefPtr<IPC::Connection>&&);

--- a/Source/WebKit/WebProcess/Notifications/WebNotificationManager.h
+++ b/Source/WebKit/WebProcess/Notifications/WebNotificationManager.h
@@ -59,8 +59,8 @@ public:
     explicit WebNotificationManager(WebProcess&);
     ~WebNotificationManager();
 
-    void ref() const;
-    void deref() const;
+    void ref() const final;
+    void deref() const final;
 
     static ASCIILiteral supplementName();
     

--- a/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.h
+++ b/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.h
@@ -48,8 +48,8 @@ public:
     explicit SpeechRecognitionRealtimeMediaSourceManager(WebProcess&);
     ~SpeechRecognitionRealtimeMediaSourceManager();
 
-    void ref() const;
-    void deref() const;
+    void ref() const final;
+    void deref() const final;
 
 private:
     // Messages::SpeechRecognitionRealtimeMediaSourceManager

--- a/Source/WebKit/WebProcess/Storage/WebSWClientConnection.h
+++ b/Source/WebKit/WebProcess/Storage/WebSWClientConnection.h
@@ -55,6 +55,9 @@ public:
     static Ref<WebSWClientConnection> create() { return adoptRef(*new WebSWClientConnection); }
     ~WebSWClientConnection();
 
+    void ref() const final { WebCore::SWClientConnection::ref(); }
+    void deref() const final { WebCore::SWClientConnection::deref(); }
+
     WebCore::SWServerConnectionIdentifier serverConnectionIdentifier() const final { return m_identifier; }
 
     void addServiceWorkerRegistrationInServer(WebCore::ServiceWorkerRegistrationIdentifier) final;

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerObjectConnection.h
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerObjectConnection.h
@@ -36,6 +36,9 @@ public:
     static Ref<WebSharedWorkerObjectConnection> create() { return adoptRef(*new WebSharedWorkerObjectConnection); }
     ~WebSharedWorkerObjectConnection();
 
+    void ref() const final { WebCore::SharedWorkerObjectConnection::ref(); }
+    void deref() const final { WebCore::SharedWorkerObjectConnection::deref(); }
+
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 
 private:

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerProvider.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerProvider.cpp
@@ -42,7 +42,7 @@ WebSharedWorkerProvider::WebSharedWorkerProvider() = default;
 
 WebCore::SharedWorkerObjectConnection* WebSharedWorkerProvider::sharedWorkerConnection()
 {
-    return &WebProcess::singleton().ensureNetworkProcessConnection().sharedWorkerConnection();
+    return &WebProcess::singleton().ensureProtectedNetworkProcessConnection()->sharedWorkerConnection();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.h
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.h
@@ -57,6 +57,9 @@ public:
     static Ref<WebUserContentController> getOrCreate(UserContentControllerIdentifier);
     virtual ~WebUserContentController();
 
+    void ref() const final { WebCore::UserContentProvider::ref(); }
+    void deref() const final { WebCore::UserContentProvider::deref(); }
+
     UserContentControllerIdentifier identifier() { return m_identifier; }
 
     void addUserScript(InjectedBundleScriptWorld&, WebCore::UserScript&&);

--- a/Source/WebKit/WebProcess/WebCoreSupport/RemoteWebLockRegistry.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/RemoteWebLockRegistry.h
@@ -40,6 +40,9 @@ public:
     static Ref<RemoteWebLockRegistry> create(WebProcess& process) { return adoptRef(*new RemoteWebLockRegistry(process)); }
     ~RemoteWebLockRegistry();
 
+    void ref() const final { WebCore::WebLockRegistry::ref(); }
+    void deref() const final { WebCore::WebLockRegistry::deref(); }
+
     // WebCore::WebLockRegistry.
     void requestLock(PAL::SessionID, const WebCore::ClientOrigin&, WebCore::WebLockIdentifier, WebCore::ScriptExecutionContextIdentifier, const String& name, WebCore::WebLockMode, bool steal, bool ifAvailable, Function<void(bool)>&& grantedHandler, Function<void()>&& lockStolenHandler) final;
     void releaseLock(PAL::SessionID, const WebCore::ClientOrigin&, WebCore::WebLockIdentifier, WebCore::ScriptExecutionContextIdentifier, const String& name) final;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDeviceOrientationUpdateProvider.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDeviceOrientationUpdateProvider.h
@@ -41,6 +41,9 @@ class WebDeviceOrientationUpdateProvider final : public WebCore::DeviceOrientati
 public:
     static Ref<WebDeviceOrientationUpdateProvider> create(WebPage& page) { return adoptRef(*new WebDeviceOrientationUpdateProvider(page));}
 
+    void ref() const final { WebCore::DeviceOrientationUpdateProvider::ref(); }
+    void deref() const final { WebCore::DeviceOrientationUpdateProvider::deref(); }
+
 private:
     WebDeviceOrientationUpdateProvider(WebPage&);
     ~WebDeviceOrientationUpdateProvider();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.h
@@ -49,6 +49,9 @@ public:
     static Ref<WebPermissionController> create(WebProcess&);
     ~WebPermissionController();
 
+    void ref() const final { WebCore::PermissionController::ref(); }
+    void deref() const final { WebCore::PermissionController::deref(); }
+
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.h
@@ -41,8 +41,8 @@ public:
     explicit WebScreenOrientationManager(WebPage&);
     ~WebScreenOrientationManager();
 
-    void ref() const;
-    void deref() const;
+    void ref() const final;
+    void deref() const final;
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechRecognitionConnection.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechRecognitionConnection.h
@@ -47,6 +47,9 @@ class WebSpeechRecognitionConnection final : public WebCore::SpeechRecognitionCo
 public:
     static Ref<WebSpeechRecognitionConnection> create(SpeechRecognitionConnectionIdentifier);
 
+    void ref() const final { WebCore::SpeechRecognitionConnection::ref(); }
+    void deref() const final { WebCore::SpeechRecognitionConnection::deref(); }
+
     void start(WebCore::SpeechRecognitionConnectionClientIdentifier, const String& lang, bool continuous, bool interimResults, uint64_t maxAlternatives, WebCore::ClientOrigin&&, WebCore::FrameIdentifier) final;
     void stop(WebCore::SpeechRecognitionConnectionClientIdentifier) final;
     void abort(WebCore::SpeechRecognitionConnectionClientIdentifier) final;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp
@@ -63,6 +63,7 @@ public:
 #endif
 private:
     RemoteRenderingBackendProxy& ensureRenderingBackend() const;
+    Ref<RemoteRenderingBackendProxy> ensureProtectedRenderingBackend() const { return ensureRenderingBackend(); }
 
     mutable RefPtr<RemoteRenderingBackendProxy> m_remoteRenderingBackendProxy;
 };
@@ -91,7 +92,7 @@ RefPtr<ImageBuffer> GPUProcessWebWorkerClient::sinkIntoImageBuffer(std::unique_p
         return nullptr;
     if (is<RemoteSerializedImageBufferProxy>(imageBuffer)) {
         auto remote = std::unique_ptr<RemoteSerializedImageBufferProxy>(static_cast<RemoteSerializedImageBufferProxy*>(imageBuffer.release()));
-        return RemoteSerializedImageBufferProxy::sinkIntoImageBuffer(WTFMove(remote), ensureRenderingBackend());
+        return RemoteSerializedImageBufferProxy::sinkIntoImageBuffer(WTFMove(remote), ensureProtectedRenderingBackend());
     }
     return WebWorkerClient::sinkIntoImageBuffer(WTFMove(imageBuffer));
 }
@@ -101,7 +102,7 @@ RefPtr<ImageBuffer> GPUProcessWebWorkerClient::createImageBuffer(const FloatSize
     if (RefPtr dispatcher = this->dispatcher())
         assertIsCurrent(*dispatcher);
     if (WebProcess::singleton().shouldUseRemoteRenderingFor(purpose))
-        return ensureRenderingBackend().createImageBuffer(size, purpose, resolutionScale, colorSpace, pixelFormat, options);
+        return ensureProtectedRenderingBackend()->createImageBuffer(size, purpose, resolutionScale, colorSpace, pixelFormat, options);
     return nullptr;
 }
 
@@ -112,7 +113,7 @@ RefPtr<GraphicsContextGL> GPUProcessWebWorkerClient::createGraphicsContextGL(con
         return nullptr;
     assertIsCurrent(*dispatcher);
     if (WebProcess::singleton().shouldUseRemoteRenderingForWebGL())
-        return RemoteGraphicsContextGLProxy::create(attributes, ensureRenderingBackend(), *dispatcher);
+        return RemoteGraphicsContextGLProxy::create(attributes, ensureProtectedRenderingBackend(), *dispatcher);
     return WebWorkerClient::createGraphicsContextGL(attributes);
 }
 
@@ -123,7 +124,7 @@ RefPtr<WebCore::WebGPU::GPU> GPUProcessWebWorkerClient::createGPUForWebGPU() con
     if (!dispatcher)
         return nullptr;
     assertIsCurrent(*dispatcher);
-    return RemoteGPUProxy::create(WebGPU::DowncastConvertToBackingContext::create(), ensureRenderingBackend(), *dispatcher);
+    return RemoteGPUProxy::create(WebGPU::DowncastConvertToBackingContext::create(), ensureProtectedRenderingBackend(), *dispatcher);
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.h
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.h
@@ -55,8 +55,8 @@ public:
     TextCheckingControllerProxy(WebPage&);
     ~TextCheckingControllerProxy();
 
-    void ref() const;
-    void deref() const;
+    void ref() const final;
+    void deref() const final;
 
     static WebCore::AttributedString annotatedSubstringBetweenPositions(const WebCore::VisiblePosition&, const WebCore::VisiblePosition&);
 

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -77,6 +77,9 @@ class DrawingArea : public RefCounted<DrawingArea>, public IPC::MessageReceiver,
 public:
     static RefPtr<DrawingArea> create(WebPage&, const WebPageCreationParameters&);
     virtual ~DrawingArea();
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
     
     DrawingAreaType type() const { return m_type; }
     DrawingAreaIdentifier identifier() const { return m_identifier; }

--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.h
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.h
@@ -81,8 +81,8 @@ public:
     explicit EventDispatcher(WebProcess&);
     ~EventDispatcher();
 
-    void ref() const;
-    void deref() const;
+    void ref() const final;
+    void deref() const final;
 
     enum class WheelEventOrigin : bool { UIProcess, MomentumEventDispatcher };
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h
@@ -50,6 +50,9 @@ public:
         return adoptRef(*new RemoteScrollingCoordinator(page));
     }
 
+    void ref() const final { WebCore::AsyncScrollingCoordinator::ref(); }
+    void deref() const final { WebCore::AsyncScrollingCoordinator::deref(); }
+
     RemoteScrollingCoordinatorTransaction buildTransaction(WebCore::FrameIdentifier);
 
     void scrollingStateInUIProcessChanged(const RemoteScrollingUIState&);

--- a/Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.h
+++ b/Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.h
@@ -53,6 +53,9 @@ public:
 
     ~ViewGestureGeometryCollector();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     void mainFrameDidLayout();
 
     void computeZoomInformationForNode(WebCore::Node&, WebCore::FloatPoint& origin, WebCore::FloatRect& absoluteBoundingRect, bool& isReplaced, double& viewportMinimumScale, double& viewportMaximumScale);

--- a/Source/WebKit/WebProcess/WebPage/ViewUpdateDispatcher.h
+++ b/Source/WebKit/WebProcess/WebPage/ViewUpdateDispatcher.h
@@ -48,8 +48,8 @@ public:
     ViewUpdateDispatcher(WebProcess&);
     ~ViewUpdateDispatcher();
 
-    void ref() const;
-    void deref() const;
+    void ref() const final;
+    void deref() const final;
 
     void initializeConnection(IPC::Connection&);
 

--- a/Source/WebKit/WebProcess/WebPage/VisitedLinkTableController.h
+++ b/Source/WebKit/WebProcess/WebPage/VisitedLinkTableController.h
@@ -38,6 +38,9 @@ public:
     static Ref<VisitedLinkTableController> getOrCreate(VisitedLinkTableIdentifier);
     virtual ~VisitedLinkTableController();
 
+    void ref() const final { WebCore::VisitedLinkStore::ref(); }
+    void deref() const final { WebCore::VisitedLinkStore::deref(); }
+
 private:
     explicit VisitedLinkTableController(VisitedLinkTableIdentifier);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9224,6 +9224,11 @@ RemoteRenderingBackendProxy& WebPage::ensureRemoteRenderingBackendProxy()
         m_remoteRenderingBackendProxy = RemoteRenderingBackendProxy::create(*this);
     return *m_remoteRenderingBackendProxy;
 }
+
+Ref<RemoteRenderingBackendProxy> WebPage::ensureProtectedRemoteRenderingBackendProxy()
+{
+    return ensureRemoteRenderingBackendProxy();
+}
 #endif
 
 Vector<Ref<SandboxExtension>> WebPage::consumeSandboxExtensions(Vector<SandboxExtension::Handle>&& sandboxExtensions)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -458,6 +458,9 @@ public:
 
     virtual ~WebPage();
 
+    void ref() const final { API::ObjectImpl<API::Object::Type::BundlePage>::ref(); }
+    void deref() const final { API::ObjectImpl<API::Object::Type::BundlePage>::deref(); }
+
     void reinitializeWebPage(WebPageCreationParameters&&);
 
     void close();
@@ -1686,6 +1689,7 @@ public:
     void gpuProcessConnectionDidBecomeAvailable(GPUProcessConnection&);
     void gpuProcessConnectionWasDestroyed();
     RemoteRenderingBackendProxy& ensureRemoteRenderingBackendProxy();
+    Ref<RemoteRenderingBackendProxy> ensureProtectedRemoteRenderingBackendProxy();
 #endif
 
 #if ENABLE(MODEL_PROCESS)

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.h
@@ -46,6 +46,9 @@ public:
     static Ref<WebPageTesting> create(WebPage&);
     virtual ~WebPageTesting();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
 private:
     explicit WebPageTesting(WebPage&);
 

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h
@@ -71,8 +71,8 @@ public:
     static std::unique_ptr<AcceleratedSurfaceDMABuf> create(ThreadedCompositor&, WebPage&, Function<void()>&& frameCompleteHandler);
     ~AcceleratedSurfaceDMABuf();
 
-    void ref() const;
-    void deref() const;
+    void ref() const final;
+    void deref() const final;
 
 private:
     uint64_t window() const override { return 0; }

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1252,6 +1252,11 @@ NetworkProcessConnection& WebProcess::ensureNetworkProcessConnection()
     return *m_networkProcessConnection;
 }
 
+Ref<NetworkProcessConnection> WebProcess::ensureProtectedNetworkProcessConnection()
+{
+    return ensureNetworkProcessConnection();
+}
+
 void WebProcess::logDiagnosticMessageForNetworkProcessCrash()
 {
     WebCore::Page* page = nullptr;
@@ -1369,6 +1374,11 @@ GPUProcessConnection& WebProcess::ensureGPUProcessConnection()
         }
     }
     return *m_gpuProcessConnection;
+}
+
+Ref<GPUProcessConnection> WebProcess::ensureProtectedGPUProcessConnection()
+{
+    return ensureGPUProcessConnection();
 }
 
 Seconds WebProcess::gpuProcessTimeoutDuration() const

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -258,6 +258,8 @@ public:
     EventDispatcher& eventDispatcher() { return m_eventDispatcher; }
 
     NetworkProcessConnection& ensureNetworkProcessConnection();
+    Ref<NetworkProcessConnection> ensureProtectedNetworkProcessConnection();
+
     void networkProcessConnectionClosed(NetworkProcessConnection*);
     NetworkProcessConnection* existingNetworkProcessConnection() { return m_networkProcessConnection.get(); }
     WebLoaderStrategy& webLoaderStrategy();
@@ -269,6 +271,7 @@ public:
 
 #if ENABLE(GPU_PROCESS)
     GPUProcessConnection& ensureGPUProcessConnection();
+    Ref<GPUProcessConnection> ensureProtectedGPUProcessConnection();
     GPUProcessConnection* existingGPUProcessConnection() { return m_gpuProcessConnection.get(); }
     // Returns timeout duration for GPU process connections. Thread-safe.
     Seconds gpuProcessTimeoutDuration() const;

--- a/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.h
+++ b/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.h
@@ -60,6 +60,9 @@ public:
 
     ~StorageAreaMap();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     WebCore::StorageType type() const { return m_type; }
 
     unsigned length();

--- a/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.h
+++ b/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.h
@@ -56,8 +56,8 @@ public:
     std::optional<PlatformXR::LayerHandle> createLayerProjection(uint32_t, uint32_t, bool);
     void submitFrame();
 
-    void ref() const;
-    void deref() const;
+    void ref() const final;
+    void deref() const final;
 
 private:
     RefPtr<XRDeviceProxy> deviceByIdentifier(XRDeviceIdentifier);

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
@@ -117,6 +117,9 @@ public:
     static Ref<PlaybackSessionManager> create(WebPage&);
     virtual ~PlaybackSessionManager();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     void invalidate();
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;

--- a/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.h
+++ b/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.h
@@ -55,8 +55,8 @@ public:
     explicit UserMediaCaptureManager(WebProcess&);
     ~UserMediaCaptureManager();
 
-    void ref() const;
-    void deref() const;
+    void ref() const final;
+    void deref() const final;
 
     static ASCIILiteral supplementName();
 

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
@@ -138,6 +138,9 @@ public:
     static Ref<VideoPresentationManager> create(WebPage&, PlaybackSessionManager&);
     virtual ~VideoPresentationManager();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     void invalidate();
 
     bool hasVideoPlayingInPictureInPicture() const;

--- a/Source/WebKit/WebProcess/glib/SystemSettingsManager.h
+++ b/Source/WebKit/WebProcess/glib/SystemSettingsManager.h
@@ -44,8 +44,8 @@ public:
     explicit SystemSettingsManager(WebProcess&);
     ~SystemSettingsManager();
 
-    void ref() const;
-    void deref() const;
+    void ref() const final;
+    void deref() const final;
 
     static ASCIILiteral supplementName();
 

--- a/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.h
+++ b/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.h
@@ -53,8 +53,8 @@ public:
     explicit UserMediaCaptureManager(WebProcess&);
     ~UserMediaCaptureManager();
 
-    void ref() const;
-    void deref() const;
+    void ref() const final;
+    void deref() const final;
 
     static ASCIILiteral supplementName() { return "UserMediaCaptureManager"_s; }
 

--- a/Source/WebKit/webpushd/PushClientConnection.h
+++ b/Source/WebKit/webpushd/PushClientConnection.h
@@ -76,6 +76,9 @@ class PushClientConnection : public RefCounted<PushClientConnection>, public Ide
 public:
     static RefPtr<PushClientConnection> create(xpc_connection_t, IPC::Decoder&);
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     std::optional<WebCore::PushSubscriptionSetIdentifier> subscriptionSetIdentifierForOrigin(const WebCore::SecurityOriginData&) const;
     const String& hostAppCodeSigningIdentifier() const { return m_hostAppCodeSigningIdentifier; }
     bool hostAppHasPushInjectEntitlement() const { return m_hostAppHasPushInjectEntitlement; };

--- a/Source/WebKit/webpushd/WebPushDaemon.mm
+++ b/Source/WebKit/webpushd/WebPushDaemon.mm
@@ -333,7 +333,7 @@ void WebPushDaemon::connectionEventHandler(xpc_object_t request)
         return;
     }
 
-    auto pushConnection = m_connectionMap.get(xpcConnection.get());
+    RefPtr pushConnection = m_connectionMap.get(xpcConnection.get());
     if (!pushConnection) {
         RELEASE_LOG_ERROR(Push, "WebPushDaemon::connectionEventHandler - Could not find a PushClientConnection mapped to this xpc request");
         tryCloseRequestConnection(request);
@@ -911,9 +911,8 @@ void WebPushDaemon::setPublicTokenForTesting(PushClientConnection& connection, c
 
 PushClientConnection* WebPushDaemon::toPushClientConnection(xpc_connection_t connection)
 {
-    auto clientConnection = m_connectionMap.get(connection);
-    RELEASE_ASSERT(clientConnection);
-    return clientConnection;
+    RELEASE_ASSERT(m_connectionMap.contains(connection));
+    return m_connectionMap.get(connection);
 }
 
 #if HAVE(FULL_FEATURED_USER_NOTIFICATIONS)

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h
@@ -68,13 +68,19 @@ struct MockTestMessageWithAsyncReply1 {
     using Promise = WTF::NativePromise<uint64_t, IPC::Error>;
 };
 
-class MockConnectionClient final : public IPC::Connection::Client {
+class MockConnectionClient final : public IPC::Connection::Client, public RefCounted<MockConnectionClient> {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MockConnectionClient);
 public:
-    ~MockConnectionClient()
+    static Ref<MockConnectionClient> create()
     {
+        return adoptRef(*new MockConnectionClient);
     }
+
+    ~MockConnectionClient() = default;
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     Vector<MessageInfo> takeMessages()
     {
@@ -146,6 +152,8 @@ public:
     }
 
 private:
+    MockConnectionClient() = default;
+
     bool m_didClose { false };
     std::optional<IPC::MessageName> m_didReceiveInvalidMessage;
     Deque<MessageInfo> m_messages;
@@ -228,7 +236,7 @@ protected:
 
     struct {
         RefPtr<IPC::Connection> connection;
-        MockConnectionClient client;
+        Ref<MockConnectionClient> client = MockConnectionClient::create();
     } m_connections[2];
 };
 


### PR DESCRIPTION
#### 880199acf9d6cffab686c6fc34564f73028e599f
<pre>
Make MessageReceiver AbstractRefCounted
<a href="https://bugs.webkit.org/show_bug.cgi?id=283877">https://bugs.webkit.org/show_bug.cgi?id=283877</a>

Reviewed by Darin Adler.

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
* Source/WebKit/GPUProcess/RemoteSharedResourceCache.h:
* Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.h:
* Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.h:
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h:
* Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.h:
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.h:
* Source/WebKit/GPUProcess/media/RemoteCDMProxy.h:
* Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.h:
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.h:
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.h:
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaEngineConfigurationFactoryProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.h:
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h:
* Source/WebKit/GPUProcess/media/RemoteRemoteCommandListenerProxy.h:
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h:
* Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.h:
* Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.h:
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h:
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.h:
* Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.h:
* Source/WebKit/ModelProcess/ModelConnectionToWebProcess.h:
* Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h:
* Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h:
* Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkSocketChannel.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h:
* Source/WebKit/Platform/IPC/MessageReceiver.h:
* Source/WebKit/Platform/IPC/StreamClientConnection.cpp:
(IPC::StreamClientConnection::DedicatedConnectionClient::DedicatedConnectionClient):
(IPC::StreamClientConnection::open):
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
* Source/WebKit/Platform/IPC/StreamServerConnection.h:
* Source/WebKit/Platform/IPC/WorkQueueMessageReceiver.h:
* Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.h:
* Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h:
* Source/WebKit/Shared/Authentication/AuthenticationManager.h:
* Source/WebKit/Shared/AuxiliaryProcess.h:
* Source/WebKit/Shared/IPCConnectionTester.h:
* Source/WebKit/Shared/IPCStreamTesterProxy.h:
* Source/WebKit/Shared/IPCTester.h:
* Source/WebKit/Shared/IPCTesterReceiver.h:
* Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.h:
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h:
* Source/WebKit/UIProcess/DigitalCredentials/DigitalCredentialsCoordinatorProxy.h:
* Source/WebKit/UIProcess/Downloads/DownloadProxy.h:
* Source/WebKit/UIProcess/DrawingAreaProxy.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
* Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h:
* Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.h:
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h:
* Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.h:
* Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.h:
* Source/WebKit/UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.h:
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::ProvisionalPageProxy):
* Source/WebKit/UIProcess/ProvisionalPageProxy.h:
* Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.h:
* Source/WebKit/UIProcess/RemotePageProxy.h:
* Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.h:
* Source/WebKit/UIProcess/SpeechRecognitionServer.h:
* Source/WebKit/UIProcess/SuspendedPageProxy.cpp:
(WebKit::SuspendedPageProxy::create):
(WebKit::SuspendedPageProxy::didDestroyNavigation):
(WebKit::SuspendedPageProxy::page const):
(WebKit::SuspendedPageProxy::protectedPage const): Deleted.
* Source/WebKit/UIProcess/SuspendedPageProxy.h:
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h:
* Source/WebKit/UIProcess/ViewGestureController.h:
* Source/WebKit/UIProcess/VisitedLinkStore.h:
* Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.h:
* Source/WebKit/UIProcess/WebBackForwardCache.cpp:
(WebKit::WebBackForwardCache::addEntry):
(WebKit::WebBackForwardCache::takeSuspendedPage):
* Source/WebKit/UIProcess/WebBackForwardCache.h:
* Source/WebKit/UIProcess/WebBackForwardCacheEntry.cpp:
(WebKit::WebBackForwardCacheEntry::create):
(WebKit::WebBackForwardCacheEntry::WebBackForwardCacheEntry):
(WebKit::WebBackForwardCacheEntry::takeSuspendedPage):
* Source/WebKit/UIProcess/WebBackForwardCacheEntry.h:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
* Source/WebKit/UIProcess/WebGeolocationManagerProxy.h:
* Source/WebKit/UIProcess/WebLockRegistryProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::suspendCurrentPageIfPossible):
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
(WebKit::WebPageProxy::continueNavigationInNewProcess):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPasteboardProxy.h:
(WebKit::WebPasteboardProxy::ref const): Deleted.
(WebKit::WebPasteboardProxy::deref const): Deleted.
* Source/WebKit/UIProcess/WebPermissionControllerProxy.h:
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::isAllowedToUpdateBackForwardItem const):
(WebKit::WebProcessProxy::removeSuspendedPageProxy):
(WebKit::WebProcessProxy::isAssociatedWithPage const):
* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h:
* Source/WebKit/UIProcess/mac/SecItemShimProxy.h:
* Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.h:
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h:
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
* Source/WebKit/WebProcess/GPU/media/RemoteCDMInstance.h:
* Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.h:
* Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.h:
* Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.h:
* Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.h:
* Source/WebKit/WebProcess/Inspector/WebInspectorInternal.h:
* Source/WebKit/WebProcess/Inspector/WebInspectorInterruptDispatcher.h:
* Source/WebKit/WebProcess/Inspector/WebInspectorUI.h:
* Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.h:
* Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.h:
* Source/WebKit/WebProcess/Model/ModelProcessConnection.h:
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h:
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.h:
* Source/WebKit/WebProcess/Network/WebSocketChannel.h:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.h:
* Source/WebKit/WebProcess/Notifications/WebNotificationManager.h:
* Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.h:
* Source/WebKit/WebProcess/Storage/WebSWClientConnection.h:
* Source/WebKit/WebProcess/Storage/WebSharedWorkerObjectConnection.h:
* Source/WebKit/WebProcess/UserContent/WebUserContentController.h:
* Source/WebKit/WebProcess/WebCoreSupport/RemoteWebLockRegistry.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebSpeechRecognitionConnection.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.h:
* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
* Source/WebKit/WebProcess/WebPage/EventDispatcher.h:
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::MessageReceiver::MessageReceiver):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::MessageReceiver::ref const):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::MessageReceiver::deref const):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h:
* Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.h:
* Source/WebKit/WebProcess/WebPage/ViewUpdateDispatcher.h:
* Source/WebKit/WebProcess/WebPage/VisitedLinkTableController.h:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPageTesting.h:
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h:
* Source/WebKit/WebProcess/WebStorage/StorageAreaMap.h:
* Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.h:
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h:
* Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.h:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h:
* Source/WebKit/WebProcess/glib/SystemSettingsManager.h:
* Source/WebKit/WebProcess/glib/UserMediaCaptureManager.h:
* Source/WebKit/webpushd/PushClientConnection.h:
* Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h:
* Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp:
(TestWebKitAPI::TEST_F(StreamConnectionTest, OpenConnections)):
(TestWebKitAPI::StreamMessageTest::StreamMessageTest):
(TestWebKitAPI::TEST_P):

Canonical link: <a href="https://commits.webkit.org/287239@main">https://commits.webkit.org/287239@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c41be64f2108be24133ac1e1a3eb430d81505e3a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78868 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57911 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32249 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83526 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30127 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81001 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67060 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6192 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61760 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19691 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81935 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51798 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/71735 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42067 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49148 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25949 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28470 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70262 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26359 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84897 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6232 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69988 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6394 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67789 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69240 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13289 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12018 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12178 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6177 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12057 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6159 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9597 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7950 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->