### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE from WOFFFileFormat

### DIFF
--- a/Source/WebCore/platform/graphics/WOFFFileFormat.cpp
+++ b/Source/WebCore/platform/graphics/WOFFFileFormat.cpp
@@ -47,9 +47,9 @@ static bool readUInt32(SharedBuffer& buffer, size_t& offset, uint32_t& value)
     if (buffer.size() - offset < sizeof(value))
         return false;
 
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
-    value = ntohl(*reinterpret_cast_ptr<const uint32_t*>(buffer.span().subspan(offset).data()));
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    uint32_t raw;
+    memcpy(&raw, buffer.span().subspan(offset, sizeof(value)).data(), sizeof(value));
+    value = ntohl(raw);
     offset += sizeof(value);
 
     return true;
@@ -61,9 +61,9 @@ static bool readUInt16(SharedBuffer& buffer, size_t& offset, uint16_t& value)
     if (buffer.size() - offset < sizeof(value))
         return false;
 
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
-    value = ntohs(*reinterpret_cast_ptr<const uint16_t*>(buffer.span().subspan(offset).data()));
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    uint16_t raw;
+    memcpy(&raw, buffer.span().subspan(offset, sizeof(value)).data(), sizeof(value));
+    value = ntohs(raw);
     offset += sizeof(value);
 
     return true;

--- a/Source/WebCore/platform/graphics/WOFFFileFormat.cpp
+++ b/Source/WebCore/platform/graphics/WOFFFileFormat.cpp
@@ -47,9 +47,8 @@ static bool readUInt32(SharedBuffer& buffer, size_t& offset, uint32_t& value)
     if (buffer.size() - offset < sizeof(value))
         return false;
 
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // non-Apple ports
-    value = ntohl(*reinterpret_cast_ptr<const uint32_t*>(buffer.span().subspan(offset).data()));
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    memcpySpan(asMutableByteSpan(value), buffer.span().subspan(offset, sizeof(value)));
+    value = ntohl(value);
     offset += sizeof(value);
 
     return true;
@@ -61,9 +60,8 @@ static bool readUInt16(SharedBuffer& buffer, size_t& offset, uint16_t& value)
     if (buffer.size() - offset < sizeof(value))
         return false;
 
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // non-Apple ports
-    value = ntohs(*reinterpret_cast_ptr<const uint16_t*>(buffer.span().subspan(offset).data()));
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    memcpySpan(asMutableByteSpan(value), buffer.span().subspan(offset, sizeof(value)));
+    value = ntohs(value);
     offset += sizeof(value);
 
     return true;
@@ -259,13 +257,11 @@ bool convertWOFFToSfnt(SharedBuffer& woff, Vector<uint8_t>& sfnt)
             return false;
 
         // Write an sfnt table directory entry.
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
-        uint32_t* sfntTableDirectoryPtr = reinterpret_cast_ptr<uint32_t*>(sfnt.mutableSpan().subspan(sfntTableDirectoryCursor).data());
-        *sfntTableDirectoryPtr++ = htonl(tableTag);
-        *sfntTableDirectoryPtr++ = htonl(tableOrigChecksum);
-        *sfntTableDirectoryPtr++ = htonl(sfnt.size());
-        *sfntTableDirectoryPtr++ = htonl(tableOrigLength);
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        auto sfntTableDirectoryEntry = spanReinterpretCast<uint32_t>(sfnt.mutableSubspan(sfntTableDirectoryCursor, 4 * sizeof(uint32_t)));
+        sfntTableDirectoryEntry[0] = htonl(tableTag);
+        sfntTableDirectoryEntry[1] = htonl(tableOrigChecksum);
+        sfntTableDirectoryEntry[2] = htonl(sfnt.size());
+        sfntTableDirectoryEntry[3] = htonl(tableOrigLength);
         sfntTableDirectoryCursor += 4 * sizeof(uint32_t);
 
         if (tableCompLength == tableOrigLength) {


### PR DESCRIPTION
#### 64d37a3906cab6ce0e50d4d10c81327f2ba2aef9
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE from WOFFFileFormat
<a href="https://bugs.webkit.org/show_bug.cgi?id=283899">https://bugs.webkit.org/show_bug.cgi?id=283899</a>

Reviewed by Adrian Perez de Castro.

The old reads were unaligned loads, undefined regardless of the
annotation; copying the bytes out is well-defined and lowers to the same
instruction. The table directory keeps a cast because its cursor is
provably four-byte aligned: it starts at 12 and advances by 16.

* Source/WebCore/platform/graphics/WOFFFileFormat.cpp:
(WebCore::readUInt32):
(WebCore::readUInt16):
(WebCore::convertWOFFToSfnt):

Canonical link: <a href="https://commits.webkit.org/319702@main">https://commits.webkit.org/319702@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51303e5742ea1577b4eca45e93ced0bbc3b4df7a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182481 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56428 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50234 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192715 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146810 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184343 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57744 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56151 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142440 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185436 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46144 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163200 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122873 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44828 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43099 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155229 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42725 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3875 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49059 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47355 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194638 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56099 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151871 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56790 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151569 "Passed tests") | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27705 "") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46148 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129074 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125076 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55301 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17724 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54682 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54921 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54749 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->