### PR TITLE
Make FontCascade loggable

### DIFF
--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -42,6 +42,7 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/AtomStringHash.h>
 #include <wtf/text/StringBuilder.h>
+#include <wtf/text/TextStream.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -1900,6 +1901,17 @@ std::optional<char32_t> capitalized(char32_t baseCharacter)
     return std::nullopt;
 }
 
+TextStream& operator<<(TextStream& ts, const FontCascade& fontCascade)
+{
+    ts << fontCascade.fontDescription();
+
+    ts << ", font selector " << fontCascade.fonts()->fontSelector();
+    ts << ", font selector version " << fontCascade.fonts()->fontSelectorVersion();
+    ts << ", generation " << fontCascade.fonts()->generation();
+
+    return ts;
 }
+
+} // namespace WebCore
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -48,6 +48,10 @@
 #undef Complex
 #endif
 
+namespace WTF {
+class TextStream;
+}
+
 namespace WebCore {
 
 class GraphicsContext;
@@ -440,5 +444,7 @@ inline float FontCascade::widthForTextUsingSimplifiedMeasuring(StringView text, 
 
 bool shouldSynthesizeSmallCaps(bool, const Font*, char32_t, std::optional<char32_t>, FontVariantCaps, bool);
 std::optional<char32_t> capitalized(char32_t);
+
+WTF::TextStream& operator<<(WTF::TextStream&, const FontCascade&);
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/FontCascadeDescription.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeDescription.cpp
@@ -32,6 +32,7 @@
 
 #include "Font.h"
 #include <wtf/text/StringHash.h>
+#include <wtf/text/TextStream.h>
 
 #if USE(CORE_TEXT)
 #include "FontCascade.h"
@@ -156,6 +157,30 @@ void FontCascadeDescription::resolveFontSizeAdjustFromFontIfNeeded(const Font& f
 
     auto aspectValue = fontSizeAdjust.resolve(computedSize(), font.fontMetrics());
     setFontSizeAdjust({ fontSizeAdjust.metric, FontSizeAdjust::ValueType::FromFont, aspectValue });
+}
+
+TextStream& operator<<(TextStream& ts, const FontCascadeDescription& fontCascadeDescription)
+{
+    bool first = true;
+    for (auto& family : fontCascadeDescription.families()) {
+        if (!first)
+            ts << ", ";
+        ts << family;
+        first = false;
+    }
+
+    ts << ", specified size " << fontCascadeDescription.specifiedSize();
+    ts << ", is absolute size " << fontCascadeDescription.isAbsoluteSize();
+    if (fontCascadeDescription.kerning() != Kerning::Auto)
+        ts << ", kerning " << fontCascadeDescription.kerning();
+
+    if (fontCascadeDescription.fontSmoothing() != FontSmoothingMode::AutoSmoothing)
+        ts << ", font smoothing " << fontCascadeDescription.fontSmoothing();
+
+    ts << ", keyword size " << fontCascadeDescription.keywordSize();
+    ts << ", is specified font " << fontCascadeDescription.isSpecifiedFont();
+
+    return ts;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/FontCascadeDescription.h
+++ b/Source/WebCore/platform/graphics/FontCascadeDescription.h
@@ -35,6 +35,10 @@
 #include "FontFamilySpecificationNull.h"
 #endif
 
+namespace WTF {
+class TextStream;
+}
+
 namespace WebCore {
 
 #if PLATFORM(COCOA)
@@ -173,5 +177,7 @@ inline bool FontCascadeDescription::operator==(const FontCascadeDescription& oth
         && m_fontSmoothing == other.m_fontSmoothing
         && m_isSpecifiedFont == other.m_isSpecifiedFont;
 }
+
+WTF::TextStream& operator<<(WTF::TextStream&, const FontCascadeDescription&);
 
 }

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
@@ -572,6 +572,12 @@ void FontCascadeFonts::pruneSystemFallbacks()
     m_systemFallbackFontSet.clear();
 }
 
+TextStream& operator<<(TextStream& ts, const FontCascadeFonts& fontCascadeFonts)
+{
+    ts << "FontCascadeFonts " << &fontCascadeFonts << " " << ValueOrNull(fontCascadeFonts.fontSelector()) << " generation " << fontCascadeFonts.generation();
+    return ts;
+}
+
 } // namespace WebCore
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.h
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.h
@@ -38,6 +38,10 @@
 #include "WebCoreThread.h"
 #endif
 
+namespace WTF {
+class TextStream;
+}
+
 namespace WebCore {
 
 class FontPlatformData;
@@ -67,6 +71,8 @@ public:
     bool isLoadingCustomFonts() const;
 
     FontSelector* fontSelector() { return m_fontSelector.get(); }
+    const FontSelector* fontSelector() const { return m_fontSelector.get(); }
+
     // FIXME: It should be possible to combine fontSelectorVersion and generation.
     unsigned fontSelectorVersion() const { return m_fontSelectorVersion; }
     unsigned generation() const { return m_generation; }
@@ -169,6 +175,8 @@ inline const Font& FontCascadeFonts::primaryFont(const FontCascadeDescription& d
     return *m_cachedPrimaryFont;
 }
 
-}
+WTF::TextStream& operator<<(WTF::TextStream&, const FontCascadeFonts&);
+
+} // namespace WebCore
 
 #endif

--- a/Source/WebCore/platform/graphics/FontSelector.cpp
+++ b/Source/WebCore/platform/graphics/FontSelector.cpp
@@ -30,4 +30,10 @@ namespace WebCore {
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(FontAccessor);
 
+TextStream& operator<<(TextStream& ts, const FontSelector& fontSelector)
+{
+    ts << "FontSelector " << &fontSelector << " id " << fontSelector.uniqueId() << " version " << fontSelector.version();
+    return ts;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/FontSelector.h
+++ b/Source/WebCore/platform/graphics/FontSelector.h
@@ -29,6 +29,10 @@
 #include <wtf/Forward.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 
+namespace WTF {
+class TextStream;
+}
+
 namespace WebCore {
 
 class FontCache;
@@ -66,5 +70,7 @@ public:
     virtual unsigned uniqueId() const = 0;
     virtual unsigned version() const = 0;
 };
+
+WTF::TextStream& operator<<(WTF::TextStream&, const FontSelector&);
 
 }

--- a/Source/WebCore/rendering/style/StyleInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleInheritedData.cpp
@@ -102,7 +102,10 @@ void StyleInheritedData::dumpDifferences(TextStream& ts, const StyleInheritedDat
     LOG_IF_DIFFERENT(specifiedLineHeight);
 #endif
 
-    LOG_IF_DIFFERENT(fontCascade);
+    // fontCascade is complex, so gets special dumping.
+    if (fontCascade != other.fontCascade)
+        ts << "fontCascade differs:\n  " << fontCascade << "\n  " << other.fontCascade;
+
     LOG_IF_DIFFERENT(color);
     LOG_IF_DIFFERENT(visitedLinkColor);
 }


### PR DESCRIPTION
#### 1758ef2b35fc15e6f4e94e75509c325511701510
<pre>
Make FontCascade loggable
<a href="https://bugs.webkit.org/show_bug.cgi?id=283932">https://bugs.webkit.org/show_bug.cgi?id=283932</a>
<a href="https://rdar.apple.com/140805857">rdar://140805857</a>

Reviewed by Tim Nguyen.

FontCascade changes are responsible for a lot of Layout style diffs.
It&apos;s useful to be able to get some logging information about FontCascade.

This is not complete logging, just enough to give some basic information,
and reflect why operator== can return false.

* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/FontCascade.h:
* Source/WebCore/platform/graphics/FontCascadeDescription.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/FontCascadeDescription.h:
* Source/WebCore/platform/graphics/FontCascadeFonts.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/FontCascadeFonts.h:
(WebCore::FontCascadeFonts::fontSelector const):
* Source/WebCore/platform/graphics/FontSelector.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/FontSelector.h:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::logStyleDifference): Just tidy it up a bit.
(WebCore::RenderElement::setStyle):
* Source/WebCore/rendering/style/StyleInheritedData.cpp:
(WebCore::StyleInheritedData::dumpDifferences const):

Canonical link: <a href="https://commits.webkit.org/287245@main">https://commits.webkit.org/287245@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c0929044c6d3e7811b2f4c28e31b139cba358e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78928 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57967 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32308 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83575 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30165 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81061 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67099 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6247 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61795 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19720 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81995 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51834 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/71815 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42099 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49184 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26014 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28520 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/70298 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26423 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84954 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6276 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70027 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6439 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67839 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69278 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17257 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13326 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12064 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6225 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6192 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9639 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7983 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->