### PR TITLE
[GStreamer][LibWebRTC] A/V sync issues

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.cpp
@@ -25,19 +25,9 @@
 #if ENABLE(MEDIA_STREAM) && USE(GSTREAMER)
 #include "GStreamerAudioCapturer.h"
 
-#if USE(LIBWEBRTC)
-#include "LibWebRTCAudioFormat.h"
-#endif
-
 #include <gst/app/gstappsink.h>
 
 namespace WebCore {
-
-#if USE(LIBWEBRTC)
-static constexpr size_t s_audioCaptureSampleRate = LibWebRTCAudioFormat::sampleRate;
-#else
-static constexpr size_t s_audioCaptureSampleRate = 48000;
-#endif
 
 GST_DEBUG_CATEGORY(webkit_audio_capturer_debug);
 #define GST_CAT_DEFAULT webkit_audio_capturer_debug
@@ -51,13 +41,13 @@ static void initializeAudioCapturerDebugCategory()
 }
 
 GStreamerAudioCapturer::GStreamerAudioCapturer(GStreamerCaptureDevice&& device)
-    : GStreamerCapturer(WTFMove(device), adoptGRef(gst_caps_new_simple("audio/x-raw", "rate", G_TYPE_INT, s_audioCaptureSampleRate, nullptr)))
+    : GStreamerCapturer(WTFMove(device), adoptGRef(gst_caps_new_empty_simple("audio/x-raw")))
 {
     initializeAudioCapturerDebugCategory();
 }
 
 GStreamerAudioCapturer::GStreamerAudioCapturer()
-    : GStreamerCapturer("appsrc", adoptGRef(gst_caps_new_simple("audio/x-raw", "rate", G_TYPE_INT, s_audioCaptureSampleRate, nullptr)), CaptureDevice::DeviceType::Microphone)
+    : GStreamerCapturer("appsrc", adoptGRef(gst_caps_new_empty_simple("audio/x-raw")), CaptureDevice::DeviceType::Microphone)
 {
     initializeAudioCapturerDebugCategory();
 }

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoFrameLibWebRTC.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoFrameLibWebRTC.cpp
@@ -61,6 +61,7 @@ GRefPtr<GstSample> convertLibWebRTCVideoFrameToGStreamerSample(const webrtc::Vid
     }));
 
     gst_buffer_add_video_meta_full(buffer.get(), GST_VIDEO_FRAME_FLAG_NONE, GST_VIDEO_FORMAT_I420, frame.width(), frame.height(), 3, offsets, strides);
+    GST_BUFFER_PTS(buffer.get()) = toGstClockTime(MediaTime(frame.timestamp_us(), G_USEC_PER_SEC));
 
     auto caps = adoptGRef(gst_video_info_to_caps(&info));
     auto sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingAudioSourceLibWebRTC.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingAudioSourceLibWebRTC.h
@@ -44,6 +44,7 @@ private:
     void OnData(const void* audioData, int bitsPerSample, int sampleRate, size_t numberOfChannels, size_t numberOfFrames) final;
 
     uint64_t m_numberOfFrames { 0 };
+    MediaTime m_baseTime { MediaTime::invalidTime() };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingVideoSourceLibWebRTC.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingVideoSourceLibWebRTC.cpp
@@ -58,7 +58,7 @@ void RealtimeIncomingVideoSourceLibWebRTC::OnFrame(const webrtc::VideoFrame& fra
     if (!isProducingData())
         return;
 
-    auto presentationTime = fromGstClockTime(frame.timestamp_us());
+    auto presentationTime = MediaTime(frame.timestamp_us(), G_USEC_PER_SEC);
     if (frame.video_frame_buffer()->type() == webrtc::VideoFrameBuffer::Type::kNative) {
         auto* framebuffer = static_cast<GStreamerVideoFrameLibWebRTC*>(frame.video_frame_buffer().get());
         videoFrameAvailable(VideoFrameGStreamer::createWrappedSample(framebuffer->getSample(), presentationTime, static_cast<VideoFrame::Rotation>(frame.rotation())), { });


### PR DESCRIPTION
#### fd33a1d498206af901c3d5337a59da1d2a7602bd
<pre>
[GStreamer][LibWebRTC] A/V sync issues
<a href="https://bugs.webkit.org/show_bug.cgi?id=283896">https://bugs.webkit.org/show_bug.cgi?id=283896</a>

Reviewed by Xabier Rodriguez-Calvar.

Since the pipeline now synchronize on the system clock the timestamps for incoming audio/video
buffers should be based on that time. It was the case for video already (though with incorrect
units) and for audio we now apply a static base time base on the monotonic time.

LibWebRTC ifdefs were also removed from the audio capturer because they were leading to a caps
mismatch on the generated samples.

* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.cpp:
(WebCore::GStreamerAudioCapturer::GStreamerAudioCapturer):
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoFrameLibWebRTC.cpp:
(WebCore::convertLibWebRTCVideoFrameToGStreamerSample):
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingAudioSourceLibWebRTC.cpp:
(WebCore::RealtimeIncomingAudioSourceLibWebRTC::OnData):
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingAudioSourceLibWebRTC.h:
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingVideoSourceLibWebRTC.cpp:
(WebCore::RealtimeIncomingVideoSourceLibWebRTC::OnFrame):

Canonical link: <a href="https://commits.webkit.org/287268@main">https://commits.webkit.org/287268@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fb23fa75f4bd774827a0d95c03bf8a853d37d05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79016 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58052 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32393 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83656 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30231 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81149 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67161 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6322 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/61844 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19762 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82083 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51882 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72024 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42148 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49233 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26104 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28596 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70347 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26518 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85042 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6341 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/70080 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6505 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67897 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69330 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17273 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13373 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12139 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6293 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6253 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9705 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8045 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->