### PR TITLE
[css-masonry] Fix intrinsic sizing ref link in test cases

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001-auto.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001-auto.html
@@ -8,7 +8,7 @@
   <title>CSS Grid Test: Masonry layout column sizing - intrinsic</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-grid-3/#track-sizing">
-  <link rel="match" href="masonry-intrinsic-sizing-cols-001-ref.html">
+  <link rel="match" href="masonry-intrinsic-sizing-cols-001-auto-ref.html">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001-fr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001-fr.html
@@ -8,7 +8,7 @@
   <title>CSS Grid Test: Masonry layout column sizing - intrinsic</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-grid-3/#track-sizing">
-  <link rel="match" href="masonry-intrinsic-sizing-cols-001-ref.html">
+  <link rel="match" href="masonry-intrinsic-sizing-cols-001-fr-ref.html">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001-mix1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001-mix1.html
@@ -8,7 +8,7 @@
   <title>CSS Grid Test: Masonry layout column sizing - intrinsic</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-grid-3/#track-sizing">
-  <link rel="match" href="masonry-intrinsic-sizing-cols-001-ref.html">
+  <link rel="match" href="masonry-intrinsic-sizing-cols-001-mix1-ref.html">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001-mix2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001-mix2.html
@@ -8,7 +8,7 @@
   <title>CSS Grid Test: Masonry layout column sizing - intrinsic</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-grid-3/#track-sizing">
-  <link rel="match" href="masonry-intrinsic-sizing-cols-001-ref.html">
+  <link rel="match" href="masonry-intrinsic-sizing-cols-001-mix2-ref.html">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-auto.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-auto.html
@@ -8,7 +8,7 @@
   <title>CSS Grid Test: Masonry layout column sizing - min-content constraint</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-grid-3/#track-sizing">
-  <link rel="match" href="masonry-intrinsic-sizing-cols-002-ref.html">
+  <link rel="match" href="masonry-intrinsic-sizing-cols-002-auto-ref.html">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-fr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-fr.html
@@ -8,7 +8,7 @@
   <title>CSS Grid Test: Masonry layout column sizing - min-content constraint</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-grid-3/#track-sizing">
-  <link rel="match" href="masonry-intrinsic-sizing-cols-002-ref.html">
+  <link rel="match" href="masonry-intrinsic-sizing-cols-002-fr-ref.html">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-mix1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-mix1.html
@@ -8,7 +8,7 @@
   <title>CSS Grid Test: Masonry layout column sizing - min-content constraint</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-grid-3/#track-sizing">
-  <link rel="match" href="masonry-intrinsic-sizing-cols-002-ref.html">
+  <link rel="match" href="masonry-intrinsic-sizing-cols-002-mix1-ref.html">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-mix2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-mix2.html
@@ -8,7 +8,7 @@
   <title>CSS Grid Test: Masonry layout column sizing - min-content constraint</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-grid-3/#track-sizing">
-  <link rel="match" href="masonry-intrinsic-sizing-cols-002-ref.html">
+  <link rel="match" href="masonry-intrinsic-sizing-cols-002-mix2-ref.html">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-auto.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-auto.html
@@ -8,7 +8,7 @@
   <title>CSS Grid Test: Masonry layout column sizing - min-content</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-grid-3/#track-sizing">
-  <link rel="match" href="masonry-intrinsic-sizing-cols-003-ref.html">
+  <link rel="match" href="masonry-intrinsic-sizing-cols-003-auto-ref.html">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-fr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-fr.html
@@ -8,7 +8,7 @@
   <title>CSS Grid Test: Masonry layout column sizing - min-content</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-grid-3/#track-sizing">
-  <link rel="match" href="masonry-intrinsic-sizing-cols-003-ref.html">
+  <link rel="match" href="masonry-intrinsic-sizing-cols-003-fr-ref.html">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-mix1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-mix1.html
@@ -8,7 +8,7 @@
   <title>CSS Grid Test: Masonry layout column sizing - min-content</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-grid-3/#track-sizing">
-  <link rel="match" href="masonry-intrinsic-sizing-cols-003-ref.html">
+  <link rel="match" href="masonry-intrinsic-sizing-cols-003-mix1-ref.html">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-mix2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-mix2.html
@@ -8,7 +8,7 @@
   <title>CSS Grid Test: Masonry layout column sizing - min-content</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-grid-3/#track-sizing">
-  <link rel="match" href="masonry-intrinsic-sizing-cols-003-ref.html">
+  <link rel="match" href="masonry-intrinsic-sizing-cols-003-mix2-ref.html">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-auto.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-auto.html
@@ -8,7 +8,7 @@
   <title>CSS Grid Test: Masonry layout column sizing - max-content</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-grid-3">
-  <link rel="match" href="masonry-intrinsic-sizing-cols-004-ref.html">
+  <link rel="match" href="masonry-intrinsic-sizing-cols-004-auto-ref.html">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-fr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-fr.html
@@ -8,7 +8,7 @@
   <title>CSS Grid Test: Masonry layout column sizing - max-content</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-grid-3">
-  <link rel="match" href="masonry-intrinsic-sizing-cols-004-ref.html">
+  <link rel="match" href="masonry-intrinsic-sizing-cols-004-fr-ref.html">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-mix1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-mix1.html
@@ -8,7 +8,7 @@
   <title>CSS Grid Test: Masonry layout column sizing - max-content</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-grid-3">
-  <link rel="match" href="masonry-intrinsic-sizing-cols-004-ref.html">
+  <link rel="match" href="masonry-intrinsic-sizing-cols-004-mix1-ref.html">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-mix2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-mix2.html
@@ -8,7 +8,7 @@
   <title>CSS Grid Test: Masonry layout column sizing - max-content</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-grid-3">
-  <link rel="match" href="masonry-intrinsic-sizing-cols-004-ref.html">
+  <link rel="match" href="masonry-intrinsic-sizing-cols-004-mix2-ref.html">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001-auto.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001-auto.html
@@ -8,7 +8,7 @@
   <title>CSS Grid Test: Masonry layout column sizing - intrinsic</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-grid-3/#track-sizing">
-  <link rel="match" href="masonry-intrinsic-sizing-rows-001-ref.html">
+  <link rel="match" href="masonry-intrinsic-sizing-rows-001-auto-ref.html">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001-fr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001-fr.html
@@ -8,7 +8,7 @@
   <title>CSS Grid Test: Masonry layout column sizing - intrinsic</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-grid-3/#track-sizing">
-  <link rel="match" href="masonry-intrinsic-sizing-rows-001-ref.html">
+  <link rel="match" href="masonry-intrinsic-sizing-rows-001-fr-ref.html">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001-mix1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001-mix1.html
@@ -8,7 +8,7 @@
   <title>CSS Grid Test: Masonry layout column sizing - intrinsic</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-grid-3/#track-sizing">
-  <link rel="match" href="masonry-intrinsic-sizing-rows-001-ref.html">
+  <link rel="match" href="masonry-intrinsic-sizing-rows-001-mix1-ref.html">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001-mix2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001-mix2.html
@@ -8,7 +8,7 @@
   <title>CSS Grid Test: Masonry layout column sizing - intrinsic</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-grid-3/#track-sizing">
-  <link rel="match" href="masonry-intrinsic-sizing-rows-001-ref.html">
+  <link rel="match" href="masonry-intrinsic-sizing-rows-001-mix2-ref.html">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-auto.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-auto.html
@@ -8,7 +8,7 @@
   <title>CSS Grid Test: Masonry layout column sizing - min-content constraint</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-grid-3/#track-sizing">
-  <link rel="match" href="masonry-intrinsic-sizing-rows-002-ref.html">
+  <link rel="match" href="masonry-intrinsic-sizing-rows-002-auto-ref.html">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-fr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-fr.html
@@ -8,7 +8,7 @@
   <title>CSS Grid Test: Masonry layout column sizing - min-content constraint</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-grid-3/#track-sizing">
-  <link rel="match" href="masonry-intrinsic-sizing-rows-002-ref.html">
+  <link rel="match" href="masonry-intrinsic-sizing-rows-002-fr-ref.html">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-mix1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-mix1.html
@@ -8,7 +8,7 @@
   <title>CSS Grid Test: Masonry layout column sizing - min-content constraint</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-grid-3/#track-sizing">
-  <link rel="match" href="masonry-intrinsic-sizing-rows-002-ref.html">
+  <link rel="match" href="masonry-intrinsic-sizing-rows-002-mix1-ref.html">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-mix2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-mix2.html
@@ -8,7 +8,7 @@
   <title>CSS Grid Test: Masonry layout column sizing - min-content constraint</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-grid-3/#track-sizing">
-  <link rel="match" href="masonry-intrinsic-sizing-rows-002-ref.html">
+  <link rel="match" href="masonry-intrinsic-sizing-rows-002-mix2-ref.html">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-auto.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-auto.html
@@ -8,7 +8,7 @@
   <title>CSS Grid Test: Masonry layout column sizing - min-content</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-grid-3/#track-sizing">
-  <link rel="match" href="masonry-intrinsic-sizing-rows-003-ref.html">
+  <link rel="match" href="masonry-intrinsic-sizing-rows-003-auto-ref.html">
   <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-fr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-fr.html
@@ -8,7 +8,7 @@
   <title>CSS Grid Test: Masonry layout column sizing - min-content</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-grid-3/#track-sizing">
-  <link rel="match" href="masonry-intrinsic-sizing-rows-003-ref.html">
+  <link rel="match" href="masonry-intrinsic-sizing-rows-003-fr-ref.html">
   <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-mix1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-mix1.html
@@ -8,7 +8,7 @@
   <title>CSS Grid Test: Masonry layout column sizing - min-content</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-grid-3/#track-sizing">
-  <link rel="match" href="masonry-intrinsic-sizing-rows-003-ref.html">
+  <link rel="match" href="masonry-intrinsic-sizing-rows-003-mix1-ref.html">
   <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-mix2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-mix2.html
@@ -8,7 +8,7 @@
   <title>CSS Grid Test: Masonry layout column sizing - min-content</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-grid-3/#track-sizing">
-  <link rel="match" href="masonry-intrinsic-sizing-rows-003-ref.html">
+  <link rel="match" href="masonry-intrinsic-sizing-rows-003-mix2-ref.html">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-auto.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-auto.html
@@ -8,7 +8,7 @@
   <title>CSS Grid Test: Masonry layout column sizing - max-content</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-grid-3">
-  <link rel="match" href="masonry-intrinsic-sizing-rows-004-ref.html">
+  <link rel="match" href="masonry-intrinsic-sizing-rows-004-auto-ref.html">
   <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-fr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-fr.html
@@ -8,7 +8,7 @@
   <title>CSS Grid Test: Masonry layout column sizing - max-content</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-grid-3">
-  <link rel="match" href="masonry-intrinsic-sizing-rows-004-ref.html">
+  <link rel="match" href="masonry-intrinsic-sizing-rows-004-fr-ref.html">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-mix1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-mix1.html
@@ -8,7 +8,7 @@
   <title>CSS Grid Test: Masonry layout column sizing - max-content</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-grid-3">
-  <link rel="match" href="masonry-intrinsic-sizing-rows-004-ref.html">
+  <link rel="match" href="masonry-intrinsic-sizing-rows-004-mix1-ref.html">
   <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-mix2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-mix2.html
@@ -8,7 +8,7 @@
   <title>CSS Grid Test: Masonry layout column sizing - max-content</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-grid-3">
-  <link rel="match" href="masonry-intrinsic-sizing-rows-004-ref.html">
+  <link rel="match" href="masonry-intrinsic-sizing-rows-004-mix2-ref.html">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";


### PR DESCRIPTION
#### 12db787eb9ee45a825d4ff3894c3f7c8e6bce0f9
<pre>
[css-masonry] Fix intrinsic sizing ref link in test cases
<a href="https://bugs.webkit.org/show_bug.cgi?id=283940">https://bugs.webkit.org/show_bug.cgi?id=283940</a>
<a href="https://rdar.apple.com/problem/140813698">rdar://problem/140813698</a>

Reviewed by Tim Nguyen.

The ref links were wrong in several intrinsic sizing tests cases.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001-auto.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001-fr.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001-mix1.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001-mix2.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-auto.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-fr.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-mix1.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-mix2.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-auto.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-fr.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-mix1.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-mix2.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-auto.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-fr.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-mix1.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-mix2.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001-auto.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001-fr.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001-mix1.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001-mix2.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-auto.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-fr.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-mix1.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-mix2.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-auto.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-fr.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-mix1.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-mix2.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-auto.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-fr.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-mix1.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-mix2.html:

Canonical link: <a href="https://commits.webkit.org/287251@main">https://commits.webkit.org/287251@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8e56eefeaa6cfe39c45dba7a295e66842a62697

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78923 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32303 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83570 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30161 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67095 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6242 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61792 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19719 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81990 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51831 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/71817 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42096 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49181 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26015 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28515 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70295 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26424 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84949 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6271 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70023 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6434 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67840 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69274 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17262 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13320 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12065 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6220 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6188 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9641 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7979 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->