### PR TITLE
Make AudioDecoder, AudioEncoder, VideoDecoder and VideoEncoder ref counted

### DIFF
--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp
@@ -165,7 +165,7 @@ ExceptionOr<void> WebCodecsAudioDecoder::decode(Ref<WebCodecsEncodedAudioChunk>&
         --m_decodeQueueSize;
         scheduleDequeueEvent();
 
-        protectedScriptExecutionContext()->enqueueTaskWhenSettled(m_internalDecoder->decode({ chunk->span(), chunk->type() == WebCodecsEncodedAudioChunkType::Key, chunk->timestamp(), chunk->duration() }), TaskSource::MediaElement, [weakThis = ThreadSafeWeakPtr { *this }, pendingActivity = makePendingActivity(*this)] (auto&& result) {
+        protectedScriptExecutionContext()->enqueueTaskWhenSettled(Ref { *m_internalDecoder }->decode({ chunk->span(), chunk->type() == WebCodecsEncodedAudioChunkType::Key, chunk->timestamp(), chunk->duration() }), TaskSource::MediaElement, [weakThis = ThreadSafeWeakPtr { *this }, pendingActivity = makePendingActivity(*this)] (auto&& result) {
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis || !!result)
                 return;
@@ -184,7 +184,7 @@ ExceptionOr<void> WebCodecsAudioDecoder::flush(Ref<DeferredPromise>&& promise)
     m_isKeyChunkRequired = true;
     m_pendingFlushPromises.append(WTFMove(promise));
     queueControlMessageAndProcess({ *this, [this, clearFlushPromiseCount = m_clearFlushPromiseCount] {
-        protectedScriptExecutionContext()->enqueueTaskWhenSettled(m_internalDecoder->flush(), TaskSource::MediaElement, [weakThis = ThreadSafeWeakPtr { *this }, clearFlushPromiseCount, pendingActivity = makePendingActivity(*this)] (auto&&) {
+        protectedScriptExecutionContext()->enqueueTaskWhenSettled(Ref { *m_internalDecoder }->flush(), TaskSource::MediaElement, [weakThis = ThreadSafeWeakPtr { *this }, clearFlushPromiseCount, pendingActivity = makePendingActivity(*this)] (auto&&) {
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis)
                 return;
@@ -245,8 +245,8 @@ ExceptionOr<void> WebCodecsAudioDecoder::resetDecoder(const Exception& exception
         return Exception { ExceptionCode::InvalidStateError, "AudioDecoder is closed"_s };
 
     m_state = WebCodecsCodecState::Unconfigured;
-    if (m_internalDecoder)
-        m_internalDecoder->reset();
+    if (RefPtr internalDecoder = std::exchange(m_internalDecoder, { }))
+        internalDecoder->reset();
     m_controlMessageQueue.clear();
     if (m_decodeQueueSize) {
         m_decodeQueueSize = 0;
@@ -272,9 +272,9 @@ void WebCodecsAudioDecoder::scheduleDequeueEvent()
     });
 }
 
-void WebCodecsAudioDecoder::setInternalDecoder(UniqueRef<AudioDecoder>&& internalDecoder)
+void WebCodecsAudioDecoder::setInternalDecoder(Ref<AudioDecoder>&& internalDecoder)
 {
-    m_internalDecoder = internalDecoder.moveToUniquePtr();
+    m_internalDecoder = WTFMove(internalDecoder);
 }
 
 void WebCodecsAudioDecoder::queueControlMessageAndProcess(WebCodecsControlMessage<WebCodecsAudioDecoder>&& message)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h
@@ -95,7 +95,7 @@ private:
 
     ExceptionOr<void> closeDecoder(Exception&&);
     ExceptionOr<void> resetDecoder(const Exception&);
-    void setInternalDecoder(UniqueRef<AudioDecoder>&&);
+    void setInternalDecoder(Ref<AudioDecoder>&&);
     void scheduleDequeueEvent();
 
     void queueControlMessageAndProcess(WebCodecsControlMessage<WebCodecsAudioDecoder>&&);
@@ -105,7 +105,7 @@ private:
     size_t m_decodeQueueSize { 0 };
     Ref<WebCodecsAudioDataOutputCallback> m_output;
     Ref<WebCodecsErrorCallback> m_error;
-    std::unique_ptr<AudioDecoder> m_internalDecoder;
+    RefPtr<AudioDecoder> m_internalDecoder;
     bool m_dequeueEventScheduled { false };
     Deque<Ref<DeferredPromise>> m_pendingFlushPromises;
     size_t m_clearFlushPromiseCount { 0 };

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.h
@@ -94,7 +94,7 @@ private:
 
     ExceptionOr<void> closeEncoder(Exception&&);
     ExceptionOr<void> resetEncoder(const Exception&);
-    void setInternalEncoder(UniqueRef<AudioEncoder>&&);
+    void setInternalEncoder(Ref<AudioEncoder>&&);
     void scheduleDequeueEvent();
 
     void queueControlMessageAndProcess(WebCodecsControlMessage<WebCodecsAudioEncoder>&&);
@@ -105,7 +105,7 @@ private:
     size_t m_encodeQueueSize { 0 };
     Ref<WebCodecsEncodedAudioChunkOutputCallback> m_output;
     Ref<WebCodecsErrorCallback> m_error;
-    std::unique_ptr<AudioEncoder> m_internalEncoder;
+    RefPtr<AudioEncoder> m_internalEncoder;
     bool m_dequeueEventScheduled { false };
     Deque<Ref<DeferredPromise>> m_pendingFlushPromises;
     size_t m_clearFlushPromiseCount { 0 };

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h
@@ -93,7 +93,7 @@ private:
 
     ExceptionOr<void> closeDecoder(Exception&&);
     ExceptionOr<void> resetDecoder(const Exception&);
-    void setInternalDecoder(UniqueRef<VideoDecoder>&&);
+    void setInternalDecoder(Ref<VideoDecoder>&&);
     void scheduleDequeueEvent();
 
     void queueControlMessageAndProcess(WebCodecsControlMessage<WebCodecsVideoDecoder>&&);
@@ -103,7 +103,7 @@ private:
     size_t m_decodeQueueSize { 0 };
     Ref<WebCodecsVideoFrameOutputCallback> m_output;
     Ref<WebCodecsErrorCallback> m_error;
-    std::unique_ptr<VideoDecoder> m_internalDecoder;
+    RefPtr<VideoDecoder> m_internalDecoder;
     bool m_dequeueEventScheduled { false };
     Deque<Ref<DeferredPromise>> m_pendingFlushPromises;
     size_t m_clearFlushPromiseCount { 0 };

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
@@ -94,7 +94,7 @@ private:
 
     ExceptionOr<void> closeEncoder(Exception&&);
     ExceptionOr<void> resetEncoder(const Exception&);
-    void setInternalEncoder(UniqueRef<VideoEncoder>&&);
+    void setInternalEncoder(Ref<VideoEncoder>&&);
     void scheduleDequeueEvent();
 
     void queueControlMessageAndProcess(WebCodecsControlMessage<WebCodecsVideoEncoder>&&);
@@ -106,7 +106,7 @@ private:
     size_t m_encodeQueueSize { 0 };
     Ref<WebCodecsEncodedVideoChunkOutputCallback> m_output;
     Ref<WebCodecsErrorCallback> m_error;
-    std::unique_ptr<VideoEncoder> m_internalEncoder;
+    RefPtr<VideoEncoder> m_internalEncoder;
     bool m_dequeueEventScheduled { false };
     Deque<Ref<DeferredPromise>> m_pendingFlushPromises;
     size_t m_clearFlushPromiseCount { 0 };

--- a/Source/WebCore/platform/AudioDecoder.h
+++ b/Source/WebCore/platform/AudioDecoder.h
@@ -36,7 +36,7 @@ namespace WebCore {
 
 class PlatformRawAudioData;
 
-class AudioDecoder {
+class AudioDecoder : public ThreadSafeRefCounted<AudioDecoder> {
 public:
     WEBCORE_EXPORT AudioDecoder();
     WEBCORE_EXPORT virtual ~AudioDecoder();
@@ -60,8 +60,8 @@ public:
     };
 
     using OutputCallback = Function<void(Expected<DecodedData, String>&&)>;
-    using CreateResult = Expected<UniqueRef<AudioDecoder>, String>;
-    using CreatePromise = NativePromise<UniqueRef<AudioDecoder>, String>;
+    using CreateResult = Expected<Ref<AudioDecoder>, String>;
+    using CreatePromise = NativePromise<Ref<AudioDecoder>, String>;
     using CreateCallback = Function<void(CreateResult&&)>;
 
     using CreatorFunction = void(*)(const String&, const Config&, CreateCallback&&, OutputCallback&&);

--- a/Source/WebCore/platform/AudioEncoder.h
+++ b/Source/WebCore/platform/AudioEncoder.h
@@ -39,7 +39,7 @@
 
 namespace WebCore {
 
-class AudioEncoder {
+class AudioEncoder : public ThreadSafeRefCounted<AudioEncoder> {
 public:
     virtual ~AudioEncoder() = default;
 
@@ -77,8 +77,8 @@ public:
         int64_t timestamp { 0 };
         std::optional<uint64_t> duration;
     };
-    using CreateResult = Expected<UniqueRef<AudioEncoder>, String>;
-    using CreatePromise = NativePromise<UniqueRef<AudioEncoder>, String>;
+    using CreateResult = Expected<Ref<AudioEncoder>, String>;
+    using CreatePromise = NativePromise<Ref<AudioEncoder>, String>;
 
     using DescriptionCallback = Function<void(ActiveConfiguration&&)>;
     using OutputCallback = Function<void(EncodedFrame&&)>;

--- a/Source/WebCore/platform/VideoDecoder.h
+++ b/Source/WebCore/platform/VideoDecoder.h
@@ -35,9 +35,8 @@ namespace WebCore {
 
 class VideoFrame;
 
-class VideoDecoder {
+class VideoDecoder : public ThreadSafeRefCounted<VideoDecoder> {
 public:
-    WEBCORE_EXPORT VideoDecoder();
     WEBCORE_EXPORT virtual ~VideoDecoder();
 
     enum class HardwareAcceleration : bool { No, Yes };
@@ -69,8 +68,8 @@ public:
     static bool isVPXSupported();
 
     using OutputCallback = Function<void(Expected<DecodedFrame, String>&&)>;
-    using CreateResult = Expected<UniqueRef<VideoDecoder>, String>;
-    using CreatePromise = NativePromise<UniqueRef<VideoDecoder>, String>;
+    using CreateResult = Expected<Ref<VideoDecoder>, String>;
+    using CreatePromise = NativePromise<Ref<VideoDecoder>, String>;
     using CreateCallback = Function<void(CreateResult&&)>;
 
     using CreatorFunction = void(*)(const String&, const Config&, CreateCallback&&, OutputCallback&&);
@@ -89,6 +88,9 @@ public:
     static String fourCCToCodecString(uint32_t fourCC);
 
     static CreatorFunction s_customCreator;
+protected:
+    WEBCORE_EXPORT VideoDecoder();
+
 };
 
 }

--- a/Source/WebCore/platform/VideoEncoder.h
+++ b/Source/WebCore/platform/VideoEncoder.h
@@ -36,7 +36,7 @@
 
 namespace WebCore {
 
-class VideoEncoder {
+class VideoEncoder : public ThreadSafeRefCounted<VideoEncoder> {
 public:
     virtual ~VideoEncoder() = default;
 
@@ -64,8 +64,8 @@ public:
         int64_t timestamp { 0 };
         std::optional<uint64_t> duration;
     };
-    using CreateResult = Expected<UniqueRef<VideoEncoder>, String>;
-    using CreatePromise = NativePromise<UniqueRef<VideoEncoder>, String>;
+    using CreateResult = Expected<Ref<VideoEncoder>, String>;
+    using CreatePromise = NativePromise<Ref<VideoEncoder>, String>;
 
     using DescriptionCallback = Function<void(ActiveConfiguration&&)>;
     using OutputCallback = Function<void(EncodedFrame&&)>;

--- a/Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.h
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.h
@@ -35,10 +35,11 @@ class GStreamerAudioDecoder final : public AudioDecoder {
 public:
     static void create(const String& codecName, const Config&, CreateCallback&&, OutputCallback&&);
 
-    GStreamerAudioDecoder(const String& codecName, const Config&, OutputCallback&&, GRefPtr<GstElement>&&);
     ~GStreamerAudioDecoder();
 
 private:
+    GStreamerAudioDecoder(const String& codecName, const Config&, OutputCallback&&, GRefPtr<GstElement>&&);
+
     Ref<DecodePromise> decode(EncodedData&&) final;
     Ref<GenericPromise> flush() final;
     void reset() final;

--- a/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp
@@ -103,8 +103,8 @@ void GStreamerAudioEncoder::create(const String& codecName, const AudioEncoder::
         }
         element = gst_element_factory_create(lookupResult.factory.get(), nullptr);
     }
-    auto encoder = makeUniqueRef<GStreamerAudioEncoder>(WTFMove(descriptionCallback), WTFMove(outputCallback), WTFMove(element));
-    auto internalEncoder = encoder->m_internalEncoder;
+    Ref encoder = adoptRef(*new GStreamerAudioEncoder(WTFMove(descriptionCallback), WTFMove(outputCallback), WTFMove(element)));
+    Ref internalEncoder = encoder->m_internalEncoder;
     auto error = internalEncoder->initialize(codecName, config);
     if (!error.isEmpty()) {
         GST_WARNING("Error creating encoder: %s", error.ascii().data());
@@ -114,7 +114,7 @@ void GStreamerAudioEncoder::create(const String& codecName, const AudioEncoder::
     gstEncoderWorkQueue().dispatch([callback = WTFMove(callback), encoder = WTFMove(encoder)]() mutable {
         auto internalEncoder = encoder->m_internalEncoder;
         GST_DEBUG("Encoder created");
-        callback(UniqueRef<AudioEncoder> { WTFMove(encoder) });
+        callback(Ref<AudioEncoder> { WTFMove(encoder) });
     });
 }
 

--- a/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.h
+++ b/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.h
@@ -36,10 +36,11 @@ class GStreamerAudioEncoder : public AudioEncoder {
 public:
     static void create(const String& codecName, const Config&, CreateCallback&&, DescriptionCallback&&, OutputCallback&&);
 
-    GStreamerAudioEncoder(DescriptionCallback&&,  OutputCallback&&, GRefPtr<GstElement>&&);
     ~GStreamerAudioEncoder();
 
 private:
+    GStreamerAudioEncoder(DescriptionCallback&&,  OutputCallback&&, GRefPtr<GstElement>&&);
+
     Ref<EncodePromise> encode(RawFrame&&) final;
     Ref<GenericPromise> flush() final;
     void reset() final;

--- a/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h
@@ -156,7 +156,7 @@ private:
 
     std::atomic<uint32_t> m_flushId { 0 };
     std::atomic<bool> m_isUsingVideoDecoder { true };
-    std::unique_ptr<VideoDecoder> m_videoDecoder WTF_GUARDED_BY_LOCK(m_lock);
+    RefPtr<VideoDecoder> m_videoDecoder WTF_GUARDED_BY_LOCK(m_lock);
     bool m_videoDecoderCreationFailed { false };
     std::atomic<bool> m_decodePending { false };
     struct PendingDecodeData {

--- a/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp
@@ -103,8 +103,8 @@ void GStreamerVideoDecoder::create(const String& codecName, const Config& config
     }
 
     GRefPtr<GstElement> element = gst_element_factory_create(lookupResult.factory.get(), nullptr);
-    auto decoder = makeUniqueRef<GStreamerVideoDecoder>(codecName, config, WTFMove(outputCallback), WTFMove(element));
-    auto internalDecoder = decoder->m_internalDecoder;
+    Ref decoder = adoptRef(*new GStreamerVideoDecoder(codecName, config, WTFMove(outputCallback), WTFMove(element)));
+    Ref internalDecoder = decoder->m_internalDecoder;
     if (!internalDecoder->isConfigured()) {
         GST_WARNING("Internal video decoder failed to configure for codec %s", codecName.utf8().data());
         callback(makeUnexpected(makeString("Internal video decoder failed to configure for codec "_s, codecName)));
@@ -114,7 +114,7 @@ void GStreamerVideoDecoder::create(const String& codecName, const Config& config
     gstDecoderWorkQueue().dispatch([callback = WTFMove(callback), decoder = WTFMove(decoder)]() mutable {
         auto internalDecoder = decoder->m_internalDecoder;
         GST_DEBUG_OBJECT(decoder->m_internalDecoder->harnessedElement(), "Video decoder created");
-        callback(UniqueRef<VideoDecoder> { WTFMove(decoder) });
+        callback(Ref<VideoDecoder> { WTFMove(decoder) });
     });
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
@@ -96,8 +96,8 @@ void GStreamerVideoEncoder::create(const String& codecName, const VideoEncoder::
         return;
     }
 
-    auto encoder = makeUniqueRef<GStreamerVideoEncoder>(config, WTFMove(descriptionCallback), WTFMove(outputCallback));
-    auto internalEncoder = encoder->m_internalEncoder;
+    Ref encoder = adoptRef(*new GStreamerVideoEncoder(config, WTFMove(descriptionCallback), WTFMove(outputCallback)));
+    Ref internalEncoder = encoder->m_internalEncoder;
     auto error = internalEncoder->initialize(codecName);
     if (!error.isEmpty()) {
         GST_WARNING("Error creating encoder: %s", error.ascii().data());
@@ -107,7 +107,7 @@ void GStreamerVideoEncoder::create(const String& codecName, const VideoEncoder::
     gstEncoderWorkQueue().dispatch([callback = WTFMove(callback), encoder = WTFMove(encoder)]() mutable {
         auto internalEncoder = encoder->m_internalEncoder;
         GST_DEBUG("Encoder created");
-        callback(UniqueRef<VideoEncoder> { WTFMove(encoder) });
+        callback(Ref<VideoEncoder> { WTFMove(encoder) });
     });
 }
 

--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp
@@ -101,7 +101,7 @@ private:
 
 void LibWebRTCVPXVideoDecoder::create(Type type, const Config& config, CreateCallback&& callback, OutputCallback&& outputCallback)
 {
-    UniqueRef<VideoDecoder> decoder = makeUniqueRef<LibWebRTCVPXVideoDecoder>(type, config, WTFMove(outputCallback));
+    Ref<VideoDecoder> decoder = adoptRef(*new LibWebRTCVPXVideoDecoder(type, config, WTFMove(outputCallback)));
     callback(WTFMove(decoder));
 }
 

--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.h
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.h
@@ -48,10 +48,11 @@ public:
     };
     static void create(Type, const Config&, CreateCallback&&, OutputCallback&&);
 
-    LibWebRTCVPXVideoDecoder(Type, const Config&, OutputCallback&&);
     ~LibWebRTCVPXVideoDecoder();
 
 private:
+    LibWebRTCVPXVideoDecoder(Type, const Config&, OutputCallback&&);
+
     Ref<DecodePromise> decode(EncodedFrame&&) final;
     Ref<GenericPromise> flush() final;
     void reset() final;

--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp
@@ -94,14 +94,14 @@ private:
 
 void LibWebRTCVPXVideoEncoder::create(Type type, const VideoEncoder::Config& config, CreateCallback&& callback, DescriptionCallback&& descriptionCallback, OutputCallback&& outputCallback)
 {
-    auto encoder = makeUniqueRef<LibWebRTCVPXVideoEncoder>(type, WTFMove(outputCallback));
+    Ref encoder = adoptRef(*new LibWebRTCVPXVideoEncoder(type, WTFMove(outputCallback)));
     auto error = encoder->initialize(type, config);
 
     if (error) {
         callback(makeUnexpected(makeString("VPx encoding initialization failed with error "_s, error)));
         return;
     }
-    callback(UniqueRef<VideoEncoder> { WTFMove(encoder) });
+    callback(Ref<VideoEncoder> { WTFMove(encoder) });
 
     VideoEncoder::ActiveConfiguration configuration;
     configuration.colorSpace = PlatformVideoColorSpace { PlatformVideoColorPrimaries::Bt709, PlatformVideoTransferCharacteristics::Bt709, PlatformVideoMatrixCoefficients::Bt709, false };

--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.h
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.h
@@ -48,10 +48,11 @@ public:
     };
     static void create(Type, const Config&, CreateCallback&&, DescriptionCallback&&, OutputCallback&&);
 
-    LibWebRTCVPXVideoEncoder(Type, OutputCallback&&);
     ~LibWebRTCVPXVideoEncoder();
 
 private:
+    LibWebRTCVPXVideoEncoder(Type, OutputCallback&&);
+
     int initialize(LibWebRTCVPXVideoEncoder::Type, const VideoEncoder::Config&);
     Ref<EncodePromise> encode(RawFrame&&, bool shouldGenerateKeyFrame) final;
     Ref<GenericPromise> flush() final;

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h
@@ -166,7 +166,7 @@ private:
     std::optional<uint8_t> m_videoTrackIndex WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     RefPtr<VideoInfo> m_videoTrackInfo WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     RetainPtr<CMFormatDescriptionRef> m_videoFormatDescription WTF_GUARDED_BY_CAPABILITY(queueSingleton());
-    std::unique_ptr<VideoEncoder> m_videoEncoder WTF_GUARDED_BY_CAPABILITY(queueSingleton());
+    RefPtr<VideoEncoder> m_videoEncoder WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     Deque<std::pair<Ref<VideoFrame>, MediaTime>> m_pendingVideoFrames WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     Deque<Ref<MediaSample>> m_encodedVideoFrames WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     bool m_firstVideoFrameProcessed WTF_GUARDED_BY_CAPABILITY(queueSingleton()) { false };


### PR DESCRIPTION
#### f8908bcb71916ec90f8d129640b99ee58e57b916
<pre>
Make AudioDecoder, AudioEncoder, VideoDecoder and VideoEncoder ref counted
<a href="https://rdar.apple.com/140773595">rdar://140773595</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=283887">https://bugs.webkit.org/show_bug.cgi?id=283887</a>

Reviewed by Jean-Yves Avenard.

To do security hardening, we make AudioDecoder, AudioEncoder, VideoDecoder and VideoEncoder ref counted.
This allows to take a ref to them whenever calling methods on these objects.

* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp:
(WebCore::WebCodecsAudioDecoder::decode):
(WebCore::WebCodecsAudioDecoder::flush):
(WebCore::WebCodecsAudioDecoder::resetDecoder):
(WebCore::WebCodecsAudioDecoder::setInternalDecoder):
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp:
(WebCore::WebCodecsAudioEncoder::configure):
(WebCore::WebCodecsAudioEncoder::encode):
(WebCore::WebCodecsAudioEncoder::flush):
(WebCore::WebCodecsAudioEncoder::resetEncoder):
(WebCore::WebCodecsAudioEncoder::setInternalEncoder):
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.h:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp:
(WebCore::WebCodecsVideoDecoder::decode):
(WebCore::WebCodecsVideoDecoder::flush):
(WebCore::WebCodecsVideoDecoder::resetDecoder):
(WebCore::WebCodecsVideoDecoder::setInternalDecoder):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp:
(WebCore::WebCodecsVideoEncoder::updateRates):
(WebCore::WebCodecsVideoEncoder::configure):
(WebCore::WebCodecsVideoEncoder::encode):
(WebCore::WebCodecsVideoEncoder::flush):
(WebCore::WebCodecsVideoEncoder::resetEncoder):
(WebCore::WebCodecsVideoEncoder::setInternalEncoder):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h:
* Source/WebCore/platform/AudioDecoder.h:
* Source/WebCore/platform/AudioEncoder.h:
* Source/WebCore/platform/VideoDecoder.h:
* Source/WebCore/platform/VideoEncoder.h:
* Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp:
(WebCore::GStreamerAudioDecoder::create):
* Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.h:
* Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp:
(WebCore::GStreamerAudioEncoder::create):
* Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.h:
* Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h:
* Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm:
(WebCore::WebCoreDecompressionSession::decodeSampleInternal):
(WebCore::WebCoreDecompressionSession::initializeVideoDecoder):
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp:
(WebCore::LibWebRTCVPXVideoDecoder::create):
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.h:
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp:
(WebCore::LibWebRTCVPXVideoEncoder::create):
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.h:
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp:
(WebCore::MediaRecorderPrivateEncoder::appendVideoFrame):
(WebCore::MediaRecorderPrivateEncoder::encodePendingVideoFrames):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h:
* Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp:
(WebKit::RemoteVideoDecoder::create):
(WebKit::RemoteVideoEncoder::create):
(WebKit::RemoteVideoCodecFactory::createDecoder):
(WebKit::RemoteVideoCodecFactory::createEncoder):

Canonical link: <a href="https://commits.webkit.org/287266@main">https://commits.webkit.org/287266@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44401db3c123fdef61f37b0e1dd765a7d961a70b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78825 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57869 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32207 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83485 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30087 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80958 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67020 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6150 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61735 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19661 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81892 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51769 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/71650 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42042 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49115 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25906 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28427 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70228 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26314 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84854 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6190 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4278 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69959 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6352 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67758 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69213 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17270 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13253 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11978 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6135 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12023 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6119 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9556 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7909 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->