### PR TITLE
[GTK][WPE][Skia] Allow cross-thread transfer of accelerated ImageBitmap

### DIFF
--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -1580,14 +1580,17 @@ private:
 
     void dumpImageBitmap(JSObject* obj, SerializationReturnCode& code)
     {
+        auto& imageBitmap = jsCast<JSImageBitmap*>(obj)->wrapped();
         auto index = m_transferredImageBitmaps.find(obj);
         if (index != m_transferredImageBitmaps.end()) {
+#if USE(SKIA)
+            imageBitmap.prepareForCrossThreadTransfer();
+#endif
             write(ImageBitmapTransferTag);
             write(index->value);
             return;
         }
 
-        auto& imageBitmap = jsCast<JSImageBitmap*>(obj)->wrapped();
         if (!imageBitmap.originClean()) {
             code = SerializationReturnCode::DataCloneError;
             return;
@@ -4457,6 +4460,9 @@ private:
             m_imageBitmaps[index] = ImageBitmap::create(*executionContext(m_lexicalGlobalObject), WTFMove(*m_detachedImageBitmaps.at(index)));
 
         auto bitmap = m_imageBitmaps[index].get();
+#if USE(SKIA)
+        bitmap->finalizeCrossThreadTransfer();
+#endif
         return getJSValue(bitmap);
     }
 

--- a/Source/WebCore/html/ImageBitmap.cpp
+++ b/Source/WebCore/html/ImageBitmap.cpp
@@ -194,6 +194,11 @@ void ImageBitmap::prepareForCrossThreadTransfer()
 {
     m_bitmap = ImageBuffer::sinkIntoImageBufferForCrossThreadTransfer(WTFMove(m_bitmap));
 }
+
+void ImageBitmap::finalizeCrossThreadTransfer()
+{
+    m_bitmap = ImageBuffer::sinkIntoImageBufferAfterCrossThreadTransfer(WTFMove(m_bitmap));
+}
 #endif
 
 void ImageBitmap::createPromise(ScriptExecutionContext& scriptExecutionContext, ImageBitmap::Source&& source, ImageBitmapOptions&& options, int sx, int sy, int sw, int sh, ImageBitmap::Promise&& promise)

--- a/Source/WebCore/html/ImageBitmap.h
+++ b/Source/WebCore/html/ImageBitmap.h
@@ -142,6 +142,7 @@ public:
 
 #if USE(SKIA)
     void prepareForCrossThreadTransfer();
+    void finalizeCrossThreadTransfer();
 #endif
 
     size_t memoryCost() const;

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -222,6 +222,7 @@ public:
     WEBCORE_EXPORT static RefPtr<ImageBuffer> sinkIntoBufferForDifferentThread(RefPtr<ImageBuffer>);
 #if USE(SKIA)
     static RefPtr<ImageBuffer> sinkIntoImageBufferForCrossThreadTransfer(RefPtr<ImageBuffer>);
+    static RefPtr<ImageBuffer> sinkIntoImageBufferAfterCrossThreadTransfer(RefPtr<ImageBuffer>);
 #endif
     static std::unique_ptr<SerializedImageBuffer> sinkIntoSerializedImageBuffer(RefPtr<ImageBuffer>&&);
 

--- a/Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp
@@ -54,10 +54,6 @@
 #include "WorkerAnimationController.h"
 #endif
 
-#if USE(SKIA)
-#include "JSImageBitmap.h"
-#endif
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(DedicatedWorkerGlobalScope);
@@ -95,15 +91,6 @@ void DedicatedWorkerGlobalScope::prepareForDestruction()
 
 ExceptionOr<void> DedicatedWorkerGlobalScope::postMessage(JSC::JSGlobalObject& state, JSC::JSValue messageValue, StructuredSerializeOptions&& options)
 {
-#if USE(SKIA)
-    // When using skia, transferring ownership of accelerated ImageBitmaps causes GrDirectContext mismatches,
-    // threfore, we need to let ImageBitmap know so that it can act accordingly.
-    for (const auto& transferItem : options.transfer) {
-        if (auto* imageBitmap = JSImageBitmap::toWrapped(state.vm(), transferItem.get()))
-            imageBitmap->prepareForCrossThreadTransfer();
-    }
-#endif
-
     Vector<Ref<MessagePort>> ports;
 
     auto message = SerializedScriptValue::create(state, messageValue, WTFMove(options.transfer), ports, SerializationForStorage::No, SerializationContext::WorkerPostMessage);

--- a/Source/WebCore/workers/Worker.cpp
+++ b/Source/WebCore/workers/Worker.cpp
@@ -56,10 +56,6 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
-#if USE(SKIA)
-#include "JSImageBitmap.h"
-#endif
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(Worker);
@@ -145,15 +141,6 @@ Worker::~Worker()
 
 ExceptionOr<void> Worker::postMessage(JSC::JSGlobalObject& state, JSC::JSValue messageValue, StructuredSerializeOptions&& options)
 {
-#if USE(SKIA)
-    // When using skia, transferring ownership of accelerated ImageBitmaps causes GrDirectContext mismatches,
-    // threfore, we need to let ImageBitmap know so that it can act accordingly.
-    for (const auto& transferItem : options.transfer) {
-        if (auto* imageBitmap = JSImageBitmap::toWrapped(state.vm(), transferItem.get()))
-            imageBitmap->prepareForCrossThreadTransfer();
-    }
-#endif
-
     Vector<Ref<MessagePort>> ports;
     auto message = SerializedScriptValue::create(state, messageValue, WTFMove(options.transfer), ports, SerializationForStorage::No, SerializationContext::WorkerPostMessage);
     if (message.hasException())


### PR DESCRIPTION
#### 756e76506075a07f145e541a5345bef05b432e3f
<pre>
[GTK][WPE][Skia] Allow cross-thread transfer of accelerated ImageBitmap
<a href="https://bugs.webkit.org/show_bug.cgi?id=283704">https://bugs.webkit.org/show_bug.cgi?id=283704</a>

Reviewed by Nikolas Zimmermann and Carlos Garcia Campos.

When using skia, transferring ownership of accelerated ImageBitmaps causes GrDirectContext mismatches
that lead to problems with reading pixels, drawing etc. So far, to fix such problems, accelerated
ImageBitmaps were decelerated before transferring.

This change improves the above fix and allows the transfer of accelerated ImageBitmaps. To make such
ImageBitmaps working correctly, however, this change utilizes the code that re-wraps ImageBuffer with
a proper GrDirectContext. To make that operation safe, the fences are used.

* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::dumpImageBitmap):
(WebCore::CloneDeserializer::readTransferredImageBitmap):
* Source/WebCore/html/ImageBitmap.cpp:
(WebCore::ImageBitmap::finalizeCrossThreadTransfer):
* Source/WebCore/html/ImageBitmap.h:
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::sinkIntoImageBufferForCrossThreadTransfer):
(WebCore::ImageBuffer::sinkIntoImageBufferAfterCrossThreadTransfer):
* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp:
(WebCore::DedicatedWorkerGlobalScope::postMessage):
* Source/WebCore/workers/Worker.cpp:
(WebCore::Worker::postMessage):

Canonical link: <a href="https://commits.webkit.org/287399@main">https://commits.webkit.org/287399@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfbcbef5552db4e3676edb6f0a0c9bb522ed0c20

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79024 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58060 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32401 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83664 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30239 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81157 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67169 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6330 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61851 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19767 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82091 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51887 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72033 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42155 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49238 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26117 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28604 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70353 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26532 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85050 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6349 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4384 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70092 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6513 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67906 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69336 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17368 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13382 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12151 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6301 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12143 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6261 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9713 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8053 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->