### PR TITLE
[block-step-sizing] Start considering box's alignment when distributing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/margin-distribution-align-items-simple-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/margin-distribution-align-items-simple-expected.txt
@@ -1,0 +1,14 @@
+x x x
+x x x
+x x x
+
+PASS div.block-step 1
+PASS div.block-step 2
+PASS div.block-step 3
+PASS div.block-step 4
+PASS div.block-step 5
+PASS div.block-step 6
+PASS div.block-step 7
+PASS div.block-step 8
+PASS div.block-step 9
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/margin-distribution-align-items-simple.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/margin-distribution-align-items-simple.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-align">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<meta name="assert" content="Margins are distributed based on the box's align-self value. In this case it will refer to the computed align-items value of the parent.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<style>
+.block-step {
+  font: 25px Ahem;
+  width: min-content;
+  block-step-size: 100px;
+}
+.fixed-height {
+  height: 50px;
+}
+.start-alignment {
+  align-items: start;
+}
+.end-alignment {
+  align-items: end;
+}
+.additional-margin {
+  margin-block: 10px;
+}
+</style>
+</head>
+<body onload="checkLayout('div.block-step')">
+
+  <div>
+    <div class="block-step fixed-height" data-expected-margin-top="25", data-expected-margin-bottom="25"></div>
+  </div>
+
+  <div class="start-alignment">
+    <div class="block-step fixed-height" data-expected-margin-top="50" data-expected-margin-bottom="0"></div>
+  </div>
+
+  <div class="end-alignment">
+    <div class="block-step fixed-height" data-expected-margin-top="0" data-expected-margin-bottom="50"></div>
+  </div>
+
+  <div>
+    <div class="block-step" data-expected-margin-top="12.5" data-expected-margin-bottom="12.5">x x x </div>
+  </div>
+
+  <div class="start-alignment">
+    <div class="block-step" data-expected-margin-top="25" data-expected-margin-bottom="0">x x x</div>
+  </div>
+
+  <div class="end-alignment">
+    <div class="block-step" data-expected-margin-top="0" data-expected-margin-bottom="25"> x x x</div>
+  </div>
+
+  <!-- Extra space is added on top of any specified margins -->
+  <div>
+    <div class="block-step fixed-height additional-margin" data-expected-margin-top="25" data-expected-margin-bottom="25"></div>
+  </div>
+
+  <div class="start-alignment">
+    <div class="block-step fixed-height additional-margin" data-expected-margin-top="40" data-expected-margin-bottom="10"></div>
+  </div>
+
+  <div class="end-alignment">
+    <div class="block-step fixed-height additional-margin" data-expected-margin-top="10" data-expected-margin-bottom="40"></div>
+  </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/margin-distribution-align-self-simple-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/margin-distribution-align-self-simple-expected.txt
@@ -1,0 +1,14 @@
+x x x
+x x x
+x x x
+
+PASS div 1
+PASS div 2
+PASS div 3
+PASS div 4
+PASS div 5
+PASS div 6
+PASS div 7
+PASS div 8
+PASS div 9
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/margin-distribution-align-self-simple.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/margin-distribution-align-self-simple.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-align">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<meta name="assert" content="Extra space is distributed according to the box's align-self when block-step-align is auto">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<style>
+.block-step {
+  font: 25px Ahem;
+  width: min-content;
+  block-step-size: 100px;
+}
+.fixed-height {
+  height: 50px;
+}
+.start-alignment {
+  align-self: start;
+}
+.end-alignment {
+  align-self: end;
+}
+.additional-margin {
+  margin-block: 10px;
+}
+</style>
+</head>
+<body onload="checkLayout('div')">
+  <div class="block-step fixed-height" data-expected-margin-top="25", data-expected-margin-bottom="25"></div>
+  <div class="block-step fixed-height start-alignment" data-expected-margin-top="50" data-expected-margin-bottom="0"></div>
+  <div class="block-step fixed-height end-alignment" data-expected-margin-top="0" data-expected-margin-bottom="50"></div>
+
+  <div class="block-step" data-expected-margin-top="12.5" data-expected-margin-bottom="12.5">x x x </div>
+  <div class="block-step start-alignment" data-expected-margin-top="25" data-expected-margin-bottom="0">x x x</div>
+  <div class="block-step end-alignment" data-expected-margin-top="0" data-expected-margin-bottom="25"> x x x</div>
+
+  <!-- Extra space is added on top of any specified margins -->
+  <div class="block-step fixed-height additional-margin" data-expected-margin-top="25" data-expected-margin-bottom="25"></div>
+  <div class="block-step fixed-height start-alignment additional-margin" data-expected-margin-top="40" data-expected-margin-bottom="10"></div>
+  <div class="block-step fixed-height end-alignment additional-margin" data-expected-margin-top="10" data-expected-margin-bottom="40"></div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/Source/WebCore/rendering/RenderBlockFlow.h
@@ -236,7 +236,7 @@ public:
     };
 
     bool shouldTrimChildMargin(MarginTrimType, const RenderBox&) const;
-    void distributeExtraBlockStepSizingSpaceToChild(RenderBox& child, LayoutUnit extraSpace) const;
+    void distributeExtraBlockStepSizingSpaceToChild(RenderBox& child, LayoutUnit extraSpace, ItemPosition alignSelfForChild) const;
 
     void layoutBlockChild(RenderBox& child, MarginInfo&, LayoutUnit& previousFloatLogicalBottom, LayoutUnit& maxFloatLogicalBottom);
     void adjustPositionedBlock(RenderBox& child, const MarginInfo&);


### PR DESCRIPTION
#### 51a5b7b71504d14ea998c8c0d3d3510b6312eab0
<pre>
[block-step-sizing] Start considering box&apos;s alignment when distributing
extra space.
<a href="https://bugs.webkit.org/show_bug.cgi?id=283585">https://bugs.webkit.org/show_bug.cgi?id=283585</a>
<a href="https://rdar.apple.com/140432622">rdar://140432622</a>

Reviewed by NOBODY (OOPS!).

We currently do not implement the behavior for the block-step-align
property when it comes to determining how to split up the extra space
that is computed. However, the property does define an auto behavior
that refers to the box&apos;s self-alignment when adjusting the margin box,
which is currently the only type of adjustment we implement, so this
patch aims to start implementing that logic.

Essentially:
- If the box&apos;s self-alignment is start, we add the extra space to the
  block start side.
- If the box&apos;s self-alignment is end, we add the extra space to the block
  end side.
- Otherwise, split the extra space among the two edges like we already do.

The tests added are similar to the ones in 286969@main in that we start
providing support for some simple pieces of content. These are boxes
that have a specified inline size and do not have any border or padding.
Some of the tests specify a block size for the content, while some others
test when the box&apos;s block size is based on its content.

* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/margin-distribution-align-items-simple-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/margin-distribution-align-items-simple.html: Added.
Some simple content and how we distribute the space is based upon the
parent&apos;s align-items property.

* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/margin-distribution-align-self-simple-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/margin-distribution-align-self-simple.html: Added.
Some simple content and how we distribute the space is based upon the
box&apos;s align-self property.

* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::layoutBlock):
(WebCore::RenderBlockFlow::distributeExtraBlockStepSizingSpaceToChild const):
(WebCore::RenderBlockFlow::layoutBlockChild):
* Source/WebCore/rendering/RenderBlockFlow.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51a5b7b71504d14ea998c8c0d3d3510b6312eab0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78981 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58018 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32358 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83621 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30198 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81114 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67128 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6288 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61818 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19741 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82048 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51853 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/71881 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42123 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49204 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26052 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28562 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70318 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26463 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85007 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6308 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4355 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70051 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6472 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67866 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69302 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13346 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12096 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6260 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12113 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6221 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9672 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8012 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->