### PR TITLE
[css-masonry] Add subgrid tests to cover track sizing cases

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1769,6 +1769,8 @@ imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/ma
 
 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-subgrid-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-subgrid-002.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/track-sizing/masonry-subgrid-flex.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/track-sizing/masonry-subgrid-intrinsic-sizing.html [ ImageOnlyFailure ]
 
 imported/w3c/web-platform-tests/css/css-grid/parsing/grid-template-columns-crash.html [ Skip ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/track-sizing/masonry-subgrid-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/track-sizing/masonry-subgrid-expected.html
@@ -1,0 +1,86 @@
+<!DOCTYPE HTML>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Verify basic CSS Masonry Subgrid support to ensure items are properly placed in the grid</title>
+  <link rel="author" title="Brandon Stewart" href="mailto:brandonstewart@apple.com">
+  <link rel="help" href="https://drafts.csswg.org/css-grid-3/#subgrids">
+  <style>
+    grid {
+      display: inline-grid;
+      grid-template-columns: 50px 100px 200px;
+      border: 1px solid;
+      background: lightgrey;
+    }
+
+    subgrid {
+      display: grid;
+      grid: subgrid / subgrid;
+      grid-column: 2 / span 2;
+      grid-row: 1 / span 2;
+      background: lightblue;
+    }
+  </style>
+</head>
+
+<body>
+<!-- Verify basic subgrid -->
+<grid>
+  <item>1</item>
+  <subgrid>
+    <item>2</item>
+    <item>3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+
+<!-- Verify subgrid with first item in subgrid set to 2ch -->
+<grid>
+  <item>1</item>
+  <subgrid>
+    <item style="width: 2ch">2</item>
+    <item>3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+
+<!-- Verify subgrid with second item in subgrid set to 3ch -->
+<grid>
+  <item>1</item>
+  <subgrid>
+    <item>2</item>
+    <item style="width: 3ch">3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+
+<!-- Verify subgrid with final item in subgrid set to 4ch -->
+<grid>
+  <item>1</item>
+  <subgrid>
+    <item>2</item>
+    <item>3</item>
+    <item style="width: 4ch">4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+
+<!-- Verify behavior when subgrid is set to masonry too -->
+<grid>
+  <item>1</item>
+  <subgrid style="grid-template-rows: masonry">
+    <item>2</item>
+    <item style="width: 3ch">3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/track-sizing/masonry-subgrid-flex-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/track-sizing/masonry-subgrid-flex-expected.html
@@ -1,0 +1,81 @@
+<!DOCTYPE HTML>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Verify correct sizing of flex tracks when using subgrid in CSS Masonry</title>
+  <link rel="author" title="Brandon Stewart" href="mailto:brandonstewart@apple.com">
+  <link rel="help" href="https://drafts.csswg.org/css-grid-3/#subgrids">
+  <style>
+    grid {
+      display: inline-grid;
+      grid-template-columns: 1fr 2fr 3fr;
+      border: 1px solid;
+      background: lightgrey;
+    }
+
+    subgrid {
+      display: grid;
+      grid: subgrid / subgrid;
+      grid-column: 2 / span 2;
+      grid-row: 1 / span 2;
+      background: lightblue;
+    }
+  </style>
+</head>
+
+<body>
+<grid>
+  <item>1</item>
+  <subgrid>
+    <item>2</item>
+    <item>3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+
+<grid>
+  <item style="width: 2ch">1</item>
+  <subgrid>
+    <item>2</item>
+    <item>3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+
+<grid>
+  <item>1</item>
+  <subgrid>
+    <item style="width: 3ch">2</item>
+    <item>3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+
+<grid>
+  <item style="width: 4ch">1</item>
+  <subgrid>
+    <item>2</item>
+    <item>3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+
+<grid>
+  <item style="width: 3ch">1</item>
+  <subgrid>
+    <item>2</item>
+    <item>3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/track-sizing/masonry-subgrid-flex-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/track-sizing/masonry-subgrid-flex-ref.html
@@ -1,0 +1,81 @@
+<!DOCTYPE HTML>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Verify correct sizing of flex tracks when using subgrid in CSS Masonry</title>
+  <link rel="author" title="Brandon Stewart" href="mailto:brandonstewart@apple.com">
+  <link rel="help" href="https://drafts.csswg.org/css-grid-3/#subgrids">
+  <style>
+    grid {
+      display: inline-grid;
+      grid-template-columns: 1fr 2fr 3fr;
+      border: 1px solid;
+      background: lightgrey;
+    }
+
+    subgrid {
+      display: grid;
+      grid: subgrid / subgrid;
+      grid-column: 2 / span 2;
+      grid-row: 1 / span 2;
+      background: lightblue;
+    }
+  </style>
+</head>
+
+<body>
+<grid>
+  <item>1</item>
+  <subgrid>
+    <item>2</item>
+    <item>3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+
+<grid>
+  <item style="width: 2ch">1</item>
+  <subgrid>
+    <item>2</item>
+    <item>3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+
+<grid>
+  <item>1</item>
+  <subgrid>
+    <item style="width: 3ch">2</item>
+    <item>3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+
+<grid>
+  <item style="width: 4ch">1</item>
+  <subgrid>
+    <item>2</item>
+    <item>3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+
+<grid>
+  <item style="width: 3ch">1</item>
+  <subgrid>
+    <item>2</item>
+    <item>3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/track-sizing/masonry-subgrid-flex.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/track-sizing/masonry-subgrid-flex.html
@@ -1,0 +1,87 @@
+<!DOCTYPE HTML>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Verify correct sizing of flex tracks when using subgrid in CSS Masonry</title>
+  <link rel="author" title="Brandon Stewart" href="mailto:brandonstewart@apple.com">
+  <link rel="help" href="https://drafts.csswg.org/css-grid-3/#subgrids">
+  <link rel="match" href="masonry-subgrid-flex-ref.html">
+  <style>
+    grid {
+      display: inline-grid;
+      grid-template-columns: 1fr 2fr 3fr;
+      grid-template-rows: masonry;
+      border: 1px solid;
+      background: lightgrey;
+    }
+
+    subgrid {
+      display: grid;
+      grid-template-columns: subgrid;
+      grid-column: 2 / span 2;
+      background: lightblue;
+    }
+  </style>
+</head>
+
+<body>
+<!-- Verify basic subgrid -->
+<grid>
+  <item>1</item>
+  <subgrid>
+    <item>2</item>
+    <item>3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+
+<!-- Verify subgrid with first item in subgrid set to 2ch -->
+<grid>
+  <item>1</item>
+  <subgrid>
+    <item style="width: 2ch">2</item>
+    <item>3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+
+<!-- Verify subgrid with second item in subgrid set to 3ch -->
+<grid>
+  <item>1</item>
+  <subgrid>
+    <item>2</item>
+    <item style="width: 3ch">3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+
+<!-- Verify subgrid with final item in subgrid set to 4ch -->
+<grid>
+  <item>1</item>
+  <subgrid>
+    <item>2</item>
+    <item>3</item>
+    <item style="width: 4ch">4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+
+<!-- Verify behavior when subgrid is set to masonry too -->
+<grid>
+  <item>1</item>
+  <subgrid style="grid-template-rows: masonry">
+    <item>2</item>
+    <item style="width: 3ch">3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/track-sizing/masonry-subgrid-intrinsic-sizing-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/track-sizing/masonry-subgrid-intrinsic-sizing-expected.html
@@ -1,0 +1,81 @@
+<!DOCTYPE HTML>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Verify correct sizing of intrinsically sized tracks when using subgrid in CSS Masonry</title>
+  <link rel="author" title="Brandon Stewart" href="mailto:brandonstewart@apple.com">
+  <link rel="help" href="https://drafts.csswg.org/css-grid-3/#subgrids">
+  <style>
+    grid {
+      display: inline-grid;
+      grid-template-columns: auto min-content max-content;
+      border: 1px solid;
+      background: lightgrey;
+    }
+
+    subgrid {
+      display: grid;
+      grid: subgrid / subgrid;
+      grid-column: 2 / span 2;
+      grid-row: 1 / span 2;
+      background: lightblue;
+    }
+  </style>
+</head>
+
+<body>
+<grid>
+  <item>1</item>
+  <subgrid>
+    <item>2</item>
+    <item>3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+
+<grid>
+  <item style="width: 2ch">1</item>
+  <subgrid>
+    <item style="width: 2ch">2</item>
+    <item style="width: 2ch">3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+
+<grid>
+  <item>1</item>
+  <subgrid>
+    <item style="width: 3ch">2</item>
+    <item style="width: 3ch">3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+
+<grid>
+  <item style="width: 4ch">1</item>
+  <subgrid>
+    <item>2</item>
+    <item style="width: 4ch">3</item>
+    <item style="width: 4ch">4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+
+<grid>
+  <item style="width: 3ch">1</item>
+  <subgrid>
+    <item style="width: 3ch">2</item>
+    <item style="width: 3ch">3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/track-sizing/masonry-subgrid-intrinsic-sizing-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/track-sizing/masonry-subgrid-intrinsic-sizing-ref.html
@@ -1,0 +1,81 @@
+<!DOCTYPE HTML>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Verify correct sizing of intrinsically sized tracks when using subgrid in CSS Masonry</title>
+  <link rel="author" title="Brandon Stewart" href="mailto:brandonstewart@apple.com">
+  <link rel="help" href="https://drafts.csswg.org/css-grid-3/#subgrids">
+  <style>
+    grid {
+      display: inline-grid;
+      grid-template-columns: auto min-content max-content;
+      border: 1px solid;
+      background: lightgrey;
+    }
+
+    subgrid {
+      display: grid;
+      grid: subgrid / subgrid;
+      grid-column: 2 / span 2;
+      grid-row: 1 / span 2;
+      background: lightblue;
+    }
+  </style>
+</head>
+
+<body>
+<grid>
+  <item>1</item>
+  <subgrid>
+    <item>2</item>
+    <item>3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+
+<grid>
+  <item style="width: 2ch">1</item>
+  <subgrid>
+    <item style="width: 2ch">2</item>
+    <item style="width: 2ch">3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+
+<grid>
+  <item>1</item>
+  <subgrid>
+    <item style="width: 3ch">2</item>
+    <item style="width: 3ch">3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+
+<grid>
+  <item style="width: 4ch">1</item>
+  <subgrid>
+    <item>2</item>
+    <item style="width: 4ch">3</item>
+    <item style="width: 4ch">4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+
+<grid>
+  <item style="width: 3ch">1</item>
+  <subgrid>
+    <item style="width: 3ch">2</item>
+    <item style="width: 3ch">3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/track-sizing/masonry-subgrid-intrinsic-sizing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/track-sizing/masonry-subgrid-intrinsic-sizing.html
@@ -1,0 +1,87 @@
+<!DOCTYPE HTML>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Verify correct sizing of intrinsically sized tracks when using subgrid in CSS Masonry</title>
+  <link rel="author" title="Brandon Stewart" href="mailto:brandonstewart@apple.com">
+  <link rel="help" href="https://drafts.csswg.org/css-grid-3/#subgrids">
+  <link rel="match" href="masonry-subgrid-intrinsic-sizing-ref.html">
+  <style>
+    grid {
+      display: inline-grid;
+      grid-template-columns: auto min-content max-content;
+      grid-template-rows: masonry;
+      border: 1px solid;
+      background: lightgrey;
+    }
+
+    subgrid {
+      display: grid;
+      grid-template-columns: subgrid;
+      grid-column: 2 / span 2;
+      background: lightblue;
+    }
+  </style>
+</head>
+
+<body>
+<!-- Verify basic subgrid -->
+<grid>
+  <item>1</item>
+  <subgrid>
+    <item>2</item>
+    <item>3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+
+<!-- Verify subgrid with first item in subgrid set to 2ch -->
+<grid>
+  <item>1</item>
+  <subgrid>
+    <item style="width: 2ch">2</item>
+    <item>3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+
+<!-- Verify subgrid with second item in subgrid set to 3ch -->
+<grid>
+  <item>1</item>
+  <subgrid>
+    <item>2</item>
+    <item style="width: 3ch">3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+
+<!-- Verify subgrid with final item in subgrid set to 4ch -->
+<grid>
+  <item>1</item>
+  <subgrid>
+    <item>2</item>
+    <item>3</item>
+    <item style="width: 4ch">4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+
+<!-- Verify behavior when subgrid is set to masonry too -->
+<grid>
+  <item>1</item>
+  <subgrid style="grid-template-rows: masonry">
+    <item>2</item>
+    <item style="width: 3ch">3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/track-sizing/masonry-subgrid-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/track-sizing/masonry-subgrid-ref.html
@@ -1,0 +1,86 @@
+<!DOCTYPE HTML>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Verify basic CSS Masonry Subgrid support to ensure items are properly placed in the grid</title>
+  <link rel="author" title="Brandon Stewart" href="mailto:brandonstewart@apple.com">
+  <link rel="help" href="https://drafts.csswg.org/css-grid-3/#subgrids">
+  <style>
+    grid {
+      display: inline-grid;
+      grid-template-columns: 50px 100px 200px;
+      border: 1px solid;
+      background: lightgrey;
+    }
+
+    subgrid {
+      display: grid;
+      grid: subgrid / subgrid;
+      grid-column: 2 / span 2;
+      grid-row: 1 / span 2;
+      background: lightblue;
+    }
+  </style>
+</head>
+
+<body>
+<!-- Verify basic subgrid -->
+<grid>
+  <item>1</item>
+  <subgrid>
+    <item>2</item>
+    <item>3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+
+<!-- Verify subgrid with first item in subgrid set to 2ch -->
+<grid>
+  <item>1</item>
+  <subgrid>
+    <item style="width: 2ch">2</item>
+    <item>3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+
+<!-- Verify subgrid with second item in subgrid set to 3ch -->
+<grid>
+  <item>1</item>
+  <subgrid>
+    <item>2</item>
+    <item style="width: 3ch">3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+
+<!-- Verify subgrid with final item in subgrid set to 4ch -->
+<grid>
+  <item>1</item>
+  <subgrid>
+    <item>2</item>
+    <item>3</item>
+    <item style="width: 4ch">4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+
+<!-- Verify behavior when subgrid is set to masonry too -->
+<grid>
+  <item>1</item>
+  <subgrid style="grid-template-rows: masonry">
+    <item>2</item>
+    <item style="width: 3ch">3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/track-sizing/masonry-subgrid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/track-sizing/masonry-subgrid.html
@@ -1,0 +1,87 @@
+<!DOCTYPE HTML>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Verify basic CSS Masonry Subgrid support to ensure items are properly placed in the grid</title>
+  <link rel="author" title="Brandon Stewart" href="mailto:brandonstewart@apple.com">
+  <link rel="help" href="https://drafts.csswg.org/css-grid-3/#subgrids">
+  <link rel="match" href="masonry-subgrid-ref.html">
+  <style>
+    grid {
+      display: inline-grid;
+      grid-template-columns: 50px 100px 200px;
+      grid-template-rows: masonry;
+      border: 1px solid;
+      background: lightgrey;
+    }
+
+    subgrid {
+      display: grid;
+      grid-template-columns: subgrid;
+      grid-column: 2 / span 2;
+      background: lightblue;
+    }
+  </style>
+</head>
+
+<body>
+<!-- Verify basic subgrid -->
+<grid>
+  <item>1</item>
+  <subgrid>
+    <item>2</item>
+    <item>3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+
+<!-- Verify subgrid with first item in subgrid set to 2ch -->
+<grid>
+  <item>1</item>
+  <subgrid>
+    <item style="width: 2ch">2</item>
+    <item>3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+
+<!-- Verify subgrid with second item in subgrid set to 3ch -->
+<grid>
+  <item>1</item>
+  <subgrid>
+    <item>2</item>
+    <item style="width: 3ch">3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+
+<!-- Verify subgrid with final item in subgrid set to 4ch -->
+<grid>
+  <item>1</item>
+  <subgrid>
+    <item>2</item>
+    <item>3</item>
+    <item style="width: 4ch">4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+
+<!-- Verify behavior when subgrid is set to masonry too -->
+<grid>
+  <item>1</item>
+  <subgrid style="grid-template-rows: masonry">
+    <item>2</item>
+    <item style="width: 3ch">3</item>
+    <item>4</item>
+  </subgrid>
+  <item>5</item>
+</grid>
+</body>
+</html>


### PR DESCRIPTION
#### e076983d51f14f57a17e950e4e75695c529700d8
<pre>
[css-masonry] Add subgrid tests to cover track sizing cases
<a href="https://bugs.webkit.org/show_bug.cgi?id=283920">https://bugs.webkit.org/show_bug.cgi?id=283920</a>
<a href="https://rdar.apple.com/problem/140799699">rdar://problem/140799699</a>

Reviewed by Sammy Gill.

The WPT tests for CSS Masonry subgrid needed tests cases to handle discrete, intrinsic,
and flex track sizing scenarios.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/track-sizing/masonry-subgrid-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/track-sizing/masonry-subgrid-flex-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/track-sizing/masonry-subgrid-flex-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/track-sizing/masonry-subgrid-flex.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/track-sizing/masonry-subgrid-intrinsic-sizing-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/track-sizing/masonry-subgrid-intrinsic-sizing-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/track-sizing/masonry-subgrid-intrinsic-sizing.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/track-sizing/masonry-subgrid-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/track-sizing/masonry-subgrid.html: Added.

Canonical link: <a href="https://commits.webkit.org/287263@main">https://commits.webkit.org/287263@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dcca2432d386320ffae389b5f170e741254680cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78994 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58030 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32371 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83634 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30209 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67139 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6300 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61829 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19748 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82061 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51862 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/71936 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42134 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49213 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26074 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28575 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70327 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26486 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85020 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6319 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4363 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70066 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6483 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67880 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/69316 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17269 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13356 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12110 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6271 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6232 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9683 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8023 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->