### PR TITLE
Add initial ImageDataArray as replacement type for ImageData::m_data

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1603,6 +1603,7 @@ html/HTMLWBRElement.cpp
 html/HiddenInputType.cpp
 html/ImageBitmap.cpp
 html/ImageData.cpp
+html/ImageDataArray.cpp
 html/ImageDocument.cpp
 html/ImageInputType.cpp
 html/InputMode.cpp

--- a/Source/WebCore/html/ImageData.cpp
+++ b/Source/WebCore/html/ImageData.cpp
@@ -72,10 +72,10 @@ RefPtr<ImageData> ImageData::create(const IntSize& size, PredefinedColorSpace co
     return adoptRef(*new ImageData(size, byteArray.releaseNonNull(), colorSpace));
 }
 
-RefPtr<ImageData> ImageData::create(const IntSize& size, Ref<Uint8ClampedArray>&& byteArray, PredefinedColorSpace colorSpace)
+RefPtr<ImageData> ImageData::create(const IntSize& size, ImageDataArray&& byteArray, PredefinedColorSpace colorSpace)
 {
     auto dataSize = computeDataSize(size);
-    if (dataSize.hasOverflowed() || dataSize != byteArray->length())
+    if (dataSize.hasOverflowed() || dataSize != byteArray.length())
         return nullptr;
 
     return adoptRef(*new ImageData(size, WTFMove(byteArray), colorSpace));
@@ -119,9 +119,9 @@ ExceptionOr<Ref<ImageData>> ImageData::create(unsigned sw, unsigned sh, std::opt
     return adoptRef(*new ImageData(size, byteArray.releaseNonNull(), colorSpace));
 }
 
-ExceptionOr<Ref<ImageData>> ImageData::create(Ref<Uint8ClampedArray>&& byteArray, unsigned sw, std::optional<unsigned> sh, std::optional<ImageDataSettings> settings)
+ExceptionOr<Ref<ImageData>> ImageData::create(ImageDataArray&& byteArray, unsigned sw, std::optional<unsigned> sh, std::optional<ImageDataSettings> settings)
 {
-    unsigned length = byteArray->length();
+    unsigned length = byteArray.length();
     if (!length || length % 4)
         return Exception { ExceptionCode::InvalidStateError, "Length is not a non-zero multiple of 4"_s };
 
@@ -135,14 +135,14 @@ ExceptionOr<Ref<ImageData>> ImageData::create(Ref<Uint8ClampedArray>&& byteArray
 
     IntSize size(sw, height);
     auto dataSize = computeDataSize(size);
-    if (dataSize.hasOverflowed() || dataSize != byteArray->length())
+    if (dataSize.hasOverflowed() || dataSize != byteArray.length())
         return Exception { ExceptionCode::RangeError };
 
     auto colorSpace = computeColorSpace(settings);
     return adoptRef(*new ImageData(size, WTFMove(byteArray), colorSpace));
 }
 
-ImageData::ImageData(const IntSize& size, Ref<JSC::Uint8ClampedArray>&& data, PredefinedColorSpace colorSpace)
+ImageData::ImageData(const IntSize& size, ImageDataArray&& data, PredefinedColorSpace colorSpace)
     : m_size(size)
     , m_data(WTFMove(data))
     , m_colorSpace(colorSpace)
@@ -159,7 +159,7 @@ Ref<ByteArrayPixelBuffer> ImageData::pixelBuffer() const
 
 RefPtr<ImageData> ImageData::clone() const
 {
-    return ImageData::create(m_size, Uint8ClampedArray::create(m_data->data(), m_data->length()), m_colorSpace);
+    return ImageData::create(m_size, Uint8ClampedArray::create(m_data.data(), m_data.length()), m_colorSpace);
 }
 
 TextStream& operator<<(TextStream& ts, const ImageData& imageData)

--- a/Source/WebCore/html/ImageData.h
+++ b/Source/WebCore/html/ImageData.h
@@ -30,6 +30,7 @@
 
 #include "ByteArrayPixelBuffer.h"
 #include "ExceptionOr.h"
+#include "ImageDataArray.h"
 #include "ImageDataSettings.h"
 #include "IntSize.h"
 #include "PredefinedColorSpace.h"
@@ -43,10 +44,10 @@ public:
     WEBCORE_EXPORT static Ref<ImageData> create(Ref<ByteArrayPixelBuffer>&&);
     WEBCORE_EXPORT static RefPtr<ImageData> create(RefPtr<ByteArrayPixelBuffer>&&);
     WEBCORE_EXPORT static RefPtr<ImageData> create(const IntSize&, PredefinedColorSpace);
-    WEBCORE_EXPORT static RefPtr<ImageData> create(const IntSize&, Ref<Uint8ClampedArray>&&, PredefinedColorSpace);
+    WEBCORE_EXPORT static RefPtr<ImageData> create(const IntSize&, ImageDataArray&&, PredefinedColorSpace);
     WEBCORE_EXPORT static ExceptionOr<Ref<ImageData>> createUninitialized(unsigned rows, unsigned pixelsPerRow, PredefinedColorSpace defaultColorSpace, std::optional<ImageDataSettings> = std::nullopt);
     WEBCORE_EXPORT static ExceptionOr<Ref<ImageData>> create(unsigned sw, unsigned sh, std::optional<ImageDataSettings>);
-    WEBCORE_EXPORT static ExceptionOr<Ref<ImageData>> create(Ref<Uint8ClampedArray>&&, unsigned sw, std::optional<unsigned> sh, std::optional<ImageDataSettings>);
+    WEBCORE_EXPORT static ExceptionOr<Ref<ImageData>> create(ImageDataArray&&, unsigned sw, std::optional<unsigned> sh, std::optional<ImageDataSettings>);
 
     WEBCORE_EXPORT ~ImageData();
 
@@ -64,10 +65,10 @@ public:
     RefPtr<ImageData> clone() const;
 
 private:
-    explicit ImageData(const IntSize&, Ref<JSC::Uint8ClampedArray>&&, PredefinedColorSpace);
+    explicit ImageData(const IntSize&, ImageDataArray&&, PredefinedColorSpace);
 
     IntSize m_size;
-    Ref<JSC::Uint8ClampedArray> m_data;
+    ImageDataArray m_data;
     PredefinedColorSpace m_colorSpace;
 };
 

--- a/Source/WebCore/html/ImageDataArray.cpp
+++ b/Source/WebCore/html/ImageDataArray.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * 3.  Neither the name of Apple Inc. ("Apple") nor the names of
+ *     its contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ImageDataArray.h"
+
+namespace WebCore {
+
+} // namespace WebCore

--- a/Source/WebCore/html/ImageDataArray.h
+++ b/Source/WebCore/html/ImageDataArray.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * 3.  Neither the name of Apple Inc. ("Apple") nor the names of
+ *     its contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <JavaScriptCore/Uint8ClampedArray.h>
+
+namespace WebCore {
+
+class ImageDataArray {
+public:
+    // FIXME: This API is the minimum subset as currently used by ImageData. More to come...
+    ImageDataArray(Ref<JSC::Uint8ClampedArray>&& data)
+        : m_bufferView(WTFMove(data))
+    { }
+
+    auto length() const
+    {
+        Ref bufferView = m_bufferView;
+        return bufferView->length();
+    }
+
+    // FIXME: Remove these temporary functions.
+    Uint8ClampedArray& get() const { return m_bufferView.get(); }
+    auto data() const
+    {
+        Ref bufferView = m_bufferView;
+        return bufferView->data();
+    }
+
+private:
+    // FIXME: Handle other typed arrays.
+    Ref<JSC::Uint8ClampedArray> m_bufferView;
+};
+
+} // namespace WebCore


### PR DESCRIPTION
#### faf054788cd86c2302c77d2d5368e342924f982a
<pre>
Add initial ImageDataArray as replacement type for ImageData::m_data
<a href="https://bugs.webkit.org/show_bug.cgi?id=283939">https://bugs.webkit.org/show_bug.cgi?id=283939</a>
<a href="https://rdar.apple.com/problem/140813668">rdar://problem/140813668</a>

Reviewed by Said Abou-Hallawa.

Currently `ImageData::m_data` is a `Ref&lt;JSC::Uint8ClampedArray&gt;` (corresponding
to ImageData.idl&apos;s `attribute ImageDataArray data`), so it can only deal with
byte-sized color components like RGBA.
To allow float16 support (the idl data type will change to something like
`typedef (Uint8ClampedArray or Float16Array) ImageDataArray`), `ImageData::m_data`
should be able to hold other typed-array types, like `JSC::Float16Array`.
As a first step, we&apos;ll move the `Ref&lt;JSC::Uint8ClampedArray&gt;` to a separate class,
and that class will eventually handle more types.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/ImageData.cpp:
(WebCore::ImageData::create):
(WebCore::ImageData::ImageData):
(WebCore::ImageData::clone const):
* Source/WebCore/html/ImageData.h:
* Source/WebCore/html/ImageDataArray.cpp: Added.
* Source/WebCore/html/ImageDataArray.h: Added.
(WebCore::ImageDataArray::ImageDataArray):
(WebCore::ImageDataArray::length const):
(WebCore::ImageDataArray::get const):
(WebCore::ImageDataArray::data const):

Canonical link: <a href="https://commits.webkit.org/287312@main">https://commits.webkit.org/287312@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94b7c6acf2da2ad32a25dc9f980d11744e40e643

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79006 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58042 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32383 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83646 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30221 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81139 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67151 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6312 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61838 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19755 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82073 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51875 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/71977 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42142 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49226 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26089 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28587 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70340 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26502 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85032 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6331 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4373 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70071 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6495 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67890 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69321 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17298 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13367 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12125 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6283 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12133 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6244 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9695 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8035 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->