### PR TITLE
Stop WebExtensionLocalization from modifying the original input

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionLocalization.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionLocalization.cpp
@@ -132,21 +132,27 @@ void WebExtensionLocalization::loadRegionalLocalization(RefPtr<JSON::Object> reg
     return;
 }
 
-void WebExtensionLocalization::localizedJSONforJSON(RefPtr<JSON::Object> json)
+RefPtr<JSON::Object> WebExtensionLocalization::localizedJSONforJSON(RefPtr<JSON::Object> json)
 {
-    if (!json || !json->size())
-        return;
+    if (!json)
+        return nullptr;
+
+    Ref newObject = JSON::Object::create();
 
     for (auto& key : json->keys()) {
         auto valueType = json->getValue(key)->type();
 
         if (valueType == JSON::Value::Type::String)
-            json->setString(key, localizedStringForString(json->getString(key)));
+            newObject->setString(key, localizedStringForString(json->getString(key)));
         else if (valueType == JSON::Value::Type::Array)
-            localizedArrayForArray(json->getArray(key));
+            newObject->setArray(key, *localizedArrayForArray(json->getArray(key)));
         else if (valueType == JSON::Value::Type::Object)
-            localizedJSONforJSON(json->getObject(key));
+            newObject->setObject(key, *localizedJSONforJSON(json->getObject(key)));
+        else
+            newObject->setValue(key, *json->getValue(key));
     }
+
+    return newObject;
 }
 
 String WebExtensionLocalization::localizedStringForKey(String key, Vector<String> placeholders)
@@ -184,21 +190,27 @@ String WebExtensionLocalization::localizedStringForKey(String key, Vector<String
     return localizedString;
 }
 
-void WebExtensionLocalization::localizedArrayForArray(RefPtr<JSON::Array> json)
+RefPtr<JSON::Array> WebExtensionLocalization::localizedArrayForArray(RefPtr<JSON::Array> json)
 {
     if (!json)
-        return;
+        return nullptr;
+
+    Ref newArray = JSON::Array::create();
 
     for (Ref value : *json) {
         auto valueType = value->type();
 
         if (valueType == JSON::Value::Type::String)
-            value->asString() = localizedStringForString(value->asString());
+            newArray->pushString(localizedStringForString(value->asString()));
         else if (valueType == JSON::Value::Type::Array)
-            localizedArrayForArray(value->asArray());
+            newArray->pushArray(*localizedArrayForArray(value->asArray()));
         else if (valueType == JSON::Value::Type::Object)
-            localizedJSONforJSON(value->asObject());
+            newArray->pushObject(*localizedJSONforJSON(value->asObject()));
+        else
+            newArray->pushValue(WTFMove(value));
     }
+
+    return newArray;
 }
 
 String WebExtensionLocalization::localizedStringForString(String sourceString)

--- a/Source/WebKit/Shared/Extensions/WebExtensionLocalization.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionLocalization.h
@@ -54,7 +54,7 @@ public:
     const String& uniqueIdentifier() { return m_uniqueIdentifier; };
     RefPtr<JSON::Object> localizationJSON() { return m_localizationJSON; };
 
-    void localizedJSONforJSON(RefPtr<JSON::Object>);
+    RefPtr<JSON::Object> localizedJSONforJSON(RefPtr<JSON::Object>);
     String localizedStringForKey(String key, Vector<String> placeholders = { });
     String localizedStringForString(String);
 
@@ -62,7 +62,7 @@ private:
     void loadRegionalLocalization(RefPtr<JSON::Object> regionalLocalization, RefPtr<JSON::Object> languageLocalization, RefPtr<JSON::Object> defaultLocalization, const String& withBestLocale = { }, const String& uniqueIdentifier = { });
 
     RefPtr<JSON::Object> localizationJSONForWebExtension(WebKit::WebExtension&, const String& withLocale);
-    void localizedArrayForArray(RefPtr<JSON::Array>);
+    RefPtr<JSON::Array> localizedArrayForArray(RefPtr<JSON::Array>);
     Ref<JSON::Object> predefinedMessages();
 
     String stringByReplacingNamedPlaceholdersInString(String sourceString, RefPtr<JSON::Object> placeholders);

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -278,7 +278,7 @@ bool WebExtension::parseManifest(NSData *manifestData)
         return false;
     }
 
-    localization->localizedJSONforJSON(manifestJSON->asObject());
+    manifestJSON = localization->localizedJSONforJSON(manifestJSON->asObject());
 
     m_localization = localization;
 


### PR DESCRIPTION
#### 8dd79f91f9c8ba584358ea164bd62cf5b32d476f
<pre>
Stop WebExtensionLocalization from modifying the original input
<a href="https://webkit.org/b/283884">https://webkit.org/b/283884</a>

Reviewed by Timothy Hatcher.

The localizedJSONforJSON and localizedArrayForArray shouldn&apos;t modify the original input,
and instead should return a modified copy of the input to keep parity with the original
Cocoa functions.

* Source/WebKit/Shared/Extensions/WebExtensionLocalization.cpp:
(WebKit::WebExtensionLocalization::localizedJSONforJSON):
(WebKit::WebExtensionLocalization::localizedArrayForArray):
* Source/WebKit/Shared/Extensions/WebExtensionLocalization.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::parseManifest):

Canonical link: <a href="https://commits.webkit.org/287225@main">https://commits.webkit.org/287225@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1684e7e1b781c70884b03a44f9a9de98a575cedd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78827 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57871 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32209 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83487 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30089 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67022 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6152 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61737 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19667 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81894 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51773 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/71667 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42044 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49119 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28429 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70232 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26320 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84856 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6192 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69965 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6354 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67761 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69219 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13257 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11983 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12170 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6137 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12025 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6121 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9558 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7911 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->