### PR TITLE
[rhythmic-sizing] Add block-step-align to CSS parser

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -37,6 +37,7 @@ PASS background-size
 PASS baseline-shift
 PASS block-ellipsis
 PASS block-size
+PASS block-step-align
 PASS block-step-insert
 PASS block-step-size
 PASS border-block-end-color

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-align-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-align-computed-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Property block-step-align value 'auto'
+PASS Property block-step-align value 'center'
+PASS Property block-step-align value 'start'
+PASS Property block-step-align value 'end'
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-align-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-align-computed.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Rhythm: block-step-align computed values</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-align">
+<meta name="assert" content="Checking computed values for block-step-align">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+    test_computed_value("block-step-align", "auto");
+    test_computed_value("block-step-align", "center");
+    test_computed_value("block-step-align", "start");
+    test_computed_value("block-step-align", "end");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-align-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-align-invalid-expected.txt
@@ -1,0 +1,15 @@
+
+PASS e.style['block-step-align'] = "auto auto" should not set the property value
+PASS e.style['block-step-align'] = "start end" should not set the property value
+PASS e.style['block-step-align'] = "center start" should not set the property value
+PASS e.style['block-step-align'] = "end auto" should not set the property value
+PASS e.style['block-step-align'] = "-1px" should not set the property value
+PASS e.style['block-step-align'] = "min-content" should not set the property value
+PASS e.style['block-step-align'] = "10%" should not set the property value
+PASS e.style['block-step-align'] = "20" should not set the property value
+PASS e.style['block-step-align'] = "none" should not set the property value
+PASS e.style['block-step-align'] = "border-box" should not set the property value
+PASS e.style['block-step-align'] = "margin" should not set the property value
+PASS e.style['block-step-align'] = "padding" should not set the property value
+PASS e.style['block-step-align'] = "content" should not set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-align-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-align-invalid.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Rhythm: block-step-align invalid values</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-align">
+<meta name="assert" content="Invalid values for block-step-align should not be parsed">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+    test_invalid_value("block-step-align", "auto auto");
+    test_invalid_value("block-step-align", "start end");
+    test_invalid_value("block-step-align", "center start");
+    test_invalid_value("block-step-align", "end auto");
+    test_invalid_value("block-step-align", "-1px");
+    test_invalid_value("block-step-align", "min-content");
+    test_invalid_value("block-step-align", "10%");
+    test_invalid_value("block-step-align", "20");
+    test_invalid_value("block-step-align", "none");
+    test_invalid_value("block-step-align", "border-box");
+    test_invalid_value('block-step-align', "margin");
+    test_invalid_value("block-step-align", "padding")
+    test_invalid_value("block-step-align", "content")
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-align-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-align-valid-expected.txt
@@ -1,0 +1,6 @@
+
+PASS e.style['block-step-align'] = "auto" should set the property value
+PASS e.style['block-step-align'] = "center" should set the property value
+PASS e.style['block-step-align'] = "start" should set the property value
+PASS e.style['block-step-align'] = "end" should set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-align-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-align-valid.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Rhythm: block-step-align valid values</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-align">
+<meta name="assert" content="Parsing valid values for block-step-align property">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+    test_valid_value("block-step-align", "auto");
+    test_valid_value("block-step-align", "center");
+    test_valid_value("block-step-align", "start");
+    test_valid_value("block-step-align", "end");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-computed.html
@@ -8,7 +8,6 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/computed-testcommon.js"></script>
-<script src="/css/support/parsing-testcommon.js"></script>
 <style>
     #target {
       font-size: 40px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-invalid.html
@@ -7,16 +7,9 @@
 <meta name="assert" content="Invalid values for block-step-insert should not be parsed">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/css/support/computed-testcommon.js"></script>
 <script src="/css/support/parsing-testcommon.js"></script>
-<style>
-    #target {
-      font-size: 40px;
-    }
-</style>
 </head>
 <body>
-<div id="target"></div>
 <script>
     test_invalid_value("block-step-insert", "auto");
     test_invalid_value("block-step-insert", "-1px");

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-valid.html
@@ -7,16 +7,9 @@
 <meta name="assert" content="Parsing valid values for block-step-insert property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/css/support/computed-testcommon.js"></script>
 <script src="/css/support/parsing-testcommon.js"></script>
-<style>
-    #target {
-      font-size: 40px;
-    }
-</style>
 </head>
 <body>
-<div id="target"></div>
 <script>
     test_valid_value("block-step-insert", "margin-box");
     test_valid_value("block-step-insert", "padding-box");

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-size-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-size-computed.html
@@ -8,7 +8,6 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/computed-testcommon.js"></script>
-<script src="/css/support/parsing-testcommon.js"></script>
 <style>
     #target {
       font-size: 40px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-size-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-size-invalid.html
@@ -7,16 +7,9 @@
 <meta name="assert" content="Invalid values for block-step-size should not be parsed">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/css/support/computed-testcommon.js"></script>
 <script src="/css/support/parsing-testcommon.js"></script>
-<style>
-    #target {
-      font-size: 40px;
-    }
-</style>
 </head>
 <body>
-<div id="target"></div>
 <script>
     test_invalid_value("block-step-size", "auto");
     test_invalid_value("block-step-size", "-1px");

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-size-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-size-valid.html
@@ -7,16 +7,9 @@
 <meta name="assert" content="Parsing valid values for block-step-size properties">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/css/support/computed-testcommon.js"></script>
 <script src="/css/support/parsing-testcommon.js"></script>
-<style>
-    #target {
-      font-size: 40px;
-    }
-</style>
 </head>
 <body>
-<div id="target"></div>
 <script>
     test_valid_value("block-step-size", "1px");
     test_valid_value("block-step-size", "2em");

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-001-expected.txt
@@ -43,6 +43,13 @@ PASS background-origin: "padding-box" onto "content-box"
 PASS background-repeat (type: discrete) has testAccumulation function
 PASS background-repeat: "round" onto "space"
 PASS background-repeat: "space" onto "round"
+PASS block-step-align (type: discrete) has testAccumulation function
+PASS block-step-align: "center" onto "auto"
+PASS block-step-align: "auto" onto "center"
+PASS block-step-align: "start" onto "end"
+PASS block-step-align: "end" onto "start"
+PASS block-step-align: "center" onto "start"
+PASS block-step-align: "start" onto "center"
 PASS block-step-insert (type: discrete) has testAccumulation function
 PASS block-step-insert: "padding-box" onto "margin-box"
 PASS block-step-insert: "margin-box" onto "padding-box"

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-001-expected.txt
@@ -43,6 +43,13 @@ PASS background-origin: "padding-box" onto "content-box"
 PASS background-repeat (type: discrete) has testAddition function
 PASS background-repeat: "round" onto "space"
 PASS background-repeat: "space" onto "round"
+PASS block-step-align (type: discrete) has testAddition function
+PASS block-step-align: "center" onto "auto"
+PASS block-step-align: "auto" onto "center"
+PASS block-step-align: "start" onto "end"
+PASS block-step-align: "end" onto "start"
+PASS block-step-align: "center" onto "start"
+PASS block-step-align: "start" onto "center"
 PASS block-step-insert (type: discrete) has testAddition function
 PASS block-step-insert: "padding-box" onto "margin-box"
 PASS block-step-insert: "margin-box" onto "padding-box"

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001-expected.txt
@@ -55,6 +55,16 @@ PASS background-repeat (type: discrete) has testInterpolation function
 PASS background-repeat uses discrete animation when animating between "space" and "round" with linear easing
 PASS background-repeat uses discrete animation when animating between "space" and "round" with effect easing
 PASS background-repeat uses discrete animation when animating between "space" and "round" with keyframe easing
+PASS block-step-align (type: discrete) has testInterpolation function
+PASS block-step-align uses discrete animation when animating between "auto" and "center" with linear easing
+PASS block-step-align uses discrete animation when animating between "auto" and "center" with effect easing
+PASS block-step-align uses discrete animation when animating between "auto" and "center" with keyframe easing
+PASS block-step-align uses discrete animation when animating between "end" and "start" with linear easing
+PASS block-step-align uses discrete animation when animating between "end" and "start" with effect easing
+PASS block-step-align uses discrete animation when animating between "end" and "start" with keyframe easing
+PASS block-step-align uses discrete animation when animating between "start" and "center" with linear easing
+PASS block-step-align uses discrete animation when animating between "start" and "center" with effect easing
+PASS block-step-align uses discrete animation when animating between "start" and "center" with keyframe easing
 PASS block-step-insert (type: discrete) has testInterpolation function
 PASS block-step-insert uses discrete animation when animating between "margin-box" and "padding-box" with linear easing
 PASS block-step-insert uses discrete animation when animating between "margin-box" and "padding-box" with effect easing

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js
@@ -104,6 +104,12 @@ const gCSSProperties1 = {
     types: [
     ]
   },
+  'block-step-align': {
+    // https://drafts.csswg.org/css-rhythm/#block-step-align
+    types: [
+      { type: 'discrete', options: [ [ 'auto', 'center'], ['end', 'start'], ['start', 'center'] ] }
+    ]
+  },
   'block-step-insert': {
     // https://drafts.csswg.org/css-rhythm/#block-step-insert
     types: [

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -34,6 +34,7 @@ PASS background-repeat
 PASS background-size
 PASS baseline-shift
 PASS block-size
+PASS block-step-align
 PASS block-step-insert
 PASS block-step-size
 PASS border-block-end-color

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -37,6 +37,7 @@ PASS background-size
 PASS baseline-shift
 PASS block-ellipsis
 PASS block-size
+PASS block-step-align
 PASS block-step-insert
 PASS block-step-size
 PASS border-block-end-color

--- a/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -35,6 +35,7 @@ PASS background-size
 PASS baseline-shift
 PASS block-ellipsis
 PASS block-size
+PASS block-step-align
 PASS block-step-insert
 PASS block-step-size
 PASS border-block-end-color

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -36,6 +36,7 @@ PASS background-size
 PASS baseline-shift
 PASS block-ellipsis
 PASS block-size
+PASS block-step-align
 PASS block-step-insert
 PASS block-step-size
 PASS border-block-end-color

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -3939,6 +3939,7 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
 
         new TabSizePropertyWrapper,
 
+        new DiscretePropertyWrapper<BlockStepAlign>(CSSPropertyBlockStepAlign, &RenderStyle::blockStepAlign, &RenderStyle::setBlockStepAlign),
         new DiscretePropertyWrapper<BlockStepInsert>(CSSPropertyBlockStepInsert, &RenderStyle::blockStepInsert, &RenderStyle::setBlockStepInsert),
         new OptionalLengthPropertyWrapper(CSSPropertyBlockStepSize, &RenderStyle::blockStepSize, &RenderStyle::setBlockStepSize, { OptionalLengthPropertyWrapper::Flags::NegativeLengthsAreInvalid }),
 

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -174,6 +174,19 @@ DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE
 #undef FOR_EACH
 
+#define TYPE BlockStepAlign
+#define FOR_EACH(CASE) CASE(Auto) CASE(Center) CASE(Start) CASE(End)
+DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
+#undef TYPE
+#undef FOR_EACH
+
+#define TYPE BlockStepInsert
+#define FOR_EACH(CASE) CASE(MarginBox) CASE(PaddingBox) CASE(ContentBox)
+DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
+#undef TYPE
+#undef FOR_EACH
+
+
 constexpr CSSValueID toCSSValueID(BorderStyle e)
 {
     switch (e) {
@@ -214,15 +227,6 @@ template<> constexpr OutlineIsAuto fromCSSValueID(CSSValueID valueID)
     if (valueID == CSSValueAuto)
         return OutlineIsAuto::On;
     return OutlineIsAuto::Off;
-}
-
-template<> constexpr BlockStepInsert fromCSSValueID(CSSValueID valueID)
-{
-    if (valueID == CSSValueMarginBox)
-        return BlockStepInsert::MarginBox;
-    if (valueID == CSSValuePaddingBox)
-        return BlockStepInsert::PaddingBox;
-    return BlockStepInsert::ContentBox;
 }
 
 constexpr CSSValueID toCSSValueID(CompositeOperator e, CSSPropertyID propertyID)

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -268,15 +268,20 @@
                 "url": "https://www.w3.org/TR/css-ui-4/#widget-accent"
             }
         },
-        "block-step-size": {
+        "block-step-align": {
+            "values": [
+                "auto",
+                "center",
+                "start",
+                "end"
+            ],
             "codegen-properties": {
                 "settings-flag": "cssRhythmicSizingEnabled",
-                "converter": "BlockStepSize",
-                "parser-grammar": "none | <length [0,inf]>"
+                "parser-grammar": "<<values>>"
             },
             "specification": {
                 "category": "css-rhythm",
-                "url": "https://drafts.csswg.org/css-rhythm/#block-step-size"
+                "url": "https://drafts.csswg.org/css-rhythm/#block-step-align"
             },
             "status": "in development"
         },
@@ -289,6 +294,18 @@
             "codegen-properties": {
                 "settings-flag": "cssRhythmicSizingEnabled",
                 "parser-grammar": "<<values>>"
+            },
+            "specification": {
+                "category": "css-rhythm",
+                "url": "https://drafts.csswg.org/css-rhythm/#block-step-size"
+            },
+            "status": "in development"
+        },
+        "block-step-size": {
+            "codegen-properties": {
+                "settings-flag": "cssRhythmicSizingEnabled",
+                "converter": "BlockStepSize",
+                "parser-grammar": "none | <length [0,inf]>"
             },
             "specification": {
                 "category": "css-rhythm",

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -3582,6 +3582,20 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
             ASSERT_NOT_REACHED();
         }
         return CSSPrimitiveValue::create(CSSValueNone);
+    case CSSPropertyBlockStepAlign:
+        switch (style.blockStepAlign()) {
+        case BlockStepAlign::Auto:
+            return CSSPrimitiveValue::create(CSSValueAuto);
+        case BlockStepAlign::Center:
+            return CSSPrimitiveValue::create(CSSValueCenter);
+        case BlockStepAlign::Start:
+            return CSSPrimitiveValue::create(CSSValueStart);
+        case BlockStepAlign::End:
+            return CSSPrimitiveValue::create(CSSValueEnd);
+        default:
+            ASSERT_NOT_REACHED();
+            return CSSPrimitiveValue::create(CSSValueAuto);
+        }
     case CSSPropertyBlockStepInsert:
         switch (style.blockStepInsert()) {
         case BlockStepInsert::MarginBox:
@@ -3592,7 +3606,7 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
             return CSSPrimitiveValue::create(CSSValueContentBox);
         default:
             ASSERT_NOT_REACHED();
-            return CSSPrimitiveValue::create(CSSValueNone);
+            return CSSPrimitiveValue::create(CSSValueMarginBox);
         }
     case CSSPropertyBlockStepSize: {
         auto blockStepSize = style.blockStepSize();

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -1810,6 +1810,8 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
     };
 
     auto conservativelyCollectChangedAnimatablePropertiesViaNonInheritedRareData = [&](auto& first, auto& second) {
+        if (first.blockStepAlign != second.blockStepAlign)
+            changingProperties.m_properties.set(CSSPropertyBlockStepAlign);
         if (first.blockStepInsert != second.blockStepInsert)
             changingProperties.m_properties.set(CSSPropertyBlockStepInsert);
         if (first.blockStepSize != second.blockStepSize)

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -116,6 +116,7 @@ enum class AutoRepeatType : uint8_t;
 enum class BackfaceVisibility : uint8_t;
 enum class BlendMode : uint8_t;
 enum class FlowDirection : uint8_t;
+enum class BlockStepAlign : uint8_t;
 enum class BlockStepInsert : uint8_t;
 enum class BorderCollapse : bool;
 enum class BorderStyle : uint8_t;
@@ -2254,6 +2255,10 @@ public:
     static inline std::optional<Length> initialBlockStepSize();
     inline std::optional<Length> blockStepSize() const;
     inline void setBlockStepSize(std::optional<Length>);
+
+    static constexpr BlockStepAlign initialBlockStepAlign();
+    inline BlockStepAlign blockStepAlign() const;
+    inline void setBlockStepAlign(BlockStepAlign);
 
     static constexpr BlockStepInsert initialBlockStepInsert();
     inline BlockStepInsert blockStepInsert() const;

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -107,6 +107,17 @@ TextStream& operator<<(TextStream& ts, BackfaceVisibility visibility)
     return ts;
 }
 
+TextStream& operator<<(TextStream& ts, BlockStepAlign blockStepAlign)
+{
+    switch (blockStepAlign) {
+    case BlockStepAlign::Auto: ts << "auto"; break;
+    case BlockStepAlign::Center: ts << "center"; break;
+    case BlockStepAlign::Start: ts << "start"; break;
+    case BlockStepAlign::End: ts << "end"; break;
+    }
+    return ts;
+}
+
 TextStream& operator<<(TextStream& ts, BlockStepInsert blockStepInsert)
 {
     switch (blockStepInsert) {

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -1197,7 +1197,13 @@ enum class ContentVisibility : uint8_t {
     Hidden,
 };
 
-// Stored as unsigned : 2 in StyleRareNonInheritedData
+enum class BlockStepAlign : uint8_t {
+    Auto,
+    Center,
+    Start,
+    End
+};
+
 enum class BlockStepInsert : uint8_t {
     MarginBox,
     PaddingBox,
@@ -1218,6 +1224,7 @@ WTF::TextStream& operator<<(WTF::TextStream&, AnimationPlayState);
 WTF::TextStream& operator<<(WTF::TextStream&, AspectRatioType);
 WTF::TextStream& operator<<(WTF::TextStream&, AutoRepeatType);
 WTF::TextStream& operator<<(WTF::TextStream&, BackfaceVisibility);
+WTF::TextStream& operator<<(WTF::TextStream&, BlockStepAlign);
 WTF::TextStream& operator<<(WTF::TextStream&, BlockStepInsert);
 WTF::TextStream& operator<<(WTF::TextStream&, BorderCollapse);
 WTF::TextStream& operator<<(WTF::TextStream&, BorderStyle);

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -100,6 +100,7 @@ inline FillSizeType RenderStyle::backgroundSizeType() const { return backgroundL
 inline const Length& RenderStyle::backgroundXPosition() const { return backgroundLayers().xPosition(); }
 inline const Length& RenderStyle::backgroundYPosition() const { return backgroundLayers().yPosition(); }
 inline const BlockEllipsis& RenderStyle::blockEllipsis() const { return m_rareInheritedData->blockEllipsis; }
+inline BlockStepAlign RenderStyle::blockStepAlign() const { return static_cast<BlockStepAlign>(m_nonInheritedData->rareData->blockStepAlign); }
 inline BlockStepInsert RenderStyle::blockStepInsert() const { return static_cast<BlockStepInsert>(m_nonInheritedData->rareData->blockStepInsert); }
 inline std::optional<Length> RenderStyle::blockStepSize() const { return m_nonInheritedData->rareData->blockStepSize; }
 inline const BorderData& RenderStyle::border() const { return m_nonInheritedData->surroundData->border; }
@@ -337,6 +338,7 @@ constexpr AspectRatioType RenderStyle::initialAspectRatioType() { return AspectR
 constexpr BackfaceVisibility RenderStyle::initialBackfaceVisibility() { return BackfaceVisibility::Visible; }
 inline Style::Color RenderStyle::initialBackgroundColor() { return Color::transparentBlack; }
 inline BlockEllipsis RenderStyle::initialBlockEllipsis() { return { }; }
+constexpr BlockStepAlign RenderStyle::initialBlockStepAlign() { return BlockStepAlign::Auto; }
 constexpr BlockStepInsert RenderStyle::initialBlockStepInsert() { return BlockStepInsert::MarginBox; }
 inline std::optional<Length> RenderStyle::initialBlockStepSize() { return std::nullopt; }
 constexpr BorderCollapse RenderStyle::initialBorderCollapse() { return BorderCollapse::Separate; }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -90,7 +90,8 @@ inline void RenderStyle::setBackgroundColor(const Style::Color& value) { SET_NES
 inline void RenderStyle::setBackgroundOrigin(FillBox fillBox) { SET_DOUBLY_NESTED_PAIR(m_nonInheritedData, backgroundData, background, m_origin, static_cast<unsigned>(fillBox), m_originSet, true); }
 inline void RenderStyle::setBackgroundRepeat(FillRepeatXY fillRepeat) { SET_DOUBLY_NESTED_PAIR(m_nonInheritedData, backgroundData, background, m_repeat, fillRepeat, m_repeatSet, true); }
 inline void RenderStyle::setBlockEllipsis(const BlockEllipsis& value) { SET(m_rareInheritedData, blockEllipsis, value); }
-inline void RenderStyle::setBlockStepInsert(BlockStepInsert newBlockStepInsert) { SET_NESTED(m_nonInheritedData, rareData, blockStepInsert, static_cast<unsigned>(newBlockStepInsert)); }
+inline void RenderStyle::setBlockStepAlign(BlockStepAlign value) { SET_NESTED(m_nonInheritedData, rareData, blockStepAlign, static_cast<unsigned>(value)); }
+inline void RenderStyle::setBlockStepInsert(BlockStepInsert value) { SET_NESTED(m_nonInheritedData, rareData, blockStepInsert, static_cast<unsigned>(value)); }
 inline void RenderStyle::setBlockStepSize(std::optional<Length> length) { SET_NESTED(m_nonInheritedData, rareData, blockStepSize, WTFMove(length)); }
 inline void RenderStyle::setBorderBottomColor(const Style::Color& value) { SET_NESTED_BORDER_COLOR(m_nonInheritedData, surroundData, border.m_bottom, value); }
 inline void RenderStyle::setBorderBottomLeftRadius(LengthSize&& size) { SET_NESTED(m_nonInheritedData, surroundData, border.m_radii.bottomLeft, WTFMove(size)); }

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
@@ -101,6 +101,7 @@ StyleRareNonInheritedData::StyleRareNonInheritedData()
     , anchorNames(RenderStyle::initialAnchorNames())
     , positionAnchor(RenderStyle::initialPositionAnchor())
     , blockStepSize(RenderStyle::initialBlockStepSize())
+    , blockStepAlign(static_cast<unsigned>(RenderStyle::initialBlockStepAlign()))
     , blockStepInsert(static_cast<unsigned>(RenderStyle::initialBlockStepInsert()))
     , overscrollBehaviorX(static_cast<unsigned>(RenderStyle::initialOverscrollBehaviorX()))
     , overscrollBehaviorY(static_cast<unsigned>(RenderStyle::initialOverscrollBehaviorY()))
@@ -198,6 +199,7 @@ inline StyleRareNonInheritedData::StyleRareNonInheritedData(const StyleRareNonIn
     , anchorNames(o.anchorNames)
     , positionAnchor(o.positionAnchor)
     , blockStepSize(o.blockStepSize)
+    , blockStepAlign(o.blockStepAlign)
     , blockStepInsert(o.blockStepInsert)
     , overscrollBehaviorX(o.overscrollBehaviorX)
     , overscrollBehaviorY(o.overscrollBehaviorY)
@@ -300,6 +302,7 @@ bool StyleRareNonInheritedData::operator==(const StyleRareNonInheritedData& o) c
         && anchorNames == o.anchorNames
         && positionAnchor == o.positionAnchor
         && blockStepSize == o.blockStepSize
+        && blockStepAlign == o.blockStepAlign
         && blockStepInsert == o.blockStepInsert
         && overscrollBehaviorX == o.overscrollBehaviorX
         && overscrollBehaviorY == o.overscrollBehaviorY
@@ -451,10 +454,11 @@ void StyleRareNonInheritedData::dumpDifferences(TextStream& ts, const StyleRareN
 
     LOG_IF_DIFFERENT(blockStepSize);
 
+    LOG_IF_DIFFERENT_WITH_CAST(BlockStepAlign, blockStepAlign);
     LOG_IF_DIFFERENT_WITH_CAST(BlockStepInsert, blockStepInsert);
 
     LOG_IF_DIFFERENT_WITH_CAST(OverscrollBehavior, overscrollBehaviorX);
-    LOG_IF_DIFFERENT_WITH_CAST(BlockStepInsert, overscrollBehaviorY);
+    LOG_IF_DIFFERENT_WITH_CAST(OverscrollBehavior, overscrollBehaviorY);
 
     LOG_IF_DIFFERENT_WITH_CAST(PageSizeType, pageSizeType);
 

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -213,6 +213,7 @@ public:
     std::optional<Style::ScopedName> positionAnchor;
 
     std::optional<Length> blockStepSize;
+    unsigned blockStepAlign : 2; // BlockStepAlign
     unsigned blockStepInsert : 2; // BlockStepInsert
 
     unsigned overscrollBehaviorX : 2; // OverscrollBehavior


### PR DESCRIPTION
#### 857aa61daa8062d9895a30b770aead1535d94a97
<pre>
[rhythmic-sizing] Add block-step-align to CSS parser
<a href="https://bugs.webkit.org/show_bug.cgi?id=252207">https://bugs.webkit.org/show_bug.cgi?id=252207</a>
<a href="https://rdar.apple.com/105421792">rdar://105421792</a>

Reviewed by Simon Fraser.

Parse block-step-align according to: <a href="https://drafts.csswg.org/css-rhythm/#block-step-align">https://drafts.csswg.org/css-rhythm/#block-step-align</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-align-computed-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-align-computed.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-align-invalid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-align-invalid.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-align-valid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-computed.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-invalid.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-valid.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-size-computed.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-size-invalid.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-size-valid.html:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle const):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::conservativelyCollectChangedAnimatableProperties const):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::blockStepAlign const):
(WebCore::RenderStyle::initialBlockStepAlign):
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setBlockStepAlign):
(WebCore::RenderStyle::setBlockStepInsert):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp:
(WebCore::StyleRareNonInheritedData::StyleRareNonInheritedData):
(WebCore::StyleRareNonInheritedData::operator== const):
(WebCore::StyleRareNonInheritedData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:

Canonical link: <a href="https://commits.webkit.org/287257@main">https://commits.webkit.org/287257@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/744f348e28f95ee9436ab44382742050ec862d42

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79004 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58040 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32381 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83644 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/30219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81137 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67149 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6310 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/61837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/30219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82071 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/51873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/71975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/42141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/49224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/26088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28585 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/70338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/26501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85030 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6329 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/70070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6493 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/67889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/69320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/13366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/12124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12186 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6281 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6242 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9693 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8033 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->