### PR TITLE
[GStreamer] Fix leak in gstStructureGetters API test

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.cpp
@@ -75,11 +75,13 @@ TEST_F(GStreamerTest, gstStructureGetters)
         FAIL() << "emptyIntOpt should be empty, but has value " << *emptyIntOpt;
 
     GUniquePtr<GstStructure> arrays(gst_structure_new_from_string("bar, empty-array=(GstStructure) <>, struct-array=(GstStructure) <[s1, a=2], [s2, b=3]>"_s));
+    GUniquePtr<GstStructure> s1(gst_structure_new_from_string("s1, a=2"_s));
+    GUniquePtr<GstStructure> s2(gst_structure_new_from_string("s2, b=3"_s));
     ASSERT_TRUE(gstStructureGetArray<const GstStructure*>(arrays.get(), "empty-array"_s).isEmpty());
 
     Vector<const GstStructure*> structArray(gstStructureGetArray<const GstStructure*>(arrays.get(), "struct-array"_s));
-    ASSERT_TRUE(gst_structure_is_equal(structArray.at(0), gst_structure_new_from_string("s1, a=2"_s)));
-    ASSERT_TRUE(gst_structure_is_equal(structArray.at(1), gst_structure_new_from_string("s2, b=3"_s)));
+    ASSERT_TRUE(gst_structure_is_equal(structArray.at(0), s1.get()));
+    ASSERT_TRUE(gst_structure_is_equal(structArray.at(1), s2.get()));
     ASSERT_EQ(structArray.size(), 2);
 }
 


### PR DESCRIPTION
#### 4583db00a37dd89863b36c5376f41a16e9715eeb
<pre>
[GStreamer] Fix leak in gstStructureGetters API test
<a href="https://bugs.webkit.org/show_bug.cgi?id=283906">https://bugs.webkit.org/show_bug.cgi?id=283906</a>

Reviewed by Philippe Normand.

Fixup for <a href="https://bugs.webkit.org/show_bug.cgi?id=280190">https://bugs.webkit.org/show_bug.cgi?id=280190</a>

* Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.cpp:
(TestWebKitAPI::TEST_F(GStreamerTest, gstStructureGetters)):

Canonical link: <a href="https://commits.webkit.org/287212@main">https://commits.webkit.org/287212@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2533c60f1f55d4754c4e4ac5d58a09606305f307

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78818 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57862 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32200 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83478 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30080 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80951 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67013 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6143 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61727 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19655 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81885 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51761 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/71613 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42034 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49107 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25895 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28420 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70220 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26302 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84847 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6183 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/69952 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6345 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67752 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69206 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17222 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13249 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/11968 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6128 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6112 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9549 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7902 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->