### PR TITLE
RTCVideoDecoderH264 should report its last available frame as not reordered

### DIFF
--- a/LayoutTests/http/tests/webcodecs/h264-reordering.html
+++ b/LayoutTests/http/tests/webcodecs/h264-reordering.html
@@ -48,11 +48,11 @@ promise_test(async () => {
 
     for (let i = 0; i < chunks.length; ++i) {
         decoder.decode(chunks[i]);
-        if (window.internals && i === 2) {
+        if (window.internals && (i === 2 || i === 4 || i === 8)) {
              let counter = 0;
              while (++counter < 100 && internals.hasPendingActivity(decoder))
                  await new Promise(resolve => setTimeout(resolve, 50));
-             assert_less_than(counter, 100);
+             assert_less_than(counter, 100, "test for " + i);
         }
     }
 

--- a/LayoutTests/http/tests/webcodecs/hevc-reordering.html
+++ b/LayoutTests/http/tests/webcodecs/hevc-reordering.html
@@ -49,11 +49,11 @@ promise_test(async () => {
 
     for (let i = 0; i < chunks.length; ++i) {
         decoder.decode(chunks[i]);
-        if (window.internals && i === 2) {
+        if (window.internals && (i === 2 || i === 4 || i === 8)) {
              let counter = 0;
              while (++counter < 100 && internals.hasPendingActivity(decoder))
                  await new Promise(resolve => setTimeout(resolve, 50));
-             assert_less_than(counter, 100);
+             assert_less_than(counter, 100, "test for " + i);
         }
     }
     await decoder.flush();

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/objc/components/video_codec/RTCVideoDecoderH264.mm
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/objc/components/video_codec/RTCVideoDecoderH264.mm
@@ -147,7 +147,6 @@ CMSampleBufferRef H264BufferToCMSampleBuffer(const uint8_t* buffer, size_t buffe
 - (NSInteger)decodeData:(const uint8_t *)data
         size:(size_t)size
         timeStamp:(int64_t)timeStamp {
-
   if (_error != noErr) {
     RTC_LOG(LS_WARNING) << "Last frame decode failed.";
     _error = noErr;
@@ -395,10 +394,14 @@ CMSampleBufferRef H264BufferToCMSampleBuffer(const uint8_t* buffer, size_t buffe
   bool hasCalledCallback = false;
   if (!_reorderQueue.isEmpty() || reorderSize) {
     _reorderQueue.append(decodedFrame, reorderSize);
-    while (auto *frame = _reorderQueue.takeIfAvailable()) {
+
+    bool moreFramesAvailable;
+    while (auto *frame = _reorderQueue.takeIfAvailable(moreFramesAvailable)) {
       hasCalledCallback = true;
-      _callback(frame, frame != decodedFrame);
+      _callback(frame, moreFramesAvailable);
     }
+    RTC_DCHECK(!moreFramesAvailable);
+
     if (!hasCalledCallback) {
       _callback(nil, true);
     }

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/objc/components/video_codec/RTCVideoDecoderH265.mm
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/objc/components/video_codec/RTCVideoDecoderH265.mm
@@ -500,10 +500,14 @@ CMSampleBufferRef H265BufferToCMSampleBuffer(const uint8_t* buffer, size_t buffe
   bool hasCalledCallback = false;
   if (!_reorderQueue.isEmpty() || reorderSize) {
     _reorderQueue.append(decodedFrame, reorderSize);
-    while (auto *frame = _reorderQueue.takeIfAvailable()) {
+
+    bool moreFramesAvailable;
+    while (auto *frame = _reorderQueue.takeIfAvailable(moreFramesAvailable)) {
       hasCalledCallback = true;
-      _callback(frame, frame != decodedFrame);
+      _callback(frame, moreFramesAvailable);
     }
+    RTC_DCHECK(!moreFramesAvailable);
+
     if (!hasCalledCallback) {
       _callback(nil, true);
     }

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/objc/components/video_codec/RTCVideoFrameReorderQueue.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/objc/components/video_codec/RTCVideoFrameReorderQueue.h
@@ -63,7 +63,7 @@ public:
     uint8_t reorderSize() const;
     void setReorderSize(uint8_t);
     void append(RTCVideoFrame*, uint8_t);
-    RTCVideoFrame *takeIfAvailable();
+    RTCVideoFrame *takeIfAvailable(bool& moreFramesAvailable);
     RTCVideoFrame *takeIfAny();
 
 private:

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/objc/components/video_codec/RTCVideoFrameReorderQueue.mm
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/objc/components/video_codec/RTCVideoFrameReorderQueue.mm
@@ -39,12 +39,14 @@ void RTCVideoFrameReorderQueue::append(RTCVideoFrame* frame, uint8_t reorderSize
     });
 }
 
-RTCVideoFrame* RTCVideoFrameReorderQueue::takeIfAvailable()
+RTCVideoFrame* RTCVideoFrameReorderQueue::takeIfAvailable(bool& moreFramesAvailable)
 {
     webrtc::MutexLock lock(&_reorderQueueLock);
-    if (_reorderQueue.size() && _reorderQueue.size() > _reorderQueue.front()->reorderSize) {
+    auto areFramesAvailable = [&] -> bool { return _reorderQueue.size() && _reorderQueue.size() > _reorderQueue.front()->reorderSize; };
+    if (areFramesAvailable()) {
         auto *frame = _reorderQueue.front()->take();
         _reorderQueue.pop_front();
+        moreFramesAvailable = areFramesAvailable();
         return frame;
     }
     return nil;


### PR DESCRIPTION
#### 6405a44520e519cba686ec5115e8cb87d6f63867
<pre>
RTCVideoDecoderH264 should report its last available frame as not reordered
<a href="https://rdar.apple.com/140786076">rdar://140786076</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=283909">https://bugs.webkit.org/show_bug.cgi?id=283909</a>

Reviewed by Eric Carlson.

RTCVideoDecoderH264 and RTCVideoDecoderH265 were not reporting the last available frame they can send to their client as not reordered.
This made LibWebRTCCodecsProxy not notifying its web page that the decoding task was done in case of reordered content.
This in turn was delaying the GC of the video decoder until the context was stopped.

We update RTCVideoDecoderH264 and RTCVideoDecoderH265 to properly notify LibWebRTCCodecsProxy and we update the tests to check for cases where this would previously fail.

* LayoutTests/http/tests/webcodecs/h264-reordering.html:
* LayoutTests/http/tests/webcodecs/hevc-reordering.html:
* Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/objc/components/video_codec/RTCVideoDecoderH264.mm:
(-[RTCVideoDecoderH264 decodeData:size:timeStamp:]):
(-[RTCVideoDecoderH264 processFrame:reorderSize:]):
* Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/objc/components/video_codec/RTCVideoDecoderH265.mm:
(-[RTCVideoDecoderH265 processFrame:reorderSize:]):
* Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/objc/components/video_codec/RTCVideoFrameReorderQueue.h:
* Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/objc/components/video_codec/RTCVideoFrameReorderQueue.mm:
(webrtc::RTCVideoFrameReorderQueue::takeIfAvailable):

Canonical link: <a href="https://commits.webkit.org/287220@main">https://commits.webkit.org/287220@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0024e89e443a1cd90de109113781ac55fc1f5fe9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78822 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57866 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32204 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83482 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30084 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67017 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6147 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61733 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19663 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81889 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51767 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/71639 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42040 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49113 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25902 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28424 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70226 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26309 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84851 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6187 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69958 "Found 2 new test failures: webanimations/accelerated-animation-easing-update-steps-after-pause.html webanimations/accelerated-web-animation-with-single-interval-and-easing-y-axis-above-1.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6349 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67755 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69212 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17228 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13250 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11973 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6132 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6116 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9553 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7906 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->