### PR TITLE
Crash when ResponsivenessTimer fires

### DIFF
--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -205,10 +205,8 @@ public:
 
     void checkForResponsiveness(CompletionHandler<void()>&& = nullptr, UseLazyStop = UseLazyStop::No);
 
-    ResponsivenessTimer& responsivenessTimer() { return m_responsivenessTimer; }
-    const ResponsivenessTimer& responsivenessTimer() const { return m_responsivenessTimer; }
-    CheckedRef<ResponsivenessTimer> checkedResponsivenessTimer() { return m_responsivenessTimer; }
-    CheckedRef<const ResponsivenessTimer> checkedResponsivenessTimer() const { return m_responsivenessTimer; }
+    ResponsivenessTimer& responsivenessTimer() const { return m_responsivenessTimer.get(); }
+    Ref<ResponsivenessTimer> protectedResponsivenessTimer() const { return m_responsivenessTimer; }
 
     void ref() const final { ThreadSafeRefCounted::ref(); }
     void deref() const final { ThreadSafeRefCounted::deref(); }
@@ -310,7 +308,7 @@ private:
     // Connection::Client
     void requestRemoteProcessTermination() final;
 
-    ResponsivenessTimer m_responsivenessTimer;
+    const Ref<ResponsivenessTimer> m_responsivenessTimer;
     Vector<PendingMessage> m_pendingMessages;
     RefPtr<ProcessLauncher> m_processLauncher;
     RefPtr<IPC::Connection> m_connection;

--- a/Source/WebKit/UIProcess/ResponsivenessTimer.h
+++ b/Source/WebKit/UIProcess/ResponsivenessTimer.h
@@ -27,15 +27,14 @@
 #define ResponsivenessTimer_h
 
 #include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
-#include <wtf/CheckedPtr.h>
+#include <wtf/RefCounted.h>
 #include <wtf/RunLoop.h>
 #include <wtf/WeakRef.h>
 
 namespace WebKit {
 
-class ResponsivenessTimer : public CanMakeCheckedPtr<ResponsivenessTimer> {
+class ResponsivenessTimer : public RefCounted<ResponsivenessTimer> {
     WTF_MAKE_FAST_ALLOCATED;
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ResponsivenessTimer);
 public:
     class Client : public AbstractRefCountedAndCanMakeWeakPtr<Client> {
     public:
@@ -50,7 +49,7 @@ public:
     };
 
     static constexpr Seconds defaultResponsivenessTimeout = 3_s;
-    ResponsivenessTimer(ResponsivenessTimer::Client&, Seconds responsivenessTimeout);
+    static Ref<ResponsivenessTimer> create(ResponsivenessTimer::Client&, Seconds responsivenessTimeout);
     ~ResponsivenessTimer();
 
     void start();
@@ -78,13 +77,13 @@ public:
     void processTerminated();
 
 private:
-    Ref<Client> protectedClient() const;
+    ResponsivenessTimer(ResponsivenessTimer::Client&, Seconds responsivenessTimeout);
 
     void timerFired();
 
     bool mayBecomeUnresponsive() const;
 
-    WeakRef<ResponsivenessTimer::Client> m_client;
+    WeakPtr<ResponsivenessTimer::Client> m_client;
 
     RunLoop::Timer m_timer;
     MonotonicTime m_restartFireTime;


### PR DESCRIPTION
#### c5617f4184ab9289950d98b59eb5803d405edf6e
<pre>
Crash when ResponsivenessTimer fires
<a href="https://bugs.webkit.org/show_bug.cgi?id=283948">https://bugs.webkit.org/show_bug.cgi?id=283948</a>
<a href="https://rdar.apple.com/140572152">rdar://140572152</a>

Reviewed by Darin Adler and Brady Eidson.

I recently made it so that RunLoop::Timer will protect the object it is calling
the &quot;timeout&quot; function on, either via a RefPtr or a CheckedPtr. Given that
ResponsivenessTimer subclassed CanMakeCheckedPtr, it would use a CheckedPtr.

As a speculative fix for the crash, make ResponsivenessTimer RefCounted. As a
result, RunLoop::Timer will now ref the ResponsivenessTimer before calling
`timerFired()` on it, which should be safer than a CheckedPtr. One could
imagine `timerFired()` causing the ResponsivenessTimer to get destroyed
otherwise, since it calls some client functions.

* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::stopResponsivenessTimer):
(WebKit::AuxiliaryProcessProxy::startResponsivenessTimer):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
(WebKit::AuxiliaryProcessProxy::protectedResponsivenessTimer):
(WebKit::AuxiliaryProcessProxy::protectedResponsivenessTimer const):
(WebKit::AuxiliaryProcessProxy::checkedResponsivenessTimer): Deleted.
(WebKit::AuxiliaryProcessProxy::checkedResponsivenessTimer const): Deleted.
* Source/WebKit/UIProcess/ResponsivenessTimer.h:
(WebKit::ResponsivenessTimer::ref const):
(WebKit::ResponsivenessTimer::deref const):

Canonical link: <a href="https://commits.webkit.org/287301@main">https://commits.webkit.org/287301@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e62fe25a662a67c152b1e5bda2cf12bc74ca401

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79070 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58106 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32447 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83709 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30284 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67214 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6376 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61884 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19803 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82137 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51930 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72068 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42188 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49281 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28648 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70397 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26589 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85096 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6394 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4423 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70125 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6558 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67940 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69374 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13419 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12202 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12210 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6345 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12171 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6304 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9757 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8097 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->