### PR TITLE
Web Inspector crashes due to using erroneous `PseudoElementIdentifier`

### DIFF
--- a/LayoutTests/inspector/css/getMatchedStylesForNodeBackdropPseudoId.html
+++ b/LayoutTests/inspector/css/getMatchedStylesForNodeBackdropPseudoId.html
@@ -42,7 +42,7 @@ function test()
         description: "A dialog should have both the User Agent and authored `::backdrop` rules.",
         selector: "#test-dialog",
         async domNodeStylesHandler(styles) {
-            InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.Backdrop), undefined, "Expected no rules entry for selector `*::backdrop` before showing the dialog.");
+            InspectorTest.expectFalse(styles.pseudoElements.has(WI.CSSManager.PseudoSelectorNames.Backdrop), "Expected no rules entry for selector `*::backdrop` before showing the dialog.");
             await InspectorTest.evaluateInPage(`openDialog()`);
             await styles.refresh();
             InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.Backdrop).matchedRules.length, 3, "Expected exactly 3 rules for selector `*::backdrop` after showing the dialog.");
@@ -54,7 +54,7 @@ function test()
         description: "A non-dialog should have no `::backdrop` rules.",
         selector: "#test-div",
         async domNodeStylesHandler(styles) {
-            InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.Marker), undefined, "Expected no rules entry for selector `*::backdrop`.");
+            InspectorTest.expectFalse(styles.pseudoElements.has(WI.CSSManager.PseudoSelectorNames.Backdrop), "Expected no rules entry for selector `*::backdrop`.");
         }
     });
 

--- a/LayoutTests/inspector/css/getMatchedStylesForNodeViewTransitionPseudoElements-expected.txt
+++ b/LayoutTests/inspector/css/getMatchedStylesForNodeViewTransitionPseudoElements-expected.txt
@@ -1,0 +1,23 @@
+Tests for the CSS.getMatchedStyleForNode command and the view transition pseudo-elements.
+
+
+== Running test suite: CSS.getMatchedStyleForNode.ViewTransitionPseudoElements
+-- Running test case: CSS.getMatchedStyleForNode.ViewTransitionPseudoElements.Root
+PASS: Expected no rules entry for selector `*::view-transition` before starting the view transition.
+PASS: Expected no rules entry for selector `*::view-transition-group()` before starting the view transition.
+PASS: Expected no rules entry for selector `*::view-transition-image-pair()` before starting the view transition.
+PASS: Expected no rules entry for selector `*::view-transition-old()` before starting the view transition.
+PASS: Expected no rules entry for selector `*::view-transition-new()` before starting the view transition.
+PASS: Expected entry for selector `*::view-transition` after starting the view transition.
+PASS: No crash
+PASS: No crash
+PASS: No crash
+PASS: No crash
+
+-- Running test case: CSS.getMatchedStyleForNode.ViewTransitionPseudoElements.Div
+PASS: Expected no rules entry for selector `*::view-transition` on non-root element.
+PASS: Expected no rules entry for selector `*::view-transition-group()` on non-root element.
+PASS: Expected no rules entry for selector `*::view-transition-image-pair()` on non-root element.
+PASS: Expected no rules entry for selector `*::view-transition-old()` on non-root element.
+PASS: Expected no rules entry for selector `*::view-transition-new()` on non-root element.
+

--- a/LayoutTests/inspector/css/getMatchedStylesForNodeViewTransitionPseudoElements.html
+++ b/LayoutTests/inspector/css/getMatchedStylesForNodeViewTransitionPseudoElements.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function startViewTransition()
+{
+    document.startViewTransition(() => {
+        document.querySelector("#change").classList.add("changed");
+    });
+}
+
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("CSS.getMatchedStyleForNode.ViewTransitionPseudoElements");
+
+    function addTestCase({name, description, selector, domNodeStylesHandler})
+    {
+        suite.addTestCase({
+            name,
+            description,
+            async test() {
+                let documentNode = await WI.domManager.requestDocument();
+                let nodeId = await documentNode.querySelector(selector);
+                let domNode = WI.domManager.nodeForId(nodeId);
+                InspectorTest.assert(domNode, `Should find DOM Node for selector '${selector}'.`);
+
+                let domNodeStyles = WI.cssManager.stylesForNode(domNode);
+                InspectorTest.assert(domNodeStyles, `Should find CSS Styles for DOM Node.`);
+                await domNodeStyles.refreshIfNeeded();
+
+                await domNodeStylesHandler(domNodeStyles);
+            },
+        });
+    }
+
+    addTestCase({
+        name: "CSS.getMatchedStyleForNode.ViewTransitionPseudoElements.Root",
+        description: "A dialog should have both the User Agent and authored `::backdrop` rules.",
+        selector: "html",
+        async domNodeStylesHandler(styles) {
+            InspectorTest.expectFalse(styles.pseudoElements.has(WI.CSSManager.PseudoSelectorNames.ViewTransition), "Expected no rules entry for selector `*::view-transition` before starting the view transition.");
+            InspectorTest.expectFalse(styles.pseudoElements.has(WI.CSSManager.PseudoSelectorNames.ViewTransitionGroup), "Expected no rules entry for selector `*::view-transition-group()` before starting the view transition.");
+            InspectorTest.expectFalse(styles.pseudoElements.has(WI.CSSManager.PseudoSelectorNames.ViewTransitionImagePair), "Expected no rules entry for selector `*::view-transition-image-pair()` before starting the view transition.");
+            InspectorTest.expectFalse(styles.pseudoElements.has(WI.CSSManager.PseudoSelectorNames.ViewTransitionOld), "Expected no rules entry for selector `*::view-transition-old()` before starting the view transition.");
+            InspectorTest.expectFalse(styles.pseudoElements.has(WI.CSSManager.PseudoSelectorNames.ViewTransitionNew), "Expected no rules entry for selector `*::view-transition-new()` before starting the view transition.");
+
+            await InspectorTest.evaluateInPage(`startViewTransition()`);
+            await styles.refresh();
+            InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.ViewTransition).matchedRules.length, 2, "Expected entry for selector `*::view-transition` after starting the view transition.");
+
+            // FIXME: These should use the correct values when adding support for named pseudo-elements. We'll also want to test different names individually. (webkit.org/b/283951)
+            InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.ViewTransitionGroup), undefined, "No crash");
+            InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.ViewTransitionImagePair), undefined, "No crash");
+            InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.ViewTransitionOld), undefined, "No crash");
+            InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.ViewTransitionNew), undefined, "No crash");
+        }
+    });
+
+    addTestCase({
+        name: "CSS.getMatchedStyleForNode.ViewTransitionPseudoElements.Div",
+        description: "A non-dialog should have no `::backdrop` rules.",
+        selector: "#test-div",
+        async domNodeStylesHandler(styles) {
+            InspectorTest.expectFalse(styles.pseudoElements.has(WI.CSSManager.PseudoSelectorNames.ViewTransition), "Expected no rules entry for selector `*::view-transition` on non-root element.");
+            InspectorTest.expectFalse(styles.pseudoElements.has(WI.CSSManager.PseudoSelectorNames.ViewTransitionGroup), "Expected no rules entry for selector `*::view-transition-group()` on non-root element.");
+            InspectorTest.expectFalse(styles.pseudoElements.has(WI.CSSManager.PseudoSelectorNames.ViewTransitionImagePair), "Expected no rules entry for selector `*::view-transition-image-pair()` on non-root element.");
+            InspectorTest.expectFalse(styles.pseudoElements.has(WI.CSSManager.PseudoSelectorNames.ViewTransitionOld), "Expected no rules entry for selector `*::view-transition-old()` on non-root element.");
+            InspectorTest.expectFalse(styles.pseudoElements.has(WI.CSSManager.PseudoSelectorNames.ViewTransitionNew), "Expected no rules entry for selector `*::view-transition-new()` on non-root element.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+<style>
+    ::view-transition {
+        background-color: red;
+    }
+
+    ::view-transition-group(*) {
+        color: orange;
+    }
+
+    ::view-transition-group(root) {
+        background-color: red;
+    }
+
+    ::view-transition-group(other-name) {
+        background-color: red;
+    }
+
+    ::view-transition-group(other-name-2) {
+        background-color: red;
+    }
+
+    ::view-transition-group(non-existant-name) {
+        color: blue;
+    }
+
+    ::view-transition-image-pair(root) {
+        background-color: red;
+    }
+
+    ::view-transition-image-pair(other-name) {
+        background-color: red;
+    }
+
+    ::view-transition-image-pair(other-name-2) {
+        background-color: red;
+    }
+
+    ::view-transition-image-pair(non-existant-name) {
+        color: blue;
+    }
+
+    ::view-transition-old(root) {
+        background-color: red;
+        animation-play-state: paused;
+        animation-duration: 30s;
+    }
+
+    ::view-transition-old(other-name) {
+        background-color: red;
+    }
+
+    ::view-transition-old(other-name-2) {
+        background-color: red;
+    }
+
+    ::view-transition-old(non-existant-name) {
+        color: blue;
+    }
+
+    ::view-transition-new(root) {
+        background-color: red;
+    }
+
+    ::view-transition-new(other-name) {
+        background-color: red;
+    }
+
+    ::view-transition-new(other-name-2) {
+        background-color: red;
+    }
+
+    ::view-transition-new(non-existant-name) {
+        color: blue;
+    }
+
+    #change.changed {
+        background-color: green;
+    }
+</style>
+</head>
+<body onload="runTest()">
+    <p>Tests for the CSS.getMatchedStyleForNode command and the view transition pseudo-elements.</p>
+    <div id="other-name" style="view-transition-name: other-name;"></div>
+    <div id="other-name-2" style="view-transition-name: other-name-2;"></div>
+    <div id="change"></div>
+    <div id="test-div"></div>
+</body>
+</html>

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -504,6 +504,13 @@ Inspector::Protocol::ErrorStringOr<std::tuple<RefPtr<JSON::ArrayOf<Inspector::Pr
                 if (pseudoId == PseudoId::Backdrop && !element->isInTopLayer())
                     continue;
 
+                if (pseudoId == PseudoId::ViewTransition && (!element->document().activeViewTransition() || element != element->document().documentElement()))
+                    continue;
+
+                // FIXME: Add named view transition pseudo-element support to Web Inspector. (webkit.org/b/283951)
+                if (isNamedViewTransitionPseudoElement(Style::PseudoElementIdentifier { pseudoId }))
+                    continue;
+
                 if (auto protocolPseudoId = protocolValueForPseudoId(pseudoId)) {
                     auto matchedRules = styleResolver.pseudoStyleRulesForElement(element, pseudoId, Style::Resolver::AllCSSRules);
                     if (!matchedRules.isEmpty()) {


### PR DESCRIPTION
#### c303cfb174dd61bb24f93bd69e41413d1efd69ec
<pre>
Web Inspector crashes due to using erroneous `PseudoElementIdentifier`
<a href="https://bugs.webkit.org/show_bug.cgi?id=283574">https://bugs.webkit.org/show_bug.cgi?id=283574</a>
<a href="https://rdar.apple.com/140243623">rdar://140243623</a>

Reviewed by Devin Rousso.

Skip named view transition pseudo-elements until we&apos;re able to pass a proper `PseudoElementIdentifier` into
`pseudoStyleRulesForElement`, and once we properly support named view transition pseudo-elements.

* LayoutTests/inspector/css/getMatchedStylesForNodeBackdropPseudoId.html:
* LayoutTests/inspector/css/getMatchedStylesForNodeViewTransitionPseudoElements-expected.txt: Added.
* LayoutTests/inspector/css/getMatchedStylesForNodeViewTransitionPseudoElements.html: Added.
* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
(WebCore::InspectorCSSAgent::getMatchedStylesForNode):

Canonical link: <a href="https://commits.webkit.org/287254@main">https://commits.webkit.org/287254@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f027442feb65797c8aab994bd7b63945baa2caab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78962 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57999 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32340 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83604 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30184 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81095 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67118 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6273 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61809 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19731 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82029 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51848 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/71859 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42113 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49199 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26043 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28547 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70313 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26453 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84988 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6298 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70046 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6462 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67860 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69298 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13337 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12089 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12185 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6248 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6211 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9662 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8002 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->