### PR TITLE
[JSC] Heap::m_maxEdenSizeWhenCritical is larger than m_maxEdenSize

### DIFF
--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -2793,7 +2793,7 @@ void Heap::collectIfNecessaryOrDefer(GCDeferralContext* deferralContext)
 #if USE(BMALLOC_MEMORY_FOOTPRINT_API)
         isCritical = overCriticalMemoryThreshold();
         if (isCritical)
-            bytesAllowedThisCycle = std::min(m_maxEdenSizeWhenCritical, bytesAllowedThisCycle);
+            bytesAllowedThisCycle = std::min(m_maxEdenSizeWhenCritical, bytesAllowedThisCycle/10);
 #endif
 
         size_t bytesAllocatedThisCycle = totalBytesAllocatedThisCycle();


### PR DESCRIPTION
#### 1ab686d0246f63ea857a8e64b6685bc218b6fa59
<pre>
[JSC] Heap::m_maxEdenSizeWhenCritical is larger than m_maxEdenSize
<a href="https://bugs.webkit.org/show_bug.cgi?id=283898">https://bugs.webkit.org/show_bug.cgi?id=283898</a>

Reviewed by NOBODY (OOPS!).

On some devices Heap::m_maxEdenSizeWhenCritical can be larger than m_maxEdenSize, leading         to JSC failing to request a GC collection before running out of memory.

My assumption is that m_maxEdenSizeWhenCritical should be strictly smaller than m_maxEdenSize.

This sets bytesAllowedThisCycle = min(m_maxEdenSizeWhenCritical, bytesAllowedThisCycle/10)
which fixes the issue in the example usecase detailed below.

Example: rpi 3b with 654,180,352 bytes of useable RAM

default criticalGCMemoryThreshold is 0.8

memoryAboveCriticalThreshold = m_ramSize * 0.2 =  130,836,070

m_maxEdenSizeWhenCritical = memoryAboveCriticalThreshold / 4 = 32,709,017

where non-critical m_maxEdenSize is around 31,967,829

* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::collectIfNecessaryOrDefer):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ab686d0246f63ea857a8e64b6685bc218b6fa59

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78808 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57852 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32190 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83468 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30070 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67003 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6133 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61719 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19647 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81875 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51758 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/71579 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42026 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49104 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25881 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28410 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/71949 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70216 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26288 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84837 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/78040 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6173 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4266 "Build is in progress. Recent messages:") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69944 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6335 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67743 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69198 "Found 8 new API test failures: /TestWebKit:WebKit.InjectedBundleBasic, /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginAndEndEditingEvents, /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginAndEndEditingEventsInReadOnlyField, /TestWebKit:WebKit.FrameMIMETypePNG, /TestWebKit:WebKit.FocusedFrameAfterCrash, /TestWebKit:WebKit2UserMessageRoundTripTest.WKString, /TestWebKit:WebKit.ParentFrame, /TestWebKit:WebKit.EvaluateJavaScriptThatCreatesBlob (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13238 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11955 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/100352 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6118 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21914 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6102 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9539 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7892 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->