### PR TITLE
[block-step-sizing] Add stubs for adjusting padding and content areas.

### DIFF
--- a/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/Source/WebCore/rendering/RenderBlockFlow.h
@@ -236,7 +236,7 @@ public:
     };
 
     bool shouldTrimChildMargin(MarginTrimType, const RenderBox&) const;
-    void distributeExtraBlockStepSizingSpaceToChild(RenderBox& child, LayoutUnit extraSpace) const;
+    void performBlockStepSizing(RenderBox& child, LayoutUnit blockStepSizeForChild) const;
 
     void layoutBlockChild(RenderBox& child, MarginInfo&, LayoutUnit& previousFloatLogicalBottom, LayoutUnit& maxFloatLogicalBottom);
     void adjustPositionedBlock(RenderBox& child, const MarginInfo&);


### PR DESCRIPTION
#### a81e0173e5704bb9984e2f2b45f02f4462dbb3b3
<pre>
[block-step-sizing] Add stubs for adjusting padding and content areas.
<a href="https://bugs.webkit.org/show_bug.cgi?id=283953">https://bugs.webkit.org/show_bug.cgi?id=283953</a>
<a href="https://rdar.apple.com/140825557">rdar://140825557</a>

Reviewed by Tim Nguyen.

This is a refactoring that adds some stub functions aimed at helping
indicate which type of adjustments we currently support for
block-step-sizing. Adjustments to the margins are currently supported
while changes to the padding and content area still need to be
implemented.

1.) Move the code that handles block step sizing from
RenderBlockFlow::layoutBlockChild to a dedicated performBlockStepSizing
method so we do not pollute layoutBlockChild.
2.) perfromBlockStepSizing will call into the appropriate helper
function after computing the extra space to distribute it based on
block-step-insert

We will also put these helper functions into their own namespace to
organize them better and makes the naming less awkward (don&apos;t need to
shove BlockStepSizing into the naming somehow).

* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::BlockStepSizing::computeExtraSpace):
(WebCore::BlockStepSizing::distributeExtraSpaceToChildMargins):
(WebCore::BlockStepSizing::distributeExtraSpaceToChildPadding):
(WebCore::BlockStepSizing::distributeExtraSpaceToChildContentArea):
(WebCore::RenderBlockFlow::performBlockStepSizing const):
(WebCore::RenderBlockFlow::layoutBlockChild):
(WebCore::computeExtraSpaceForBlockStepSizing): Deleted.
(WebCore::RenderBlockFlow::distributeExtraBlockStepSizingSpaceToChild const): Deleted.
* Source/WebCore/rendering/RenderBlockFlow.h:

Canonical link: <a href="https://commits.webkit.org/287315@main">https://commits.webkit.org/287315@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91575d01987d5d346edf4759c95069c452d94fac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79105 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58141 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32482 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83743 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30315 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81238 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67247 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6410 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61908 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19824 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82172 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51953 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72100 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42212 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49304 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26214 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28682 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70420 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26635 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85130 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6426 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4445 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70148 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6589 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67971 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69396 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17303 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13444 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12244 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6378 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12190 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6331 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9788 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8123 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->