### PR TITLE
[OpenXR] Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE from OpenXRInputSource

### DIFF
--- a/Source/WebCore/platform/xr/openxr/OpenXRInputMappings.h
+++ b/Source/WebCore/platform/xr/openxr/OpenXRInputMappings.h
@@ -91,18 +91,14 @@ inline String axisTypetoString(OpenXRAxisType type)
 struct OpenXRAxis {
     OpenXRAxisType type;
     OpenXRButtonPath path;
-}; 
+};
 
 struct OpenXRInputProfile {
     const char* const path { nullptr };
-    const OpenXRProfileId* profileIds { nullptr };
-    size_t profileIdsSize { 0 };
-    const OpenXRButton* leftButtons { nullptr };
-    size_t leftButtonsSize { 0 };
-    const OpenXRButton* rightButtons { nullptr };
-    size_t rightButtonsSize { 0 };
-    const OpenXRAxis* axes { nullptr };
-    size_t axesSize { 0 };
+    std::span<const OpenXRProfileId> profileIds;
+    std::span<const OpenXRButton> leftButtons;
+    std::span<const OpenXRButton> rightButtons;
+    std::span<const OpenXRAxis> axes;
 };
 
 // https://github.com/immersive-web/webxr-input-profiles/blob/master/packages/registry/profiles/htc/htc-vive.json
@@ -120,14 +116,10 @@ constexpr std::array<OpenXRAxis, 1> HTCViveAxes {
 
 constexpr OpenXRInputProfile HTCViveInputProfile {
     "/interaction_profiles/htc/vive_controller",
-    HTCViveProfileIds.data(),
-    HTCViveProfileIds.size(),
-    HTCViveButtons.data(),
-    HTCViveButtons.size(),
-    HTCViveButtons.data(),
-    HTCViveButtons.size(),
-    HTCViveAxes.data(),
-    HTCViveAxes.size()
+    HTCViveProfileIds,
+    HTCViveButtons,
+    HTCViveButtons,
+    HTCViveAxes,
 };
 
 // Default fallback when there isn't a specific controller binding.
@@ -139,14 +131,10 @@ constexpr std::array<OpenXRButton, 1> KHRSimpleButtons {
 
 constexpr OpenXRInputProfile KHRSimpleInputProfile {
     "/interaction_profiles/khr/simple_controller",
-    KHRSimpleProfileIds.data(),
-    KHRSimpleProfileIds.size(),
-    KHRSimpleButtons.data(),
-    KHRSimpleButtons.size(),
-    KHRSimpleButtons.data(),
-    KHRSimpleButtons.size(),
-    nullptr,
-    0
+    KHRSimpleProfileIds,
+    KHRSimpleButtons,
+    KHRSimpleButtons,
+    { }
 };
 
 constexpr std::array<OpenXRInputProfile, 2> openXRInputProfiles { HTCViveInputProfile, KHRSimpleInputProfile };

--- a/Source/WebCore/platform/xr/openxr/OpenXRInputSource.cpp
+++ b/Source/WebCore/platform/xr/openxr/OpenXRInputSource.cpp
@@ -107,21 +107,7 @@ XrResult OpenXRInputSource::suggestBindings(SuggestedBindings& bindings) const
         RETURN_RESULT_IF_FAILED(createBinding(profile.path, m_gripAction, makeString(m_subactionPathName, OPENXR_INPUT_GRIP_PATH), bindings), m_instance);
         RETURN_RESULT_IF_FAILED(createBinding(profile.path, m_pointerAction, makeString(m_subactionPathName, OPENXR_INPUT_AIM_PATH), bindings), m_instance);
 
-        // Suggest binding for button actions.
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // WPE port
-        const OpenXRButton* buttons;
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-        size_t buttonsSize;
-        if (m_handeness == XRHandedness::Left) {
-            buttons = profile.leftButtons;
-            buttonsSize = profile.leftButtonsSize;
-        } else {
-            buttons = profile.rightButtons;
-            buttonsSize = profile.rightButtonsSize;
-        }
-
-        for (size_t i = 0; i < buttonsSize; ++i) {
-            const auto& button = buttons[i];
+        for (const auto& button : m_handeness == XRHandedness::Left ? profile.leftButtons : profile.rightButtons) {
             const auto& actions = m_buttonActions.get(button.type);
             if (button.press) {
                 ASSERT(actions.press != XR_NULL_HANDLE);
@@ -138,10 +124,7 @@ XrResult OpenXRInputSource::suggestBindings(SuggestedBindings& bindings) const
         }
 
         // Suggest binding for axis actions.
-        for (size_t i = 0; i < profile.axesSize; ++i) {
-            WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // WPE port
-            const auto& axis = profile.axes[i];
-            WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        for (const auto& axis : profile.axes) {
             auto action = m_axisActions.get(axis.type);
             ASSERT(action != XR_NULL_HANDLE);
             RETURN_RESULT_IF_FAILED(createBinding(profile.path, action, makeString(m_subactionPathName, span(axis.path)), bindings), m_instance);
@@ -225,11 +208,9 @@ XrResult OpenXRInputSource::updateInteractionProfile()
     m_profiles.clear();
     for (auto& profile : openXRInputProfiles) {
         if (!strncmp(profile.path, buffer, writtenCount)) {
-            WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // WPE port
-            for (size_t i = 0; i < profile.profileIdsSize; ++i)
-                m_profiles.append(String::fromUTF8(profile.profileIds[i]));
+            for (const auto& id : profile.profileIds)
+                m_profiles.append(String::fromUTF8(id));
             break;
-            WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         }
     }
 


### PR DESCRIPTION
#### 5d23f677f4a8aebe3b8d18db600ca5003f6cd8e2
<pre>
[OpenXR] Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE from OpenXRInputSource
<a href="https://bugs.webkit.org/show_bug.cgi?id=283912">https://bugs.webkit.org/show_bug.cgi?id=283912</a>

Reviewed by Adrian Perez de Castro.

Use spans for profile data accesses.

* Source/WebCore/platform/xr/openxr/OpenXRInputSource.cpp:
(PlatformXR::OpenXRInputSource::suggestBindings const):
(PlatformXR::OpenXRInputSource::updateInteractionProfile):

Canonical link: <a href="https://commits.webkit.org/287270@main">https://commits.webkit.org/287270@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de4cd5fe3311c24e28796629993e88e061753dd7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79014 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58050 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32391 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83654 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30229 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81147 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67159 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6320 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61845 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19760 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82081 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51880 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72028 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42149 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49231 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/26109 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28594 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70345 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26523 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85040 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6339 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70079 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6503 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67901 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69329 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13374 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12143 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12189 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6291 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6251 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9703 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8043 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->