### PR TITLE
[WebGPU] BindGroups with destroyed resources should result in dropping the command buffer submission

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-283943-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-283943-expected.txt
@@ -1,0 +1,1 @@
+Test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-283943.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-283943.html
@@ -1,0 +1,23697 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = console.log;
+
+async function gc() {
+  await 0;
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUComputePassEncoder} computePassEncoder
+ */
+function clearResourceUsages(device, computePassEncoder) {
+  let code = `@compute @workgroup_size(1) fn c() {}`;
+  let module = device.createShaderModule({code});
+  computePassEncoder.setPipeline(device.createComputePipeline(
+    {
+      layout: 'auto',
+      compute: {module},
+    }));
+  computePassEncoder.dispatchWorkgroups(1);
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+const videoUrls = [
+
+];
+
+/**
+ * @param {number} index
+ * @returns {Promise<HTMLVideoElement>}
+ */
+function videoWithData(index) {
+  let video = document.createElement('video');
+  video.src = videoUrls[index % videoUrls.length];
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+/**
+ * @param {string} payload
+ * @returns {string}
+ */
+function toBlobUrl(payload) {
+  let blob = new Blob([payload], {type: 'text/javascript'});
+  return URL.createObjectURL(blob);
+}
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+let promise0 = navigator.gpu.requestAdapter({});
+let promise1 = navigator.gpu.requestAdapter({});
+let adapter0 = await promise1;
+let device0 = await adapter0.requestDevice({
+  defaultQueue: {},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxBindGroups: 4,
+    maxStorageTexturesPerShaderStage: 4,
+    maxVertexBuffers: 8,
+    maxBindGroupsPlusVertexBuffers: 24,
+    maxUniformBufferBindingSize: 15056727,
+    maxStorageBufferBindingSize: 162356192,
+  },
+});
+let canvas0 = document.createElement('canvas');
+let imageData0 = new ImageData(12, 20);
+let buffer0 = device0.createBuffer({
+  label: '\u0a18\u85b1\u1844\udb59',
+  size: 5085,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder0 = device0.createCommandEncoder({});
+try {
+device0.label = '\u0c1f\u{1f989}\u0057\u{1fecf}\u360d\u07f6\u4c92\u2784\u5dfe\u{1ff5f}\u61b8';
+} catch {}
+let commandEncoder1 = device0.createCommandEncoder();
+let computePassEncoder0 = commandEncoder1.beginComputePass({label: '\u08c3\uefaa\u1a4c\u6bd7\u{1fed4}\u016d\u0a96\u2e77'});
+let commandEncoder2 = device0.createCommandEncoder({label: '\ub164\ud3e1\u01c3\u{1fe12}\u0eb6\u0e9d'});
+let computePassEncoder1 = commandEncoder0.beginComputePass({});
+let gpuCanvasContext0 = canvas0.getContext('webgpu');
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let bindGroupLayout0 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 7,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup0 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 7, resource: {buffer: buffer0, offset: 0, size: 264}}]});
+let commandEncoder3 = device0.createCommandEncoder({});
+let computePassEncoder2 = commandEncoder2.beginComputePass({});
+let sampler0 = device0.createSampler({
+  label: '\u0159\u0a2e\uc0f5\u01ad\u051b\u02b2\u0ea3\ua17a\u{1fbe3}\u{1fa2a}',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 90.14,
+  lodMaxClamp: 100.00,
+});
+try {
+commandEncoder3.insertDebugMarker('\u0946');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+document.body.prepend(canvas0);
+let buffer1 = device0.createBuffer({
+  size: 23942,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+try {
+computePassEncoder2.setBindGroup(1, bindGroup0, new Uint32Array(684), 277, 0);
+} catch {}
+let bindGroup1 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 7, resource: {buffer: buffer0, offset: 1280, size: 836}}],
+});
+let buffer2 = device0.createBuffer({
+  size: 20725,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder4 = device0.createCommandEncoder({});
+let sampler1 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 52.40,
+});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup0, new Uint32Array(595), 1, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 3316, new Int16Array(8752), 958, 404);
+} catch {}
+let bindGroupLayout1 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 460,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'float', multisampled: false },
+    },
+    {binding: 296, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let commandEncoder5 = device0.createCommandEncoder({label: '\u9322\u06b1'});
+let texture0 = device0.createTexture({
+  label: '\u2d7d\u{1fbb7}\udfef\ub2b3\u13d8\ua809\u{1ff60}\u2df3\u{1f6af}\u2fda',
+  size: {width: 576, height: 576, depthOrArrayLayers: 1},
+  format: 'astc-6x6-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder3 = commandEncoder5.beginComputePass({});
+try {
+computePassEncoder3.setBindGroup(3, bindGroup0, new Uint32Array(30), 0, 0);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let textureView0 = texture0.createView({dimension: '2d-array'});
+let texture1 = device0.createTexture({
+  size: {width: 8},
+  dimension: '1d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder4 = commandEncoder4.beginComputePass({});
+try {
+commandEncoder3.clearBuffer(buffer2, 740, 10300);
+} catch {}
+await gc();
+let commandEncoder6 = device0.createCommandEncoder({});
+let sampler2 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 62.71,
+  lodMaxClamp: 96.73,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder2.setBindGroup(3, bindGroup0, new Uint32Array(1246), 16, 0);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let buffer3 = device0.createBuffer({
+  label: '\u4019\u0bfc\u085b\uadc8\ub261',
+  size: 13396,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let computePassEncoder5 = commandEncoder3.beginComputePass({label: '\u4080\ufe64\u09e6\u0c69\u8135\u{1fe90}\u4e88'});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let textureView1 = texture1.createView({mipLevelCount: 1});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+commandEncoder6.copyTextureToBuffer({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1043 */
+  offset: 1043,
+  bytesPerRow: 99840,
+  rowsPerImage: 1913,
+  buffer: buffer0,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer4 = device0.createBuffer({size: 3213, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+let sampler3 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 90.17,
+  lodMaxClamp: 92.66,
+});
+let computePassEncoder6 = commandEncoder6.beginComputePass({});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup0, []);
+} catch {}
+document.body.prepend(canvas0);
+let commandEncoder7 = device0.createCommandEncoder({});
+let texture2 = device0.createTexture({
+  size: [16, 10, 9],
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView2 = texture2.createView({});
+let videoFrame0 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'film', transfer: 'smpteSt4281'} });
+let renderPassEncoder0 = commandEncoder7.beginRenderPass({
+  colorAttachments: [{
+  view: textureView2,
+  depthSlice: 8,
+  clearValue: { r: -165.4, g: 337.7, b: 878.4, a: -471.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+device0.queue.writeBuffer(buffer2, 3684, new DataView(new ArrayBuffer(19498)), 4360, 308);
+} catch {}
+document.body.append(canvas0);
+let commandEncoder8 = device0.createCommandEncoder({label: '\u607b\uf08b\ua414\u3cfd\u7e89\u{1f82a}\u{1fe8f}\u0259\ue6b0\u0bd5\u0876'});
+let texture3 = device0.createTexture({
+  size: [256, 256, 15],
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture4 = device0.createTexture({
+  size: [16, 10, 1],
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView3 = texture4.createView({format: 'r8uint'});
+let computePassEncoder7 = commandEncoder8.beginComputePass({});
+try {
+computePassEncoder4.setBindGroup(2, bindGroup0, []);
+} catch {}
+document.body.prepend(canvas0);
+let bindGroupLayout2 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 420,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+    {binding: 121, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 218,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let pipelineLayout0 = device0.createPipelineLayout({label: '\u0399\u5fc6\u87ab', bindGroupLayouts: []});
+let querySet0 = device0.createQuerySet({type: 'occlusion', count: 135});
+let texture5 = device0.createTexture({
+  size: [256, 256, 150],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture6 = device0.createTexture({
+  label: '\u591e\u{1fe2f}\u{1f75e}\u2be4\u569a\ue570',
+  size: {width: 256, height: 256, depthOrArrayLayers: 8},
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let textureView4 = texture5.createView({label: '\u044f\u2437\uf0cc\u0202\u732c\u09a7', dimension: '3d', aspect: 'all'});
+let texture7 = device0.createTexture({
+  size: [4, 2, 1],
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture8 = gpuCanvasContext0.getCurrentTexture();
+try {
+renderPassEncoder0.setStencilReference(495);
+} catch {}
+let videoFrame1 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte240m', primaries: 'bt470bg', transfer: 'bt1361ExtendedColourGamut'} });
+try {
+globalThis.someLabel = device0.label;
+} catch {}
+let querySet1 = device0.createQuerySet({type: 'occlusion', count: 425});
+try {
+renderPassEncoder0.setVertexBuffer(4, buffer2, 6_960, 6_786);
+} catch {}
+await gc();
+let pipelineLayout1 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout1]});
+let texture9 = device0.createTexture({size: {width: 4}, dimension: '1d', format: 'r8uint', usage: GPUTextureUsage.COPY_SRC});
+try {
+computePassEncoder3.setBindGroup(3, bindGroup0, new Uint32Array(39), 12, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer4, 'uint32', 1_220, 12);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 7, y: 23, z: 1},
+  aspect: 'all',
+}, new Uint8Array(261_023).fill(194), /* required buffer size: 261_023 */
+{offset: 6, bytesPerRow: 155, rowsPerImage: 71}, {width: 19, height: 51, depthOrArrayLayers: 24});
+} catch {}
+await gc();
+let shaderModule0 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires pointer_composite_access;
+
+requires readonly_and_readwrite_storage_textures;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(296) var et0: texture_external;
+
+@group(0) @binding(460) var tex0: texture_2d_array<f32>;
+
+struct T0 {
+  @size(744) f0: array<u32>,
+}
+
+struct T1 {
+  @align(8) @size(72) f0: array<u32>,
+}
+
+struct T2 {
+  @size(336) f0: array<array<mat2x4f, 1>>,
+}
+
+struct VertexOutput0 {
+  @builtin(position) f0: vec4f,
+}
+
+struct FragmentOutput0 {
+  @location(3) @interpolate(flat, center) f0: u32,
+  @location(0) f1: u32,
+}
+
+struct FragmentOutput1 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: u32,
+}
+
+alias vec3b = vec3<bool>;
+
+fn fn0(a0: ptr<storage, VertexOutput0, read_write>, a1: ptr<uniform, vec2f>) -> mat3x2f {
+  var out: mat3x2f;
+  let ptr0: ptr<storage, VertexOutput0, read_write> = &(*a0);
+  let ptr1: ptr<storage, VertexOutput0, read_write> = &(*ptr0);
+  let ptr2: ptr<uniform, vec2f> = &(*a1);
+  let vf0: f32 = step(f32(unconst_f32(0.3537)), f32(unconst_f32(0.5000)));
+  out -= mat3x2f(f32(pack4xU8Clamp(vec4u((*ptr0).f0))), bitcast<f32>(pack4xU8Clamp(vec4u((*ptr0).f0))), bitcast<f32>(pack4xU8Clamp(vec4u((*ptr0).f0))), bitcast<f32>(pack4xU8Clamp(vec4u((*ptr0).f0))), bitcast<f32>(pack4xU8Clamp(vec4u((*ptr0).f0))), f32(pack4xU8Clamp(vec4u((*ptr0).f0))));
+  out = mat3x2f((*a1), (*a1), (*a1));
+  let ptr3: ptr<storage, vec4f, read_write> = &(*ptr1).f0;
+  let vf1: vec2h = sqrt(vec2h((*ptr1).f0.aa));
+  let vf2: vec2u = countOneBits(vec2u(unconst_u32(27), unconst_u32(224)));
+  var vf3: f16 = determinant(mat2x2h(f16(step(f32(unconst_f32(0.2100)), f32(unconst_f32(0.03194)))), f16(step(f32(unconst_f32(0.2100)), f32(unconst_f32(0.03194)))), f16(step(f32(unconst_f32(0.2100)), f32(unconst_f32(0.03194)))), f16(step(f32(unconst_f32(0.2100)), f32(unconst_f32(0.03194))))));
+  var vf4: vec2h = vf1;
+  (*a0).f0 = vec4f(f32(pack4xU8Clamp(vec4u(unconst_u32(38), unconst_u32(811), unconst_u32(135), unconst_u32(512)))));
+  vf4 += radians(vec2h(unconst_f16(15492.1), unconst_f16(842.0)));
+  out += mat3x2f(vec2f(vf4), vec2f(vf4), vec2f(vf4));
+  var vf5: vec4h = inverseSqrt(vec4h(unconst_f16(4738.8), unconst_f16(1884.6), unconst_f16(1539.2), unconst_f16(2982.1)));
+  vf5 *= vec4h(f16((*ptr2)[u32(unconst_u32(63))]));
+  let ptr4: ptr<uniform, vec2f> = &(*a1);
+  let vf6: f16 = vf5[u32(unconst_u32(234))];
+  var vf7: f16 = determinant(mat2x2h(unconst_f16(27411.9), unconst_f16(16878.8), unconst_f16(3921.4), unconst_f16(7228.2)));
+  return out;
+}
+
+fn fn1() -> FragmentOutput1 {
+  var out: FragmentOutput1;
+  out.f1 |= pack4xU8Clamp(vec4u(unconst_u32(243), unconst_u32(11), unconst_u32(333), unconst_u32(230)));
+  let vf8: u32 = textureNumLayers(tex0);
+  out.f0 = bitcast<u32>(smoothstep(vec2h(unconst_f16(12975.5), unconst_f16(-2860.9)), vec2h(unpack4x8snorm(u32(unconst_u32(1000))).ba), vec2h(unconst_f16(24987.5), unconst_f16(787.5))));
+  out.f0 = u32(length(vec2h(unconst_f16(-34.34), unconst_f16(-225.3))));
+  let vf9: vec4f = textureLoad(tex0, vec2i(unconst_i32(142), unconst_i32(214)), i32(unconst_i32(17)), i32(unconst_i32(-44)));
+  let vf10: vec2u = textureDimensions(tex0);
+  out.f1 += u32(length(vec2h(unconst_f16(20552.6), unconst_f16(3060.4))));
+  out.f1 |= textureDimensions(tex0).y;
+  var vf11: f32 = vf9[u32(unconst_u32(60))];
+  var vf12: vec2h = min(vec2h(unconst_f16(25400.2), unconst_f16(172.1)), vec2h(unconst_f16(-6996.8), unconst_f16(38900.7)));
+  out.f1 &= bitcast<u32>(tan(vec2h(unconst_f16(39048.6), unconst_f16(-651.9))));
+  var vf13: vec2h = tan(vec2h(unconst_f16(52.66), unconst_f16(29380.3)));
+  out.f0 ^= textureNumLevels(tex0);
+  let vf14: vec2u = textureDimensions(tex0, i32(unconst_i32(170)));
+  var vf15: vec2u = vf10;
+  out.f1 = countTrailingZeros(vec2u(unconst_u32(35), unconst_u32(79))).y;
+  let ptr5: ptr<function, vec2u> = &vf15;
+  return out;
+}
+
+fn fn2(a0: ptr<storage, atomic<i32>, read_write>, a1: ptr<workgroup, atomic<i32>>, a2: ptr<workgroup, f32>) -> vec4<bool> {
+  var out: vec4<bool>;
+  atomicCompareExchangeWeak(&(*a1), unconst_i32(336), unconst_i32(31));
+  atomicCompareExchangeWeak(&(*a0), unconst_i32(280), unconst_i32(102));
+  (*a2) *= bitcast<f32>(tanh(vec2h(unconst_f16(10552.0), unconst_f16(29415.1))));
+  (*a2) *= (*a2);
+  out = vec4<bool>(bool(atomicLoad(&(*a1))));
+  var vf16: i32 = atomicExchange(&(*a1), i32(unconst_i32(-176)));
+  out = vec4<bool>(bool(sin(f32(atomicLoad(&(*a1))))));
+  let vf17: vec4f = unpack4x8unorm(u32(unconst_u32(102)));
+  let ptr6: ptr<workgroup, atomic<i32>> = &(*a1);
+  var vf18: f32 = sin(f32(unconst_f32(0.1284)));
+  atomicAdd(&(*a1), i32(unconst_i32(444)));
+  (*a2) += bitcast<f32>(atomicLoad(&(*a1)));
+  let vf19: u32 = dot4U8Packed(u32(unconst_u32(177)), u32(unconst_u32(111)));
+  vf16 &= atomicLoad(&(*a1));
+  var vf20: f32 = vf17[u32(unconst_u32(245))];
+  let ptr7: ptr<function, f32> = &vf20;
+  var vf21: i32 = atomicLoad(&(*a1));
+  vf20 = quantizeToF16(vec4f(unconst_f32(0.00135), unconst_f32(-0.03879), unconst_f32(0.6251), unconst_f32(0.06943))).z;
+  atomicAdd(&(*a0), i32(unconst_i32(239)));
+  return out;
+}
+
+var<workgroup> vw0: array<FragmentOutput1, 3>;
+
+var<workgroup> vw1: VertexOutput0;
+
+var<workgroup> vw2: mat2x2h;
+
+var<workgroup> vw3: atomic<i32>;
+
+var<workgroup> vw4: mat2x3h;
+
+@vertex @must_use
+fn vertex0(@location(14) @interpolate(linear) a0: vec2h, @builtin(vertex_index) a1: u32) -> VertexOutput0 {
+  var out: VertexOutput0;
+  let vf22: vec2h = sqrt(vec2h(unconst_f16(10861.4), unconst_f16(-7054.4)));
+  let vf23: u32 = textureNumLevels(tex0);
+  out.f0 += vec4f(log(vec3h(unconst_f16(10174.8), unconst_f16(634.7), unconst_f16(13917.0))).yxyx);
+  out.f0 = unpack2x16snorm(u32(unconst_u32(14))).xyxy;
+  var vf24: vec2h = a0;
+  var vf25 = fn1();
+  return out;
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  var vf26: vec3f = ldexp(vec3f(unconst_f32(0.01767), unconst_f32(0.4938), unconst_f32(0.2323)), vec3i(unconst_i32(38), unconst_i32(6), unconst_i32(-159)));
+  var vf27: vec3f = cosh(vec3f(unconst_f32(0.08776), unconst_f32(0.09136), unconst_f32(0.00445)));
+  let vf28: f32 = vf27[u32(unconst_u32(276))];
+  out.f0 = bitcast<u32>(ldexp(vec3f(unconst_f32(0.1080), unconst_f32(0.1462), unconst_f32(0.2935)), vec3i(unconst_i32(68), unconst_i32(59), unconst_i32(-272))).z);
+  out.f1 >>= textureDimensions(tex0)[1];
+  let ptr8: ptr<function, vec3f> = &vf27;
+  vf26 *= vec3f(f32(textureNumLevels(tex0)));
+  var vf29: vec2u = textureDimensions(tex0, i32(unconst_i32(-97)));
+  let vf30: f32 = (*ptr8)[u32(unconst_u32(286))];
+  var vf31: u32 = textureNumLayers(tex0);
+  var vf32 = fn1();
+  out.f0 += bitcast<u32>(abs(f32(unconst_f32(0.04826))));
+  out.f1 += vf31;
+  vf26 = vec3f(vf26[u32(unconst_u32(189))]);
+  return out;
+}
+
+@fragment
+fn fragment1() -> FragmentOutput1 {
+  var out: FragmentOutput1;
+  var vf33: vec2u = textureDimensions(et0);
+  var vf34 = fn1();
+  vf33 += vec2u(vf33[u32(unconst_u32(215))]);
+  var vf35: vec4f = unpack4x8snorm(u32(unconst_u32(2)));
+  out.f0 *= bitcast<u32>(vf35[u32(vf35[u32(unconst_u32(156))])]);
+  vf35 = unpack4x8snorm(u32(unconst_u32(196)));
+  var vf36: vec3i = abs(vec3i(unconst_i32(165), unconst_i32(20), unconst_i32(104)));
+  vf34 = FragmentOutput1(u32(any(vec3<bool>(unconst_bool(false), unconst_bool(false), unconst_bool(false)))), u32(any(vec3<bool>(unconst_bool(false), unconst_bool(false), unconst_bool(false)))));
+  vf36 ^= vec3i(textureDimensions(tex0, i32(unconst_i32(113))).rgr);
+  vf35 *= unpack4x8snorm(u32(unconst_u32(195)));
+  out.f1 *= u32(sign(vec3f(unconst_f32(0.1496), unconst_f32(0.06656), unconst_f32(0.2107)))[2]);
+  let vf37: f16 = smoothstep(f16(unconst_f16(10552.2)), f16(unconst_f16(-30.41)), smoothstep(f16(unconst_f16(14607.1)), f16(unconst_f16(16076.1)), f16(unconst_f16(13643.4))));
+  vf34.f1 >>= vf33[u32(unconst_u32(162))];
+  vf34 = FragmentOutput1(bitcast<u32>(sign(vec3f(vf36))[1]), bitcast<vec3u>(sign(vec3f(vf36)))[2]);
+  let vf38: vec2u = textureDimensions(tex0);
+  let ptr9: ptr<function, vec3i> = &vf36;
+  return out;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder9 = device0.createCommandEncoder({});
+let textureView5 = texture7.createView({format: 'r8uint'});
+let computePassEncoder8 = commandEncoder9.beginComputePass();
+try {
+device0.queue.writeBuffer(buffer4, 408, new Int16Array(10111), 355, 12);
+} catch {}
+let texture10 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 15},
+  mipLevelCount: 2,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView6 = texture7.createView({label: '\ue67c\u000e\u4b9b\u{1f99a}\u3d04\u0cc0\u4c26\u02c6\u0d0d\u{1f750}', dimension: '2d-array'});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({colorFormats: ['r16float'], stencilReadOnly: false});
+let sampler4 = device0.createSampler({addressModeU: 'clamp-to-edge', addressModeV: 'clamp-to-edge', magFilter: 'nearest', lodMaxClamp: 61.01});
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup1, new Uint32Array(6107), 2_184, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer4, 'uint16', 712, 360);
+} catch {}
+try {
+renderBundleEncoder0.setBindGroup(1, bindGroup1, new Uint32Array(4102), 494, 0);
+} catch {}
+try {
+renderBundleEncoder0.insertDebugMarker('\u{1fbfd}');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 1, y: 38, z: 2},
+  aspect: 'all',
+}, new Uint8Array(352_459).fill(243), /* required buffer size: 352_459 */
+{offset: 75, bytesPerRow: 136, rowsPerImage: 200}, {width: 1, height: 192, depthOrArrayLayers: 13});
+} catch {}
+let bindGroup2 = device0.createBindGroup({
+  label: '\u5cb7\u{1fb4c}',
+  layout: bindGroupLayout0,
+  entries: [{binding: 7, resource: {buffer: buffer0, offset: 512, size: 792}}],
+});
+let texture11 = device0.createTexture({
+  size: {width: 8, height: 5, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let texture12 = gpuCanvasContext0.getCurrentTexture();
+let renderBundle0 = renderBundleEncoder0.finish({});
+let sampler5 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 76.50,
+  lodMaxClamp: 89.80,
+});
+try {
+computePassEncoder7.setBindGroup(1, bindGroup1, new Uint32Array(619), 100, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer4, 'uint32', 320, 301);
+} catch {}
+document.body.append(canvas0);
+let bindGroup3 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 7, resource: {buffer: buffer0, offset: 512, size: 76}}],
+});
+let buffer5 = device0.createBuffer({size: 7903, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({colorFormats: ['r8uint'], stencilReadOnly: true});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup3, new Uint32Array(1289), 319, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer4, 'uint16', 950, 182);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(5, buffer1, 0);
+} catch {}
+try {
+renderBundleEncoder1.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder1.setBindGroup(3, bindGroup2, new Uint32Array(1728), 111, 0);
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(0, buffer2);
+} catch {}
+let sampler6 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 23.67,
+  lodMaxClamp: 82.63,
+  compare: 'greater-equal',
+});
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer4, 'uint32', 12, 305);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer2, 3_768);
+} catch {}
+try {
+renderBundleEncoder1.setIndexBuffer(buffer5, 'uint16', 568, 1_247);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+document.body.append(canvas0);
+try {
+adapter0.label = '\u0246\ub46a';
+} catch {}
+let pipelineLayout2 = device0.createPipelineLayout({bindGroupLayouts: []});
+let textureView7 = texture5.createView({});
+let renderBundle1 = renderBundleEncoder1.finish({});
+let externalTexture0 = device0.importExternalTexture({source: videoFrame1});
+let bindGroup4 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 460, resource: textureView0}, {binding: 296, resource: externalTexture0}],
+});
+let commandEncoder10 = device0.createCommandEncoder({label: '\u{1f785}\u4301\u{1f8de}\u0b4e\u{1f6c0}\u07d2\u08d4\ubb58'});
+let computePassEncoder9 = commandEncoder10.beginComputePass({});
+try {
+renderPassEncoder0.setVertexBuffer(4, buffer1);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+await gc();
+let sampler7 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 50.89,
+  lodMaxClamp: 82.61,
+  compare: 'greater-equal',
+});
+let textureView8 = texture5.createView({});
+let sampler8 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 65.93,
+  lodMaxClamp: 75.53,
+  maxAnisotropy: 8,
+});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+computePassEncoder9.setBindGroup(0, bindGroup4, new Uint32Array(202), 77, 0);
+} catch {}
+try {
+computePassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder0.setViewport(7.305631755067042, 4.177062530846535, 7.9549497162837515, 5.184429534816229, 0.40104238968394756, 0.8243512825741226);
+} catch {}
+let buffer6 = device0.createBuffer({
+  size: 18661,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let texture13 = device0.createTexture({
+  size: {width: 8, height: 5, depthOrArrayLayers: 925},
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView9 = texture9.createView({});
+let computePassEncoder10 = commandEncoder5.beginComputePass();
+let sampler9 = device0.createSampler({
+  label: '\u0719\uced4\u0812\u{1fa15}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 51.08,
+  lodMaxClamp: 84.98,
+});
+let externalTexture1 = device0.importExternalTexture({source: videoFrame1, colorSpace: 'srgb'});
+try {
+computePassEncoder4.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+computePassEncoder0.setBindGroup(1, bindGroup3, new Uint32Array(4163), 898, 0);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder11 = device0.createCommandEncoder({});
+let computePassEncoder11 = commandEncoder11.beginComputePass({});
+try {
+computePassEncoder2.setBindGroup(2, bindGroup3);
+} catch {}
+canvas0.width = 394;
+let commandEncoder12 = device0.createCommandEncoder();
+let texture14 = device0.createTexture({
+  size: [4, 2, 1],
+  mipLevelCount: 1,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder12 = commandEncoder12.beginComputePass({});
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup1, new Uint32Array(532), 105, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer4, 'uint16', 2_036, 254);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(23).fill(57), /* required buffer size: 23 */
+{offset: 23, bytesPerRow: 25}, {width: 1, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup5 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 460, resource: textureView0}, {binding: 296, resource: externalTexture0}],
+});
+let buffer7 = device0.createBuffer({
+  label: '\uaf12\u8d23',
+  size: 20450,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let sampler10 = device0.createSampler({
+  label: '\u39ca\u2fe4\u{1fbb0}\u3fff\u0e41\u{1f98a}\u0f94\u682e\u054f\u8ef8',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 87.47,
+  maxAnisotropy: 20,
+});
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup0, new Uint32Array(1475), 819, 0);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let canvas1 = document.createElement('canvas');
+let textureView10 = texture14.createView({dimension: '2d-array', arrayLayerCount: 1});
+let externalTexture2 = device0.importExternalTexture({source: videoFrame1});
+try {
+computePassEncoder9.setBindGroup(0, bindGroup0);
+} catch {}
+let bindGroup6 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 460, resource: textureView0}, {binding: 296, resource: externalTexture1}],
+});
+let textureView11 = texture1.createView({});
+let textureView12 = texture7.createView({label: '\u064b\u0882\u4adf\u0b66\uc2a9\u5a1d\u0206\u5f41'});
+try {
+computePassEncoder10.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+computePassEncoder11.setBindGroup(0, bindGroup0, new Uint32Array(6289), 64, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 108, y: 228, z: 0},
+  aspect: 'all',
+}, new Uint8Array(5).fill(80), /* required buffer size: 5 */
+{offset: 5, bytesPerRow: 318, rowsPerImage: 181}, {width: 108, height: 162, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas1);
+try {
+sampler3.label = '\u07aa\u{1fae5}\u0e68';
+} catch {}
+let commandEncoder13 = device0.createCommandEncoder();
+let textureView13 = texture10.createView({
+  label: '\u{1fae7}\u{1ff4e}\u2054\u087c\ud158\u{1fb5a}\u0d9d',
+  dimension: 'cube',
+  aspect: 'all',
+  mipLevelCount: 1,
+});
+try {
+commandEncoder13.copyBufferToTexture({
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1907 */
+  offset: 1907,
+  bytesPerRow: 6144,
+  buffer: buffer6,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 4},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture15 = device0.createTexture({size: {width: 2}, dimension: '1d', format: 'r16float', usage: GPUTextureUsage.COPY_DST});
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup3, new Uint32Array(314), 45, 0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle1, renderBundle1, renderBundle1, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer5, 'uint32', 832, 1_175);
+} catch {}
+let buffer8 = device0.createBuffer({size: 15060, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView14 = texture8.createView({dimension: '2d-array'});
+try {
+renderPassEncoder0.setIndexBuffer(buffer5, 'uint16', 924, 602);
+} catch {}
+try {
+commandEncoder13.copyBufferToTexture({
+  /* bytesInLastRow: 3 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 483 */
+  offset: 483,
+  bytesPerRow: 23040,
+  buffer: buffer0,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer9 = device0.createBuffer({
+  size: 18684,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture16 = device0.createTexture({
+  label: '\ub833\u2b06\uac2e\u0f94\u{1f8df}\u0280\u{1f9dd}\uf95c',
+  size: {width: 16, height: 10, depthOrArrayLayers: 17},
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder13 = commandEncoder13.beginComputePass({});
+let bindGroup7 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 296, resource: externalTexture1}, {binding: 460, resource: textureView0}],
+});
+let texture17 = device0.createTexture({
+  size: {width: 8, height: 5, depthOrArrayLayers: 26},
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView15 = texture16.createView({label: '\ub1cf\ucd88\uca65', dimension: '3d'});
+let externalTexture3 = device0.importExternalTexture({source: videoFrame1});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup7, new Uint32Array(360), 65, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer5, 'uint16', 3_902, 1_065);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(7, buffer1);
+} catch {}
+let texture18 = device0.createTexture({
+  size: [256, 256, 1500],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder11.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+computePassEncoder7.setBindGroup(1, bindGroup7, new Uint32Array(381), 12, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer6, 'uint16', 8_414, 7_908);
+} catch {}
+try {
+querySet1.destroy();
+} catch {}
+let imageBitmap0 = await createImageBitmap(canvas1);
+let commandEncoder14 = device0.createCommandEncoder({});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup6, []);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle1, renderBundle1]);
+} catch {}
+try {
+commandEncoder14.copyBufferToTexture({
+  /* bytesInLastRow: 176 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 3008 */
+  offset: 3008,
+  bytesPerRow: 256,
+  buffer: buffer0,
+}, {
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 150, y: 6, z: 0},
+  aspect: 'all',
+}, {width: 66, height: 222, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 5536, new BigUint64Array(7840), 3312, 364);
+} catch {}
+let pipelineLayout3 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer10 = device0.createBuffer({
+  label: '\ua5d2\u{1fc2f}\u{1f6c1}\ufc63\u{1f7e9}\u{1f6c2}',
+  size: 25070,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+try {
+renderPassEncoder0.setVertexBuffer(4, buffer1);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder14.clearBuffer(buffer10, 4, 908);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let videoFrame2 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'fcc', primaries: 'smpteRp431', transfer: 'logSqrt'} });
+let bindGroup8 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 218, resource: textureView3},
+    {binding: 121, resource: externalTexture0},
+    {binding: 420, resource: textureView7},
+  ],
+});
+let texture19 = device0.createTexture({
+  size: [256],
+  dimension: '1d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder14 = commandEncoder14.beginComputePass({});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({colorFormats: ['r16float']});
+let renderBundle2 = renderBundleEncoder2.finish({});
+let sampler11 = device0.createSampler({addressModeV: 'repeat', magFilter: 'linear', minFilter: 'nearest', lodMaxClamp: 83.17, maxAnisotropy: 1});
+try {
+computePassEncoder2.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+computePassEncoder10.setBindGroup(2, bindGroup2, new Uint32Array(2329), 320, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer4, 'uint32', 1_056, 99);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+document.body.prepend(canvas0);
+let shaderModule1 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(296) var et1: texture_external;
+
+@group(0) @binding(460) var tex1: texture_2d_array<f32>;
+
+struct T0 {
+  @align(64) @size(3968) f0: array<atomic<i32>>,
+}
+
+struct VertexOutput1 {
+  @location(11) f1: vec2u,
+  @location(13) @interpolate(flat, sample) f2: vec2h,
+  @location(5) f3: vec4u,
+  @builtin(position) f4: vec4f,
+  @location(12) @interpolate(flat, centroid) f5: vec2u,
+}
+
+struct FragmentOutput2 {
+  @location(0) @interpolate(linear, center) f0: f32,
+}
+
+alias vec3b = vec3<bool>;
+
+fn fn0() -> FragmentOutput2 {
+  var out: FragmentOutput2;
+  out.f0 -= f32(textureNumLayers(tex1));
+  out.f0 = bitcast<f32>(textureNumLayers(tex1));
+  out.f0 = vec3f(faceForward(vec3h(unconst_f16(-2612.7), unconst_f16(804.3), unconst_f16(4130.8)), vec3h(unconst_f16(11176.3), unconst_f16(7011.5), unconst_f16(-5806.4)), vec3h(unconst_f16(23418.5), unconst_f16(191.5), unconst_f16(717.7))))[1];
+  out = FragmentOutput2(f32(inverseSqrt(vec4h(unconst_f16(4248.8), unconst_f16(5580.5), unconst_f16(550.6), unconst_f16(5988.6)))[2]));
+  out = FragmentOutput2(f32(atan2(f16(unconst_f16(2521.6)), f16(unconst_f16(15505.4)))));
+  let vf39: vec2h = reflect(vec2h(unconst_f16(10203.5), unconst_f16(2165.6)), vec2h(unconst_f16(7946.5), unconst_f16(16717.1)));
+  var vf40: u32 = textureNumLevels(tex1);
+  out.f0 *= unpack2x16float(u32(unconst_u32(2))).r;
+  var vf41: vec2u = textureDimensions(tex1, i32(unconst_i32(317)));
+  let vf42: u32 = reverseBits(u32(unconst_u32(38)));
+  var vf43: vec2h = min(vec2h(unconst_f16(19788.4), unconst_f16(16892.3)), vec2h(unconst_f16(4613.7), unconst_f16(4477.4)));
+  vf41 >>= vec2u(bitcast<u32>(distance(f32(unconst_f32(0.07882)), f32(unconst_f32(0.1353)))));
+  vf43 -= min(vec2h(unconst_f16(-3994.7), unconst_f16(18273.8)), vec2h(unconst_f16(497.1), unconst_f16(3835.7)));
+  vf40 |= vf41.x;
+  let vf44: vec2u = textureDimensions(et1);
+  let vf45: u32 = textureNumLayers(tex1);
+  let vf46: u32 = pack4xI8(vec4i(unconst_i32(417), unconst_i32(84), unconst_i32(-146), unconst_i32(3)));
+  var vf47: vec3h = faceForward(vec3h(unconst_f16(-2317.4), unconst_f16(-1087.9), unconst_f16(3406.2)), vec3h(unconst_f16(28280.6), unconst_f16(17443.6), unconst_f16(-1400.8)), vec3h(unconst_f16(9026.6), unconst_f16(272.4), unconst_f16(13840.0)));
+  let vf48: vec2f = unpack2x16unorm(u32(unconst_u32(725)));
+  let ptr10: ptr<function, u32> = &vf40;
+  let vf49: f16 = vf39[u32(unconst_u32(124))];
+  let ptr11: ptr<function, u32> = &vf40;
+  return out;
+}
+
+fn fn1(a0: array<FragmentOutput2, 4>, a1: array<f16, 1>) {
+  var vf50: vec2h = mix(vec2h(unconst_f16(19097.8), unconst_f16(17882.1)), vec2h(unconst_f16(16462.2), unconst_f16(676.5)), vec2h(unconst_f16(36369.1), unconst_f16(13171.2)));
+  vf50 += vec2h(a1[0]);
+  vf50 = bitcast<vec2h>(insertBits(i32(unconst_i32(14)), i32(unconst_i32(97)), u32(unconst_u32(27)), u32(unconst_u32(150))));
+  var vf51: vec3f = atan2(vec3f(unconst_f32(-0.2760), unconst_f32(0.06433), unconst_f32(0.3181)), vec3f(unconst_f32(0.1010), unconst_f32(0.1176), unconst_f32(0.1351)));
+  vf50 = bitcast<vec2h>(a0[u32(unconst_u32(3))].f0);
+  let ptr12: ptr<function, vec2h> = &vf50;
+  vf50 += bitcast<vec2h>(a0[3].f0);
+}
+
+fn fn2(a0: mat2x2h) -> i32 {
+  var out: i32;
+  out &= bitcast<i32>(pack4x8unorm(vec4f(unconst_f32(0.3236), unconst_f32(0.2202), unconst_f32(0.1226), unconst_f32(-0.2424))));
+  let vf52: f32 = sin(f32(unconst_f32(0.04750)));
+  let vf53: f32 = log(bitcast<f32>(unpack4xU8(u32(unconst_u32(396))).r));
+  var vf54: vec4f = atan(vec4f(unconst_f32(0.2224), unconst_f32(0.06198), unconst_f32(0.07178), unconst_f32(0.01666)));
+  out = i32(vf53);
+  var vf55: vec4f = atan2(vec4f(unconst_f32(0.04070), unconst_f32(0.1303), unconst_f32(0.1093), unconst_f32(0.01749)), vec4f(unconst_f32(-0.1214), unconst_f32(0.1974), unconst_f32(0.06299), unconst_f32(0.4331)));
+  var vf56: f32 = vf52;
+  vf55 = atan2(vec4f(unconst_f32(0.01984), unconst_f32(0.1743), unconst_f32(0.00239), unconst_f32(0.1421)), atan(vec4f(unconst_f32(0.1975), unconst_f32(0.3730), unconst_f32(0.3239), unconst_f32(0.05304))));
+  var vf57: u32 = pack4x8unorm(vec4f(a0[u32(unconst_u32(107))].xyxy));
+  var vf58: f16 = max(f16(unconst_f16(4984.4)), f16(unconst_f16(8174.0)));
+  let vf59: bool = any(bool(unconst_bool(true)));
+  let vf60: vec4u = unpack4xU8(u32(unconst_u32(32)));
+  vf54 = vec4f(f32(a0[u32(unconst_u32(423))][u32(unconst_u32(51))]));
+  vf57 |= bitcast<u32>(log(f32(unconst_f32(0.1820))));
+  vf55 = vec4f(f32(a0[u32(unconst_u32(317))][u32(unconst_u32(294))]));
+  out = bitcast<i32>(vf56);
+  vf55 = vec4f(a0[u32(unconst_u32(116))].xxxy);
+  return out;
+}
+
+var<workgroup> vw5: bool;
+
+@vertex
+fn vertex1() -> VertexOutput1 {
+  var out: VertexOutput1;
+  var vf61 = fn2(mat2x2h(f16(countLeadingZeros(bitcast<i32>(smoothstep(f32(unconst_f32(0.02071)), f32(unconst_f32(-0.4326)), f32(unconst_f32(0.2626)))))), f16(countLeadingZeros(bitcast<i32>(smoothstep(f32(unconst_f32(0.02071)), f32(unconst_f32(-0.4326)), f32(unconst_f32(0.2626)))))), f16(countLeadingZeros(bitcast<i32>(smoothstep(f32(unconst_f32(0.02071)), f32(unconst_f32(-0.4326)), f32(unconst_f32(0.2626)))))), f16(countLeadingZeros(bitcast<i32>(smoothstep(f32(unconst_f32(0.02071)), f32(unconst_f32(-0.4326)), f32(unconst_f32(0.2626))))))));
+  out.f4 += bitcast<vec4f>(unpack4xU8(textureNumLayers(tex1)));
+  let vf62: vec4h = tan(vec4h(unconst_f16(3973.9), unconst_f16(1407.2), unconst_f16(1778.1), unconst_f16(3469.6)));
+  fn1(array<FragmentOutput2, 4>(FragmentOutput2(fma(fma(vec3f(unconst_f32(-0.07020), unconst_f32(0.2282), unconst_f32(0.1107)), vec3f(unconst_f32(0.04083), unconst_f32(0.1257), unconst_f32(0.04433)), vec3f(vf62.bgg)), vec3f(unconst_f32(-0.2057), unconst_f32(0.1267), unconst_f32(0.1486)), textureLoad(tex1, vec2i(insertBits(i32(unconst_i32(25)), i32(unconst_i32(8)), u32(unconst_u32(13)), u32(unconst_u32(151)))), i32(unconst_i32(-180)), i32(unconst_i32(236))).bgg).b), FragmentOutput2(fma(fma(vec3f(unconst_f32(-0.07020), unconst_f32(0.2282), unconst_f32(0.1107)), vec3f(unconst_f32(0.04083), unconst_f32(0.1257), unconst_f32(0.04433)), vec3f(vf62.bgg)), vec3f(unconst_f32(-0.2057), unconst_f32(0.1267), unconst_f32(0.1486)), textureLoad(tex1, vec2i(insertBits(i32(unconst_i32(25)), i32(unconst_i32(8)), u32(unconst_u32(13)), u32(unconst_u32(151)))), i32(unconst_i32(-180)), i32(unconst_i32(236))).bgg).z), FragmentOutput2(fma(fma(vec3f(unconst_f32(-0.07020), unconst_f32(0.2282), unconst_f32(0.1107)), vec3f(unconst_f32(0.04083), unconst_f32(0.1257), unconst_f32(0.04433)), vec3f(vf62.bgg)), vec3f(unconst_f32(-0.2057), unconst_f32(0.1267), unconst_f32(0.1486)), textureLoad(tex1, vec2i(insertBits(i32(unconst_i32(25)), i32(unconst_i32(8)), u32(unconst_u32(13)), u32(unconst_u32(151)))), i32(unconst_i32(-180)), i32(unconst_i32(236))).bgg).r), FragmentOutput2(fma(fma(vec3f(unconst_f32(-0.07020), unconst_f32(0.2282), unconst_f32(0.1107)), vec3f(unconst_f32(0.04083), unconst_f32(0.1257), unconst_f32(0.04433)), vec3f(vf62.bgg)), vec3f(unconst_f32(-0.2057), unconst_f32(0.1267), unconst_f32(0.1486)), textureLoad(tex1, vec2i(insertBits(i32(unconst_i32(25)), i32(unconst_i32(8)), u32(unconst_u32(13)), u32(unconst_u32(151)))), i32(unconst_i32(-180)), i32(unconst_i32(236))).bgg).x)), array<f16, 1>(f16(textureDimensions(tex1, bitcast<i32>(tanh(vec3f(unconst_f32(0.1573), unconst_f32(0.01437), unconst_f32(-0.1516)))[2])).x)));
+  out.f2 *= vec2h(textureDimensions(tex1, i32(unconst_i32(-103))));
+  return out;
+}
+
+@fragment
+fn fragment2() -> FragmentOutput2 {
+  var out: FragmentOutput2;
+  let vf63: u32 = pack2x16float(vec2f(unconst_f32(0.05949), unconst_f32(0.08568)));
+  out = FragmentOutput2(unpack2x16unorm(u32(unconst_u32(20))).y);
+  let vf64: vec2u = textureDimensions(et1);
+  out.f0 = vec3f(sin(vec3h(unconst_f16(9595.0), unconst_f16(22291.2), unconst_f16(22493.2)))).x;
+  out.f0 = determinant(mat2x2f(bitcast<vec2f>(textureDimensions(tex1, i32(unconst_i32(19)))), bitcast<vec2f>(textureDimensions(tex1, i32(unconst_i32(19))))));
+  out.f0 += f32(textureDimensions(et1)[1]);
+  out.f0 = f32(all(vec2<bool>(unconst_bool(false), unconst_bool(true))));
+  out.f0 -= f32(vf64[0]);
+  let vf65: f32 = determinant(mat2x2f(unconst_f32(-0.8909), unconst_f32(0.02615), unconst_f32(0.09459), unconst_f32(0.4125)));
+  let vf66: vec2u = textureDimensions(tex1, i32(unconst_i32(224)));
+  out.f0 += bitcast<f32>(textureNumLevels(tex1));
+  out.f0 = vf65;
+  let vf67: bool = all(vec2<bool>(unconst_bool(true), unconst_bool(false)));
+  var vf68 = fn0();
+  return out;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout3 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 5,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 146,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8uint', access: 'write-only', viewDimension: '1d' },
+    },
+  ],
+});
+let buffer11 = device0.createBuffer({
+  size: 9477,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder15 = device0.createCommandEncoder({label: '\u{1fd98}\u08e7\u{1f7dd}\u3631\u0630\u460c\u1cac\u{1fb24}\u0f3c'});
+let textureView16 = texture10.createView({
+  label: '\u8f57\u{1ff6a}\ufd8d\u07da\u00d1\u5262\uf9ae\uc835\u4a9c\u2ee9\u0db7',
+  dimension: 'cube-array',
+  mipLevelCount: 1,
+  baseArrayLayer: 2,
+  arrayLayerCount: 6,
+});
+let texture20 = device0.createTexture({
+  size: [4, 2, 1],
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder1 = commandEncoder15.beginRenderPass({
+  colorAttachments: [{
+  view: textureView10,
+  clearValue: { r: 519.5, g: 423.1, b: -903.0, a: 591.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet1,
+});
+try {
+renderPassEncoder1.executeBundles([renderBundle1]);
+} catch {}
+let commandEncoder16 = device0.createCommandEncoder({});
+let texture21 = device0.createTexture({
+  label: '\uf90b\u08ba\u06be\u8efa\ucc04\ubefc\ub54b\u{1fb56}\u663d\u9fff',
+  size: {width: 4},
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView17 = texture1.createView({label: '\u00d3\u0c4d\u07b4\u0474\u9f39\u0d14\u{1fc49}\u{1fedf}'});
+let computePassEncoder15 = commandEncoder16.beginComputePass({label: '\u{1fdcd}\u346b\u0e13\u5d98\u{1fffb}\u0829'});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView18 = texture21.createView({aspect: 'all'});
+let texture22 = device0.createTexture({
+  size: [1158, 415, 1],
+  format: 'astc-6x5-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup0, new Uint32Array(129), 4, 0);
+} catch {}
+try {
+adapter0.label = '\ued18\u1eda\u4eb4\uc0c8\udf05\u0994\ub1fc';
+} catch {}
+let commandEncoder17 = device0.createCommandEncoder({label: '\u{1fd9f}\uca95\u9d64'});
+let texture23 = device0.createTexture({
+  size: {width: 4, height: 2, depthOrArrayLayers: 1},
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup7, new Uint32Array(1463), 19, 0);
+} catch {}
+let buffer12 = device0.createBuffer({
+  size: 4746,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView19 = texture12.createView({dimension: '2d-array', baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 0});
+try {
+computePassEncoder5.setBindGroup(1, bindGroup2, new Uint32Array(220), 9, 0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle1]);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder18 = device0.createCommandEncoder({});
+let textureView20 = texture23.createView({dimension: '2d-array', format: 'r16float'});
+let renderPassEncoder2 = commandEncoder18.beginRenderPass({
+  colorAttachments: [{view: textureView20, loadOp: 'clear', storeOp: 'store'}],
+  occlusionQuerySet: querySet1,
+});
+try {
+computePassEncoder13.setBindGroup(2, bindGroup7, new Uint32Array(360), 58, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup0, new Uint32Array(43), 3, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer5, 'uint32', 1_880, 2_796);
+} catch {}
+let bindGroup9 = device0.createBindGroup({
+  label: '\u3ccd\u{1feb8}\ub912\u{1f6cb}\u{1fef4}\ubadd',
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 218, resource: textureView3},
+    {binding: 420, resource: textureView4},
+    {binding: 121, resource: externalTexture3},
+  ],
+});
+let texture24 = device0.createTexture({
+  size: [8, 5, 87],
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView21 = texture21.createView({});
+let computePassEncoder16 = commandEncoder17.beginComputePass({label: '\u2dfa\u{1fc5e}'});
+try {
+computePassEncoder7.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+computePassEncoder10.setBindGroup(2, bindGroup3, new Uint32Array(6417), 462, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer10, 'uint16', 1_224, 13_112);
+} catch {}
+let imageData1 = new ImageData(36, 56);
+try {
+device0.queue.writeBuffer(buffer0, 148, new DataView(new ArrayBuffer(878)), 252, 20);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 25, y: 47, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup10 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 7, resource: {buffer: buffer2, offset: 19968, size: 24}}],
+});
+let buffer13 = device0.createBuffer({
+  size: 19899,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let textureView22 = texture9.createView({});
+let sampler12 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 68.95,
+  lodMaxClamp: 82.32,
+});
+try {
+computePassEncoder15.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+computePassEncoder11.setBindGroup(0, bindGroup8, new Uint32Array(2852), 780, 0);
+} catch {}
+document.body.prepend(canvas1);
+let buffer14 = device0.createBuffer({size: 2018, usage: GPUBufferUsage.COPY_SRC});
+let commandEncoder19 = device0.createCommandEncoder();
+let texture25 = device0.createTexture({
+  size: {width: 2, height: 1, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let computePassEncoder17 = commandEncoder19.beginComputePass({});
+let sampler13 = device0.createSampler({
+  label: '\uae60\u0485\uf711\u0cad\u69c9',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 93.28,
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder4.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(201).fill(80), /* required buffer size: 201 */
+{offset: 201}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder20 = device0.createCommandEncoder({label: '\uf182\u05c5\u0861\u{1ffaf}\uc3b1\u2093\u5034\ufd16\u9b2d'});
+let textureView23 = texture10.createView({
+  label: '\u77fd\u8024\u6005\u6bf4',
+  dimension: 'cube-array',
+  baseMipLevel: 0,
+  mipLevelCount: 1,
+  arrayLayerCount: 6,
+});
+let textureView24 = texture22.createView({dimension: '2d-array', format: 'astc-6x5-unorm-srgb', baseArrayLayer: 0});
+let computePassEncoder18 = commandEncoder20.beginComputePass({});
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup8, new Uint32Array(2433), 27, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(7, buffer1, 4_796, 19_146);
+} catch {}
+let gpuCanvasContext1 = canvas1.getContext('webgpu');
+let bindGroupLayout4 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 84,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32sint', access: 'read-only', viewDimension: '2d' },
+    },
+  ],
+});
+let commandEncoder21 = device0.createCommandEncoder({});
+let texture26 = device0.createTexture({
+  size: {width: 8, height: 5, depthOrArrayLayers: 1},
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler14 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 59.51,
+  lodMaxClamp: 84.74,
+  maxAnisotropy: 13,
+});
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(2);
+} catch {}
+try {
+commandEncoder21.copyBufferToBuffer(buffer9, 252, buffer13, 924, 788);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(0).fill(160), /* required buffer size: 0 */
+{offset: 0}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView25 = texture26.createView({format: 'r32sint'});
+let computePassEncoder19 = commandEncoder21.beginComputePass({});
+let sampler15 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'linear',
+  lodMinClamp: 76.88,
+  lodMaxClamp: 94.55,
+});
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup9, new Uint32Array(2142), 304, 0);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+let imageData2 = new ImageData(92, 72);
+let buffer15 = device0.createBuffer({
+  size: 390,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+try {
+computePassEncoder15.setBindGroup(3, bindGroup9, new Uint32Array(1007), 43, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup4, new Uint32Array(1256), 684, 0);
+} catch {}
+try {
+renderPassEncoder1.setViewport(2.2176501786069025, 0.2676295546165586, 0.3417945925531652, 0.8578983837075307, 0.9094411962603237, 0.9426050152586719);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer6, 'uint16', 328, 1_515);
+} catch {}
+let texture27 = device0.createTexture({
+  size: {width: 16, height: 10, depthOrArrayLayers: 116},
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder2.beginOcclusionQuery(6);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: -57.00, g: -632.1, b: 137.5, a: -333.2, });
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer13, 'uint16', 1_686, 5_324);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(5, buffer1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 8, y: 5, z: 0},
+  aspect: 'all',
+}, new Uint8Array(37_186).fill(110), /* required buffer size: 37_186 */
+{offset: 62, bytesPerRow: 225, rowsPerImage: 97}, {width: 56, height: 68, depthOrArrayLayers: 2});
+} catch {}
+let buffer16 = device0.createBuffer({size: 21677, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+try {
+computePassEncoder10.setBindGroup(3, bindGroup5, new Uint32Array(30), 2, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup7, new Uint32Array(1130), 14, 0);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(2, buffer12, 544, 401);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 1416, new DataView(new ArrayBuffer(28099)), 8948, 800);
+} catch {}
+let querySet2 = device0.createQuerySet({type: 'occlusion', count: 112});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({colorFormats: ['r8uint'], stencilReadOnly: true});
+let sampler16 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 52.76,
+  lodMaxClamp: 69.98,
+});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup9, []);
+} catch {}
+try {
+computePassEncoder8.setBindGroup(1, bindGroup9, new Uint32Array(976), 220, 0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer4, 'uint32', 76, 646);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer1, 0);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(buffer5, 'uint32', 2_120, 142);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+computePassEncoder9.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(3, bindGroup9, new Uint32Array(1325), 414, 0);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let buffer17 = device0.createBuffer({
+  size: 10579,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder22 = device0.createCommandEncoder({label: '\u06fd\u872c\udf76\u3f4d'});
+let textureView26 = texture16.createView({baseMipLevel: 0, mipLevelCount: 1});
+let computePassEncoder20 = commandEncoder22.beginComputePass({});
+let externalTexture4 = device0.importExternalTexture({source: videoFrame0});
+try {
+renderPassEncoder1.setVertexBuffer(3, buffer9);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(buffer4, 'uint16', 712, 467);
+} catch {}
+let shaderModule2 = device0.createShaderModule({
+  label: '\u78ea\ue265\u57c0\u{1f655}\u{1fccc}\u795f\u032a\ucaa9',
+  code: `
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(296) var et2: texture_external;
+
+@group(0) @binding(460) var tex2: texture_2d_array<f32>;
+
+struct T0 {
+  @align(8) @size(3520) f0: array<atomic<u32>>,
+}
+
+struct T1 {
+  @align(16) @size(80) f0: array<mat2x2h, 1>,
+}
+
+struct S0 {
+  @location(5) f0: vec4u,
+  @location(13) @interpolate(flat, sample) f1: vec2h,
+}
+
+struct FragmentOutput3 {
+  @location(3) @interpolate(flat, center) f0: i32,
+  @location(1) f1: vec2f,
+  @location(0) @interpolate(flat) f2: vec4u,
+  @location(4) f3: vec4f,
+}
+
+alias vec3b = vec3<bool>;
+
+fn fn0() -> array<array<FragmentOutput3, 1>, 1> {
+  var out: array<array<FragmentOutput3, 1>, 1>;
+  vw6 += mat4x2h((*&vw6)[u32(unconst_u32(35))][u32(unconst_u32(283))], (*&vw6)[u32(unconst_u32(35))][u32(unconst_u32(283))], (*&vw6)[u32(unconst_u32(35))][u32(unconst_u32(283))], (*&vw6)[u32(unconst_u32(35))][u32(unconst_u32(283))], (*&vw6)[u32(unconst_u32(35))][u32(unconst_u32(283))], (*&vw6)[u32(unconst_u32(35))][u32(unconst_u32(283))], (*&vw6)[u32(unconst_u32(35))][u32(unconst_u32(283))], (*&vw6)[u32(unconst_u32(35))][u32(unconst_u32(283))]);
+  let vf69: f16 = vw6[u32(vw6[u32(unconst_u32(5))][u32(unconst_u32(363))])][u32(unconst_u32(272))];
+  var vf70: mat4x2h = workgroupUniformLoad(&vw6);
+  out[u32(unconst_u32(17))][u32(unconst_u32(54))] = FragmentOutput3(i32(vf70[u32(unconst_u32(410))][u32(unconst_u32(49))]), vec2f(f32(vf70[u32(unconst_u32(410))][u32(unconst_u32(49))])), vec4u(u32(vf70[u32(unconst_u32(410))][u32(unconst_u32(49))])), vec4f(f32(vf70[u32(unconst_u32(410))][u32(unconst_u32(49))])));
+  vf70 += mat4x2h(vec2h(quantizeToF16(vec4f(unconst_f32(0.1900), unconst_f32(0.05968), unconst_f32(0.00506), unconst_f32(0.2880))).ga), vec2h(quantizeToF16(vec4f(unconst_f32(0.1900), unconst_f32(0.05968), unconst_f32(0.00506), unconst_f32(0.2880))).bb), vec2h(quantizeToF16(vec4f(unconst_f32(0.1900), unconst_f32(0.05968), unconst_f32(0.00506), unconst_f32(0.2880))).xx), vec2h(quantizeToF16(vec4f(unconst_f32(0.1900), unconst_f32(0.05968), unconst_f32(0.00506), unconst_f32(0.2880))).yy));
+  vw6 = workgroupUniformLoad(&vw6);
+  out[u32(unconst_u32(105))][u32(unconst_u32(10))] = FragmentOutput3(bitcast<i32>((*&vw6)[u32(unconst_u32(304))]), vec2f((*&vw6)[u32(unconst_u32(304))]), vec4u((*&vw6)[u32(unconst_u32(304))].rrgg), vec4f((*&vw6)[u32(unconst_u32(304))].gggg));
+  var vf71: mat4x2h = workgroupUniformLoad(&vw6);
+  vf71 -= mat4x2h(sin(f16(unconst_f16(-4732.0))), sin(f16(unconst_f16(-4732.0))), sin(f16(unconst_f16(-4732.0))), sin(f16(unconst_f16(-4732.0))), sin(f16(unconst_f16(-4732.0))), sin(f16(unconst_f16(-4732.0))), sin(f16(unconst_f16(-4732.0))), sin(f16(unconst_f16(-4732.0))));
+  vf70 = (*&vw6);
+  let vf72: f16 = (*&vw6)[u32(unconst_u32(46))][u32(unconst_u32(363))];
+  var vf73: u32 = dot4U8Packed(bitcast<u32>(vw6[bitcast<u32>((*&vw6)[unconst_i32(2)])]), u32(unconst_u32(161)));
+  let ptr13: ptr<function, mat4x2h> = &vf71;
+  var vf74: vec2h = vf70[u32(unconst_u32(53))];
+  var vf75: u32 = dot4U8Packed(u32(unconst_u32(227)), u32(unconst_u32(61)));
+  vf74 -= bitcast<vec2h>(pack4xU8(vec4u(unconst_u32(79), unconst_u32(408), unconst_u32(240), unconst_u32(335))));
+  vf70 = mat4x2h((*ptr13)[u32(unconst_u32(2))], (*ptr13)[u32(unconst_u32(2))], (*ptr13)[u32(unconst_u32(2))], (*ptr13)[u32(unconst_u32(2))]);
+  vf75 = u32(vf71[u32(unconst_u32(407))][bitcast<u32>((*ptr13)[u32(unconst_u32(70))])]);
+  vf73 >>= insertBits(vec4u(unconst_u32(24), unconst_u32(43), unconst_u32(346), unconst_u32(110)), vec4u(unconst_u32(445), unconst_u32(21), unconst_u32(37), unconst_u32(165)), u32(unconst_u32(636)), u32(unconst_u32(209)))[1];
+  var vf76: u32 = dot4U8Packed(u32(unconst_u32(295)), u32(unconst_u32(63)));
+  var vf77: u32 = pack4xU8(vec4u(unconst_u32(23), unconst_u32(133), unconst_u32(476), unconst_u32(91)));
+  var vf78: mat4x2h = workgroupUniformLoad(&vw6);
+  vf75 *= bitcast<u32>(vf78[unconst_i32(1)]);
+  let vf79: u32 = pack4xU8(vec4u(unconst_u32(248), unconst_u32(130), unconst_u32(17), unconst_u32(176)));
+  return out;
+}
+
+var<workgroup> vw6: mat4x2h;
+
+@fragment
+fn fragment3(a0: S0, @location(12) @interpolate(flat) a1: vec2u) -> FragmentOutput3 {
+  var out: FragmentOutput3;
+  var vf80: u32 = textureNumLevels(tex2);
+  out.f2 += unpack4xU8(pack2x16unorm(vec2f(unconst_f32(0.2732), unconst_f32(0.1280))));
+  var vf81: f16 = a0.f1[u32(unconst_u32(18))];
+  out.f2 |= insertBits(vec3u(unconst_u32(367), unconst_u32(40), unconst_u32(35)), vec3u(unconst_u32(384), unconst_u32(73), unconst_u32(182)), u32(unconst_u32(27)), u32(unconst_u32(21))).zxzy;
+  var vf82: vec2u = textureDimensions(tex2);
+  let vf83: i32 = dot(vec3i(unconst_i32(85), unconst_i32(73), unconst_i32(213)), vec3i(unconst_i32(142), unconst_i32(164), unconst_i32(161)));
+  out.f3 *= vec4f(step(sin(vec3h(unconst_f16(6661.6), unconst_f16(33163.6), unconst_f16(13666.0))), vec3h(unconst_f16(7075.5), unconst_f16(1045.1), unconst_f16(4753.6))).xzzz);
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+  fn0();
+  vw6 += mat4x2h(f16(distance(vec4f(unconst_f32(0.1119), unconst_f32(0.1503), unconst_f32(0.01874), unconst_f32(0.3803)), vec4f(unconst_f32(0.1612), unconst_f32(0.07094), unconst_f32(0.2415), unconst_f32(0.01666)))), f16(distance(vec4f(unconst_f32(0.1119), unconst_f32(0.1503), unconst_f32(0.01874), unconst_f32(0.3803)), vec4f(unconst_f32(0.1612), unconst_f32(0.07094), unconst_f32(0.2415), unconst_f32(0.01666)))), f16(distance(vec4f(unconst_f32(0.1119), unconst_f32(0.1503), unconst_f32(0.01874), unconst_f32(0.3803)), vec4f(unconst_f32(0.1612), unconst_f32(0.07094), unconst_f32(0.2415), unconst_f32(0.01666)))), f16(distance(vec4f(unconst_f32(0.1119), unconst_f32(0.1503), unconst_f32(0.01874), unconst_f32(0.3803)), vec4f(unconst_f32(0.1612), unconst_f32(0.07094), unconst_f32(0.2415), unconst_f32(0.01666)))), f16(distance(vec4f(unconst_f32(0.1119), unconst_f32(0.1503), unconst_f32(0.01874), unconst_f32(0.3803)), vec4f(unconst_f32(0.1612), unconst_f32(0.07094), unconst_f32(0.2415), unconst_f32(0.01666)))), f16(distance(vec4f(unconst_f32(0.1119), unconst_f32(0.1503), unconst_f32(0.01874), unconst_f32(0.3803)), vec4f(unconst_f32(0.1612), unconst_f32(0.07094), unconst_f32(0.2415), unconst_f32(0.01666)))), f16(distance(vec4f(unconst_f32(0.1119), unconst_f32(0.1503), unconst_f32(0.01874), unconst_f32(0.3803)), vec4f(unconst_f32(0.1612), unconst_f32(0.07094), unconst_f32(0.2415), unconst_f32(0.01666)))), f16(distance(vec4f(unconst_f32(0.1119), unconst_f32(0.1503), unconst_f32(0.01874), unconst_f32(0.3803)), vec4f(unconst_f32(0.1612), unconst_f32(0.07094), unconst_f32(0.2415), unconst_f32(0.01666)))));
+  vw6 = mat4x2h(f16(pack4x8snorm(vec4f(unconst_f32(0.1172), unconst_f32(0.02253), unconst_f32(0.1867), unconst_f32(0.1459)))), f16(pack4x8snorm(vec4f(unconst_f32(0.1172), unconst_f32(0.02253), unconst_f32(0.1867), unconst_f32(0.1459)))), f16(pack4x8snorm(vec4f(unconst_f32(0.1172), unconst_f32(0.02253), unconst_f32(0.1867), unconst_f32(0.1459)))), f16(pack4x8snorm(vec4f(unconst_f32(0.1172), unconst_f32(0.02253), unconst_f32(0.1867), unconst_f32(0.1459)))), f16(pack4x8snorm(vec4f(unconst_f32(0.1172), unconst_f32(0.02253), unconst_f32(0.1867), unconst_f32(0.1459)))), f16(pack4x8snorm(vec4f(unconst_f32(0.1172), unconst_f32(0.02253), unconst_f32(0.1867), unconst_f32(0.1459)))), f16(pack4x8snorm(vec4f(unconst_f32(0.1172), unconst_f32(0.02253), unconst_f32(0.1867), unconst_f32(0.1459)))), f16(pack4x8snorm(vec4f(unconst_f32(0.1172), unconst_f32(0.02253), unconst_f32(0.1867), unconst_f32(0.1459)))));
+  let vf84: f16 = vw6[u32(unconst_u32(264))][u32(unconst_u32(28))];
+  fn0();
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder23 = device0.createCommandEncoder({});
+let texture28 = device0.createTexture({
+  label: '\ufdd3\u6962\u0ae6\u0c0b\u48b3\u{1fc2c}\u04ba\u4500',
+  size: [256, 256, 15],
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView27 = texture5.createView({label: '\u{1ff79}\ufcbd\u8031\u{1fd6b}\u{1f7a1}\ua8eb\u9901\u0704\u7333\uea21'});
+let renderBundle3 = renderBundleEncoder3.finish({});
+let sampler17 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 3.952,
+  lodMaxClamp: 36.33,
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder16.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer13, 'uint16', 1_734, 11_445);
+} catch {}
+try {
+commandEncoder23.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 0 */
+  offset: 0,
+  buffer: buffer9,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder0.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+computePassEncoder15.setBindGroup(0, bindGroup8, new Uint32Array(4985), 1_851, 0);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(86);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder23.copyBufferToBuffer(buffer0, 40, buffer4, 44, 604);
+} catch {}
+let commandEncoder24 = device0.createCommandEncoder({});
+let computePassEncoder21 = commandEncoder23.beginComputePass({});
+let renderPassEncoder3 = commandEncoder24.beginRenderPass({
+  label: '\u08b3\u{1ff1f}\uf806\u{1fbe9}\ud34b',
+  colorAttachments: [{
+  view: textureView2,
+  depthSlice: 7,
+  clearValue: { r: 144.6, g: 497.8, b: 137.5, a: 331.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet2,
+  maxDrawCount: 126123959,
+});
+try {
+externalTexture3.label = '\ud94a\u3dd8';
+} catch {}
+let bindGroup11 = device0.createBindGroup({
+  label: '\ub8cc\u4207\u4dca\u{1fa5c}\u5621\u0177\u00d7\u1f2d\u2d0b\u8816\u{1f8c4}',
+  layout: bindGroupLayout4,
+  entries: [{binding: 84, resource: textureView25}],
+});
+let textureView28 = texture15.createView({});
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup11, new Uint32Array(170), 15, 0);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer9);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+let buffer18 = device0.createBuffer({
+  size: 26854,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: false,
+});
+let commandEncoder25 = device0.createCommandEncoder({label: '\u7603\u0c17\u{1fd40}\u0218'});
+let querySet3 = device0.createQuerySet({type: 'occlusion', count: 818});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup7, new Uint32Array(161), 2, 0);
+} catch {}
+try {
+renderPassEncoder3.end();
+} catch {}
+try {
+commandEncoder24.copyBufferToTexture({
+  /* bytesInLastRow: 27 widthInBlocks: 27 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1585 */
+  offset: 1558,
+  bytesPerRow: 47104,
+  rowsPerImage: 54,
+  buffer: buffer10,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 30, y: 32, z: 1},
+  aspect: 'all',
+}, {width: 27, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder24.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 11, y: 188, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder24.clearBuffer(buffer16, 1708, 4756);
+} catch {}
+try {
+commandEncoder25.insertDebugMarker('\u238e');
+} catch {}
+let buffer19 = device0.createBuffer({size: 3903, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let commandEncoder26 = device0.createCommandEncoder({});
+let texture29 = device0.createTexture({size: [16], dimension: '1d', format: 'r8uint', usage: GPUTextureUsage.COPY_SRC});
+let renderPassEncoder4 = commandEncoder25.beginRenderPass({
+  colorAttachments: [{
+  view: textureView2,
+  depthSlice: 2,
+  clearValue: { r: -382.4, g: 245.7, b: 536.1, a: -49.25, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup10, new Uint32Array(689), 261, 0);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: -447.5, g: 16.92, b: -763.3, a: -631.8, });
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(3, buffer17, 2_292, 673);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 51, y: 17, z: 1},
+  aspect: 'all',
+}, new Uint8Array(6_778).fill(33), /* required buffer size: 6_778 */
+{offset: 38, bytesPerRow: 205}, {width: 45, height: 33, depthOrArrayLayers: 1});
+} catch {}
+let buffer20 = device0.createBuffer({
+  size: 34969,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder27 = device0.createCommandEncoder({});
+let textureView29 = texture24.createView({format: 'r8uint', baseMipLevel: 0});
+try {
+commandEncoder24.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 31, y: 51, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 1812, new Int16Array(27895), 2716, 2908);
+} catch {}
+let bindGroupLayout5 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 487, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }},
+    {
+      binding: 143,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 33,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '1d' },
+    },
+  ],
+});
+let commandEncoder28 = device0.createCommandEncoder({});
+let texture30 = device0.createTexture({
+  size: [256],
+  dimension: '1d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture31 = device0.createTexture({
+  size: {width: 16, height: 10, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let buffer21 = device0.createBuffer({size: 10931, usage: GPUBufferUsage.VERTEX});
+let textureView30 = texture30.createView({});
+let computePassEncoder22 = commandEncoder28.beginComputePass({});
+let sampler18 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 88.54,
+  maxAnisotropy: 13,
+});
+let bindGroup12 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 460, resource: textureView14}, {binding: 296, resource: externalTexture2}],
+});
+let commandEncoder29 = device0.createCommandEncoder({});
+let texture32 = device0.createTexture({
+  size: {width: 256},
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture33 = device0.createTexture({
+  size: {width: 8, height: 5, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  sampleCount: 4,
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView31 = texture16.createView({dimension: '3d'});
+let computePassEncoder23 = commandEncoder27.beginComputePass({});
+let renderPassEncoder5 = commandEncoder24.beginRenderPass({
+  label: '\u1cc3\u01ac\u{1fe3d}\ufe7d\u{1f874}\u0b2d',
+  colorAttachments: [{
+  view: textureView20,
+  clearValue: { r: -544.5, g: 187.3, b: 378.1, a: -854.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet1,
+});
+let sampler19 = device0.createSampler({
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 29.25,
+  lodMaxClamp: 95.46,
+});
+try {
+computePassEncoder16.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+computePassEncoder20.setBindGroup(3, bindGroup12, new Uint32Array(2078), 858, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup0, new Uint32Array(1), 0, 0);
+} catch {}
+try {
+computePassEncoder6.pushDebugGroup('\uf079');
+} catch {}
+document.body.prepend(canvas0);
+let videoFrame3 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'jedecP22Phosphors', transfer: 'smpteSt4281'} });
+let bindGroup13 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 296, resource: externalTexture2}, {binding: 460, resource: textureView24}],
+});
+let querySet4 = device0.createQuerySet({type: 'occlusion', count: 508});
+let textureView32 = texture32.createView({dimension: '1d', arrayLayerCount: 1});
+let textureView33 = texture33.createView({});
+let computePassEncoder24 = commandEncoder29.beginComputePass({});
+let renderPassEncoder6 = commandEncoder26.beginRenderPass({
+  colorAttachments: [{
+  view: textureView10,
+  clearValue: { r: -69.33, g: 949.7, b: -952.3, a: 558.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet0,
+  maxDrawCount: 228619604,
+});
+try {
+renderPassEncoder5.setVertexBuffer(2, undefined, 0, 114_308_017);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+let buffer22 = device0.createBuffer({
+  size: 5595,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: false,
+});
+let querySet5 = device0.createQuerySet({type: 'occlusion', count: 370});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({colorFormats: ['r8uint']});
+try {
+renderPassEncoder0.setBlendConstant({ r: 225.0, g: -541.7, b: -360.6, a: 41.16, });
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer22, 'uint32', 2_664, 471);
+} catch {}
+let texture34 = device0.createTexture({
+  size: {width: 2},
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView34 = texture18.createView({baseMipLevel: 0});
+try {
+renderBundleEncoder4.setIndexBuffer(buffer15, 'uint16', 80, 145);
+} catch {}
+let buffer23 = device0.createBuffer({
+  label: '\u045d\ua22c\u07cd\u824d\u2402\u0bba\u0296\u036c',
+  size: 1816,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let texture35 = device0.createTexture({
+  size: [2, 1, 1],
+  sampleCount: 1,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView35 = texture8.createView({format: 'rgba8unorm'});
+let renderBundle4 = renderBundleEncoder4.finish();
+try {
+computePassEncoder19.setBindGroup(2, bindGroup13);
+} catch {}
+let buffer24 = device0.createBuffer({
+  size: 17692,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder30 = device0.createCommandEncoder({});
+let querySet6 = device0.createQuerySet({type: 'occlusion', count: 1017});
+let computePassEncoder25 = commandEncoder30.beginComputePass({});
+try {
+computePassEncoder14.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup8, new Uint32Array(416), 8, 0);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle3]);
+} catch {}
+try {
+computePassEncoder6.popDebugGroup();
+} catch {}
+await gc();
+let texture36 = device0.createTexture({
+  size: [2, 1, 380],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup8, []);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer4, 'uint16', 554, 537);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 256, depthOrArrayLayers: 150}
+*/
+{
+  source: imageData2,
+  origin: { x: 16, y: 7 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 3, y: 86, z: 6},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 20, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas1);
+await gc();
+let buffer25 = device0.createBuffer({size: 18683, usage: GPUBufferUsage.MAP_WRITE});
+let texture37 = device0.createTexture({
+  size: [16, 10, 1],
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView36 = texture36.createView({label: '\u35f5\u93cd\u0f6b\u0958\u04b5\u3116\u{1fc11}\u53b8', mipLevelCount: 1});
+try {
+computePassEncoder19.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(77);
+} catch {}
+document.body.prepend(canvas0);
+let bindGroup14 = device0.createBindGroup({layout: bindGroupLayout4, entries: [{binding: 84, resource: textureView25}]});
+let buffer26 = device0.createBuffer({
+  size: 3187,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let texture38 = device0.createTexture({
+  size: [4, 2, 1],
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView37 = texture1.createView({baseArrayLayer: 0});
+try {
+renderPassEncoder6.setIndexBuffer(buffer20, 'uint16', 9_822, 596);
+} catch {}
+let textureView38 = texture32.createView({});
+let texture39 = device0.createTexture({
+  size: [16, 10, 60],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView39 = texture14.createView({dimension: '2d-array'});
+let videoFrame4 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'unspecified', primaries: 'bt470m', transfer: 'smpte170m'} });
+let buffer27 = device0.createBuffer({
+  label: '\uf468\u0e60\u7c89\u99e0\u0436\u5f00',
+  size: 4012,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView40 = texture8.createView({dimension: '2d-array'});
+try {
+computePassEncoder21.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+computePassEncoder1.setBindGroup(0, bindGroup1, new Uint32Array(2919), 618, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer10, 'uint32', 5_468, 2_372);
+} catch {}
+try {
+computePassEncoder5.pushDebugGroup('\u0a5b');
+} catch {}
+await gc();
+let imageData3 = new ImageData(80, 88);
+try {
+adapter0.label = '\u0b1a\u923d\u48ec\u{1f67d}';
+} catch {}
+try {
+commandEncoder1.label = '\ud70b\u{1ff81}\u1c68\u3aab\u{1fcc4}\u018d\ucfbd\u7ed0\ua85b\u{1fd1f}';
+} catch {}
+let commandEncoder31 = device0.createCommandEncoder({});
+let querySet7 = device0.createQuerySet({type: 'occlusion', count: 111});
+let computePassEncoder26 = commandEncoder31.beginComputePass({});
+try {
+computePassEncoder25.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup0, new Uint32Array(3750), 72, 0);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle4, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer6, 'uint16', 2_628, 4_520);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(3, buffer2);
+} catch {}
+let bindGroupLayout6 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 93,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {binding: 24, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'uniform', hasDynamicOffset: false }},
+    {
+      binding: 62,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'bgra8unorm', access: 'read-only', viewDimension: '2d' },
+    },
+  ],
+});
+let texture40 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 15},
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder0.executeBundles([renderBundle3, renderBundle4, renderBundle4, renderBundle4]);
+} catch {}
+let commandEncoder32 = device0.createCommandEncoder({});
+let textureView41 = texture40.createView({
+  label: '\u{1f7f7}\ue6f8\u0342\u0445\u3f98\u2bbc\u{1fc54}\u012b\u9943\u0758',
+  dimension: '2d',
+  mipLevelCount: 1,
+});
+let bindGroup15 = device0.createBindGroup({
+  label: '\u{1f753}\u071f\u6416\uf46a',
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 218, resource: textureView12},
+    {binding: 121, resource: externalTexture1},
+    {binding: 420, resource: textureView4},
+  ],
+});
+let commandEncoder33 = device0.createCommandEncoder({});
+let computePassEncoder27 = commandEncoder32.beginComputePass({});
+let renderPassEncoder7 = commandEncoder33.beginRenderPass({
+  label: '\u0521\u8892\u03a2\u9326\u{1f841}\ud43b\u06cc\u2471\uefb2\ud48e',
+  colorAttachments: [{
+  view: textureView34,
+  depthSlice: 871,
+  clearValue: { r: -619.5, g: 198.6, b: -745.7, a: 960.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({colorFormats: ['r16float'], stencilReadOnly: true});
+try {
+computePassEncoder2.setBindGroup(1, bindGroup7, new Uint32Array(1237), 285, 0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(2, buffer20, 5_292, 4_678);
+} catch {}
+let videoFrame5 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'bt470m', transfer: 'logSqrt'} });
+let buffer28 = device0.createBuffer({
+  size: 2026,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView42 = texture17.createView({dimension: '3d'});
+try {
+computePassEncoder23.setBindGroup(1, bindGroup11, new Uint32Array(1048), 227, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder5.setIndexBuffer(buffer20, 'uint32', 3_524, 8_189);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(2, buffer20);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.label = '\u{1fd27}\u0800\ua552\ud8a9\uf91b\u3ec4\u{1f7d9}\u{1f737}\u{1f99c}';
+} catch {}
+let bindGroup16 = device0.createBindGroup({layout: bindGroupLayout4, entries: [{binding: 84, resource: textureView25}]});
+let texture41 = device0.createTexture({
+  size: {width: 2, height: 1, depthOrArrayLayers: 42},
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView43 = texture28.createView({dimension: '2d'});
+let renderBundle5 = renderBundleEncoder5.finish({});
+document.body.prepend(canvas1);
+try {
+adapter0.label = '\u1310\u{1f9eb}\u5a6d\ucead\u11a6';
+} catch {}
+let texture42 = device0.createTexture({
+  size: [16, 10, 1],
+  mipLevelCount: 2,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler20 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 47.94,
+  lodMaxClamp: 58.92,
+  compare: 'not-equal',
+});
+try {
+computePassEncoder5.setBindGroup(2, bindGroup15);
+} catch {}
+try {
+computePassEncoder26.setBindGroup(2, bindGroup0, new Uint32Array(588), 13, 0);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(7, 0, 1, 0);
+} catch {}
+try {
+renderPassEncoder4.setStencilReference(449);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer2, 452, 237);
+} catch {}
+let querySet8 = device0.createQuerySet({type: 'occlusion', count: 87});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup6, new Uint32Array(5262), 34, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 1, y: 26, z: 21},
+  aspect: 'all',
+}, new Uint8Array(30_685).fill(206), /* required buffer size: 30_685 */
+{offset: 12, bytesPerRow: 351, rowsPerImage: 22}, {width: 17, height: 22, depthOrArrayLayers: 4});
+} catch {}
+let commandEncoder34 = device0.createCommandEncoder({});
+let texture43 = device0.createTexture({
+  size: [16, 10, 1],
+  sampleCount: 1,
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(29);
+} catch {}
+await gc();
+let commandEncoder35 = device0.createCommandEncoder({});
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer6, 'uint32', 2_880, 2_749);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+await gc();
+let computePassEncoder28 = commandEncoder34.beginComputePass({});
+let renderPassEncoder8 = commandEncoder35.beginRenderPass({colorAttachments: [{view: textureView43, loadOp: 'clear', storeOp: 'store'}]});
+try {
+renderPassEncoder7.executeBundles([renderBundle1, renderBundle1]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 24, y: 56, z: 7},
+  aspect: 'all',
+}, new Uint8Array(25).fill(67), /* required buffer size: 25 */
+{offset: 25, bytesPerRow: 60}, {width: 10, height: 41, depthOrArrayLayers: 0});
+} catch {}
+let buffer29 = device0.createBuffer({size: 6527, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE});
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup16, new Uint32Array(159), 127, 0);
+} catch {}
+let commandEncoder36 = device0.createCommandEncoder();
+let texture44 = device0.createTexture({
+  label: '\ud2cd\u0c16',
+  size: [4],
+  dimension: '1d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView44 = texture35.createView({dimension: '2d-array', baseArrayLayer: 0});
+let renderPassEncoder9 = commandEncoder36.beginRenderPass({colorAttachments: [{view: textureView20, loadOp: 'clear', storeOp: 'discard'}]});
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle1, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(0, buffer21, 0);
+} catch {}
+let imageData4 = new ImageData(8, 48);
+let querySet9 = device0.createQuerySet({type: 'occlusion', count: 61});
+let textureView45 = texture43.createView({});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({colorFormats: ['r8uint'], depthReadOnly: true});
+let sampler21 = device0.createSampler({addressModeU: 'clamp-to-edge', magFilter: 'linear', lodMinClamp: 16.61, lodMaxClamp: 64.51});
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer15, 'uint32', 20, 8);
+} catch {}
+let textureView46 = texture8.createView({dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 0});
+let renderBundle6 = renderBundleEncoder6.finish({});
+try {
+renderPassEncoder7.setIndexBuffer(buffer24, 'uint32', 2_160, 108);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(0, buffer19, 152, 590);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+  await shaderModule2.getCompilationInfo();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(45).fill(68), /* required buffer size: 45 */
+{offset: 45, rowsPerImage: 75}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet10 = device0.createQuerySet({type: 'occlusion', count: 414});
+try {
+computePassEncoder23.setBindGroup(3, bindGroup14);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup15);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup3, new Uint32Array(161), 9, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData4,
+  origin: { x: 1, y: 5 },
+  flipY: true,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 91, y: 4, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 14, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let bindGroup17 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 121, resource: externalTexture2},
+    {binding: 218, resource: textureView3},
+    {binding: 420, resource: textureView36},
+  ],
+});
+let commandEncoder37 = device0.createCommandEncoder({});
+let textureView47 = texture3.createView({dimension: 'cube', baseArrayLayer: 2});
+let externalTexture5 = device0.importExternalTexture({source: videoFrame2});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup4, new Uint32Array(2597), 509, 0);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer11, 276, new Int16Array(28818), 1512, 2880);
+} catch {}
+let commandEncoder38 = device0.createCommandEncoder({});
+let renderPassEncoder10 = commandEncoder38.beginRenderPass({
+  colorAttachments: [{
+  view: textureView20,
+  clearValue: { r: -90.59, g: 104.6, b: 540.0, a: -581.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet9,
+});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(4, buffer19, 468, 1_049);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let img0 = await imageWithData(92, 12, '#10101010', '#20202020');
+let commandBuffer0 = commandEncoder37.finish();
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer28, 'uint16', 800, 95);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(3, buffer17, 0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer0]);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let pipelineLayout4 = device0.createPipelineLayout({bindGroupLayouts: []});
+let sampler22 = device0.createSampler({
+  label: '\u{1fdef}\u7adc\u38dc\u792f',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 12.90,
+});
+try {
+computePassEncoder16.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup3, new Uint32Array(316), 24, 0);
+} catch {}
+try {
+renderPassEncoder7.setViewport(60.830786995499665, 193.79188450366945, 45.91913176352424, 48.70939606321121, 0.8760026182998679, 0.9387474564269231);
+} catch {}
+try {
+computePassEncoder18.insertDebugMarker('\ubc0d');
+} catch {}
+let bindGroup18 = device0.createBindGroup({layout: bindGroupLayout4, entries: [{binding: 84, resource: textureView25}]});
+let buffer30 = device0.createBuffer({size: 3854, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView48 = texture18.createView({});
+let externalTexture6 = device0.importExternalTexture({source: videoFrame3});
+try {
+device0.queue.writeBuffer(buffer26, 156, new Float32Array(1895), 506, 508);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(388).fill(155), /* required buffer size: 388 */
+{offset: 388}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let sampler23 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 23.94,
+  lodMaxClamp: 30.39,
+  maxAnisotropy: 18,
+});
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup15, []);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup9, new Uint32Array(113), 81, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(0, buffer2, 9_800, 3_665);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 86, y: 62, z: 0},
+  aspect: 'all',
+}, new Uint8Array(127).fill(54), /* required buffer size: 127 */
+{offset: 127, bytesPerRow: 126}, {width: 28, height: 23, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder39 = device0.createCommandEncoder({});
+let computePassEncoder29 = commandEncoder39.beginComputePass({});
+let sampler24 = device0.createSampler({
+  label: '\u0223\u87ab\u19b5',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 41.84,
+});
+try {
+computePassEncoder27.setBindGroup(3, bindGroup11, new Uint32Array(262), 162, 0);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle6, renderBundle3, renderBundle6, renderBundle1, renderBundle6, renderBundle3]);
+} catch {}
+let imageBitmap1 = await createImageBitmap(imageBitmap0);
+let buffer31 = device0.createBuffer({size: 14914, usage: GPUBufferUsage.MAP_READ});
+let commandEncoder40 = device0.createCommandEncoder({});
+let computePassEncoder30 = commandEncoder40.beginComputePass({});
+try {
+computePassEncoder12.setBindGroup(2, bindGroup13, new Uint32Array(9677), 810, 0);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle4, renderBundle4]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData2,
+  origin: { x: 13, y: 2 },
+  flipY: true,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 182, y: 36, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 36, height: 15, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder10.beginOcclusionQuery(6);
+} catch {}
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+computePassEncoder5.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 268, new Int16Array(22352), 1419, 356);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 2, y: 43, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder6.setBindGroup(2, bindGroup0, new Uint32Array(1657), 826, 0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup13, new Uint32Array(934), 88, 0);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let commandEncoder41 = device0.createCommandEncoder();
+let renderPassEncoder11 = commandEncoder41.beginRenderPass({
+  colorAttachments: [{
+  view: textureView34,
+  depthSlice: 227,
+  clearValue: { r: -79.06, g: -900.2, b: 639.1, a: 799.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet3,
+});
+try {
+renderPassEncoder4.setVertexBuffer(5, buffer12);
+} catch {}
+try {
+buffer28.unmap();
+} catch {}
+let bindGroup19 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [{binding: 146, resource: textureView18}, {binding: 5, resource: textureView23}],
+});
+let commandEncoder42 = device0.createCommandEncoder();
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({colorFormats: ['r16float'], depthReadOnly: true});
+try {
+computePassEncoder8.setBindGroup(3, bindGroup9, new Uint32Array(1041), 602, 0);
+} catch {}
+try {
+computePassEncoder10.pushDebugGroup('\u{1fab0}');
+} catch {}
+let buffer32 = device0.createBuffer({
+  size: 15761,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder43 = device0.createCommandEncoder({});
+let texture45 = gpuCanvasContext0.getCurrentTexture();
+let computePassEncoder31 = commandEncoder42.beginComputePass();
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({colorFormats: ['r8uint']});
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer12, 'uint16', 296, 1_521);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(2, bindGroup17, []);
+} catch {}
+try {
+buffer17.unmap();
+} catch {}
+try {
+computePassEncoder10.popDebugGroup();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData2,
+  origin: { x: 7, y: 7 },
+  flipY: true,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 29, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 12, height: 21, depthOrArrayLayers: 0});
+} catch {}
+canvas0.height = 501;
+let shaderModule3 = device0.createShaderModule({
+  label: '\u{1f664}\u02f3\uc5ef\u{1fdce}\uc8de\u{1f9f7}\u277e\u0be4\u{1ff46}\u{1f9ec}\u589e',
+  code: `
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+requires unrestricted_pointer_parameters;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(296) var et3: texture_external;
+
+@group(0) @binding(460) var tex3: texture_2d_array<f32>;
+
+struct T0 {
+  @align(8) @size(8) f0: array<array<array<i32, 1>, 1>, 1>,
+}
+
+struct S1 {
+  @location(10) @interpolate(linear, centroid) f0: vec4h,
+  @location(1) f1: f32,
+  @location(14) @interpolate(flat, sample) f2: vec2h,
+  @builtin(instance_index) f3: u32,
+}
+
+struct VertexOutput2 {
+  @builtin(position) f6: vec4f,
+}
+
+struct FragmentOutput4 {
+  @location(0) f0: vec2f,
+}
+
+fn fn0() -> mat3x3f {
+  var out: mat3x3f;
+  out = mat3x3f(vec3f(reflect(vec4h(unconst_f16(6230.9), unconst_f16(5902.8), unconst_f16(14376.9), unconst_f16(20120.6)), vec4h(unconst_f16(18720.7), unconst_f16(8090.8), unconst_f16(7488.5), unconst_f16(-262.4))).xxx), vec3f(reflect(vec4h(unconst_f16(6230.9), unconst_f16(5902.8), unconst_f16(14376.9), unconst_f16(20120.6)), vec4h(unconst_f16(18720.7), unconst_f16(8090.8), unconst_f16(7488.5), unconst_f16(-262.4))).zzz), vec3f(reflect(vec4h(unconst_f16(6230.9), unconst_f16(5902.8), unconst_f16(14376.9), unconst_f16(20120.6)), vec4h(unconst_f16(18720.7), unconst_f16(8090.8), unconst_f16(7488.5), unconst_f16(-262.4))).brr));
+  out = mat3x3f(quantizeToF16(vec4f(unconst_f32(0.2456), unconst_f32(0.1100), unconst_f32(0.3238), unconst_f32(0.1439))).zxy, quantizeToF16(vec4f(unconst_f32(0.2456), unconst_f32(0.1100), unconst_f32(0.3238), unconst_f32(0.1439))).yzz, quantizeToF16(vec4f(unconst_f32(0.2456), unconst_f32(0.1100), unconst_f32(0.3238), unconst_f32(0.1439))).bbr);
+  let vf85: u32 = textureNumLayers(tex3);
+  out = mat3x3f(textureLoad(tex3, vec2i(unconst_i32(254), unconst_i32(89)), i32(unconst_i32(108)), i32(unconst_i32(16))).xwy, textureLoad(tex3, vec2i(unconst_i32(254), unconst_i32(89)), i32(unconst_i32(108)), i32(unconst_i32(16))).xyz, textureLoad(tex3, vec2i(unconst_i32(254), unconst_i32(89)), i32(unconst_i32(108)), i32(unconst_i32(16))).rbr);
+  let vf86: vec2f = unpack2x16snorm(pack4x8unorm(vec4f(f32(pack4xU8Clamp(vec4u(unconst_u32(22), unconst_u32(54), unconst_u32(72), unconst_u32(31)))))));
+  var vf87: vec2u = textureDimensions(tex3);
+  let vf88: u32 = textureNumLevels(tex3);
+  var vf89: vec3f = asin(vec3f(unconst_f32(0.1733), unconst_f32(0.02015), unconst_f32(0.07993)));
+  var vf90: vec3f = asin(vec3f(unconst_f32(0.3049), unconst_f32(0.08847), unconst_f32(0.1789)));
+  var vf91: f16 = floor(f16(unconst_f16(5621.5)));
+  let vf92: vec4h = cos(vec4h(unconst_f16(12419.5), unconst_f16(891.2), unconst_f16(10022.0), unconst_f16(9216.9)));
+  return out;
+}
+
+fn fn1(a0: FragmentOutput4) -> array<FragmentOutput4, 3> {
+  var out: array<FragmentOutput4, 3>;
+  let vf93: vec4u = unpack4xU8(u32(unconst_u32(138)));
+  out[u32(unconst_u32(15))].f0 = vec2f(bitcast<f32>(dot4I8Packed(u32(unconst_u32(175)), u32(unconst_u32(72)))));
+  var vf94: vec4h = cosh(vec4h(unconst_f16(6769.2), unconst_f16(12864.9), unconst_f16(4371.2), unconst_f16(24086.9)));
+  let ptr14: ptr<function, vec4h> = &vf94;
+  out[u32(unconst_u32(45))] = FragmentOutput4(bitcast<vec2f>(reverseBits(vec4u(unconst_u32(26), unconst_u32(119), unconst_u32(273), unconst_u32(155))).bb));
+  let vf95: vec4u = unpack4xU8(u32(unconst_u32(70)));
+  var vf96: vec3f = log(vec3f(unconst_f32(0.1770), unconst_f32(0.1891), unconst_f32(0.09618)));
+  var vf97: f16 = vf94[u32(unconst_u32(58))];
+  vf94 = (*ptr14);
+  var vf98: i32 = dot4I8Packed(u32(unconst_u32(522)), u32(unconst_u32(6)));
+  vf94 = vec4h(unpack4xU8(u32(vf98)));
+  vf98 ^= bitcast<vec2i>(a0.f0)[0];
+  var vf99: vec2h = fract(vec2h(unconst_f16(3843.8), unconst_f16(2402.5)));
+  let ptr15: ptr<function, f16> = &vf97;
+  var vf100: i32 = dot4I8Packed(u32(unconst_u32(76)), u32(unconst_u32(206)));
+  var vf101: f32 = vf96[u32(unconst_u32(42))];
+  let vf102: vec4u = reverseBits(vec4u(unconst_u32(72), unconst_u32(661), unconst_u32(239), unconst_u32(275)));
+  let vf103: f16 = vf94[pack4xU8(vec4u((*ptr14)))];
+  vf98 &= bitcast<vec3i>(log(vec3f(unpack4xU8(u32(unconst_u32(186))).yyz)))[2];
+  let ptr16: ptr<function, vec2h> = &vf99;
+  vf101 = bitcast<f32>(fract(vec2h(a0.f0)));
+  vf94 *= vec4h(f16(a0.f0[u32(unconst_u32(175))]));
+  vf100 -= i32((*ptr15));
+  return out;
+}
+
+fn fn2(a0: ptr<workgroup, VertexOutput2>) -> array<f32, 15> {
+  var out: array<f32, 15>;
+  out[u32(unconst_u32(129))] = f32(all(select(vec2<bool>(unconst_bool(false), unconst_bool(false)), vec2<bool>(unconst_bool(true), unconst_bool(false)), bool(unconst_bool(false)))));
+  let vf104: f32 = atan(f32(unconst_f32(0.06948)));
+  let vf105: f16 = smoothstep(f16(unconst_f16(3946.7)), f16(unconst_f16(-11732.9)), f16(unconst_f16(1829.1)));
+  out[u32(unconst_u32(58))] += (*a0).f6[0];
+  let vf106: f32 = (*a0).f6[u32(unconst_u32(129))];
+  out[u32(unconst_u32(20))] = f32(smoothstep(f16(unconst_f16(2652.7)), f16(unconst_f16(2383.8)), f16(unconst_f16(920.5))));
+  out[u32(unconst_u32(22))] = vec2f(select(vec2<bool>(unconst_bool(true), unconst_bool(false)), vec2<bool>(unconst_bool(true), unconst_bool(true)), bool(unconst_bool(true)))).x;
+  let ptr17: ptr<workgroup, vec4f> = &(*a0).f6;
+  let vf107: f32 = vf106;
+  var vf108: f32 = atan(f32(unconst_f32(0.2661)));
+  var vf109: vec2h = reflect(vec2h((*a0).f6.zx), vec2h(unconst_f16(14566.8), unconst_f16(20317.4)));
+  out[u32(unconst_u32(54))] *= (*ptr17)[u32(unconst_u32(68))];
+  let vf110: f32 = vf104;
+  var vf111: f32 = vf107;
+  let ptr18: ptr<function, vec2h> = &vf109;
+  return out;
+}
+
+@vertex
+fn vertex2(@location(9) @interpolate(flat, sample) a0: vec2u, @location(4) a1: f16, @location(6) a2: u32, a3: S1, @location(15) @interpolate(flat, centroid) a4: vec2i) -> VertexOutput2 {
+  var out: VertexOutput2;
+  out.f6 *= quantizeToF16(vec3f(unconst_f32(0.1374), unconst_f32(-0.2264), unconst_f32(0.1798))).xxxx;
+  fn0();
+  out = VertexOutput2(vec4f(bitcast<f32>(pack4x8snorm(vec4f(unconst_f32(0.3852), unconst_f32(0.2333), unconst_f32(-0.1921), unconst_f32(0.03931))))));
+  out.f6 *= textureLoad(tex3, vec2i(unconst_i32(90), unconst_i32(147)), i32(unconst_i32(71)), i32(unconst_i32(255)));
+  let vf112: vec2f = max(vec2f(unconst_f32(0.03249), unconst_f32(0.2060)), vec2f(unconst_f32(0.3188), unconst_f32(0.1673)));
+  out.f6 *= vec4f(f32(a3.f3));
+  out.f6 = vec4f(asinh(vec4h(unconst_f16(16603.0), unconst_f16(39625.6), unconst_f16(10967.7), unconst_f16(1490.2))));
+  var vf113 = fn0();
+  fn0();
+  let vf114: vec4h = asinh(vec4h(unconst_f16(7444.3), unconst_f16(19530.0), unconst_f16(6517.6), unconst_f16(14448.5)));
+  fn0();
+  out = VertexOutput2(vec4f(a3.f0));
+  out.f6 += vec4f(normalize(vec4h(unconst_f16(584.3), unconst_f16(9849.9), unconst_f16(-22078.9), unconst_f16(9745.5))));
+  vf113 = mat3x3f(f32(distance(vec4h(unconst_f16(26003.9), unconst_f16(4533.9), unconst_f16(12604.3), unconst_f16(20968.1)), vec4h(unconst_f16(10981.8), unconst_f16(602.6), unconst_f16(3721.1), unconst_f16(8756.1)))), f32(distance(vec4h(unconst_f16(26003.9), unconst_f16(4533.9), unconst_f16(12604.3), unconst_f16(20968.1)), vec4h(unconst_f16(10981.8), unconst_f16(602.6), unconst_f16(3721.1), unconst_f16(8756.1)))), f32(distance(vec4h(unconst_f16(26003.9), unconst_f16(4533.9), unconst_f16(12604.3), unconst_f16(20968.1)), vec4h(unconst_f16(10981.8), unconst_f16(602.6), unconst_f16(3721.1), unconst_f16(8756.1)))), f32(distance(vec4h(unconst_f16(26003.9), unconst_f16(4533.9), unconst_f16(12604.3), unconst_f16(20968.1)), vec4h(unconst_f16(10981.8), unconst_f16(602.6), unconst_f16(3721.1), unconst_f16(8756.1)))), f32(distance(vec4h(unconst_f16(26003.9), unconst_f16(4533.9), unconst_f16(12604.3), unconst_f16(20968.1)), vec4h(unconst_f16(10981.8), unconst_f16(602.6), unconst_f16(3721.1), unconst_f16(8756.1)))), f32(distance(vec4h(unconst_f16(26003.9), unconst_f16(4533.9), unconst_f16(12604.3), unconst_f16(20968.1)), vec4h(unconst_f16(10981.8), unconst_f16(602.6), unconst_f16(3721.1), unconst_f16(8756.1)))), f32(distance(vec4h(unconst_f16(26003.9), unconst_f16(4533.9), unconst_f16(12604.3), unconst_f16(20968.1)), vec4h(unconst_f16(10981.8), unconst_f16(602.6), unconst_f16(3721.1), unconst_f16(8756.1)))), f32(distance(vec4h(unconst_f16(26003.9), unconst_f16(4533.9), unconst_f16(12604.3), unconst_f16(20968.1)), vec4h(unconst_f16(10981.8), unconst_f16(602.6), unconst_f16(3721.1), unconst_f16(8756.1)))), f32(distance(vec4h(unconst_f16(26003.9), unconst_f16(4533.9), unconst_f16(12604.3), unconst_f16(20968.1)), vec4h(unconst_f16(10981.8), unconst_f16(602.6), unconst_f16(3721.1), unconst_f16(8756.1)))));
+  fn0();
+  fn0();
+  out.f6 = transpose(mat2x2f(unconst_f32(0.2005), unconst_f32(0.1935), unconst_f32(0.1837), unconst_f32(-0.1240)))[unconst_i32(1)].rgrg;
+  let vf115: u32 = a3.f3;
+  let vf116: vec2u = textureDimensions(tex3);
+  fn0();
+  out.f6 = vec4f(normalize(vec4h(unconst_f16(28312.0), unconst_f16(13519.2), unconst_f16(-360.5), unconst_f16(2203.6))));
+  return out;
+}
+
+@fragment
+fn fragment4() -> FragmentOutput4 {
+  var out: FragmentOutput4;
+  var vf117: u32 = textureNumLevels(tex3);
+  out.f0 -= unpack2x16float(pack2x16snorm(vec2f(unconst_f32(0.1228), unconst_f32(0.2635))));
+  let ptr19: ptr<function, u32> = &vf117;
+  let vf118: vec4f = quantizeToF16(vec4f(unconst_f32(0.02479), unconst_f32(0.08666), unconst_f32(0.2223), unconst_f32(0.3634)));
+  var vf119: vec4h = inverseSqrt(vec4h(unconst_f16(23446.8), unconst_f16(3192.2), unconst_f16(1468.9), unconst_f16(3648.3)));
+  var vf120: vec4f = textureLoad(et3, vec2u(unconst_u32(4), unconst_u32(247)));
+  vf120 += bitcast<vec4f>(textureDimensions(tex3, i32(unconst_i32(131))).xxyx);
+  let ptr20: ptr<function, vec4h> = &vf119;
+  return out;
+}`,
+  sourceMap: {},
+});
+let commandEncoder44 = device0.createCommandEncoder({});
+let texture46 = device0.createTexture({
+  size: {width: 4, height: 2, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let texture47 = gpuCanvasContext0.getCurrentTexture();
+let renderPassEncoder12 = commandEncoder43.beginRenderPass({
+  label: '\ud76d\u0b50\u877f',
+  colorAttachments: [{
+  view: textureView20,
+  clearValue: { r: 598.8, g: -529.8, b: -39.99, a: 46.76, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet3,
+  maxDrawCount: 256604449,
+});
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup14);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer20, 'uint32', 76, 407);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(0, bindGroup4, new Uint32Array(2571), 1_384, 0);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer22, 'uint32', 540, 2_550);
+} catch {}
+try {
+commandEncoder44.copyBufferToBuffer(buffer3, 1496, buffer20, 2012, 1296);
+} catch {}
+try {
+computePassEncoder21.insertDebugMarker('\ufa6b');
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let videoFrame6 = new VideoFrame(videoFrame5, {timestamp: 0});
+let texture48 = device0.createTexture({
+  label: '\u{1fac6}\u0d6b\u05a0\ub1e6\u0f55\u0b87',
+  size: [16, 10, 1],
+  sampleCount: 4,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder32 = commandEncoder44.beginComputePass({label: '\u8160\ub79e\u{1f616}\u{1fa91}\u9cb2'});
+try {
+computePassEncoder6.setBindGroup(3, bindGroup3, new Uint32Array(1953), 411, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup1, new Uint32Array(177), 11, 0);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(5, undefined, 715_532_678);
+} catch {}
+let promise2 = shaderModule0.getCompilationInfo();
+await gc();
+let videoFrame7 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'film', transfer: 'bt2020_10bit'} });
+let texture49 = device0.createTexture({
+  size: [4],
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView49 = texture1.createView({});
+let sampler25 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 99.00,
+  lodMaxClamp: 99.91,
+  compare: 'not-equal',
+});
+try {
+renderPassEncoder12.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(0, bindGroup18, new Uint32Array(1664), 61, 0);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer15, 'uint32', 124, 16);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 256, depthOrArrayLayers: 15}
+*/
+{
+  source: img0,
+  origin: { x: 10, y: 0 },
+  flipY: true,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 24, y: 8, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 10, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame8 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'bt470m', transfer: 'gamma28curve'} });
+let texture50 = device0.createTexture({
+  size: [256, 256, 15],
+  dimension: '2d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView50 = texture4.createView({dimension: '2d-array', aspect: 'all'});
+try {
+renderBundleEncoder8.setBindGroup(0, bindGroup8, new Uint32Array(1171), 120, 0);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(2, buffer19, 44, 1_670);
+} catch {}
+let bindGroup20 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 7, resource: {buffer: buffer26, offset: 0, size: 388}}],
+});
+let querySet11 = device0.createQuerySet({type: 'occlusion', count: 38});
+let renderBundle7 = renderBundleEncoder7.finish({});
+try {
+renderPassEncoder8.setIndexBuffer(buffer32, 'uint16', 42, 1_583);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(1, bindGroup0, new Uint32Array(207), 95, 0);
+} catch {}
+try {
+device0.label = '\u06e5\u0fe6\u87c9';
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup6, new Uint32Array(1216), 1, 0);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle5, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer10, 'uint16', 1_138, 1_304);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer12, 'uint32', 164, 208);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(0, buffer9, 0, 1_167);
+} catch {}
+let videoFrame9 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'unspecified', primaries: 'smpte432', transfer: 'pq'} });
+let commandEncoder45 = device0.createCommandEncoder({});
+let texture51 = device0.createTexture({
+  size: [256, 256, 531],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler26 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 99.90,
+  lodMaxClamp: 99.91,
+});
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup20, new Uint32Array(3313), 556, 0);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(5, buffer27, 796);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(3, buffer20);
+} catch {}
+try {
+commandEncoder45.copyBufferToBuffer(buffer10, 8416, buffer9, 1256, 2652);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup21 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 218, resource: textureView12},
+    {binding: 121, resource: externalTexture5},
+    {binding: 420, resource: textureView27},
+  ],
+});
+let commandEncoder46 = device0.createCommandEncoder({});
+let computePassEncoder33 = commandEncoder45.beginComputePass({label: '\u{1fc3a}\u0449\u0dab\u09ee\u{1ffbc}'});
+try {
+renderBundleEncoder8.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+commandEncoder46.copyBufferToBuffer(buffer27, 840, buffer2, 1340, 700);
+} catch {}
+try {
+commandEncoder46.copyTextureToBuffer({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 207 */
+  offset: 207,
+  bytesPerRow: 25600,
+  buffer: buffer4,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup22 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 7, resource: {buffer: buffer12, offset: 512, size: 744}}],
+});
+let buffer33 = device0.createBuffer({
+  size: 4909,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture52 = device0.createTexture({
+  label: '\u0bf3\u4f2b\u0892\u04f2',
+  size: [4, 2, 1],
+  sampleCount: 1,
+  format: 'r16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView51 = texture44.createView({mipLevelCount: 1});
+let renderPassEncoder13 = commandEncoder46.beginRenderPass({
+  colorAttachments: [{view: textureView20, loadOp: 'clear', storeOp: 'store'}],
+  maxDrawCount: 144001864,
+});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({colorFormats: ['r8uint'], stencilReadOnly: true});
+let renderBundle8 = renderBundleEncoder9.finish({label: '\u{1fdcb}\u055b'});
+let externalTexture7 = device0.importExternalTexture({source: videoFrame9});
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup7);
+} catch {}
+let commandEncoder47 = device0.createCommandEncoder({});
+let textureView52 = texture17.createView({});
+let renderPassEncoder14 = commandEncoder47.beginRenderPass({colorAttachments: [{view: textureView20, loadOp: 'clear', storeOp: 'store'}]});
+try {
+renderPassEncoder1.setViewport(1.4953680785084944, 0.9164141605412279, 1.844240360118502, 0.2611579371348476, 0.22461098365225474, 0.8281304100769802);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer15, 'uint32', 84, 79);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(5, buffer19, 224, 192);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(0, bindGroup12, new Uint32Array(2595), 81, 0);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 66, y: 22, z: 16},
+  aspect: 'all',
+}, new Uint8Array(30_581).fill(111), /* required buffer size: 30_581 */
+{offset: 58, bytesPerRow: 449}, {width: 55, height: 68, depthOrArrayLayers: 1});
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(0, 0, 0, 0);
+} catch {}
+try {
+computePassEncoder30.pushDebugGroup('\u9fdb');
+} catch {}
+let imageBitmap2 = await createImageBitmap(imageData3);
+let buffer34 = device0.createBuffer({
+  size: 22,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView53 = texture40.createView({label: '\u{1f6df}\u0858\udbc7\u{1f9b1}', dimension: '2d'});
+let texture53 = device0.createTexture({
+  label: '\ubcce\u{1fb71}\u0342\u{1f8de}\ub066\u3b83',
+  size: {width: 16},
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup10, new Uint32Array(133), 23, 0);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer13, 'uint16', 440, 1_142);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+document.body.append(img0);
+let bindGroup23 = device0.createBindGroup({
+  label: '\u0b2f\u0244\uf4e1\u0643\u{1f7d5}\u4ff0\u{1fc1a}\u08b8',
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 218, resource: textureView12},
+    {binding: 420, resource: textureView7},
+    {binding: 121, resource: externalTexture0},
+  ],
+});
+try {
+computePassEncoder30.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup22);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(2, bindGroup18);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(1, bindGroup6, new Uint32Array(4243), 308, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 11016, new Int16Array(1440), 222, 56);
+} catch {}
+let buffer35 = device0.createBuffer({label: '\u{1f862}\u5902\u0434\u1fce\u4c9b\u{1f7a8}', size: 6043, usage: GPUBufferUsage.INDIRECT});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({colorFormats: ['r16float'], stencilReadOnly: true});
+try {
+renderBundleEncoder8.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame8,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 16, y: 14, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup24 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [{binding: 146, resource: textureView21}, {binding: 5, resource: textureView23}],
+});
+let commandEncoder48 = device0.createCommandEncoder({});
+let texture54 = device0.createTexture({
+  label: '\udc93\u39da\uaf8a\u082b\u{1fd5a}\u{1fe1d}\ua25a\u4331',
+  size: [16],
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let computePassEncoder34 = commandEncoder48.beginComputePass({});
+try {
+renderPassEncoder5.setVertexBuffer(2, buffer1, 2_712, 2_220);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer26, 'uint32', 736, 342);
+} catch {}
+try {
+buffer25.unmap();
+} catch {}
+await gc();
+let commandEncoder49 = device0.createCommandEncoder({label: '\uc3ae\u02c5\u7291'});
+let renderPassEncoder15 = commandEncoder49.beginRenderPass({colorAttachments: [{view: textureView6, loadOp: 'load', storeOp: 'store'}], maxDrawCount: 77206565});
+try {
+computePassEncoder23.setBindGroup(2, bindGroup9);
+} catch {}
+try {
+computePassEncoder17.setBindGroup(3, bindGroup0, new Uint32Array(3705), 375, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup19, []);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup5, new Uint32Array(669), 74, 0);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle3, renderBundle4, renderBundle8, renderBundle1, renderBundle3, renderBundle6]);
+} catch {}
+try {
+computePassEncoder30.popDebugGroup();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData0,
+  origin: { x: 2, y: 1 },
+  flipY: false,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 133, y: 19, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let bindGroup25 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [
+    {binding: 24, resource: {buffer: buffer15, offset: 0, size: 68}},
+    {binding: 93, resource: {buffer: buffer24, offset: 2304}},
+    {binding: 62, resource: textureView53},
+  ],
+});
+let commandEncoder50 = device0.createCommandEncoder({});
+let texture55 = gpuCanvasContext0.getCurrentTexture();
+let externalTexture8 = device0.importExternalTexture({source: videoFrame9, colorSpace: 'display-p3'});
+try {
+computePassEncoder12.setBindGroup(0, bindGroup22, new Uint32Array(3650), 890, 0);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer32, 'uint32', 80, 8_743);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(118).fill(1), /* required buffer size: 118 */
+{offset: 118, rowsPerImage: 18}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter0.label = '\u93ba\u{1ff38}\u0e9f\ucee3\u2674\u202b\u{1fb66}\u50eb\u3b64\u9563\u{1fef7}';
+} catch {}
+let buffer36 = device0.createBuffer({size: 24567, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView54 = texture26.createView({label: '\u083e\u06ff\u0329', arrayLayerCount: 1});
+let computePassEncoder35 = commandEncoder50.beginComputePass({label: '\u8492\u11cf\u0453\u0bc3'});
+try {
+computePassEncoder9.setBindGroup(3, bindGroup16, new Uint32Array(115), 1, 0);
+} catch {}
+try {
+renderPassEncoder15.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(5, buffer1, 0, 1_411);
+} catch {}
+let bindGroup26 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 7, resource: {buffer: buffer32, offset: 768, size: 408}}],
+});
+let buffer37 = device0.createBuffer({size: 7550, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder51 = device0.createCommandEncoder({});
+let commandBuffer1 = commandEncoder51.finish();
+let textureView55 = texture41.createView({});
+let renderBundle9 = renderBundleEncoder10.finish({});
+try {
+computePassEncoder19.setBindGroup(2, bindGroup24, new Uint32Array(4945), 961, 0);
+} catch {}
+try {
+renderPassEncoder12.beginOcclusionQuery(111);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 1992, new Float32Array(11755), 1767, 8);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+  await promise2;
+} catch {}
+let commandEncoder52 = device0.createCommandEncoder();
+let renderBundle10 = renderBundleEncoder8.finish();
+let sampler27 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 66.06,
+  lodMaxClamp: 76.61,
+});
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup13);
+} catch {}
+try {
+renderPassEncoder12.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder52.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 131 */
+  offset: 131,
+  bytesPerRow: 6144,
+  buffer: buffer9,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer20, 19112, new BigUint64Array(17014), 1845, 20);
+} catch {}
+let imageData5 = new ImageData(64, 36);
+let textureView56 = texture8.createView({});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({colorFormats: ['r8uint'], stencilReadOnly: true});
+let sampler28 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 22.29,
+  lodMaxClamp: 38.35,
+  compare: 'not-equal',
+});
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup10, new Uint32Array(764), 147, 0);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(1, bindGroup22);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer12, 'uint32', 660, 185);
+} catch {}
+try {
+  await buffer8.mapAsync(GPUMapMode.READ, 4408, 964);
+} catch {}
+try {
+commandEncoder52.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2696 */
+  offset: 2696,
+  bytesPerRow: 16384,
+  rowsPerImage: 109,
+  buffer: buffer30,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame9,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 16, y: 25, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let buffer38 = device0.createBuffer({size: 24974, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder53 = device0.createCommandEncoder();
+let computePassEncoder36 = commandEncoder53.beginComputePass({});
+try {
+computePassEncoder23.setBindGroup(3, bindGroup26);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup17, new Uint32Array(2985), 90, 0);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer15, 'uint16', 252, 3);
+} catch {}
+let texture56 = device0.createTexture({
+  size: {width: 8, height: 5, depthOrArrayLayers: 1},
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let renderBundle11 = renderBundleEncoder11.finish({});
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup23, new Uint32Array(1694), 47, 0);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle9]);
+} catch {}
+try {
+commandEncoder52.copyTextureToBuffer({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 19, y: 74, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 516 widthInBlocks: 129 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2104 */
+  offset: 2104,
+  bytesPerRow: 14848,
+  buffer: buffer16,
+}, {width: 129, height: 10, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let buffer39 = device0.createBuffer({size: 5800, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let commandEncoder54 = device0.createCommandEncoder({});
+let textureView57 = texture51.createView({mipLevelCount: 1, arrayLayerCount: 1});
+let renderPassEncoder16 = commandEncoder54.beginRenderPass({
+  colorAttachments: [{view: textureView39, loadOp: 'clear', storeOp: 'store'}],
+  occlusionQuerySet: querySet6,
+});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({colorFormats: ['r8uint'], stencilReadOnly: true});
+try {
+computePassEncoder8.setBindGroup(3, bindGroup7, []);
+} catch {}
+try {
+computePassEncoder26.setBindGroup(1, bindGroup1, new Uint32Array(1931), 52, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer29, 208, new Float32Array(8303), 80, 36);
+} catch {}
+document.body.append(canvas1);
+let texture57 = device0.createTexture({
+  size: {width: 2, height: 1, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  dimension: '2d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture58 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 492},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let computePassEncoder37 = commandEncoder52.beginComputePass({});
+let renderBundle12 = renderBundleEncoder12.finish({});
+let sampler29 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 53.04,
+  lodMaxClamp: 60.51,
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder30.setBindGroup(0, bindGroup9);
+} catch {}
+let bindGroupLayout7 = device0.createBindGroupLayout({
+  entries: [{binding: 13, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}}],
+});
+let textureView58 = texture16.createView({baseMipLevel: 0});
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup16, new Uint32Array(4340), 489, 0);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(6, buffer27, 328, 3);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture36,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 9},
+  aspect: 'all',
+}, new Uint8Array(143_721).fill(45), /* required buffer size: 143_721 */
+{offset: 105, bytesPerRow: 64, rowsPerImage: 68}, {width: 0, height: 0, depthOrArrayLayers: 34});
+} catch {}
+let bindGroup27 = device0.createBindGroup({layout: bindGroupLayout4, entries: [{binding: 84, resource: textureView25}]});
+try {
+computePassEncoder34.setBindGroup(3, bindGroup15, new Uint32Array(304), 10, 0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup6, new Uint32Array(83), 17, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer12, 'uint16', 286, 331);
+} catch {}
+let texture59 = gpuCanvasContext0.getCurrentTexture();
+let textureView59 = texture53.createView({});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({colorFormats: ['r16float'], sampleCount: 1, stencilReadOnly: true});
+try {
+computePassEncoder12.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer20, 'uint32', 5_348, 8_785);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(1, bindGroup10);
+} catch {}
+let imageData6 = new ImageData(52, 128);
+let textureView60 = texture3.createView({
+  label: '\u{1ff9d}\ua007\u0963\uae7a\u18d0\u0431\u01fa\u6fe2\u41df\u0212\ucec8',
+  aspect: 'all',
+  baseArrayLayer: 3,
+  arrayLayerCount: 3,
+});
+let sampler30 = device0.createSampler({
+  label: '\u4e11\u5738\u{1f61b}\u9eb2\u03cf',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 35.59,
+  lodMaxClamp: 88.41,
+  maxAnisotropy: 11,
+});
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(1, bindGroup20, new Uint32Array(4440), 595, 0);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+document.body.append(canvas0);
+let commandEncoder55 = device0.createCommandEncoder();
+let texture60 = device0.createTexture({
+  label: '\u{1f7db}\u{1fc1d}\u{1f7bb}\u{1f697}',
+  size: {width: 2, height: 1, depthOrArrayLayers: 67},
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView61 = texture34.createView({label: '\ue795\u{1f698}\u06f9\u1f85\u50b7\uff6b\u08ee\u4fc5\ubb51\u58ce\u5bd0', dimension: '1d'});
+try {
+computePassEncoder21.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(0, undefined);
+} catch {}
+try {
+commandEncoder55.resolveQuerySet(querySet10, 48, 36, buffer24, 768);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let buffer40 = device0.createBuffer({size: 462, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX});
+let renderPassEncoder17 = commandEncoder55.beginRenderPass({
+  label: '\u20a0\u2f7e\u3f49',
+  colorAttachments: [{
+  view: textureView55,
+  depthSlice: 20,
+  clearValue: { r: 528.3, g: 990.6, b: 633.1, a: -773.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet3,
+  maxDrawCount: 360069386,
+});
+let renderBundle13 = renderBundleEncoder13.finish({});
+let sampler31 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 35.22,
+  lodMaxClamp: 93.79,
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder28.setBindGroup(2, bindGroup21, new Uint32Array(2461), 176, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer10, 'uint32', 1_084, 3_825);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let textureView62 = texture56.createView({dimension: '2d-array', format: 'r16float'});
+try {
+renderPassEncoder9.setVertexBuffer(3, buffer2);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let bindGroup28 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 13, resource: externalTexture0}]});
+let texture61 = gpuCanvasContext0.getCurrentTexture();
+let externalTexture9 = device0.importExternalTexture({source: videoFrame2, colorSpace: 'srgb'});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let buffer41 = device0.createBuffer({size: 2787, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder56 = device0.createCommandEncoder({label: '\uca0b\u{1f9cb}\u0056\u0549'});
+let computePassEncoder38 = commandEncoder56.beginComputePass({});
+let externalTexture10 = device0.importExternalTexture({label: '\u467d\ua33b\u{1f7f6}\u274b\ud362\u{1ff51}\uc8c6\u0d83\u3e7a', source: videoFrame2});
+try {
+computePassEncoder22.setBindGroup(3, bindGroup12);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup17);
+} catch {}
+let buffer42 = device0.createBuffer({
+  label: '\ucc36\u3c94\u8741\u{1fac5}',
+  size: 12063,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+try {
+renderPassEncoder2.setIndexBuffer(buffer24, 'uint32', 956, 1_615);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup29 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [
+    {binding: 24, resource: {buffer: buffer2, offset: 2560, size: 642}},
+    {binding: 93, resource: {buffer: buffer6, offset: 3072, size: 2804}},
+    {binding: 62, resource: textureView53},
+  ],
+});
+let buffer43 = device0.createBuffer({size: 2947, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+let externalTexture11 = device0.importExternalTexture({source: videoFrame1, colorSpace: 'display-p3'});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup17);
+} catch {}
+try {
+computePassEncoder21.setBindGroup(2, bindGroup15, new Uint32Array(46), 7, 0);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup27);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(3, bindGroup20, new Uint32Array(423), 60, 0);
+} catch {}
+try {
+renderPassEncoder14.setBlendConstant({ r: 43.76, g: -532.0, b: 827.4, a: -273.9, });
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let videoFrame10 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'film', transfer: 'iec61966-2-1'} });
+let commandEncoder57 = device0.createCommandEncoder({});
+let textureView63 = texture40.createView({dimension: 'cube', mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder39 = commandEncoder57.beginComputePass({});
+try {
+computePassEncoder10.setBindGroup(2, bindGroup29, new Uint32Array(5363), 1_554, 0);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup8, new Uint32Array(1234), 642, 0);
+} catch {}
+try {
+renderPassEncoder6.beginOcclusionQuery(19);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(6, buffer39);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer20, 152, new BigUint64Array(9083), 58, 1064);
+} catch {}
+try {
+adapter0.label = '\ua953\u0ef3\u868a\u2213\u3678\u0646\u0189\u0ff4';
+} catch {}
+let pipelineLayout5 = device0.createPipelineLayout({bindGroupLayouts: []});
+let texture62 = device0.createTexture({
+  label: '\u48de\u07e6\u0af9\u5547\u{1fd7a}\u3642\u{1ff97}\u6ce1\ued7b\u5655\u{1f729}',
+  size: [16, 10, 1],
+  mipLevelCount: 2,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let externalTexture12 = device0.importExternalTexture({source: videoFrame9});
+document.body.prepend(canvas1);
+let commandEncoder58 = device0.createCommandEncoder({label: '\uce81\u{1f79c}\u1e11\uc38c\u8ef3\ub9f3\u94b2\u46b2'});
+let commandBuffer2 = commandEncoder58.finish({label: '\u4b4c\u0af4\u0576\u0a8b'});
+try {
+computePassEncoder21.setBindGroup(1, bindGroup26, new Uint32Array(812), 243, 0);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(3, bindGroup29);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer13, 'uint32', 18_760, 211);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let textureView64 = texture48.createView({});
+let textureView65 = texture17.createView({dimension: '3d'});
+let sampler32 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 49.26,
+  lodMaxClamp: 81.70,
+});
+let commandEncoder59 = device0.createCommandEncoder({});
+let computePassEncoder40 = commandEncoder59.beginComputePass();
+try {
+computePassEncoder0.setBindGroup(2, bindGroup26, new Uint32Array(1427), 314, 0);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(7, buffer19, 0, 191);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(179).fill(60), /* required buffer size: 179 */
+{offset: 179, bytesPerRow: 105}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img0);
+let commandEncoder60 = device0.createCommandEncoder({});
+let renderPassEncoder18 = commandEncoder60.beginRenderPass({
+  colorAttachments: [{
+  view: textureView20,
+  clearValue: { r: 204.2, g: -692.3, b: 81.12, a: 822.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet11,
+});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 256, depthOrArrayLayers: 150}
+*/
+{
+  source: imageData2,
+  origin: { x: 9, y: 5 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 54, y: 70, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 15, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder61 = device0.createCommandEncoder({label: '\u{1fa28}\u{1fbcc}\u0732\u{1f727}\u027f\uab07\u{1fac9}\u{1f9ac}\u{1fb60}'});
+let textureView66 = texture10.createView({dimension: 'cube', mipLevelCount: 1});
+let renderPassEncoder19 = commandEncoder61.beginRenderPass({
+  colorAttachments: [{view: textureView55, depthSlice: 13, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet3,
+});
+try {
+computePassEncoder33.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+computePassEncoder12.setBindGroup(2, bindGroup29, new Uint32Array(2992), 508, 0);
+} catch {}
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle9, renderBundle2, renderBundle9]);
+} catch {}
+try {
+computePassEncoder35.setBindGroup(0, bindGroup8, new Uint32Array(3951), 957, 0);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(3, bindGroup18);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup9, new Uint32Array(13), 0, 0);
+} catch {}
+try {
+renderPassEncoder19.setViewport(1.1760293019816046, 0.7695325497367155, 0.1469697271112008, 0.07986607219112404, 0.26249819663156204, 0.9919062760177543);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer22, 'uint16', 332, 682);
+} catch {}
+let bindGroup30 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 13, resource: externalTexture8}]});
+let buffer44 = device0.createBuffer({
+  label: '\u47d6\uf8cf\u2432\u0ea3\uc785\u0cae\u{1f683}\u2bb8\u063c\u9a1c',
+  size: 12781,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+try {
+computePassEncoder28.setBindGroup(2, bindGroup24);
+} catch {}
+try {
+device0.queue.submit([commandBuffer2]);
+} catch {}
+let buffer45 = device0.createBuffer({
+  size: 7194,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder62 = device0.createCommandEncoder({});
+let querySet12 = device0.createQuerySet({type: 'occlusion', count: 1062});
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle5, renderBundle7, renderBundle7]);
+} catch {}
+try {
+computePassEncoder6.insertDebugMarker('\ub63d');
+} catch {}
+let computePassEncoder41 = commandEncoder62.beginComputePass({});
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup9, new Uint32Array(1806), 44, 0);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(0, buffer9);
+} catch {}
+let arrayBuffer0 = buffer8.getMappedRange(4408, 80);
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 3, y: 4, z: 0},
+  aspect: 'all',
+}, new Uint8Array(77).fill(252), /* required buffer size: 77 */
+{offset: 77}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData7 = new ImageData(8, 24);
+let bindGroupLayout8 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 271,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rg32float', access: 'write-only', viewDimension: '1d' },
+    },
+    {
+      binding: 340,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '1d' },
+    },
+  ],
+});
+let buffer46 = device0.createBuffer({
+  label: '\u{1fb5f}\u{1f849}\u{1f754}\u0587\u{1f98b}\u8862\u2d98\u4b0a\u0934',
+  size: 6084,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let texture63 = device0.createTexture({
+  size: {width: 16},
+  dimension: '1d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView67 = texture14.createView({
+  label: '\u{1f87d}\u{1ffef}\u{1f7ab}\u5323\u5d4d\u{1fff9}\u{1ffc4}\u0507',
+  dimension: '2d',
+  aspect: 'all',
+});
+let commandEncoder63 = device0.createCommandEncoder();
+let texture64 = device0.createTexture({
+  size: [4],
+  dimension: '1d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture65 = device0.createTexture({
+  size: {width: 4, height: 2, depthOrArrayLayers: 140},
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView68 = texture52.createView({dimension: '2d-array'});
+let sampler33 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 20.50,
+});
+try {
+computePassEncoder11.setBindGroup(3, bindGroup19);
+} catch {}
+try {
+commandEncoder63.copyTextureToTexture({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 17},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup31 = device0.createBindGroup({
+  label: '\u{1fd9e}\u07f1',
+  layout: bindGroupLayout0,
+  entries: [{binding: 7, resource: {buffer: buffer9, offset: 1280}}],
+});
+let commandEncoder64 = device0.createCommandEncoder({});
+let textureView69 = texture64.createView({label: '\uf0ba\u9039\u09b2\u9a14\u{1fd82}\udfe7\u0618\u01a2\u11ff\uf7d9\u{1fe95}', mipLevelCount: 1});
+let texture66 = device0.createTexture({
+  size: [16, 10, 1],
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder42 = commandEncoder64.beginComputePass({});
+let renderPassEncoder20 = commandEncoder63.beginRenderPass({
+  colorAttachments: [{
+  view: textureView55,
+  depthSlice: 40,
+  clearValue: { r: -660.0, g: 532.4, b: 501.9, a: -129.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 27468904,
+});
+let sampler34 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 91.06,
+  maxAnisotropy: 2,
+});
+try {
+computePassEncoder19.setBindGroup(0, bindGroup21, new Uint32Array(3590), 943, 0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup19);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle6]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer47 = device0.createBuffer({size: 1625, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder65 = device0.createCommandEncoder({});
+let textureView70 = texture65.createView({});
+try {
+computePassEncoder29.setBindGroup(3, bindGroup24, []);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup23, new Uint32Array(195), 7, 0);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer20, 12896, new BigUint64Array(4161), 143, 1232);
+} catch {}
+let buffer48 = device0.createBuffer({
+  label: '\u{1f9c6}\u5e1f\u2751\u038b',
+  size: 5284,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let texture67 = device0.createTexture({
+  size: {width: 256},
+  dimension: '1d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture68 = device0.createTexture({
+  size: {width: 2, height: 1, depthOrArrayLayers: 1},
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView71 = texture42.createView({label: '\u017f\u1ecd', baseMipLevel: 0, mipLevelCount: 1});
+let computePassEncoder43 = commandEncoder65.beginComputePass();
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({label: '\ua600\u17c4\u0fba\u0f5a', colorFormats: ['r8uint'], depthReadOnly: true});
+let sampler35 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 11.19,
+  lodMaxClamp: 46.41,
+  compare: 'greater',
+  maxAnisotropy: 14,
+});
+try {
+renderPassEncoder8.setIndexBuffer(buffer15, 'uint32', 176, 5);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(1, bindGroup21);
+} catch {}
+let arrayBuffer1 = buffer8.getMappedRange(4720, 156);
+let commandEncoder66 = device0.createCommandEncoder({});
+let texture69 = device0.createTexture({
+  size: {width: 2, height: 1, depthOrArrayLayers: 1},
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle14 = renderBundleEncoder14.finish({});
+let sampler36 = device0.createSampler({addressModeW: 'clamp-to-edge', minFilter: 'nearest', lodMaxClamp: 96.96});
+try {
+computePassEncoder34.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle13, renderBundle0, renderBundle13, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder8.pushDebugGroup('\ua4e1');
+} catch {}
+try {
+renderPassEncoder8.popDebugGroup();
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(30, 171);
+let querySet13 = device0.createQuerySet({type: 'occlusion', count: 673});
+let texture70 = device0.createTexture({size: [8, 5, 1279], dimension: '3d', format: 'r8uint', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let computePassEncoder44 = commandEncoder66.beginComputePass({label: '\u{1faec}\u{1f990}\uf200\u05b0\u064d\u{1fdfc}\ua326'});
+let sampler37 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 44.25,
+  lodMaxClamp: 67.93,
+  compare: 'greater',
+  maxAnisotropy: 18,
+});
+try {
+renderPassEncoder11.beginOcclusionQuery(41);
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer20, 'uint32', 156, 9_820);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder67 = device0.createCommandEncoder({});
+let texture71 = device0.createTexture({
+  label: '\u5206\u{1f9ec}\u06e3\u5577\u0e29\u0b4b\u8a85\uc2d2\uf485\u828b',
+  size: [16, 10, 1],
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView72 = texture2.createView({});
+let sampler38 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'clamp-to-edge', lodMinClamp: 83.99, lodMaxClamp: 86.01});
+try {
+computePassEncoder9.setBindGroup(2, bindGroup26);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: -554.5, g: 381.3, b: -452.1, a: 17.12, });
+} catch {}
+try {
+commandEncoder67.copyBufferToTexture({
+  /* bytesInLastRow: 352 widthInBlocks: 88 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1224 */
+  offset: 1224,
+  bytesPerRow: 24320,
+  buffer: buffer11,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 88, height: 35, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder67.copyTextureToTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 76, y: 63, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder67.resolveQuerySet(querySet5, 42, 25, buffer22, 0);
+} catch {}
+document.body.append(canvas0);
+let bindGroup32 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 7, resource: {buffer: buffer28, offset: 0, size: 8}}]});
+let textureView73 = texture30.createView({format: 'bgra8unorm-srgb'});
+let computePassEncoder45 = commandEncoder67.beginComputePass({label: '\u0ae7\u0ed9\ud9b8\u{1f81a}\u6484'});
+try {
+renderPassEncoder17.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup7, new Uint32Array(1771), 231, 0);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(1, buffer40);
+} catch {}
+let buffer49 = device0.createBuffer({
+  label: '\ub410\u4a74\u0b0b',
+  size: 17024,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture72 = device0.createTexture({
+  size: [4, 2, 1],
+  mipLevelCount: 2,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView74 = texture30.createView({format: 'bgra8unorm-srgb'});
+let sampler39 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 42.37,
+  lodMaxClamp: 86.12,
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup6, []);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder4.setViewport(3.622155954391575, 1.1020056313535076, 8.760651871406939, 3.678047392654143, 0.9642661089054816, 0.9825764989169635);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+offscreenCanvas0.getContext('2d');
+} catch {}
+let commandEncoder68 = device0.createCommandEncoder({});
+let texture73 = device0.createTexture({
+  label: '\u5db6\u0951\u0925\u0f58\u0b8a\u00f0\u07cf\u623e\u{1f987}',
+  size: {width: 4},
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder21 = commandEncoder68.beginRenderPass({
+  colorAttachments: [{
+  view: textureView55,
+  depthSlice: 35,
+  clearValue: { r: -506.1, g: 57.82, b: 493.7, a: -942.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let externalTexture13 = device0.importExternalTexture({source: videoFrame2});
+try {
+computePassEncoder23.setBindGroup(2, bindGroup10, new Uint32Array(2194), 605, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle9, renderBundle9]);
+} catch {}
+try {
+device0.queue.submit([commandBuffer1]);
+} catch {}
+let promise3 = device0.queue.onSubmittedWorkDone();
+let commandEncoder69 = device0.createCommandEncoder({});
+let computePassEncoder46 = commandEncoder69.beginComputePass({});
+let sampler40 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 21.40,
+  lodMaxClamp: 69.80,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder6.beginOcclusionQuery(14);
+} catch {}
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer22, 'uint32', 936, 87);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(7, buffer49, 0);
+} catch {}
+document.body.prepend(canvas1);
+let imageData8 = new ImageData(8, 8);
+let texture74 = device0.createTexture({
+  size: {width: 2, height: 1, depthOrArrayLayers: 1},
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let sampler41 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 92.94,
+  lodMaxClamp: 95.09,
+  maxAnisotropy: 6,
+});
+let externalTexture14 = device0.importExternalTexture({label: '\u1d98\u{1f869}\u0ffe\u3ddd\u{1fe83}\u0d7e\u5999', source: videoFrame3});
+try {
+computePassEncoder42.setBindGroup(1, bindGroup13, new Uint32Array(2083), 576, 0);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer15, 'uint16', 22, 12);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(4, buffer12);
+} catch {}
+try {
+adapter0.label = '\u3c1a\u089e\u05cb\uaac3\u6c9a\u2577\ua038';
+} catch {}
+let texture75 = device0.createTexture({
+  size: [16, 10, 39],
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+try {
+computePassEncoder38.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup32, new Uint32Array(2111), 219, 0);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer29, 'uint16', 910, 209);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let buffer50 = device0.createBuffer({size: 6403, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let texture76 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 15},
+  sampleCount: 1,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler42 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 99.54,
+  compare: 'less-equal',
+});
+try {
+computePassEncoder20.setBindGroup(0, bindGroup19);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer6, 'uint32', 4_396, 5_579);
+} catch {}
+let pipelineLayout6 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout1]});
+let commandEncoder70 = device0.createCommandEncoder();
+let computePassEncoder47 = commandEncoder70.beginComputePass({});
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle10, renderBundle1, renderBundle11, renderBundle6, renderBundle10]);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(3, buffer12, 0, 1_649);
+} catch {}
+let videoFrame11 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'rgb', primaries: 'film', transfer: 'gamma28curve'} });
+let texture77 = device0.createTexture({
+  size: {width: 2, height: 1, depthOrArrayLayers: 339},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let sampler43 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 75.93,
+  maxAnisotropy: 8,
+});
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup1, new Uint32Array(2896), 338, 0);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer13, 'uint16', 2_846, 9_567);
+} catch {}
+try {
+computePassEncoder42.insertDebugMarker('\u0035');
+} catch {}
+let promise4 = device0.queue.onSubmittedWorkDone();
+let buffer51 = device0.createBuffer({
+  size: 14116,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let texture78 = device0.createTexture({
+  size: [4, 2, 1],
+  mipLevelCount: 1,
+  sampleCount: 4,
+  dimension: '2d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8uint'],
+});
+let sampler44 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 45.69,
+  lodMaxClamp: 94.28,
+  compare: 'not-equal',
+});
+try {
+computePassEncoder6.setBindGroup(3, bindGroup12);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(7, buffer48, 1_668);
+} catch {}
+document.body.append(canvas0);
+let commandEncoder71 = device0.createCommandEncoder();
+let texture79 = device0.createTexture({
+  size: {width: 4, height: 2, depthOrArrayLayers: 151},
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder48 = commandEncoder71.beginComputePass({});
+try {
+renderPassEncoder18.setVertexBuffer(1, buffer49);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 42}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 3, y: 74 },
+  flipY: true,
+}, {
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 6},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise3;
+} catch {}
+let videoFrame12 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'bt470bg', transfer: 'smpte170m'} });
+let bindGroup33 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 487, resource: sampler3},
+    {binding: 33, resource: textureView32},
+    {binding: 143, resource: textureView30},
+  ],
+});
+let texture80 = device0.createTexture({
+  size: {width: 16, height: 10, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder4.setViewport(0.3044318017743812, 2.871082084900327, 2.0294138037736635, 1.342609447083085, 0.5971805366161622, 0.601603368277108);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer6, 'uint32', 2_428, 1_871);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(7, buffer17);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas0,
+  origin: { x: 37, y: 29 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 20, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 181, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise4;
+} catch {}
+document.body.append(canvas0);
+let imageData9 = new ImageData(24, 64);
+let bindGroupLayout9 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 114,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup34 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 460, resource: textureView19}, {binding: 296, resource: externalTexture5}],
+});
+try {
+computePassEncoder19.setBindGroup(0, bindGroup14);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder16.setScissorRect(0, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(6, undefined, 0);
+} catch {}
+let sampler45 = device0.createSampler({
+  label: '\u9211\u0447\ubb6e\u0742\u09f4\u579b\uda9a\u97df\u{1fafa}\u6c89',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 67.30,
+});
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup11, new Uint32Array(597), 26, 0);
+} catch {}
+try {
+renderPassEncoder6.beginOcclusionQuery(1);
+} catch {}
+try {
+renderPassEncoder16.setScissorRect(0, 0, 0, 0);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 256, depthOrArrayLayers: 150}
+*/
+{
+  source: imageData8,
+  origin: { x: 1, y: 2 },
+  flipY: true,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 9, y: 2, z: 12},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout7 = device0.createPipelineLayout({bindGroupLayouts: []});
+let texture81 = device0.createTexture({
+  size: {width: 16, height: 10, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder0.end();
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer12, 'uint16', 812, 374);
+} catch {}
+let arrayBuffer2 = buffer8.getMappedRange(4488, 0);
+try {
+commandEncoder1.copyBufferToBuffer(buffer26, 540, buffer0, 304, 1044);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+adapter0.label = '\u9038\ua0fb\u958d\u0ed8\u{1f8ad}\u{1f70a}\ufae7';
+} catch {}
+let texture82 = device0.createTexture({
+  size: [16, 10, 1],
+  mipLevelCount: 3,
+  dimension: '2d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder49 = commandEncoder1.beginComputePass({});
+try {
+computePassEncoder7.setBindGroup(2, bindGroup13, new Uint32Array(2517), 132, 0);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(0, bindGroup16);
+} catch {}
+let bindGroupLayout10 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 112,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({colorFormats: ['r16float'], depthReadOnly: false});
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer20, 'uint16', 13_742, 4_067);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(5, buffer21, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(91).fill(145), /* required buffer size: 91 */
+{offset: 91, bytesPerRow: 1}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise5 = device0.queue.onSubmittedWorkDone();
+let commandEncoder72 = device0.createCommandEncoder();
+let computePassEncoder50 = commandEncoder72.beginComputePass({});
+try {
+renderPassEncoder19.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(5, buffer21, 384, 1_140);
+} catch {}
+let bindGroup35 = device0.createBindGroup({
+  layout: bindGroupLayout9,
+  entries: [{binding: 114, resource: {buffer: buffer7, offset: 0, size: 1042}}],
+});
+let commandEncoder73 = device0.createCommandEncoder({});
+let textureView75 = texture63.createView({arrayLayerCount: 1});
+let computePassEncoder51 = commandEncoder73.beginComputePass();
+let sampler46 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 20.56,
+  lodMaxClamp: 98.16,
+  compare: 'never',
+});
+try {
+computePassEncoder37.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(0, 1, 1, 3);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer10, 'uint16', 14_610, 1_112);
+} catch {}
+let arrayBuffer3 = buffer8.getMappedRange(5064, 28);
+try {
+buffer20.unmap();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let bindGroup36 = device0.createBindGroup({layout: bindGroupLayout10, entries: [{binding: 112, resource: textureView41}]});
+let commandEncoder74 = device0.createCommandEncoder({label: '\udef3\u767c\u713d\u51c6\u00c4\u6b31\u09e7\ua4f5\ufeca\u162b\ue06e'});
+let texture83 = device0.createTexture({
+  size: [4, 2, 1],
+  format: 'r8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder22 = commandEncoder74.beginRenderPass({
+  colorAttachments: [{
+  view: textureView6,
+  clearValue: { r: -274.5, g: 638.1, b: 443.1, a: 157.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let renderBundle15 = renderBundleEncoder15.finish();
+try {
+computePassEncoder45.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup34, new Uint32Array(672), 36, 0);
+} catch {}
+try {
+renderPassEncoder6.end();
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer12, 'uint32', 992, 619);
+} catch {}
+try {
+buffer27.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 4, height: 2, depthOrArrayLayers: 151}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 10},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup37 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [{binding: 5, resource: textureView23}, {binding: 146, resource: textureView21}],
+});
+let commandEncoder75 = device0.createCommandEncoder({label: '\u3a1e\u242f\ua684\ude29\uf37d\ufdad\u0ee1\u{1f60a}\u99cd'});
+let texture84 = device0.createTexture({
+  label: '\uc382\u9ddc',
+  size: {width: 2, height: 1, depthOrArrayLayers: 1},
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView76 = texture73.createView({label: '\u2c27\uf0f0\u{1f7de}\ua326\u50e9\u0b31\u0694', baseMipLevel: 0});
+let externalTexture15 = device0.importExternalTexture({source: videoFrame5, colorSpace: 'display-p3'});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup1, new Uint32Array(6096), 1_453, 0);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup28);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(2, buffer34, 0, 2);
+} catch {}
+let arrayBuffer4 = buffer8.getMappedRange(4496, 12);
+try {
+commandEncoder75.copyBufferToBuffer(buffer14, 252, buffer33, 2220, 444);
+} catch {}
+let bindGroup38 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 143, resource: textureView30},
+    {binding: 487, resource: sampler5},
+    {binding: 33, resource: textureView32},
+  ],
+});
+let commandEncoder76 = device0.createCommandEncoder({});
+let sampler47 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.59,
+  maxAnisotropy: 2,
+});
+try {
+renderPassEncoder18.setBindGroup(1, bindGroup8, new Uint32Array(624), 30, 0);
+} catch {}
+let pipeline0 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout1,
+  fragment: {module: shaderModule0, entryPoint: 'fragment0', constants: {}, targets: [{format: 'r8uint'}]},
+  vertex: {
+    module: shaderModule0,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 640,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x4', offset: 88, shaderLocation: 14}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw'},
+});
+let buffer52 = device0.createBuffer({
+  size: 9499,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let texture85 = device0.createTexture({
+  size: [16, 10, 357],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderPassEncoder23 = commandEncoder76.beginRenderPass({
+  label: '\u{1f740}\ub5c7\uf81c',
+  colorAttachments: [{
+  view: textureView57,
+  depthSlice: 345,
+  clearValue: { r: 151.8, g: -348.5, b: 678.4, a: -106.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let sampler48 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 1.020,
+  lodMaxClamp: 54.92,
+});
+try {
+renderPassEncoder7.setIndexBuffer(buffer10, 'uint16', 486, 947);
+} catch {}
+try {
+commandEncoder75.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2724 */
+  offset: 2724,
+  buffer: buffer20,
+}, {
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder75.copyTextureToBuffer({
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2580 */
+  offset: 2580,
+  rowsPerImage: 48,
+  buffer: buffer41,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder26.resolveQuerySet(querySet2, 1, 8, buffer32, 256);
+} catch {}
+let buffer53 = device0.createBuffer({
+  size: 7846,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder77 = device0.createCommandEncoder({});
+let texture86 = device0.createTexture({
+  size: {width: 2, height: 1, depthOrArrayLayers: 1},
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder52 = commandEncoder77.beginComputePass({});
+let renderPassEncoder24 = commandEncoder75.beginRenderPass({
+  label: '\u4c22\ucd99\u724b\u{1f689}\u02f4',
+  colorAttachments: [{
+  view: textureView2,
+  depthSlice: 3,
+  clearValue: { r: -545.8, g: 271.6, b: -433.2, a: -934.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let sampler49 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 20.47,
+  lodMaxClamp: 26.50,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder45.setBindGroup(3, bindGroup30);
+} catch {}
+try {
+computePassEncoder32.setBindGroup(1, bindGroup1, new Uint32Array(112), 20, 0);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(3, bindGroup1, new Uint32Array(60), 1, 0);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle0, renderBundle0, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer51, 'uint32', 5_304, 79);
+} catch {}
+try {
+commandEncoder26.copyBufferToTexture({
+  /* bytesInLastRow: 304 widthInBlocks: 76 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 552 */
+  offset: 552,
+  bytesPerRow: 20224,
+  buffer: buffer48,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 102, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 76, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup39 = device0.createBindGroup({
+  layout: bindGroupLayout9,
+  entries: [{binding: 114, resource: {buffer: buffer33, offset: 512, size: 633}}],
+});
+let commandEncoder78 = device0.createCommandEncoder({});
+let textureView77 = texture40.createView({dimension: 'cube', baseArrayLayer: 3});
+let texture87 = device0.createTexture({
+  label: '\u02d4\u5992\u43cc\u6003\u03f9\u40c6\u21a4\u25f8\u7532\u19c4',
+  size: {width: 8, height: 5, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder16.setBindGroup(1, bindGroup35, new Uint32Array(1353), 82, 0);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(3, bindGroup27, new Uint32Array(630), 46, 0);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline0);
+} catch {}
+try {
+buffer45.unmap();
+} catch {}
+try {
+commandEncoder26.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2170 */
+  offset: 2170,
+  buffer: buffer20,
+}, {
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let sampler50 = device0.createSampler({addressModeV: 'clamp-to-edge', addressModeW: 'clamp-to-edge', lodMaxClamp: 84.10});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 5, y: 16, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+await gc();
+let bindGroupLayout11 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 62,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 103,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 22,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 55,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 236,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 132,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let commandBuffer3 = commandEncoder26.finish();
+let texture88 = device0.createTexture({
+  size: [256, 256, 15],
+  mipLevelCount: 1,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture89 = device0.createTexture({
+  size: {width: 2, height: 1, depthOrArrayLayers: 9},
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder53 = commandEncoder78.beginComputePass({});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup4, []);
+} catch {}
+let imageData10 = new ImageData(4, 40);
+let texture90 = device0.createTexture({
+  size: {width: 16, height: 10, depthOrArrayLayers: 1},
+  format: 'rg32float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler51 = device0.createSampler({
+  label: '\uf412\u0f76\u20a9\u{1fcca}\u{1fe8d}\u02da\u04e7\ua0f2\u{1f61f}\u{1ff04}',
+  addressModeV: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 61.27,
+  lodMaxClamp: 76.43,
+});
+try {
+computePassEncoder11.setBindGroup(0, bindGroup23, new Uint32Array(3960), 3_163, 0);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(0, bindGroup12, new Uint32Array(939), 219, 0);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer10, 'uint32', 768, 2_319);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline0);
+} catch {}
+let arrayBuffer5 = buffer8.getMappedRange(4568, 0);
+let bindGroup40 = device0.createBindGroup({
+  label: '\u8c73\u01b1\ud476',
+  layout: bindGroupLayout0,
+  entries: [{binding: 7, resource: {buffer: buffer39, offset: 2816}}],
+});
+let commandEncoder79 = device0.createCommandEncoder({});
+let textureView78 = texture88.createView({dimension: '2d', baseArrayLayer: 2});
+let computePassEncoder54 = commandEncoder79.beginComputePass({});
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup4, new Uint32Array(860), 86, 0);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer10, 'uint32', 5_944, 584);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline0);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+let bindGroupLayout12 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 112,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 232,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 497, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let textureView79 = texture90.createView({label: '\u0e8c\u555d\u05c1'});
+let externalTexture16 = device0.importExternalTexture({source: videoFrame6});
+try {
+renderPassEncoder21.setIndexBuffer(buffer52, 'uint16', 104, 1_438);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(5, buffer27, 432, 811);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+adapter0.label = '\u0958\u0065\u4807\u00c8\u84fb';
+} catch {}
+let commandEncoder80 = device0.createCommandEncoder({});
+let texture91 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 401},
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder25 = commandEncoder80.beginRenderPass({
+  colorAttachments: [{
+  view: textureView10,
+  clearValue: { r: -128.2, g: 857.8, b: -644.4, a: -662.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder14.setBlendConstant({ r: -39.83, g: 12.73, b: -468.8, a: 582.6, });
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline0);
+} catch {}
+let bindGroup41 = device0.createBindGroup({
+  layout: bindGroupLayout9,
+  entries: [{binding: 114, resource: {buffer: buffer13, offset: 7168, size: 7481}}],
+});
+let buffer54 = device0.createBuffer({
+  label: '\u073c\u54f8\u3728',
+  size: 13154,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder81 = device0.createCommandEncoder({});
+let textureView80 = texture90.createView({});
+let computePassEncoder55 = commandEncoder81.beginComputePass({});
+try {
+computePassEncoder45.setBindGroup(3, bindGroup34, []);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(3);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle15, renderBundle15, renderBundle5]);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer3]);
+} catch {}
+let texture92 = gpuCanvasContext1.getCurrentTexture();
+try {
+computePassEncoder41.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup39);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer15, 'uint32', 0, 103);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+let pipelineLayout8 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder82 = device0.createCommandEncoder();
+let texture93 = device0.createTexture({
+  size: [2, 1, 1],
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let computePassEncoder56 = commandEncoder82.beginComputePass({});
+let externalTexture17 = device0.importExternalTexture({label: '\u6238\u{1ff8e}\u67e1\u0004', source: videoFrame0, colorSpace: 'srgb'});
+try {
+renderPassEncoder13.setIndexBuffer(buffer32, 'uint16', 2_052, 719);
+} catch {}
+let commandEncoder83 = device0.createCommandEncoder({});
+let querySet14 = device0.createQuerySet({type: 'occlusion', count: 54});
+let renderPassEncoder26 = commandEncoder83.beginRenderPass({
+  label: '\u{1fa37}\u8bcc\u{1f902}\u{1fbdb}\u0246',
+  colorAttachments: [{
+  view: textureView2,
+  depthSlice: 8,
+  clearValue: { r: 826.1, g: -436.5, b: -408.0, a: 89.40, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 108783531,
+});
+let sampler52 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 52.03,
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder49.setBindGroup(3, bindGroup23, []);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer22, 'uint32', 256, 596);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer42.unmap();
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 39, y: 17, z: 30},
+  aspect: 'all',
+}, new Uint8Array(97_933).fill(29), /* required buffer size: 97_933 */
+{offset: 71, bytesPerRow: 125, rowsPerImage: 120}, {width: 14, height: 63, depthOrArrayLayers: 7});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 42}
+*/
+{
+  source: videoFrame7,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer55 = device0.createBuffer({
+  size: 23449,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({colorFormats: ['r8uint']});
+try {
+renderPassEncoder25.executeBundles([renderBundle12]);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer32, 'uint32', 224, 4_816);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer26, 'uint32', 2_640, 6);
+} catch {}
+let commandEncoder84 = device0.createCommandEncoder();
+let renderPassEncoder27 = commandEncoder84.beginRenderPass({
+  colorAttachments: [{view: textureView39, loadOp: 'clear', storeOp: 'store'}],
+  occlusionQuerySet: querySet7,
+});
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({label: '\u{1fadc}\u{1f8fe}\u0533\u0dbf\u090a\u{1f885}\u0bb4\u67bd\u028a', colorFormats: ['r16float']});
+try {
+renderPassEncoder0.setScissorRect(4, 0, 2, 0);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(6, buffer21, 1_556, 1_709);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer32, 'uint16', 608, 3_072);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 37, y: 5, z: 0},
+  aspect: 'all',
+}, new Uint8Array(199).fill(141), /* required buffer size: 199 */
+{offset: 199, bytesPerRow: 231}, {width: 57, height: 25, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap3 = await createImageBitmap(videoFrame0);
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup29);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(3, bindGroup24, new Uint32Array(3440), 296, 0);
+} catch {}
+let arrayBuffer6 = buffer8.getMappedRange(5096, 12);
+try {
+device0.queue.writeTexture({
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(139).fill(36), /* required buffer size: 139 */
+{offset: 139}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup42 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 143, resource: textureView76},
+    {binding: 33, resource: textureView61},
+    {binding: 487, resource: sampler9},
+  ],
+});
+try {
+computePassEncoder54.setBindGroup(3, bindGroup32);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup21, new Uint32Array(583), 34, 0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle2, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder12.setBlendConstant({ r: 248.4, g: -148.3, b: -89.89, a: 622.6, });
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+computePassEncoder53.pushDebugGroup('\u94f5');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 288, new DataView(new ArrayBuffer(117)), 9, 0);
+} catch {}
+let bindGroup43 = device0.createBindGroup({layout: bindGroupLayout4, entries: [{binding: 84, resource: textureView54}]});
+let commandEncoder85 = device0.createCommandEncoder({});
+let texture94 = device0.createTexture({
+  label: '\u2324\u02b6\ud8fa\u{1f9da}\uabad\u{1f78e}',
+  size: {width: 4, height: 2, depthOrArrayLayers: 697},
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler53 = device0.createSampler({addressModeU: 'clamp-to-edge', addressModeV: 'mirror-repeat', lodMinClamp: 78.62, lodMaxClamp: 91.12});
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup26);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle14, renderBundle4, renderBundle1, renderBundle11, renderBundle4, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(4, buffer19);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer55, 'uint16', 9_394, 3_293);
+} catch {}
+try {
+commandEncoder85.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1694 */
+  offset: 1694,
+  bytesPerRow: 512,
+  buffer: buffer22,
+}, {
+  texture: texture87,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise6 = device0.queue.onSubmittedWorkDone();
+let textureView81 = texture88.createView({dimension: '2d', baseArrayLayer: 2});
+let textureView82 = texture7.createView({dimension: '2d-array'});
+try {
+renderPassEncoder1.setIndexBuffer(buffer13, 'uint32', 348, 7);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(3, bindGroup20);
+} catch {}
+try {
+renderBundleEncoder16.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer26, 468, new Float32Array(8674), 969, 24);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+try {
+  await promise6;
+} catch {}
+let texture95 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 15},
+  mipLevelCount: 2,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder18 = device0.createRenderBundleEncoder({colorFormats: ['r8uint'], sampleCount: 1, stencilReadOnly: true});
+try {
+computePassEncoder4.setBindGroup(1, bindGroup42, new Uint32Array(1056), 42, 0);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline0);
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer49, 2536, new BigUint64Array(7204), 380, 136);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 256, depthOrArrayLayers: 15}
+*/
+{
+  source: videoFrame9,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 14, y: 24, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer56 = device0.createBuffer({
+  size: 46134,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder86 = device0.createCommandEncoder({});
+let texture96 = device0.createTexture({size: {width: 2}, dimension: '1d', format: 'r16float', usage: GPUTextureUsage.COPY_SRC});
+let textureView83 = texture22.createView({label: '\u6da6\ua968\u{1fdb8}\u01a6\u1e39\u2cb4\uade9\u0e70'});
+let computePassEncoder57 = commandEncoder86.beginComputePass({});
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({colorFormats: ['r16float'], depthReadOnly: true, stencilReadOnly: true});
+let sampler54 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 22.06,
+  lodMaxClamp: 94.20,
+  maxAnisotropy: 14,
+});
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup7, []);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(5, buffer1, 0);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(6, buffer51, 10_152, 445);
+} catch {}
+try {
+buffer56.unmap();
+} catch {}
+try {
+commandEncoder85.copyBufferToBuffer(buffer32, 6568, buffer42, 6060, 420);
+} catch {}
+try {
+commandEncoder85.copyTextureToTexture({
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 184, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout13 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 286,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 21, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 314,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba16uint', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 153,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '1d' },
+    },
+  ],
+});
+let texture97 = device0.createTexture({
+  size: [16, 10, 189],
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder58 = commandEncoder85.beginComputePass({});
+let externalTexture18 = device0.importExternalTexture({label: '\u026e\u9995\ub100\u8059\u076a\u033e\u00d5', source: videoFrame1, colorSpace: 'srgb'});
+try {
+renderBundleEncoder19.setIndexBuffer(buffer15, 'uint32', 48, 88);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let bindGroup44 = device0.createBindGroup({
+  layout: bindGroupLayout8,
+  entries: [{binding: 271, resource: textureView69}, {binding: 340, resource: textureView38}],
+});
+let commandEncoder87 = device0.createCommandEncoder({});
+let texture98 = device0.createTexture({
+  size: [8],
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder28 = commandEncoder87.beginRenderPass({
+  colorAttachments: [{
+  view: textureView44,
+  clearValue: { r: -745.0, g: -373.3, b: 818.2, a: -328.0, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 205224332,
+});
+try {
+computePassEncoder40.setBindGroup(3, bindGroup17);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup16, []);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer28, 'uint16', 378, 46);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(6, buffer21, 0, 2_904);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer10, 'uint32', 2_008, 6_285);
+} catch {}
+try {
+computePassEncoder53.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer42, 1464, new BigUint64Array(28136), 16151, 812);
+} catch {}
+let videoFrame13 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'film', transfer: 'logSqrt'} });
+let commandEncoder88 = device0.createCommandEncoder({});
+let texture99 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 30},
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder59 = commandEncoder88.beginComputePass({label: '\u7ec5\u1fc9\u{1f673}\u0947\u0d56\u{1fe23}\u{1f936}\ua296\ucbe6\u498f\ua4c3'});
+let renderBundle16 = renderBundleEncoder16.finish({});
+try {
+renderPassEncoder13.executeBundles([renderBundle2]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 3, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(362).fill(115), /* required buffer size: 362 */
+{offset: 362, bytesPerRow: 3, rowsPerImage: 72}, {width: 3, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup45 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 7, resource: {buffer: buffer53, offset: 1024, size: 548}}],
+});
+let textureView84 = texture98.createView({});
+let texture100 = device0.createTexture({
+  label: '\u18bf\u029c\u{1fcb3}\u70de\u{1fdab}\ub564\ua0f7\u1baf\u{1f799}\u{1fb69}\ua4ff',
+  size: [16, 10, 1],
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView85 = texture65.createView({});
+let renderBundle17 = renderBundleEncoder17.finish({});
+let sampler55 = device0.createSampler({magFilter: 'linear', minFilter: 'linear', mipmapFilter: 'linear', lodMaxClamp: 88.41, maxAnisotropy: 15});
+try {
+renderPassEncoder8.setIndexBuffer(buffer4, 'uint32', 92, 759);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(1, buffer21, 0, 1_901);
+} catch {}
+document.body.append(canvas1);
+let videoFrame14 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'film', transfer: 'bt2020_10bit'} });
+let textureView86 = texture98.createView({baseArrayLayer: 0});
+let texture101 = device0.createTexture({
+  size: {width: 8, height: 5, depthOrArrayLayers: 556},
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let renderBundle18 = renderBundleEncoder19.finish({});
+let sampler56 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 15.31,
+  lodMaxClamp: 33.54,
+});
+try {
+computePassEncoder43.setBindGroup(2, bindGroup12, new Uint32Array(506), 21, 0);
+} catch {}
+try {
+renderPassEncoder26.setStencilReference(112);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer10, 'uint16', 1_714, 10_048);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(5, buffer53, 932, 9);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(2, bindGroup28, new Uint32Array(5862), 599, 0);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(1, buffer56);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer26, 524, new DataView(new ArrayBuffer(17131)), 490, 300);
+} catch {}
+let commandEncoder89 = device0.createCommandEncoder({});
+let textureView87 = texture99.createView({});
+try {
+computePassEncoder44.setBindGroup(3, bindGroup9, new Uint32Array(493), 93, 0);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(1, bindGroup17);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(1, buffer2, 10_352, 4_447);
+} catch {}
+let commandEncoder90 = device0.createCommandEncoder({});
+let textureView88 = texture28.createView({dimension: 'cube'});
+let renderPassEncoder29 = commandEncoder90.beginRenderPass({
+  colorAttachments: [{
+  view: textureView67,
+  clearValue: { r: 902.9, g: 633.8, b: 689.7, a: 826.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let sampler57 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 55.41,
+  lodMaxClamp: 91.24,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder8.setBindGroup(1, bindGroup17);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer33, 'uint16', 1_140, 139);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer29, 'uint32', 208, 488);
+} catch {}
+let bindGroup46 = device0.createBindGroup({
+  layout: bindGroupLayout9,
+  entries: [{binding: 114, resource: {buffer: buffer1, offset: 1536, size: 2319}}],
+});
+let textureView89 = texture30.createView({});
+let sampler58 = device0.createSampler({
+  label: '\u8876\uebb2\uf092\u08ee\uf472\ue276\u1aaa\u18af',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 0.6125,
+  lodMaxClamp: 64.67,
+});
+try {
+computePassEncoder44.setBindGroup(0, bindGroup35, new Uint32Array(1149), 0, 0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup45, new Uint32Array(183), 4, 0);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer26, 'uint32', 100, 481);
+} catch {}
+try {
+buffer38.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer53, 444, new Int16Array(912), 146, 256);
+} catch {}
+let videoFrame15 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'smpte432', transfer: 'bt1361ExtendedColourGamut'} });
+let renderPassEncoder30 = commandEncoder89.beginRenderPass({
+  colorAttachments: [{
+  view: textureView12,
+  clearValue: { r: 510.8, g: 947.9, b: -486.3, a: 697.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder59.setBindGroup(3, bindGroup14);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline0);
+} catch {}
+let renderBundle19 = renderBundleEncoder18.finish({});
+try {
+renderPassEncoder17.setBindGroup(1, bindGroup37, new Uint32Array(1912), 52, 0);
+} catch {}
+try {
+renderPassEncoder0.end();
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer22, 'uint16', 190, 678);
+} catch {}
+let commandEncoder91 = device0.createCommandEncoder();
+let renderBundleEncoder20 = device0.createRenderBundleEncoder({colorFormats: ['r8uint']});
+try {
+computePassEncoder26.setBindGroup(2, bindGroup12, new Uint32Array(527), 114, 0);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer43, 'uint32', 296, 961);
+} catch {}
+try {
+renderBundleEncoder20.setIndexBuffer(buffer55, 'uint16', 4_620, 2_442);
+} catch {}
+document.body.append(canvas1);
+await gc();
+let texture102 = device0.createTexture({
+  size: {width: 16, height: 10, depthOrArrayLayers: 1},
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView90 = texture41.createView({baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 0, arrayLayerCount: 1});
+let computePassEncoder60 = commandEncoder7.beginComputePass({label: '\u0c47\u7532\udc6d\u620e\u0481'});
+let renderPassEncoder31 = commandEncoder91.beginRenderPass({colorAttachments: [{view: textureView90, depthSlice: 13, loadOp: 'load', storeOp: 'store'}]});
+let sampler59 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 77.16,
+  lodMaxClamp: 94.42,
+});
+try {
+computePassEncoder24.setBindGroup(3, bindGroup26);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle2, renderBundle18]);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer26, 'uint16', 100, 1_102);
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let buffer57 = device0.createBuffer({
+  label: '\u0b7e\ued89\u1cb8\u{1faad}',
+  size: 3287,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture103 = device0.createTexture({
+  size: [256, 256, 69],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderBundleEncoder20.setBindGroup(2, bindGroup9, new Uint32Array(2855), 125, 0);
+} catch {}
+let bindGroup47 = device0.createBindGroup({
+  label: '\ufa2a\u212b\u{1fb5e}\u0225\u{1f6c3}\uac87\u{1f899}\u66e1\u{1fdf6}',
+  layout: bindGroupLayout3,
+  entries: [{binding: 146, resource: textureView21}, {binding: 5, resource: textureView16}],
+});
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+buffer50.unmap();
+} catch {}
+try {
+adapter0.label = '\ua4e7\u0a90\u2fd9\u{1f8f0}\ub583\uf559\u0615\uaf4e\uf08e\uc1d5';
+} catch {}
+let pipelineLayout9 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer58 = device0.createBuffer({size: 9656, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture104 = device0.createTexture({
+  size: {width: 2, height: 1, depthOrArrayLayers: 1},
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView91 = texture31.createView({});
+let sampler60 = device0.createSampler({addressModeU: 'repeat', magFilter: 'nearest', mipmapFilter: 'nearest', lodMaxClamp: 21.15});
+try {
+renderPassEncoder17.setBindGroup(2, bindGroup26, new Uint32Array(1587), 497, 0);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer6, 'uint32', 6_280, 3_431);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 54, y: 126, z: 0},
+  aspect: 'all',
+}, new Uint8Array(48).fill(46), /* required buffer size: 48 */
+{offset: 48, bytesPerRow: 576}, {width: 204, height: 204, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup48 = device0.createBindGroup({
+  layout: bindGroupLayout13,
+  entries: [
+    {binding: 21, resource: externalTexture1},
+    {binding: 286, resource: externalTexture18},
+    {binding: 314, resource: textureView87},
+    {binding: 153, resource: textureView86},
+  ],
+});
+try {
+renderPassEncoder20.setBindGroup(2, bindGroup27);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle5, renderBundle18]);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer52, 'uint16', 626, 1_693);
+} catch {}
+try {
+renderBundleEncoder20.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(3, buffer40);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 2516, new DataView(new ArrayBuffer(852)), 30, 116);
+} catch {}
+let pipeline1 = await device0.createRenderPipelineAsync({
+  label: '\u4c85\u0b78\u0446\u1028\u{1fcea}\ubc55\u45aa\u521c\u0e24',
+  layout: pipelineLayout6,
+  fragment: {
+  module: shaderModule3,
+  targets: [{format: 'r16float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {module: shaderModule1, constants: {}, buffers: []},
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'back'},
+});
+let renderBundle20 = renderBundleEncoder20.finish({});
+try {
+computePassEncoder13.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+computePassEncoder56.setBindGroup(2, bindGroup44, new Uint32Array(1764), 563, 0);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle16, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer54, 'uint16', 6, 525);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(1, buffer39);
+} catch {}
+await gc();
+let bindGroup49 = device0.createBindGroup({
+  label: '\u0e86\u80ff\u1ee2\u1d23\u4aeb\ubb7c\u{1f727}',
+  layout: bindGroupLayout10,
+  entries: [{binding: 112, resource: textureView83}],
+});
+try {
+computePassEncoder25.setBindGroup(3, bindGroup34);
+} catch {}
+try {
+computePassEncoder43.setBindGroup(2, bindGroup39, new Uint32Array(321), 24, 0);
+} catch {}
+try {
+renderPassEncoder15.executeBundles([renderBundle1, renderBundle12]);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer6, 'uint32', 836, 2_539);
+} catch {}
+let buffer59 = device0.createBuffer({
+  label: '\ude1a\u{1f6d9}\ucb86\u051b\u2fee\u0bcb\u{1f648}',
+  size: 19080,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder92 = device0.createCommandEncoder({});
+let sampler61 = device0.createSampler({
+  label: '\ueb8d\u516d\u{1fc55}\uc79c\u09e3\u6af7',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 40.86,
+  lodMaxClamp: 46.58,
+});
+let externalTexture19 = device0.importExternalTexture({source: videoFrame12, colorSpace: 'display-p3'});
+try {
+computePassEncoder47.setBindGroup(0, bindGroup37, []);
+} catch {}
+try {
+renderPassEncoder17.setViewport(1.2570053295699624, 0.7723563594551274, 0.6593980453690997, 0.06034774336468017, 0.6378184969648304, 0.6466348631109914);
+} catch {}
+let commandEncoder93 = device0.createCommandEncoder();
+let texture105 = device0.createTexture({
+  size: [2, 1, 10],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView92 = texture70.createView({});
+let computePassEncoder61 = commandEncoder92.beginComputePass();
+let renderPassEncoder32 = commandEncoder93.beginRenderPass({
+  colorAttachments: [{
+  view: textureView20,
+  clearValue: { r: -968.6, g: 415.0, b: -123.7, a: 473.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet11,
+});
+let sampler62 = device0.createSampler({
+  label: '\uaecc\u{1fe7c}\ub860\u06b2\u04af',
+  addressModeU: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 52.05,
+  lodMaxClamp: 55.37,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder22.setIndexBuffer(buffer32, 'uint32', 340, 1_452);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer20, 6620, new BigUint64Array(5581), 552, 340);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 42}
+*/
+{
+  source: imageData9,
+  origin: { x: 7, y: 8 },
+  flipY: false,
+}, {
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 5},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup50 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 296, resource: externalTexture11}, {binding: 460, resource: textureView0}],
+});
+let textureView93 = texture42.createView({dimension: '2d-array', baseMipLevel: 0, mipLevelCount: 1, arrayLayerCount: 1});
+try {
+computePassEncoder19.setBindGroup(3, bindGroup15, new Uint32Array(391), 2, 0);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline0);
+} catch {}
+let buffer60 = device0.createBuffer({
+  size: 1111,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder94 = device0.createCommandEncoder();
+let computePassEncoder62 = commandEncoder94.beginComputePass({});
+let renderBundleEncoder21 = device0.createRenderBundleEncoder({
+  label: '\u51b0\u{1f679}\u5062\u06ed\ua9fb\u{1fe1d}\ucc78\u2b9f\u0714\u0416',
+  colorFormats: ['r16float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder46.setBindGroup(0, bindGroup48, new Uint32Array(2838), 28, 0);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer24, 'uint32', 7_512, 1_913);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(6, buffer21, 0, 910);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer51, 'uint16', 1_120, 8_833);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 644, new BigUint64Array(5190), 1628, 148);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture106 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 2},
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView94 = texture4.createView({dimension: '2d-array', baseMipLevel: 0, mipLevelCount: 1});
+try {
+computePassEncoder58.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+computePassEncoder28.setBindGroup(3, bindGroup15, new Uint32Array(2509), 327, 0);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer33, 'uint16', 1_640, 460);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer28, 'uint16', 54, 419);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(4, buffer17, 0);
+} catch {}
+let arrayBuffer7 = buffer8.getMappedRange(4512, 16);
+await gc();
+let buffer61 = device0.createBuffer({
+  size: 13821,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder10.setBindGroup(2, bindGroup33);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup5, new Uint32Array(2013), 159, 0);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer55, 'uint16', 536, 3_732);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer61, 'uint16', 244, 1_293);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 2, y: 22 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 75, y: 20, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let buffer62 = device0.createBuffer({
+  size: 16844,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let sampler63 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 21.57,
+  lodMaxClamp: 55.03,
+  compare: 'equal',
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder61.setBindGroup(2, bindGroup44);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(3, bindGroup42, new Uint32Array(3643), 381, 0);
+} catch {}
+try {
+renderPassEncoder7.setStencilReference(3128);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer15, 'uint16', 42, 70);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(2, undefined);
+} catch {}
+try {
+buffer54.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 256, depthOrArrayLayers: 150}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 24, y: 28, z: 50},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+canvas0.height = 2208;
+let img1 = await imageWithData(30, 147, '#10101010', '#20202020');
+try {
+globalThis.someLabel = externalTexture4.label;
+} catch {}
+let buffer63 = device0.createBuffer({size: 13376, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let texture107 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 63},
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle21 = renderBundleEncoder21.finish();
+try {
+computePassEncoder55.setBindGroup(2, bindGroup6, new Uint32Array(2738), 102, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup14);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+globalThis.someLabel = computePassEncoder21.label;
+} catch {}
+let shaderModule4 = device0.createShaderModule({
+  label: '\u078d\u76c9\u4d7c',
+  code: `
+enable f16;
+
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(296) var et4: texture_external;
+
+@group(0) @binding(460) var tex4: texture_2d_array<f32>;
+
+struct T0 {
+  f0: array<f32, 1>,
+}
+
+struct T1 {
+  @size(64) f0: T0,
+  @size(768) f1: mat3x2h,
+  @align(64) @size(128) f2: atomic<i32>,
+}
+
+struct VertexOutput3 {
+  @builtin(position) f7: vec4f,
+  @location(1) @interpolate(perspective, centroid) f8: vec4h,
+}
+
+alias vec3b = vec3<bool>;
+
+var<workgroup> vw7: u32;
+
+var<private> vp0 = modf(vec4h(-5284.5, 1288.0, 1616.9, 862.0));
+
+@vertex
+fn vertex3() -> VertexOutput3 {
+  var out: VertexOutput3;
+  let vf121: u32 = dot4U8Packed(u32(unconst_u32(372)), u32(unconst_u32(82)));
+  out.f8 *= vec4h(textureLoad(tex4, vec2i(unconst_i32(96), unconst_i32(177)), i32(unconst_i32(78)), i32(unconst_i32(120))));
+  out.f7 = vec4f(textureDimensions(tex4).rrgg);
+  let vf122: vec3f = quantizeToF16(vec3f(unconst_f32(0.07682), unconst_f32(0.1106), unconst_f32(0.2592)));
+  let vf123: vec2u = textureDimensions(tex4);
+  let vf124: vec3f = cross(vec3f(unconst_f32(-0.5233), unconst_f32(0.08345), unconst_f32(0.00372)), vec3f(tan(vec4h(unconst_f16(-10181.9), unconst_f16(11080.1), unconst_f16(8765.6), unconst_f16(1180.0))).zwy));
+  let vf125: vec3f = atan(vec3f(unconst_f32(-0.1900), unconst_f32(0.6318), unconst_f32(0.1807)));
+  var vf126: vec4h = tan(vec4h(unconst_f16(411.6), unconst_f16(1543.6), unconst_f16(10221.8), unconst_f16(1560.6)));
+  let vf127: vec2f = atan(vec2f(unconst_f32(0.00159), unconst_f32(0.2490)));
+  vf126 *= vec4h(vf122.zyyx);
+  return out;
+}
+
+@fragment
+fn fragment5() -> @location(200) @interpolate(linear, center) vec4u {
+  var out: vec4u;
+  var vf128: vec2u = textureDimensions(et4);
+  var vf129: u32 = pack2x16snorm(vec2f(unconst_f32(0.2740), unconst_f32(0.04617)));
+  vf129 ^= pack4x8snorm(vec4f(unconst_f32(0.06895), unconst_f32(0.04061), unconst_f32(0.4674), unconst_f32(0.3414)));
+  let vf130: vec4f = textureLoad(tex4, vec2i(unconst_i32(10), unconst_i32(179)), i32(unconst_i32(13)), bitcast<vec2i>(tan(vec2f(unconst_f32(0.1472), unconst_f32(0.3346))))[0]);
+  let vf131: f32 = length(f32(unconst_f32(0.1338)));
+  vp0.fract = bitcast<vec4h>(sign(vec2i(unconst_i32(796), unconst_i32(102))));
+  let vf132: vec2u = textureDimensions(tex4, i32(unconst_i32(62)));
+  vp0.whole -= vec4h(f16(vf129));
+  return out;
+}
+
+@compute @workgroup_size(2, 1, 1)
+fn compute1() {
+  let vf133: vec3i = insertBits(vec3i(i32(pack2x16snorm(vec2f(unconst_f32(0.3280), unconst_f32(0.00391))))), vec3i(i32(pack4x8unorm(vec4f(unconst_f32(0.07045), unconst_f32(-0.00842), unconst_f32(-0.05645), unconst_f32(0.1117))))), u32(unconst_u32(841)), u32(unconst_u32(414)));
+  vp0 = modf(vec4h(reverseBits(vec3u(unconst_u32(122), unconst_u32(37), unconst_u32(84))).xzyz));
+  vp0 = modf(vec4h(smoothstep(f16(unconst_f16(9841.1)), f16(unconst_f16(1957.2)), max(f16(unconst_f16(17835.6)), f16(unconst_f16(43133.7))))));
+  var vf134: vec3u = reverseBits(vec3u(unconst_u32(196), unconst_u32(286), unconst_u32(256)));
+  var vf135: u32 = pack2x16snorm(vec2f(unconst_f32(0.1820), unconst_f32(0.03426)));
+  var vf136: vec4f = unpack4x8unorm(u32(unconst_u32(280)));
+  var vf137: vec4f = normalize(vec4f(unconst_f32(0.04086), unconst_f32(0.04280), unconst_f32(0.1933), unconst_f32(0.1348)));
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let pipelineLayout10 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout9, bindGroupLayout8]});
+let buffer64 = device0.createBuffer({
+  size: 2514,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+try {
+computePassEncoder34.setBindGroup(0, bindGroup30);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer6, 'uint32', 2_436, 1_459);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData3,
+  origin: { x: 4, y: 24 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 37, y: 21, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 13, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer65 = device0.createBuffer({
+  size: 18641,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let renderBundleEncoder22 = device0.createRenderBundleEncoder({label: '\u08a1\u{1fe45}\u30fc\u5f5b\u5fe5\u0d95\u0f28\u0fa2', colorFormats: ['r16float']});
+try {
+renderPassEncoder28.setBindGroup(1, bindGroup34);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+renderBundleEncoder22.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(7, buffer63);
+} catch {}
+try {
+computePassEncoder54.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+computePassEncoder16.setBindGroup(1, bindGroup11, new Uint32Array(2097), 390, 0);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(0, bindGroup47, new Uint32Array(1114), 0, 0);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(6, buffer53, 668);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(0, bindGroup46, new Uint32Array(2992), 74, 0);
+} catch {}
+try {
+renderBundleEncoder22.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer55, 2016, new DataView(new ArrayBuffer(12766)), 366, 152);
+} catch {}
+document.body.prepend(img1);
+await gc();
+let buffer66 = device0.createBuffer({
+  size: 53318,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture108 = device0.createTexture({
+  size: [2],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder1.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup16, new Uint32Array(1512), 162, 0);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle13, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder12.setViewport(1.8343958662935633, 1.88331707144887, 2.129547031795998, 0.017620751460144746, 0.508354981819767, 0.5538749877740509);
+} catch {}
+let videoFrame16 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'bt470bg', transfer: 'iec61966-2-1'} });
+let buffer67 = device0.createBuffer({
+  label: '\u746c\u76a5',
+  size: 10940,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder95 = device0.createCommandEncoder({});
+let computePassEncoder63 = commandEncoder95.beginComputePass();
+try {
+buffer44.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let textureView95 = texture76.createView({
+  label: '\u0721\u0c8d\u45c7\u{1f876}\u11d5\uced8\u0703\u{1fce3}\u{1fada}',
+  dimension: '2d',
+  baseArrayLayer: 2,
+  arrayLayerCount: 1,
+});
+try {
+renderPassEncoder22.setBindGroup(2, bindGroup39);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup6, new Uint32Array(775), 197, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 256, depthOrArrayLayers: 150}
+*/
+{
+  source: imageData9,
+  origin: { x: 0, y: 18 },
+  flipY: true,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 205, y: 48, z: 10},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 7, height: 14, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup51 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 296, resource: externalTexture10}, {binding: 460, resource: textureView68}],
+});
+let texture109 = device0.createTexture({
+  size: [16, 10, 1],
+  format: 'r8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder34.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+computePassEncoder59.setBindGroup(1, bindGroup33, new Uint32Array(750), 93, 0);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline1);
+} catch {}
+try {
+  await promise5;
+} catch {}
+let videoFrame17 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-ncl', primaries: 'smpteRp431', transfer: 'linear'} });
+let commandEncoder96 = device0.createCommandEncoder({});
+let computePassEncoder64 = commandEncoder96.beginComputePass({label: '\ueb4a\ub26f\u{1fbe5}\u0b51\u3704\u59a4'});
+let externalTexture20 = device0.importExternalTexture({label: '\u26ce\u7dd4\u6ece', source: videoFrame2});
+try {
+computePassEncoder64.setBindGroup(1, bindGroup24);
+} catch {}
+try {
+computePassEncoder32.end();
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup35, new Uint32Array(1865), 462, 0);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer53, 'uint16', 370, 1_192);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer24, 'uint32', 1_144, 34);
+} catch {}
+let commandEncoder97 = device0.createCommandEncoder();
+let texture110 = device0.createTexture({
+  label: '\ucc46\u{1f737}\ue9bc\u{1f80b}\u0be1\u{1fbcf}\u05bc\u5121\u{1fab3}\u{1fd91}',
+  size: {width: 256, height: 256, depthOrArrayLayers: 15},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder65 = commandEncoder97.beginComputePass({});
+let renderPassEncoder33 = commandEncoder44.beginRenderPass({
+  colorAttachments: [{
+  view: textureView55,
+  depthSlice: 19,
+  clearValue: { r: 709.9, g: 91.49, b: -358.2, a: -84.47, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 53893158,
+});
+try {
+computePassEncoder22.setBindGroup(1, bindGroup26);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup8, new Uint32Array(1839), 24, 0);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer28, 'uint16', 124, 97);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(0, bindGroup12, []);
+} catch {}
+try {
+renderBundleEncoder22.draw(119, 386, 55_885_866, 59_661_135);
+} catch {}
+try {
+renderBundleEncoder22.drawIndexed(0, 235, 0, 240_445_209, 21_615_903);
+} catch {}
+try {
+renderBundleEncoder22.drawIndirect(buffer15, 28);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let buffer68 = device0.createBuffer({size: 5413, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX});
+let commandEncoder98 = device0.createCommandEncoder({});
+let texture111 = device0.createTexture({
+  size: [2, 1, 56],
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle22 = renderBundleEncoder22.finish({});
+try {
+renderPassEncoder21.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(1, buffer39, 0);
+} catch {}
+try {
+commandEncoder98.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 768 */
+  offset: 768,
+  buffer: buffer64,
+}, {
+  texture: texture81,
+  mipLevel: 1,
+  origin: {x: 2, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame18 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte240m', primaries: 'bt470m', transfer: 'iec61966-2-1'} });
+let texture112 = device0.createTexture({
+  size: {width: 4, height: 2, depthOrArrayLayers: 1},
+  format: 'r8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder66 = commandEncoder98.beginComputePass({});
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup51);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(0, bindGroup44, new Uint32Array(3763), 1_530, 0);
+} catch {}
+try {
+renderPassEncoder25.executeBundles([renderBundle4, renderBundle8]);
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+await gc();
+let bindGroup52 = device0.createBindGroup({layout: bindGroupLayout10, entries: [{binding: 112, resource: textureView35}]});
+let texture113 = device0.createTexture({
+  size: {width: 8, height: 5, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView96 = texture70.createView({});
+try {
+renderPassEncoder31.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 256, depthOrArrayLayers: 531}
+*/
+{
+  source: imageData8,
+  origin: { x: 1, y: 2 },
+  flipY: true,
+}, {
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 9, y: 18, z: 226},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas2 = document.createElement('canvas');
+let bindGroupLayout14 = device0.createBindGroupLayout({
+  label: '\u0361\u{1f600}\u{1f6de}\u0077\u4457',
+  entries: [
+    {
+      binding: 157,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 47,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 87,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let bindGroup53 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 218, resource: textureView5},
+    {binding: 121, resource: externalTexture19},
+    {binding: 420, resource: textureView8},
+  ],
+});
+let querySet15 = device0.createQuerySet({
+  label: '\u{1fa2c}\u3529\u{1ff31}\u299a\ubb0b\u032f\u045e\u97cd\u{1f626}\u85dd\ub295',
+  type: 'occlusion',
+  count: 196,
+});
+let sampler64 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 37.27,
+  lodMaxClamp: 65.37,
+});
+try {
+computePassEncoder28.setBindGroup(0, bindGroup42, new Uint32Array(2719), 215, 0);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+let texture114 = device0.createTexture({
+  label: '\ufc5a\udf8e\ueee3\u0e48\u{1f8f0}\u{1f959}\u1749',
+  size: [4, 2, 1],
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder7.setBindGroup(1, bindGroup51);
+} catch {}
+try {
+computePassEncoder27.end();
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer5, 'uint16', 502, 2_254);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder32.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1166 */
+  offset: 1166,
+  buffer: buffer17,
+}, {
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup54 = device0.createBindGroup({
+  layout: bindGroupLayout8,
+  entries: [{binding: 340, resource: textureView38}, {binding: 271, resource: textureView75}],
+});
+let texture115 = device0.createTexture({
+  size: [16, 10, 24],
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder67 = commandEncoder32.beginComputePass();
+try {
+computePassEncoder54.setBindGroup(0, bindGroup7, new Uint32Array(90), 33, 0);
+} catch {}
+let bindGroup55 = device0.createBindGroup({layout: bindGroupLayout4, entries: [{binding: 84, resource: textureView54}]});
+let renderBundleEncoder23 = device0.createRenderBundleEncoder({colorFormats: ['r8uint'], stencilReadOnly: true});
+try {
+computePassEncoder66.setBindGroup(2, bindGroup6, new Uint32Array(807), 121, 0);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(3, bindGroup8, new Uint32Array(130), 2, 0);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle1, renderBundle6]);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(0, bindGroup33, new Uint32Array(195), 17, 0);
+} catch {}
+try {
+renderBundleEncoder23.setIndexBuffer(buffer29, 'uint32', 84, 1_908);
+} catch {}
+try {
+renderPassEncoder12.insertDebugMarker('\u8e60');
+} catch {}
+let pipelineLayout11 = device0.createPipelineLayout({label: '\u{1fc37}\u6317\u053b', bindGroupLayouts: []});
+let commandEncoder99 = device0.createCommandEncoder();
+let texture116 = device0.createTexture({
+  size: [4, 2, 1],
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder68 = commandEncoder99.beginComputePass({label: '\u4bc7\u{1fc4e}\u9fea\u{1f775}\u0c3f\u9de7'});
+let renderBundle23 = renderBundleEncoder23.finish({});
+let sampler65 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 40.25,
+  lodMaxClamp: 73.28,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder17.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+computePassEncoder31.setBindGroup(2, bindGroup28, new Uint32Array(925), 52, 0);
+} catch {}
+let gpuCanvasContext2 = canvas2.getContext('webgpu');
+let textureView97 = texture14.createView({});
+try {
+computePassEncoder54.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+computePassEncoder49.setBindGroup(3, bindGroup36, new Uint32Array(542), 6, 0);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(7, buffer39, 2_132, 788);
+} catch {}
+let querySet16 = device0.createQuerySet({type: 'occlusion', count: 749});
+try {
+computePassEncoder54.setBindGroup(0, bindGroup48, new Uint32Array(1684), 262, 0);
+} catch {}
+try {
+renderPassEncoder5.setScissorRect(0, 0, 2, 0);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(2, buffer20, 0, 22_325);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 5, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData10,
+  origin: { x: 0, y: 13 },
+  flipY: false,
+}, {
+  texture: texture81,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture117 = device0.createTexture({
+  size: {width: 8, height: 5, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  dimension: '2d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder18.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+renderPassEncoder19.setStencilReference(487);
+} catch {}
+try {
+buffer38.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer57, 244, new BigUint64Array(4822), 1057, 8);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 256, depthOrArrayLayers: 150}
+*/
+{
+  source: videoFrame17,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 104, y: 7, z: 21},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer69 = device0.createBuffer({
+  label: '\u{1f719}\u057a\ud082\u{1fcc1}\u{1ff94}\uf8ea\u6676\u85d3\u0650\udeba\u{1fa87}',
+  size: 1137,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder100 = device0.createCommandEncoder({});
+let textureView98 = texture99.createView({});
+let computePassEncoder69 = commandEncoder100.beginComputePass();
+let sampler66 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 19.62,
+  lodMaxClamp: 71.20,
+});
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup53, new Uint32Array(66), 12, 0);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle4, renderBundle16]);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(2, buffer12, 688, 205);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture108,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(71).fill(126), /* required buffer size: 71 */
+{offset: 71, bytesPerRow: 1}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise7 = device0.queue.onSubmittedWorkDone();
+let commandEncoder101 = device0.createCommandEncoder({});
+let computePassEncoder70 = commandEncoder101.beginComputePass({});
+try {
+renderPassEncoder8.setIndexBuffer(buffer62, 'uint32', 2_944, 4_318);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(3, buffer20, 0, 7_958);
+} catch {}
+document.body.append(canvas2);
+let bindGroup56 = device0.createBindGroup({
+  layout: bindGroupLayout9,
+  entries: [{binding: 114, resource: {buffer: buffer64, offset: 0, size: 718}}],
+});
+let texture118 = device0.createTexture({
+  size: [256],
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder1.executeBundles([renderBundle11]);
+} catch {}
+try {
+renderPassEncoder33.setBlendConstant({ r: -631.9, g: -864.2, b: -891.6, a: 88.69, });
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture82,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(144).fill(167), /* required buffer size: 144 */
+{offset: 144}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise8 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise8;
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(1, bindGroup45);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer10, 'uint16', 8_320, 1_728);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(5, buffer62, 0, 1_748);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture36,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+}, new Uint8Array(36_561).fill(94), /* required buffer size: 36_561 */
+{offset: 105, bytesPerRow: 7, rowsPerImage: 62}, {width: 0, height: 0, depthOrArrayLayers: 85});
+} catch {}
+let videoFrame19 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'jedecP22Phosphors', transfer: 'iec6196624'} });
+let textureView99 = texture59.createView({dimension: '2d-array', aspect: 'all', arrayLayerCount: 1});
+let sampler67 = device0.createSampler({
+  label: '\u0b33\u0229\ufa20\ua02f\u{1f61e}\uc746\ud707',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 59.73,
+  lodMaxClamp: 87.02,
+});
+try {
+renderPassEncoder33.setPipeline(pipeline1);
+} catch {}
+let imageData11 = new ImageData(84, 20);
+let commandEncoder102 = device0.createCommandEncoder({});
+let textureView100 = texture55.createView({dimension: '2d-array'});
+let computePassEncoder71 = commandEncoder102.beginComputePass();
+try {
+computePassEncoder66.setBindGroup(3, bindGroup0);
+} catch {}
+let commandEncoder103 = device0.createCommandEncoder({label: '\u0d51\u0ea1\u08f0'});
+let texture119 = device0.createTexture({
+  size: [2, 1, 1],
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder34 = commandEncoder103.beginRenderPass({
+  colorAttachments: [{view: textureView55, depthSlice: 20, loadOp: 'load', storeOp: 'discard'}],
+  occlusionQuerySet: querySet1,
+});
+let sampler68 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 0.4284,
+  lodMaxClamp: 29.35,
+  compare: 'always',
+});
+try {
+renderPassEncoder24.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+  await promise7;
+} catch {}
+document.body.append(canvas1);
+let buffer70 = device0.createBuffer({
+  size: 30737,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let commandEncoder104 = device0.createCommandEncoder({});
+let sampler69 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 72.04,
+  lodMaxClamp: 93.61,
+});
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup32);
+} catch {}
+try {
+renderPassEncoder13.setBlendConstant({ r: 935.1, g: -333.5, b: 585.4, a: -843.0, });
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+try {
+commandEncoder104.copyTextureToTexture({
+  texture: texture101,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 186},
+  aspect: 'all',
+},
+{
+  texture: texture100,
+  mipLevel: 0,
+  origin: {x: 5, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let texture120 = gpuCanvasContext1.getCurrentTexture();
+let computePassEncoder72 = commandEncoder104.beginComputePass();
+try {
+renderPassEncoder10.setIndexBuffer(buffer66, 'uint16', 2_774, 5_550);
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let bindGroup57 = device0.createBindGroup({
+  layout: bindGroupLayout8,
+  entries: [{binding: 271, resource: textureView69}, {binding: 340, resource: textureView38}],
+});
+let commandEncoder105 = device0.createCommandEncoder({});
+let texture121 = device0.createTexture({
+  size: [4, 2, 1],
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView101 = texture50.createView({dimension: 'cube-array', baseArrayLayer: 5, arrayLayerCount: 6});
+let computePassEncoder73 = commandEncoder105.beginComputePass();
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup21);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(1, bindGroup51, new Uint32Array(1354), 135, 0);
+} catch {}
+let commandEncoder106 = device0.createCommandEncoder({});
+let textureView102 = texture76.createView({dimension: '2d', mipLevelCount: 1});
+try {
+computePassEncoder52.setBindGroup(1, bindGroup57, new Uint32Array(276), 5, 0);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer6, 'uint16', 2_368, 3_893);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(2, buffer19);
+} catch {}
+try {
+commandEncoder106.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 932 */
+  offset: 932,
+  buffer: buffer6,
+}, {
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(498).fill(103), /* required buffer size: 498 */
+{offset: 498}, {width: 105, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipelineLayout12 = device0.createPipelineLayout({bindGroupLayouts: []});
+let textureView103 = texture29.createView({});
+let computePassEncoder74 = commandEncoder106.beginComputePass({label: '\u05b3\u{1f8f3}'});
+try {
+renderPassEncoder24.setIndexBuffer(buffer53, 'uint32', 376, 518);
+} catch {}
+let textureView104 = texture36.createView({mipLevelCount: 1});
+try {
+computePassEncoder15.setBindGroup(3, bindGroup39);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer32, 'uint32', 6_696, 5_906);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 10, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas1,
+  origin: { x: 12, y: 21 },
+  flipY: false,
+}, {
+  texture: texture100,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup58 = device0.createBindGroup({
+  layout: bindGroupLayout13,
+  entries: [
+    {binding: 314, resource: textureView87},
+    {binding: 286, resource: externalTexture1},
+    {binding: 21, resource: externalTexture8},
+    {binding: 153, resource: textureView86},
+  ],
+});
+let commandEncoder107 = device0.createCommandEncoder({});
+let renderPassEncoder35 = commandEncoder107.beginRenderPass({
+  label: '\u0011\u{1ff9a}\u58cb',
+  colorAttachments: [{
+  view: textureView12,
+  clearValue: { r: -560.1, g: -860.8, b: -868.5, a: -776.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 266873455,
+});
+try {
+computePassEncoder57.setBindGroup(1, bindGroup28, new Uint32Array(2596), 205, 0);
+} catch {}
+try {
+renderPassEncoder28.setViewport(0.9090125732639283, 0.39615283080906727, 0.7297350024438817, 0.5687447727521029, 0.7913415779342876, 0.8632451334620552);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline0);
+} catch {}
+let arrayBuffer8 = buffer8.getMappedRange(5160, 104);
+try {
+device0.queue.writeTexture({
+  texture: texture100,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(115).fill(23), /* required buffer size: 115 */
+{offset: 115, bytesPerRow: 51}, {width: 7, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder37.setBindGroup(3, bindGroup27);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer52, 1_352);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer10, 'uint32', 7_028, 2_645);
+} catch {}
+try {
+computePassEncoder62.setBindGroup(0, bindGroup36);
+} catch {}
+try {
+renderPassEncoder35.executeBundles([renderBundle19, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder4.setViewport(2.7453927432242384, 4.696016786524574, 5.6051198774212665, 2.2661369257734485, 0.7000169582300029, 0.7412306953552276);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(8, 0, 10, 200_163_741);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline0);
+} catch {}
+try {
+  await buffer41.mapAsync(GPUMapMode.READ, 336, 184);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer53, 240, new Float32Array(2268), 321, 108);
+} catch {}
+let videoFrame20 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'unspecified', transfer: 'bt1361ExtendedColourGamut'} });
+try {
+computePassEncoder68.setBindGroup(0, bindGroup55, new Uint32Array(501), 40, 0);
+} catch {}
+try {
+renderPassEncoder4.draw(43, 0, 253_813_335);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(6, undefined, 345_219_263, 3_599_352);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(181).fill(119), /* required buffer size: 181 */
+{offset: 181}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise9 = device0.queue.onSubmittedWorkDone();
+let buffer71 = device0.createBuffer({
+  label: '\u0efa\u000c\u0fc7\u57a3\u{1f84c}\u{1fcf2}\uca3a\ucedc',
+  size: 10310,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+try {
+renderPassEncoder4.drawIndirect(buffer7, 936);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer71, 'uint16', 506, 2_929);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 3456, new BigUint64Array(27240), 2831, 508);
+} catch {}
+let sampler70 = device0.createSampler({addressModeU: 'repeat', magFilter: 'nearest', lodMinClamp: 14.22, compare: 'always'});
+try {
+computePassEncoder28.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(0, bindGroup4, new Uint32Array(2350), 60, 0);
+} catch {}
+try {
+renderPassEncoder4.draw(26, 0, 34_765_499, 0);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(16, 0, 3, 198_135_593);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer5, 952);
+} catch {}
+let buffer72 = device0.createBuffer({
+  size: 6896,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder4.drawIndexed(3, 0, 7, 1_303_793_382);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer22, 632);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(156).fill(66), /* required buffer size: 156 */
+{offset: 156}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise9;
+} catch {}
+document.body.prepend(canvas0);
+let buffer73 = device0.createBuffer({size: 1243, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let texture122 = device0.createTexture({
+  label: '\uebd5\u082c\u064b\u{1fa26}\u0e65\u0859\u{1fe2b}\u08fc\u{1fcef}',
+  size: {width: 8, height: 5, depthOrArrayLayers: 5},
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView105 = texture95.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 1});
+try {
+computePassEncoder69.setBindGroup(1, bindGroup32);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(2, bindGroup19);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer57, 188);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup34);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle9, renderBundle15]);
+} catch {}
+try {
+renderPassEncoder12.draw(176, 20, 1_028_049_689, 46_605_629);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer4, 'uint16', 0, 1_566);
+} catch {}
+try {
+renderPassEncoder35.setPipeline(pipeline0);
+} catch {}
+let texture123 = device0.createTexture({size: [8], dimension: '1d', format: 'r8uint', usage: GPUTextureUsage.COPY_DST});
+try {
+computePassEncoder25.setBindGroup(0, bindGroup55, new Uint32Array(2632), 924, 0);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup21, new Uint32Array(1391), 10, 0);
+} catch {}
+try {
+renderPassEncoder4.draw(62, 0, 136_565_903);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer5, 1_456);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer32, 'uint16', 2_084, 599);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'opaque',
+});
+} catch {}
+let bindGroup59 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [
+    {binding: 55, resource: textureView83},
+    {binding: 22, resource: textureView78},
+    {binding: 62, resource: {buffer: buffer15, offset: 0, size: 38}},
+    {binding: 132, resource: sampler51},
+    {binding: 103, resource: textureView12},
+    {binding: 236, resource: textureView80},
+  ],
+});
+let commandEncoder108 = device0.createCommandEncoder({});
+let computePassEncoder75 = commandEncoder108.beginComputePass({});
+try {
+renderPassEncoder11.executeBundles([renderBundle1, renderBundle19]);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer29, 'uint32', 176, 5_847);
+} catch {}
+let pipelineLayout13 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout12]});
+let texture124 = device0.createTexture({
+  size: [2, 1, 1],
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView106 = texture108.createView({arrayLayerCount: 1});
+try {
+renderPassEncoder32.setBindGroup(1, bindGroup46);
+} catch {}
+try {
+renderPassEncoder12.draw(19, 465, 29_722_187, 286_115_113);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(116, 27, 74, -1_609_235_765, 569_070_093);
+} catch {}
+try {
+computePassEncoder33.pushDebugGroup('\u0105');
+} catch {}
+let texture125 = device0.createTexture({
+  size: {width: 16, height: 10, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture21 = device0.importExternalTexture({source: videoFrame4, colorSpace: 'display-p3'});
+try {
+computePassEncoder5.setBindGroup(1, bindGroup55, new Uint32Array(2283), 95, 0);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(2, bindGroup28);
+} catch {}
+try {
+renderPassEncoder30.executeBundles([renderBundle6, renderBundle4, renderBundle20]);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(18, 0, 2, 315_588_004);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(buffer15, 40);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 10, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame10,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture100,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline2 = await device0.createComputePipelineAsync({layout: pipelineLayout1, compute: {module: shaderModule2, constants: {}}});
+let imageData12 = new ImageData(24, 84);
+try {
+computePassEncoder18.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(3, bindGroup17);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let imageData13 = new ImageData(100, 8);
+let videoFrame21 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'bt470bg', transfer: 'gamma28curve'} });
+try {
+computePassEncoder19.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+computePassEncoder69.setBindGroup(1, bindGroup46, new Uint32Array(296), 4, 0);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer55, 'uint16', 7_110, 5_053);
+} catch {}
+let bindGroup60 = device0.createBindGroup({
+  layout: bindGroupLayout12,
+  entries: [
+    {binding: 112, resource: textureView81},
+    {binding: 497, resource: externalTexture9},
+    {binding: 232, resource: sampler59},
+  ],
+});
+try {
+computePassEncoder67.setBindGroup(3, bindGroup18, new Uint32Array(8266), 4_416, 0);
+} catch {}
+try {
+computePassEncoder69.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(0, bindGroup7, new Uint32Array(4301), 31, 0);
+} catch {}
+try {
+renderPassEncoder12.draw(477, 148, 801_507_342, 1_043_852_124);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(5, 0, 2, 633_108_726);
+} catch {}
+let pipeline3 = await device0.createComputePipelineAsync({layout: pipelineLayout1, compute: {module: shaderModule4}});
+let imageData14 = new ImageData(160, 124);
+let externalTexture22 = device0.importExternalTexture({source: videoFrame3});
+try {
+computePassEncoder2.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle17]);
+} catch {}
+try {
+renderPassEncoder12.draw(26, 7, 284_890_268, 355_427_608);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(buffer65, 832);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer24, 1_116);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline1);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+adapter0.label = '\u7fe1\uf247\u{1f782}\u2976\u{1fb13}\ubf34';
+} catch {}
+let buffer74 = device0.createBuffer({
+  size: 20266,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder109 = device0.createCommandEncoder();
+let querySet17 = device0.createQuerySet({type: 'occlusion', count: 1752});
+let renderPassEncoder36 = commandEncoder109.beginRenderPass({
+  label: '\u{1f79d}\u264a\u{1fa8a}\u8d6d\u{1fa60}',
+  colorAttachments: [{
+  view: textureView6,
+  clearValue: { r: 634.9, g: 996.3, b: 735.9, a: 789.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder38.setBindGroup(3, bindGroup57);
+} catch {}
+try {
+computePassEncoder24.setBindGroup(2, bindGroup16, new Uint32Array(4571), 1_616, 0);
+} catch {}
+try {
+computePassEncoder37.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder34.setViewport(1.0381239607039814, 0.795715971255083, 0.6890691381683618, 0.15782976206353375, 0.2577535327040479, 0.2680229682918789);
+} catch {}
+try {
+renderPassEncoder5.draw(140, 241, 1_304_630_860, 303_963_173);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer22, 1_060);
+} catch {}
+let commandEncoder110 = device0.createCommandEncoder({label: '\u4fea\u2d8e\u{1fa2a}\u590a\ucd14\u074d\u0691'});
+try {
+computePassEncoder50.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup15);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup9, new Uint32Array(939), 28, 0);
+} catch {}
+try {
+renderPassEncoder5.draw(57, 344, 79_848_630, 102_977_058);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(buffer2, 2_168);
+} catch {}
+try {
+computePassEncoder33.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer26, 520, new Int16Array(9633), 476, 8);
+} catch {}
+let buffer75 = device0.createBuffer({
+  size: 15096,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture126 = device0.createTexture({
+  size: [16, 10, 115],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let renderPassEncoder37 = commandEncoder110.beginRenderPass({
+  colorAttachments: [{
+  view: textureView90,
+  depthSlice: 16,
+  clearValue: { r: 983.7, g: -332.0, b: 429.2, a: -710.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder12.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle15, renderBundle21, renderBundle18]);
+} catch {}
+try {
+renderPassEncoder20.setBlendConstant({ r: 365.6, g: 320.9, b: 282.5, a: 49.50, });
+} catch {}
+try {
+renderPassEncoder4.draw(78, 0, 1_275_958_752);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(229, 111, 166, 442_427_986, 747_597_278);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(buffer66, 5_044);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer73, 76);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 4, height: 2, depthOrArrayLayers: 151}
+*/
+{
+  source: imageData6,
+  origin: { x: 1, y: 31 },
+  flipY: false,
+}, {
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 42},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData15 = new ImageData(4, 12);
+let commandEncoder111 = device0.createCommandEncoder({});
+let textureView107 = texture82.createView({dimension: '2d-array', mipLevelCount: 1});
+let renderBundleEncoder24 = device0.createRenderBundleEncoder({colorFormats: ['r8uint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder33.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(3, buffer2, 3_264, 1_370);
+} catch {}
+try {
+renderBundleEncoder24.setPipeline(pipeline0);
+} catch {}
+document.body.append(img0);
+let commandEncoder112 = device0.createCommandEncoder({label: '\u0373\u063e\u04eb\u3fc7\u85ff\u03ba\uf46a\u0623'});
+let querySet18 = device0.createQuerySet({type: 'occlusion', count: 13});
+let computePassEncoder76 = commandEncoder112.beginComputePass({});
+let renderPassEncoder38 = commandEncoder24.beginRenderPass({
+  colorAttachments: [{
+  view: textureView82,
+  clearValue: { r: 668.5, g: -696.4, b: -37.53, a: -736.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let sampler71 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 60.89,
+});
+let externalTexture23 = device0.importExternalTexture({source: videoFrame13});
+try {
+computePassEncoder51.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder12.draw(182, 0, 97_456_975, 487_626_711);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer4, 'uint32', 1_312, 317);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 128, height: 128, depthOrArrayLayers: 265}
+*/
+{
+  source: imageData4,
+  origin: { x: 2, y: 0 },
+  flipY: true,
+}, {
+  texture: texture51,
+  mipLevel: 1,
+  origin: {x: 15, y: 59, z: 11},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas1);
+let bindGroupLayout15 = device0.createBindGroupLayout({
+  label: '\udbac\u37e7\u{1f64d}\uc0dc',
+  entries: [
+    {
+      binding: 294,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32uint', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 26,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d' },
+    },
+  ],
+});
+let bindGroup61 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 33, resource: textureView38},
+    {binding: 143, resource: textureView74},
+    {binding: 487, resource: sampler60},
+  ],
+});
+let buffer76 = device0.createBuffer({size: 3579, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let texture127 = device0.createTexture({
+  size: [8, 5, 1],
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder77 = commandEncoder111.beginComputePass({label: '\u6bf8\u0c1b\uf311\ue9c6'});
+let sampler72 = device0.createSampler({
+  label: '\u50c1\u006f\uc229',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 80.87,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder16.setBindGroup(3, bindGroup39);
+} catch {}
+try {
+computePassEncoder24.setBindGroup(3, bindGroup22, new Uint32Array(381), 55, 0);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(buffer24, 6_320);
+} catch {}
+try {
+renderBundleEncoder24.setPipeline(pipeline0);
+} catch {}
+await gc();
+let texture128 = device0.createTexture({
+  size: [16, 10, 297],
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderBundle24 = renderBundleEncoder24.finish({label: '\u25fe\u06d0\u68be\ub4c3\u060f\u{1fa1d}\u4f16'});
+try {
+computePassEncoder13.setBindGroup(2, bindGroup57, new Uint32Array(61), 0, 0);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer53, 'uint16', 2_004, 1_272);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(3, buffer59, 0);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let buffer77 = device0.createBuffer({
+  size: 12402,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let texture129 = device0.createTexture({
+  label: '\u{1fe04}\u0d8e\u0b6b\u{1f877}\u{1fd07}\u0707\u{1fdba}\u{1f9ab}\u02c2\u467d',
+  size: [16, 10, 1],
+  format: 'r32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture130 = device0.createTexture({
+  size: {width: 16, height: 10, depthOrArrayLayers: 1},
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup43);
+} catch {}
+try {
+computePassEncoder1.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder33.setScissorRect(0, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder12.draw(141, 58, 102_312_991, 2_074_572_393);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(46, 0, 0, -1_048_114_953);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(buffer65, 980);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer28, 1_464);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer28, 'uint32', 580, 8);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+await gc();
+let bindGroup62 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [
+    {binding: 132, resource: sampler3},
+    {binding: 55, resource: textureView80},
+    {binding: 236, resource: textureView80},
+    {binding: 62, resource: {buffer: buffer11, offset: 5376, size: 623}},
+    {binding: 103, resource: textureView105},
+    {binding: 22, resource: textureView81},
+  ],
+});
+let buffer78 = device0.createBuffer({
+  label: '\udd2d\u{1ff1b}\u{1fb2d}\ub3b3',
+  size: 4777,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture131 = device0.createTexture({
+  size: {width: 16, height: 10, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture132 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 15},
+  sampleCount: 1,
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder29.executeBundles([renderBundle6, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(buffer5, 332);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer55, 'uint32', 1_296, 2_895);
+} catch {}
+let bindGroup63 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 7, resource: {buffer: buffer72, offset: 256}}]});
+let commandEncoder113 = device0.createCommandEncoder({label: '\u7b54\u0f0d\u4548\u{1fe70}\u{1f641}\u50f7\ua600\u{1fcfd}\ufe25\uacf3'});
+let textureView108 = texture128.createView({baseArrayLayer: 0});
+let texture133 = device0.createTexture({
+  size: [8, 5, 474],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView109 = texture124.createView({dimension: '2d-array', format: 'r8uint'});
+let externalTexture24 = device0.importExternalTexture({source: videoFrame8, colorSpace: 'display-p3'});
+try {
+renderPassEncoder22.setBindGroup(0, bindGroup44, new Uint32Array(52), 3, 0);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle11]);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer71, 'uint16', 868, 1_212);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let commandEncoder114 = device0.createCommandEncoder({});
+let textureView110 = texture128.createView({mipLevelCount: 1});
+let computePassEncoder78 = commandEncoder114.beginComputePass({});
+let renderPassEncoder39 = commandEncoder113.beginRenderPass({
+  colorAttachments: [{
+  view: textureView55,
+  depthSlice: 40,
+  clearValue: { r: -454.8, g: 413.9, b: 645.1, a: -0.3222, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet7,
+  maxDrawCount: 34223498,
+});
+let renderBundleEncoder25 = device0.createRenderBundleEncoder({colorFormats: ['r16float'], stencilReadOnly: true});
+let renderBundle25 = renderBundleEncoder25.finish({});
+try {
+computePassEncoder33.setBindGroup(1, bindGroup38, new Uint32Array(4659), 456, 0);
+} catch {}
+try {
+computePassEncoder43.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup44);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle22]);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer4, 'uint16', 144, 397);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer79 = device0.createBuffer({size: 8050, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+let textureView111 = texture129.createView({baseMipLevel: 0});
+try {
+computePassEncoder5.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder65.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle7, renderBundle17, renderBundle9, renderBundle13, renderBundle25]);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(buffer50, 3_408);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer70, 848);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(1, buffer66, 5_860, 101);
+} catch {}
+document.body.prepend(img1);
+let bindGroupLayout16 = device0.createBindGroupLayout({
+  label: '\u9dad\u93dc\u615f\u2b46\u{1f63c}\u0fa2\u057d',
+  entries: [
+    {
+      binding: 38,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '3d' },
+    },
+    {
+      binding: 24,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 301,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 128,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '2d-array' },
+    },
+    {
+      binding: 15,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 141,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '1d' },
+    },
+  ],
+});
+let commandEncoder115 = device0.createCommandEncoder({});
+let texture134 = device0.createTexture({
+  size: {width: 8, height: 5, depthOrArrayLayers: 1},
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder40 = commandEncoder115.beginRenderPass({
+  colorAttachments: [{view: textureView90, depthSlice: 17, loadOp: 'load', storeOp: 'discard'}],
+  maxDrawCount: 954607234,
+});
+try {
+computePassEncoder42.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder15.executeBundles([renderBundle4, renderBundle6, renderBundle24, renderBundle24, renderBundle12, renderBundle12, renderBundle11, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(2, buffer55);
+} catch {}
+try {
+computePassEncoder1.pushDebugGroup('\u{1fe8d}');
+} catch {}
+try {
+renderPassEncoder38.insertDebugMarker('\u7c91');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer49, 2864, new DataView(new ArrayBuffer(648)));
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup64 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 13, resource: externalTexture5}]});
+let texture135 = device0.createTexture({
+  size: [2, 1, 1],
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture136 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 15},
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder14.setBindGroup(1, bindGroup35, new Uint32Array(191), 36, 0);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(buffer12, 1_588);
+} catch {}
+try {
+gpuCanvasContext1.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer72, 704, new BigUint64Array(13567), 1044, 108);
+} catch {}
+let pipeline4 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout6,
+  fragment: {
+  module: shaderModule3,
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'constant'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule0,
+    constants: {},
+    buffers: [{arrayStride: 200, attributes: [{format: 'snorm8x2', offset: 6, shaderLocation: 14}]}],
+  },
+});
+let commandEncoder116 = device0.createCommandEncoder({});
+let textureView112 = texture135.createView({dimension: '2d-array'});
+let texture137 = device0.createTexture({size: {width: 16}, dimension: '1d', format: 'r8uint', usage: GPUTextureUsage.COPY_SRC});
+let renderPassEncoder41 = commandEncoder116.beginRenderPass({
+  colorAttachments: [{
+  view: textureView57,
+  depthSlice: 375,
+  clearValue: { r: 365.8, g: -559.5, b: -122.9, a: -336.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder53.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder33); computePassEncoder33.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder72.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(0, 0, 25, 708_655_142);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer2, 216);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(7, buffer21);
+} catch {}
+let buffer80 = device0.createBuffer({
+  size: 371,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let texture138 = device0.createTexture({
+  size: [256, 256, 111],
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder73.setBindGroup(2, bindGroup46, new Uint32Array(407), 78, 0);
+} catch {}
+try {
+renderPassEncoder4.draw(7, 0, 320_351_352);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer5, 0);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(3, buffer61, 680, 942);
+} catch {}
+try {
+computePassEncoder51.insertDebugMarker('\u{1f7d7}');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame12,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture135,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder117 = device0.createCommandEncoder();
+let textureView113 = texture138.createView({});
+let computePassEncoder79 = commandEncoder117.beginComputePass({});
+let sampler73 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 53.27,
+  lodMaxClamp: 95.03,
+});
+try {
+renderPassEncoder12.end();
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer66, 53_296);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer42, 4_592);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(6, buffer73);
+} catch {}
+let arrayBuffer9 = buffer8.getMappedRange(4528, 0);
+try {
+buffer36.unmap();
+} catch {}
+try {
+commandEncoder43.copyBufferToBuffer(buffer64, 752, buffer54, 2124, 108);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 42}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 6, y: 11 },
+  flipY: true,
+}, {
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 11},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup65 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 33, resource: textureView38},
+    {binding: 487, resource: sampler50},
+    {binding: 143, resource: textureView74},
+  ],
+});
+let commandBuffer4 = commandEncoder43.finish();
+let texture139 = device0.createTexture({size: [4, 2, 1], format: 'r8uint', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC});
+try {
+computePassEncoder70.setBindGroup(2, bindGroup24, []);
+} catch {}
+try {
+computePassEncoder2.setBindGroup(3, bindGroup30, new Uint32Array(9646), 3_793, 0);
+} catch {}
+try {
+computePassEncoder56.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup2, new Uint32Array(173), 48, 0);
+} catch {}
+try {
+renderPassEncoder13.setViewport(2.2349655130850414, 1.0032676756486085, 0.15811758228997627, 0.17614998622064973, 0.28623257994248874, 0.656613780995905);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(2, 0, 1, 597_077_204);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer63, 24);
+} catch {}
+let commandEncoder118 = device0.createCommandEncoder({});
+let computePassEncoder80 = commandEncoder118.beginComputePass();
+try {
+computePassEncoder58.setBindGroup(3, bindGroup59);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(2, bindGroup44, new Uint32Array(157), 45, 0);
+} catch {}
+try {
+renderPassEncoder4.draw(46, 0, 1_471_289_901);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(10, 0, 7, 196_616_037);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer63, 10_148);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer26, 'uint16', 276, 280);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(6, buffer73, 0, 488);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(87).fill(14), /* required buffer size: 87 */
+{offset: 87}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder119 = device0.createCommandEncoder({});
+let textureView114 = texture131.createView({label: '\u07da\u{1f860}\u1647\u0892\u{1fbf3}\u9ed4\u0776\u{1fb5f}\u47e9', dimension: '2d'});
+try {
+computePassEncoder50.setBindGroup(1, bindGroup58);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder33); computePassEncoder33.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder75.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(1, bindGroup61);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(3, bindGroup37, new Uint32Array(4904), 1_382, 0);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer72, 2_384);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer64, 496);
+} catch {}
+try {
+commandEncoder119.copyBufferToBuffer(buffer72, 3760, buffer2, 5032, 324);
+} catch {}
+try {
+gpuCanvasContext1.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.STORAGE_BINDING});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 256, depthOrArrayLayers: 15}
+*/
+{
+  source: videoFrame21,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 91, y: 39, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame22 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'unspecified', transfer: 'smpte240m'} });
+let texture140 = device0.createTexture({
+  size: [2, 1, 1],
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderPassEncoder42 = commandEncoder119.beginRenderPass({
+  colorAttachments: [{view: textureView48, depthSlice: 1466, loadOp: 'load', storeOp: 'discard'}],
+  occlusionQuerySet: querySet17,
+});
+let sampler74 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 10.05,
+});
+try {
+computePassEncoder20.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+renderPassEncoder4.draw(131, 0, 4_294_967_164);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(4, 0, 0, 299_096_885);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer62, 'uint32', 2_924, 4_739);
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+try {
+computePassEncoder80.setBindGroup(2, bindGroup62);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(4, 0, 10, 1_795_335_996);
+} catch {}
+try {
+computePassEncoder1.popDebugGroup();
+} catch {}
+let pipeline5 = await device0.createRenderPipelineAsync({
+  label: '\u2404\u08af\u9499\u{1ffb2}',
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule1,
+  constants: {},
+  targets: [{format: 'r16float', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule3,
+    buffers: [
+      {
+        arrayStride: 20,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 2, shaderLocation: 14},
+          {format: 'float32', offset: 0, shaderLocation: 10},
+          {format: 'sint16x4', offset: 0, shaderLocation: 15},
+          {format: 'unorm8x2', offset: 2, shaderLocation: 4},
+          {format: 'snorm8x4', offset: 8, shaderLocation: 1},
+          {format: 'uint32x2', offset: 0, shaderLocation: 6},
+          {format: 'uint32x3', offset: 0, shaderLocation: 9},
+        ],
+      },
+    ],
+  },
+});
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let textureView115 = texture26.createView({dimension: '2d-array'});
+let sampler75 = device0.createSampler({
+  label: '\u95b8\u{1f93e}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 3.657,
+  lodMaxClamp: 82.77,
+});
+try {
+computePassEncoder19.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(1, 0, 1, 534_325_428);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer76, 168);
+} catch {}
+let texture141 = device0.createTexture({
+  size: {width: 8, height: 5, depthOrArrayLayers: 24},
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder34.setBindGroup(2, bindGroup12, new Uint32Array(156), 0, 0);
+} catch {}
+try {
+computePassEncoder9.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder39.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder4.draw(168, 0, 618_292_726);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer60, 0);
+} catch {}
+try {
+renderPassEncoder39.setPipeline(pipeline4);
+} catch {}
+await gc();
+let buffer81 = device0.createBuffer({
+  size: 40405,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let textureView116 = texture99.createView({dimension: '3d', mipLevelCount: 1, arrayLayerCount: 1});
+let sampler76 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 64.91,
+  lodMaxClamp: 98.22,
+  compare: 'greater',
+});
+try {
+computePassEncoder60.setBindGroup(1, bindGroup21);
+} catch {}
+try {
+computePassEncoder52.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 1160, new DataView(new ArrayBuffer(9344)), 892, 652);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 19},
+  aspect: 'all',
+}, new Uint8Array(198_262).fill(26), /* required buffer size: 198_262 */
+{offset: 162, bytesPerRow: 50, rowsPerImage: 37}, {width: 0, height: 4, depthOrArrayLayers: 108});
+} catch {}
+document.body.prepend(canvas0);
+offscreenCanvas0.width = 726;
+try {
+computePassEncoder26.setBindGroup(2, bindGroup64);
+} catch {}
+try {
+computePassEncoder69.setBindGroup(3, bindGroup29, new Uint32Array(773), 373, 0);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(0, bindGroup34);
+} catch {}
+try {
+renderPassEncoder4.end();
+} catch {}
+try {
+renderPassEncoder42.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture51,
+  mipLevel: 1,
+  origin: {x: 18, y: 24, z: 70},
+  aspect: 'all',
+}, new Uint8Array(25_076).fill(128), /* required buffer size: 25_076 */
+{offset: 632, bytesPerRow: 61, rowsPerImage: 22}, {width: 22, height: 5, depthOrArrayLayers: 19});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 256, depthOrArrayLayers: 15}
+*/
+{
+  source: videoFrame16,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 23, y: 78, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder120 = device0.createCommandEncoder({});
+let texture142 = device0.createTexture({
+  size: {width: 60, height: 5, depthOrArrayLayers: 162},
+  format: 'astc-6x5-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder43 = commandEncoder120.beginRenderPass({
+  colorAttachments: [{
+  view: textureView96,
+  depthSlice: 1177,
+  clearValue: { r: 67.85, g: 320.9, b: -136.3, a: -251.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder59.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder36.executeBundles([renderBundle8]);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer72, 'uint16', 488, 60);
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder25.copyBufferToTexture({
+  /* bytesInLastRow: 336 widthInBlocks: 21 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 3344 */
+  offset: 3344,
+  bytesPerRow: 1280,
+  buffer: buffer5,
+}, {
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 18, y: 20, z: 0},
+  aspect: 'all',
+}, {width: 126, height: 75, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder25.copyTextureToBuffer({
+  texture: texture104,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1270 */
+  offset: 1270,
+  bytesPerRow: 12032,
+  buffer: buffer72,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder25.clearBuffer(buffer54, 1892, 3776);
+} catch {}
+try {
+commandEncoder25.insertDebugMarker('\u04c8');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 848, new BigUint64Array(2958), 967, 164);
+} catch {}
+let videoFrame23 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'film', transfer: 'iec61966-2-1'} });
+let commandEncoder121 = device0.createCommandEncoder({});
+let textureView117 = texture128.createView({});
+try {
+computePassEncoder33.setBindGroup(1, bindGroup21);
+} catch {}
+try {
+renderPassEncoder39.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder121.copyBufferToTexture({
+  /* bytesInLastRow: 308 widthInBlocks: 77 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 7524 */
+  offset: 7524,
+  bytesPerRow: 15104,
+  buffer: buffer20,
+}, {
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 9, y: 7, z: 0},
+  aspect: 'all',
+}, {width: 77, height: 18, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder25.clearBuffer(buffer49);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let texture143 = device0.createTexture({
+  size: [2, 1, 1],
+  mipLevelCount: 1,
+  format: 'r8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView118 = texture103.createView({mipLevelCount: 1});
+let computePassEncoder81 = commandEncoder121.beginComputePass();
+let renderPassEncoder44 = commandEncoder25.beginRenderPass({colorAttachments: [{view: textureView92, depthSlice: 128, loadOp: 'load', storeOp: 'store'}]});
+let sampler77 = device0.createSampler({label: '\u038d\u2e81', addressModeW: 'clamp-to-edge', minFilter: 'nearest', lodMaxClamp: 92.08});
+try {
+computePassEncoder62.setBindGroup(3, bindGroup36);
+} catch {}
+try {
+computePassEncoder33.end();
+} catch {}
+try {
+computePassEncoder4.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup20);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(2, buffer27, 504, 386);
+} catch {}
+try {
+buffer40.unmap();
+} catch {}
+try {
+commandEncoder45.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 712 */
+  offset: 712,
+  buffer: buffer20,
+}, {
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture91,
+  mipLevel: 0,
+  origin: {x: 12, y: 58, z: 1},
+  aspect: 'all',
+}, new Uint8Array(256_722).fill(37), /* required buffer size: 256_722 */
+{offset: 211, bytesPerRow: 15, rowsPerImage: 96}, {width: 11, height: 13, depthOrArrayLayers: 179});
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+let bindGroup66 = device0.createBindGroup({
+  layout: bindGroupLayout8,
+  entries: [{binding: 271, resource: textureView75}, {binding: 340, resource: textureView38}],
+});
+let textureView119 = texture56.createView({});
+try {
+computePassEncoder64.setBindGroup(3, bindGroup28, new Uint32Array(65), 7, 0);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline5);
+} catch {}
+try {
+buffer65.unmap();
+} catch {}
+try {
+commandEncoder45.copyBufferToTexture({
+  /* bytesInLastRow: 71 widthInBlocks: 71 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2134 */
+  offset: 2134,
+  bytesPerRow: 37376,
+  buffer: buffer11,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 17, y: 10, z: 0},
+  aspect: 'all',
+}, {width: 71, height: 26, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder122 = device0.createCommandEncoder({});
+let texture144 = device0.createTexture({
+  size: [4, 2, 1],
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let computePassEncoder82 = commandEncoder45.beginComputePass({});
+let externalTexture25 = device0.importExternalTexture({source: videoFrame17});
+try {
+computePassEncoder68.setBindGroup(2, bindGroup32);
+} catch {}
+try {
+computePassEncoder45.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(2, bindGroup43);
+} catch {}
+try {
+renderPassEncoder32.executeBundles([renderBundle25, renderBundle7, renderBundle17, renderBundle21, renderBundle22, renderBundle15, renderBundle0, renderBundle22, renderBundle15, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline5);
+} catch {}
+try {
+commandEncoder122.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2329 */
+  offset: 2329,
+  bytesPerRow: 16128,
+  buffer: buffer57,
+}, {
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup67 = device0.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [{binding: 294, resource: textureView117}, {binding: 26, resource: textureView114}],
+});
+let commandEncoder123 = device0.createCommandEncoder({});
+try {
+computePassEncoder81.setBindGroup(0, bindGroup45);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(1, bindGroup35, new Uint32Array(597), 12, 0);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer76, 'uint32', 208, 485);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline0);
+} catch {}
+let texture145 = device0.createTexture({
+  size: [2, 1, 1],
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder45 = commandEncoder122.beginRenderPass({
+  colorAttachments: [{
+  view: textureView55,
+  depthSlice: 5,
+  clearValue: { r: -576.8, g: -736.8, b: -878.0, a: 379.1, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 100081895,
+});
+try {
+computePassEncoder20.setBindGroup(3, bindGroup34, new Uint32Array(35), 7, 0);
+} catch {}
+try {
+computePassEncoder16.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 100, y: 122, z: 0},
+  aspect: 'all',
+}, new Uint8Array(36).fill(125), /* required buffer size: 36 */
+{offset: 36, bytesPerRow: 66, rowsPerImage: 23}, {width: 48, height: 16, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup68 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 33, resource: textureView32},
+    {binding: 143, resource: textureView106},
+    {binding: 487, resource: sampler22},
+  ],
+});
+let buffer82 = device0.createBuffer({
+  size: 9478,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder83 = commandEncoder123.beginComputePass({});
+let externalTexture26 = device0.importExternalTexture({source: videoFrame4});
+try {
+computePassEncoder47.setBindGroup(2, bindGroup45);
+} catch {}
+try {
+computePassEncoder61.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(2, bindGroup48);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(3, bindGroup41, new Uint32Array(750), 42, 0);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(5, buffer34, 4, 1);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(2, bindGroup24);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(1, bindGroup47, new Uint32Array(793), 599, 0);
+} catch {}
+document.body.prepend(img0);
+try {
+{ clearResourceUsages(device0, computePassEncoder19); computePassEncoder19.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder24.setPipeline(pipeline2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer69, 484, new DataView(new ArrayBuffer(7166)), 165, 16);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(158).fill(154), /* required buffer size: 158 */
+{offset: 158}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer83 = device0.createBuffer({size: 410, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder124 = device0.createCommandEncoder({});
+let texture146 = device0.createTexture({
+  size: [8, 5, 1],
+  mipLevelCount: 2,
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView120 = texture62.createView({mipLevelCount: 1});
+let renderPassEncoder46 = commandEncoder124.beginRenderPass({
+  colorAttachments: [{
+  view: textureView2,
+  depthSlice: 1,
+  clearValue: { r: 576.0, g: 405.1, b: 126.5, a: 215.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder22.setBindGroup(1, bindGroup23);
+} catch {}
+try {
+computePassEncoder30.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder45.setVertexBuffer(3, undefined, 0, 647_567_182);
+} catch {}
+let promise10 = device0.queue.onSubmittedWorkDone();
+document.body.append(img0);
+try {
+computePassEncoder7.setBindGroup(0, bindGroup33, new Uint32Array(476), 13, 0);
+} catch {}
+try {
+computePassEncoder53.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup28, []);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle25, renderBundle21, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder16.setViewport(2.793584668034269, 1.9129426197533597, 0.37018128250951304, 0.07287775791929242, 0.9768302945348603, 0.9782664573915348);
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(2, buffer57);
+} catch {}
+try {
+buffer29.unmap();
+} catch {}
+let promise11 = device0.queue.onSubmittedWorkDone();
+let commandEncoder125 = device0.createCommandEncoder({});
+try {
+computePassEncoder65.setBindGroup(2, bindGroup43, new Uint32Array(1260), 159, 0);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(3, bindGroup39, []);
+} catch {}
+try {
+commandEncoder125.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1632 */
+  offset: 1632,
+  buffer: buffer46,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer69, 76, new Float32Array(28031), 1126, 60);
+} catch {}
+let buffer84 = device0.createBuffer({
+  size: 6430,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandBuffer5 = commandEncoder125.finish({});
+let texture147 = device0.createTexture({
+  size: [2, 1, 1],
+  mipLevelCount: 1,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+});
+let textureView121 = texture0.createView({});
+try {
+{ clearResourceUsages(device0, computePassEncoder19); computePassEncoder19.dispatchWorkgroupsIndirect(buffer35, 268); };
+} catch {}
+try {
+computePassEncoder49.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup5, new Uint32Array(927), 85, 0);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle12]);
+} catch {}
+let arrayBuffer10 = buffer8.getMappedRange(4536, 12);
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 256, depthOrArrayLayers: 531}
+*/
+{
+  source: imageData15,
+  origin: { x: 0, y: 5 },
+  flipY: true,
+}, {
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 109, y: 19, z: 68},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas2);
+let videoFrame24 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte240m', primaries: 'bt470bg', transfer: 'iec61966-2-1'} });
+let bindGroup69 = device0.createBindGroup({
+  layout: bindGroupLayout16,
+  entries: [
+    {binding: 301, resource: {buffer: buffer62, offset: 1024}},
+    {binding: 15, resource: {buffer: buffer42, offset: 3840, size: 60}},
+    {binding: 141, resource: textureView38},
+    {binding: 128, resource: textureView112},
+    {binding: 24, resource: textureView53},
+    {binding: 38, resource: textureView113},
+  ],
+});
+let commandEncoder126 = device0.createCommandEncoder();
+let textureView122 = texture138.createView({});
+let textureView123 = texture81.createView({dimension: '2d-array', mipLevelCount: 1});
+let renderPassEncoder47 = commandEncoder126.beginRenderPass({
+  colorAttachments: [{
+  view: textureView57,
+  depthSlice: 410,
+  clearValue: { r: 542.8, g: 808.9, b: 162.3, a: 56.93, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 37140445,
+});
+try {
+computePassEncoder73.setBindGroup(0, bindGroup30, new Uint32Array(2490), 70, 0);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(2, bindGroup49);
+} catch {}
+let bindGroup70 = device0.createBindGroup({
+  layout: bindGroupLayout9,
+  entries: [{binding: 114, resource: {buffer: buffer84, offset: 512, size: 787}}],
+});
+let buffer85 = device0.createBuffer({
+  label: '\u{1f72e}\u0274\u1e6d\u4176',
+  size: 13471,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE,
+});
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup46);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(0, bindGroup59, new Uint32Array(6960), 2_940, 0);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer26, 'uint32', 212, 401);
+} catch {}
+let videoFrame25 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte170m', primaries: 'bt470bg', transfer: 'gamma28curve'} });
+let bindGroupLayout17 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 162,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let textureView124 = texture121.createView({dimension: '2d-array'});
+let texture148 = device0.createTexture({
+  size: {width: 4, height: 2, depthOrArrayLayers: 1},
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView125 = texture68.createView({label: '\u{1f94c}\u71d8\ucb4a', aspect: 'all'});
+let sampler78 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 58.75,
+  lodMaxClamp: 78.72,
+});
+try {
+computePassEncoder49.setBindGroup(1, bindGroup14, []);
+} catch {}
+try {
+computePassEncoder12.setBindGroup(2, bindGroup22, new Uint32Array(189), 30, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder16); computePassEncoder16.dispatchWorkgroupsIndirect(buffer71, 372); };
+} catch {}
+try {
+computePassEncoder67.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer71, 'uint16', 366, 1_850);
+} catch {}
+try {
+buffer79.unmap();
+} catch {}
+await gc();
+let buffer86 = device0.createBuffer({
+  size: 5742,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let textureView126 = texture99.createView({baseMipLevel: 0});
+try {
+computePassEncoder66.setBindGroup(1, bindGroup70, new Uint32Array(1006), 26, 0);
+} catch {}
+try {
+computePassEncoder20.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder45.setIndexBuffer(buffer54, 'uint16', 5_826, 2_403);
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer5]);
+} catch {}
+try {
+  await promise11;
+} catch {}
+let buffer87 = device0.createBuffer({size: 5372, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView127 = texture28.createView({dimension: 'cube', format: 'r8uint', baseMipLevel: 0, baseArrayLayer: 0});
+try {
+computePassEncoder7.setBindGroup(0, bindGroup0, []);
+} catch {}
+try {
+computePassEncoder48.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder26.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder36.setScissorRect(0, 0, 0, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer51, 324, new DataView(new ArrayBuffer(21554)), 7171, 7040);
+} catch {}
+await gc();
+let bindGroup71 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 420, resource: textureView8},
+    {binding: 121, resource: externalTexture25},
+    {binding: 218, resource: textureView43},
+  ],
+});
+let commandEncoder127 = device0.createCommandEncoder();
+let querySet19 = device0.createQuerySet({label: '\uf4a7\ud8c8\u{1fbc7}\u0ca9\u005f\u94b8\u1af7', type: 'occlusion', count: 290});
+let sampler79 = device0.createSampler({
+  label: '\uff38\u0d8f\ud2f7\u{1f679}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 94.92,
+  lodMaxClamp: 95.30,
+});
+try {
+computePassEncoder12.setBindGroup(2, bindGroup56);
+} catch {}
+try {
+computePassEncoder38.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup6, new Uint32Array(1085), 54, 0);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer4, 'uint16', 462, 164);
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+let commandEncoder128 = device0.createCommandEncoder();
+let querySet20 = device0.createQuerySet({type: 'occlusion', count: 250});
+let computePassEncoder84 = commandEncoder128.beginComputePass();
+try {
+computePassEncoder19.end();
+} catch {}
+try {
+renderPassEncoder29.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder47.setPipeline(pipeline5);
+} catch {}
+try {
+commandEncoder127.clearBuffer(buffer55, 1748, 2632);
+} catch {}
+try {
+commandEncoder127.insertDebugMarker('\u{1fc5e}');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(181).fill(242), /* required buffer size: 181 */
+{offset: 181, bytesPerRow: 47}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter0.label = '\ue6b2\u01d1\u451b';
+} catch {}
+let textureView128 = texture94.createView({baseMipLevel: 0});
+let computePassEncoder85 = commandEncoder21.beginComputePass({});
+let renderPassEncoder48 = commandEncoder127.beginRenderPass({
+  colorAttachments: [{
+  view: textureView20,
+  clearValue: { r: -560.5, g: 557.6, b: 970.6, a: -258.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet18,
+});
+let sampler80 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'clamp-to-edge', lodMinClamp: 34.24, lodMaxClamp: 67.94});
+try {
+computePassEncoder59.setBindGroup(3, bindGroup58);
+} catch {}
+try {
+computePassEncoder62.setBindGroup(3, bindGroup2, new Uint32Array(2611), 325, 0);
+} catch {}
+try {
+computePassEncoder29.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer55, 'uint32', 1_240, 4_586);
+} catch {}
+try {
+renderPassEncoder43.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer4]);
+} catch {}
+let commandEncoder129 = device0.createCommandEncoder({});
+let textureView129 = texture37.createView({});
+let computePassEncoder86 = commandEncoder129.beginComputePass({});
+try {
+computePassEncoder79.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(0, bindGroup5, []);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer54, 'uint32', 896, 3_909);
+} catch {}
+let videoFrame26 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'smpte432', transfer: 'smpte170m'} });
+let commandEncoder130 = device0.createCommandEncoder();
+let texture149 = device0.createTexture({
+  size: [256, 256, 15],
+  mipLevelCount: 2,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8uint'],
+});
+let textureView130 = texture18.createView({});
+let renderPassEncoder49 = commandEncoder130.beginRenderPass({
+  colorAttachments: [{
+  view: textureView67,
+  clearValue: { r: -706.2, g: 365.6, b: -321.9, a: 799.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let renderBundleEncoder26 = device0.createRenderBundleEncoder({colorFormats: ['r8uint'], depthReadOnly: true});
+try {
+renderPassEncoder23.setIndexBuffer(buffer53, 'uint16', 1_252, 3_189);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(5, buffer62, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline6 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout1,
+  multisample: {mask: 0x3ae9c09e},
+  fragment: {
+  module: shaderModule3,
+  constants: {},
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one', dstFactor: 'constant'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA,
+}],
+},
+  vertex: {module: shaderModule1, constants: {}, buffers: []},
+});
+await gc();
+let commandEncoder131 = device0.createCommandEncoder({});
+let texture150 = device0.createTexture({
+  size: {width: 16, height: 10, depthOrArrayLayers: 1},
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let computePassEncoder87 = commandEncoder131.beginComputePass({label: '\u9359\uace1\u021c\u021c\u3328\u{1ff7d}\u0642\ubec3\u{1ffc5}\u0686\u5563'});
+try {
+renderPassEncoder31.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(1, bindGroup23, new Uint32Array(2907), 145, 0);
+} catch {}
+try {
+renderPassEncoder30.setScissorRect(0, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder47.setVertexBuffer(6, buffer62, 0, 8_244);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(3, bindGroup68);
+} catch {}
+let arrayBuffer11 = buffer41.getMappedRange(336, 16);
+try {
+device0.queue.writeBuffer(buffer0, 92, new BigUint64Array(5440), 754, 20);
+} catch {}
+let textureView131 = texture116.createView({label: '\u085b\u04cb\u4e24\u2ed6\u{1fb3d}\u130d\u0310\uca8e\u029a\u0d46', mipLevelCount: 1});
+let renderBundleEncoder27 = device0.createRenderBundleEncoder({colorFormats: ['r16float'], depthReadOnly: true});
+try {
+computePassEncoder31.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(5, buffer84, 0);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(buffer26, 'uint32', 532, 94);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+try {
+globalThis.someLabel = commandEncoder100.label;
+} catch {}
+let textureView132 = texture94.createView({});
+try {
+computePassEncoder2.setBindGroup(3, bindGroup13, new Uint32Array(1651), 299, 0);
+} catch {}
+try {
+computePassEncoder74.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer29, 'uint16', 2_800, 258);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(0, buffer53, 1_344, 919);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer33, 0, new Int16Array(6187), 3949, 300);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup72 = device0.createBindGroup({layout: bindGroupLayout4, entries: [{binding: 84, resource: textureView54}]});
+let buffer88 = device0.createBuffer({
+  size: 4945,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView133 = texture133.createView({format: 'r8uint', mipLevelCount: 1});
+try {
+renderPassEncoder32.setIndexBuffer(buffer13, 'uint16', 2_018, 1_630);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(1, buffer84, 3_228, 1_317);
+} catch {}
+let bindGroup73 = device0.createBindGroup({
+  layout: bindGroupLayout14,
+  entries: [
+    {binding: 157, resource: textureView121},
+    {binding: 87, resource: textureView36},
+    {binding: 47, resource: {buffer: buffer66, offset: 14592, size: 5422}},
+  ],
+});
+let sampler81 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 58.50,
+  lodMaxClamp: 59.47,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder16.end();
+} catch {}
+try {
+computePassEncoder6.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer52, 'uint32', 1_948, 200);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(3, buffer76, 1_452);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(buffer15, 'uint32', 28, 72);
+} catch {}
+try {
+renderBundleEncoder27.setPipeline(pipeline6);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+let videoFrame27 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'bt470m', transfer: 'logSqrt'} });
+let commandEncoder132 = device0.createCommandEncoder();
+let renderPassEncoder50 = commandEncoder132.beginRenderPass({
+  colorAttachments: [{
+  view: textureView118,
+  depthSlice: 38,
+  clearValue: { r: 985.8, g: 637.2, b: 815.7, a: -202.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet7,
+  maxDrawCount: 955920033,
+});
+try {
+computePassEncoder64.setBindGroup(2, bindGroup24, []);
+} catch {}
+try {
+computePassEncoder81.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(1, bindGroup1, new Uint32Array(173), 14, 0);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(1, bindGroup53, new Uint32Array(1054), 35, 0);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer51, 'uint16', 870, 226);
+} catch {}
+try {
+renderBundleEncoder27.insertDebugMarker('\u3b8c');
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let bindGroup74 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 487, resource: sampler77},
+    {binding: 143, resource: textureView106},
+    {binding: 33, resource: textureView38},
+  ],
+});
+let textureView134 = texture58.createView({baseMipLevel: 3, mipLevelCount: 1});
+let computePassEncoder88 = commandEncoder17.beginComputePass({label: '\u249c\u{1f81f}\u0b85\uea3f\u3ef5\ud05a\ue25d\u{1f6d8}'});
+let renderBundle26 = renderBundleEncoder26.finish({label: '\u3ac2\u06cf\u9fd5\u0824\u0b5b\u0356\u0de8\ua769\u06fd\u0443'});
+try {
+computePassEncoder17.setBindGroup(2, bindGroup64);
+} catch {}
+try {
+computePassEncoder73.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer13, 'uint32', 1_484, 1_226);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(1, bindGroup61);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+renderBundleEncoder27.insertDebugMarker('\u1777');
+} catch {}
+let texture151 = device0.createTexture({size: [256, 256, 15], mipLevelCount: 1, format: 'r8uint', usage: GPUTextureUsage.COPY_DST});
+try {
+{ clearResourceUsages(device0, computePassEncoder20); computePassEncoder20.dispatchWorkgroupsIndirect(buffer35, 272); };
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(3, bindGroup32);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 55, y: 9, z: 0},
+  aspect: 'all',
+}, new Uint8Array(459).fill(128), /* required buffer size: 459 */
+{offset: 459, bytesPerRow: 442}, {width: 107, height: 38, depthOrArrayLayers: 0});
+} catch {}
+let textureView135 = texture77.createView({baseMipLevel: 0, mipLevelCount: 1});
+try {
+computePassEncoder83.setPipeline(pipeline2);
+} catch {}
+let commandEncoder133 = device0.createCommandEncoder();
+let texture152 = device0.createTexture({
+  label: '\u{1f73d}\ud638',
+  size: {width: 8, height: 5, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let texture153 = gpuCanvasContext0.getCurrentTexture();
+try {
+computePassEncoder21.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(0, bindGroup38);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer43, 'uint32', 564, 1_186);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer52, 'uint16', 1_386, 1_211);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(1, buffer1, 1_088, 7_483);
+} catch {}
+let buffer89 = device0.createBuffer({
+  size: 977,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder134 = device0.createCommandEncoder({});
+let texture154 = device0.createTexture({
+  size: [4, 2, 277],
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView136 = texture117.createView({});
+try {
+computePassEncoder20.end();
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(1, bindGroup66);
+} catch {}
+try {
+renderPassEncoder47.executeBundles([renderBundle7, renderBundle25, renderBundle13]);
+} catch {}
+try {
+renderPassEncoder45.setIndexBuffer(buffer32, 'uint16', 2_300, 3_256);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(0, buffer88, 48, 208);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer29, 'uint32', 452, 2_328);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(6, buffer82, 1_588, 2_442);
+} catch {}
+let commandEncoder135 = device0.createCommandEncoder({});
+let computePassEncoder89 = commandEncoder22.beginComputePass();
+let sampler82 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 69.79,
+  compare: 'never',
+});
+try {
+computePassEncoder57.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(2, bindGroup48, new Uint32Array(282), 81, 0);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder27.setPipeline(pipeline1);
+} catch {}
+try {
+buffer86.unmap();
+} catch {}
+try {
+commandEncoder134.clearBuffer(buffer57, 8, 148);
+} catch {}
+try {
+  await promise10;
+} catch {}
+let renderPassEncoder51 = commandEncoder134.beginRenderPass({
+  colorAttachments: [{view: textureView130, depthSlice: 545, loadOp: 'clear', storeOp: 'store'}],
+  maxDrawCount: 256202817,
+});
+let sampler83 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 90.89,
+  lodMaxClamp: 94.19,
+});
+try {
+computePassEncoder44.setBindGroup(0, bindGroup45);
+} catch {}
+try {
+computePassEncoder54.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer20, 'uint16', 1_238, 10_582);
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(1, buffer89, 0, 19);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer54, 'uint32', 1_096, 710);
+} catch {}
+try {
+renderBundleEncoder27.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer79, 4820, new Int16Array(2365), 836, 532);
+} catch {}
+let buffer90 = device0.createBuffer({size: 13123, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder136 = device0.createCommandEncoder({});
+let texture155 = device0.createTexture({
+  size: {width: 16, height: 10, depthOrArrayLayers: 76},
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder90 = commandEncoder133.beginComputePass({});
+let sampler84 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 85.15,
+  lodMaxClamp: 87.68,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder44.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup74);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(1, bindGroup60, new Uint32Array(66), 18, 0);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(0, bindGroup4, new Uint32Array(2268), 481, 0);
+} catch {}
+try {
+renderBundleEncoder27.drawIndexed(11, 167, 67, 250_889_011, 551_441_305);
+} catch {}
+try {
+renderBundleEncoder27.drawIndirect(buffer64, 204);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(6, buffer1);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+externalTexture25.label = '\u4cd8\u68a1\uc218\u41cd\u{1f867}\u716e\u{1fe0f}\u0df6';
+} catch {}
+let commandEncoder137 = device0.createCommandEncoder({});
+let renderPassEncoder52 = commandEncoder137.beginRenderPass({
+  label: '\u9041\u0a34\u5817\u189e\ucb63\ufddf\u8bb2\u7cc2\u0f5d\u{1f662}',
+  colorAttachments: [{
+  view: textureView67,
+  clearValue: { r: -982.7, g: 688.1, b: 939.0, a: 659.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let sampler85 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 54.77,
+  lodMaxClamp: 79.57,
+});
+let externalTexture27 = device0.importExternalTexture({source: videoFrame9});
+try {
+computePassEncoder89.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder34.setPipeline(pipeline5);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData1,
+  origin: { x: 1, y: 0 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 127, y: 10, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup75 = device0.createBindGroup({
+  label: '\u80df\u08ad\u14d4\u025a\u6e07\u7521\u1bcb',
+  layout: bindGroupLayout16,
+  entries: [
+    {binding: 301, resource: {buffer: buffer73, offset: 0, size: 400}},
+    {binding: 38, resource: textureView113},
+    {binding: 15, resource: {buffer: buffer42, offset: 8960, size: 60}},
+    {binding: 24, resource: textureView121},
+    {binding: 141, resource: textureView61},
+    {binding: 128, resource: textureView112},
+  ],
+});
+let buffer91 = device0.createBuffer({
+  label: '\u207f\ucac7\u{1f783}\uc722\u7135\ue174\u{1fc85}\u{1f8b8}',
+  size: 2698,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder138 = device0.createCommandEncoder({});
+let texture156 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 15},
+  format: 'r16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView137 = texture34.createView({label: '\ueaa4\u1efb\ua620\u0dc3\u{1f8d1}\u0987'});
+try {
+computePassEncoder70.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder27.drawIndexed(16, 273, 2, 150_812_718, 1_113_199_851);
+} catch {}
+try {
+renderBundleEncoder27.setPipeline(pipeline5);
+} catch {}
+let buffer92 = device0.createBuffer({size: 11023, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+try {
+renderBundleEncoder27.setBindGroup(1, bindGroup45);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(0, bindGroup6, new Uint32Array(1898), 222, 0);
+} catch {}
+try {
+renderBundleEncoder27.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(6, buffer19);
+} catch {}
+try {
+buffer21.unmap();
+} catch {}
+let commandEncoder139 = device0.createCommandEncoder({});
+let textureView138 = texture52.createView({dimension: '2d-array'});
+let renderPassEncoder53 = commandEncoder135.beginRenderPass({
+  colorAttachments: [{
+  view: textureView125,
+  clearValue: { r: 958.6, g: 372.8, b: 696.5, a: 99.18, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 16037828,
+});
+try {
+computePassEncoder26.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(4, buffer1, 2_632);
+} catch {}
+try {
+renderBundleEncoder27.draw(97, 180, 145_622_583, 2_661_295_672);
+} catch {}
+try {
+renderBundleEncoder27.drawIndexed(13, 296, 65, 123_134_750, 2_207_463_329);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(7, buffer88, 1_268, 431);
+} catch {}
+let arrayBuffer12 = buffer41.getMappedRange(376, 12);
+try {
+commandEncoder136.copyTextureToBuffer({
+  texture: texture122,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1672 */
+  offset: 1672,
+  bytesPerRow: 11264,
+  buffer: buffer91,
+}, {width: 1, height: 2, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img0);
+let commandEncoder140 = device0.createCommandEncoder({});
+let textureView139 = texture135.createView({label: '\u{1f7b7}\u{1f989}\u879f\u0f9b\ubfc8\uc6c0\u0d63', dimension: '2d-array'});
+let texture157 = device0.createTexture({
+  size: [8, 5, 87],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler86 = device0.createSampler({
+  label: '\u0cc4\udc7d\u{1f880}\u2859\u6cde',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 12.81,
+  lodMaxClamp: 47.35,
+});
+try {
+computePassEncoder90.setBindGroup(1, bindGroup52, new Uint32Array(975), 19, 0);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(2, bindGroup13, new Uint32Array(520), 167, 0);
+} catch {}
+try {
+renderPassEncoder36.setScissorRect(0, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder45.setVertexBuffer(5, buffer68);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(1, bindGroup28);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(1, bindGroup24, new Uint32Array(684), 63, 0);
+} catch {}
+try {
+renderBundleEncoder27.drawIndexed(4, 125, 11, -1_943_538_014, 308_078_266);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer82, 'uint16', 1_404, 234);
+} catch {}
+try {
+commandEncoder139.copyTextureToTexture({
+  texture: texture48,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture48,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 16, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let texture158 = gpuCanvasContext0.getCurrentTexture();
+let renderPassEncoder54 = commandEncoder138.beginRenderPass({
+  colorAttachments: [{
+  view: textureView132,
+  depthSlice: 553,
+  clearValue: { r: 203.3, g: -668.5, b: 361.6, a: -682.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+renderPassEncoder46.setViewport(5.8687171444119635, 0.7807143406454498, 8.168336859353515, 3.222977993624412, 0.036512126620023344, 0.3969608557357245);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer10, 'uint16', 642, 4_962);
+} catch {}
+try {
+renderBundleEncoder27.draw(107, 159, 227_139_986, 601_119_814);
+} catch {}
+try {
+renderBundleEncoder27.drawIndexedIndirect(buffer52, 208);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer51, 'uint32', 1_428, 146);
+} catch {}
+try {
+renderBundleEncoder27.setPipeline(pipeline5);
+} catch {}
+try {
+commandEncoder139.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1028 */
+  offset: 1028,
+  buffer: buffer10,
+}, {
+  texture: texture147,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder140.copyTextureToBuffer({
+  texture: texture100,
+  mipLevel: 0,
+  origin: {x: 1, y: 2, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 6 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2506 */
+  offset: 2506,
+  bytesPerRow: 20480,
+  rowsPerImage: 452,
+  buffer: buffer16,
+}, {width: 3, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer57, 76, new DataView(new ArrayBuffer(5711)), 366, 20);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let buffer93 = device0.createBuffer({
+  size: 1220,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder141 = device0.createCommandEncoder({});
+let texture159 = device0.createTexture({
+  label: '\u006e\u{1fe22}\uae91\u27c4\ucba0\u8f05\u0e76\u{1fd55}\udd4c',
+  size: {width: 16, height: 10, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder55 = commandEncoder139.beginRenderPass({
+  colorAttachments: [{view: textureView43, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet8,
+});
+try {
+computePassEncoder86.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(2, bindGroup3, new Uint32Array(1298), 53, 0);
+} catch {}
+try {
+renderPassEncoder48.setIndexBuffer(buffer85, 'uint16', 2_970, 4_994);
+} catch {}
+try {
+renderPassEncoder35.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(1, bindGroup42);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(5, buffer66, 5_492);
+} catch {}
+try {
+commandEncoder140.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 25 */
+  offset: 25,
+  buffer: buffer51,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer90, 1784, new Int16Array(3428), 913, 60);
+} catch {}
+let texture160 = device0.createTexture({
+  size: {width: 2},
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView140 = texture109.createView({});
+let computePassEncoder91 = commandEncoder140.beginComputePass();
+let renderPassEncoder56 = commandEncoder141.beginRenderPass({
+  colorAttachments: [{
+  view: textureView57,
+  depthSlice: 85,
+  clearValue: { r: -312.2, g: -678.2, b: -169.9, a: -510.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let renderBundleEncoder28 = device0.createRenderBundleEncoder({colorFormats: ['r16float'], depthReadOnly: true});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup41);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder26); computePassEncoder26.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder85.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder56.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderPassEncoder52.setBindGroup(3, bindGroup41, new Uint32Array(1841), 635, 0);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer75, 'uint16', 3_632, 4_011);
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(0, buffer20, 24_984, 3_376);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(0, bindGroup17);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(1, bindGroup72, new Uint32Array(2125), 1_730, 0);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer79, 'uint32', 964, 2_137);
+} catch {}
+try {
+renderBundleEncoder27.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(1, buffer60, 0, 327);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 48, y: 123, z: 0},
+  aspect: 'all',
+}, new Uint8Array(12).fill(123), /* required buffer size: 12 */
+{offset: 12, bytesPerRow: 276, rowsPerImage: 209}, {width: 111, height: 94, depthOrArrayLayers: 0});
+} catch {}
+let textureView141 = texture113.createView({dimension: '2d-array', baseMipLevel: 0, baseArrayLayer: 0});
+let renderPassEncoder57 = commandEncoder136.beginRenderPass({
+  colorAttachments: [{view: textureView132, depthSlice: 604, loadOp: 'load', storeOp: 'store'}],
+  maxDrawCount: 421305013,
+});
+let sampler87 = device0.createSampler({addressModeW: 'repeat', lodMinClamp: 19.69, lodMaxClamp: 94.00});
+try {
+computePassEncoder40.setBindGroup(0, bindGroup38, new Uint32Array(468), 105, 0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup12);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(3, bindGroup47, new Uint32Array(136), 26, 0);
+} catch {}
+try {
+renderPassEncoder57.setVertexBuffer(0, buffer21, 3_868);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(2, bindGroup65);
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+let videoFrame28 = new VideoFrame(videoFrame17, {timestamp: 0});
+let texture161 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 15},
+  mipLevelCount: 3,
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView142 = texture122.createView({aspect: 'all'});
+let sampler88 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 96.10,
+  lodMaxClamp: 97.15,
+});
+try {
+computePassEncoder63.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+computePassEncoder17.setBindGroup(3, bindGroup62, new Uint32Array(3794), 666, 0);
+} catch {}
+try {
+computePassEncoder23.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer10, 'uint32', 308, 5_752);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(7, buffer53);
+} catch {}
+let bindGroupLayout18 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 97,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup76 = device0.createBindGroup({
+  layout: bindGroupLayout14,
+  entries: [
+    {binding: 157, resource: textureView53},
+    {binding: 87, resource: textureView142},
+    {binding: 47, resource: {buffer: buffer78, offset: 0, size: 483}},
+  ],
+});
+let commandEncoder142 = device0.createCommandEncoder({});
+let renderBundle27 = renderBundleEncoder28.finish();
+try {
+computePassEncoder26.end();
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(0, bindGroup4, new Uint32Array(427), 54, 0);
+} catch {}
+try {
+renderPassEncoder43.executeBundles([renderBundle24]);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(0, buffer88, 0, 164);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(3, buffer82, 876, 2_680);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let bindGroup77 = device0.createBindGroup({
+  layout: bindGroupLayout8,
+  entries: [{binding: 271, resource: textureView69}, {binding: 340, resource: textureView61}],
+});
+let commandEncoder143 = device0.createCommandEncoder({});
+let commandBuffer6 = commandEncoder31.finish({});
+let texture162 = device0.createTexture({
+  size: {width: 4, height: 2, depthOrArrayLayers: 1},
+  format: 'r16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder58 = commandEncoder142.beginRenderPass({
+  label: '\uf801\u01ba\u081f\u9618\u7eeb\u{1fad5}\ub042',
+  colorAttachments: [{
+  view: textureView131,
+  clearValue: { r: -550.1, g: -78.20, b: -53.79, a: 29.56, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup73);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer12, 'uint16', 818, 919);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(7, buffer60, 308, 135);
+} catch {}
+try {
+commandEncoder143.copyTextureToTexture({
+  texture: texture145,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture121,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder143.clearBuffer(buffer42, 2284, 1752);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer6]);
+} catch {}
+let computePassEncoder92 = commandEncoder143.beginComputePass({label: '\u6f49\u4de3\u42b3\uc0a5\u{1f996}\u0275\u14b3'});
+let sampler89 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMinClamp: 88.07,
+  lodMaxClamp: 92.01,
+  compare: 'equal',
+});
+try {
+computePassEncoder55.setBindGroup(2, bindGroup59);
+} catch {}
+try {
+computePassEncoder18.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder14.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(2, bindGroup41, new Uint32Array(3009), 1_191, 0);
+} catch {}
+try {
+renderPassEncoder30.executeBundles([renderBundle16, renderBundle20]);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer93, 'uint16', 44, 365);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(4, buffer89, 28, 431);
+} catch {}
+try {
+renderBundleEncoder27.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(5, buffer59, 0, 4_254);
+} catch {}
+let promise12 = device0.queue.onSubmittedWorkDone();
+let buffer94 = device0.createBuffer({
+  size: 2230,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder144 = device0.createCommandEncoder({});
+let textureView143 = texture40.createView({dimension: '2d', format: 'bgra8unorm', baseArrayLayer: 2});
+let textureView144 = texture35.createView({});
+let computePassEncoder93 = commandEncoder144.beginComputePass();
+let sampler90 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 25.21,
+  lodMaxClamp: 65.65,
+  compare: 'never',
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder58.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer76, 'uint32', 368, 445);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder42.setVertexBuffer(0, buffer9, 2_688, 4_052);
+} catch {}
+try {
+renderBundleEncoder27.drawIndexedIndirect(buffer81, 972);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer4, 'uint16', 340, 798);
+} catch {}
+try {
+renderBundleEncoder27.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder10.insertDebugMarker('\u1977');
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55); };
+} catch {}
+try {
+renderBundleEncoder27.draw(27, 20, 1_416_713_231, 19_162_819);
+} catch {}
+try {
+renderBundleEncoder27.drawIndexed(68, 181, 90, -2_005_306_343, 83_357_981);
+} catch {}
+try {
+renderBundleEncoder27.drawIndexedIndirect(buffer74, 1_360);
+} catch {}
+try {
+renderBundleEncoder27.drawIndirect(buffer10, 7_476);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer82, 'uint32', 0, 1_182);
+} catch {}
+let bindGroup78 = device0.createBindGroup({layout: bindGroupLayout4, entries: [{binding: 84, resource: textureView25}]});
+try {
+computePassEncoder17.setBindGroup(2, bindGroup1, new Uint32Array(1690), 887, 0);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer61, 'uint32', 0, 2_437);
+} catch {}
+try {
+renderBundleEncoder27.drawIndirect(buffer62, 5_860);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture100,
+  mipLevel: 0,
+  origin: {x: 2, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(309).fill(27), /* required buffer size: 309 */
+{offset: 309, bytesPerRow: 50}, {width: 1, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append(canvas1);
+let querySet21 = device0.createQuerySet({type: 'occlusion', count: 544});
+let texture163 = device0.createTexture({
+  size: [8, 5, 3],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle28 = renderBundleEncoder27.finish({});
+try {
+computePassEncoder35.setBindGroup(0, bindGroup58);
+} catch {}
+try {
+computePassEncoder15.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder39.setViewport(0.47314064886984863, 0.3070063568233382, 1.0865104629147833, 0.5737259030118663, 0.3876449191891571, 0.46718715729437954);
+} catch {}
+document.body.append(canvas1);
+try {
+globalThis.someLabel = commandEncoder98.label;
+} catch {}
+let bindGroup79 = device0.createBindGroup({
+  layout: bindGroupLayout12,
+  entries: [
+    {binding: 232, resource: sampler67},
+    {binding: 497, resource: externalTexture3},
+    {binding: 112, resource: textureView78},
+  ],
+});
+let textureView145 = texture97.createView({});
+let externalTexture28 = device0.importExternalTexture({source: videoFrame16, colorSpace: 'display-p3'});
+try {
+computePassEncoder7.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(0, bindGroup21, new Uint32Array(2789), 1_334, 0);
+} catch {}
+try {
+renderPassEncoder44.setIndexBuffer(buffer29, 'uint16', 124, 1_576);
+} catch {}
+try {
+computePassEncoder29.pushDebugGroup('\ubf88');
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+try {
+computePassEncoder76.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup76, new Uint32Array(3624), 324, 0);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer54, 'uint16', 72, 1_258);
+} catch {}
+try {
+computePassEncoder29.popDebugGroup();
+} catch {}
+let bindGroup80 = device0.createBindGroup({
+  layout: bindGroupLayout14,
+  entries: [
+    {binding: 157, resource: textureView143},
+    {binding: 47, resource: {buffer: buffer33, offset: 512, size: 284}},
+    {binding: 87, resource: textureView142},
+  ],
+});
+let commandEncoder145 = device0.createCommandEncoder({label: '\u156e\u0ebb\ud38c\u{1fd2c}'});
+let textureView146 = texture114.createView({label: '\u0eb6\u054c\u2572', dimension: '2d-array'});
+let renderPassEncoder59 = commandEncoder145.beginRenderPass({
+  colorAttachments: [{
+  view: textureView118,
+  depthSlice: 54,
+  clearValue: { r: 474.4, g: -188.9, b: 783.4, a: 683.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet5,
+});
+try {
+computePassEncoder5.setBindGroup(1, bindGroup44, new Uint32Array(360), 123, 0);
+} catch {}
+try {
+computePassEncoder2.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(1, bindGroup59);
+} catch {}
+try {
+renderPassEncoder53.setBindGroup(3, bindGroup27, new Uint32Array(1132), 15, 0);
+} catch {}
+try {
+renderPassEncoder51.executeBundles([renderBundle14]);
+} catch {}
+try {
+renderPassEncoder53.setPipeline(pipeline0);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 256, depthOrArrayLayers: 150}
+*/
+{
+  source: videoFrame18,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 16, y: 4, z: 27},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+renderPassEncoder39.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(5, buffer62, 3_188, 8_549);
+} catch {}
+try {
+gpuCanvasContext2.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_SRC, alphaMode: 'premultiplied'});
+} catch {}
+let buffer95 = device0.createBuffer({size: 3408, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+try {
+computePassEncoder91.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer72, 'uint32', 2_800, 162);
+} catch {}
+document.body.append(canvas2);
+let buffer96 = device0.createBuffer({size: 5116, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX});
+let sampler91 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 54.50,
+  lodMaxClamp: 61.28,
+});
+let externalTexture29 = device0.importExternalTexture({source: videoFrame3});
+try {
+computePassEncoder48.setBindGroup(2, bindGroup27);
+} catch {}
+try {
+computePassEncoder6.end();
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(0, bindGroup57, new Uint32Array(2486), 1_113, 0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let bindGroup81 = device0.createBindGroup({
+  label: '\uf6f8\u2597\ue71c\u{1ffd0}\uba34\uc692',
+  layout: bindGroupLayout15,
+  entries: [{binding: 26, resource: textureView111}, {binding: 294, resource: textureView110}],
+});
+let commandEncoder146 = device0.createCommandEncoder({});
+let textureView147 = texture111.createView({label: '\u0f3e\u034d\u{1fca0}\u{1faf1}\u46e4\u0ff8\u04f2', baseArrayLayer: 0});
+let computePassEncoder94 = commandEncoder146.beginComputePass({});
+try {
+computePassEncoder28.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderPassEncoder44.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder6.copyBufferToTexture({
+  /* bytesInLastRow: 3 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1295 */
+  offset: 1295,
+  rowsPerImage: 78,
+  buffer: buffer44,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas0);
+let imageData16 = new ImageData(60, 32);
+let bindGroup82 = device0.createBindGroup({
+  layout: bindGroupLayout16,
+  entries: [
+    {binding: 24, resource: textureView56},
+    {binding: 128, resource: textureView112},
+    {binding: 38, resource: textureView122},
+    {binding: 15, resource: {buffer: buffer56, offset: 13312, size: 1108}},
+    {binding: 301, resource: {buffer: buffer65, offset: 256, size: 272}},
+    {binding: 141, resource: textureView32},
+  ],
+});
+let buffer97 = device0.createBuffer({
+  size: 32600,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder95 = commandEncoder6.beginComputePass({});
+try {
+computePassEncoder4.setBindGroup(2, bindGroup15, new Uint32Array(2948), 9, 0);
+} catch {}
+try {
+computePassEncoder55.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder59.setBindGroup(3, bindGroup70, new Uint32Array(2), 0, 0);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer97, 'uint16', 2_746, 2_019);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder13.insertDebugMarker('\uad21');
+} catch {}
+let commandEncoder147 = device0.createCommandEncoder();
+let renderBundleEncoder29 = device0.createRenderBundleEncoder({colorFormats: ['r8uint'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle29 = renderBundleEncoder29.finish({});
+let externalTexture30 = device0.importExternalTexture({label: '\u7bb4\u{1faac}\u4f03\u040f', source: videoFrame7});
+try {
+computePassEncoder56.setBindGroup(1, bindGroup44, new Uint32Array(2255), 25, 0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup48, new Uint32Array(98), 8, 0);
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(5, buffer40, 0, 66);
+} catch {}
+try {
+commandEncoder147.clearBuffer(buffer42, 1844, 1240);
+} catch {}
+try {
+commandEncoder147.resolveQuerySet(querySet20, 12, 35, buffer75, 1792);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer20, 916, new DataView(new ArrayBuffer(1707)), 231, 64);
+} catch {}
+let texture164 = device0.createTexture({
+  size: {width: 256},
+  dimension: '1d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView148 = texture117.createView({});
+let sampler92 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 60.02,
+  lodMaxClamp: 82.20,
+  compare: 'less',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder13.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(3, bindGroup54);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(3, buffer59, 2_572, 3_400);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 1576, new Float32Array(28644), 4727, 16);
+} catch {}
+let texture165 = device0.createTexture({
+  size: {width: 2},
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder46.setBindGroup(3, bindGroup67, new Uint32Array(1013), 465, 0);
+} catch {}
+try {
+computePassEncoder50.end();
+} catch {}
+try {
+computePassEncoder82.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle5, renderBundle15]);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer6, 'uint32', 876, 971);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(4, buffer62);
+} catch {}
+try {
+commandEncoder72.copyBufferToTexture({
+  /* bytesInLastRow: 28 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1444 */
+  offset: 1444,
+  rowsPerImage: 540,
+  buffer: buffer27,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 17, y: 16, z: 0},
+  aspect: 'all',
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+document.body.append(canvas1);
+await gc();
+try {
+globalThis.someLabel = buffer74.label;
+} catch {}
+let textureView149 = texture79.createView({aspect: 'all'});
+let renderPassEncoder60 = commandEncoder72.beginRenderPass({
+  colorAttachments: [{
+  view: textureView57,
+  depthSlice: 477,
+  clearValue: { r: -815.1, g: -430.3, b: -287.4, a: -457.1, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 344357075,
+});
+try {
+computePassEncoder94.setBindGroup(3, bindGroup26);
+} catch {}
+try {
+computePassEncoder34.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(3, buffer93);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 256, depthOrArrayLayers: 15}
+*/
+{
+  source: videoFrame22,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 40, y: 12, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup83 = device0.createBindGroup({
+  layout: bindGroupLayout16,
+  entries: [
+    {binding: 301, resource: {buffer: buffer71, offset: 1792, size: 3920}},
+    {binding: 141, resource: textureView32},
+    {binding: 24, resource: textureView83},
+    {binding: 128, resource: textureView139},
+    {binding: 15, resource: {buffer: buffer9, offset: 2816}},
+    {binding: 38, resource: textureView113},
+  ],
+});
+let buffer98 = device0.createBuffer({
+  size: 16676,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder96 = commandEncoder147.beginComputePass({label: '\ufeb0\u0456\u{1feac}\u0196\u01b3\uc8db\uf5b5\u{1fb2f}'});
+try {
+computePassEncoder55.setBindGroup(3, bindGroup19);
+} catch {}
+try {
+computePassEncoder86.setBindGroup(0, bindGroup4, new Uint32Array(2379), 201, 0);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup29, new Uint32Array(476), 30, 0);
+} catch {}
+try {
+renderPassEncoder49.insertDebugMarker('\u09ea');
+} catch {}
+let commandEncoder148 = device0.createCommandEncoder({});
+let texture166 = device0.createTexture({
+  size: [256, 256, 15],
+  dimension: '2d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let renderPassEncoder61 = commandEncoder148.beginRenderPass({
+  colorAttachments: [{
+  view: textureView130,
+  depthSlice: 1378,
+  clearValue: { r: 539.3, g: -264.0, b: -136.2, a: 782.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet16,
+  maxDrawCount: 258774091,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder86); computePassEncoder86.dispatchWorkgroupsIndirect(buffer80, 32); };
+} catch {}
+try {
+  await promise12;
+} catch {}
+let bindGroup84 = device0.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [{binding: 294, resource: textureView117}, {binding: 26, resource: textureView114}],
+});
+let commandEncoder149 = device0.createCommandEncoder({});
+let texture167 = device0.createTexture({
+  label: '\u04fe\u0c95\ue499\u0c3b\u9a5f',
+  size: {width: 4},
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder78.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle1]);
+} catch {}
+try {
+commandEncoder149.resolveQuerySet(querySet0, 1, 6, buffer24, 768);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer86, 544, new BigUint64Array(126), 30, 4);
+} catch {}
+let commandEncoder150 = device0.createCommandEncoder({});
+try {
+computePassEncoder66.setBindGroup(3, bindGroup5, new Uint32Array(1284), 705, 0);
+} catch {}
+try {
+renderPassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer22, 'uint32', 144, 431);
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(7, undefined, 0, 453_552_871);
+} catch {}
+let arrayBuffer13 = buffer8.getMappedRange(5120, 0);
+try {
+commandEncoder150.copyBufferToTexture({
+  /* bytesInLastRow: 38 widthInBlocks: 38 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1767 */
+  offset: 1767,
+  bytesPerRow: 17920,
+  buffer: buffer56,
+}, {
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 7, y: 34, z: 4},
+  aspect: 'all',
+}, {width: 38, height: 51, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 256, depthOrArrayLayers: 150}
+*/
+{
+  source: imageData10,
+  origin: { x: 0, y: 11 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 7, y: 39, z: 28},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 1, height: 9, depthOrArrayLayers: 0});
+} catch {}
+let imageData17 = new ImageData(100, 72);
+let bindGroup85 = device0.createBindGroup({
+  label: '\ub7c2\uce34\u0cbc\ue604\u{1f971}\u2dc9\u2665\u980a',
+  layout: bindGroupLayout17,
+  entries: [{binding: 162, resource: textureView27}],
+});
+let commandEncoder151 = device0.createCommandEncoder();
+let textureView150 = texture57.createView({aspect: 'all'});
+try {
+computePassEncoder46.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder53.setViewport(0.735875181206574, 0.8717742955140139, 0.5183056829280899, 0.09424207117744385, 0.4856185065577705, 0.727109862025218);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer53, 'uint16', 1_846, 683);
+} catch {}
+try {
+renderPassEncoder54.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(7, buffer27, 0);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+commandEncoder149.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 16 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1200 */
+  offset: 1200,
+  buffer: buffer47,
+}, {
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 16, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer72, 652, new Float32Array(23724), 8932, 248);
+} catch {}
+let promise13 = device0.queue.onSubmittedWorkDone();
+document.body.append(canvas0);
+let commandBuffer7 = commandEncoder18.finish();
+let computePassEncoder97 = commandEncoder150.beginComputePass({label: '\u05e6\ub0cf'});
+try {
+renderPassEncoder51.setPipeline(pipeline0);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+document.body.prepend(img0);
+canvas1.height = 1723;
+let imageBitmap4 = await createImageBitmap(videoFrame26);
+let buffer99 = device0.createBuffer({
+  size: 1583,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture168 = device0.createTexture({size: {width: 16}, dimension: '1d', format: 'r16float', usage: GPUTextureUsage.COPY_DST});
+let textureView151 = texture71.createView({label: '\ub59c\u0fec\u{1f9af}', dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 0});
+try {
+renderPassEncoder23.setBindGroup(2, bindGroup22);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(1, bindGroup7, new Uint32Array(2189), 81, 0);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 6784, new BigUint64Array(4567), 964, 116);
+} catch {}
+document.body.append(canvas0);
+let offscreenCanvas1 = new OffscreenCanvas(400, 282);
+let commandEncoder152 = device0.createCommandEncoder({label: '\u335b\u0b13\u57f9\u64be\ua56a'});
+let texture169 = gpuCanvasContext2.getCurrentTexture();
+try {
+computePassEncoder73.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+computePassEncoder86.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(6, buffer84);
+} catch {}
+try {
+commandEncoder151.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 550 */
+  offset: 550,
+  buffer: buffer10,
+}, {
+  texture: texture144,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder149.clearBuffer(buffer88, 840, 120);
+} catch {}
+try {
+textureView123.label = '\ucbbf\u9d1f\u{1f8de}\ua89d\u{1ff55}\uca90\u061d\ud730\u0adf\u0168';
+} catch {}
+let texture170 = device0.createTexture({size: [16, 10, 1], format: 'rgb10a2unorm', usage: GPUTextureUsage.COPY_DST});
+let computePassEncoder98 = commandEncoder149.beginComputePass({});
+try {
+computePassEncoder76.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder88.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(2, bindGroup24);
+} catch {}
+try {
+renderPassEncoder24.setViewport(4.898396819449323, 9.556453707538454, 1.2103092742753105, 0.3648565865264323, 0.3096630414188294, 0.327913888494179);
+} catch {}
+try {
+renderPassEncoder58.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(6, buffer1, 1_384, 1_080);
+} catch {}
+await gc();
+let buffer100 = device0.createBuffer({
+  size: 19459,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+try {
+computePassEncoder60.setBindGroup(0, bindGroup46);
+} catch {}
+try {
+computePassEncoder47.setBindGroup(3, bindGroup82, new Uint32Array(571), 42, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder86); computePassEncoder86.dispatchWorkgroupsIndirect(buffer24, 3_236); };
+} catch {}
+try {
+computePassEncoder64.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(2, bindGroup28);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(1, buffer88, 724, 598);
+} catch {}
+document.body.append(canvas1);
+let buffer101 = device0.createBuffer({size: 10060, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX});
+let commandEncoder153 = device0.createCommandEncoder({});
+let sampler93 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 59.03,
+  lodMaxClamp: 78.97,
+  compare: 'greater-equal',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder12.setBindGroup(1, bindGroup71);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder86); computePassEncoder86.dispatchWorkgroupsIndirect(buffer24, 12_272); };
+} catch {}
+try {
+buffer85.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer86, 952, new BigUint64Array(11963), 2263, 84);
+} catch {}
+let buffer102 = device0.createBuffer({size: 6983, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+let renderPassEncoder62 = commandEncoder151.beginRenderPass({
+  colorAttachments: [{
+  view: textureView34,
+  depthSlice: 1009,
+  clearValue: { r: 995.7, g: -416.3, b: 138.2, a: 654.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder89.setBindGroup(0, bindGroup55);
+} catch {}
+try {
+computePassEncoder61.setBindGroup(3, bindGroup58, new Uint32Array(742), 67, 0);
+} catch {}
+try {
+renderPassEncoder62.setBindGroup(3, bindGroup62);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer88, 'uint32', 1_016, 447);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline6);
+} catch {}
+try {
+commandEncoder153.copyBufferToBuffer(buffer47, 88, buffer72, 292, 208);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture107,
+  mipLevel: 0,
+  origin: {x: 12, y: 4, z: 4},
+  aspect: 'all',
+}, new Uint8Array(270_501).fill(229), /* required buffer size: 270_501 */
+{offset: 147, bytesPerRow: 314, rowsPerImage: 41}, {width: 213, height: 0, depthOrArrayLayers: 22});
+} catch {}
+let sampler94 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 2.815,
+  lodMaxClamp: 56.54,
+});
+try {
+computePassEncoder57.setBindGroup(1, bindGroup61, []);
+} catch {}
+try {
+computePassEncoder86.end();
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(2, bindGroup85);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle12, renderBundle23, renderBundle10]);
+} catch {}
+try {
+renderPassEncoder44.setIndexBuffer(buffer12, 'uint16', 984, 328);
+} catch {}
+try {
+commandEncoder152.copyBufferToBuffer(buffer54, 1380, buffer67, 2400, 172);
+} catch {}
+try {
+commandEncoder152.copyTextureToBuffer({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 7, y: 7, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 128 widthInBlocks: 32 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2688 */
+  offset: 2688,
+  bytesPerRow: 11520,
+  buffer: buffer72,
+}, {width: 32, height: 49, depthOrArrayLayers: 0});
+} catch {}
+let promise14 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData0,
+  origin: { x: 3, y: 0 },
+  flipY: true,
+}, {
+  texture: texture135,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder154 = device0.createCommandEncoder({});
+try {
+computePassEncoder62.setBindGroup(2, bindGroup22);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle8, renderBundle14, renderBundle1, renderBundle19, renderBundle4, renderBundle6, renderBundle23, renderBundle10, renderBundle23, renderBundle16]);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(5, buffer17, 1_316, 2_016);
+} catch {}
+try {
+commandEncoder152.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 580 */
+  offset: 580,
+  bytesPerRow: 7936,
+  buffer: buffer69,
+}, {
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer42, 80, new Int16Array(8783), 199, 80);
+} catch {}
+let promise15 = device0.queue.onSubmittedWorkDone();
+let gpuCanvasContext3 = offscreenCanvas1.getContext('webgpu');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let imageData18 = new ImageData(56, 16);
+let commandEncoder155 = device0.createCommandEncoder({});
+let texture171 = device0.createTexture({
+  size: {width: 4, height: 2, depthOrArrayLayers: 1},
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture172 = device0.createTexture({
+  label: '\u66c9\udfe2\u83ff\u006c\u08e8\u9fb2\uf58c',
+  size: {width: 16, height: 10, depthOrArrayLayers: 49},
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder99 = commandEncoder152.beginComputePass({label: '\ua810\u0305\uf1a8\u6fa4\u4b27\u3e2f\u9211\u99e7\u8984\u{1f9c4}\u998e'});
+try {
+computePassEncoder96.setBindGroup(2, bindGroup19);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let shaderModule5 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+requires readonly_and_readwrite_storage_textures;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(114) var<uniform> buffer103: array<array<array<array<array<array<vec4i, 1>, 1>, 3>, 1>, 12>, 1>;
+
+@group(1) @binding(340) var st0: texture_storage_1d<r32sint, read_write>;
+
+struct T0 {
+  @size(576) f0: array<atomic<i32>>,
+}
+
+struct T1 {
+  @align(16) @size(576) f0: array<u32>,
+}
+
+struct T2 {
+  f0: array<array<array<array<mat2x4h, 1>, 1>, 1>, 28>,
+}
+
+struct VertexOutput4 {
+  @location(3) @interpolate(flat, sample) f9: vec4h,
+  @location(15) f10: i32,
+  @location(2) @interpolate(linear) f11: vec4f,
+  @location(4) f12: vec2f,
+  @location(8) @interpolate(perspective, centroid) f13: f16,
+  @location(11) @interpolate(flat) f14: vec2u,
+  @builtin(position) f15: vec4f,
+}
+
+fn fn0() -> array<f16, 1> {
+  var out: array<f16, 1>;
+  var vf138: vec3h = refract(vec3h(unconst_f16(105.3), unconst_f16(2447.8), unconst_f16(5859.5)), vec3h(unconst_f16(451.2), unconst_f16(13478.6), unconst_f16(11176.0)), f16(unconst_f16(8361.6)));
+  vf138 = fma(vec2h(unconst_f16(8455.9), unconst_f16(-1473.8)), vec2h(unconst_f16(371.9), unconst_f16(11335.1)), vec2h(unconst_f16(1613.0), unconst_f16(8570.6))).xxx;
+  out[u32(unconst_u32(209))] += refract(vec4h(unconst_f16(7924.8), unconst_f16(15520.6), unconst_f16(7036.5), unconst_f16(4912.4)), vec4h(unconst_f16(35138.7), unconst_f16(9596.6), unconst_f16(-12492.4), unconst_f16(49119.2)), f16(unconst_f16(12103.6))).w;
+  out[u32(unconst_u32(35))] -= f16(unpack2x16float(u32(unconst_u32(157))).x);
+  let vf139: f16 = vf138[bitcast<u32>(mix(vec2h(unconst_f16(6739.4), unconst_f16(38797.1)), vec2h(unconst_f16(38110.9), unconst_f16(21316.1)), vec2h(unconst_f16(24267.5), unconst_f16(8798.2))))];
+  vf138 = vec3h(cross(vec3f(unconst_f32(0.00427), unconst_f32(0.1006), unconst_f32(0.09440)), vec3f(unconst_f32(0.05277), unconst_f32(0.01490), unconst_f32(0.4379))));
+  let vf140: vec2h = mix(vec2h(unconst_f16(3506.7), unconst_f16(2474.5)), vec2h(unconst_f16(5413.1), unconst_f16(24601.8)), vec2h(unconst_f16(522.1), unconst_f16(3406.8)));
+  var vf141: vec2h = mix(vec2h(unconst_f16(3380.9), unconst_f16(6176.4)), vec2h(unconst_f16(8999.7), unconst_f16(5865.7)), vec2h(unconst_f16(13199.5), unconst_f16(19701.6)));
+  vf138 = vec3h(unpack2x16float(u32(mix(vec2f(unconst_f32(0.3028), unconst_f32(0.1945)), vec2f(f32(clamp(u32(unconst_u32(118)), u32(unconst_u32(40)), u32(unconst_u32(44))))), vec2f(unconst_f32(-0.1485), unconst_f32(0.02349)))[1])).ggg);
+  vf138 = vf138;
+  let ptr21: ptr<function, vec2h> = &vf141;
+  var vf142: vec2h = mix(vec2h(unconst_f16(5887.9), unconst_f16(21557.1)), vec2h(unconst_f16(3902.8), unconst_f16(9074.5)), vec2h(unconst_f16(33260.2), unconst_f16(20094.9)));
+  var vf143: vec3h = refract(vec3h(unconst_f16(11315.0), unconst_f16(17135.1), unconst_f16(961.7)), vec3h(unconst_f16(1779.0), unconst_f16(-33614.6), unconst_f16(5117.4)), f16(unconst_f16(2359.6)));
+  var vf144: vec2h = fma(vec2h(unconst_f16(30476.1), unconst_f16(1436.7)), vec2h(unconst_f16(1201.9), unconst_f16(27309.4)), vec2h(unconst_f16(4620.7), unconst_f16(-614.7)));
+  var vf145: f16 = vf138[u32(unconst_u32(102))];
+  var vf146: f16 = vf140[u32(firstTrailingBit(vec2i(unconst_i32(200), unconst_i32(40))).x)];
+  let vf147: u32 = clamp(u32(unconst_u32(44)), u32(unconst_u32(87)), u32(unconst_u32(500)));
+  let vf148: vec4h = refract(vec4h(unconst_f16(2668.9), unconst_f16(4083.0), unconst_f16(4986.8), unconst_f16(3895.2)), vec4h(unconst_f16(21457.8), unconst_f16(1402.5), unconst_f16(10137.9), unconst_f16(12234.5)), f16(unconst_f16(6524.1)));
+  vf141 -= vf143.gr;
+  let vf149: u32 = pack4xI8(vec4i(unconst_i32(29), unconst_i32(17), unconst_i32(6), unconst_i32(146)));
+  var vf150: f16 = vf143[u32(unconst_u32(2))];
+  vf141 += vec2h(cross(vec3f(unconst_f32(0.07860), unconst_f32(0.06759), unconst_f32(0.3982)), vec3f(unconst_f32(0.1126), unconst_f32(0.3945), unconst_f32(0.04259))).yz);
+  vf145 += vf139;
+  vf145 *= f16(firstTrailingBit(vec2i(unconst_i32(-20), unconst_i32(31)))[1]);
+  return out;
+}
+
+fn fn1(a0: mat4x4h) -> array<array<vec2u, 1>, 1> {
+  var out: array<array<vec2u, 1>, 1>;
+  var vf151: vec2h = fract(vec2h(unconst_f16(6248.5), unconst_f16(14150.9)));
+  var vf152: bool = any(vec4<bool>(unconst_bool(false), unconst_bool(false), unconst_bool(true), unconst_bool(true)));
+  let vf153: vec3f = atan(vec3f(unconst_f32(0.2979), unconst_f32(0.1651), unconst_f32(0.4844)));
+  let vf154: vec3f = atan(vec3f(unconst_f32(0.01203), unconst_f32(0.08734), unconst_f32(0.04087)));
+  var vf155: vec2h = atan2(vec2h(unconst_f16(8150.6), unconst_f16(5483.8)), vec2h(unconst_f16(13332.6), unconst_f16(4034.2)));
+  vf152 = bool(ldexp(f16(unconst_f16(33.01)), i32(unconst_i32(47))));
+  vf155 = vf151;
+  var vf156: u32 = pack4x8snorm(vec4f(unconst_f32(0.06629), unconst_f32(0.1095), unconst_f32(0.1044), unconst_f32(0.4234)));
+  vf156 <<= vec3u(cross(vec3f(unconst_f32(0.07323), unconst_f32(0.3597), unconst_f32(0.05470)), vec3f(unconst_f32(-0.4919), unconst_f32(0.1672), unconst_f32(0.05568)))).r;
+  vf152 = bool(sign(vec4f(unconst_f32(-0.2558), unconst_f32(0.2577), unconst_f32(0.5113), unconst_f32(0.3296))).r);
+  var vf157: f16 = vf155[u32(unconst_u32(26))];
+  return out;
+}
+
+var<workgroup> vw8: array<VertexOutput4, 2>;
+
+@vertex
+fn vertex4(@location(3) @interpolate(perspective, sample) a0: vec2f) -> VertexOutput4 {
+  var out: VertexOutput4;
+  fn1(mat4x4h(vec4h(min(vec4u(unconst_u32(15), unconst_u32(45), unconst_u32(390), unconst_u32(17)), vec4u(unconst_u32(56), unconst_u32(85), unconst_u32(233), unconst_u32(14)))), vec4h(min(vec4u(unconst_u32(15), unconst_u32(45), unconst_u32(390), unconst_u32(17)), vec4u(unconst_u32(56), unconst_u32(85), unconst_u32(233), unconst_u32(14)))), vec4h(min(vec4u(unconst_u32(15), unconst_u32(45), unconst_u32(390), unconst_u32(17)), vec4u(unconst_u32(56), unconst_u32(85), unconst_u32(233), unconst_u32(14)))), vec4h(min(vec4u(unconst_u32(15), unconst_u32(45), unconst_u32(390), unconst_u32(17)), vec4u(unconst_u32(56), unconst_u32(85), unconst_u32(233), unconst_u32(14))))));
+  let vf158: bool = select(bool(unconst_bool(false)), bool(unconst_bool(false)), bool(unconst_bool(true)));
+  let vf159: vec3h = sinh(vec3h(unconst_f16(3370.5), unconst_f16(19768.2), unconst_f16(-1879.7)));
+  out.f13 += vec4h(faceForward(vec4f(unconst_f32(0.4365), unconst_f32(0.3303), unconst_f32(0.06132), unconst_f32(0.5005)), vec4f(unconst_f32(0.1409), unconst_f32(0.1351), unconst_f32(0.2076), unconst_f32(0.1134)), vec4f(unconst_f32(0.1692), unconst_f32(-0.00508), unconst_f32(0.4113), unconst_f32(0.00659)))).z;
+  var vf160 = fn0();
+  out.f14 *= vec2u(extractBits(vec4i(unconst_i32(118), unconst_i32(72), unconst_i32(407), unconst_i32(183)), u32(unconst_u32(158)), u32(unconst_u32(32))).bb);
+  var vf161 = fn0();
+  let vf162: f32 = clamp(f32(unconst_f32(0.1788)), f32(unconst_f32(0.03348)), f32(unconst_f32(0.05391)));
+  out.f14 += vec2u(u32(vf160[0]));
+  var vf163 = fn1(mat4x4h(f16(clamp(f32(unconst_f32(-0.1322)), f32(unconst_f32(0.7254)), f32(unconst_f32(0.1006)))), f16(clamp(f32(unconst_f32(-0.1322)), f32(unconst_f32(0.7254)), f32(unconst_f32(0.1006)))), f16(clamp(f32(unconst_f32(-0.1322)), f32(unconst_f32(0.7254)), f32(unconst_f32(0.1006)))), f16(clamp(f32(unconst_f32(-0.1322)), f32(unconst_f32(0.7254)), f32(unconst_f32(0.1006)))), f16(clamp(f32(unconst_f32(-0.1322)), f32(unconst_f32(0.7254)), f32(unconst_f32(0.1006)))), f16(clamp(f32(unconst_f32(-0.1322)), f32(unconst_f32(0.7254)), f32(unconst_f32(0.1006)))), f16(clamp(f32(unconst_f32(-0.1322)), f32(unconst_f32(0.7254)), f32(unconst_f32(0.1006)))), f16(clamp(f32(unconst_f32(-0.1322)), f32(unconst_f32(0.7254)), f32(unconst_f32(0.1006)))), f16(clamp(f32(unconst_f32(-0.1322)), f32(unconst_f32(0.7254)), f32(unconst_f32(0.1006)))), f16(clamp(f32(unconst_f32(-0.1322)), f32(unconst_f32(0.7254)), f32(unconst_f32(0.1006)))), f16(clamp(f32(unconst_f32(-0.1322)), f32(unconst_f32(0.7254)), f32(unconst_f32(0.1006)))), f16(clamp(f32(unconst_f32(-0.1322)), f32(unconst_f32(0.7254)), f32(unconst_f32(0.1006)))), f16(clamp(f32(unconst_f32(-0.1322)), f32(unconst_f32(0.7254)), f32(unconst_f32(0.1006)))), f16(clamp(f32(unconst_f32(-0.1322)), f32(unconst_f32(0.7254)), f32(unconst_f32(0.1006)))), f16(clamp(f32(unconst_f32(-0.1322)), f32(unconst_f32(0.7254)), f32(unconst_f32(0.1006)))), f16(clamp(f32(unconst_f32(-0.1322)), f32(unconst_f32(0.7254)), f32(unconst_f32(0.1006))))));
+  var vf164: u32 = vf163[u32(unconst_u32(282))][0][u32(unconst_u32(19))];
+  var vf165: vec4i = extractBits(vec4i(unconst_i32(99), unconst_i32(116), unconst_i32(654), unconst_i32(249)), u32(unconst_u32(10)), u32(unconst_u32(123)));
+  fn0();
+  var vf166 = fn0();
+  let ptr22: ptr<function, array<f16, 1>> = &vf160;
+  var vf167 = fn0();
+  fn0();
+  let ptr23: ptr<function, vec2u> = &vf163[0][0];
+  let vf168: u32 = vf163[u32(unconst_u32(40))][u32(unconst_u32(187))][min(vec4u(unconst_u32(429), unconst_u32(1), unconst_u32(37), unconst_u32(163)), vec4u(unconst_u32(32), unconst_u32(106), unconst_u32(145), unconst_u32(200))).y];
+  let ptr24: ptr<function, f16> = &vf161[u32(unconst_u32(135))];
+  return out;
+}
+
+@compute @workgroup_size(3, 2, 1)
+fn compute2(@builtin(workgroup_id) a0: vec3u) {
+  fn1(mat4x4h(vec4h(buffer103[0][u32(unconst_u32(115))][u32(unconst_u32(5))][2][0][0]), vec4h(buffer103[0][u32(unconst_u32(115))][u32(unconst_u32(5))][2][0][0]), vec4h(buffer103[0][u32(unconst_u32(115))][u32(unconst_u32(5))][2][0][0]), vec4h(buffer103[0][u32(unconst_u32(115))][u32(unconst_u32(5))][2][0][0])));
+  vw8[1].f11 = max(vec2f(unconst_f32(0.4454), unconst_f32(0.08342)), vec2f(unconst_f32(0.1243), unconst_f32(0.3234))).xxxy;
+  textureBarrier();
+  var vf169 = fn1(mat4x4h(vec4h((*&buffer103)[0][11][0][2][u32(unconst_u32(19))][0]), vec4h((*&buffer103)[0][11][0][2][u32(unconst_u32(19))][0]), vec4h((*&buffer103)[0][11][0][2][u32(unconst_u32(19))][0]), vec4h((*&buffer103)[0][11][0][2][u32(unconst_u32(19))][0])));
+  vf169[u32(unconst_u32(34))][0] &= bitcast<vec2u>(buffer103[u32(unconst_u32(261))][pack4xI8((*&buffer103)[0][u32(unconst_u32(118))][u32(unconst_u32(21))][2][0][0])][0][u32(unconst_u32(42))][0][0].xw);
+  var vf170 = fn1(mat4x4h());
+  vf170[u32(unconst_u32(162))][u32(unconst_u32(5))] >>= vec2u(vf170[0][0][u32(unconst_u32(457))]);
+  vw8[u32(unconst_u32(139))].f10 = buffer103[0][vec4u(buffer103[0][11][u32(unconst_u32(605))][u32(unconst_u32(255))][0][0]).y][u32(unconst_u32(91))][2][0][u32(unconst_u32(86))][3];
+  vw8[u32(unconst_u32(125))].f12 = bitcast<vec2f>((*&buffer103)[u32(unconst_u32(610))][u32(unconst_u32(73))][0][2][u32(unconst_u32(148))][0].br);
+  let ptr25: ptr<workgroup, vec4f> = &(*&vw8)[1].f11;
+  var vf171 = fn1(mat4x4h(vec4h((*&buffer103)[u32(unconst_u32(187))][u32(unconst_u32(410))][u32(unconst_u32(129))][u32(unconst_u32(227))][u32(unconst_u32(193))][0]), vec4h((*&buffer103)[u32(unconst_u32(187))][u32(unconst_u32(410))][u32(unconst_u32(129))][u32(unconst_u32(227))][u32(unconst_u32(193))][0]), vec4h((*&buffer103)[u32(unconst_u32(187))][u32(unconst_u32(410))][u32(unconst_u32(129))][u32(unconst_u32(227))][u32(unconst_u32(193))][0]), vec4h((*&buffer103)[u32(unconst_u32(187))][u32(unconst_u32(410))][u32(unconst_u32(129))][u32(unconst_u32(227))][u32(unconst_u32(193))][0])));
+  let ptr26: ptr<uniform, array<array<array<vec4i, 1>, 1>, 3>> = &(*&buffer103)[0][11][u32(unconst_u32(2))];
+  let vf172: u32 = vw8[1].f14[u32(unconst_u32(137))];
+  let ptr27: ptr<uniform, vec4i> = &buffer103[0][u32(unconst_u32(96))][u32(buffer103[0][11][u32(unconst_u32(20))][2][0][0][2])][u32(unconst_u32(69))][u32(unconst_u32(391))][u32(unconst_u32(438))];
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let texture173 = device0.createTexture({
+  size: [2],
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView152 = texture149.createView({dimension: 'cube-array', format: 'r8uint', baseMipLevel: 0, mipLevelCount: 1, arrayLayerCount: 6});
+let computePassEncoder100 = commandEncoder153.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder73); computePassEncoder73.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder54.setBindGroup(2, bindGroup79);
+} catch {}
+try {
+renderPassEncoder62.setScissorRect(37, 3, 9, 13);
+} catch {}
+try {
+renderPassEncoder43.setIndexBuffer(buffer28, 'uint16', 198, 431);
+} catch {}
+try {
+renderPassEncoder59.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder44.setVertexBuffer(0, buffer80, 0, 10);
+} catch {}
+let promise16 = device0.queue.onSubmittedWorkDone();
+let texture174 = device0.createTexture({
+  label: '\ue0e7\u9b0a\u0272\ud482\ua8f2\u{1fd64}\u{1fa5f}\u5571\ub036',
+  size: [8, 5, 1],
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture175 = gpuCanvasContext1.getCurrentTexture();
+let textureView153 = texture54.createView({baseMipLevel: 0});
+let computePassEncoder101 = commandEncoder129.beginComputePass({});
+let sampler95 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 55.91,
+  lodMaxClamp: 76.12,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder39.setBindGroup(3, bindGroup73);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(1, bindGroup79);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle6, renderBundle10, renderBundle24]);
+} catch {}
+try {
+renderPassEncoder52.setIndexBuffer(buffer51, 'uint32', 716, 3_105);
+} catch {}
+try {
+renderPassEncoder48.setVertexBuffer(3, buffer27, 916, 33);
+} catch {}
+let promise17 = shaderModule0.getCompilationInfo();
+document.body.append(canvas1);
+let videoFrame29 = new VideoFrame(imageBitmap3, {timestamp: 0});
+let pipelineLayout14 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout11]});
+try {
+computePassEncoder18.setBindGroup(2, bindGroup62, new Uint32Array(670), 300, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder73); computePassEncoder73.dispatchWorkgroupsIndirect(buffer28, 200); };
+} catch {}
+try {
+computePassEncoder17.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(2, bindGroup49, new Uint32Array(926), 385, 0);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer99, 'uint16', 98, 180);
+} catch {}
+let texture176 = device0.createTexture({
+  size: [256, 256, 15],
+  mipLevelCount: 4,
+  dimension: '2d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup24);
+} catch {}
+try {
+computePassEncoder73.end();
+} catch {}
+try {
+computePassEncoder101.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder56.setBlendConstant({ r: -488.1, g: -311.8, b: -586.8, a: 537.4, });
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer61, 'uint16', 1_956, 1_697);
+} catch {}
+try {
+renderPassEncoder52.setVertexBuffer(6, undefined, 166_803_146);
+} catch {}
+try {
+commandEncoder105.copyTextureToBuffer({
+  texture: texture81,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2144 */
+  offset: 2144,
+  bytesPerRow: 15104,
+  buffer: buffer29,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame30 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'bt470m', transfer: 'pq'} });
+let buffer104 = device0.createBuffer({
+  size: 7904,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+try {
+renderPassEncoder17.setBindGroup(0, bindGroup55);
+} catch {}
+let videoFrame31 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'smpte240m', transfer: 'bt1361ExtendedColourGamut'} });
+try {
+computePassEncoder83.setBindGroup(2, bindGroup26, new Uint32Array(350), 219, 0);
+} catch {}
+try {
+renderPassEncoder35.executeBundles([renderBundle16]);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer97, 'uint16', 10_542, 684);
+} catch {}
+try {
+renderPassEncoder57.setVertexBuffer(3, buffer82, 1_216, 3_841);
+} catch {}
+let videoFrame32 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'fcc', primaries: 'jedecP22Phosphors', transfer: 'logSqrt'} });
+let querySet22 = device0.createQuerySet({type: 'occlusion', count: 1009});
+let textureView154 = texture100.createView({label: '\u3d5a\u5a98\u0721\uc948\u997d\u325b\u9294'});
+let computePassEncoder102 = commandEncoder154.beginComputePass({});
+try {
+computePassEncoder79.setBindGroup(1, bindGroup67, []);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(2, bindGroup41);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer96, 'uint32', 1_020, 647);
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder105.copyTextureToBuffer({
+  texture: texture173,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 172 */
+  offset: 172,
+  bytesPerRow: 33792,
+  buffer: buffer9,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup86 = device0.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [{binding: 26, resource: textureView111}, {binding: 294, resource: textureView108}],
+});
+let buffer105 = device0.createBuffer({
+  label: '\u607c\ubb0c\ue5fc\ueda8\u{1ffa9}\u687b',
+  size: 2417,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture177 = device0.createTexture({
+  size: {width: 2, height: 1, depthOrArrayLayers: 1},
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView155 = texture117.createView({dimension: '2d'});
+try {
+computePassEncoder68.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder51.setVertexBuffer(3, buffer57, 316, 283);
+} catch {}
+try {
+commandEncoder155.copyTextureToBuffer({
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 776 */
+  offset: 776,
+  bytesPerRow: 34048,
+  buffer: buffer89,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer51, 1392, new Float32Array(18316), 5014, 704);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 10, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame32,
+  origin: { x: 1, y: 0 },
+  flipY: false,
+}, {
+  texture: texture150,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer106 = device0.createBuffer({
+  size: 25428,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder156 = device0.createCommandEncoder({});
+let texture178 = device0.createTexture({
+  label: '\u9dd6\ud072\ub212\u{1f9f2}\u2384\u91f0\u05d6\u0041',
+  size: [16],
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let computePassEncoder103 = commandEncoder155.beginComputePass({});
+try {
+computePassEncoder74.setBindGroup(1, bindGroup43, new Uint32Array(864), 3, 0);
+} catch {}
+try {
+computePassEncoder94.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(1, bindGroup65, new Uint32Array(2017), 536, 0);
+} catch {}
+try {
+renderPassEncoder20.setScissorRect(0, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder105.copyBufferToTexture({
+  /* bytesInLastRow: 88 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2568 */
+  offset: 2568,
+  buffer: buffer62,
+}, {
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise16;
+} catch {}
+try {
+computePassEncoder77.setBindGroup(1, bindGroup14, new Uint32Array(107), 13, 0);
+} catch {}
+try {
+computePassEncoder44.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(2, bindGroup20, []);
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant({ r: -666.3, g: -73.57, b: 314.7, a: -220.9, });
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(2, buffer49, 292);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup87 = device0.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [{binding: 294, resource: textureView110}, {binding: 26, resource: textureView111}],
+});
+let pipelineLayout15 = device0.createPipelineLayout({bindGroupLayouts: []});
+let textureView156 = texture156.createView({baseArrayLayer: 4, arrayLayerCount: 3});
+let textureView157 = texture159.createView({mipLevelCount: 1});
+try {
+renderPassEncoder49.executeBundles([renderBundle8, renderBundle6, renderBundle11, renderBundle19]);
+} catch {}
+try {
+renderPassEncoder43.setIndexBuffer(buffer70, 'uint32', 1_744, 2_509);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline4);
+} catch {}
+try {
+  await buffer37.mapAsync(GPUMapMode.WRITE, 0, 2392);
+} catch {}
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55); };
+} catch {}
+try {
+  await promise14;
+} catch {}
+let commandBuffer8 = commandEncoder105.finish();
+let renderBundleEncoder30 = device0.createRenderBundleEncoder({colorFormats: ['r16sint']});
+let sampler96 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 67.02,
+  lodMaxClamp: 97.43,
+});
+try {
+renderPassEncoder55.setBindGroup(1, bindGroup51);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle0, renderBundle7, renderBundle9]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 28, y: 5, z: 1},
+  aspect: 'all',
+}, new Uint8Array(39_605).fill(215), /* required buffer size: 39_605 */
+{offset: 61, bytesPerRow: 194, rowsPerImage: 167}, {width: 81, height: 37, depthOrArrayLayers: 2});
+} catch {}
+let texture179 = device0.createTexture({
+  label: '\u641b\u9bc0\ub839\u9c39\u{1fdb0}\ufab1\uf379\u0055\u{1fdf4}\u0877',
+  size: {width: 2, height: 1, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView158 = texture136.createView({dimension: 'cube', arrayLayerCount: 6});
+try {
+computePassEncoder29.setBindGroup(2, bindGroup39, new Uint32Array(2867), 606, 0);
+} catch {}
+try {
+renderPassEncoder15.setScissorRect(0, 0, 1, 0);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline5);
+} catch {}
+try {
+commandEncoder156.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 6 */
+  offset: 6,
+  bytesPerRow: 2048,
+  buffer: buffer92,
+}, {
+  texture: texture139,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderPassEncoder63 = commandEncoder156.beginRenderPass({colorAttachments: [{view: textureView90, depthSlice: 14, loadOp: 'load', storeOp: 'discard'}]});
+let renderBundle30 = renderBundleEncoder30.finish({});
+try {
+computePassEncoder48.setBindGroup(2, bindGroup59);
+} catch {}
+try {
+computePassEncoder45.setBindGroup(0, bindGroup59, new Uint32Array(545), 10, 0);
+} catch {}
+try {
+computePassEncoder8.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline6);
+} catch {}
+let pipelineLayout16 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout0]});
+let buffer107 = device0.createBuffer({
+  label: '\u0b2f\u5371',
+  size: 2274,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+try {
+computePassEncoder102.setBindGroup(0, bindGroup53);
+} catch {}
+try {
+computePassEncoder17.setBindGroup(0, bindGroup39, new Uint32Array(981), 351, 0);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(3, bindGroup85, new Uint32Array(127), 5, 0);
+} catch {}
+try {
+renderPassEncoder26.end();
+} catch {}
+try {
+renderPassEncoder47.setVertexBuffer(5, buffer48, 0, 192);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba16float'],
+  alphaMode: 'opaque',
+});
+} catch {}
+let videoFrame33 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'jedecP22Phosphors', transfer: 'smpte170m'} });
+let commandEncoder157 = device0.createCommandEncoder({label: '\u0a37\u25a9\u0e75\u1eb5\ud5f7\u0420'});
+let commandBuffer9 = commandEncoder83.finish();
+let texture180 = device0.createTexture({
+  size: {width: 16, height: 10, depthOrArrayLayers: 1},
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture181 = device0.createTexture({
+  label: '\u2098\uc652\uc41b\u0f1d\u0611\u0327\uf96c',
+  size: [256, 256, 458],
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder104 = commandEncoder157.beginComputePass({});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup50, new Uint32Array(5110), 3_476, 0);
+} catch {}
+try {
+computePassEncoder63.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(0, bindGroup86, new Uint32Array(401), 151, 0);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(4, buffer66, 0, 2_759);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 312, y: 185, z: 0},
+  aspect: 'all',
+}, new Uint8Array(26).fill(67), /* required buffer size: 26 */
+{offset: 26, bytesPerRow: 1430}, {width: 492, height: 10, depthOrArrayLayers: 0});
+} catch {}
+let canvas3 = document.createElement('canvas');
+let videoFrame34 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'unspecified', transfer: 'pq'} });
+let buffer108 = device0.createBuffer({
+  size: 11268,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let texture182 = device0.createTexture({size: [2, 1, 1], format: 'r8uint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let textureView159 = texture76.createView({dimension: 'cube-array', baseMipLevel: 0, mipLevelCount: 1, arrayLayerCount: 6});
+try {
+computePassEncoder9.setBindGroup(1, bindGroup61);
+} catch {}
+try {
+computePassEncoder41.setBindGroup(3, bindGroup45, new Uint32Array(648), 75, 0);
+} catch {}
+try {
+computePassEncoder93.setPipeline(pipeline3);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let bindGroup88 = device0.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [{binding: 294, resource: textureView117}, {binding: 26, resource: textureView111}],
+});
+let buffer109 = device0.createBuffer({
+  size: 7830,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let querySet23 = device0.createQuerySet({label: '\u3790\u4659\ufb0b', type: 'occlusion', count: 570});
+try {
+{ clearResourceUsages(device0, computePassEncoder1); computePassEncoder1.dispatchWorkgroupsIndirect(buffer107, 96); };
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer84, 'uint16', 1_590, 244);
+} catch {}
+let buffer110 = device0.createBuffer({
+  size: 4226,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder158 = device0.createCommandEncoder({});
+let computePassEncoder105 = commandEncoder158.beginComputePass({});
+try {
+computePassEncoder46.setBindGroup(3, bindGroup62);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder62.setIndexBuffer(buffer100, 'uint16', 5_306, 2_108);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(6, buffer59, 32, 551);
+} catch {}
+let gpuCanvasContext4 = canvas3.getContext('webgpu');
+let textureView160 = texture138.createView({format: 'r32float'});
+let sampler97 = device0.createSampler({
+  label: '\u{1fd02}\u8d3f\u{1fc6f}\u0d27\udff4\u02d3\u02c7\ue925\uf955',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 97.38,
+  lodMaxClamp: 97.67,
+  compare: 'always',
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder58.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+computePassEncoder59.setBindGroup(3, bindGroup75, new Uint32Array(1167), 2, 0);
+} catch {}
+try {
+computePassEncoder92.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder57.setIndexBuffer(buffer4, 'uint32', 2_072, 36);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer8]);
+} catch {}
+try {
+  await promise15;
+} catch {}
+let bindGroup89 = device0.createBindGroup({layout: bindGroupLayout4, entries: [{binding: 84, resource: textureView54}]});
+try {
+renderPassEncoder47.setIndexBuffer(buffer84, 'uint16', 2_964, 39);
+} catch {}
+let sampler98 = device0.createSampler({
+  label: '\u0d72\u{1fad4}\u{1f9df}\u5bb2\u4af7\uc5bc\u0a55\u{1f9a0}\uf6b5',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 8.397,
+  lodMaxClamp: 25.33,
+  compare: 'greater-equal',
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder65.setBindGroup(1, bindGroup86);
+} catch {}
+try {
+computePassEncoder68.setBindGroup(3, bindGroup77, new Uint32Array(873), 343, 0);
+} catch {}
+try {
+computePassEncoder102.setPipeline(pipeline2);
+} catch {}
+document.body.append(canvas2);
+let buffer111 = device0.createBuffer({
+  size: 30936,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let sampler99 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 39.86,
+  lodMaxClamp: 44.41,
+});
+try {
+computePassEncoder100.setBindGroup(3, bindGroup29, new Uint32Array(191), 13, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder58); computePassEncoder58.dispatchWorkgroupsIndirect(buffer66, 8_964); };
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer61, 'uint32', 4_400, 1_230);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline5);
+} catch {}
+let buffer112 = device0.createBuffer({size: 23624, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder159 = device0.createCommandEncoder({});
+let querySet24 = device0.createQuerySet({type: 'occlusion', count: 150});
+let computePassEncoder106 = commandEncoder159.beginComputePass();
+let sampler100 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 82.30,
+  lodMaxClamp: 97.11,
+  compare: 'less',
+});
+try {
+computePassEncoder39.setBindGroup(3, bindGroup0, new Uint32Array(515), 4, 0);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer71, 'uint32', 444, 370);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder51.setVertexBuffer(2, buffer111, 0, 9_394);
+} catch {}
+let promise18 = device0.queue.onSubmittedWorkDone();
+let videoFrame35 = new VideoFrame(videoFrame13, {timestamp: 0});
+let bindGroup90 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 7, resource: {buffer: buffer28, offset: 512, size: 20}}],
+});
+let commandEncoder160 = device0.createCommandEncoder();
+let querySet25 = device0.createQuerySet({label: '\u{1fe5e}\u{1fbaa}\u03e2\u{1f78a}\u2a20\u0aeb\u0d6c', type: 'occlusion', count: 166});
+let texture183 = device0.createTexture({
+  label: '\ube53\u81ca\u2f85',
+  size: [8],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let computePassEncoder107 = commandEncoder160.beginComputePass({});
+try {
+computePassEncoder79.setBindGroup(2, bindGroup14);
+} catch {}
+try {
+computePassEncoder72.setBindGroup(0, bindGroup6, new Uint32Array(3443), 33, 0);
+} catch {}
+try {
+computePassEncoder71.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer99, 'uint32', 96, 81);
+} catch {}
+try {
+renderPassEncoder58.setVertexBuffer(2, buffer1, 0, 475);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer102, 6980, new Int16Array(21310), 1211, 0);
+} catch {}
+let bindGroup91 = device0.createBindGroup({
+  layout: bindGroupLayout8,
+  entries: [{binding: 271, resource: textureView69}, {binding: 340, resource: textureView61}],
+});
+let commandEncoder161 = device0.createCommandEncoder({});
+let querySet26 = device0.createQuerySet({label: '\u0465\u11f2\u0ffe\u{1ff97}\ue92a', type: 'occlusion', count: 1027});
+let texture184 = device0.createTexture({
+  size: {width: 16},
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let renderPassEncoder64 = commandEncoder161.beginRenderPass({
+  colorAttachments: [{
+  view: textureView72,
+  depthSlice: 8,
+  clearValue: { r: 539.3, g: -802.7, b: 216.7, a: 394.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet8,
+  maxDrawCount: 25292168,
+});
+try {
+computePassEncoder97.setBindGroup(3, bindGroup36, new Uint32Array(1655), 94, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder72); computePassEncoder72.dispatchWorkgroupsIndirect(buffer45, 1_708); };
+} catch {}
+try {
+computePassEncoder72.end();
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(1, bindGroup81, new Uint32Array(15), 6, 0);
+} catch {}
+try {
+renderPassEncoder39.executeBundles([renderBundle17, renderBundle9, renderBundle21]);
+} catch {}
+try {
+renderPassEncoder58.setViewport(1.8218752844805675, 0.5407396938477536, 1.5408536104875625, 0.08117438418649484, 0.911765762413231, 0.9521420334760253);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer12, 'uint32', 76, 1_054);
+} catch {}
+try {
+buffer112.unmap();
+} catch {}
+try {
+commandEncoder104.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 8072 */
+  offset: 8072,
+  buffer: buffer54,
+}, {
+  texture: texture81,
+  mipLevel: 0,
+  origin: {x: 2, y: 3, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer113 = device0.createBuffer({size: 5488, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM});
+let commandEncoder162 = device0.createCommandEncoder();
+let commandBuffer10 = commandEncoder104.finish();
+let texture185 = device0.createTexture({size: [4], dimension: '1d', format: 'r16sint', usage: GPUTextureUsage.COPY_DST});
+let textureView161 = texture117.createView({mipLevelCount: 1});
+let computePassEncoder108 = commandEncoder162.beginComputePass({});
+let sampler101 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 29.64,
+  lodMaxClamp: 92.19,
+  maxAnisotropy: 13,
+});
+try {
+renderPassEncoder25.setIndexBuffer(buffer93, 'uint32', 276, 6);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline0);
+} catch {}
+try {
+buffer87.unmap();
+} catch {}
+try {
+renderPassEncoder28.insertDebugMarker('\u0728');
+} catch {}
+let commandEncoder163 = device0.createCommandEncoder({});
+let renderPassEncoder65 = commandEncoder163.beginRenderPass({
+  label: '\u28a2\u{1fdd2}\uc7d0\u1406',
+  colorAttachments: [{
+  view: textureView128,
+  depthSlice: 247,
+  clearValue: { r: -779.4, g: -188.0, b: -578.5, a: 329.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet0,
+  maxDrawCount: 23375032,
+});
+try {
+computePassEncoder28.setBindGroup(2, bindGroup67, new Uint32Array(600), 43, 0);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(1, bindGroup86);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([renderBundle10, renderBundle1, renderBundle24]);
+} catch {}
+try {
+renderPassEncoder45.setIndexBuffer(buffer71, 'uint32', 140, 483);
+} catch {}
+try {
+renderPassEncoder56.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.submit([commandBuffer9]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+externalTexture8.label = '\u0222\u{1ff72}';
+} catch {}
+let bindGroup92 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [
+    {binding: 55, resource: textureView41},
+    {binding: 132, resource: sampler1},
+    {binding: 62, resource: {buffer: buffer1, offset: 1280, size: 636}},
+    {binding: 236, resource: textureView80},
+    {binding: 22, resource: textureView81},
+    {binding: 103, resource: textureView125},
+  ],
+});
+let buffer114 = device0.createBuffer({size: 7920, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let commandEncoder164 = device0.createCommandEncoder({});
+let sampler102 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 23.43,
+  lodMaxClamp: 25.77,
+  compare: 'greater-equal',
+});
+try {
+renderPassEncoder56.setBindGroup(3, bindGroup84);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(3, bindGroup88, new Uint32Array(110), 56, 0);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer76, 'uint16', 190, 114);
+} catch {}
+try {
+commandEncoder164.copyTextureToBuffer({
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 92, y: 91, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 14 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 562 */
+  offset: 562,
+  bytesPerRow: 4096,
+  buffer: buffer88,
+}, {width: 7, height: 13, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder14.insertDebugMarker('\u708e');
+} catch {}
+try {
+  await promise13;
+} catch {}
+let commandEncoder165 = device0.createCommandEncoder({});
+let querySet27 = device0.createQuerySet({type: 'occlusion', count: 1461});
+let computePassEncoder109 = commandEncoder165.beginComputePass({});
+try {
+renderPassEncoder10.setVertexBuffer(3, buffer63, 4_396, 1_882);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData19 = new ImageData(4, 32);
+let bindGroup93 = device0.createBindGroup({
+  label: '\u1d33\u{1f994}\u8bd9\uc842',
+  layout: bindGroupLayout9,
+  entries: [{binding: 114, resource: {buffer: buffer104, offset: 1024}}],
+});
+let buffer115 = device0.createBuffer({
+  size: 17639,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let textureView162 = texture116.createView({});
+let computePassEncoder110 = commandEncoder164.beginComputePass();
+let sampler103 = device0.createSampler({
+  label: '\uf94e\uc878\udc66\u{1fd89}\u9e09',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 59.62,
+  lodMaxClamp: 89.19,
+  compare: 'less',
+  maxAnisotropy: 18,
+});
+try {
+renderPassEncoder28.setBindGroup(3, bindGroup37);
+} catch {}
+try {
+renderPassEncoder61.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder100.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder48.beginOcclusionQuery(3);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle4, renderBundle19, renderBundle6]);
+} catch {}
+let commandEncoder166 = device0.createCommandEncoder();
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup54, new Uint32Array(3724), 180, 0);
+} catch {}
+try {
+renderPassEncoder41.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder166.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1132 */
+  offset: 1132,
+  bytesPerRow: 29184,
+  buffer: buffer106,
+}, {
+  texture: texture147,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame17,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 40, y: 23, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer116 = device0.createBuffer({
+  label: '\u79f0\u{1fa09}\u0ec0\u1dbc\u{1fa1e}\u5af4\u01fb\u0da1\u0156\u{1fdba}\u0b30',
+  size: 1688,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder80.setBindGroup(3, bindGroup70, []);
+} catch {}
+try {
+computePassEncoder91.setBindGroup(1, bindGroup11, new Uint32Array(2949), 171, 0);
+} catch {}
+try {
+computePassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder61.setBindGroup(1, bindGroup47, new Uint32Array(1085), 29, 0);
+} catch {}
+try {
+renderPassEncoder7.end();
+} catch {}
+try {
+renderPassEncoder48.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder49.executeBundles([renderBundle12, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder50.setIndexBuffer(buffer80, 'uint16', 72, 159);
+} catch {}
+try {
+commandEncoder0.copyBufferToTexture({
+  /* bytesInLastRow: 5 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 8726 */
+  offset: 8726,
+  bytesPerRow: 1280,
+  rowsPerImage: 223,
+  buffer: buffer54,
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer10]);
+} catch {}
+document.body.prepend(img1);
+let commandEncoder167 = device0.createCommandEncoder({});
+let texture186 = device0.createTexture({
+  label: '\u0264\u00e9\u{1feb0}\u0d8d\u{1fa93}\u33fd\ub328\ue320',
+  size: {width: 8},
+  dimension: '1d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView163 = texture112.createView({});
+let computePassEncoder111 = commandEncoder0.beginComputePass({});
+let renderPassEncoder66 = commandEncoder167.beginRenderPass({
+  colorAttachments: [{
+  view: textureView5,
+  clearValue: { r: 647.7, g: 675.6, b: 90.34, a: -274.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet25,
+  maxDrawCount: 264949370,
+});
+try {
+computePassEncoder85.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let commandBuffer11 = commandEncoder33.finish();
+let texture187 = device0.createTexture({size: [4, 2, 1], mipLevelCount: 1, dimension: '2d', format: 'r16float', usage: GPUTextureUsage.COPY_DST});
+let textureView164 = texture87.createView({dimension: '2d', mipLevelCount: 1});
+try {
+computePassEncoder53.setBindGroup(1, bindGroup80);
+} catch {}
+try {
+computePassEncoder25.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder166.clearBuffer(buffer111);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup94 = device0.createBindGroup({layout: bindGroupLayout4, entries: [{binding: 84, resource: textureView54}]});
+try {
+computePassEncoder53.setBindGroup(0, bindGroup57);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder85); computePassEncoder85.dispatchWorkgroupsIndirect(buffer35, 2_164); };
+} catch {}
+try {
+computePassEncoder35.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup30);
+} catch {}
+let commandEncoder168 = device0.createCommandEncoder({});
+let textureView165 = texture96.createView({label: '\u78cc\u00e3\u06ce\u990a\u446c\uf0aa\u0a5c\u0cf9\u037f\u0224\u9d14'});
+let computePassEncoder112 = commandEncoder168.beginComputePass({});
+try {
+computePassEncoder22.setBindGroup(1, bindGroup27, new Uint32Array(471), 81, 0);
+} catch {}
+try {
+computePassEncoder49.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer22, 'uint16', 560, 546);
+} catch {}
+let arrayBuffer14 = buffer41.getMappedRange(400, 16);
+try {
+commandEncoder166.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 178 */
+  offset: 178,
+  buffer: buffer17,
+}, {
+  texture: texture187,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55); };
+} catch {}
+let textureView166 = texture7.createView({mipLevelCount: 1});
+let computePassEncoder113 = commandEncoder166.beginComputePass({});
+let sampler104 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 40.58,
+  lodMaxClamp: 53.24,
+});
+try {
+computePassEncoder110.setPipeline(pipeline3);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+device0.queue.submit([commandBuffer11]);
+} catch {}
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55); };
+} catch {}
+let commandEncoder169 = device0.createCommandEncoder();
+let texture188 = device0.createTexture({size: {width: 16}, dimension: '1d', format: 'r8uint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let textureView167 = texture140.createView({dimension: '2d-array', baseArrayLayer: 0});
+let computePassEncoder114 = commandEncoder169.beginComputePass({label: '\uec3f\ucc90\u0977\u3f57\uc5d6\u5443\ue759\ub527'});
+try {
+{ clearResourceUsages(device0, computePassEncoder85); computePassEncoder85.dispatchWorkgroupsIndirect(buffer42, 752); };
+} catch {}
+let commandEncoder170 = device0.createCommandEncoder({});
+let texture189 = device0.createTexture({size: {width: 256}, dimension: '1d', format: 'r8uint', usage: GPUTextureUsage.COPY_SRC});
+let texture190 = gpuCanvasContext0.getCurrentTexture();
+let computePassEncoder115 = commandEncoder170.beginComputePass({});
+let sampler105 = device0.createSampler({
+  label: '\u2332\u0278\ua771\u{1fb36}\u2c3b\u7dc3\uf1c8',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 43.39,
+  lodMaxClamp: 73.51,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder92.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+renderPassEncoder17.setBlendConstant({ r: -608.6, g: 359.1, b: -630.2, a: -503.3, });
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55); };
+} catch {}
+let textureView168 = texture88.createView({dimension: '2d', mipLevelCount: 1, arrayLayerCount: 1});
+try {
+renderPassEncoder52.setBindGroup(1, bindGroup32, new Uint32Array(635), 40, 0);
+} catch {}
+try {
+renderPassEncoder44.setIndexBuffer(buffer52, 'uint32', 1_640, 372);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+let videoFrame36 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'bt470bg', transfer: 'smpteSt4281'} });
+let buffer117 = device0.createBuffer({
+  label: '\u1035\u02bd\u0cb3\u7731\uac31\u0b41\u9f41\u6a6c',
+  size: 5559,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup76);
+} catch {}
+try {
+renderPassEncoder63.setIndexBuffer(buffer84, 'uint16', 394, 908);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline0);
+} catch {}
+try {
+buffer30.unmap();
+} catch {}
+let texture191 = device0.createTexture({
+  size: [256, 256, 15],
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView169 = texture1.createView({});
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+try {
+  await promise17;
+} catch {}
+await gc();
+try {
+adapter0.label = '\u9bb3\ud58f';
+} catch {}
+try {
+computePassEncoder99.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder63.setBindGroup(0, bindGroup79, new Uint32Array(1498), 61, 0);
+} catch {}
+try {
+renderPassEncoder60.setVertexBuffer(2, buffer73, 0, 263);
+} catch {}
+let bindGroupLayout19 = device0.createBindGroupLayout({
+  label: '\u037f\uaf77\u60cd\u{1f801}',
+  entries: [
+    {binding: 235, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 61,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {binding: 438, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder58); computePassEncoder58.dispatchWorkgroupsIndirect(buffer80, 56); };
+} catch {}
+try {
+computePassEncoder85.end();
+} catch {}
+try {
+computePassEncoder87.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder35.end();
+} catch {}
+try {
+commandEncoder21.copyTextureToTexture({
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 580, new Int16Array(25773), 5217, 1908);
+} catch {}
+let promise19 = device0.queue.onSubmittedWorkDone();
+let bindGroup95 = device0.createBindGroup({layout: bindGroupLayout17, entries: [{binding: 162, resource: textureView27}]});
+let sampler106 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 93.86,
+  lodMaxClamp: 99.94,
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder97.setPipeline(pipeline2);
+} catch {}
+document.body.prepend(canvas3);
+let pipelineLayout17 = device0.createPipelineLayout({bindGroupLayouts: []});
+let textureView170 = texture142.createView({baseArrayLayer: 35, arrayLayerCount: 2});
+let renderBundleEncoder31 = device0.createRenderBundleEncoder({colorFormats: ['r16sint']});
+let renderBundle31 = renderBundleEncoder31.finish({});
+try {
+computePassEncoder60.setBindGroup(0, bindGroup52, new Uint32Array(2387), 1_615, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder58); computePassEncoder58.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder38.setViewport(1.0880737511413994, 1.1749720539151565, 2.0828873556957683, 0.23193537977383938, 0.2685172890210269, 0.3298573367549005);
+} catch {}
+try {
+renderPassEncoder62.setIndexBuffer(buffer75, 'uint16', 3_466, 812);
+} catch {}
+try {
+commandEncoder21.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 6482 */
+  offset: 6482,
+  bytesPerRow: 1536,
+  rowsPerImage: 629,
+  buffer: buffer44,
+}, {
+  texture: texture100,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let buffer118 = device0.createBuffer({
+  size: 7987,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder171 = device0.createCommandEncoder({label: '\uefb6\u30ea\u5976\u0e8b\u{1fa3f}\u3ce8\u{1f9e1}\u07ed\u5e15'});
+let sampler107 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 99.53,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder93.setBindGroup(0, bindGroup58, new Uint32Array(3004), 121, 0);
+} catch {}
+try {
+renderPassEncoder64.setBindGroup(3, bindGroup82, new Uint32Array(1375), 364, 0);
+} catch {}
+let bindGroup96 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 13, resource: externalTexture15}]});
+let buffer119 = device0.createBuffer({size: 5306, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let computePassEncoder116 = commandEncoder171.beginComputePass({});
+let renderPassEncoder67 = commandEncoder21.beginRenderPass({colorAttachments: [{view: textureView131, loadOp: 'load', storeOp: 'store'}]});
+try {
+computePassEncoder49.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+computePassEncoder112.setBindGroup(2, bindGroup41, new Uint32Array(1674), 542, 0);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer106, 'uint16', 2_848, 1_399);
+} catch {}
+let sampler108 = device0.createSampler({
+  label: '\ua266\ufcf7\u47a5',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 41.06,
+  lodMaxClamp: 62.02,
+  maxAnisotropy: 14,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder58); computePassEncoder58.dispatchWorkgroupsIndirect(buffer71, 172); };
+} catch {}
+try {
+computePassEncoder116.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(3, bindGroup49, new Uint32Array(6435), 1_017, 0);
+} catch {}
+try {
+commandEncoder107.copyBufferToBuffer(buffer26, 868, buffer69, 152, 268);
+} catch {}
+try {
+commandEncoder107.copyTextureToTexture({
+  texture: texture163,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 5},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroupLayout20 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 557,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let textureView171 = texture77.createView({mipLevelCount: 1});
+let renderPassEncoder68 = commandEncoder107.beginRenderPass({
+  colorAttachments: [{
+  view: textureView141,
+  clearValue: { r: -314.6, g: -889.7, b: -402.4, a: -569.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet9,
+  maxDrawCount: 449297641,
+});
+let renderBundleEncoder32 = device0.createRenderBundleEncoder({label: '\u18ae\u8dab\u037c\u00a1\ue320\u29db\u242c\u0a00\u2728', colorFormats: ['r16sint']});
+try {
+computePassEncoder113.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder58); computePassEncoder58.dispatchWorkgroupsIndirect(buffer114, 216); };
+} catch {}
+try {
+computePassEncoder80.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder46.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder32.setVertexBuffer(6, buffer1, 2_904, 959);
+} catch {}
+await gc();
+let bindGroup97 = device0.createBindGroup({
+  layout: bindGroupLayout12,
+  entries: [
+    {binding: 497, resource: externalTexture17},
+    {binding: 232, resource: sampler77},
+    {binding: 112, resource: textureView78},
+  ],
+});
+let querySet28 = device0.createQuerySet({label: '\u1863\u9762\u{1f788}\uda72', type: 'occlusion', count: 902});
+let textureView172 = texture36.createView({format: 'r16float', mipLevelCount: 1});
+let renderBundleEncoder33 = device0.createRenderBundleEncoder({colorFormats: ['r16sint'], depthReadOnly: true});
+try {
+computePassEncoder113.setBindGroup(1, bindGroup4, new Uint32Array(3043), 60, 0);
+} catch {}
+try {
+computePassEncoder62.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder57.setBindGroup(1, bindGroup42);
+} catch {}
+let renderBundle32 = renderBundleEncoder33.finish({label: '\u{1fa1b}\u010d\u0453\ue71a\u372d'});
+try {
+computePassEncoder111.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(0, bindGroup5, new Uint32Array(1230), 25, 0);
+} catch {}
+try {
+renderPassEncoder19.beginOcclusionQuery(312);
+} catch {}
+try {
+renderPassEncoder62.setIndexBuffer(buffer72, 'uint32', 2_896, 162);
+} catch {}
+try {
+renderBundleEncoder32.setVertexBuffer(6, buffer55);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let shaderModule6 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires pointer_composite_access;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(1) @binding(271) var st1: texture_storage_1d<rg32float, write>;
+
+@group(1) @binding(340) var st2: texture_storage_1d<r32sint, read_write>;
+
+struct T0 {
+  @align(64) @size(576) f0: array<u32>,
+}
+
+struct T1 {
+  @align(64) @size(576) f0: array<array<array<u32, 1>, 2>>,
+}
+
+struct T2 {
+  @size(192) f0: mat2x2f,
+}
+
+struct T3 {
+  @size(576) f0: array<array<atomic<i32>, 1>>,
+}
+
+struct T4 {
+  @size(576) f0: array<mat2x4f>,
+}
+
+struct S2 {
+  @location(11) f0: vec2i,
+  @location(6) @interpolate(flat, sample) f1: vec4i,
+  @location(7) f2: f16,
+}
+
+struct VertexOutput5 {
+  @builtin(position) f16: vec4f,
+  @location(14) @interpolate(flat, center) f17: vec4u,
+  @location(9) f18: u32,
+}
+
+alias vec3b = vec3<bool>;
+
+var<workgroup> vw9: array<array<S2, 1>, 1>;
+
+var<workgroup> vw10: atomic<i32>;
+
+var<workgroup> vw11: array<VertexOutput5, 1>;
+
+var<workgroup> vw12: mat2x3h;
+
+var<private> vp1 = modf(vec2h(7442.8, 9525.9));
+
+var<private> vp2: VertexOutput5 = VertexOutput5();
+
+@vertex
+fn vertex5(@location(4) a0: vec4f, @location(12) a1: vec4h, @location(0) @interpolate(flat, centroid) a2: u32, @location(1) @interpolate(flat, centroid) a3: vec2u, @location(3) @interpolate(perspective, centroid) a4: vec4h, @location(15) a5: f32, @location(8) @interpolate(flat, sample) a6: vec2i, @location(10) @interpolate(flat) a7: vec4u, a8: S2, @location(13) a9: f32, @location(14) @interpolate(linear) a10: vec4h) -> VertexOutput5 {
+  var out: VertexOutput5;
+  let ptr28: ptr<private, u32> = &vp2.f18;
+  out.f18 -= u32(a1[u32(unconst_u32(55))]);
+  out.f16 = bitcast<vec4f>(unpack4xI8(u32(unconst_u32(44))));
+  let ptr29: ptr<private, vec4f> = &vp2.f16;
+  out.f17 -= bitcast<vec4u>(quantizeToF16(vec2f(unconst_f32(0.04680), unconst_f32(0.01885))).yxxy);
+  var vf173: mat3x4f = transpose(mat4x3f());
+  let vf174: S2 = a8;
+  var vf175: vec4i = vf174.f1;
+  let vf176: f16 = a8.f2;
+  let vf177: vec2i = a6;
+  vf175 += vec4i(i32(vf174.f2));
+  vf175 = vec4i(quantizeToF16(vec2f(unconst_f32(0.2089), unconst_f32(0.1551))).xyyx);
+  let vf178: vec2f = asin(vec2f(unconst_f32(0.2651), unconst_f32(0.4510)));
+  vf173 = mat3x4f(bitcast<f32>(a8.f1[u32(unconst_u32(63))]), f32(a8.f1[u32(unconst_u32(63))]), f32(a8.f1[u32(unconst_u32(63))]), bitcast<f32>(a8.f1[u32(unconst_u32(63))]), f32(a8.f1[u32(unconst_u32(63))]), f32(a8.f1[u32(unconst_u32(63))]), bitcast<f32>(a8.f1[u32(unconst_u32(63))]), f32(a8.f1[u32(unconst_u32(63))]), f32(a8.f1[u32(unconst_u32(63))]), bitcast<f32>(a8.f1[u32(unconst_u32(63))]), f32(a8.f1[u32(unconst_u32(63))]), bitcast<f32>(a8.f1[u32(unconst_u32(63))]));
+  vf173 = mat3x4f(f32(a2), bitcast<f32>(a2), f32(a2), f32(a2), f32(a2), bitcast<f32>(a2), f32(a2), f32(a2), f32(a2), f32(a2), bitcast<f32>(a2), f32(a2));
+  vf173 = mat3x4f((*ptr29), (*ptr29), (*ptr29));
+  var vf179: vec4i = a8.f1;
+  let vf180: u32 = a7[u32(unconst_u32(212))];
+  let ptr30: ptr<private, vec4f> = &vp2.f16;
+  var vf181: f32 = a9;
+  return out;
+}
+
+@fragment
+fn fragment6(@location(13) a0: vec2h, @builtin(front_facing) a1: bool, @location(5) @interpolate(flat, centroid) a2: vec4u) -> @location(200) @interpolate(flat) u32 {
+  var out: u32;
+  out &= vp2.f17[0];
+  vp1 = modf(vec2h(trunc(vec4f(unconst_f32(0.3614), unconst_f32(0.07218), unconst_f32(0.07002), unconst_f32(0.09370))).ba));
+  let vf182: u32 = dot4U8Packed(bitcast<u32>(vp1.whole), u32(unconst_u32(129)));
+  vp2 = VertexOutput5(vec4f(vp1.whole.xxyx), vec4u(vp1.whole.xyxx), bitcast<u32>(vp1.whole));
+  discard;
+  let ptr31: ptr<private, vec4f> = &vp2.f16;
+  var vf183: vec4u = a2;
+  let ptr32: ptr<private, vec4u> = &vp2.f17;
+  let ptr33: ptr<private, u32> = &vp2.f18;
+  let ptr34: ptr<private, vec4f> = &vp2.f16;
+  let vf184: f32 = (*ptr31)[u32(unconst_u32(250))];
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute3() {
+  let ptr35: ptr<workgroup, VertexOutput5> = &(*&vw11)[vec3u((*&vw12)[unconst_i32(1)])[1]];
+  var vf185: i32 = (*&vw9)[u32(unconst_u32(458))][u32(unconst_u32(332))].f0[bitcast<u32>((*&vw9)[u32(unconst_u32(483))][u32(unconst_u32(286))].f0[u32(unconst_u32(38))])];
+  vp2.f16 = vec4f((*&vw9)[0][0].f0.gggr);
+  let ptr36: ptr<workgroup, S2> = &vw9[u32(unconst_u32(56))][u32(unconst_u32(22))];
+  let ptr37: ptr<workgroup, f16> = &(*&vw9)[0][0].f2;
+  vp1 = modf(vec2h((*&vw9)[0][0].f1.br));
+  vw9[u32(unconst_u32(116))][u32(unconst_u32(320))] = vw9[0][0];
+  textureStore(st1, i32((*ptr35).f18), vec4f(vec4f(unconst_f32(0.1066), unconst_f32(0.2235), unconst_f32(0.00647), unconst_f32(0.09903))));
+  vw12 = mat2x3h(vec3h(vw11[u32(unconst_u32(216))].f16.gab), vec3h(vw11[u32(unconst_u32(216))].f16.gab));
+}`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+computePassEncoder93.setBindGroup(0, bindGroup91, new Uint32Array(1172), 158, 0);
+} catch {}
+try {
+computePassEncoder114.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(0, bindGroup89, new Uint32Array(1366), 58, 0);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+texture82.label = '\u6fbe\uc89c\u2154\uf906\u0394\u{1f93a}\u4122\u0674\ue776\u{1f9d4}\ud207';
+} catch {}
+let texture192 = device0.createTexture({
+  size: [2, 1, 1],
+  sampleCount: 1,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder58); computePassEncoder58.dispatchWorkgroups(3, 1); };
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(0, bindGroup73);
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(0, bindGroup74, new Uint32Array(1195), 264, 0);
+} catch {}
+let commandEncoder172 = device0.createCommandEncoder();
+let textureView173 = texture169.createView({});
+let renderBundle33 = renderBundleEncoder32.finish({});
+try {
+renderPassEncoder19.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(4, buffer12, 1_188, 710);
+} catch {}
+try {
+commandEncoder172.insertDebugMarker('\u{1fbc9}');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 24},
+  aspect: 'all',
+}, new Uint8Array(110_571).fill(153), /* required buffer size: 110_571 */
+{offset: 87, bytesPerRow: 81, rowsPerImage: 44}, {width: 0, height: 0, depthOrArrayLayers: 32});
+} catch {}
+let bindGroup98 = device0.createBindGroup({
+  layout: bindGroupLayout18,
+  entries: [{binding: 97, resource: {buffer: buffer19, offset: 1280, size: 528}}],
+});
+let textureView174 = texture70.createView({label: '\ud1d5\u7a38\u0066\ucf55\ub44e', mipLevelCount: 1});
+let computePassEncoder117 = commandEncoder172.beginComputePass({label: '\u4415\ua038\u9691\u36d2\u27c6\u2456\u{1fb1b}\u0cfc\u0747\uea49'});
+try {
+computePassEncoder90.setBindGroup(3, bindGroup66, new Uint32Array(682), 82, 0);
+} catch {}
+try {
+computePassEncoder66.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder41.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(5, buffer84, 160, 182);
+} catch {}
+try {
+renderPassEncoder68.insertDebugMarker('\u46d7');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup99 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 7, resource: {buffer: buffer54, offset: 256, size: 724}}],
+});
+let texture193 = device0.createTexture({
+  label: '\u0973\u5907',
+  size: [2, 1, 214],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder69.setBindGroup(3, bindGroup9, new Uint32Array(1984), 84, 0);
+} catch {}
+try {
+computePassEncoder84.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder31.setViewport(0.8794551972582323, 0.5825539436532472, 0.7870865238456736, 0.3896740376592414, 0.6595774650375578, 0.7799821025031993);
+} catch {}
+try {
+renderPassEncoder44.setIndexBuffer(buffer43, 'uint32', 8, 103);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(4, buffer93);
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let commandEncoder173 = device0.createCommandEncoder({label: '\u{1fe85}\u{1fff9}\u0263\u0799\u{1fb4d}'});
+let textureView175 = texture111.createView({baseArrayLayer: 0, arrayLayerCount: 1});
+let externalTexture31 = device0.importExternalTexture({label: '\u{1fd43}\u{1f785}\ud2f5\u0ebf\ua07d\u6f95', source: videoFrame10});
+try {
+computePassEncoder110.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+computePassEncoder103.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup95, new Uint32Array(3343), 1_405, 0);
+} catch {}
+try {
+renderPassEncoder52.setPipeline(pipeline0);
+} catch {}
+let bindGroup100 = device0.createBindGroup({
+  layout: bindGroupLayout13,
+  entries: [
+    {binding: 153, resource: textureView86},
+    {binding: 286, resource: externalTexture17},
+    {binding: 314, resource: textureView145},
+    {binding: 21, resource: externalTexture13},
+  ],
+});
+let texture194 = device0.createTexture({
+  size: {width: 4},
+  dimension: '1d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler109 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.25,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder55.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle27, renderBundle5, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder56.setStencilReference(667);
+} catch {}
+try {
+buffer72.unmap();
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame27,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 0, y: 13, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup101 = device0.createBindGroup({
+  layout: bindGroupLayout18,
+  entries: [{binding: 97, resource: {buffer: buffer19, offset: 512, size: 620}}],
+});
+let renderBundleEncoder34 = device0.createRenderBundleEncoder({colorFormats: ['r8uint'], sampleCount: 1, depthReadOnly: true, stencilReadOnly: true});
+let sampler110 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 48.14,
+  lodMaxClamp: 90.79,
+});
+try {
+renderPassEncoder31.setBindGroup(2, bindGroup56);
+} catch {}
+try {
+renderPassEncoder9.setStencilReference(1231);
+} catch {}
+try {
+renderPassEncoder65.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(7, buffer116);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(1, bindGroup56, new Uint32Array(862), 138, 0);
+} catch {}
+try {
+renderBundleEncoder34.setPipeline(pipeline0);
+} catch {}
+let arrayBuffer15 = buffer37.getMappedRange(0, 204);
+await gc();
+let buffer120 = device0.createBuffer({
+  size: 9168,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT,
+});
+let commandEncoder174 = device0.createCommandEncoder({});
+let texture195 = device0.createTexture({
+  size: {width: 4, height: 2, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle34 = renderBundleEncoder34.finish({});
+try {
+computePassEncoder41.setPipeline(pipeline3);
+} catch {}
+try {
+  await promise18;
+} catch {}
+offscreenCanvas0.width = 1586;
+let bindGroup102 = device0.createBindGroup({layout: bindGroupLayout10, entries: [{binding: 112, resource: textureView154}]});
+let commandEncoder175 = device0.createCommandEncoder({});
+let computePassEncoder118 = commandEncoder175.beginComputePass({});
+let renderPassEncoder69 = commandEncoder173.beginRenderPass({
+  colorAttachments: [{
+  view: textureView90,
+  depthSlice: 6,
+  clearValue: { r: -872.5, g: -856.5, b: -622.9, a: -40.32, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder37.setBindGroup(3, bindGroup77, new Uint32Array(4543), 686, 0);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(2, bindGroup8, new Uint32Array(1770), 51, 0);
+} catch {}
+try {
+renderPassEncoder61.setBlendConstant({ r: -90.80, g: 693.3, b: 891.0, a: 590.9, });
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55); };
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(59, 301);
+let buffer121 = device0.createBuffer({
+  size: 2086,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView176 = texture19.createView({label: '\u{1f818}\ua61f\u028e\u{1fe91}\uf3d5'});
+let computePassEncoder119 = commandEncoder174.beginComputePass();
+try {
+computePassEncoder117.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder57.setBindGroup(3, bindGroup66);
+} catch {}
+let textureView177 = texture98.createView({arrayLayerCount: 1});
+let sampler111 = device0.createSampler({addressModeW: 'mirror-repeat', magFilter: 'nearest', lodMinClamp: 3.601, lodMaxClamp: 4.692});
+try {
+computePassEncoder13.setBindGroup(2, bindGroup87, new Uint32Array(2228), 588, 0);
+} catch {}
+try {
+computePassEncoder12.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder50.setBlendConstant({ r: -995.8, g: 397.9, b: 200.9, a: -814.6, });
+} catch {}
+try {
+computePassEncoder101.insertDebugMarker('\u0d4f');
+} catch {}
+try {
+  await promise19;
+} catch {}
+let commandEncoder176 = device0.createCommandEncoder({});
+let texture196 = device0.createTexture({size: [16, 10, 1], format: 'r16sint', usage: GPUTextureUsage.COPY_DST});
+let sampler112 = device0.createSampler({
+  addressModeU: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 25.81,
+  lodMaxClamp: 83.15,
+});
+try {
+computePassEncoder38.setBindGroup(3, bindGroup88, new Uint32Array(640), 60, 0);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(2, bindGroup20);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([renderBundle24, renderBundle1]);
+} catch {}
+let textureView178 = texture8.createView({label: '\ua575\uec98\u0200\u{1f65e}\u36f2\ued38\u9ec4\u489c', dimension: '2d-array'});
+let commandEncoder177 = device0.createCommandEncoder({});
+let texture197 = device0.createTexture({
+  size: {width: 16, height: 10, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let computePassEncoder120 = commandEncoder177.beginComputePass({});
+let sampler113 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 38.31,
+  lodMaxClamp: 43.62,
+});
+try {
+computePassEncoder58.end();
+} catch {}
+try {
+computePassEncoder112.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder66.beginOcclusionQuery(6);
+} catch {}
+try {
+renderPassEncoder66.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder61.setVertexBuffer(5, buffer93, 692, 112);
+} catch {}
+try {
+commandEncoder85.copyBufferToTexture({
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1537 */
+  offset: 1537,
+  buffer: buffer46,
+}, {
+  texture: texture139,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout21 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 272,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let texture198 = device0.createTexture({
+  label: '\u05fb\u43e5\u060a\u{1f9da}\uf266\u{1fbdc}\u5cd8',
+  size: {width: 16, height: 10, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView179 = texture70.createView({});
+let computePassEncoder121 = commandEncoder85.beginComputePass({});
+let renderPassEncoder70 = commandEncoder176.beginRenderPass({
+  colorAttachments: [{
+  view: textureView179,
+  depthSlice: 1255,
+  clearValue: { r: 383.2, g: -580.3, b: 453.6, a: 841.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 473473,
+});
+try {
+computePassEncoder106.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder50.setVertexBuffer(4, buffer76);
+} catch {}
+let commandEncoder178 = device0.createCommandEncoder({});
+let texture199 = device0.createTexture({
+  size: [8, 5, 134],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder122 = commandEncoder178.beginComputePass();
+try {
+computePassEncoder30.setBindGroup(1, bindGroup1, new Uint32Array(2233), 204, 0);
+} catch {}
+try {
+computePassEncoder108.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle25, renderBundle17]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData7,
+  origin: { x: 0, y: 7 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 41, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer122 = device0.createBuffer({size: 896, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE});
+try {
+computePassEncoder115.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder45.setBindGroup(2, bindGroup55, new Uint32Array(537), 50, 0);
+} catch {}
+try {
+renderPassEncoder28.executeBundles([renderBundle1, renderBundle11, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder47.setScissorRect(21, 4, 29, 51);
+} catch {}
+let commandEncoder179 = device0.createCommandEncoder();
+let texture200 = device0.createTexture({
+  size: [16, 10, 1],
+  dimension: '2d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture201 = gpuCanvasContext3.getCurrentTexture();
+let computePassEncoder123 = commandEncoder179.beginComputePass({label: '\ua478\ude0c\u2fd1'});
+let sampler114 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 26.48,
+  lodMaxClamp: 52.94,
+  compare: 'greater',
+});
+try {
+computePassEncoder34.setBindGroup(1, bindGroup64, new Uint32Array(462), 23, 0);
+} catch {}
+try {
+computePassEncoder77.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(1, bindGroup65, []);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder56.setVertexBuffer(7, buffer88);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 28, y: 11, z: 0},
+  aspect: 'all',
+}, new Uint8Array(199).fill(231), /* required buffer size: 199 */
+{offset: 199, bytesPerRow: 130}, {width: 15, height: 14, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let videoFrame37 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'unspecified', primaries: 'bt709', transfer: 'logSqrt'} });
+let shaderModule7 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires pointer_composite_access;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(232) var sam0: sampler;
+
+@group(0) @binding(497) var et5: texture_external;
+
+struct T0 {
+  @align(8) @size(88) f0: array<u32>,
+}
+
+struct T1 {
+  @align(16) @size(16) f0: atomic<i32>,
+}
+
+struct T2 {
+  @size(84) f0: array<mat4x2h>,
+}
+
+var<workgroup> vw13: T1;
+
+var<workgroup> vw14: mat2x2f;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute4(@builtin(num_workgroups) a0: vec3u) {
+  atomicMin(&vw13.f0, i32(unconst_i32(95)));
+  let ptr38: ptr<workgroup, T1> = &vw13;
+  vw14 += mat2x2f(bitcast<f32>(pack4xI8(vec4i(unconst_i32(174), unconst_i32(51), unconst_i32(97), unconst_i32(3)))), f32(pack4xI8(vec4i(unconst_i32(174), unconst_i32(51), unconst_i32(97), unconst_i32(3)))), f32(pack4xI8(vec4i(unconst_i32(174), unconst_i32(51), unconst_i32(97), unconst_i32(3)))), f32(pack4xI8(vec4i(unconst_i32(174), unconst_i32(51), unconst_i32(97), unconst_i32(3)))));
+  var vf186: vec4f = textureSampleBaseClampToEdge(et5, sam0, vec2f(unconst_f32(0.06724), unconst_f32(0.4491)));
+  let vf187: f32 = vf186[u32(unconst_u32(63))];
+  var vf188: i32 = dot4I8Packed(u32(unconst_u32(18)), u32(unconst_u32(105)));
+  let ptr39: ptr<workgroup, atomic<i32>> = &(*ptr38).f0;
+  atomicCompareExchangeWeak(&vw13.f0, unconst_i32(42), unconst_i32(78));
+  vf188 = bitcast<vec2i>((*&vw14)[unconst_i32(1)])[0];
+  let vf189: i32 = atomicExchange(&vw13.f0, i32(unconst_i32(-109)));
+  var vf190: bool = all(vec2<bool>(unconst_bool(false), unconst_bool(true)));
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout22 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 241,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 485,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16sint', access: 'write-only', viewDimension: '2d' },
+    },
+    {
+      binding: 76,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 124,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let commandEncoder180 = device0.createCommandEncoder({});
+let texture202 = device0.createTexture({
+  size: {width: 8, height: 5, depthOrArrayLayers: 1},
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView180 = texture137.createView({label: '\u00f3\u17a4'});
+try {
+computePassEncoder75.setBindGroup(1, bindGroup53, new Uint32Array(4849), 1_082, 0);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(2, bindGroup29, new Uint32Array(4863), 267, 0);
+} catch {}
+try {
+renderPassEncoder48.executeBundles([renderBundle27, renderBundle9, renderBundle28, renderBundle2, renderBundle2, renderBundle5, renderBundle7, renderBundle15, renderBundle27, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder180.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2212 */
+  offset: 2212,
+  bytesPerRow: 6144,
+  buffer: buffer120,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder55.insertDebugMarker('\u0dc3');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture108,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(10).fill(143), /* required buffer size: 10 */
+{offset: 10}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+offscreenCanvas2.getContext('webgl2');
+} catch {}
+let textureView181 = texture202.createView({mipLevelCount: 1});
+let texture203 = device0.createTexture({size: [16], mipLevelCount: 1, dimension: '1d', format: 'r8uint', usage: GPUTextureUsage.COPY_SRC});
+let textureView182 = texture176.createView({dimension: 'cube-array', mipLevelCount: 1, baseArrayLayer: 0, arrayLayerCount: 6});
+try {
+computePassEncoder2.setBindGroup(1, bindGroup88);
+} catch {}
+try {
+commandEncoder180.resolveQuerySet(querySet9, 4, 1, buffer88, 768);
+} catch {}
+try {
+globalThis.someLabel = externalTexture29.label;
+} catch {}
+let bindGroup103 = device0.createBindGroup({
+  layout: bindGroupLayout8,
+  entries: [{binding: 340, resource: textureView61}, {binding: 271, resource: textureView75}],
+});
+let commandEncoder181 = device0.createCommandEncoder({});
+let computePassEncoder124 = commandEncoder181.beginComputePass({});
+let sampler115 = device0.createSampler({
+  addressModeU: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 71.98,
+  compare: 'always',
+  maxAnisotropy: 14,
+});
+try {
+renderPassEncoder28.setBindGroup(2, bindGroup96, new Uint32Array(6396), 470, 0);
+} catch {}
+try {
+renderPassEncoder10.beginOcclusionQuery(1);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(4, buffer117, 556, 575);
+} catch {}
+try {
+commandEncoder180.copyBufferToTexture({
+  /* bytesInLastRow: 13 widthInBlocks: 13 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 342 */
+  offset: 342,
+  buffer: buffer0,
+}, {
+  texture: texture164,
+  mipLevel: 0,
+  origin: {x: 107, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 13, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder180.copyTextureToTexture({
+  texture: texture203,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture149,
+  mipLevel: 1,
+  origin: {x: 63, y: 7, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder182 = device0.createCommandEncoder({label: '\u3052\uf67d\u0113\u{1f7b6}\uf050\u03d5\ub13c\u7550'});
+let texture204 = device0.createTexture({
+  size: [4, 2, 1],
+  sampleCount: 1,
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture205 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 15},
+  mipLevelCount: 4,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder125 = commandEncoder180.beginComputePass({label: '\u{1fec6}\u{1f863}\u081e\u381b\u0f17'});
+let sampler116 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 56.96,
+  lodMaxClamp: 82.79,
+});
+try {
+computePassEncoder105.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder59.setVertexBuffer(2, buffer114);
+} catch {}
+try {
+commandEncoder182.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 648 */
+  offset: 648,
+  buffer: buffer5,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder182.resolveQuerySet(querySet27, 926, 87, buffer106, 0);
+} catch {}
+let bindGroup104 = device0.createBindGroup({
+  layout: bindGroupLayout9,
+  entries: [{binding: 114, resource: {buffer: buffer28, offset: 256, size: 1444}}],
+});
+let textureView183 = texture3.createView({dimension: 'cube-array', baseArrayLayer: 1, arrayLayerCount: 6});
+let computePassEncoder126 = commandEncoder182.beginComputePass();
+try {
+renderPassEncoder51.executeBundles([renderBundle11, renderBundle16, renderBundle34]);
+} catch {}
+let sampler117 = device0.createSampler({
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 91.62,
+  lodMaxClamp: 91.97,
+  compare: 'equal',
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder110); computePassEncoder110.dispatchWorkgroupsIndirect(buffer42, 2_288); };
+} catch {}
+try {
+computePassEncoder110.end();
+} catch {}
+try {
+renderPassEncoder18.beginOcclusionQuery(10);
+} catch {}
+try {
+renderPassEncoder69.setPipeline(pipeline6);
+} catch {}
+try {
+buffer18.unmap();
+} catch {}
+try {
+commandEncoder164.copyBufferToBuffer(buffer120, 608, buffer104, 912, 428);
+} catch {}
+try {
+commandEncoder164.copyTextureToBuffer({
+  texture: texture114,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1223 */
+  offset: 1223,
+  buffer: buffer26,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder164.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 54, y: 1, z: 57},
+  aspect: 'all',
+},
+{
+  texture: texture180,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder164.clearBuffer(buffer106);
+} catch {}
+let pipelineLayout18 = device0.createPipelineLayout({label: '\u0995\u1bdd', bindGroupLayouts: []});
+let commandEncoder183 = device0.createCommandEncoder({});
+let querySet29 = device0.createQuerySet({type: 'occlusion', count: 82});
+let textureView184 = texture75.createView({baseMipLevel: 0});
+let computePassEncoder127 = commandEncoder164.beginComputePass();
+let sampler118 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 78.01,
+});
+try {
+computePassEncoder124.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder63.setBindGroup(0, bindGroup52);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(3, bindGroup86, new Uint32Array(1890), 618, 0);
+} catch {}
+try {
+renderPassEncoder57.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let videoFrame38 = new VideoFrame(offscreenCanvas0, {timestamp: 0});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup92);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderPassEncoder59.setBindGroup(1, bindGroup53, new Uint32Array(1512), 123, 0);
+} catch {}
+try {
+renderPassEncoder64.beginOcclusionQuery(2);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer24, 'uint32', 872, 4_574);
+} catch {}
+try {
+renderPassEncoder40.setPipeline(pipeline5);
+} catch {}
+await gc();
+let commandEncoder184 = device0.createCommandEncoder({});
+let renderPassEncoder71 = commandEncoder183.beginRenderPass({
+  colorAttachments: [{
+  view: textureView144,
+  clearValue: { r: 467.8, g: 919.9, b: 669.4, a: 679.4, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet25,
+});
+try {
+computePassEncoder112.setBindGroup(0, bindGroup5, new Uint32Array(4914), 691, 0);
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder51.setVertexBuffer(5, undefined, 0, 69_683_133);
+} catch {}
+try {
+commandEncoder184.resolveQuerySet(querySet12, 208, 71, buffer1, 1024);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 256, depthOrArrayLayers: 150}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 1, y: 2 },
+  flipY: true,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 10, y: 33, z: 127},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 24, height: 13, depthOrArrayLayers: 0});
+} catch {}
+let textureView185 = texture97.createView({});
+let computePassEncoder128 = commandEncoder184.beginComputePass({label: '\ub3b7\ubc2c\u3297\u{1f6ed}\u0a1f\u{1f8b3}\u{1fde2}'});
+try {
+computePassEncoder121.setBindGroup(3, bindGroup73, []);
+} catch {}
+try {
+computePassEncoder93.setBindGroup(0, bindGroup95, new Uint32Array(581), 400, 0);
+} catch {}
+try {
+computePassEncoder121.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder60.setBindGroup(2, bindGroup38);
+} catch {}
+try {
+renderPassEncoder61.setBindGroup(3, bindGroup85, new Uint32Array(613), 147, 0);
+} catch {}
+try {
+renderPassEncoder51.setPipeline(pipeline0);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer88, 860, new Float32Array(30737), 4198, 136);
+} catch {}
+let commandEncoder185 = device0.createCommandEncoder({});
+let computePassEncoder129 = commandEncoder185.beginComputePass();
+try {
+computePassEncoder96.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+renderPassEncoder51.setIndexBuffer(buffer6, 'uint16', 1_238, 1_713);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let shaderModule8 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(296) var et6: texture_external;
+
+@group(0) @binding(460) var tex6: texture_2d_array<f32>;
+
+struct T0 {
+  f0: array<array<vec2u, 1>, 1>,
+  @align(8) f1: array<array<array<f32, 1>, 2>, 1>,
+  @size(256) f2: mat3x4f,
+  @size(8) f3: f32,
+  @size(64) f4: vec4i,
+  @align(8) @size(248) f5: array<array<array<vec2h, 1>, 38>, 1>,
+}
+
+struct T1 {
+  @size(160) f0: mat3x3f,
+  @align(8) @size(176) f1: array<u32>,
+}
+
+struct FragmentOutput5 {
+  @location(1) f0: vec2i,
+  @location(0) f1: vec4f,
+  @location(4) f2: vec4i,
+}
+
+alias vec3b = vec3<bool>;
+
+@id(37891) override override0 = true;
+
+@vertex
+fn vertex6(@location(1) @interpolate(flat, center) a0: f16) -> @builtin(position) vec4f {
+  var out: vec4f;
+  out = textureLoad(tex6, vec2i(unconst_i32(457), unconst_i32(36)), select(vec3i(unconst_i32(556), unconst_i32(123), unconst_i32(670)), vec3i(unconst_i32(38), unconst_i32(196), unconst_i32(-125)), vec3<bool>(unconst_bool(false), unconst_bool(false), unconst_bool(false))).y, i32(unconst_i32(6)));
+  let vf191: vec2u = textureDimensions(tex6);
+  var vf192: u32 = textureNumLevels(tex6);
+  let vf193: vec2u = textureDimensions(tex6, i32(unconst_i32(267)));
+  let vf194: bool = any(vec3<bool>(unconst_bool(false), unconst_bool(false), unconst_bool(false)));
+  var vf195: vec2u = vf193;
+  vf195 |= textureDimensions(tex6);
+  out *= vec4f(reverseBits(vec2i(unconst_i32(87), unconst_i32(1))).yyyy);
+  vf192 = vf193[u32(unconst_u32(58))];
+  let vf196: u32 = vf195[u32(unconst_u32(30))];
+  out += fma(vec3f(unconst_f32(0.1573), unconst_f32(0.04549), unconst_f32(0.1950)), vec3f(unconst_f32(0.05163), unconst_f32(0.1024), unconst_f32(0.07212)), vec3f(unconst_f32(0.06405), unconst_f32(-0.3736), unconst_f32(0.1043))).grrr;
+  vf195 &= vec2u(u32(dot4I8Packed(u32(unconst_u32(242)), u32(unconst_u32(152)))));
+  vf195 = bitcast<vec2u>(fma(vec3f(unconst_f32(0.1281), unconst_f32(0.3035), unconst_f32(0.1834)), vec3f(faceForward(vec3h(unconst_f16(9455.5), unconst_f16(3747.1), unconst_f16(4402.4)), vec3h(unconst_f16(1076.8), unconst_f16(2757.6), unconst_f16(8860.4)), vec3h(unconst_f16(29873.2), unconst_f16(1607.8), unconst_f16(-13377.5)))), vec3f(unconst_f32(0.06399), unconst_f32(-0.1850), unconst_f32(0.1778))).bb);
+  var vf197: i32 = dot4I8Packed(u32(unconst_u32(102)), u32(unconst_u32(329)));
+  let vf198: f16 = smoothstep(f16(unconst_f16(4254.6)), f16(unconst_f16(22912.6)), f16(unconst_f16(-964.0)));
+  out = vec4f(f32(vf198));
+  var vf199: vec2h = cos(vec2h(unconst_f16(5465.0), unconst_f16(4108.9)));
+  var vf200: bool = any(bool(vf199[1]));
+  return out;
+}
+
+@fragment
+fn fragment7() -> FragmentOutput5 {
+  var out: FragmentOutput5;
+  out.f1 = unpack2x16unorm(u32(unconst_u32(297))).xxyy;
+  out.f2 = bitcast<vec4i>(countTrailingZeros(vec4u(unconst_u32(84), unconst_u32(43), unconst_u32(208), unconst_u32(136))));
+  var vf201: vec2u = textureDimensions(et6);
+  let vf202: vec4h = exp2(vec4h(unconst_f16(1451.4), unconst_f16(2610.0), unconst_f16(145.0), unconst_f16(17715.0)));
+  var vf203: vec2f = unpack2x16float(u32(unconst_u32(26)));
+  var vf204: vec2u = textureDimensions(et6);
+  vf204 = unpack4xU8(u32(unconst_u32(35))).rr;
+  var vf205: vec4f = textureLoad(tex6, vec2i(unconst_i32(103), unconst_i32(179)), i32(unconst_i32(105)), i32(unconst_i32(-5)));
+  let vf206: u32 = pack4xI8(vec4i(unconst_i32(105), unconst_i32(149), unconst_i32(162), unconst_i32(164)));
+  var vf207: vec3h = atan2(vec3h(unconst_f16(8052.1), unconst_f16(4377.3), unconst_f16(27795.2)), vec3h(unconst_f16(21174.5), unconst_f16(13196.9), unconst_f16(23618.9)));
+  out.f2 -= bitcast<vec4i>(mix(vec4f(unconst_f32(-0.00716), unconst_f32(0.2484), unconst_f32(0.4096), unconst_f32(0.2677)), vec4f(unconst_f32(0.1730), unconst_f32(0.2998), unconst_f32(0.1799), unconst_f32(0.01196)), vec4f(unconst_f32(0.4835), unconst_f32(0.1474), unconst_f32(0.1132), unconst_f32(0.5214))));
+  out.f0 &= vec2i(i32(saturate(f16(unconst_f16(11138.1)))));
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute5(@builtin(global_invocation_id) a0: vec3u) {
+  var vf208: vec4f = tan(vec4f(unconst_f32(0.03372), unconst_f32(0.03282), unconst_f32(0.07238), unconst_f32(0.09580)));
+  vf208 = vec4f(asinh(vec2h(unconst_f16(5596.9), unconst_f16(-3925.6))).rrrr);
+  var vf209: u32 = a0[u32(unconst_u32(85))];
+  let vf210: u32 = pack2x16snorm(vec2f(unconst_f32(0.03026), unconst_f32(0.1895)));
+  vf208 -= inverseSqrt(vec3f(unconst_f32(0.09922), unconst_f32(0.01163), unconst_f32(0.01101))).zxzz;
+  vf208 += unpack4x8snorm(firstLeadingBit(u32(unconst_u32(64))));
+  vf208 -= vec4f(step(f32(unconst_f32(0.1300)), f32(unconst_f32(0.3605))));
+  vf209 ^= bitcast<vec3u>(degrees(vec3f(unconst_f32(0.1487), unconst_f32(0.04366), unconst_f32(0.2520))))[1];
+  let vf211: u32 = pack4xU8Clamp(vec4u(unconst_u32(57), unconst_u32(64), unconst_u32(333), unconst_u32(441)));
+  vf208 = vec4f(f32(override0));
+  vf209 &= u32(max(vec3i(unconst_i32(31), unconst_i32(101), unconst_i32(101)), vec3i(unconst_i32(-322), unconst_i32(58), unconst_i32(517)))[0]);
+  let vf212: vec2h = asinh(vec2h(unconst_f16(2752.3), unconst_f16(4004.9)));
+  var vf213: vec4f = tan(vec4f(unconst_f32(0.03597), unconst_f32(0.4683), unconst_f32(0.1085), unconst_f32(-0.3443)));
+  var vf214: f32 = step(f32(unconst_f32(0.03900)), f32(unconst_f32(0.07365)));
+  vf214 -= vf208[1];
+  let vf215: u32 = pack4xI8Clamp(vec4i(unconst_i32(217), unconst_i32(85), unconst_i32(-83), unconst_i32(44)));
+  vf209 = u32(vf213[u32(unconst_u32(283))]);
+  var vf216: vec2h = asinh(vec2h(unconst_f16(41099.0), unconst_f16(56888.1)));
+  let ptr40: ptr<function, f32> = &vf214;
+  vf208 *= cross(vec3f(unconst_f32(0.1131), unconst_f32(0.1391), unconst_f32(0.00067)), vec3f(unconst_f32(-0.5279), unconst_f32(0.00307), unconst_f32(0.04459))).gbgr;
+  vf208 = vec4f(degrees(vec3h(unconst_f16(8888.0), unconst_f16(11133.9), unconst_f16(92.38))).xxzy);
+  var vf217: f32 = vf213[u32(unconst_u32(106))];
+  var vf218: vec3h = fma(vec3h(unconst_f16(1544.2), unconst_f16(20896.1), unconst_f16(5877.0)), vec3h(unconst_f16(3661.0), unconst_f16(19235.0), unconst_f16(1861.9)), vec3h(unconst_f16(1837.6), unconst_f16(14119.8), unconst_f16(12767.5)));
+  vf209 -= bitcast<vec4u>(vf208)[0];
+  _ = override0;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup105 = device0.createBindGroup({
+  layout: bindGroupLayout16,
+  entries: [
+    {binding: 128, resource: textureView112},
+    {binding: 38, resource: textureView122},
+    {binding: 301, resource: {buffer: buffer24, offset: 512, size: 2820}},
+    {binding: 15, resource: {buffer: buffer106, offset: 3072}},
+    {binding: 24, resource: textureView56},
+    {binding: 141, resource: textureView38},
+  ],
+});
+let buffer123 = device0.createBuffer({size: 32252, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let commandEncoder186 = device0.createCommandEncoder({});
+try {
+computePassEncoder90.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(3, bindGroup17);
+} catch {}
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle13]);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer76, 'uint16', 202, 108);
+} catch {}
+try {
+commandEncoder186.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 50 */
+  offset: 50,
+  rowsPerImage: 380,
+  buffer: buffer72,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+try {
+renderPassEncoder21.setVertexBuffer(2, buffer73, 0, 49);
+} catch {}
+try {
+commandEncoder186.copyTextureToTexture({
+  texture: texture152,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture152,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 8, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder41.insertDebugMarker('\u02eb');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer90, 11192, new Float32Array(1735), 527, 160);
+} catch {}
+let buffer124 = device0.createBuffer({size: 3147, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+let sampler119 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 45.30,
+  lodMaxClamp: 66.75,
+});
+try {
+renderPassEncoder53.setBindGroup(3, bindGroup87);
+} catch {}
+try {
+renderPassEncoder64.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder37.executeBundles([renderBundle18]);
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer20, 'uint32', 5_544, 2_169);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(4, buffer80);
+} catch {}
+try {
+  await buffer46.mapAsync(GPUMapMode.WRITE, 0, 244);
+} catch {}
+let texture206 = device0.createTexture({size: [8], dimension: '1d', format: 'r16sint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let computePassEncoder130 = commandEncoder186.beginComputePass({});
+try {
+computePassEncoder31.setBindGroup(3, bindGroup24, new Uint32Array(1216), 48, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder112); computePassEncoder112.dispatchWorkgroupsIndirect(buffer50, 188); };
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer110, 'uint16', 0, 229);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(5, buffer76, 0, 33);
+} catch {}
+try {
+computePassEncoder113.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder24.setViewport(13.378794752949998, 4.4478143740670895, 0.28766194106757625, 2.922229553735985, 0.3578012753896991, 0.8769960262608899);
+} catch {}
+try {
+  await buffer31.mapAsync(GPUMapMode.READ, 1888, 2952);
+} catch {}
+let texture207 = device0.createTexture({
+  label: '\u0d19\u0cce\u5dd0\u26e4',
+  size: {width: 8, height: 5, depthOrArrayLayers: 1},
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView186 = texture79.createView({baseMipLevel: 0});
+let renderBundleEncoder35 = device0.createRenderBundleEncoder({colorFormats: ['r8uint'], stencilReadOnly: true});
+let sampler120 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 24.67,
+  lodMaxClamp: 51.80,
+});
+try {
+computePassEncoder126.setBindGroup(2, bindGroup87);
+} catch {}
+try {
+computePassEncoder36.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(2, bindGroup56, new Uint32Array(3383), 51, 0);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(1, bindGroup45, new Uint32Array(727), 96, 0);
+} catch {}
+try {
+renderBundleEncoder35.setIndexBuffer(buffer26, 'uint32', 564, 619);
+} catch {}
+let imageData20 = new ImageData(92, 96);
+let commandEncoder187 = device0.createCommandEncoder({});
+let computePassEncoder131 = commandEncoder187.beginComputePass({label: '\u0692\ud411'});
+try {
+computePassEncoder98.setBindGroup(3, bindGroup29, new Uint32Array(2807), 20, 0);
+} catch {}
+try {
+computePassEncoder47.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder66.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(6, buffer111, 0, 169);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(2, bindGroup45);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(2, bindGroup46, new Uint32Array(696), 15, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 0, y: 36, z: 0},
+  aspect: 'all',
+}, new Uint8Array(116).fill(184), /* required buffer size: 116 */
+{offset: 116}, {width: 256, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let videoFrame39 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'bt470bg', transfer: 'unspecified'} });
+let sampler121 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 63.46,
+  lodMaxClamp: 96.97,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder41); computePassEncoder41.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder89.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder118.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup3, new Uint32Array(2864), 1_460, 0);
+} catch {}
+try {
+renderPassEncoder68.setIndexBuffer(buffer33, 'uint16', 324, 1_021);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let buffer125 = device0.createBuffer({
+  size: 190,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder188 = device0.createCommandEncoder({});
+let sampler122 = device0.createSampler({
+  label: '\u43ef\uac03\uf1cc\u0ff9',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 56.40,
+  lodMaxClamp: 77.60,
+});
+try {
+renderPassEncoder71.setBindGroup(3, bindGroup104);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(3, bindGroup102, new Uint32Array(3222), 158, 0);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(0, buffer49, 8_380);
+} catch {}
+try {
+commandEncoder188.copyBufferToBuffer(buffer59, 3500, buffer33, 756, 316);
+} catch {}
+let buffer126 = device0.createBuffer({
+  size: 785,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let querySet30 = device0.createQuerySet({type: 'occlusion', count: 600});
+try {
+computePassEncoder18.setBindGroup(1, bindGroup59);
+} catch {}
+try {
+renderPassEncoder57.setIndexBuffer(buffer5, 'uint32', 2_196, 206);
+} catch {}
+try {
+renderBundleEncoder35.setIndexBuffer(buffer32, 'uint32', 400, 3_754);
+} catch {}
+let arrayBuffer16 = buffer8.getMappedRange(4576, 28);
+try {
+commandEncoder188.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1644 */
+  offset: 1644,
+  bytesPerRow: 15616,
+  buffer: buffer65,
+}, {
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder188.copyTextureToBuffer({
+  texture: texture119,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 49 */
+  offset: 49,
+  buffer: buffer84,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder188.copyTextureToTexture({
+  texture: texture62,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture76,
+  mipLevel: 0,
+  origin: {x: 70, y: 25, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView187 = texture202.createView({});
+let texture208 = device0.createTexture({
+  size: {width: 16, height: 10, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let texture209 = gpuCanvasContext0.getCurrentTexture();
+let computePassEncoder132 = commandEncoder188.beginComputePass({label: '\u{1f79e}\u07d1\u2af2\u01fa\u9954'});
+try {
+{ clearResourceUsages(device0, computePassEncoder41); computePassEncoder41.dispatchWorkgroups(2); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder112); computePassEncoder112.dispatchWorkgroupsIndirect(buffer57, 8); };
+} catch {}
+try {
+renderPassEncoder56.setBindGroup(1, bindGroup43, []);
+} catch {}
+try {
+renderPassEncoder71.executeBundles([renderBundle34, renderBundle10, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer116, 'uint16', 426, 145);
+} catch {}
+try {
+renderPassEncoder67.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(2, bindGroup26, new Uint32Array(3050), 299, 0);
+} catch {}
+try {
+renderBundleEncoder35.setIndexBuffer(buffer89, 'uint16', 114, 168);
+} catch {}
+try {
+renderBundleEncoder35.setVertexBuffer(7, buffer93, 36, 125);
+} catch {}
+let pipeline7 = device0.createComputePipeline({layout: pipelineLayout6, compute: {module: shaderModule8, entryPoint: 'compute5'}});
+let renderBundle35 = renderBundleEncoder35.finish({});
+let sampler123 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 30.72,
+  lodMaxClamp: 83.80,
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder36.setBindGroup(2, bindGroup33);
+} catch {}
+try {
+computePassEncoder41.end();
+} catch {}
+try {
+renderPassEncoder17.setViewport(1.7815230664752506, 0.5172884705398698, 0.0877973206381641, 0.3311513219862925, 0.6484527336583477, 0.7613502876073083);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(4, buffer107, 52);
+} catch {}
+try {
+commandEncoder62.copyBufferToBuffer(buffer106, 9652, buffer67, 2112, 3428);
+} catch {}
+try {
+commandEncoder62.copyBufferToTexture({
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 480 */
+  offset: 480,
+  buffer: buffer99,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder22.insertDebugMarker('\u{1ff04}');
+} catch {}
+let buffer127 = device0.createBuffer({
+  label: '\u03bb\u1211\u{1f84f}\u89bc\u115b',
+  size: 2291,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let textureView188 = texture129.createView({dimension: '2d-array', arrayLayerCount: 1});
+let renderPassEncoder72 = commandEncoder62.beginRenderPass({
+  colorAttachments: [{
+  view: textureView39,
+  clearValue: { r: -495.9, g: -871.1, b: 467.9, a: -857.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder96.setBindGroup(2, bindGroup38);
+} catch {}
+try {
+computePassEncoder22.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder59.beginOcclusionQuery(6);
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(7, buffer53, 748);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 1296, new DataView(new ArrayBuffer(9329)), 883, 2168);
+} catch {}
+document.body.prepend(canvas0);
+let buffer128 = device0.createBuffer({
+  size: 34090,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let sampler124 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 47.85,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder99.setBindGroup(3, bindGroup14, []);
+} catch {}
+try {
+computePassEncoder40.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(162);
+} catch {}
+try {
+renderPassEncoder56.executeBundles([renderBundle9, renderBundle15, renderBundle28, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline0);
+} catch {}
+let arrayBuffer17 = buffer41.getMappedRange(392, 0);
+let bindGroupLayout23 = device0.createBindGroupLayout({entries: [{binding: 175, visibility: GPUShaderStage.COMPUTE, externalTexture: {}}]});
+let buffer129 = device0.createBuffer({size: 4002, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT});
+let commandEncoder189 = device0.createCommandEncoder({label: '\uda3f\uc1d2\u530f\uc8d9\u{1fe41}\u{1fb5a}\uf5a3\u7292\u0466\u087b'});
+let renderBundleEncoder36 = device0.createRenderBundleEncoder({colorFormats: ['r16sint']});
+let externalTexture32 = device0.importExternalTexture({label: '\u{1ff8f}\u2af3\u{1ffd0}\u0b62\u{1f762}\u0378', source: videoFrame7});
+try {
+renderPassEncoder54.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder189.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3216 */
+  offset: 3216,
+  buffer: buffer30,
+}, {
+  texture: texture134,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder189.copyTextureToTexture({
+  texture: texture145,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let texture210 = device0.createTexture({
+  size: {width: 16, height: 10, depthOrArrayLayers: 1},
+  format: 'r16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder103.setBindGroup(1, bindGroup21, new Uint32Array(6256), 1_322, 0);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer80, 'uint32', 0, 8);
+} catch {}
+try {
+renderPassEncoder54.setPipeline(pipeline5);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder190 = device0.createCommandEncoder({});
+let texture211 = device0.createTexture({
+  size: [4, 2, 1],
+  format: 'r32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture212 = device0.createTexture({
+  size: {width: 8, height: 5, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder133 = commandEncoder189.beginComputePass({});
+let renderPassEncoder73 = commandEncoder190.beginRenderPass({
+  colorAttachments: [{
+  view: textureView20,
+  clearValue: { r: 904.9, g: -518.0, b: -462.8, a: 131.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet28,
+});
+let sampler125 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 25.56,
+});
+try {
+computePassEncoder101.setBindGroup(2, bindGroup78, []);
+} catch {}
+try {
+computePassEncoder98.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder47.setBindGroup(2, bindGroup55);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer106, 'uint16', 3_350, 2_067);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(43).fill(134), /* required buffer size: 43 */
+{offset: 43}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+textureView9.label = '\uc3e3\u0a63\u03a9\u8b6f\u68af';
+} catch {}
+let sampler126 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 37.11,
+  lodMaxClamp: 72.10,
+});
+try {
+computePassEncoder96.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(2, buffer82, 0, 1_106);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(3, bindGroup66);
+} catch {}
+try {
+computePassEncoder106.insertDebugMarker('\u0d89');
+} catch {}
+let bindGroup106 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 33, resource: textureView38},
+    {binding: 487, resource: sampler12},
+    {binding: 143, resource: textureView30},
+  ],
+});
+let textureView189 = texture128.createView({baseMipLevel: 0});
+let textureView190 = texture12.createView({dimension: '2d-array'});
+try {
+renderPassEncoder36.setVertexBuffer(4, buffer119, 352, 846);
+} catch {}
+let bindGroup107 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [{binding: 5, resource: textureView159}, {binding: 146, resource: textureView18}],
+});
+let commandEncoder191 = device0.createCommandEncoder({});
+let textureView191 = texture29.createView({});
+let renderPassEncoder74 = commandEncoder191.beginRenderPass({
+  colorAttachments: [{
+  view: textureView44,
+  clearValue: { r: 930.2, g: -664.1, b: 30.75, a: 206.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder75.setBindGroup(3, bindGroup94, new Uint32Array(1766), 34, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder112); computePassEncoder112.dispatchWorkgroupsIndirect(buffer83, 144); };
+} catch {}
+try {
+computePassEncoder120.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder72.setBlendConstant({ r: -619.5, g: -766.8, b: 871.9, a: 755.5, });
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer100, 'uint32', 5_364, 233);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(3, buffer68);
+} catch {}
+try {
+buffer37.unmap();
+} catch {}
+try {
+  await buffer112.mapAsync(GPUMapMode.READ, 9080, 2204);
+} catch {}
+let bindGroup108 = device0.createBindGroup({
+  layout: bindGroupLayout8,
+  entries: [{binding: 271, resource: textureView69}, {binding: 340, resource: textureView38}],
+});
+try {
+computePassEncoder125.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder45.setBindGroup(1, bindGroup84);
+} catch {}
+try {
+renderPassEncoder65.beginOcclusionQuery(25);
+} catch {}
+try {
+renderPassEncoder64.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder66.setVertexBuffer(0, buffer123, 480, 1_311);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer24, 'uint16', 1_574, 1_476);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(4, buffer60, 96, 96);
+} catch {}
+try {
+buffer70.unmap();
+} catch {}
+let bindGroup109 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 7, resource: {buffer: buffer57, offset: 0, size: 100}}],
+});
+let commandEncoder192 = device0.createCommandEncoder({label: '\u14e1\uadee\ua535\u143e\u0c91\u0458\u1f92\u04ba\uffb9\u55b7'});
+let texture213 = device0.createTexture({
+  label: '\u08ef\u{1fef6}\ud82e\ue5f2\udd45\u26ae',
+  size: {width: 256, height: 256, depthOrArrayLayers: 15},
+  sampleCount: 1,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder134 = commandEncoder192.beginComputePass();
+try {
+computePassEncoder134.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder58.setBindGroup(0, bindGroup6, new Uint32Array(1926), 200, 0);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(3, bindGroup34, new Uint32Array(579), 60, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder87.setBindGroup(2, bindGroup61);
+} catch {}
+try {
+renderPassEncoder71.setVertexBuffer(7, buffer12);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer6, 'uint16', 3_632, 1_052);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(0, buffer89);
+} catch {}
+document.body.prepend(img0);
+let textureView192 = texture2.createView({});
+try {
+computePassEncoder106.setBindGroup(1, bindGroup57);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder112); computePassEncoder112.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder127.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder43.setIndexBuffer(buffer5, 'uint16', 2_208, 2_551);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer6, 'uint32', 844, 1_195);
+} catch {}
+try {
+  await buffer87.mapAsync(GPUMapMode.WRITE, 432, 1088);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let bindGroupLayout24 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 468,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 172,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let commandEncoder193 = device0.createCommandEncoder({});
+let textureView193 = texture145.createView({baseMipLevel: 0, baseArrayLayer: 0});
+let computePassEncoder135 = commandEncoder193.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder112); computePassEncoder112.dispatchWorkgroupsIndirect(buffer71, 280); };
+} catch {}
+try {
+computePassEncoder126.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(2, bindGroup79);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+try {
+if (!arrayBuffer15.detached) { new Uint8Array(arrayBuffer15).fill(0x55); };
+} catch {}
+await gc();
+let imageData21 = new ImageData(28, 40);
+let bindGroup110 = device0.createBindGroup({layout: bindGroupLayout20, entries: [{binding: 557, resource: {buffer: buffer106, offset: 2304}}]});
+let texture214 = device0.createTexture({size: [8], dimension: '1d', format: 'rgb10a2unorm', usage: GPUTextureUsage.COPY_DST});
+try {
+renderPassEncoder31.setIndexBuffer(buffer64, 'uint16', 130, 533);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(6, buffer82);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+await gc();
+let buffer130 = device0.createBuffer({size: 175, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+try {
+computePassEncoder95.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder54.setVertexBuffer(5, buffer53, 1_884, 2_904);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(1, bindGroup107, new Uint32Array(470), 0, 0);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer29, 'uint16', 1_022, 108);
+} catch {}
+let renderBundleEncoder37 = device0.createRenderBundleEncoder({colorFormats: ['r8uint'], depthReadOnly: true});
+try {
+{ clearResourceUsages(device0, computePassEncoder112); computePassEncoder112.dispatchWorkgroupsIndirect(buffer81, 4_272); };
+} catch {}
+try {
+computePassEncoder107.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(0, bindGroup24);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(2, bindGroup73, new Uint32Array(208), 12, 0);
+} catch {}
+let commandEncoder194 = device0.createCommandEncoder();
+let texture215 = device0.createTexture({
+  size: [256, 256, 15],
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView194 = texture11.createView({label: '\u{1fe29}\u{1f704}', dimension: '2d-array', aspect: 'all', mipLevelCount: 1});
+let renderPassEncoder75 = commandEncoder194.beginRenderPass({
+  colorAttachments: [{
+  view: textureView164,
+  clearValue: { r: 200.3, g: -994.1, b: -359.4, a: 820.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet4,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder112); computePassEncoder112.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer120, 'uint32', 132, 129);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer88, 'uint16', 828, 212);
+} catch {}
+try {
+renderBundleEncoder36.insertDebugMarker('\ua9a0');
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let canvas4 = document.createElement('canvas');
+let textureView195 = texture131.createView({dimension: '2d-array'});
+let sampler127 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 42.60,
+  lodMaxClamp: 52.45,
+  maxAnisotropy: 12,
+});
+let externalTexture33 = device0.importExternalTexture({source: videoFrame8, colorSpace: 'display-p3'});
+try {
+computePassEncoder34.setBindGroup(1, bindGroup94, []);
+} catch {}
+try {
+computePassEncoder128.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder18.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder63.setIndexBuffer(buffer29, 'uint16', 322, 572);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer62, 684, new BigUint64Array(18924), 1978, 328);
+} catch {}
+let texture216 = device0.createTexture({
+  size: {width: 30, height: 30, depthOrArrayLayers: 1},
+  format: 'astc-10x5-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let renderBundle36 = renderBundleEncoder37.finish({});
+try {
+computePassEncoder105.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+computePassEncoder109.setBindGroup(3, bindGroup44, new Uint32Array(1179), 75, 0);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer22, 'uint32', 4, 337);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(1, bindGroup7, new Uint32Array(421), 33, 0);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let externalTexture34 = device0.importExternalTexture({source: videoFrame8});
+try {
+computePassEncoder120.setBindGroup(1, bindGroup47, new Uint32Array(5620), 1_255, 0);
+} catch {}
+try {
+computePassEncoder60.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+renderPassEncoder59.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(0, bindGroup92, new Uint32Array(3543), 64, 0);
+} catch {}
+try {
+computePassEncoder82.pushDebugGroup('\u0018');
+} catch {}
+try {
+renderPassEncoder44.insertDebugMarker('\ueadc');
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let gpuCanvasContext5 = canvas4.getContext('webgpu');
+let commandEncoder195 = device0.createCommandEncoder({});
+let texture217 = device0.createTexture({size: [8, 5, 1], mipLevelCount: 2, format: 'r16float', usage: GPUTextureUsage.TEXTURE_BINDING});
+let computePassEncoder136 = commandEncoder195.beginComputePass({});
+let renderBundle37 = renderBundleEncoder36.finish();
+try {
+renderPassEncoder38.setViewport(0.08252549183864932, 1.113528654764835, 3.7470416070979744, 0.7254680548991719, 0.7310794774986532, 0.9993881800722924);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(2, buffer20, 2_528);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture121,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(69).fill(255), /* required buffer size: 69 */
+{offset: 69, rowsPerImage: 11}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 10, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame38,
+  origin: { x: 59, y: 8 },
+  flipY: false,
+}, {
+  texture: texture150,
+  mipLevel: 0,
+  origin: {x: 4, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 2, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas3);
+let buffer131 = device0.createBuffer({label: '\ucde4\u{1f781}\u2eb8\u6820\u0869', size: 1838, usage: GPUBufferUsage.COPY_DST});
+let commandEncoder196 = device0.createCommandEncoder({label: '\u0ab8\u7847'});
+let textureView196 = texture129.createView({});
+let sampler128 = device0.createSampler({
+  label: '\u7282\ua9d4\ua8ab\u0d0d\u69f2\u0708\u07d5\u{1f71e}\u03bc\u{1fe7e}',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 29.67,
+  lodMaxClamp: 81.32,
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder29.setBindGroup(0, bindGroup47);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder112); computePassEncoder112.dispatchWorkgroups(1, 2, 1); };
+} catch {}
+try {
+computePassEncoder109.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer127, 716, new BigUint64Array(5379), 707, 8);
+} catch {}
+let sampler129 = device0.createSampler({
+  label: '\u0ec7\u694c',
+  addressModeU: 'clamp-to-edge',
+  magFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 86.15,
+  lodMaxClamp: 89.42,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder65.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder57.executeBundles([renderBundle28, renderBundle27, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder196.copyBufferToBuffer(buffer94, 692, buffer49, 6260, 124);
+} catch {}
+await gc();
+let texture218 = device0.createTexture({size: {width: 256}, dimension: '1d', format: 'r16float', usage: GPUTextureUsage.TEXTURE_BINDING});
+try {
+computePassEncoder121.setBindGroup(2, bindGroup27, new Uint32Array(1428), 278, 0);
+} catch {}
+try {
+computePassEncoder112.end();
+} catch {}
+try {
+renderPassEncoder69.setIndexBuffer(buffer20, 'uint32', 3_572, 11_745);
+} catch {}
+try {
+commandEncoder196.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1969 */
+  offset: 1969,
+  bytesPerRow: 8448,
+  buffer: buffer117,
+}, {
+  texture: texture124,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+await gc();
+let videoFrame40 = videoFrame24.clone();
+let buffer132 = device0.createBuffer({
+  size: 12096,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder197 = device0.createCommandEncoder({label: '\u006b\u0f61\u420f'});
+let commandBuffer12 = commandEncoder168.finish();
+let renderBundleEncoder38 = device0.createRenderBundleEncoder({colorFormats: ['r8uint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder132.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder38.setBindGroup(2, bindGroup9, new Uint32Array(225), 68, 0);
+} catch {}
+try {
+renderBundleEncoder38.setVertexBuffer(1, buffer76, 64, 1_132);
+} catch {}
+try {
+commandEncoder196.copyBufferToBuffer(buffer127, 144, buffer108, 1184, 176);
+} catch {}
+let commandEncoder198 = device0.createCommandEncoder({});
+let renderPassEncoder76 = commandEncoder197.beginRenderPass({
+  colorAttachments: [{
+  view: textureView157,
+  clearValue: { r: -90.14, g: 274.7, b: 272.7, a: 739.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet19,
+});
+let renderBundle38 = renderBundleEncoder38.finish({});
+let sampler130 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 24.87,
+  lodMaxClamp: 65.88,
+});
+try {
+renderPassEncoder62.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(2, buffer110, 160);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let texture219 = device0.createTexture({
+  size: [2, 1, 1],
+  sampleCount: 4,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder39 = device0.createRenderBundleEncoder({colorFormats: ['r16float'], stencilReadOnly: true});
+try {
+computePassEncoder17.setBindGroup(3, bindGroup109, []);
+} catch {}
+try {
+computePassEncoder10.setBindGroup(1, bindGroup65, new Uint32Array(1594), 108, 0);
+} catch {}
+try {
+computePassEncoder123.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder47.setBindGroup(3, bindGroup79);
+} catch {}
+try {
+renderBundleEncoder39.setBindGroup(0, bindGroup96);
+} catch {}
+try {
+renderBundleEncoder39.setIndexBuffer(buffer6, 'uint32', 468, 5_823);
+} catch {}
+try {
+renderBundleEncoder39.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder39.setVertexBuffer(0, buffer116, 156, 1_136);
+} catch {}
+try {
+commandEncoder198.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 776 */
+  offset: 776,
+  buffer: buffer74,
+}, {
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder196.resolveQuerySet(querySet7, 10, 73, buffer32, 10240);
+} catch {}
+try {
+renderPassEncoder64.pushDebugGroup('\u0b2a');
+} catch {}
+try {
+device0.queue.submit([commandBuffer12]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 256, depthOrArrayLayers: 531}
+*/
+{
+  source: videoFrame19,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 28, y: 150, z: 73},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer133 = device0.createBuffer({
+  label: '\u0efd\u{1f98d}\u{1f72d}\u0564\u7207\u{1f859}\u0724\u0b5e\u{1fb8a}',
+  size: 20826,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder199 = device0.createCommandEncoder();
+let texture220 = device0.createTexture({
+  size: {width: 4, height: 2, depthOrArrayLayers: 1},
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder137 = commandEncoder199.beginComputePass({});
+let renderBundle39 = renderBundleEncoder39.finish({});
+try {
+computePassEncoder122.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(3, bindGroup77);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(1, bindGroup15, new Uint32Array(1679), 718, 0);
+} catch {}
+try {
+renderPassEncoder60.setIndexBuffer(buffer100, 'uint32', 6_200, 161);
+} catch {}
+let imageData22 = new ImageData(24, 36);
+let bindGroupLayout25 = device0.createBindGroupLayout({
+  entries: [{binding: 230, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}}],
+});
+let bindGroup111 = device0.createBindGroup({
+  layout: bindGroupLayout20,
+  entries: [{binding: 557, resource: {buffer: buffer130, offset: 0, size: 117}}],
+});
+let buffer134 = device0.createBuffer({
+  label: '\u5312\u635c',
+  size: 3199,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder200 = device0.createCommandEncoder({});
+try {
+computePassEncoder130.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(3, bindGroup77, new Uint32Array(2072), 135, 0);
+} catch {}
+try {
+renderPassEncoder48.setPipeline(pipeline6);
+} catch {}
+try {
+globalThis.someLabel = externalTexture25.label;
+} catch {}
+let bindGroup112 = device0.createBindGroup({
+  label: '\u0488\ufb4f\u4563\u2126',
+  layout: bindGroupLayout21,
+  entries: [{binding: 272, resource: textureView168}],
+});
+let textureView197 = texture5.createView({baseMipLevel: 0});
+let sampler131 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 62.89,
+  lodMaxClamp: 71.95,
+});
+let externalTexture35 = device0.importExternalTexture({source: videoFrame13});
+try {
+computePassEncoder126.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderPassEncoder31.setBlendConstant({ r: -285.6, g: -635.1, b: -836.1, a: 911.1, });
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer79, 'uint32', 980, 689);
+} catch {}
+try {
+renderPassEncoder74.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder200.copyBufferToBuffer(buffer26, 228, buffer7, 4744, 112);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView198 = texture147.createView({});
+let sampler132 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 1.470,
+  lodMaxClamp: 12.63,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder60.setBindGroup(0, bindGroup58);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let buffer135 = device0.createBuffer({
+  size: 14743,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let texture221 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 82},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder138 = commandEncoder198.beginComputePass({});
+let renderPassEncoder77 = commandEncoder196.beginRenderPass({
+  colorAttachments: [{
+  view: textureView55,
+  depthSlice: 7,
+  clearValue: { r: -484.5, g: -38.06, b: 128.6, a: -298.4, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let renderBundleEncoder40 = device0.createRenderBundleEncoder({colorFormats: ['r16float']});
+let sampler133 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  lodMinClamp: 9.890,
+  lodMaxClamp: 68.90,
+});
+try {
+renderPassEncoder54.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer115, 'uint16', 6_046, 1_588);
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(2, bindGroup79, new Uint32Array(1282), 330, 0);
+} catch {}
+try {
+renderBundleEncoder40.setIndexBuffer(buffer10, 'uint32', 44, 4_462);
+} catch {}
+try {
+renderBundleEncoder40.setPipeline(pipeline6);
+} catch {}
+let bindGroup113 = device0.createBindGroup({layout: bindGroupLayout10, entries: [{binding: 112, resource: textureView121}]});
+let buffer136 = device0.createBuffer({
+  label: '\u0569\u0034\u3077\u05b8\u0827',
+  size: 9530,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder201 = device0.createCommandEncoder({label: '\u106a\u{1f840}\u{1f8de}'});
+let textureView199 = texture116.createView({dimension: '2d'});
+let computePassEncoder139 = commandEncoder201.beginComputePass();
+try {
+computePassEncoder89.setBindGroup(1, bindGroup88);
+} catch {}
+try {
+renderPassEncoder76.setBindGroup(2, bindGroup91);
+} catch {}
+try {
+renderPassEncoder27.beginOcclusionQuery(2);
+} catch {}
+try {
+renderPassEncoder71.setIndexBuffer(buffer62, 'uint16', 422, 1_568);
+} catch {}
+try {
+renderBundleEncoder40.setPipeline(pipeline6);
+} catch {}
+try {
+commandEncoder200.copyTextureToTexture({
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 2, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder200.resolveQuerySet(querySet1, 99, 121, buffer11, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 7976, new DataView(new ArrayBuffer(2819)), 1781, 68);
+} catch {}
+await gc();
+let videoFrame41 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'film', transfer: 'log'} });
+let textureView200 = texture83.createView({
+  label: '\u9188\u89de\u89e8\u02e9\u{1fdb8}\u98c2\u0deb\u1d3b\u047c\u8c98\u{1fd33}',
+  dimension: '2d-array',
+  baseMipLevel: 0,
+});
+try {
+computePassEncoder127.setBindGroup(2, bindGroup92, new Uint32Array(605), 118, 0);
+} catch {}
+try {
+computePassEncoder135.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder27.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder69.setVertexBuffer(4, buffer55, 0, 12_931);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(5, buffer48, 0, 648);
+} catch {}
+try {
+renderPassEncoder64.popDebugGroup();
+} catch {}
+let videoFrame42 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-ncl', primaries: 'film', transfer: 'bt2020_12bit'} });
+let commandEncoder202 = device0.createCommandEncoder({});
+let computePassEncoder140 = commandEncoder202.beginComputePass({label: '\u6997\u{1f86f}\u7cb6\u{1fb0e}'});
+let renderPassEncoder78 = commandEncoder200.beginRenderPass({colorAttachments: [{view: textureView128, depthSlice: 428, loadOp: 'clear', storeOp: 'store'}]});
+let renderBundleEncoder41 = device0.createRenderBundleEncoder({colorFormats: ['r16float'], stencilReadOnly: true});
+let sampler134 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 21.22,
+  lodMaxClamp: 65.64,
+});
+try {
+renderPassEncoder61.setBlendConstant({ r: -795.3, g: 773.7, b: -657.6, a: -636.6, });
+} catch {}
+let videoFrame43 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte240m', primaries: 'bt709', transfer: 'smpteSt4281'} });
+let sampler135 = device0.createSampler({
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 77.99,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder131.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder74.setViewport(1.5471496212475546, 0.8988369712982406, 0.3966180423182882, 0.08439879825852584, 0.024844319722012842, 0.24648058469503636);
+} catch {}
+try {
+renderPassEncoder59.setIndexBuffer(buffer22, 'uint32', 0, 18);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(1, bindGroup17);
+} catch {}
+try {
+renderBundleEncoder40.setIndexBuffer(buffer70, 'uint16', 4_190, 13_717);
+} catch {}
+try {
+renderBundleEncoder41.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(0, buffer119, 2_140, 383);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer89, 216, new Int16Array(15814), 2602, 16);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture222 = device0.createTexture({
+  size: {width: 4, height: 2, depthOrArrayLayers: 28},
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundle40 = renderBundleEncoder41.finish({});
+try {
+computePassEncoder137.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup74, new Uint32Array(1040), 158, 0);
+} catch {}
+try {
+renderPassEncoder55.beginOcclusionQuery(16);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle25, renderBundle40]);
+} catch {}
+try {
+renderBundleEncoder40.setPipeline(pipeline1);
+} catch {}
+try {
+buffer132.unmap();
+} catch {}
+try {
+renderBundleEncoder40.insertDebugMarker('\u0a4a');
+} catch {}
+let bindGroup114 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 7, resource: {buffer: buffer12, offset: 256, size: 536}}],
+});
+let textureView201 = texture206.createView({});
+try {
+computePassEncoder74.setBindGroup(2, bindGroup80);
+} catch {}
+try {
+computePassEncoder93.setBindGroup(0, bindGroup99, new Uint32Array(1454), 16, 0);
+} catch {}
+try {
+computePassEncoder10.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder11.beginOcclusionQuery(13);
+} catch {}
+try {
+renderPassEncoder55.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder67.setIndexBuffer(buffer26, 'uint32', 2_388, 343);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(6, buffer82);
+} catch {}
+let bindGroup115 = device0.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [{binding: 294, resource: textureView108}, {binding: 26, resource: textureView196}],
+});
+let buffer137 = device0.createBuffer({size: 26781, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder203 = device0.createCommandEncoder({});
+let texture223 = device0.createTexture({size: {width: 16}, dimension: '1d', format: 'r16sint', usage: GPUTextureUsage.COPY_SRC});
+let computePassEncoder141 = commandEncoder203.beginComputePass({});
+try {
+computePassEncoder95.setBindGroup(2, bindGroup53, new Uint32Array(2642), 598, 0);
+} catch {}
+try {
+computePassEncoder119.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer70, 'uint16', 7_744, 5_219);
+} catch {}
+try {
+renderBundleEncoder40.setPipeline(pipeline5);
+} catch {}
+try {
+computePassEncoder5.setBindGroup(3, bindGroup67);
+} catch {}
+try {
+computePassEncoder140.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(2, bindGroup112, new Uint32Array(2072), 287, 0);
+} catch {}
+try {
+renderBundleEncoder40.setPipeline(pipeline6);
+} catch {}
+let arrayBuffer18 = buffer112.getMappedRange(10304, 152);
+try {
+computePassEncoder82.popDebugGroup();
+} catch {}
+let buffer138 = device0.createBuffer({
+  label: '\u4813\u{1fd07}\u039b\u828c\u{1f787}\u68d4\u0203\u4b1d',
+  size: 6853,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE,
+});
+let commandEncoder204 = device0.createCommandEncoder({});
+let texture224 = device0.createTexture({
+  size: {width: 16, height: 10, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture225 = gpuCanvasContext3.getCurrentTexture();
+let computePassEncoder142 = commandEncoder204.beginComputePass({});
+try {
+computePassEncoder126.setBindGroup(3, bindGroup43);
+} catch {}
+try {
+computePassEncoder138.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer66, 'uint16', 6_120, 5_438);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(2, bindGroup20, new Uint32Array(5281), 9, 0);
+} catch {}
+let buffer139 = device0.createBuffer({
+  size: 3436,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let texture226 = device0.createTexture({
+  size: [4, 2, 50],
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle41 = renderBundleEncoder40.finish();
+try {
+computePassEncoder136.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup90, new Uint32Array(56), 12, 0);
+} catch {}
+try {
+renderPassEncoder19.setBlendConstant({ r: 432.9, g: -564.7, b: -65.78, a: 838.7, });
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(31, 43, 6, 17);
+} catch {}
+try {
+renderPassEncoder67.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let texture227 = device0.createTexture({
+  size: [16, 10, 1],
+  mipLevelCount: 1,
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler136 = device0.createSampler({
+  label: '\u6d88\u0fbf\u09f5\u{1fa20}\u9ea6\u{1f73c}\u{1f938}\u{1f77e}\u05a9\u7c17',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 25.42,
+});
+try {
+computePassEncoder133.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder74.setBindGroup(1, bindGroup97, new Uint32Array(469), 4, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer109, 584, new DataView(new ArrayBuffer(2880)), 1057, 432);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder205 = device0.createCommandEncoder();
+let computePassEncoder143 = commandEncoder205.beginComputePass({});
+let sampler137 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 3.658,
+  lodMaxClamp: 90.00,
+});
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55); };
+} catch {}
+let offscreenCanvas3 = new OffscreenCanvas(61, 92);
+try {
+computePassEncoder104.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup51);
+} catch {}
+try {
+renderPassEncoder54.executeBundles([renderBundle5]);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer75, 'uint16', 2_422, 1_682);
+} catch {}
+try {
+renderPassEncoder53.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(7, buffer67, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture181,
+  mipLevel: 0,
+  origin: {x: 32, y: 6, z: 52},
+  aspect: 'all',
+}, new Uint8Array(68_684).fill(152), /* required buffer size: 68_684 */
+{offset: 120, bytesPerRow: 105, rowsPerImage: 35}, {width: 26, height: 23, depthOrArrayLayers: 19});
+} catch {}
+try {
+computePassEncoder44.setBindGroup(2, bindGroup15, new Uint32Array(4009), 262, 0);
+} catch {}
+try {
+renderPassEncoder53.setBindGroup(1, bindGroup95, new Uint32Array(1243), 214, 0);
+} catch {}
+try {
+renderPassEncoder60.setIndexBuffer(buffer53, 'uint16', 6_340, 304);
+} catch {}
+let gpuCanvasContext6 = offscreenCanvas3.getContext('webgpu');
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let textureView202 = texture58.createView({baseMipLevel: 4});
+let externalTexture36 = device0.importExternalTexture({source: videoFrame20, colorSpace: 'srgb'});
+try {
+computePassEncoder119.end();
+} catch {}
+try {
+renderPassEncoder62.setBindGroup(0, bindGroup102, []);
+} catch {}
+try {
+buffer127.unmap();
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+let texture228 = device0.createTexture({
+  size: {width: 16, height: 10, depthOrArrayLayers: 1163},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler138 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 62.73,
+  lodMaxClamp: 79.49,
+});
+try {
+computePassEncoder71.setBindGroup(0, bindGroup87);
+} catch {}
+try {
+computePassEncoder51.setBindGroup(0, bindGroup54, new Uint32Array(13), 2, 0);
+} catch {}
+try {
+computePassEncoder142.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder66.setVertexBuffer(2, buffer119);
+} catch {}
+try {
+computePassEncoder2.pushDebugGroup('\u0088');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame43,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img1);
+await gc();
+let buffer140 = device0.createBuffer({
+  label: '\uc5e6\u00fa',
+  size: 25264,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: false,
+});
+let computePassEncoder144 = commandEncoder174.beginComputePass({});
+try {
+renderPassEncoder60.executeBundles([renderBundle25, renderBundle18, renderBundle13, renderBundle2]);
+} catch {}
+try {
+adapter0.label = '\u0692\u0f9b\u{1f9d6}\u0298\uc7fe\ua0a5';
+} catch {}
+let buffer141 = device0.createBuffer({label: '\u892f\ua2d5', size: 1516, usage: GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX});
+let commandEncoder206 = device0.createCommandEncoder();
+let texture229 = device0.createTexture({
+  size: [16],
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder145 = commandEncoder206.beginComputePass();
+try {
+computePassEncoder11.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder63.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+renderPassEncoder64.executeBundles([renderBundle24]);
+} catch {}
+try {
+renderPassEncoder43.setBlendConstant({ r: 924.3, g: 308.2, b: -636.1, a: -33.21, });
+} catch {}
+try {
+computePassEncoder2.popDebugGroup();
+} catch {}
+document.body.append(img0);
+let textureView203 = texture67.createView({arrayLayerCount: 1});
+try {
+computePassEncoder57.setBindGroup(0, bindGroup51, new Uint32Array(107), 4, 0);
+} catch {}
+try {
+computePassEncoder143.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder55.executeBundles([renderBundle11]);
+} catch {}
+try {
+renderPassEncoder69.setIndexBuffer(buffer15, 'uint32', 36, 11);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup53);
+} catch {}
+try {
+renderPassEncoder67.executeBundles([renderBundle15, renderBundle41]);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer134, 'uint16', 100, 1_215);
+} catch {}
+try {
+renderPassEncoder47.setVertexBuffer(2, buffer101, 0);
+} catch {}
+let shaderModule9 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires pointer_composite_access;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(296) var et7: texture_external;
+
+@group(0) @binding(460) var tex7: texture_2d_array<f32>;
+
+struct T0 {
+  @size(7232) f0: array<u32>,
+}
+
+struct FragmentOutput6 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: u32,
+}
+
+fn fn0() {
+  let vf219: vec3u = insertBits(vec3u(unconst_u32(289), unconst_u32(187), unconst_u32(140)), vec3u(unconst_u32(48), unconst_u32(48), unconst_u32(89)), pack4xI8Clamp(vec4i(unconst_i32(418), unconst_i32(1), unconst_i32(135), unconst_i32(-368))), u32(unconst_u32(87)));
+  let vf220: f32 = quantizeToF16(f32(min(f16(extractBits(vec4i(unconst_i32(-118), unconst_i32(278), unconst_i32(126), unconst_i32(20)), u32(unconst_u32(35)), u32(unconst_u32(26))).w), f16(unconst_f16(13893.4)))));
+  let vf221: vec4f = quantizeToF16(vec4f(unconst_f32(0.7985), unconst_f32(0.00220), unconst_f32(0.1017), unconst_f32(0.01983)));
+  let vf222: u32 = vf219[u32(unconst_u32(97))];
+}
+
+var<workgroup> vw15: vec4<bool>;
+
+@vertex
+fn vertex7(@builtin(vertex_index) a0: u32, @location(2) a1: f16, @location(9) @interpolate(flat, centroid) a2: vec2h, @builtin(instance_index) a3: u32) -> @builtin(position) vec4f {
+  var out: vec4f;
+  let vf223: vec3h = asin(vec3h(unconst_f16(21344.8), unconst_f16(4616.7), unconst_f16(29936.9)));
+  out = unpack4x8unorm(dot4U8Packed(u32(unconst_u32(137)), u32(unconst_u32(697))));
+  out = vec4f(cosh(f32(unconst_f32(0.2567))));
+  out = vec4f(bitcast<f32>(dot4U8Packed(u32(unconst_u32(461)), u32(unconst_u32(231)))));
+  out = textureLoad(tex7, vec2i(unconst_i32(159), unconst_i32(17)), i32(unconst_i32(138)), i32(unconst_i32(16)));
+  out = vec4f(f32(a1));
+  let vf224: u32 = textureNumLevels(tex7);
+  var vf225: vec3h = vf223;
+  out = bitcast<vec4f>(textureDimensions(tex7, i32(unconst_i32(184))).rggr);
+  let vf226: vec2f = pow(vec2f(unconst_f32(-0.2458), unconst_f32(0.4227)), vec2f(unconst_f32(0.01382), unconst_f32(0.01416)));
+  out = vec4f(f32(vf225[u32(unconst_u32(422))]));
+  out = vec4f(f32(countTrailingZeros(i32(unconst_i32(27)))));
+  out = vec4f(transpose(mat2x3h())[unconst_i32(2)].xyxx);
+  out -= vec4f(asin(vec3h(unconst_f16(13652.8), unconst_f16(21465.6), unconst_f16(13046.9))).zyxy);
+  vf225 = vf225;
+  var vf227: i32 = firstTrailingBit(i32(unconst_i32(-78)));
+  fn0();
+  fn0();
+  var vf228: vec4h = acosh(vec4h(unconst_f16(3575.3), unconst_f16(3371.7), unconst_f16(1673.6), unconst_f16(3702.1)));
+  let vf229: f16 = vf223[u32(asin(vec3h(unconst_f16(17442.0), unconst_f16(3931.8), unconst_f16(-879.5)))[0])];
+  vf227 *= i32(asin(vec3h(unconst_f16(22735.0), unconst_f16(13675.8), unconst_f16(13739.8)))[1]);
+  out += vec4f(transpose(mat2x3h(unconst_f16(5461.2), unconst_f16(3335.1), unconst_f16(1193.6), unconst_f16(-11182.9), unconst_f16(1804.3), unconst_f16(1828.0)))[unconst_i32(2)].xyyx);
+  let vf230: u32 = pack2x16unorm(vec2f(unconst_f32(0.1341), unconst_f32(0.07319)));
+  return out;
+}
+
+@fragment
+fn fragment8() -> FragmentOutput6 {
+  var out: FragmentOutput6;
+  let vf231: vec2u = textureDimensions(tex7);
+  fn0();
+  fn0();
+  fn0();
+  var vf232: u32 = textureNumLayers(tex7);
+  out.f1 ^= textureDimensions(et7).x;
+  fn0();
+  let vf233: vec3f = cross(vec3f(unconst_f32(0.01291), unconst_f32(-0.01489), unconst_f32(0.2399)), vec3f(unconst_f32(0.04231), unconst_f32(0.2276), unconst_f32(0.04898)));
+  out.f1 += bitcast<vec3u>(vf233).y;
+  var vf234: vec2u = textureDimensions(et7);
+  let ptr41: ptr<function, u32> = &vf232;
+  out = FragmentOutput6(vf234[0], vf234[1]);
+  let ptr42: ptr<function, u32> = &vf232;
+  out = FragmentOutput6((*ptr42), (*ptr42));
+  fn0();
+  vf232 |= u32(any(bool(pack4xI8(vec4i(unconst_i32(66), unconst_i32(311), unconst_i32(2), unconst_i32(3))))));
+  out.f1 <<= bitcast<u32>(quantizeToF16(f32(unconst_f32(0.06046))));
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute6() {
+  let ptr43: ptr<workgroup, vec4<bool>> = &(*&vw15);
+  vw15 = vec4<bool>(extractBits(vec3i(i32(pack4xI8(vec4i(unconst_i32(92), unconst_i32(19), unconst_i32(224), unconst_i32(131))))), pack2x16unorm(vec2f(workgroupUniformLoad(&vw15).br)), u32(unconst_u32(255))).zxyx);
+  workgroupBarrier();
+  vw15 = vec4<bool>(firstLeadingBit(vec3u(unpack2x16snorm(u32(unconst_u32(37))).xxy)).zzyy);
+  vw15 = (*ptr43);
+  vw15 = vec4<bool>(atan2(atan2(vec3h(f16(pack2x16unorm(vec2f(unconst_f32(-0.1421), unconst_f32(-0.09124))))), vec3h(unconst_f16(16402.4), unconst_f16(7492.0), unconst_f16(1169.1))), vec3h(unconst_f16(331.7), unconst_f16(6281.8), unconst_f16(755.7))).zyxy);
+  let ptr44: ptr<workgroup, vec4<bool>> = &(*ptr43);
+  fn0();
+  var vf235: bool = vw15[u32(unconst_u32(131))];
+  vf235 = bool(atan2(vec3h(unconst_f16(23128.7), unconst_f16(8450.9), unconst_f16(4561.6)), vec3h(unconst_f16(11596.2), unconst_f16(14559.4), unconst_f16(24184.9)))[0]);
+  let ptr45: ptr<workgroup, vec4<bool>> = &(*ptr44);
+  let vf236: vec4<bool> = workgroupUniformLoad(&vw15);
+  var vf237: vec2f = unpack2x16snorm(u32(unconst_u32(145)));
+  var vf238: vec2f = reflect(vec2f(unconst_f32(0.06248), unconst_f32(0.1217)), vec2f(unconst_f32(0.09452), unconst_f32(-0.2609)));
+  vf237 += vec2f((*ptr43).xx);
+  let vf239: f32 = dot(vec2f(unconst_f32(0.2941), unconst_f32(0.03235)), vec2f((*&vw15).ab));
+  fn0();
+  fn0();
+}`,
+  hints: {},
+});
+let buffer142 = device0.createBuffer({
+  size: 43366,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let texture230 = device0.createTexture({
+  size: [8, 5, 1],
+  dimension: '2d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder52.setBindGroup(0, bindGroup67);
+} catch {}
+try {
+computePassEncoder92.setBindGroup(1, bindGroup72, new Uint32Array(2195), 254, 0);
+} catch {}
+try {
+renderPassEncoder28.executeBundles([renderBundle1, renderBundle19, renderBundle38]);
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder53.setVertexBuffer(0, buffer94);
+} catch {}
+let bindGroup116 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 143, resource: textureView74},
+    {binding: 487, resource: sampler83},
+    {binding: 33, resource: textureView32},
+  ],
+});
+let sampler139 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 28.17,
+});
+try {
+computePassEncoder111.setBindGroup(0, bindGroup5, new Uint32Array(6), 0, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder111); computePassEncoder111.dispatchWorkgroupsIndirect(buffer128, 992); };
+} catch {}
+try {
+renderPassEncoder67.setBindGroup(2, bindGroup98);
+} catch {}
+try {
+renderPassEncoder78.setIndexBuffer(buffer51, 'uint16', 3_560, 468);
+} catch {}
+let commandEncoder207 = device0.createCommandEncoder();
+let texture231 = device0.createTexture({
+  label: '\u003f\ud45d\u{1fcf7}\u07ac\u22cb\u0ee9',
+  size: [16, 10, 1],
+  mipLevelCount: 1,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+computePassEncoder145.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup97);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder207.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 956 */
+  offset: 956,
+  bytesPerRow: 1792,
+  buffer: buffer32,
+}, {
+  texture: texture167,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let bindGroup117 = device0.createBindGroup({
+  layout: bindGroupLayout24,
+  entries: [{binding: 172, resource: textureView144}, {binding: 468, resource: {buffer: buffer59, offset: 2560}}],
+});
+let buffer143 = device0.createBuffer({
+  size: 20799,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder146 = commandEncoder207.beginComputePass({label: '\u7d00\u7ac5\uc729'});
+try {
+computePassEncoder84.setBindGroup(0, bindGroup70);
+} catch {}
+try {
+computePassEncoder21.setBindGroup(2, bindGroup44, new Uint32Array(1030), 366, 0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup96, new Uint32Array(378), 65, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+document.body.prepend(canvas4);
+let buffer144 = device0.createBuffer({
+  label: '\u0238\u0146\u83f8\u00e2\u{1ff2c}',
+  size: 5776,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let texture232 = device0.createTexture({size: [2, 1, 1], sampleCount: 4, format: 'r8uint', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+try {
+computePassEncoder111.end();
+} catch {}
+try {
+computePassEncoder144.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder73.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder57.setVertexBuffer(1, buffer76);
+} catch {}
+document.body.prepend(canvas0);
+let bindGroup118 = device0.createBindGroup({layout: bindGroupLayout4, entries: [{binding: 84, resource: textureView54}]});
+let buffer145 = device0.createBuffer({
+  size: 3922,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture233 = device0.createTexture({
+  size: [16, 10, 45],
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup67, new Uint32Array(1619), 138, 0);
+} catch {}
+try {
+renderPassEncoder68.setVertexBuffer(7, buffer55, 4_932, 5_880);
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+let buffer146 = device0.createBuffer({size: 3613, usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let commandEncoder208 = device0.createCommandEncoder({label: '\u2841\u1cd4\u2a3a\u5118\ua678\uf94d\u269f\u7bba\ubde1\u021c'});
+let textureView204 = texture180.createView({dimension: '2d-array'});
+let renderPassEncoder79 = commandEncoder0.beginRenderPass({
+  colorAttachments: [{view: textureView125, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet14,
+});
+try {
+computePassEncoder141.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder78.setIndexBuffer(buffer20, 'uint32', 15_932, 283);
+} catch {}
+try {
+commandEncoder208.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1372 */
+  offset: 1372,
+  buffer: buffer22,
+}, {
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder208.copyTextureToBuffer({
+  texture: texture134,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 488 */
+  offset: 488,
+  buffer: buffer91,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder208.copyTextureToTexture({
+  texture: texture134,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture134,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer85, 2592, new DataView(new ArrayBuffer(1707)), 353, 60);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 4, height: 2, depthOrArrayLayers: 151}
+*/
+{
+  source: offscreenCanvas3,
+  origin: { x: 26, y: 10 },
+  flipY: true,
+}, {
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 60},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let buffer147 = device0.createBuffer({size: 5257, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM});
+let commandEncoder209 = device0.createCommandEncoder({});
+let texture234 = device0.createTexture({
+  label: '\uacd1\u391d\u0f22\u06d1\u7b11\u{1f78a}\u9856',
+  size: [4],
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+commandEncoder208.insertDebugMarker('\u98a2');
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let bindGroup119 = device0.createBindGroup({
+  layout: bindGroupLayout22,
+  entries: [
+    {binding: 485, resource: textureView181},
+    {binding: 241, resource: {buffer: buffer142, offset: 19200, size: 1216}},
+    {binding: 76, resource: textureView131},
+    {binding: 124, resource: textureView81},
+  ],
+});
+let commandEncoder210 = device0.createCommandEncoder({label: '\u01ad\uf8f7\u7400\ucafb\u9a81\uc053\u0824\u6da5\u{1ff89}'});
+let computePassEncoder147 = commandEncoder208.beginComputePass({});
+try {
+computePassEncoder61.setBindGroup(1, bindGroup96, []);
+} catch {}
+try {
+computePassEncoder146.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(0, bindGroup66, new Uint32Array(300), 90, 0);
+} catch {}
+try {
+renderPassEncoder67.executeBundles([renderBundle15]);
+} catch {}
+try {
+renderPassEncoder72.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(0, buffer116, 0, 904);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 4, height: 2, depthOrArrayLayers: 151}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 1, y: 1 },
+  flipY: false,
+}, {
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 35},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline8 = await device0.createRenderPipelineAsync({
+  label: '\ue9ec\u197a\ua013\u040c\uf920\u96fa\u07a7',
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule9,
+  targets: [{format: 'r8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {module: shaderModule4, buffers: []},
+  primitive: {topology: 'point-list', cullMode: 'front'},
+});
+let commandEncoder211 = device0.createCommandEncoder({});
+let computePassEncoder148 = commandEncoder209.beginComputePass({label: '\u01d8\u7bb1\u{1fa1c}\ue87c\uf5db\u7c11\uf419\u037e'});
+try {
+computePassEncoder129.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(1, bindGroup107, new Uint32Array(3596), 190, 0);
+} catch {}
+document.body.append(canvas3);
+try {
+computePassEncoder148.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(1, bindGroup92);
+} catch {}
+try {
+if (!arrayBuffer15.detached) { new Uint8Array(arrayBuffer15).fill(0x55); };
+} catch {}
+let imageData23 = new ImageData(48, 28);
+let shaderModule10 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(22) var tex8: texture_depth_2d;
+
+@group(0) @binding(55) var tex9: texture_2d<f32>;
+
+@group(0) @binding(62) var<uniform> buffer148: mat2x2h;
+
+@group(0) @binding(103) var tex10: texture_2d<u32>;
+
+@group(0) @binding(132) var sam1: sampler;
+
+struct T0 {
+  @align(8) @size(8) f0: array<u32>,
+}
+
+struct T1 {
+  @align(8) @size(8) f0: f32,
+}
+
+struct T2 {
+  @size(8) f0: array<f32, 1>,
+}
+
+struct VertexOutput6 {
+  @location(6) @interpolate(flat, sample) f19: f16,
+  @location(7) f20: u32,
+  @builtin(position) f21: vec4f,
+  @location(15) f22: vec4i,
+  @location(3) @interpolate(linear) f23: vec4f,
+}
+
+struct FragmentOutput7 {
+  @location(0) @interpolate(flat, centroid) f0: vec2u,
+  @location(5) f1: vec4i,
+}
+
+alias vec3b = vec3<bool>;
+
+@id(57199) override override1: i32;
+
+@id(64498) override override2: f32;
+
+override override3: u32 = 79;
+
+override override4: i32;
+
+override override5: f16 = 11287.5;
+
+@id(4927) override override6: i32;
+
+@id(52769) override override7: u32 = 27;
+
+var<workgroup> vw16: T2;
+
+var<private> vp3 = modf(vec4h(-6919.5, 2934.7, 1358.8, -32895.7));
+
+var<private> vp4 = modf(vec4h(-5087.3, 10023.8, 10528.3, 26031.0));
+
+var<private> vp5: FragmentOutput7 = FragmentOutput7(vec2u(135, 420), vec4i(-13, 173, 9, 155));
+
+@vertex
+fn vertex8(@location(3) a0: vec4i) -> VertexOutput6 {
+  var out: VertexOutput6;
+  let vf240: vec4u = textureGather(323 % 4, tex10, sam1, vec2f(unconst_f32(0.2096), unconst_f32(0.03220)));
+  var vf241: vec4u = textureGather(417 % 4, tex10, sam1, vec2f(unconst_f32(0.07996), unconst_f32(0.1676)));
+  vf241 *= vp5.f0.grgr;
+  let vf242: vec2u = textureDimensions(tex9);
+  let vf243: i32 = a0[u32(unconst_u32(177))];
+  vp5.f0 |= vp5.f0;
+  var vf244: f16 = length(vec3h(unconst_f16(5794.1), unconst_f16(9205.2), unconst_f16(1169.5)));
+  return out;
+}
+
+@fragment
+fn fragment9() -> FragmentOutput7 {
+  var out: FragmentOutput7;
+  let vf245: vec2u = textureDimensions(tex10, bitcast<i32>(textureNumLevels(tex10)));
+  out.f1 -= vec4i(vp5.f1[u32(unconst_u32(254))]);
+  var vf246: i32 = override6;
+  out.f1 = bitcast<vec4i>(textureLoad(tex10, vec2i(unconst_i32(-178), unconst_i32(504)), i32(unconst_i32(77))));
+  var vf247: f16 = sinh(f16(unconst_f16(6053.1)));
+  vp4.fract -= vec4h(textureGather(75 % 4, tex10, sam1, vec2f(unconst_f32(-0.1470), unconst_f32(0.4882))));
+  vf246 |= vec3i(log(vec3f(unconst_f32(0.1953), unconst_f32(0.1311), unconst_f32(0.1451))))[2];
+  let ptr46: ptr<function, i32> = &vf246;
+  out = FragmentOutput7(vec2u(vf245[bitcast<vec2u>(unpack2x16float(u32(unconst_u32(0))))[0]]), vec4i(i32(vf245[bitcast<vec2u>(unpack2x16float(u32(unconst_u32(0))))[0]])));
+  let vf248: f16 = buffer148[u32(unconst_u32(4))][u32(unconst_u32(17))];
+  var vf249: u32 = pack2x16float(vec2f(unconst_f32(0.06378), unconst_f32(-0.2402)));
+  let vf250: vec2f = cos(vec2f(unconst_f32(0.02035), unconst_f32(0.00825)));
+  let vf251: u32 = pack4xI8Clamp(vec4i(unconst_i32(7), unconst_i32(117), unconst_i32(780), unconst_i32(27)));
+  return out;
+  _ = override6;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute7() {
+  vw16.f0[0] = sqrt(f32(unconst_f32(0.06922)));
+  let ptr47: ptr<workgroup, T2> = &vw16;
+  var vf252: vec2h = buffer148[u32(unconst_u32(342))];
+  vp5.f1 *= vec4i(unpack2x16float(u32(unconst_u32(248))).rggr);
+  let vf253: i32 = override4;
+  var vf254: f16 = (*&buffer148)[u32(unconst_u32(30))][u32(unconst_u32(72))];
+  vp3.whole = vec4h(f16(override4));
+  vw16.f0[u32(unconst_u32(85))] = (*&vw16).f0[0];
+  vp3.whole = vec4h(f16((*&vw16).f0[0]));
+  let ptr48: ptr<workgroup, T2> = &vw16;
+  vw16.f0[u32(unconst_u32(90))] = override2;
+  vf252 = vec2h(buffer148[u32(unconst_u32(92))][u32(vf252[bitcast<u32>((*ptr47).f0[0])])]);
+  vw16 = T2(array<f32, 1>((*&vw16).f0[0]));
+  let ptr49: ptr<uniform, mat2x2h> = &(*&buffer148);
+  let ptr50: ptr<workgroup, array<f32, 1>> = &(*&vw16).f0;
+  var vf255: u32 = override7;
+  vw16.f0[u32(unconst_u32(28))] = textureLoad(tex8, vec2i(unconst_i32(219), unconst_i32(-99)), i32(unconst_i32(190)));
+  var vf256: vec4f = asin(vec4f(unconst_f32(0.01478), unconst_f32(0.1837), unconst_f32(-0.05192), unconst_f32(0.06355)));
+  var vf257: u32 = override3;
+  let ptr51: ptr<workgroup, array<f32, 1>> = &(*ptr50);
+  vw16 = T2(array<f32, 1>(f32(override3)));
+  var vf258: f16 = vf252[u32(unconst_u32(57))];
+  _ = override4;
+  _ = override7;
+  _ = override2;
+  _ = override3;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder212 = device0.createCommandEncoder({label: '\u002b\u{1fd8e}\u3e14\u{1f7c6}\u10fd\u4669\u0bd2\u2a86\u3d32\udeec'});
+let texture235 = device0.createTexture({
+  size: [256, 256, 15],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder149 = commandEncoder210.beginComputePass({});
+try {
+computePassEncoder35.setBindGroup(1, bindGroup72);
+} catch {}
+try {
+computePassEncoder99.setBindGroup(1, bindGroup62, new Uint32Array(1539), 109, 0);
+} catch {}
+try {
+computePassEncoder147.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(2, bindGroup113, new Uint32Array(316), 90, 0);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(4, buffer82, 508);
+} catch {}
+try {
+commandEncoder211.copyBufferToTexture({
+  /* bytesInLastRow: 39 widthInBlocks: 39 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 877 */
+  offset: 877,
+  bytesPerRow: 57344,
+  buffer: buffer96,
+}, {
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 38, y: 28, z: 0},
+  aspect: 'all',
+}, {width: 39, height: 22, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let buffer149 = device0.createBuffer({
+  size: 14204,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let sampler140 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 46.99,
+  maxAnisotropy: 1,
+});
+let externalTexture37 = device0.importExternalTexture({label: '\ue54b\u0693\u1430\u0b29', source: videoFrame27});
+try {
+computePassEncoder149.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer43, 'uint16', 192, 822);
+} catch {}
+try {
+renderPassEncoder67.setVertexBuffer(3, buffer88, 2_352);
+} catch {}
+try {
+commandEncoder211.copyBufferToBuffer(buffer122, 104, buffer118, 96, 144);
+} catch {}
+try {
+commandEncoder212.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 85},
+  aspect: 'all',
+},
+{
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let videoFrame44 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'smpteSt4281', transfer: 'iec61966-2-1'} });
+let shaderModule11 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(22) var tex11: texture_depth_2d;
+
+@group(0) @binding(55) var tex12: texture_2d<f32>;
+
+@group(0) @binding(62) var<uniform> buffer150: vec2u;
+
+@group(0) @binding(103) var tex13: texture_2d<u32>;
+
+@group(0) @binding(132) var sam2: sampler;
+
+@group(0) @binding(236) var st3: texture_storage_2d<rg32float, read>;
+
+struct T0 {
+  @align(8) @size(56) f0: array<u32>,
+}
+
+struct T1 {
+  @size(88) f0: array<array<array<atomic<i32>, 1>, 1>>,
+}
+
+struct T2 {
+  f0: vec2u,
+}
+
+struct T3 {
+  @align(32) @size(160) f0: T0,
+}
+
+struct T4 {
+  @align(16) f0: mat2x4h,
+  @align(16) @size(32) f1: array<array<array<mat2x3h, 1>, 1>, 1>,
+}
+
+struct T5 {
+  @align(8) @size(8) f0: array<atomic<u32>, 1>,
+}
+
+struct VertexOutput7 {
+  @builtin(position) f24: vec4f,
+  @location(5) f25: vec2h,
+}
+
+struct VertexOutput8 {
+  @builtin(position) f26: vec4f,
+}
+
+struct FragmentOutput8 {
+  @location(2) @interpolate(flat, sample) f0: i32,
+  @location(0) f1: vec4f,
+  @location(6) @interpolate(perspective) f2: vec2f,
+}
+
+fn fn0() -> mat4x4h {
+  var out: mat4x4h;
+  let vf259: vec4u = textureGather(379 % 4, tex13, sam2, vec2f(unconst_f32(0.2933), unconst_f32(0.1468)), clamp(vec2i(126, 37), vec2i(-8), vec2i(7)));
+  var vf260: vec3f = tan(vec3f(unconst_f32(-0.03707), unconst_f32(0.1672), unconst_f32(-0.01981)));
+  var vf261: vec4u = vf259;
+  let ptr52: ptr<private, vec3h> = &vp6.whole;
+  let vf262: u32 = (*&buffer150)[u32(unconst_u32(535))];
+  let vf263: f16 = acosh(f16(unconst_f16(-10739.4)));
+  let vf264: vec2i = min(vec2i(unconst_i32(212), unconst_i32(-346)), vec2i(sin(vec2h(unconst_f16(-7496.3), unconst_f16(4552.1)))));
+  var vf265: vec4u = textureLoad(tex13, vec2i(unconst_i32(37), unconst_i32(28)), i32(unconst_i32(42)));
+  vf261 = textureLoad(tex13, vec2i(unconst_i32(190), unconst_i32(670)), i32(unconst_i32(41)));
+  vf261 &= unpack4xU8(bitcast<u32>(sqrt(f32(unconst_f32(0.2553)))));
+  vf261 >>= vec4u(quantizeToF16(bitcast<vec2f>(textureDimensions(st3))).grgr);
+  let vf266: vec4i = unpack4xI8(u32(unconst_u32(358)));
+  let vf267: f16 = acosh(f16(unconst_f16(10618.1)));
+  vf260 += vec3f(vf259.bgb);
+  discard;
+  return out;
+}
+
+fn fn1() -> array<FragmentOutput8, 1> {
+  var out: array<FragmentOutput8, 1>;
+  out[0].f2 = bitcast<vec2f>(textureLoad(tex13, vec2i(unconst_i32(69), unconst_i32(63)), i32(unconst_i32(160))).xy);
+  vp6.fract = vec3h(f16(textureNumLevels(tex12)));
+  let vf268: vec4f = textureLoad(st3, vec2i(unconst_i32(274), unconst_i32(573)));
+  let vf269: vec2u = textureDimensions(tex12);
+  var vf270: vec2u = vf269;
+  var vf271: vec2u = vf269;
+  let vf272: f32 = vf268[u32(unconst_u32(363))];
+  out[u32(vp6.fract.y)].f0 = bitcast<vec4i>(textureGather(35 % 4, tex13, sam2, vec2f(unconst_f32(0.4855), unconst_f32(0.06787))))[2];
+  let vf273: vec4u = textureLoad(tex13, vec2i(unconst_i32(112), unconst_i32(303)), i32(vf272));
+  vf270 |= vec2u(vf271[u32(unconst_u32(197))]);
+  let ptr53: ptr<uniform, vec2u> = &(*&buffer150);
+  var vf274: f32 = vf272;
+  let ptr54: ptr<private, vec3h> = &vp6.whole;
+  var vf275: f32 = floor(f32(unconst_f32(0.05488)));
+  var vf276: f16 = (*ptr54)[u32(unconst_u32(5))];
+  var vf277: u32 = vf269[u32(unconst_u32(40))];
+  let ptr55: ptr<function, u32> = &vf277;
+  vf277 = vf269.y;
+  return out;
+}
+
+fn fn2() {
+  var vf278: u32 = (*&buffer150)[u32(unconst_u32(127))];
+  let vf279: u32 = buffer150[u32(unconst_u32(553))];
+  let vf280: vec3h = inverseSqrt(vec3h(unconst_f16(8580.1), unconst_f16(19678.0), unconst_f16(10014.4)));
+  let vf281: vec2u = textureDimensions(tex13);
+  let vf282: u32 = textureNumLevels(tex13);
+  vf278 &= (*&buffer150).y;
+  let ptr56: ptr<private, vec3h> = &vp6.whole;
+  vf278 >>= vf281[u32(unconst_u32(48))];
+  vp6.whole -= vec3h(f16(vf282));
+  let vf283: f16 = (*ptr56)[u32(unconst_u32(893))];
+  var vf284: u32 = textureNumLevels(tex13);
+  vf284 |= pack4xU8Clamp(vec4u(sinh(vec4f(unconst_f32(0.01643), unconst_f32(0.1175), unconst_f32(-0.03302), unconst_f32(-0.3221)))));
+  vp6.fract += vec3h(f16((*&buffer150)[u32(unconst_u32(198))]));
+  vp6 = vp6;
+  let vf285: vec4f = sinh(vec4f(unconst_f32(0.01640), unconst_f32(0.1590), unconst_f32(0.02866), unconst_f32(0.00846)));
+  var vf286: u32 = pack4x8snorm(vec4f(unconst_f32(0.3938), unconst_f32(0.2735), unconst_f32(-0.2537), unconst_f32(0.06395)));
+}
+
+var<workgroup> vw17: T2;
+
+var<workgroup> vw18: atomic<u32>;
+
+var<workgroup> vw19: T4;
+
+var<workgroup> vw20: vec2<bool>;
+
+var<workgroup> vw21: array<vec4h, 17>;
+
+var<workgroup> vw22: VertexOutput8;
+
+var<private> vp6 = modf(vec3h(2186.3, 9064.4, 942.6));
+
+@vertex
+fn vertex9(@location(2) a0: vec2f, @location(5) a1: f16) -> VertexOutput7 {
+  var out: VertexOutput7;
+  vp6 = modf(vp6.whole);
+  let vf287: vec2u = textureDimensions(tex13, i32(unconst_i32(47)));
+  var vf288: vec2u = textureDimensions(tex13, i32(unconst_i32(219)));
+  vp6.whole -= vec3h(vf287.ggr);
+  let vf289: bool = all(bool(vf288.r));
+  var vf290 = fn1();
+  let ptr57: ptr<function, vec4f> = &vf290[u32(unconst_u32(86))].f1;
+  var vf291 = fn1();
+  var vf292: f32 = vf291[u32(unconst_u32(195))].f1[u32(unconst_u32(62))];
+  let ptr58: ptr<function, i32> = &vf290[u32(unconst_u32(30))].f0;
+  out.f24 *= vf291[0].f2.rggg;
+  var vf293: f32 = vf291[u32(unconst_u32(170))].f2[u32(unconst_u32(11))];
+  return out;
+}
+
+@vertex
+fn vertex10(@location(7) a0: vec4u, @builtin(instance_index) a1: u32) -> VertexOutput8 {
+  var out: VertexOutput8;
+  vp6.whole = vec3h(f16(a1));
+  return out;
+}
+
+@fragment
+fn fragment10(@location(5) @interpolate(linear, center) a0: vec2h) -> FragmentOutput8 {
+  var out: FragmentOutput8;
+  let vf294: vec2u = textureDimensions(tex13, i32(unconst_i32(272)));
+  fn2();
+  let vf295: u32 = buffer150[u32(unconst_u32(15))];
+  var vf296: u32 = vf294[u32(unconst_u32(21))];
+  vf296 |= buffer150[u32(unconst_u32(670))];
+  let vf297: vec2f = unpack2x16snorm(u32(unconst_u32(321)));
+  fn0();
+  fn0();
+  vf296 = pack4xI8Clamp(vec4i(vp6.whole.xyyx));
+  fn0();
+  fn0();
+  vf296 = buffer150.x;
+  vf296 ^= u32(fma(f32(unconst_f32(0.1045)), f32(unconst_f32(-0.1183)), bitcast<vec4f>(textureGather(118 % 4, tex13, sam2, vec2f(unconst_f32(-0.1534), unconst_f32(0.00319)), clamp(vec2i(652, 417), vec2i(-8), vec2i(7))))[0]));
+  var vf298: u32 = buffer150[u32(unconst_u32(198))];
+  let vf299: vec2f = vf297;
+  var vf300 = fn0();
+  vp6.fract -= vec3h(f16(pack2x16float(vec2f(unconst_f32(0.04535), unconst_f32(0.4932)))));
+  out = FragmentOutput8(i32(vf294[u32(unconst_u32(515))]), unpack4x8unorm(vf294[u32(unconst_u32(515))]), unpack2x16float(vf294[u32(unconst_u32(515))]));
+  out.f0 *= bitcast<i32>(buffer150[bitcast<u32>(clamp(vec2h(unconst_f16(3032.9), unconst_f16(4052.9)), vec2h(unconst_f16(7289.9), unconst_f16(6682.0)), vec2h(unconst_f16(14625.7), unconst_f16(6650.4))))]);
+  out.f2 = vec2f(min(vec3h(unconst_f16(2825.3), unconst_f16(1467.1), unconst_f16(10203.8)), vec3h(unconst_f16(15279.7), unconst_f16(35509.2), unconst_f16(5053.0))).xx);
+  let vf301: vec2f = unpack2x16snorm(u32(unconst_u32(137)));
+  vp6 = modf(vec3h(textureGather(139 % 4, tex13, sam2, vec2f(unconst_f32(0.04520), unconst_f32(0.00927)), clamp(vec2i(209, 119), vec2i(-8), vec2i(7))).xzw));
+  var vf302 = fn0();
+  var vf303 = fn0();
+  vf300 = mat4x4h(f16(vf296), f16(vf296), f16(vf296), f16(vf296), f16(vf296), f16(vf296), f16(vf296), f16(vf296), f16(vf296), f16(vf296), f16(vf296), f16(vf296), f16(vf296), f16(vf296), f16(vf296), f16(vf296));
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute8() {
+  vp6.whole += vec3h(vw22.f26.zyw);
+  vw19 = T4(mat2x4h((*&vw19).f1[0][0][0][unconst_i32(1)].xxxy, (*&vw19).f1[0][0][0][unconst_i32(0)].brgb), array<array<array<mat2x3h, 1>, 1>, 1>(array<array<mat2x3h, 1>, 1>(array<mat2x3h, 1>((*&vw19).f1[0][0][0]))));
+  fn2();
+  var vf304: vec3h = (*&vw19).f1[0][0][0][u32(unconst_u32(1))];
+  fn2();
+  vw22 = VertexOutput8(vec4f(f32(vf304[u32(unconst_u32(100))])));
+  fn2();
+  vw22.f26 = vec4f((*&vw19).f0[unconst_i32(1)]);
+  fn2();
+  let ptr59: ptr<workgroup, mat2x4h> = &vw19.f0;
+  let vf305: vec3h = vw19.f1[0][0][u32(unconst_u32(240))][u32(unconst_u32(206))];
+  fn2();
+  var vf306: vec2u = textureDimensions(tex11);
+  let ptr60: ptr<workgroup, T4> = &vw19;
+  vf304 = vw19.f0[unconst_i32(0)].agr;
+  let vf307: f16 = (*&vw19).f1[u32(unconst_u32(83))][0][u32(unconst_u32(291))][u32(unconst_u32(224))][u32(unconst_u32(27))];
+  vf306 += vec2u((*&vw19).f1[u32(unconst_u32(62))][u32(unconst_u32(257))][0][unconst_i32(1)].xz);
+  let vf308: vec3h = vw19.f1[u32(unconst_u32(217))][u32(unconst_u32(64))][0][u32(unconst_u32(157))];
+  vf304 = vec3h(f16(textureNumLevels(tex11)));
+  fn2();
+  let ptr61: ptr<workgroup, mat2x3h> = &(*&vw19).f1[u32(unconst_u32(98))][u32(unconst_u32(158))][0];
+  vw17 = T2(vec2u(log(vec3h(unconst_f16(7825.7), unconst_f16(66.81), unconst_f16(19737.6))).yx));
+  vw22 = VertexOutput8(vec4f((*ptr60).f1[0][u32(unconst_u32(10))][0][unconst_i32(1)].gbrr));
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup120 = device0.createBindGroup({
+  label: '\u91ea\ua860\u{1fa9d}\u0980\u9f98\u{1f6c1}\u5c3c',
+  layout: bindGroupLayout25,
+  entries: [{binding: 230, resource: externalTexture36}],
+});
+let commandEncoder213 = device0.createCommandEncoder({});
+let textureView205 = texture222.createView({});
+try {
+computePassEncoder30.setBindGroup(2, bindGroup52);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder57); computePassEncoder57.dispatchWorkgroupsIndirect(buffer0, 1_256); };
+} catch {}
+try {
+computePassEncoder57.end();
+} catch {}
+try {
+computePassEncoder139.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder52.setIndexBuffer(buffer82, 'uint32', 364, 239);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(7, buffer84, 0, 1_756);
+} catch {}
+try {
+commandEncoder211.copyBufferToBuffer(buffer74, 2852, buffer8, 6616, 2624);
+} catch {}
+try {
+commandEncoder86.copyTextureToTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture207,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(141).fill(133), /* required buffer size: 141 */
+{offset: 141, rowsPerImage: 26}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder214 = device0.createCommandEncoder({label: '\uce70\u{1fba7}'});
+let textureView206 = texture154.createView({baseMipLevel: 0});
+let computePassEncoder150 = commandEncoder213.beginComputePass({});
+let renderPassEncoder80 = commandEncoder211.beginRenderPass({
+  label: '\u0b74\uc311',
+  colorAttachments: [{view: textureView157, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet11,
+  maxDrawCount: 812675480,
+});
+let externalTexture38 = device0.importExternalTexture({source: videoFrame14});
+try {
+computePassEncoder7.setBindGroup(3, bindGroup89);
+} catch {}
+let bindGroup121 = device0.createBindGroup({
+  layout: bindGroupLayout16,
+  entries: [
+    {binding: 15, resource: {buffer: buffer49, offset: 5120}},
+    {binding: 38, resource: textureView113},
+    {binding: 24, resource: textureView83},
+    {binding: 128, resource: textureView112},
+    {binding: 141, resource: textureView32},
+    {binding: 301, resource: {buffer: buffer105, offset: 0, size: 388}},
+  ],
+});
+let commandEncoder215 = device0.createCommandEncoder({label: '\u8129\u6e73\u47f1\u{1fab0}\u{1f6a7}\u{1f80c}'});
+let textureView207 = texture13.createView({});
+try {
+computePassEncoder96.setBindGroup(2, bindGroup46);
+} catch {}
+try {
+renderPassEncoder28.executeBundles([renderBundle14]);
+} catch {}
+try {
+renderPassEncoder63.setVertexBuffer(6, buffer80);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let buffer151 = device0.createBuffer({
+  size: 15538,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandBuffer13 = commandEncoder86.finish();
+let computePassEncoder151 = commandEncoder214.beginComputePass({});
+try {
+computePassEncoder134.setBindGroup(3, bindGroup57);
+} catch {}
+try {
+computePassEncoder115.setBindGroup(1, bindGroup87, new Uint32Array(662), 186, 0);
+} catch {}
+let arrayBuffer19 = buffer31.getMappedRange(1968, 224);
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder216 = device0.createCommandEncoder({label: '\u3d20\u{1f92c}\u{1f94b}\u0d5f\ud87e'});
+let querySet31 = device0.createQuerySet({type: 'occlusion', count: 189});
+let texture236 = device0.createTexture({size: [256, 256, 28], dimension: '3d', format: 'r16sint', usage: GPUTextureUsage.COPY_SRC});
+let computePassEncoder152 = commandEncoder215.beginComputePass({label: '\u0a50\u07ae\ub9c1\u9e6c\u{1f8e1}\u2df1\u432d\uf933'});
+let sampler141 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 43.87,
+});
+try {
+computePassEncoder24.setBindGroup(2, bindGroup2, new Uint32Array(82), 12, 0);
+} catch {}
+try {
+computePassEncoder151.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder49.setBindGroup(1, bindGroup79);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup32, new Uint32Array(1016), 195, 0);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer22, 'uint16', 180, 2_206);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(3, buffer78, 0);
+} catch {}
+let img2 = await imageWithData(32, 56, '#10101010', '#20202020');
+let videoFrame45 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte170m', primaries: 'bt470m', transfer: 'bt709'} });
+let buffer152 = device0.createBuffer({size: 14418, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX, mappedAtCreation: false});
+let textureView208 = texture5.createView({});
+let computePassEncoder153 = commandEncoder216.beginComputePass({label: '\u0fe1\u09ff'});
+let renderPassEncoder81 = commandEncoder212.beginRenderPass({
+  colorAttachments: [{
+  view: textureView205,
+  depthSlice: 10,
+  clearValue: { r: -499.8, g: -984.2, b: -789.5, a: 701.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet1,
+});
+try {
+renderPassEncoder65.setVertexBuffer(7, buffer17, 9_640, 139);
+} catch {}
+let pipelineLayout19 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder217 = device0.createCommandEncoder({label: '\u09f3\u{1ff5f}\ud4be\u02a4\u0d31\u0590'});
+let texture237 = device0.createTexture({size: [2, 1, 1], format: 'r16float', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let computePassEncoder154 = commandEncoder217.beginComputePass({});
+let sampler142 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 72.26,
+  lodMaxClamp: 89.80,
+});
+try {
+computePassEncoder153.setBindGroup(3, bindGroup74);
+} catch {}
+try {
+computePassEncoder154.setBindGroup(3, bindGroup29, new Uint32Array(1509), 123, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer101, 2608, new DataView(new ArrayBuffer(7227)), 146, 516);
+} catch {}
+try {
+computePassEncoder154.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder58.setIndexBuffer(buffer15, 'uint16', 242, 9);
+} catch {}
+try {
+device0.queue.submit([commandBuffer13]);
+} catch {}
+let bindGroupLayout26 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 400,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let pipelineLayout20 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer153 = device0.createBuffer({size: 6200, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let sampler143 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 37.09,
+  lodMaxClamp: 75.59,
+  compare: 'always',
+});
+try {
+computePassEncoder71.setBindGroup(0, bindGroup55, new Uint32Array(987), 92, 0);
+} catch {}
+try {
+renderPassEncoder79.setBindGroup(2, bindGroup29);
+} catch {}
+try {
+renderPassEncoder36.executeBundles([renderBundle36]);
+} catch {}
+try {
+buffer40.unmap();
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipelineLayout21 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder218 = device0.createCommandEncoder({});
+let renderPassEncoder82 = commandEncoder218.beginRenderPass({
+  label: '\u6673\u07a7\u0be1\ue639\u{1f775}',
+  colorAttachments: [{
+  view: textureView205,
+  depthSlice: 19,
+  clearValue: { r: -75.05, g: 278.5, b: -965.9, a: -953.5, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder153.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder53.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderPassEncoder70.setVertexBuffer(0, buffer126, 0, 81);
+} catch {}
+try {
+buffer30.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture89,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(1_135).fill(141), /* required buffer size: 1_135 */
+{offset: 85, bytesPerRow: 35, rowsPerImage: 6}, {width: 0, height: 0, depthOrArrayLayers: 6});
+} catch {}
+let promise20 = device0.queue.onSubmittedWorkDone();
+let texture238 = device0.createTexture({
+  size: [16, 10, 46],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler144 = device0.createSampler({
+  label: '\u36e3\u08d6\u0353\u81cf\ue7d2\u{1fcbc}\u020f\u215e\u{1fce5}\u0c68\ub8b3',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 22.86,
+  maxAnisotropy: 7,
+});
+let externalTexture39 = device0.importExternalTexture({label: '\uf064\u649f', source: videoFrame23});
+try {
+renderPassEncoder17.executeBundles([renderBundle13]);
+} catch {}
+let commandEncoder219 = device0.createCommandEncoder({});
+let texture239 = device0.createTexture({
+  size: [4, 2, 1],
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r8uint'],
+});
+let computePassEncoder155 = commandEncoder219.beginComputePass({});
+let sampler145 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 9.798,
+  lodMaxClamp: 31.43,
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder30.setBindGroup(2, bindGroup23, new Uint32Array(418), 31, 0);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer106, 'uint16', 3_252, 12_276);
+} catch {}
+document.body.prepend(canvas0);
+try {
+computePassEncoder117.setBindGroup(1, bindGroup102);
+} catch {}
+try {
+computePassEncoder150.setPipeline(pipeline2);
+} catch {}
+let bindGroup122 = device0.createBindGroup({
+  layout: bindGroupLayout16,
+  entries: [
+    {binding: 38, resource: textureView122},
+    {binding: 128, resource: textureView112},
+    {binding: 141, resource: textureView38},
+    {binding: 24, resource: textureView162},
+    {binding: 15, resource: {buffer: buffer82, offset: 0, size: 324}},
+    {binding: 301, resource: {buffer: buffer32, offset: 4608, size: 664}},
+  ],
+});
+let commandEncoder220 = device0.createCommandEncoder({label: '\u0f04\u{1f999}\u273d\ud78e\u{1f65e}\u05ff\u{1f751}\u3175\u39a0'});
+try {
+computePassEncoder91.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+computePassEncoder122.setBindGroup(1, bindGroup57, new Uint32Array(2981), 883, 0);
+} catch {}
+try {
+renderPassEncoder53.setBindGroup(3, bindGroup79);
+} catch {}
+try {
+renderPassEncoder25.setViewport(0.7846883097420014, 1.211748310496534, 0.9069393286802637, 0.008831983134569054, 0.30267442727771654, 0.7076639689887747);
+} catch {}
+try {
+commandEncoder220.copyTextureToTexture({
+  texture: texture89,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup123 = device0.createBindGroup({
+  label: '\u6731\u1ef4\u{1fb33}',
+  layout: bindGroupLayout20,
+  entries: [{binding: 557, resource: {buffer: buffer98, offset: 1536}}],
+});
+let renderPassEncoder83 = commandEncoder220.beginRenderPass({
+  colorAttachments: [{
+  view: textureView166,
+  clearValue: { r: 137.8, g: 933.6, b: -801.9, a: 204.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let renderBundleEncoder42 = device0.createRenderBundleEncoder({colorFormats: ['r16float'], depthReadOnly: true});
+let sampler146 = device0.createSampler({
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 22.62,
+  lodMaxClamp: 51.63,
+});
+try {
+renderPassEncoder52.setViewport(2.2702891571036483, 1.2972991172450206, 1.3178268128222124, 0.15327884581053441, 0.8223986390993026, 0.9438545049685693);
+} catch {}
+try {
+renderBundleEncoder42.setPipeline(pipeline6);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer29, 156, new Int16Array(15556), 3479, 504);
+} catch {}
+let buffer154 = device0.createBuffer({
+  size: 41241,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture240 = device0.createTexture({size: [8, 5, 1], format: 'r8uint', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC});
+let sampler147 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 3.679,
+  lodMaxClamp: 67.52,
+});
+try {
+renderPassEncoder49.setBindGroup(1, bindGroup44);
+} catch {}
+try {
+renderBundleEncoder42.setIndexBuffer(buffer29, 'uint16', 910, 294);
+} catch {}
+let arrayBuffer20 = buffer87.getMappedRange(432, 196);
+try {
+buffer121.unmap();
+} catch {}
+canvas2.width = 375;
+let buffer155 = device0.createBuffer({size: 10303, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView209 = texture11.createView({label: '\uf046\u6298\u04db\ua11f\u93aa\u{1fa5f}\u0828\u0c5e\u{1fadf}\u6d38', mipLevelCount: 1});
+try {
+computePassEncoder94.setBindGroup(2, bindGroup114);
+} catch {}
+try {
+renderPassEncoder39.executeBundles([renderBundle5]);
+} catch {}
+try {
+renderBundleEncoder42.setPipeline(pipeline1);
+} catch {}
+let imageData24 = new ImageData(56, 36);
+let bindGroupLayout27 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 27,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let texture241 = gpuCanvasContext6.getCurrentTexture();
+let textureView210 = texture105.createView({arrayLayerCount: 1});
+let renderBundle42 = renderBundleEncoder42.finish({});
+let sampler148 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 78.61,
+  lodMaxClamp: 87.82,
+});
+try {
+computePassEncoder152.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder83.setVertexBuffer(1, buffer53, 0, 935);
+} catch {}
+try {
+renderPassEncoder45.pushDebugGroup('\uf7c1');
+} catch {}
+let externalTexture40 = device0.importExternalTexture({source: videoFrame18, colorSpace: 'srgb'});
+try {
+computePassEncoder155.setPipeline(pipeline7);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 256, depthOrArrayLayers: 111}
+*/
+{
+  source: imageData14,
+  origin: { x: 14, y: 12 },
+  flipY: true,
+}, {
+  texture: texture138,
+  mipLevel: 0,
+  origin: {x: 4, y: 4, z: 11},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 16, depthOrArrayLayers: 0});
+} catch {}
+try {
+globalThis.someLabel = externalTexture24.label;
+} catch {}
+let buffer156 = device0.createBuffer({
+  size: 16816,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder221 = device0.createCommandEncoder({});
+let computePassEncoder156 = commandEncoder221.beginComputePass();
+try {
+computePassEncoder156.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer22, 'uint32', 1_792, 187);
+} catch {}
+document.body.append(img1);
+let textureView211 = texture129.createView({});
+try {
+computePassEncoder127.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder78.setBindGroup(0, bindGroup85);
+} catch {}
+try {
+renderPassEncoder39.beginOcclusionQuery(4);
+} catch {}
+try {
+renderPassEncoder54.setVertexBuffer(0, buffer56, 0, 4_724);
+} catch {}
+try {
+  await promise20;
+} catch {}
+document.body.append(canvas3);
+await gc();
+let texture242 = gpuCanvasContext1.getCurrentTexture();
+try {
+renderPassEncoder83.setIndexBuffer(buffer12, 'uint32', 440, 906);
+} catch {}
+let buffer157 = device0.createBuffer({
+  size: 3394,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let textureView212 = texture202.createView({dimension: '2d-array', format: 'rgba16sint'});
+let sampler149 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  lodMinClamp: 98.56,
+  lodMaxClamp: 99.48,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder39.endOcclusionQuery();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 146, y: 10, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let imageData25 = new ImageData(48, 40);
+let shaderModule12 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires pointer_composite_access;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(22) var tex14: texture_depth_2d;
+
+@group(0) @binding(55) var tex15: texture_2d<f32>;
+
+@group(0) @binding(62) var<uniform> buffer158: vec2f;
+
+@group(0) @binding(103) var tex16: texture_2d<u32>;
+
+@group(0) @binding(132) var sam3: sampler;
+
+@group(0) @binding(236) var st4: texture_storage_2d<rg32float, read>;
+
+struct T0 {
+  @align(8) @size(8) f0: u32,
+}
+
+struct T1 {
+  @align(8) @size(8) f0: atomic<i32>,
+}
+
+struct S3 {
+  @location(11) f0: vec2u,
+}
+
+struct S4 {
+  @location(7) @interpolate(perspective) f0: vec2h,
+  @location(8) @interpolate(perspective) f1: vec4h,
+  @location(10) @interpolate(perspective) f2: vec4f,
+  @location(13) @interpolate(flat, centroid) f3: f16,
+}
+
+struct VertexOutput9 {
+  @builtin(position) f27: vec4f,
+}
+
+struct FragmentOutput9 {
+  @location(0) f0: vec4f,
+}
+
+alias vec3b = vec3<bool>;
+
+fn fn0() -> i32 {
+  var out: i32;
+  let ptr62: ptr<workgroup, vec4u> = &(*&vw27)[0];
+  let ptr63: ptr<workgroup, u32> = &vw33[u32(unconst_u32(91))][4].f0;
+  vw32.f27 -= vec4f((*&vw40)[u32(unconst_u32(64))]);
+  var vf309: i32 = atomicExchange(&(*&vw23), i32(unconst_i32(112)));
+  var vf310: u32 = (*&vw27)[0][u32(unconst_u32(64))];
+  vw38 = bitcast<vec4i>(vw24[unconst_i32(0)])[2];
+  let vf311: u32 = textureNumLevels(tex14);
+  vw40 *= vec2f(bitcast<f32>(atomicLoad(&(*&vw25).f0)));
+  return out;
+}
+
+var<workgroup> vw23: atomic<i32>;
+
+var<workgroup> vw24: mat2x4f;
+
+var<workgroup> vw25: T1;
+
+var<workgroup> vw26: mat2x4f;
+
+var<workgroup> vw27: array<vec4u, 1>;
+
+var<workgroup> vw28: i32;
+
+var<workgroup> vw29: atomic<i32>;
+
+var<workgroup> vw30: T0;
+
+var<workgroup> vw31: array<mat3x4f, 1>;
+
+var<workgroup> vw32: VertexOutput9;
+
+var<workgroup> vw33: array<array<T0, 5>, 1>;
+
+var<workgroup> vw34: T0;
+
+var<workgroup> vw35: T1;
+
+var<workgroup> vw36: T0;
+
+var<workgroup> vw37: atomic<u32>;
+
+var<workgroup> vw38: i32;
+
+var<workgroup> vw39: f32;
+
+var<workgroup> vw40: vec2f;
+
+var<workgroup> vw41: FragmentOutput9;
+
+@vertex @must_use
+fn vertex11(a0: S3, a1: S4, @location(3) @interpolate(perspective, sample) a2: vec4f) -> VertexOutput9 {
+  var out: VertexOutput9;
+  out = VertexOutput9(vec4f(f32(acosh(f16(a0.f0[u32(unconst_u32(103))])))));
+  let vf312: f16 = a1.f0[u32(unconst_u32(163))];
+  let ptr64: ptr<uniform, vec2f> = &(*&buffer158);
+  var vf313: u32 = textureNumLevels(tex16);
+  out = VertexOutput9(vec4f(bitcast<f32>(vf313)));
+  let vf314: vec4f = a2;
+  var vf315: f16 = a1.f3;
+  let vf316: vec4u = reverseBits(vec4u(unconst_u32(257), unconst_u32(1000), unconst_u32(77), unconst_u32(172)));
+  out = VertexOutput9(vec4f(bitcast<f32>(vf313)));
+  out = VertexOutput9(vec4f(f32(vf312)));
+  var vf317: vec4u = reverseBits(vec4u(unconst_u32(91), unconst_u32(78), unconst_u32(273), unconst_u32(125)));
+  return out;
+}
+
+@fragment
+fn fragment11(@builtin(position) a0: vec4f) -> FragmentOutput9 {
+  var out: FragmentOutput9;
+  let vf318: vec2u = textureDimensions(tex16);
+  var vf319: vec4f = textureLoad(st4, vec2i(unconst_i32(-56), unconst_i32(104)));
+  out.f0 = vec4f(cross(vec3h(unconst_f16(4358.9), unconst_f16(16803.7), unconst_f16(1897.8)), vec3h(textureDimensions(tex16, i32(unconst_i32(149))).grr)).gbrg);
+  var vf320: vec4u = textureLoad(tex16, vec2i(unconst_i32(163), unconst_i32(83)), i32(unconst_i32(163)));
+  var vf321: mat4x3f = transpose(mat3x4f(unconst_f32(0.5571), unconst_f32(0.3277), unconst_f32(0.2384), unconst_f32(-0.06139), unconst_f32(0.02281), unconst_f32(0.2876), unconst_f32(0.00740), unconst_f32(0.1065), unconst_f32(0.04103), unconst_f32(-0.1096), unconst_f32(0.09287), unconst_f32(0.2786)));
+  var vf322: vec4h = reflect(vec4h(unconst_f16(27560.0), unconst_f16(18975.3), unconst_f16(2695.7), unconst_f16(13096.9)), vec4h(unconst_f16(1864.9), unconst_f16(23981.6), unconst_f16(10131.8), unconst_f16(6143.5)));
+  vf319 = vec4f(textureDimensions(tex16).rrrg);
+  vf320 |= vec4u(reverseBits(vec2i(unconst_i32(226), unconst_i32(260))).yxyy);
+  out.f0 += vec4f(vf321[pack2x16unorm(asin(vec2f(unconst_f32(0.08298), unconst_f32(0.07155))))][u32(unconst_u32(148))]);
+  var vf323: f32 = ldexp(vec3f(cross(vec3h(unconst_f16(7007.1), unconst_f16(248.1), unconst_f16(6068.8)), vec3h(unconst_f16(9564.2), unconst_f16(1625.8), unconst_f16(7192.2))))[0], i32(unconst_i32(64)));
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute9() {
+  var vf324 = fn0();
+  vw26 = mat2x4f(f32((*&vw33)[0][4].f0), f32((*&vw33)[0][4].f0), f32((*&vw33)[0][4].f0), f32((*&vw33)[0][4].f0), bitcast<f32>((*&vw33)[0][4].f0), f32((*&vw33)[0][4].f0), bitcast<f32>((*&vw33)[0][4].f0), f32((*&vw33)[0][4].f0));
+  var vf325 = fn0();
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup124 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [
+    {binding: 55, resource: textureView168},
+    {binding: 62, resource: {buffer: buffer55, offset: 768, size: 4390}},
+    {binding: 103, resource: textureView43},
+    {binding: 236, resource: textureView80},
+    {binding: 22, resource: textureView78},
+    {binding: 132, resource: sampler73},
+  ],
+});
+let buffer159 = device0.createBuffer({
+  size: 12105,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false,
+});
+let commandEncoder222 = device0.createCommandEncoder();
+let textureView213 = texture67.createView({format: 'rg32float'});
+try {
+computePassEncoder104.setBindGroup(2, bindGroup75);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer104, 'uint32', 88, 1_050);
+} catch {}
+try {
+commandEncoder222.clearBuffer(buffer144);
+} catch {}
+try {
+renderPassEncoder45.popDebugGroup();
+} catch {}
+let commandEncoder223 = device0.createCommandEncoder({label: '\u{1f9e1}\u87f9\u{1feb1}\u{1f6e0}'});
+let computePassEncoder157 = commandEncoder223.beginComputePass({});
+let renderPassEncoder84 = commandEncoder222.beginRenderPass({
+  colorAttachments: [{
+  view: textureView205,
+  depthSlice: 0,
+  clearValue: { r: 13.85, g: -340.2, b: 368.2, a: -894.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet1,
+});
+try {
+computePassEncoder91.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder84.setBindGroup(0, bindGroup82);
+} catch {}
+try {
+renderPassEncoder73.setIndexBuffer(buffer135, 'uint16', 5_848, 1_541);
+} catch {}
+try {
+renderPassEncoder79.setPipeline(pipeline8);
+} catch {}
+let commandEncoder224 = device0.createCommandEncoder();
+let sampler150 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 26.38,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder157.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer61, 'uint32', 3_564, 1_313);
+} catch {}
+try {
+renderPassEncoder72.setVertexBuffer(6, buffer12);
+} catch {}
+let arrayBuffer21 = buffer8.getMappedRange(4880, 12);
+try {
+buffer82.unmap();
+} catch {}
+try {
+commandEncoder224.clearBuffer(buffer112);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+try {
+adapter0.label = '\u3030\ud42a\ucd3e\u0927\u058d\u{1fe60}\u7bb6\u{1fe5c}\u02ca\ue3f5';
+} catch {}
+let computePassEncoder158 = commandEncoder224.beginComputePass({});
+try {
+computePassEncoder56.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(2, bindGroup58, new Uint32Array(2449), 1_647, 0);
+} catch {}
+try {
+renderPassEncoder81.setStencilReference(61);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(6, buffer118, 696, 64);
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let promise21 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise21;
+} catch {}
+let buffer160 = device0.createBuffer({
+  label: '\u0966\u{1fc52}\u9dbb\uafa4\u568e\uf3fc\u0044\u92e3\u0897\u{1f73c}\ubb7f',
+  size: 6579,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder225 = device0.createCommandEncoder({});
+let texture243 = device0.createTexture({size: [8], dimension: '1d', format: 'r16float', usage: GPUTextureUsage.COPY_SRC, viewFormats: []});
+try {
+commandEncoder225.copyBufferToTexture({
+  /* bytesInLastRow: 6 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 7483 */
+  offset: 7483,
+  bytesPerRow: 30720,
+  buffer: buffer106,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 36, y: 39, z: 2},
+  aspect: 'all',
+}, {width: 6, height: 103, depthOrArrayLayers: 0});
+} catch {}
+let textureView214 = texture202.createView({dimension: '2d-array', baseArrayLayer: 0});
+let textureView215 = texture129.createView({arrayLayerCount: 1});
+let renderPassEncoder85 = commandEncoder225.beginRenderPass({
+  label: '\u4570\u04e5\u6092\u0426\u3367\u367d\ua425\u0a4d\u767d\u{1f9b4}\u9b8d',
+  colorAttachments: [{view: textureView205, depthSlice: 24, loadOp: 'load', storeOp: 'discard'}],
+});
+try {
+renderPassEncoder83.setPipeline(pipeline8);
+} catch {}
+let commandEncoder226 = device0.createCommandEncoder({});
+let querySet32 = device0.createQuerySet({type: 'occlusion', count: 1219});
+let computePassEncoder159 = commandEncoder226.beginComputePass({});
+let sampler151 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 37.57,
+  lodMaxClamp: 88.89,
+});
+try {
+renderPassEncoder46.setPipeline(pipeline8);
+} catch {}
+try {
+  await shaderModule8.getCompilationInfo();
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let textureView216 = texture202.createView({});
+let texture244 = device0.createTexture({
+  label: '\u{1f940}\u43ce\u67e2\u{1f7ef}\u{1fee4}\uaa42\uf2e5\u0958\u{1fca9}',
+  size: {width: 8, height: 5, depthOrArrayLayers: 1},
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView217 = texture208.createView({label: '\u4489\u4b0f\u1faf\u75ec\u3651\u3016\u67b1\u11db'});
+let sampler152 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 65.10,
+  maxAnisotropy: 8,
+});
+try {
+renderPassEncoder59.setIndexBuffer(buffer55, 'uint16', 7_496, 1_895);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(3, buffer53, 84, 151);
+} catch {}
+let texture245 = device0.createTexture({
+  size: [256, 256, 12],
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundleEncoder43 = device0.createRenderBundleEncoder({colorFormats: ['r16float'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderPassEncoder81.setBlendConstant({ r: -201.5, g: 480.1, b: -436.9, a: 339.7, });
+} catch {}
+try {
+renderBundleEncoder43.setBindGroup(0, bindGroup64);
+} catch {}
+try {
+renderBundleEncoder43.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer84, 44, new Float32Array(13715), 1625, 52);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 5, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData19,
+  origin: { x: 0, y: 5 },
+  flipY: true,
+}, {
+  texture: texture81,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer161 = device0.createBuffer({
+  label: '\uf2f9\u117c',
+  size: 6494,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let renderBundle43 = renderBundleEncoder43.finish({});
+let sampler153 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 87.44,
+  lodMaxClamp: 98.27,
+});
+try {
+computePassEncoder104.setBindGroup(0, bindGroup112);
+} catch {}
+try {
+computePassEncoder158.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder83.setIndexBuffer(buffer106, 'uint16', 2_596, 11_285);
+} catch {}
+try {
+renderPassEncoder51.setVertexBuffer(4, buffer12, 1_068);
+} catch {}
+try {
+buffer22.unmap();
+} catch {}
+document.body.append(img1);
+let commandEncoder227 = device0.createCommandEncoder({label: '\u276b\u{1f9fe}\ue9ac\u{1fa8f}\u0efb\u4113\u0c29\u44bd'});
+let computePassEncoder160 = commandEncoder227.beginComputePass({});
+let sampler154 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 40.43,
+  lodMaxClamp: 60.84,
+});
+try {
+computePassEncoder65.setBindGroup(3, bindGroup92);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(2, bindGroup77, new Uint32Array(4727), 501, 0);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(4, buffer156, 0, 2_236);
+} catch {}
+let buffer162 = device0.createBuffer({size: 8128, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let texture246 = device0.createTexture({size: [256, 256, 57], dimension: '3d', format: 'rgb10a2unorm', usage: GPUTextureUsage.COPY_SRC});
+let sampler155 = device0.createSampler({addressModeV: 'clamp-to-edge', addressModeW: 'mirror-repeat', lodMinClamp: 81.75, lodMaxClamp: 86.08});
+try {
+computePassEncoder139.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+renderPassEncoder80.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder65.setVertexBuffer(5, buffer143, 2_604);
+} catch {}
+try {
+  await buffer47.mapAsync(GPUMapMode.WRITE, 136, 40);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let videoFrame46 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'smpte170m', transfer: 'unspecified'} });
+try {
+adapter0.label = '\u581d\uc918';
+} catch {}
+let commandEncoder228 = device0.createCommandEncoder({});
+let texture247 = device0.createTexture({
+  label: '\u000e\u0c01\u4e5a',
+  size: [256, 256, 15],
+  mipLevelCount: 3,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r8uint'],
+});
+let renderPassEncoder86 = commandEncoder228.beginRenderPass({
+  colorAttachments: [{
+  view: textureView144,
+  clearValue: { r: 839.4, g: 323.3, b: -633.2, a: 731.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let sampler156 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 32.04,
+  lodMaxClamp: 63.15,
+  compare: 'never',
+  maxAnisotropy: 20,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder56); computePassEncoder56.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder56); computePassEncoder56.dispatchWorkgroupsIndirect(buffer10, 432); };
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture248 = device0.createTexture({
+  label: '\u3b8f\u0976\ue756\u0048\ucdf1\u69df\u68a3\u57e4\u{1f6fe}\u94f3',
+  size: [256, 256, 15],
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler157 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  compare: 'never',
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder56); computePassEncoder56.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder160.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder44.setVertexBuffer(0, buffer68, 344);
+} catch {}
+try {
+renderPassEncoder47.pushDebugGroup('\u03ec');
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let querySet33 = device0.createQuerySet({type: 'occlusion', count: 68});
+let sampler158 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 96.47,
+  lodMaxClamp: 97.07,
+});
+try {
+computePassEncoder56.end();
+} catch {}
+try {
+computePassEncoder159.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup66, new Uint32Array(1801), 103, 0);
+} catch {}
+try {
+renderPassEncoder55.setVertexBuffer(2, buffer161, 104, 808);
+} catch {}
+let arrayBuffer22 = buffer8.getMappedRange(5112, 4);
+let computePassEncoder161 = commandEncoder82.beginComputePass({});
+let renderBundleEncoder44 = device0.createRenderBundleEncoder({colorFormats: ['r16float'], sampleCount: 1});
+try {
+computePassEncoder154.setBindGroup(0, bindGroup7, []);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder154); computePassEncoder154.dispatchWorkgroupsIndirect(buffer22, 136); };
+} catch {}
+try {
+computePassEncoder154.end();
+} catch {}
+try {
+computePassEncoder161.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(3, bindGroup92);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder50.setIndexBuffer(buffer125, 'uint16', 14, 61);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(3, buffer117, 0);
+} catch {}
+try {
+renderBundleEncoder44.setBindGroup(3, bindGroup1, []);
+} catch {}
+try {
+renderBundleEncoder44.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder44.setVertexBuffer(3, buffer117, 0, 857);
+} catch {}
+try {
+commandEncoder217.clearBuffer(buffer143, 1260, 2888);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture249 = device0.createTexture({size: [256], sampleCount: 1, dimension: '1d', format: 'r8uint', usage: GPUTextureUsage.COPY_SRC});
+let renderPassEncoder87 = commandEncoder217.beginRenderPass({colorAttachments: [{view: textureView205, depthSlice: 8, loadOp: 'load', storeOp: 'discard'}]});
+let sampler159 = device0.createSampler({
+  label: '\u{1ff43}\u{1ff27}\u4958',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 1.404,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder106.setBindGroup(3, bindGroup91, new Uint32Array(2027), 658, 0);
+} catch {}
+try {
+renderPassEncoder42.setStencilReference(288);
+} catch {}
+try {
+renderPassEncoder31.setViewport(0.9587344135585223, 0.28404271739286246, 0.2914222337971973, 0.32964942138267617, 0.03467920370311439, 0.9112925399048201);
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+await gc();
+let buffer163 = device0.createBuffer({size: 3743, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM});
+let commandEncoder229 = device0.createCommandEncoder();
+let texture250 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 15},
+  mipLevelCount: 4,
+  sampleCount: 1,
+  format: 'r8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundleEncoder45 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2unorm'], stencilReadOnly: false});
+let renderBundle44 = renderBundleEncoder45.finish({});
+try {
+computePassEncoder96.setBindGroup(2, bindGroup116);
+} catch {}
+try {
+renderPassEncoder57.setBindGroup(3, bindGroup14);
+} catch {}
+try {
+renderPassEncoder53.setStencilReference(396);
+} catch {}
+try {
+renderPassEncoder56.setIndexBuffer(buffer142, 'uint16', 4_408, 7_041);
+} catch {}
+try {
+renderBundleEncoder44.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder47.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture89,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(54).fill(73), /* required buffer size: 54 */
+{offset: 54}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData26 = new ImageData(20, 64);
+let videoFrame47 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'bt709', transfer: 'hlg'} });
+let texture251 = device0.createTexture({size: {width: 4}, dimension: '1d', format: 'rgb10a2unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+let computePassEncoder162 = commandEncoder229.beginComputePass();
+try {
+computePassEncoder159.setBindGroup(0, bindGroup9, new Uint32Array(68), 3, 0);
+} catch {}
+try {
+computePassEncoder162.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder11.beginOcclusionQuery(52);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer20, 1300, new BigUint64Array(1592), 174, 160);
+} catch {}
+let bindGroupLayout28 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 208,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba16uint', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 64,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '2d-array' },
+    },
+    {binding: 217, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let buffer164 = device0.createBuffer({
+  size: 1938,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let sampler160 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 40.60,
+  lodMaxClamp: 56.94,
+});
+try {
+computePassEncoder79.setBindGroup(0, bindGroup74, []);
+} catch {}
+try {
+renderPassEncoder71.setBindGroup(3, bindGroup99, new Uint32Array(3179), 303, 0);
+} catch {}
+try {
+renderPassEncoder48.setIndexBuffer(buffer115, 'uint32', 4_948, 288);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture239,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(113).fill(9), /* required buffer size: 113 */
+{offset: 113, bytesPerRow: 18}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline9 = device0.createRenderPipeline({
+  layout: pipelineLayout6,
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment4',
+  constants: {},
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'src', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}],
+},
+  vertex: {
+    module: shaderModule0,
+    buffers: [{arrayStride: 392, attributes: [{format: 'float16x4', offset: 60, shaderLocation: 14}]}],
+  },
+  primitive: {unclippedDepth: true},
+});
+let bindGroup125 = device0.createBindGroup({
+  layout: bindGroupLayout28,
+  entries: [
+    {binding: 208, resource: textureView175},
+    {binding: 64, resource: textureView139},
+    {binding: 217, resource: externalTexture31},
+  ],
+});
+let texture252 = device0.createTexture({size: [16], dimension: '1d', format: 'r8uint', usage: GPUTextureUsage.COPY_SRC});
+try {
+renderPassEncoder34.setBindGroup(2, bindGroup35);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(4, buffer152, 496, 405);
+} catch {}
+let promise22 = device0.queue.onSubmittedWorkDone();
+let pipelineLayout22 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout19]});
+let texture253 = device0.createTexture({
+  size: {width: 256},
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler161 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 30.85,
+  lodMaxClamp: 30.99,
+  compare: 'less',
+});
+try {
+computePassEncoder116.end();
+} catch {}
+try {
+renderPassEncoder63.setVertexBuffer(6, buffer12, 0);
+} catch {}
+try {
+renderBundleEncoder44.setIndexBuffer(buffer106, 'uint32', 4_616, 301);
+} catch {}
+try {
+buffer114.unmap();
+} catch {}
+try {
+commandEncoder171.copyBufferToBuffer(buffer105, 784, buffer142, 10836, 124);
+} catch {}
+try {
+commandEncoder171.resolveQuerySet(querySet13, 254, 43, buffer99, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(canvas4);
+let imageData27 = new ImageData(4, 28);
+let computePassEncoder163 = commandEncoder171.beginComputePass({});
+let sampler162 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 31.35,
+  lodMaxClamp: 33.70,
+  maxAnisotropy: 19,
+});
+try {
+renderPassEncoder56.setBindGroup(1, bindGroup111);
+} catch {}
+try {
+renderPassEncoder36.executeBundles([renderBundle3, renderBundle23]);
+} catch {}
+try {
+renderBundleEncoder44.setBindGroup(2, bindGroup53);
+} catch {}
+try {
+renderBundleEncoder44.setBindGroup(2, bindGroup100, new Uint32Array(158), 8, 0);
+} catch {}
+let buffer165 = device0.createBuffer({size: 1252, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let texture254 = device0.createTexture({
+  size: [2, 1, 1],
+  mipLevelCount: 1,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView218 = texture207.createView({aspect: 'all', mipLevelCount: 1});
+let sampler163 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 89.61,
+  lodMaxClamp: 98.67,
+  maxAnisotropy: 20,
+});
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup50);
+} catch {}
+try {
+renderPassEncoder47.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder44.setBindGroup(1, bindGroup64, new Uint32Array(1260), 203, 0);
+} catch {}
+try {
+renderBundleEncoder44.insertDebugMarker('\u01c6');
+} catch {}
+try {
+adapter0.label = '\u92eb\u0ae7\uce55';
+} catch {}
+let renderBundleEncoder46 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2unorm'], stencilReadOnly: true});
+let sampler164 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 74.21,
+});
+try {
+computePassEncoder60.setBindGroup(2, bindGroup48);
+} catch {}
+try {
+computePassEncoder163.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(4, buffer21, 0, 258);
+} catch {}
+try {
+renderBundleEncoder44.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture36,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 16},
+  aspect: 'all',
+}, new Uint8Array(2_800).fill(46), /* required buffer size: 2_800 */
+{offset: 136, bytesPerRow: 12, rowsPerImage: 37}, {width: 0, height: 0, depthOrArrayLayers: 7});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 256, depthOrArrayLayers: 15}
+*/
+{
+  source: videoFrame41,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 20, y: 10, z: 9},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture255 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 70},
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder52.setBindGroup(0, bindGroup114, new Uint32Array(279), 7, 0);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer84, 'uint32', 948, 274);
+} catch {}
+let bindGroup126 = device0.createBindGroup({
+  label: '\u0804\u501b\u6121\u809e\u0f1c\ubd19\u3f48\ude87\u5140',
+  layout: bindGroupLayout14,
+  entries: [
+    {binding: 87, resource: textureView197},
+    {binding: 157, resource: textureView79},
+    {binding: 47, resource: {buffer: buffer161, offset: 768, size: 571}},
+  ],
+});
+let commandEncoder230 = device0.createCommandEncoder({});
+try {
+computePassEncoder105.setBindGroup(0, bindGroup122);
+} catch {}
+try {
+computePassEncoder65.setBindGroup(1, bindGroup43, new Uint32Array(1549), 43, 0);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(1, bindGroup9, new Uint32Array(135), 40, 0);
+} catch {}
+try {
+renderPassEncoder81.setIndexBuffer(buffer82, 'uint32', 240, 2_207);
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder61.setVertexBuffer(7, buffer111, 0, 1_018);
+} catch {}
+try {
+commandEncoder230.copyBufferToBuffer(buffer40, 16, buffer165, 188, 180);
+} catch {}
+try {
+commandEncoder230.copyTextureToBuffer({
+  texture: texture158,
+  mipLevel: 0,
+  origin: {x: 104, y: 478, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1240 widthInBlocks: 155 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2056 */
+  offset: 2056,
+  bytesPerRow: 5632,
+  buffer: buffer104,
+}, {width: 155, height: 265, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let sampler165 = device0.createSampler({
+  label: '\u035e\u8829\u9018\u3e4e\u01db\u{1fa8e}\u661d\u193c\u47b3\u9379',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 86.60,
+  lodMaxClamp: 92.17,
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder97.setBindGroup(0, bindGroup78, new Uint32Array(423), 30, 0);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(1, bindGroup109);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup62, new Uint32Array(2048), 1_160, 0);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer93, 'uint16', 258, 521);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer111, 216, new Int16Array(4041), 101, 900);
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let computePassEncoder164 = commandEncoder230.beginComputePass();
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder79.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder44.setVertexBuffer(3, buffer20, 1_304, 13_246);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer124, 192, new BigUint64Array(38706), 12, 8);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture102,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(147).fill(212), /* required buffer size: 147 */
+{offset: 147}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let img3 = await imageWithData(77, 176, '#10101010', '#20202020');
+let commandEncoder231 = device0.createCommandEncoder({label: '\u0c2f\u79b4\u203b\u9c36\u0da1\u{1fff6}'});
+let computePassEncoder165 = commandEncoder231.beginComputePass({});
+try {
+computePassEncoder98.setBindGroup(0, bindGroup50, new Uint32Array(3841), 156, 0);
+} catch {}
+try {
+renderPassEncoder52.executeBundles([renderBundle36]);
+} catch {}
+try {
+renderPassEncoder81.setVertexBuffer(0, buffer49, 0);
+} catch {}
+try {
+renderBundleEncoder46.setBindGroup(1, bindGroup103, new Uint32Array(3250), 587, 0);
+} catch {}
+try {
+renderBundleEncoder46.setIndexBuffer(buffer121, 'uint32', 452, 192);
+} catch {}
+let img4 = await imageWithData(28, 77, '#10101010', '#20202020');
+let videoFrame48 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'smpte432', transfer: 'smpte240m'} });
+let bindGroup127 = device0.createBindGroup({
+  layout: bindGroupLayout18,
+  entries: [{binding: 97, resource: {buffer: buffer28, offset: 0, size: 292}}],
+});
+let buffer166 = device0.createBuffer({size: 25271, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let textureView219 = texture66.createView({});
+let sampler166 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 79.34,
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder108.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder47.setBindGroup(1, bindGroup111);
+} catch {}
+try {
+renderPassEncoder77.executeBundles([renderBundle25, renderBundle40]);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer52, 'uint32', 1_520, 508);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder46.setBindGroup(2, bindGroup115);
+} catch {}
+let imageData28 = new ImageData(20, 24);
+let videoFrame49 = new VideoFrame(videoFrame41, {timestamp: 0});
+let commandEncoder232 = device0.createCommandEncoder({});
+let textureView220 = texture134.createView({dimension: '2d-array'});
+let texture256 = device0.createTexture({size: [2, 1, 1], format: 'r8uint', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING});
+let computePassEncoder166 = commandEncoder232.beginComputePass({});
+try {
+renderPassEncoder52.setBindGroup(3, bindGroup28, new Uint32Array(1004), 77, 0);
+} catch {}
+try {
+renderPassEncoder59.setIndexBuffer(buffer100, 'uint16', 8_646, 889);
+} catch {}
+try {
+renderBundleEncoder44.setPipeline(pipeline9);
+} catch {}
+document.body.append(img4);
+let bindGroup128 = device0.createBindGroup({
+  layout: bindGroupLayout24,
+  entries: [{binding: 172, resource: textureView12}, {binding: 468, resource: {buffer: buffer106, offset: 768}}],
+});
+let renderBundle45 = renderBundleEncoder46.finish({});
+let sampler167 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 84.31,
+});
+try {
+computePassEncoder156.setBindGroup(2, bindGroup24);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder98); computePassEncoder98.dispatchWorkgroupsIndirect(buffer133, 15_228); };
+} catch {}
+try {
+renderPassEncoder67.executeBundles([renderBundle25, renderBundle25, renderBundle5, renderBundle40]);
+} catch {}
+try {
+renderPassEncoder57.setScissorRect(2, 0, 0, 0);
+} catch {}
+try {
+renderBundleEncoder44.setBindGroup(3, bindGroup101, new Uint32Array(347), 26, 0);
+} catch {}
+try {
+renderBundleEncoder44.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder44.insertDebugMarker('\u7a7d');
+} catch {}
+let buffer167 = device0.createBuffer({
+  size: 14439,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let renderBundleEncoder47 = device0.createRenderBundleEncoder({colorFormats: ['r16sint'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle46 = renderBundleEncoder47.finish({});
+let sampler168 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.14,
+  compare: 'greater-equal',
+});
+try {
+computePassEncoder89.setBindGroup(2, bindGroup76, new Uint32Array(4725), 493, 0);
+} catch {}
+try {
+computePassEncoder165.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder77.setIndexBuffer(buffer61, 'uint32', 11_572, 8);
+} catch {}
+try {
+renderBundleEncoder44.setIndexBuffer(buffer10, 'uint32', 5_760, 4_104);
+} catch {}
+try {
+renderBundleEncoder44.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder44.setVertexBuffer(5, buffer73, 0, 446);
+} catch {}
+let shaderModule13 = device0.createShaderModule({
+  code: `
+enable f16;
+
+enable f16;
+
+requires pointer_composite_access;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(55) var tex18: texture_2d<f32>;
+
+@group(0) @binding(62) var<uniform> buffer168: mat2x2h;
+
+@group(0) @binding(103) var tex19: texture_2d<u32>;
+
+@group(0) @binding(132) var sam4: sampler;
+
+@group(0) @binding(236) var st5: texture_storage_2d<rg32float, read>;
+
+struct T0 {
+  f0: vec2i,
+}
+
+struct T1 {
+  @align(8) @size(8) f0: array<array<atomic<i32>, 1>, 1>,
+}
+
+struct T2 {
+  @size(8) f0: atomic<u32>,
+}
+
+struct S5 {
+  @location(9) f0: vec2h,
+  @location(4) @interpolate(flat, center) f1: f32,
+}
+
+struct S6 {
+  @location(11) f0: i32,
+  @location(3) f1: vec2f,
+  @location(6) f2: vec4h,
+  @location(5) @interpolate(flat, center) f3: vec2f,
+}
+
+struct S7 {
+  @builtin(instance_index) f0: u32,
+}
+
+struct VertexOutput10 {
+  @location(12) f28: vec2h,
+  @builtin(position) f29: vec4f,
+  @location(11) f30: vec2h,
+}
+
+struct FragmentOutput10 {
+  @location(1) @interpolate(flat, centroid) f0: u32,
+  @location(0) @interpolate(perspective) f1: vec4f,
+}
+
+alias vec3b = vec3<bool>;
+
+@id(38991) override override8: f16 = 4664.3;
+
+@id(3749) override override9: u32 = 99;
+
+override override10 = 0.3508;
+
+@id(23248) override override11 = true;
+
+fn fn0(a0: array<array<mat4x3f, 1>, 1>, a1: mat4x2f) -> array<vec2<bool>, 1> {
+  var out: array<vec2<bool>, 1>;
+  let vf326: vec2u = textureDimensions(tex18);
+  let vf327: array<mat4x3f, 1> = a0[u32(unconst_u32(171))];
+  var vf328: mat4x3f = a0[0][u32(unconst_u32(404))];
+  var vf329: vec4f = textureLoad(tex18, vec2i(unconst_i32(-331), unconst_i32(30)), i32(unconst_i32(220)));
+  vp7 = modf(a1[unconst_i32(0)].ggg);
+  return out;
+}
+
+var<private> vp7 = modf(vec3f(0.09057, 0.4788, 0.6460));
+
+@vertex
+fn vertex12(@location(14) @interpolate(flat) a0: vec4u, @location(10) @interpolate(perspective, centroid) a1: vec2h, @location(0) @interpolate(flat) a2: vec4i, a3: S5, a4: S6, @location(12) a5: u32, @location(15) a6: i32, @location(8) @interpolate(flat, centroid) a7: i32, @location(2) a8: vec4i, @location(1) a9: vec2u, a10: S7, @location(13) a11: f32) -> VertexOutput10 {
+  var out: VertexOutput10;
+  out.f30 = vec2h(textureDimensions(tex19, i32(unconst_i32(8))));
+  out.f29 += vec4f(bitcast<f32>(a9[u32(unconst_u32(163))]));
+  out.f30 = vec2h(a0.gr);
+  out.f28 = bitcast<vec2h>(a5);
+  out.f30 = a3.f0;
+  return out;
+}
+
+@fragment
+fn fragment12() -> FragmentOutput10 {
+  var out: FragmentOutput10;
+  out.f1 = fract(vec4f(unconst_f32(0.1498), unconst_f32(0.00703), unconst_f32(0.1841), unconst_f32(0.2039)));
+  let vf330: vec4u = textureGather(75 % 4, tex19, sam4, vec2f(unconst_f32(0.09958), unconst_f32(0.1935)));
+  let vf331: u32 = vf330[u32(unconst_u32(350))];
+  out = FragmentOutput10(pack2x16snorm(unpack2x16float(u32(unconst_u32(4)))), unpack2x16float(u32(unconst_u32(4))).yxxx);
+  return out;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder233 = device0.createCommandEncoder();
+let textureView221 = texture167.createView({dimension: '1d', format: 'r16float'});
+try {
+computePassEncoder166.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder74.executeBundles([renderBundle19, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer10, 'uint16', 2_956, 736);
+} catch {}
+try {
+renderPassEncoder68.setVertexBuffer(6, buffer27, 0);
+} catch {}
+try {
+renderBundleEncoder44.setBindGroup(0, bindGroup54, []);
+} catch {}
+let imageData29 = new ImageData(28, 28);
+let videoFrame50 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'fcc', primaries: 'smpteRp431', transfer: 'bt709'} });
+let texture257 = gpuCanvasContext4.getCurrentTexture();
+let renderPassEncoder88 = commandEncoder233.beginRenderPass({
+  colorAttachments: [{
+  view: textureView205,
+  depthSlice: 22,
+  clearValue: { r: -32.17, g: -273.3, b: 992.8, a: 503.3, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet33,
+});
+let renderBundle47 = renderBundleEncoder44.finish();
+try {
+renderPassEncoder32.executeBundles([renderBundle43]);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer64, 'uint32', 1_536, 379);
+} catch {}
+try {
+renderPassEncoder60.setVertexBuffer(0, buffer88);
+} catch {}
+let buffer169 = device0.createBuffer({size: 1940, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+try {
+computePassEncoder166.setBindGroup(1, bindGroup39);
+} catch {}
+try {
+computePassEncoder25.setBindGroup(1, bindGroup111, new Uint32Array(19), 6, 0);
+} catch {}
+try {
+renderPassEncoder41.setStencilReference(2);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer160, 'uint16', 2_238, 230);
+} catch {}
+try {
+renderPassEncoder65.setPipeline(pipeline9);
+} catch {}
+let texture258 = device0.createTexture({
+  size: {width: 4, height: 2, depthOrArrayLayers: 6},
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler169 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 2.388,
+  lodMaxClamp: 73.07,
+});
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let commandEncoder234 = device0.createCommandEncoder({});
+let renderPassEncoder89 = commandEncoder234.beginRenderPass({
+  colorAttachments: [{
+  view: textureView205,
+  depthSlice: 23,
+  clearValue: { r: -95.69, g: -991.7, b: 940.1, a: -792.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet31,
+});
+try {
+computePassEncoder91.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+computePassEncoder138.setBindGroup(3, bindGroup11, new Uint32Array(12), 1, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder98); computePassEncoder98.dispatchWorkgroupsIndirect(buffer0, 1_476); };
+} catch {}
+try {
+renderPassEncoder87.setBindGroup(0, bindGroup120);
+} catch {}
+try {
+renderPassEncoder82.end();
+} catch {}
+let arrayBuffer23 = buffer41.getMappedRange(480, 4);
+let buffer170 = device0.createBuffer({size: 17269, usage: GPUBufferUsage.INDEX});
+let commandEncoder235 = device0.createCommandEncoder({label: '\u52c8\u04ad\u0f69\u522b\u04e0\u{1fdef}\u504b\u4acf\ubdba\u401e'});
+let computePassEncoder167 = commandEncoder235.beginComputePass();
+let sampler170 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 16.58,
+  lodMaxClamp: 86.59,
+  maxAnisotropy: 8,
+});
+try {
+computePassEncoder98.end();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 5, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap3,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let sampler171 = device0.createSampler({addressModeV: 'clamp-to-edge', mipmapFilter: 'nearest', lodMinClamp: 52.00, lodMaxClamp: 84.83});
+try {
+computePassEncoder130.setBindGroup(1, bindGroup77, new Uint32Array(2100), 906, 0);
+} catch {}
+try {
+computePassEncoder167.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer13, 'uint16', 1_626, 2_849);
+} catch {}
+let shaderModule14 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(296) var et8: texture_external;
+
+struct T0 {
+  @size(192) f0: mat3x2h,
+  @align(64) @size(128) f1: mat4x3f,
+  @align(64) @size(64) f2: f16,
+  @align(64) @size(192) f3: vec2u,
+  @align(8) @size(192) f4: array<u32, 3>,
+  @align(32) @size(640) f5: vec2u,
+  @align(16) @size(832) f6: mat3x4h,
+}
+
+struct T1 {
+  @size(332) f0: f32,
+}
+
+struct VertexOutput11 {
+  @location(5) f31: u32,
+  @location(12) @interpolate(flat, sample) f32: vec2u,
+  @location(9) @interpolate(perspective, centroid) f33: f32,
+  @invariant @builtin(position) f34: vec4f,
+  @location(1) @interpolate(perspective, centroid) f35: vec4h,
+  @location(11) @interpolate(flat) f36: vec2u,
+}
+
+struct FragmentOutput11 {
+  @location(0) @interpolate(perspective) f0: vec4f,
+}
+
+fn fn0() -> array<FragmentOutput11, 1> {
+  var out: array<FragmentOutput11, 1>;
+  let vf332: vec2f = smoothstep(vec2f(unconst_f32(0.1200), unconst_f32(0.3177)), vec2f(unconst_f32(-0.00051), unconst_f32(0.1786)), ldexp(vec2f(unconst_f32(-0.1421), unconst_f32(0.00735)), vec2i(unconst_i32(162), unconst_i32(37))));
+  out[u32(unconst_u32(82))].f0 *= sinh(vec3f(unconst_f32(0.3086), unconst_f32(0.2590), unconst_f32(0.5729))).yzxx;
+  var vf333: vec2u = textureDimensions(et8);
+  vf333 = vec2u(bitcast<u32>(vf332[u32(unconst_u32(122))]));
+  var vf334: vec3h = reflect(vec3h(unconst_f16(2262.6), unconst_f16(18550.5), unconst_f16(47408.0)), vec3h(unconst_f16(8744.3), unconst_f16(187.0), unconst_f16(11352.1)));
+  let ptr65: ptr<function, vec2u> = &vf333;
+  vf334 = vec3h(f16(pack2x16unorm(vec2f(unconst_f32(-0.2177), unconst_f32(0.01916)))));
+  var vf335: u32 = (*ptr65)[u32(unconst_u32(11))];
+  let vf336: vec4f = textureLoad(et8, vec2u(unconst_u32(329), unconst_u32(631)));
+  var vf337: u32 = (*ptr65)[u32(unconst_u32(479))];
+  let vf338: vec4f = vf336;
+  vf335 *= u32(vf338[u32(unconst_u32(112))]);
+  vf334 = vec3h(ldexp(vec2f(unconst_f32(0.5727), unconst_f32(0.00446)), vec2i(unconst_i32(66), unconst_i32(4))).xyy);
+  var vf339: vec4f = vf338;
+  let vf340: vec4f = vf336;
+  var vf341: vec2f = unpack2x16float(u32(unconst_u32(697)));
+  let vf342: vec4f = vf336;
+  let vf343: f32 = vf342[u32(unconst_u32(620))];
+  return out;
+}
+
+fn fn1() -> VertexOutput11 {
+  var out: VertexOutput11;
+  let vf344: vec3f = smoothstep(vec3f(radians(f32(unconst_f32(0.2348)))), vec3f(unconst_f32(0.1717), unconst_f32(0.05018), unconst_f32(0.03392)), vec3f(radians(f32(unconst_f32(0.1333)))));
+  var vf345: f16 = step(f16(unconst_f16(5906.3)), f16(unconst_f16(21126.4)));
+  var vf346: f32 = radians(f32(unconst_f32(0.00547)));
+  let vf347: vec4h = acosh(vec4h(unconst_f16(-5141.1), unconst_f16(7175.6), unconst_f16(3901.6), unconst_f16(-14339.4)));
+  var vf348: u32 = pack4xI8Clamp(vec4i(unconst_i32(84), unconst_i32(216), unconst_i32(245), unconst_i32(68)));
+  out.f35 = vec4h(f16(pack4xI8Clamp(vec4i(vf347))));
+  var vf349: f32 = vf344[u32(unconst_u32(258))];
+  var vf350: vec2f = radians(vec2f(unconst_f32(0.5407), unconst_f32(0.04423)));
+  var vf351: vec4h = acosh(vec4h(unconst_f16(2005.7), unconst_f16(9549.0), unconst_f16(9129.0), unconst_f16(2491.1)));
+  out.f36 += vec2u(u32(step(f16(unconst_f16(25755.0)), f16(unconst_f16(4049.1)))));
+  out.f35 = bitcast<vec4h>(vf350);
+  let ptr66: ptr<function, vec2f> = &vf350;
+  let vf352: vec3f = vf344;
+  let vf353: f32 = vf352[u32(unconst_u32(181))];
+  var vf354: f16 = vf351[u32(unconst_u32(107))];
+  let vf355: vec2f = radians(vec2f(unconst_f32(0.1134), unconst_f32(0.1253)));
+  out.f31 >>= u32(vf353);
+  return out;
+}
+
+fn fn2() -> VertexOutput11 {
+  var out: VertexOutput11;
+  out.f33 = f32(sqrt(f16(unconst_f16(3149.6))));
+  out.f36 *= vec2u(textureLoad(et8, bitcast<vec2u>(refract(vec4h(unconst_f16(-2554.0), unconst_f16(34326.2), unconst_f16(22798.0), unconst_f16(1504.1)), vec4h(unconst_f16(7831.5), unconst_f16(8873.5), unconst_f16(7196.7), unconst_f16(4871.2)), f16(unconst_f16(7753.1))))).yy);
+  let vf356: vec3f = cross(vec3f(unconst_f32(0.01581), unconst_f32(0.04181), unconst_f32(0.1249)), vec3f(unconst_f32(0.4535), unconst_f32(0.8019), unconst_f32(0.2897)));
+  out.f31 <<= pack2x16float(vec2f(unconst_f32(0.2389), unconst_f32(0.3002)));
+  var vf357 = fn0();
+  return out;
+}
+
+var<workgroup> vw42: FragmentOutput11;
+
+var<workgroup> vw43: mat2x3h;
+
+@vertex
+fn vertex13(@location(5) @interpolate(flat, centroid) a0: vec4i) -> VertexOutput11 {
+  var out: VertexOutput11;
+  out.f32 &= vec2u(u32(sin(f16(unconst_f16(1829.7)))));
+  out.f32 ^= vec2u(u32(pow(f16(unconst_f16(4790.0)), f16(unconst_f16(7193.0)))));
+  let vf358: vec2f = unpack2x16snorm(u32(unconst_u32(15)));
+  out.f35 = vec4h(f16(vf358[pack2x16unorm(vf358)]));
+  out.f36 <<= vec2u(normalize(vec4f(unconst_f32(0.1095), unconst_f32(-0.02770), unconst_f32(0.4119), unconst_f32(0.3467))).gr);
+  fn0();
+  out.f32 = vec2u(reverseBits(u32(unconst_u32(77))));
+  fn1();
+  out.f34 = vec4f(vf358[u32(unconst_u32(78))]);
+  var vf359 = fn0();
+  var vf360: u32 = reverseBits(u32(unconst_u32(810)));
+  var vf361 = fn1();
+  var vf362 = fn0();
+  let vf363: u32 = pack4x8snorm(vec4f(unconst_f32(0.04858), unconst_f32(0.1003), unconst_f32(0.00408), unconst_f32(0.4501)));
+  let ptr67: ptr<function, u32> = &vf360;
+  vf362[u32(vf359[u32(unconst_u32(252))].f0[pack4x8snorm(vec4f(unconst_f32(0.02893), unconst_f32(0.05076), unconst_f32(0.02537), unconst_f32(0.5304)))])] = FragmentOutput11(vec4f(f32(pack4x8snorm(vec4f(unconst_f32(0.1109), unconst_f32(0.00757), unconst_f32(0.07237), unconst_f32(0.3955))))));
+  out.f31 = vf361.f36[0];
+  let ptr68: ptr<function, u32> = &vf361.f31;
+  var vf364 = fn0();
+  vf364[u32(vf362[0].f0.a)] = FragmentOutput11(vf361.f34);
+  let ptr69: ptr<function, f32> = &vf361.f33;
+  let ptr70: ptr<function, vec4f> = &vf361.f34;
+  let ptr71: ptr<function, vec4f> = &(*ptr70);
+  vf359[u32(unconst_u32(145))].f0 -= vec4f(vf361.f36.grgg);
+  return out;
+}
+
+@fragment
+fn fragment13() -> FragmentOutput11 {
+  var out: FragmentOutput11;
+  out.f0 = vec4f(bitcast<f32>(pack4x8unorm(vec4f(unconst_f32(0.3944), unconst_f32(0.08026), unconst_f32(0.06638), unconst_f32(0.4617)))));
+  fn2();
+  return out;
+}`,
+  hints: {},
+});
+let commandEncoder236 = device0.createCommandEncoder({});
+let sampler172 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 47.24,
+  lodMaxClamp: 91.20,
+});
+try {
+computePassEncoder164.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder236.copyBufferToBuffer(buffer5, 196, buffer66, 6464, 4236);
+} catch {}
+let bindGroup129 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 7, resource: {buffer: buffer134, offset: 0, size: 172}}],
+});
+let buffer171 = device0.createBuffer({
+  size: 26964,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder237 = device0.createCommandEncoder({});
+let texture259 = device0.createTexture({
+  label: '\u3b96\u00f1\u0e30\u064a\u076b',
+  size: {width: 2, height: 1, depthOrArrayLayers: 533},
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let computePassEncoder168 = commandEncoder218.beginComputePass();
+let renderPassEncoder90 = commandEncoder149.beginRenderPass({colorAttachments: [{view: textureView157, loadOp: 'load', storeOp: 'discard'}]});
+try {
+computePassEncoder168.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder90.setIndexBuffer(buffer110, 'uint32', 48, 239);
+} catch {}
+try {
+renderPassEncoder45.setPipeline(pipeline6);
+} catch {}
+document.body.append(img4);
+let bindGroupLayout29 = device0.createBindGroupLayout({
+  label: '\u9b1d\ub433\u{1f6da}\ue728',
+  entries: [
+    {
+      binding: 184,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 90,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 178,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '1d' },
+    },
+    {
+      binding: 13,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let buffer172 = device0.createBuffer({
+  size: 12949,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView222 = texture145.createView({dimension: '2d-array'});
+let texture260 = device0.createTexture({
+  label: '\u0759\u07bc',
+  size: {width: 8, height: 5, depthOrArrayLayers: 2},
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let textureView223 = texture137.createView({dimension: '1d'});
+try {
+computePassEncoder91.setBindGroup(0, bindGroup2, new Uint32Array(2496), 312, 0);
+} catch {}
+try {
+renderPassEncoder39.executeBundles([renderBundle43, renderBundle22]);
+} catch {}
+try {
+renderPassEncoder48.setPipeline(pipeline9);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer108, 5764, new DataView(new ArrayBuffer(32090)), 776, 60);
+} catch {}
+let bindGroup130 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [{binding: 146, resource: textureView21}, {binding: 5, resource: textureView23}],
+});
+let commandEncoder238 = device0.createCommandEncoder();
+let texture261 = device0.createTexture({
+  size: [16],
+  dimension: '1d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView224 = texture136.createView({dimension: 'cube'});
+let computePassEncoder169 = commandEncoder238.beginComputePass({});
+try {
+computePassEncoder93.setBindGroup(2, bindGroup97);
+} catch {}
+try {
+computePassEncoder169.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder51.setViewport(207.89847879594862, 58.831195807912025, 29.56787878459887, 7.123719452238661, 0.6457288192393048, 0.6838643639670065);
+} catch {}
+try {
+commandEncoder236.copyTextureToTexture({
+  texture: texture240,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture119,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let buffer173 = device0.createBuffer({size: 1533, usage: GPUBufferUsage.COPY_DST});
+let textureView225 = texture46.createView({dimension: '2d-array', baseMipLevel: 0});
+let renderPassEncoder91 = commandEncoder236.beginRenderPass({
+  colorAttachments: [{
+  view: textureView118,
+  depthSlice: 3,
+  clearValue: { r: -446.2, g: 294.2, b: 233.4, a: -555.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet0,
+});
+try {
+computePassEncoder60.setBindGroup(3, bindGroup70);
+} catch {}
+try {
+computePassEncoder120.setBindGroup(2, bindGroup30, new Uint32Array(3063), 592, 0);
+} catch {}
+try {
+renderPassEncoder66.beginOcclusionQuery(13);
+} catch {}
+try {
+renderPassEncoder71.executeBundles([renderBundle19]);
+} catch {}
+try {
+renderPassEncoder53.setIndexBuffer(buffer43, 'uint32', 732, 10);
+} catch {}
+let arrayBuffer24 = buffer41.getMappedRange(488, 4);
+try {
+commandEncoder237.insertDebugMarker('\u0096');
+} catch {}
+let computePassEncoder170 = commandEncoder237.beginComputePass({});
+try {
+computePassEncoder129.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder170.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder88.beginOcclusionQuery(2);
+} catch {}
+try {
+renderPassEncoder88.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer157, 'uint16', 1_150, 1_252);
+} catch {}
+try {
+renderPassEncoder83.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder55.setVertexBuffer(7, buffer56);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 194, y: 13, z: 0},
+  aspect: 'all',
+}, new Uint8Array(143).fill(16), /* required buffer size: 143 */
+{offset: 143, bytesPerRow: 40, rowsPerImage: 86}, {width: 8, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let pipeline10 = device0.createComputePipeline({layout: pipelineLayout10, compute: {module: shaderModule6, constants: {}}});
+let texture262 = device0.createTexture({
+  size: {width: 8, height: 5, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder128.setBindGroup(2, bindGroup29);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(3, bindGroup66, new Uint32Array(6770), 497, 0);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer104, 'uint32', 1_988, 899);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame42,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 81, y: 16, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer174 = device0.createBuffer({
+  size: 6063,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder8.setBindGroup(2, bindGroup108);
+} catch {}
+let bindGroup131 = device0.createBindGroup({
+  layout: bindGroupLayout24,
+  entries: [
+    {binding: 468, resource: {buffer: buffer28, offset: 0, size: 1452}},
+    {binding: 172, resource: textureView157},
+  ],
+});
+let buffer175 = device0.createBuffer({
+  size: 3950,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+try {
+computePassEncoder82.setBindGroup(0, bindGroup80, new Uint32Array(1744), 386, 0);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle40]);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+let bindGroup132 = device0.createBindGroup({
+  layout: bindGroupLayout28,
+  entries: [
+    {binding: 208, resource: textureView98},
+    {binding: 217, resource: externalTexture15},
+    {binding: 64, resource: textureView139},
+  ],
+});
+try {
+renderPassEncoder66.endOcclusionQuery();
+} catch {}
+let imageBitmap5 = await createImageBitmap(offscreenCanvas3);
+let bindGroupLayout30 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 307,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 210,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup133 = device0.createBindGroup({
+  label: '\u{1ff91}\u147e\u0c1f',
+  layout: bindGroupLayout4,
+  entries: [{binding: 84, resource: textureView25}],
+});
+let renderBundleEncoder48 = device0.createRenderBundleEncoder({colorFormats: ['r8uint'], depthReadOnly: true});
+try {
+renderPassEncoder79.setBindGroup(1, bindGroup90, new Uint32Array(131), 0, 0);
+} catch {}
+try {
+renderPassEncoder63.setIndexBuffer(buffer160, 'uint32', 3_264, 196);
+} catch {}
+let sampler173 = device0.createSampler({
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 93.83,
+  lodMaxClamp: 95.59,
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder29.setBindGroup(3, bindGroup103, new Uint32Array(1971), 682, 0);
+} catch {}
+try {
+renderPassEncoder55.setBindGroup(0, bindGroup111, new Uint32Array(977), 274, 0);
+} catch {}
+try {
+renderPassEncoder57.setIndexBuffer(buffer133, 'uint16', 8_940, 1_220);
+} catch {}
+try {
+renderPassEncoder72.setVertexBuffer(2, buffer53, 5_720, 687);
+} catch {}
+try {
+renderBundleEncoder48.setBindGroup(1, bindGroup23);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let texture263 = device0.createTexture({
+  size: {width: 2},
+  dimension: '1d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8uint', 'r8uint'],
+});
+let textureView226 = texture37.createView({baseArrayLayer: 0});
+let sampler174 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 74.61,
+  lodMaxClamp: 82.45,
+});
+try {
+renderBundleEncoder48.setBindGroup(2, bindGroup49, new Uint32Array(2832), 162, 0);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+let textureView227 = texture21.createView({label: '\u524f\u0615', aspect: 'all', baseMipLevel: 0, arrayLayerCount: 1});
+let textureView228 = texture260.createView({label: '\u0fbe\u0d15\u68ed\u197c\u4062\u{1fab3}\u708e\u41e8', format: 'r16sint'});
+try {
+renderPassEncoder48.setVertexBuffer(7, buffer1, 1_660);
+} catch {}
+try {
+renderBundleEncoder48.setPipeline(pipeline8);
+} catch {}
+let arrayBuffer25 = buffer31.getMappedRange(2192, 76);
+let imageData30 = new ImageData(52, 40);
+try {
+renderPassEncoder27.beginOcclusionQuery(19);
+} catch {}
+try {
+renderBundleEncoder48.setBindGroup(3, bindGroup130);
+} catch {}
+try {
+renderBundleEncoder48.setIndexBuffer(buffer71, 'uint16', 916, 337);
+} catch {}
+document.body.prepend(canvas0);
+let bindGroup134 = device0.createBindGroup({
+  label: '\ud6f0\u{1fb8d}\u{1f913}\u048a',
+  layout: bindGroupLayout28,
+  entries: [
+    {binding: 217, resource: externalTexture0},
+    {binding: 208, resource: textureView147},
+    {binding: 64, resource: textureView220},
+  ],
+});
+let buffer176 = device0.createBuffer({size: 29099, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX});
+let texture264 = device0.createTexture({
+  label: '\u0ca2\u09c0\u{1fbe8}\u0a41\u04f4',
+  size: [2, 1, 1],
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle48 = renderBundleEncoder48.finish({});
+try {
+computePassEncoder132.end();
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(6);
+} catch {}
+try {
+renderPassEncoder73.setPipeline(pipeline5);
+} catch {}
+let bindGroup135 = device0.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [{binding: 26, resource: textureView111}, {binding: 294, resource: textureView189}],
+});
+let buffer177 = device0.createBuffer({size: 6411, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let querySet34 = device0.createQuerySet({type: 'occlusion', count: 1352});
+let commandBuffer14 = commandEncoder188.finish();
+let renderBundleEncoder49 = device0.createRenderBundleEncoder({label: '\u0a03\uedfb', colorFormats: ['r8uint']});
+try {
+renderBundleEncoder49.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder49.setVertexBuffer(2, buffer72);
+} catch {}
+let bindGroup136 = device0.createBindGroup({
+  layout: bindGroupLayout22,
+  entries: [
+    {binding: 485, resource: textureView187},
+    {binding: 76, resource: textureView56},
+    {binding: 124, resource: textureView78},
+    {binding: 241, resource: {buffer: buffer34, offset: 0, size: 8}},
+  ],
+});
+let buffer178 = device0.createBuffer({
+  size: 6469,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder239 = device0.createCommandEncoder();
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup1);
+} catch {}
+let renderBundle49 = renderBundleEncoder49.finish();
+try {
+renderPassEncoder25.setBindGroup(1, bindGroup111);
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(1, bindGroup131, new Uint32Array(1680), 48, 0);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline4);
+} catch {}
+let sampler175 = device0.createSampler({
+  label: '\u{1f903}\u{1ffa1}\u0a4a\u0a8a',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 55.27,
+  lodMaxClamp: 84.69,
+  compare: 'greater-equal',
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder28.setBindGroup(0, bindGroup52, new Uint32Array(366), 37, 0);
+} catch {}
+try {
+renderPassEncoder49.setBindGroup(1, bindGroup64, new Uint32Array(3120), 307, 0);
+} catch {}
+try {
+renderPassEncoder27.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder239.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 3264 */
+  offset: 3264,
+  bytesPerRow: 38400,
+  buffer: buffer101,
+}, {
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 48, y: 115, z: 0},
+  aspect: 'all',
+}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer14]);
+} catch {}
+try {
+  await promise22;
+} catch {}
+let bindGroup137 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [{binding: 146, resource: textureView21}, {binding: 5, resource: textureView23}],
+});
+let commandEncoder240 = device0.createCommandEncoder();
+let renderPassEncoder92 = commandEncoder239.beginRenderPass({
+  colorAttachments: [{
+  view: textureView199,
+  clearValue: { r: -44.43, g: 9.084, b: -941.3, a: 339.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder105.setBindGroup(0, bindGroup52, new Uint32Array(269), 38, 0);
+} catch {}
+try {
+renderPassEncoder83.setIndexBuffer(buffer120, 'uint16', 2_410, 2_175);
+} catch {}
+try {
+commandEncoder240.copyBufferToTexture({
+  /* bytesInLastRow: 38 widthInBlocks: 38 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1914 */
+  offset: 1914,
+  bytesPerRow: 26368,
+  buffer: buffer133,
+}, {
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 3, y: 10, z: 4},
+  aspect: 'all',
+}, {width: 38, height: 15, depthOrArrayLayers: 0});
+} catch {}
+let buffer179 = device0.createBuffer({
+  size: 4536,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder241 = device0.createCommandEncoder({});
+let textureView229 = texture217.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder171 = commandEncoder240.beginComputePass({label: '\uf2cf\u0451\u43c7\u{1f689}\u0c6c\u{1fe25}\u0505\u{1fd11}\u0a68\u{1f710}\u0420'});
+try {
+computePassEncoder11.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+computePassEncoder171.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(3, bindGroup35, new Uint32Array(1807), 450, 0);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder74.setViewport(1.85977273641674, 0.869499289981369, 0.0977241392748934, 0.07425890581561659, 0.4456870734999111, 0.9261329172168609);
+} catch {}
+let promise23 = device0.queue.onSubmittedWorkDone();
+let bindGroup138 = device0.createBindGroup({
+  label: '\u327d\u6430\u2c19\u2de6\u5a95\u0028',
+  layout: bindGroupLayout18,
+  entries: [{binding: 97, resource: {buffer: buffer154, offset: 3840, size: 3176}}],
+});
+try {
+renderPassEncoder52.setBindGroup(0, bindGroup39);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer52, 'uint16', 7_192, 105);
+} catch {}
+try {
+commandEncoder241.copyBufferToBuffer(buffer3, 1100, buffer2, 492, 140);
+} catch {}
+let videoFrame51 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'bt470bg', transfer: 'iec6196624'} });
+let textureView230 = texture191.createView({dimension: '2d'});
+try {
+computePassEncoder63.setBindGroup(3, bindGroup62, []);
+} catch {}
+try {
+computePassEncoder89.setBindGroup(2, bindGroup22, new Uint32Array(2602), 513, 0);
+} catch {}
+try {
+renderPassEncoder75.setVertexBuffer(3, undefined, 489_780_565, 358_383_280);
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let querySet35 = device0.createQuerySet({label: '\uac58\u5d0b\u{1f707}\u50ff', type: 'occlusion', count: 426});
+let computePassEncoder172 = commandEncoder241.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder11); computePassEncoder11.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+computePassEncoder172.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder60.setViewport(196.16899836032405, 217.57893762341652, 43.9723801118834, 0.2305533616186493, 0.8140911663010453, 0.9562583102005056);
+} catch {}
+try {
+renderPassEncoder59.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(5, buffer117, 0, 107);
+} catch {}
+let bindGroup139 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [{binding: 146, resource: textureView18}, {binding: 5, resource: textureView23}],
+});
+try {
+computePassEncoder151.setBindGroup(3, bindGroup36, new Uint32Array(3178), 97, 0);
+} catch {}
+try {
+renderPassEncoder47.executeBundles([renderBundle17, renderBundle28]);
+} catch {}
+let bindGroup140 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [
+    {binding: 93, resource: {buffer: buffer63, offset: 512}},
+    {binding: 24, resource: {buffer: buffer71, offset: 512, size: 1942}},
+    {binding: 62, resource: textureView143},
+  ],
+});
+let texture265 = device0.createTexture({
+  size: {width: 8, height: 5, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder134.setBindGroup(0, bindGroup139);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(1, bindGroup112);
+} catch {}
+let commandEncoder242 = device0.createCommandEncoder({});
+let texture266 = device0.createTexture({
+  size: {width: 8, height: 5, depthOrArrayLayers: 1},
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder173 = commandEncoder242.beginComputePass();
+try {
+renderPassEncoder80.setIndexBuffer(buffer130, 'uint16', 10, 15);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline8);
+} catch {}
+let commandEncoder243 = device0.createCommandEncoder();
+let textureView231 = texture17.createView({label: '\u3e3d\u0470\ufad4\u0815\u07e7', baseArrayLayer: 0});
+let computePassEncoder174 = commandEncoder243.beginComputePass({});
+try {
+computePassEncoder167.setBindGroup(2, bindGroup64);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder11); computePassEncoder11.dispatchWorkgroupsIndirect(buffer18, 8_932); };
+} catch {}
+try {
+computePassEncoder174.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder35.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder173.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder75.setBindGroup(1, bindGroup24, []);
+} catch {}
+try {
+renderPassEncoder84.setBindGroup(0, bindGroup6, new Uint32Array(499), 13, 0);
+} catch {}
+try {
+renderPassEncoder83.setIndexBuffer(buffer110, 'uint16', 348, 153);
+} catch {}
+try {
+renderPassEncoder77.setPipeline(pipeline9);
+} catch {}
+let bindGroupLayout31 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 152,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 69,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+try {
+renderPassEncoder28.setPipeline(pipeline0);
+} catch {}
+try {
+buffer144.unmap();
+} catch {}
+try {
+computePassEncoder71.insertDebugMarker('\u0bac');
+} catch {}
+let bindGroup141 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 121, resource: externalTexture39},
+    {binding: 218, resource: textureView166},
+    {binding: 420, resource: textureView27},
+  ],
+});
+let buffer180 = device0.createBuffer({
+  size: 25638,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder244 = device0.createCommandEncoder({});
+let textureView232 = texture45.createView({});
+let computePassEncoder175 = commandEncoder244.beginComputePass({label: '\u01d0\u0f62\u49d1\u9498\u4e73\u{1fa99}\u9941\u8c48\u0c2d\ua248'});
+try {
+computePassEncoder126.setBindGroup(0, bindGroup3, new Uint32Array(216), 31, 0);
+} catch {}
+try {
+renderPassEncoder67.setBindGroup(0, bindGroup37, new Uint32Array(914), 74, 0);
+} catch {}
+try {
+renderPassEncoder29.setBlendConstant({ r: -231.0, g: 312.8, b: 272.9, a: -359.1, });
+} catch {}
+let bindGroup142 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 13, resource: externalTexture33}]});
+let commandEncoder245 = device0.createCommandEncoder({});
+let texture267 = device0.createTexture({
+  label: '\uc3e7\u9eb2\u{1f93e}\u44ed\u8a89\u{1ff1d}',
+  size: {width: 8, height: 5, depthOrArrayLayers: 135},
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView233 = texture216.createView({});
+let computePassEncoder176 = commandEncoder245.beginComputePass();
+let renderBundleEncoder50 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2unorm'], sampleCount: 1, stencilReadOnly: true});
+try {
+computePassEncoder176.setBindGroup(1, bindGroup26);
+} catch {}
+try {
+computePassEncoder176.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder89.setStencilReference(369);
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder50.setBindGroup(2, bindGroup5, new Uint32Array(3473), 111, 0);
+} catch {}
+let textureView234 = texture197.createView({dimension: '2d-array'});
+try {
+gpuCanvasContext6.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.TEXTURE_BINDING});
+} catch {}
+let img5 = await imageWithData(9, 26, '#10101010', '#20202020');
+let texture268 = device0.createTexture({
+  size: {width: 2, height: 1, depthOrArrayLayers: 1},
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture269 = device0.createTexture({
+  size: {width: 4, height: 2, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView235 = texture234.createView({aspect: 'all'});
+let renderBundle50 = renderBundleEncoder50.finish({});
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(136).fill(81), /* required buffer size: 136 */
+{offset: 136, rowsPerImage: 69}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let commandEncoder246 = device0.createCommandEncoder({label: '\uaba5\u01dd\u{1f99a}\u9fe9'});
+let renderPassEncoder93 = commandEncoder246.beginRenderPass({
+  colorAttachments: [{
+  view: textureView179,
+  depthSlice: 984,
+  clearValue: { r: -871.9, g: 424.2, b: 100.5, a: -16.94, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder105.setBindGroup(1, bindGroup29);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder11); computePassEncoder11.dispatchWorkgroupsIndirect(buffer2, 4_724); };
+} catch {}
+try {
+computePassEncoder11.end();
+} catch {}
+try {
+computePassEncoder175.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(7, buffer88, 0, 1_125);
+} catch {}
+try {
+buffer17.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise23;
+} catch {}
+document.body.append(canvas4);
+let videoFrame52 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'smpte432', transfer: 'unspecified'} });
+let computePassEncoder177 = commandEncoder11.beginComputePass({});
+try {
+computePassEncoder177.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder102.setBindGroup(0, bindGroup142);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(1, bindGroup45, new Uint32Array(609), 92, 0);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline6);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+document.body.append(canvas3);
+let commandEncoder247 = device0.createCommandEncoder();
+let texture270 = device0.createTexture({
+  size: [4, 2, 451],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+computePassEncoder80.setBindGroup(2, bindGroup65, new Uint32Array(314), 38, 0);
+} catch {}
+try {
+renderPassEncoder78.setBindGroup(1, bindGroup100);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer170, 'uint16', 1_466, 200);
+} catch {}
+let videoFrame53 = videoFrame4.clone();
+let buffer181 = device0.createBuffer({
+  size: 8416,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder248 = device0.createCommandEncoder({});
+let texture271 = device0.createTexture({
+  size: [16, 10, 1],
+  mipLevelCount: 1,
+  sampleCount: 1,
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView236 = texture126.createView({label: '\u0bf1\u47ca\u0122\u5804\u096d\uf243\ufc16', mipLevelCount: 1});
+let computePassEncoder178 = commandEncoder248.beginComputePass({});
+try {
+computePassEncoder178.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder90.setBindGroup(3, bindGroup18, new Uint32Array(2081), 441, 0);
+} catch {}
+try {
+renderPassEncoder49.setIndexBuffer(buffer116, 'uint16', 682, 58);
+} catch {}
+try {
+renderPassEncoder64.setPipeline(pipeline8);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let shaderModule15 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(296) var et9: texture_external;
+
+@group(0) @binding(460) var tex20: texture_2d_array<f32>;
+
+struct T0 {
+  @size(108) f0: array<u32>,
+}
+
+struct T1 {
+  @size(4096) f0: array<array<vec4i, 2>>,
+}
+
+struct VertexOutput12 {
+  @location(5) f37: vec4i,
+  @location(9) @interpolate(flat, sample) f38: vec2h,
+  @location(1) @interpolate(perspective, sample) f39: f32,
+  @location(8) @interpolate(flat, center) f40: vec4i,
+  @location(0) f41: u32,
+  @location(3) f42: vec4u,
+  @location(2) f43: vec4h,
+  @location(4) f44: vec2f,
+  @location(14) @interpolate(flat, sample) f45: vec4i,
+  @location(12) f46: vec2i,
+  @invariant @builtin(position) f47: vec4f,
+}
+
+@id(1247) override override12: i32;
+
+override override13: bool;
+
+@id(37971) override override14: i32 = 31;
+
+fn fn0(a0: array<mat3x2h, 2>) -> array<mat4x4h, 1> {
+  var out: array<mat4x4h, 1>;
+  vw45 = vec2<bool>(vw44[0].f43.gb);
+  vw47 = mat2x4h(f16((*&vw46).f46[u32(unconst_u32(462))]), f16((*&vw46).f46[u32(unconst_u32(462))]), f16((*&vw46).f46[u32(unconst_u32(462))]), f16((*&vw46).f46[u32(unconst_u32(462))]), f16((*&vw46).f46[u32(unconst_u32(462))]), f16((*&vw46).f46[u32(unconst_u32(462))]), f16((*&vw46).f46[u32(unconst_u32(462))]), f16((*&vw46).f46[u32(unconst_u32(462))]));
+  var vf365: vec3h = cross(vec3h(f16(vw44[0].f39)), vec3h(unconst_f16(-941.3), unconst_f16(4813.5), unconst_f16(678.4)));
+  vw46.f38 *= vec2h(vw44[0].f44);
+  out[u32(unconst_u32(307))] = mat4x4h(vec4h(vw46.f47), vec4h(vw46.f47), vec4h(vw46.f47), vec4h(vw46.f47));
+  let ptr72: ptr<workgroup, vec2<bool>> = &(*&vw45);
+  vw44[u32(unconst_u32(0))].f45 = bitcast<vec4i>((*&vw44)[0].f42);
+  let ptr73: ptr<workgroup, vec4h> = &(*&vw44)[u32(unconst_u32(439))].f43;
+  let ptr74: ptr<workgroup, vec2h> = &vw44[0].f38;
+  vw44[u32(unconst_u32(61))].f40 = vec4i(bitcast<i32>((*&vw44)[u32(unconst_u32(41))].f39));
+  vw44[u32(unconst_u32(132))].f44 = unpack2x16snorm(vw44[u32(unconst_u32(124))].f41);
+  let ptr75: ptr<workgroup, vec4u> = &vw44[u32(unconst_u32(211))].f42;
+  vw44[0].f40 = vec4i(i32((*&vw44)[u32(unconst_u32(84))].f38[vec4u((*&vw44)[u32(unconst_u32(126))].f43)[1]]));
+  let ptr76: ptr<workgroup, vec4u> = &vw46.f42;
+  let ptr77: ptr<workgroup, vec4h> = &(*&vw46).f43;
+  let vf366: vec4f = log(vec4f((*&vw44)[u32((*ptr72)[u32(unconst_u32(139))])].f44[u32(unconst_u32(108))]));
+  let ptr78: ptr<workgroup, vec4i> = &(*&vw46).f40;
+  let ptr79: ptr<workgroup, vec4h> = &vw44[0].f43;
+  out[u32(unconst_u32(131))] = mat4x4h(vec4h(vw44[pack4x8snorm(vw44[u32(unconst_u32(361))].f47)].f40), vec4h(vw44[pack4x8snorm(vw44[u32(unconst_u32(361))].f47)].f40), vec4h(vw44[pack4x8snorm(vw44[u32(unconst_u32(361))].f47)].f40), vec4h(vw44[pack4x8snorm(vw44[u32(unconst_u32(361))].f47)].f40));
+  let ptr80: ptr<workgroup, vec4i> = &vw46.f45;
+  vf365 *= (*&vw47)[unconst_i32(1)].xwz;
+  return out;
+}
+
+fn fn1() -> VertexOutput12 {
+  var out: VertexOutput12;
+  let vf367: vec3f = vp8[u32(unconst_u32(175))][u32(unconst_u32(1))];
+  let vf368: vec3f = vp8[0][u32(unconst_u32(71))];
+  out.f43 += vec4h(f16(acosh(acosh(f32(unconst_f32(0.5566))))));
+  out.f43 = degrees(vec4h(unconst_f16(15322.9), unconst_f16(7686.0), unconst_f16(9439.2), unconst_f16(16216.0)));
+  out = VertexOutput12(bitcast<vec4i>(smoothstep(vec3f(unconst_f32(0.04515), unconst_f32(0.09579), unconst_f32(0.06382)), vec3f(unconst_f32(0.01758), unconst_f32(0.2365), unconst_f32(0.1696)), vec3f(unconst_f32(0.1141), unconst_f32(0.1022), unconst_f32(0.2383))).bbgr), vec2h(smoothstep(vec3f(unconst_f32(0.04515), unconst_f32(0.09579), unconst_f32(0.06382)), vec3f(unconst_f32(0.01758), unconst_f32(0.2365), unconst_f32(0.1696)), vec3f(unconst_f32(0.1141), unconst_f32(0.1022), unconst_f32(0.2383))).zx), smoothstep(vec3f(unconst_f32(0.04515), unconst_f32(0.09579), unconst_f32(0.06382)), vec3f(unconst_f32(0.01758), unconst_f32(0.2365), unconst_f32(0.1696)), vec3f(unconst_f32(0.1141), unconst_f32(0.1022), unconst_f32(0.2383))).g, vec4i(smoothstep(vec3f(unconst_f32(0.04515), unconst_f32(0.09579), unconst_f32(0.06382)), vec3f(unconst_f32(0.01758), unconst_f32(0.2365), unconst_f32(0.1696)), vec3f(unconst_f32(0.1141), unconst_f32(0.1022), unconst_f32(0.2383))).bgbb), bitcast<vec3u>(smoothstep(vec3f(unconst_f32(0.04515), unconst_f32(0.09579), unconst_f32(0.06382)), vec3f(unconst_f32(0.01758), unconst_f32(0.2365), unconst_f32(0.1696)), vec3f(unconst_f32(0.1141), unconst_f32(0.1022), unconst_f32(0.2383))))[1], bitcast<vec4u>(smoothstep(vec3f(unconst_f32(0.04515), unconst_f32(0.09579), unconst_f32(0.06382)), vec3f(unconst_f32(0.01758), unconst_f32(0.2365), unconst_f32(0.1696)), vec3f(unconst_f32(0.1141), unconst_f32(0.1022), unconst_f32(0.2383))).xzzz), vec4h(smoothstep(vec3f(unconst_f32(0.04515), unconst_f32(0.09579), unconst_f32(0.06382)), vec3f(unconst_f32(0.01758), unconst_f32(0.2365), unconst_f32(0.1696)), vec3f(unconst_f32(0.1141), unconst_f32(0.1022), unconst_f32(0.2383))).bgbg), smoothstep(vec3f(unconst_f32(0.04515), unconst_f32(0.09579), unconst_f32(0.06382)), vec3f(unconst_f32(0.01758), unconst_f32(0.2365), unconst_f32(0.1696)), vec3f(unconst_f32(0.1141), unconst_f32(0.1022), unconst_f32(0.2383))).rb, bitcast<vec4i>(smoothstep(vec3f(unconst_f32(0.04515), unconst_f32(0.09579), unconst_f32(0.06382)), vec3f(unconst_f32(0.01758), unconst_f32(0.2365), unconst_f32(0.1696)), vec3f(unconst_f32(0.1141), unconst_f32(0.1022), unconst_f32(0.2383))).yyzx), vec2i(smoothstep(vec3f(unconst_f32(0.04515), unconst_f32(0.09579), unconst_f32(0.06382)), vec3f(unconst_f32(0.01758), unconst_f32(0.2365), unconst_f32(0.1696)), vec3f(unconst_f32(0.1141), unconst_f32(0.1022), unconst_f32(0.2383))).zz), smoothstep(vec3f(unconst_f32(0.04515), unconst_f32(0.09579), unconst_f32(0.06382)), vec3f(unconst_f32(0.01758), unconst_f32(0.2365), unconst_f32(0.1696)), vec3f(unconst_f32(0.1141), unconst_f32(0.1022), unconst_f32(0.2383))).bgrb);
+  out.f37 = unpack4xI8(textureNumLevels(tex20));
+  var vf369: u32 = textureNumLevels(tex20);
+  out.f42 -= bitcast<vec4u>(smoothstep(vec3f(unconst_f32(-0.07681), unconst_f32(0.1441), unconst_f32(0.3665)), vec3f(unconst_f32(-0.2141), unconst_f32(0.2929), unconst_f32(0.5344)), vec3f(vf367[u32(unconst_u32(42))])).rrrg);
+  let vf370: vec2u = textureDimensions(tex20, i32(unconst_i32(132)));
+  let vf371: vec3f = vf367;
+  out.f42 ^= bitcast<vec4u>(quantizeToF16(vec3f(unconst_f32(0.2627), unconst_f32(0.1166), unconst_f32(0.04694))).xzzy);
+  var vf372: bool = all(vec2<bool>(unconst_bool(false), unconst_bool(true)));
+  out.f44 *= bitcast<vec2f>(degrees(vec4h(unconst_f16(4153.3), unconst_f16(726.3), unconst_f16(11745.0), unconst_f16(11109.4))));
+  out.f47 += vec4f(bitcast<f32>(override12));
+  let vf373: vec3f = vf368;
+  out.f40 = vec4i(override14);
+  out.f37 = vec4i(i32(vf372));
+  var vf374: vec3f = vf368;
+  var vf375: u32 = textureNumLevels(tex20);
+  out.f42 = bitcast<vec4u>(vf368.yyyy);
+  vf372 = bool(vf371.x);
+  let vf376: f32 = radians(f32(unconst_f32(0.01926)));
+  out.f45 = vec4i(vf373.xyzx);
+  return out;
+  _ = override12;
+  _ = override14;
+}
+
+var<workgroup> vw44: array<VertexOutput12, 1>;
+
+var<workgroup> vw45: vec2<bool>;
+
+var<workgroup> vw46: VertexOutput12;
+
+var<workgroup> vw47: mat2x4h;
+
+var<private> vp8: array<mat4x3f, 1> = array(mat4x3f());
+
+@vertex
+fn vertex14() -> VertexOutput12 {
+  var out: VertexOutput12;
+  out.f42 >>= vec4u(u32(cos(f32(unconst_f32(0.1352)))));
+  fn1();
+  out.f39 = vp8[0][unconst_i32(3)].b;
+  fn1();
+  var vf377 = fn1();
+  var vf378: vec3f = vp8[0][u32(unconst_u32(127))];
+  fn1();
+  var vf379: f32 = vf377.f47[u32(unconst_u32(129))];
+  out.f44 += bitcast<vec2f>(unpack4xU8(u32(unconst_u32(48))).aa);
+  let vf380: i32 = vf377.f40[u32(unconst_u32(17))];
+  var vf381 = fn1();
+  out.f42 |= unpack4xU8(u32(vf377.f38[u32(unconst_u32(1000))]));
+  vf378 += vp8[0][unconst_i32(2)];
+  fn1();
+  let vf382: vec4f = select(vec4f(unconst_f32(0.06932), unconst_f32(0.3980), unconst_f32(0.00812), unconst_f32(0.4160)), vp8[u32(unconst_u32(3))][u32(unconst_u32(51))].yxyy, vec4<bool>(unconst_bool(false), unconst_bool(false), unconst_bool(false), unconst_bool(false)));
+  out.f37 = bitcast<vec4i>(textureLoad(tex20, vec2i(unconst_i32(109), unconst_i32(59)), i32(unconst_i32(44)), i32(unconst_i32(31))));
+  out.f44 -= vec2f(f32(vf377.f37[u32(unconst_u32(181))]));
+  vf381.f41 &= u32(vp8[u32(unconst_u32(408))][u32(unconst_u32(74))][u32(unconst_u32(45))]);
+  fn1();
+  return out;
+  _ = override14;
+  _ = override12;
+}
+
+@fragment
+fn fragment14(@location(14) @interpolate(flat) a0: vec4u) -> @location(200) vec2i {
+  var out: vec2i;
+  vp8[u32(unconst_u32(45))] = mat4x3f(textureLoad(et9, vec2u(unconst_u32(271), unconst_u32(247))).rba, textureLoad(et9, vec2u(unconst_u32(271), unconst_u32(247))).bab, textureLoad(et9, vec2u(unconst_u32(271), unconst_u32(247))).zyw, textureLoad(et9, vec2u(unconst_u32(271), unconst_u32(247))).raa);
+  let vf383: vec4h = select(vec4h(unconst_f16(5030.8), unconst_f16(7762.2), unconst_f16(10551.3), unconst_f16(2463.2)), vec4h(unconst_f16(2988.4), unconst_f16(987.7), unconst_f16(11705.4), unconst_f16(18572.6)), vec4<bool>(unconst_bool(true), unconst_bool(false), unconst_bool(true), unconst_bool(true)));
+  var vf384 = fn1();
+  vp8[u32(unconst_u32(360))] -= mat4x3f(vp8[0][u32(unconst_u32(727))][u32(unconst_u32(34))], vp8[0][u32(unconst_u32(727))][u32(unconst_u32(34))], vp8[0][u32(unconst_u32(727))][u32(unconst_u32(34))], vp8[0][u32(unconst_u32(727))][u32(unconst_u32(34))], vp8[0][u32(unconst_u32(727))][u32(unconst_u32(34))], vp8[0][u32(unconst_u32(727))][u32(unconst_u32(34))], vp8[0][u32(unconst_u32(727))][u32(unconst_u32(34))], vp8[0][u32(unconst_u32(727))][u32(unconst_u32(34))], vp8[0][u32(unconst_u32(727))][u32(unconst_u32(34))], vp8[0][u32(unconst_u32(727))][u32(unconst_u32(34))], vp8[0][u32(unconst_u32(727))][u32(unconst_u32(34))], vp8[0][u32(unconst_u32(727))][u32(unconst_u32(34))]);
+  return out;
+  _ = override12;
+  _ = override14;
+}
+
+@compute @workgroup_size(2, 1, 1)
+fn compute10() {
+  var vf385 = fn0(array<mat3x2h, 2>(mat3x2h(f16(vw46.f42[u32(unconst_u32(18))]), f16(vw46.f42[u32(unconst_u32(18))]), f16(vw46.f42[u32(unconst_u32(18))]), f16(vw46.f42[u32(unconst_u32(18))]), f16(vw46.f42[u32(unconst_u32(18))]), f16(vw46.f42[u32(unconst_u32(18))])), mat3x2h(f16(vw46.f42[u32(unconst_u32(18))]), f16(vw46.f42[u32(unconst_u32(18))]), f16(vw46.f42[u32(unconst_u32(18))]), f16(vw46.f42[u32(unconst_u32(18))]), f16(vw46.f42[u32(unconst_u32(18))]), f16(vw46.f42[u32(unconst_u32(18))]))));
+  var vf386 = fn0(array<mat3x2h, 2>(mat3x2h(), mat3x2h()));
+  fn0(array<mat3x2h, 2>(mat3x2h(vec2h(vw44[u32(unconst_u32(366))].f40.bb), vec2h(vw44[u32(unconst_u32(366))].f40.ww), vec2h(vw44[u32(unconst_u32(366))].f40.wy)), mat3x2h(vec2h(vw44[u32(unconst_u32(366))].f40.xz), vec2h(vw44[u32(unconst_u32(366))].f40.wz), vec2h(vw44[u32(unconst_u32(366))].f40.ga))));
+  var vf387: f16 = vf385[0][u32(unconst_u32(155))][u32(unconst_u32(107))];
+  fn0(array<mat3x2h, 2>(mat3x2h(vf385[0][unconst_i32(1)].bb, vf385[0][unconst_i32(3)].wy, vf385[0][unconst_i32(2)].zz), mat3x2h(vf385[0][unconst_i32(0)].rg, vf385[0][unconst_i32(2)].ag, vf385[0][unconst_i32(2)].xy)));
+  let ptr81: ptr<workgroup, vec4f> = &(*&vw46).f47;
+  vw45 = vec2<bool>((*&vw46).f38);
+  vp8[u32(unconst_u32(19))] = mat4x3f(vec3f(vw44[u32(unconst_u32(50))].f38.grr), vec3f(vw44[u32(unconst_u32(50))].f38.rrr), vec3f(vw44[u32(unconst_u32(50))].f38.rgg), vec3f(vw44[u32(unconst_u32(50))].f38.grr));
+  vw45 = vec2<bool>(bool((*&vw44)[0].f38[u32(unconst_u32(74))]));
+  vf386[0] = mat4x4h(f16(vw44[u32(unconst_u32(275))].f39), f16(vw44[u32(unconst_u32(275))].f39), f16(vw44[u32(unconst_u32(275))].f39), f16(vw44[u32(unconst_u32(275))].f39), f16(vw44[u32(unconst_u32(275))].f39), f16(vw44[u32(unconst_u32(275))].f39), f16(vw44[u32(unconst_u32(275))].f39), f16(vw44[u32(unconst_u32(275))].f39), f16(vw44[u32(unconst_u32(275))].f39), f16(vw44[u32(unconst_u32(275))].f39), f16(vw44[u32(unconst_u32(275))].f39), f16(vw44[u32(unconst_u32(275))].f39), f16(vw44[u32(unconst_u32(275))].f39), f16(vw44[u32(unconst_u32(275))].f39), f16(vw44[u32(unconst_u32(275))].f39), f16(vw44[u32(unconst_u32(275))].f39));
+  vf386[u32(unconst_u32(90))] = mat4x4h(f16((*&vw44)[0].f46[u32(unconst_u32(54))]), f16((*&vw44)[0].f46[u32(unconst_u32(54))]), f16((*&vw44)[0].f46[u32(unconst_u32(54))]), f16((*&vw44)[0].f46[u32(unconst_u32(54))]), f16((*&vw44)[0].f46[u32(unconst_u32(54))]), f16((*&vw44)[0].f46[u32(unconst_u32(54))]), f16((*&vw44)[0].f46[u32(unconst_u32(54))]), f16((*&vw44)[0].f46[u32(unconst_u32(54))]), f16((*&vw44)[0].f46[u32(unconst_u32(54))]), f16((*&vw44)[0].f46[u32(unconst_u32(54))]), f16((*&vw44)[0].f46[u32(unconst_u32(54))]), f16((*&vw44)[0].f46[u32(unconst_u32(54))]), f16((*&vw44)[0].f46[u32(unconst_u32(54))]), f16((*&vw44)[0].f46[u32(unconst_u32(54))]), f16((*&vw44)[0].f46[u32(unconst_u32(54))]), f16((*&vw44)[0].f46[u32(unconst_u32(54))]));
+  vw46 = VertexOutput12(vec4i(vw46.f38.grrg), vw46.f38, bitcast<f32>(vw46.f38), vec4i(vw46.f38.xxxy), bitcast<u32>(vw46.f38), vec4u(vw46.f38.xxyx), vw46.f38.xyyy, vec2f(vw46.f38), vec4i(vw46.f38.rggr), vec2i(vw46.f38), vec4f(vw46.f38.grgr));
+  vw47 += mat2x4h(vec4h(vw44[0].f42), vec4h(vw44[0].f42));
+  vw47 += mat2x4h(f16(vw44[0].f37[u32(unconst_u32(47))]), f16(vw44[0].f37[u32(unconst_u32(47))]), f16(vw44[0].f37[u32(unconst_u32(47))]), f16(vw44[0].f37[u32(unconst_u32(47))]), f16(vw44[0].f37[u32(unconst_u32(47))]), f16(vw44[0].f37[u32(unconst_u32(47))]), f16(vw44[0].f37[u32(unconst_u32(47))]), f16(vw44[0].f37[u32(unconst_u32(47))]));
+  vf387 -= vw46.f43.a;
+  var vf388 = fn0(array<mat3x2h, 2>(mat3x2h(f16(vw44[0].f42[u32(unconst_u32(273))]), f16(vw44[0].f42[u32(unconst_u32(273))]), f16(vw44[0].f42[u32(unconst_u32(273))]), f16(vw44[0].f42[u32(unconst_u32(273))]), f16(vw44[0].f42[u32(unconst_u32(273))]), f16(vw44[0].f42[u32(unconst_u32(273))])), mat3x2h(f16(vw44[0].f42[u32(unconst_u32(273))]), f16(vw44[0].f42[u32(unconst_u32(273))]), f16(vw44[0].f42[u32(unconst_u32(273))]), f16(vw44[0].f42[u32(unconst_u32(273))]), f16(vw44[0].f42[u32(unconst_u32(273))]), f16(vw44[0].f42[u32(unconst_u32(273))]))));
+  fn0(array<mat3x2h, 2>(mat3x2h(f16(vw46.f37[u32(unconst_u32(68))]), f16(vw46.f37[u32(unconst_u32(68))]), f16(vw46.f37[u32(unconst_u32(68))]), f16(vw46.f37[u32(unconst_u32(68))]), f16(vw46.f37[u32(unconst_u32(68))]), f16(vw46.f37[u32(unconst_u32(68))])), mat3x2h(f16(vw46.f37[u32(unconst_u32(68))]), f16(vw46.f37[u32(unconst_u32(68))]), f16(vw46.f37[u32(unconst_u32(68))]), f16(vw46.f37[u32(unconst_u32(68))]), f16(vw46.f37[u32(unconst_u32(68))]), f16(vw46.f37[u32(unconst_u32(68))]))));
+  vw47 = mat2x4h(f16(vw44[u32(unconst_u32(202))].f41), f16(vw44[u32(unconst_u32(202))].f41), f16(vw44[u32(unconst_u32(202))].f41), f16(vw44[u32(unconst_u32(202))].f41), f16(vw44[u32(unconst_u32(202))].f41), f16(vw44[u32(unconst_u32(202))].f41), f16(vw44[u32(unconst_u32(202))].f41), f16(vw44[u32(unconst_u32(202))].f41));
+  let ptr82: ptr<workgroup, VertexOutput12> = &vw44[u32(unconst_u32(274))];
+  let vf389: f32 = (*ptr82).f47[u32(unconst_u32(33))];
+  fn0(array<mat3x2h, 2>(mat3x2h(f16(vw46.f41), f16(vw46.f41), f16(vw46.f41), f16(vw46.f41), f16(vw46.f41), f16(vw46.f41)), mat3x2h(f16(vw46.f41), f16(vw46.f41), f16(vw46.f41), f16(vw46.f41), f16(vw46.f41), f16(vw46.f41))));
+}`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+renderPassEncoder45.setBindGroup(1, bindGroup26, new Uint32Array(1164), 131, 0);
+} catch {}
+try {
+renderPassEncoder90.setIndexBuffer(buffer96, 'uint32', 540, 357);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+document.body.prepend(canvas0);
+let renderPassEncoder94 = commandEncoder247.beginRenderPass({
+  colorAttachments: [{
+  view: textureView205,
+  depthSlice: 1,
+  clearValue: { r: 531.5, g: -851.8, b: -877.1, a: -565.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet14,
+  maxDrawCount: 277047491,
+});
+try {
+renderPassEncoder55.setBindGroup(3, bindGroup130, new Uint32Array(178), 31, 0);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float'],
+});
+} catch {}
+let bindGroup143 = device0.createBindGroup({layout: bindGroupLayout23, entries: [{binding: 175, resource: externalTexture1}]});
+let bindGroup144 = device0.createBindGroup({
+  layout: bindGroupLayout9,
+  entries: [{binding: 114, resource: {buffer: buffer105, offset: 768, size: 641}}],
+});
+let buffer182 = device0.createBuffer({
+  size: 454,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder249 = device0.createCommandEncoder({});
+let renderPassEncoder95 = commandEncoder249.beginRenderPass({
+  label: '\u014b\u432c',
+  colorAttachments: [{view: textureView174, depthSlice: 426, loadOp: 'load', storeOp: 'discard'}],
+});
+let renderBundleEncoder51 = device0.createRenderBundleEncoder({colorFormats: ['r16float'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder2.setBindGroup(0, bindGroup103);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(3, bindGroup88, []);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle40]);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer76, 'uint16', 178, 186);
+} catch {}
+try {
+renderPassEncoder71.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(1, buffer94, 0);
+} catch {}
+try {
+renderBundleEncoder51.setPipeline(pipeline6);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer89, 292, new Float32Array(14642), 5237, 4);
+} catch {}
+let pipeline11 = await device0.createComputePipelineAsync({
+  label: '\u036e\u0834\u0d2c',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule9, entryPoint: 'compute6'},
+});
+let commandEncoder250 = device0.createCommandEncoder({});
+let texture272 = device0.createTexture({
+  size: {width: 4, height: 2, depthOrArrayLayers: 1},
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let computePassEncoder179 = commandEncoder250.beginComputePass({});
+let renderBundle51 = renderBundleEncoder51.finish();
+try {
+computePassEncoder124.setBindGroup(3, bindGroup119, new Uint32Array(590), 36, 0);
+} catch {}
+try {
+renderPassEncoder56.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder55.setBindGroup(2, bindGroup1, new Uint32Array(1574), 344, 0);
+} catch {}
+try {
+renderPassEncoder76.setVertexBuffer(7, buffer40, 44, 106);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture245,
+  mipLevel: 2,
+  origin: {x: 4, y: 10, z: 0},
+  aspect: 'all',
+}, new Uint8Array(132).fill(27), /* required buffer size: 132 */
+{offset: 132, bytesPerRow: 51}, {width: 11, height: 12, depthOrArrayLayers: 0});
+} catch {}
+let buffer183 = device0.createBuffer({size: 2837, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder251 = device0.createCommandEncoder({label: '\u1453\uc60b\u{1fed3}'});
+let texture273 = device0.createTexture({
+  size: [256, 256, 15],
+  mipLevelCount: 1,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderPassEncoder96 = commandEncoder251.beginRenderPass({
+  colorAttachments: [{
+  view: textureView234,
+  clearValue: { r: 731.1, g: 788.7, b: 270.0, a: -996.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder65.setIndexBuffer(buffer20, 'uint32', 17_328, 10_086);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder67.setVertexBuffer(7, buffer9, 0, 2_749);
+} catch {}
+try {
+buffer91.unmap();
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder252 = device0.createCommandEncoder({});
+let texture274 = device0.createTexture({
+  label: '\u880f\u0bf6\u34f1\u{1ff4c}\u6356\udeee',
+  size: {width: 8, height: 5, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder180 = commandEncoder252.beginComputePass({});
+try {
+computePassEncoder180.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline0);
+} catch {}
+let arrayBuffer26 = buffer41.getMappedRange(416, 4);
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55); };
+} catch {}
+let texture275 = device0.createTexture({
+  size: {width: 8, height: 5, depthOrArrayLayers: 1},
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView237 = texture93.createView({label: '\u{1f980}\u5446\u0184\uacce\u0cd2\ubfba\ue495\u1d4a\u{1f710}', format: 'r8uint'});
+let sampler176 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 93.99,
+});
+try {
+computePassEncoder61.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+computePassEncoder22.setBindGroup(3, bindGroup99, new Uint32Array(529), 5, 0);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder85.setVertexBuffer(4, buffer56);
+} catch {}
+let querySet36 = device0.createQuerySet({type: 'occlusion', count: 543});
+let texture276 = device0.createTexture({
+  size: [4, 2, 7],
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder179.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder32.draw(60, 64, 319_389_380, 160_052_089);
+} catch {}
+try {
+renderPassEncoder32.drawIndexed(639, 14, 18, 18_596_235, 37_089_065);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder61.setVertexBuffer(5, buffer110, 916, 684);
+} catch {}
+let imageBitmap6 = await createImageBitmap(imageBitmap0);
+let sampler177 = device0.createSampler({
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 47.71,
+  lodMaxClamp: 52.06,
+  compare: 'greater-equal',
+  maxAnisotropy: 2,
+});
+try {
+computePassEncoder79.setBindGroup(3, bindGroup141, new Uint32Array(170), 20, 0);
+} catch {}
+try {
+renderPassEncoder71.setBindGroup(0, bindGroup79, new Uint32Array(2641), 227, 0);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(24, 72, 8, 315_309_279, 1_546_800_474);
+} catch {}
+try {
+renderPassEncoder32.drawIndexedIndirect(buffer154, 3_088);
+} catch {}
+try {
+renderPassEncoder32.drawIndirect(buffer128, 3_640);
+} catch {}
+try {
+renderPassEncoder94.setIndexBuffer(buffer26, 'uint32', 3_184, 0);
+} catch {}
+let arrayBuffer27 = buffer8.getMappedRange(4896, 12);
+try {
+device0.queue.writeTexture({
+  texture: texture183,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(63).fill(209), /* required buffer size: 63 */
+{offset: 63, bytesPerRow: 31}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout32 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 120,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d' },
+    },
+    {
+      binding: 207,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16float', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 41,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let texture277 = device0.createTexture({
+  label: '\u{1fb08}\u{1fbc8}\ubd33\u79ba\u8e97\u{1fbaa}\u2273\uf090',
+  size: [4, 2, 1],
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture41 = device0.importExternalTexture({label: '\u{1fb74}\ueba6\u{1fd1c}\ubf3c\u{1f80a}\u0ede\u4796\u7d8e', source: videoFrame46});
+try {
+computePassEncoder113.setBindGroup(3, bindGroup33);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(0, bindGroup5, new Uint32Array(3999), 587, 0);
+} catch {}
+try {
+renderPassEncoder8.end();
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder35.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1504 */
+  offset: 1504,
+  bytesPerRow: 5888,
+  buffer: buffer68,
+}, {
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder35.copyTextureToBuffer({
+  texture: texture212,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3156 */
+  offset: 3156,
+  bytesPerRow: 3840,
+  buffer: buffer144,
+}, {width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder35.copyTextureToTexture({
+  texture: texture230,
+  mipLevel: 0,
+  origin: {x: 2, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture36,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 37},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData31 = new ImageData(60, 100);
+let buffer184 = device0.createBuffer({size: 18780, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+let renderPassEncoder97 = commandEncoder35.beginRenderPass({
+  colorAttachments: [{
+  view: textureView72,
+  depthSlice: 7,
+  clearValue: { r: 800.9, g: 776.7, b: -529.7, a: 548.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet30,
+});
+let renderBundleEncoder52 = device0.createRenderBundleEncoder({colorFormats: ['r16float'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle52 = renderBundleEncoder52.finish({});
+try {
+computePassEncoder66.setBindGroup(1, bindGroup44);
+} catch {}
+try {
+renderPassEncoder24.drawIndexed(23, 106, 0, 37_849_600, 204_887_616);
+} catch {}
+try {
+renderPassEncoder24.drawIndexedIndirect(buffer24, 2_304);
+} catch {}
+try {
+renderPassEncoder52.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder180.insertDebugMarker('\u{1fc82}');
+} catch {}
+let commandEncoder253 = device0.createCommandEncoder({});
+try {
+computePassEncoder77.setBindGroup(2, bindGroup49);
+} catch {}
+try {
+renderPassEncoder32.draw(201, 51, 579_494_185, 62_185_740);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(0, buffer116, 0, 39);
+} catch {}
+try {
+commandEncoder253.copyBufferToBuffer(buffer11, 1236, buffer171, 9568, 3916);
+} catch {}
+let bindGroup145 = device0.createBindGroup({
+  layout: bindGroupLayout20,
+  entries: [{binding: 557, resource: {buffer: buffer74, offset: 256, size: 704}}],
+});
+let commandEncoder254 = device0.createCommandEncoder({});
+let textureView238 = texture34.createView({dimension: '1d'});
+try {
+computePassEncoder10.setBindGroup(0, bindGroup82);
+} catch {}
+try {
+computePassEncoder103.setBindGroup(2, bindGroup87, new Uint32Array(176), 104, 0);
+} catch {}
+try {
+renderPassEncoder54.executeBundles([renderBundle42, renderBundle43]);
+} catch {}
+try {
+renderPassEncoder32.drawIndirect(buffer175, 220);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer52, 'uint32', 3_888, 304);
+} catch {}
+try {
+  await buffer44.mapAsync(GPUMapMode.WRITE, 4520, 4172);
+} catch {}
+try {
+commandEncoder253.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 4028 */
+  offset: 4028,
+  buffer: buffer17,
+}, {
+  texture: texture165,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer185 = device0.createBuffer({size: 8867, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+let sampler178 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 78.12,
+  lodMaxClamp: 86.42,
+  maxAnisotropy: 13,
+});
+try {
+renderPassEncoder32.draw(177, 111, 194_584_656, 95_240_677);
+} catch {}
+try {
+renderPassEncoder32.drawIndexed(98, 558, 5, -2_102_913_201, 1_105_336_240);
+} catch {}
+try {
+renderPassEncoder24.drawIndirect(buffer152, 5_980);
+} catch {}
+try {
+renderPassEncoder60.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 4, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: img1,
+  origin: { x: 6, y: 11 },
+  flipY: false,
+}, {
+  texture: texture224,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView239 = texture132.createView({dimension: 'cube-array', baseArrayLayer: 2, arrayLayerCount: 6});
+let computePassEncoder181 = commandEncoder253.beginComputePass({});
+let renderPassEncoder98 = commandEncoder254.beginRenderPass({colorAttachments: [{view: textureView205, depthSlice: 8, loadOp: 'load', storeOp: 'discard'}]});
+try {
+computePassEncoder74.setBindGroup(2, bindGroup87);
+} catch {}
+try {
+computePassEncoder181.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder86.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+renderPassEncoder24.drawIndexed(8, 7, 12, -1_964_332_871, 92_076_494);
+} catch {}
+try {
+renderPassEncoder24.drawIndirect(buffer159, 5_468);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline8);
+} catch {}
+let arrayBuffer28 = buffer47.getMappedRange(136, 8);
+try {
+externalTexture3.label = '\ua6e1\u8359\u0a20\u8d9a\ufbd6\u760a\u0e42';
+} catch {}
+let textureView240 = texture97.createView({baseMipLevel: 0});
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup82, new Uint32Array(2236), 189, 0);
+} catch {}
+try {
+renderPassEncoder24.end();
+} catch {}
+try {
+renderPassEncoder32.drawIndexed(10, 111, 203, 230_982_248, 15_210_842);
+} catch {}
+try {
+renderPassEncoder32.drawIndexedIndirect(buffer128, 2_016);
+} catch {}
+try {
+renderPassEncoder67.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder62.setVertexBuffer(3, buffer157, 12, 369);
+} catch {}
+let bindGroup146 = device0.createBindGroup({
+  layout: bindGroupLayout22,
+  entries: [
+    {binding: 241, resource: {buffer: buffer6, offset: 256, size: 2956}},
+    {binding: 76, resource: textureView131},
+    {binding: 485, resource: textureView181},
+    {binding: 124, resource: textureView168},
+  ],
+});
+let buffer186 = device0.createBuffer({
+  size: 21225,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder255 = device0.createCommandEncoder({});
+let computePassEncoder182 = commandEncoder75.beginComputePass({});
+try {
+renderPassEncoder66.executeBundles([renderBundle26]);
+} catch {}
+try {
+renderPassEncoder22.drawIndirect(buffer161, 264);
+} catch {}
+try {
+renderPassEncoder80.setPipeline(pipeline0);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+computePassEncoder143.setBindGroup(0, bindGroup54, new Uint32Array(521), 52, 0);
+} catch {}
+try {
+computePassEncoder182.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder32.draw(362, 51, 809_487_166, 127_188_504);
+} catch {}
+try {
+renderPassEncoder97.setVertexBuffer(0, buffer89, 560);
+} catch {}
+try {
+commandEncoder255.copyBufferToBuffer(buffer114, 336, buffer143, 6404, 3556);
+} catch {}
+let textureView241 = texture72.createView({dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 0});
+let renderPassEncoder99 = commandEncoder255.beginRenderPass({colorAttachments: [{view: textureView205, depthSlice: 19, loadOp: 'load', storeOp: 'discard'}]});
+try {
+computePassEncoder51.setBindGroup(1, bindGroup49);
+} catch {}
+try {
+renderPassEncoder22.end();
+} catch {}
+try {
+renderPassEncoder84.beginOcclusionQuery(14);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle42]);
+} catch {}
+try {
+renderPassEncoder32.draw(13, 255, 994_230_683, 715_541_570);
+} catch {}
+try {
+renderPassEncoder32.drawIndexed(254, 122, 60, 709_808_322, 569_284_819);
+} catch {}
+try {
+renderPassEncoder32.drawIndexedIndirect(buffer12, 196);
+} catch {}
+try {
+renderPassEncoder32.drawIndirect(buffer186, 716);
+} catch {}
+try {
+renderPassEncoder79.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder74.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1564 */
+  offset: 1564,
+  bytesPerRow: 1024,
+  rowsPerImage: 397,
+  buffer: buffer115,
+}, {
+  texture: texture148,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+globalThis.someLabel = commandEncoder166.label;
+} catch {}
+let bindGroupLayout33 = device0.createBindGroupLayout({
+  label: '\u09c6\u081a\u{1fe25}\u09aa\u8389\u4297\u0a9d\u0177\ud89f\u148a\u02b4',
+  entries: [
+    {
+      binding: 144,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let commandEncoder256 = device0.createCommandEncoder({});
+let texture278 = gpuCanvasContext1.getCurrentTexture();
+let textureView242 = texture208.createView({label: '\u4168\u9b82', dimension: '2d-array'});
+let computePassEncoder183 = commandEncoder256.beginComputePass();
+try {
+computePassEncoder79.setBindGroup(3, bindGroup30, new Uint32Array(186), 7, 0);
+} catch {}
+try {
+renderPassEncoder58.setBindGroup(1, bindGroup100, []);
+} catch {}
+try {
+renderPassEncoder88.setBindGroup(3, bindGroup90, new Uint32Array(291), 63, 0);
+} catch {}
+try {
+renderPassEncoder32.end();
+} catch {}
+try {
+renderPassEncoder62.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder97.setVertexBuffer(7, buffer165, 44, 20);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder93.copyTextureToBuffer({
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 7, y: 59, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 32 widthInBlocks: 32 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2858 */
+  offset: 2858,
+  bytesPerRow: 29440,
+  buffer: buffer176,
+}, {width: 32, height: 27, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 4, height: 2, depthOrArrayLayers: 7}
+*/
+{
+  source: imageBitmap3,
+  origin: { x: 1, y: 0 },
+  flipY: false,
+}, {
+  texture: texture276,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let bindGroup147 = device0.createBindGroup({
+  label: '\u0446\u0a1d\u4787\u9ebe\u5187\u4aa5\ud852\u08a1\u1230',
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 420, resource: textureView36},
+    {binding: 121, resource: externalTexture16},
+    {binding: 218, resource: textureView140},
+  ],
+});
+let commandEncoder257 = device0.createCommandEncoder({});
+let renderPassEncoder100 = commandEncoder74.beginRenderPass({
+  colorAttachments: [{
+  view: textureView234,
+  clearValue: { r: 421.4, g: -154.7, b: -396.0, a: 870.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 273849828,
+});
+try {
+renderPassEncoder84.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle17, renderBundle42]);
+} catch {}
+let arrayBuffer29 = buffer44.getMappedRange(7848, 76);
+try {
+commandEncoder93.copyBufferToTexture({
+  /* bytesInLastRow: 64 widthInBlocks: 16 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 692 */
+  offset: 692,
+  bytesPerRow: 5376,
+  rowsPerImage: 646,
+  buffer: buffer81,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 2, y: 5, z: 0},
+  aspect: 'all',
+}, {width: 16, height: 14, depthOrArrayLayers: 0});
+} catch {}
+let img6 = await imageWithData(164, 102, '#10101010', '#20202020');
+let textureView243 = texture111.createView({});
+let computePassEncoder184 = commandEncoder257.beginComputePass({});
+try {
+renderPassEncoder89.setViewport(3.7160908383295577, 0.11874012277456969, 0.07924984801863802, 0.6777638681268516, 0.028381372660511883, 0.8592587540196533);
+} catch {}
+try {
+renderPassEncoder41.setPipeline(pipeline9);
+} catch {}
+try {
+commandEncoder93.copyTextureToTexture({
+  texture: texture189,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture136,
+  mipLevel: 0,
+  origin: {x: 69, y: 54, z: 0},
+  aspect: 'all',
+},
+{width: 16, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder124.insertDebugMarker('\u{1f7d6}');
+} catch {}
+let commandEncoder258 = device0.createCommandEncoder();
+let sampler179 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 89.73,
+  lodMaxClamp: 92.94,
+  compare: 'never',
+});
+let offscreenCanvas4 = new OffscreenCanvas(75, 444);
+let commandEncoder259 = device0.createCommandEncoder();
+let texture279 = device0.createTexture({size: [16, 10, 1], format: 'r16sint', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let computePassEncoder185 = commandEncoder259.beginComputePass({});
+let renderPassEncoder101 = commandEncoder93.beginRenderPass({
+  colorAttachments: [{
+  view: textureView205,
+  depthSlice: 8,
+  clearValue: { r: 107.5, g: -715.4, b: -51.15, a: -638.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet12,
+});
+try {
+computePassEncoder183.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(2, bindGroup72);
+} catch {}
+try {
+renderPassEncoder50.beginOcclusionQuery(17);
+} catch {}
+try {
+commandEncoder258.clearBuffer(buffer58);
+} catch {}
+let bindGroupLayout34 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 139, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform', hasDynamicOffset: false }},
+    {
+      binding: 169,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {binding: 128, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform', hasDynamicOffset: false }},
+    {
+      binding: 259,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer187 = device0.createBuffer({
+  size: 1686,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder260 = device0.createCommandEncoder({});
+let texture280 = device0.createTexture({
+  size: [4],
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView244 = texture95.createView({
+  dimension: 'cube-array',
+  format: 'r8uint',
+  baseMipLevel: 0,
+  mipLevelCount: 1,
+  baseArrayLayer: 8,
+  arrayLayerCount: 6,
+});
+let renderPassEncoder102 = commandEncoder258.beginRenderPass({
+  colorAttachments: [{
+  view: textureView205,
+  depthSlice: 22,
+  clearValue: { r: 273.3, g: -17.94, b: 785.4, a: 354.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet28,
+  maxDrawCount: 280101487,
+});
+try {
+computePassEncoder102.setBindGroup(2, bindGroup109);
+} catch {}
+try {
+computePassEncoder48.setBindGroup(0, bindGroup92, new Uint32Array(1277), 556, 0);
+} catch {}
+try {
+computePassEncoder184.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder55.beginOcclusionQuery(38);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.append(img1);
+let bindGroup148 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 7, resource: {buffer: buffer134, offset: 0, size: 636}}],
+});
+let buffer188 = device0.createBuffer({size: 14489, usage: GPUBufferUsage.MAP_WRITE});
+let texture281 = device0.createTexture({
+  size: [256, 256, 15],
+  format: 'r16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder103 = commandEncoder260.beginRenderPass({
+  colorAttachments: [{
+  view: textureView128,
+  depthSlice: 663,
+  clearValue: { r: -880.0, g: -63.69, b: 567.3, a: -978.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet12,
+});
+try {
+computePassEncoder133.setBindGroup(1, bindGroup64, new Uint32Array(1055), 12, 0);
+} catch {}
+try {
+computePassEncoder185.setPipeline(pipeline3);
+} catch {}
+try {
+buffer135.unmap();
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let commandEncoder261 = device0.createCommandEncoder({});
+let computePassEncoder186 = commandEncoder261.beginComputePass({});
+try {
+computePassEncoder95.setBindGroup(1, bindGroup57);
+} catch {}
+try {
+renderPassEncoder55.executeBundles([renderBundle11]);
+} catch {}
+try {
+renderPassEncoder80.setPipeline(pipeline8);
+} catch {}
+let pipeline12 = device0.createRenderPipeline({
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule3,
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'src-alpha-saturated', dstFactor: 'src'},
+  },
+  writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  vertex: {module: shaderModule15, constants: {1_247: 0}, buffers: []},
+  primitive: {topology: 'point-list', frontFace: 'cw'},
+});
+await gc();
+let sampler180 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 88.36,
+  lodMaxClamp: 96.08,
+  maxAnisotropy: 3,
+});
+try {
+renderPassEncoder94.setIndexBuffer(buffer142, 'uint32', 9_208, 560);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer57, 1148, new DataView(new ArrayBuffer(6288)), 775, 1060);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 256, depthOrArrayLayers: 111}
+*/
+{
+  source: videoFrame42,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture138,
+  mipLevel: 0,
+  origin: {x: 52, y: 159, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+externalTexture23.label = '\ua4dd\u{1fc80}\uaa6f\u0696';
+} catch {}
+let bindGroupLayout35 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 122,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 58,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let commandEncoder262 = device0.createCommandEncoder({});
+let renderPassEncoder104 = commandEncoder262.beginRenderPass({
+  label: '\ud8c4\u0eac\ue227\u{1fc63}\u0ab4\u882c\uaa9e\u2a79\u1de7',
+  colorAttachments: [{
+  view: textureView234,
+  clearValue: { r: -492.2, g: 55.15, b: 780.1, a: -637.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder75.setBindGroup(0, bindGroup41);
+} catch {}
+try {
+computePassEncoder134.setBindGroup(2, bindGroup24, new Uint32Array(5003), 554, 0);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer151, 'uint16', 7_972, 1_376);
+} catch {}
+let commandEncoder263 = device0.createCommandEncoder();
+let computePassEncoder187 = commandEncoder263.beginComputePass({label: '\u0871\ue8a0\u{1f7b5}\u04ee\u{1fd44}\ua3d0\u{1fe0c}\ubfc6'});
+try {
+computePassEncoder146.setBindGroup(2, bindGroup42, []);
+} catch {}
+try {
+computePassEncoder186.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(2, bindGroup75);
+} catch {}
+try {
+renderPassEncoder92.setBindGroup(2, bindGroup43, new Uint32Array(1123), 1, 0);
+} catch {}
+try {
+renderPassEncoder50.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder60.executeBundles([renderBundle13]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture282 = device0.createTexture({
+  label: '\uf361\u{1ffc6}\u{1fb92}\u{1fe44}\u6a3c\u8060\u{1fb95}',
+  size: [2, 1, 1],
+  sampleCount: 4,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder104.setBindGroup(1, bindGroup80, new Uint32Array(1154), 252, 0);
+} catch {}
+try {
+renderPassEncoder43.setIndexBuffer(buffer32, 'uint32', 1_136, 281);
+} catch {}
+try {
+renderPassEncoder89.setVertexBuffer(1, buffer72);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture130,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(81).fill(176), /* required buffer size: 81 */
+{offset: 81}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img4);
+let commandEncoder264 = device0.createCommandEncoder({});
+let commandBuffer15 = commandEncoder264.finish();
+let texture283 = device0.createTexture({
+  size: [256, 256, 15],
+  mipLevelCount: 2,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder125.setBindGroup(0, bindGroup129, new Uint32Array(1316), 610, 0);
+} catch {}
+try {
+renderPassEncoder55.endOcclusionQuery();
+} catch {}
+try {
+computePassEncoder38.insertDebugMarker('\u0e9e');
+} catch {}
+let gpuCanvasContext7 = offscreenCanvas4.getContext('webgpu');
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+let commandEncoder265 = device0.createCommandEncoder();
+let renderPassEncoder105 = commandEncoder265.beginRenderPass({
+  colorAttachments: [{
+  view: textureView234,
+  clearValue: { r: -121.7, g: 804.7, b: 807.2, a: 403.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder137.setBindGroup(1, bindGroup92);
+} catch {}
+try {
+computePassEncoder12.setBindGroup(0, bindGroup80, new Uint32Array(2987), 2_110, 0);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(3, bindGroup109, new Uint32Array(1578), 209, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer176, 8, new Int16Array(11580), 1390, 980);
+} catch {}
+let shaderModule16 = device0.createShaderModule({
+  label: '\u{1fdf7}\u5e85\u0727\u0e6e',
+  code: `
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(7) var<storage, read> buffer189: array<array<array<f16, 2>, 1>>;
+
+struct T0 {
+  @align(64) @size(1600) f0: array<atomic<i32>>,
+}
+
+struct T1 {
+  @align(16) @size(1504) f0: mat3x2h,
+}
+
+struct VertexOutput13 {
+  @builtin(position) f48: vec4f,
+  @location(5) @interpolate(flat, centroid) f49: vec4i,
+}
+
+struct FragmentOutput12 {
+  @location(0) @interpolate(perspective) f0: f32,
+  @location(7) f1: vec4i,
+}
+
+alias vec3b = vec3<bool>;
+
+override override15: bool;
+
+@id(1391) override override16: u32 = 18;
+
+fn fn0() -> mat2x2f {
+  var out: mat2x2f;
+  let ptr83: ptr<storage, f16, read> = &(*&buffer189)[u32(unconst_u32(106))][u32(unconst_u32(10))][1];
+  let ptr84: ptr<storage, array<f16, 2>, read> = &buffer189[arrayLength(&buffer189)][0];
+  out = mat2x2f(f32((*&buffer189)[arrayLength(&(*&buffer189))][u32(unconst_u32(54))][u32(unconst_u32(66))]), f32((*&buffer189)[arrayLength(&(*&buffer189))][u32(unconst_u32(54))][u32(unconst_u32(66))]), f32((*&buffer189)[arrayLength(&(*&buffer189))][u32(unconst_u32(54))][u32(unconst_u32(66))]), f32((*&buffer189)[arrayLength(&(*&buffer189))][u32(unconst_u32(54))][u32(unconst_u32(66))]));
+  vp11 = vec2u(u32((*ptr84)[1]));
+  vp11 &= vec2u(unpack4x8snorm(u32(unconst_u32(3))).ag);
+  let vf390: vec2f = log2(vec2f(unconst_f32(0.6153), unconst_f32(0.1905)));
+  let ptr85: ptr<storage, array<array<f16, 2>, 1>, read> = &(*&buffer189)[u32(unconst_u32(567))];
+  vp10[u32(unconst_u32(3))] -= mat3x4h((*ptr84)[u32(unconst_u32(33))], (*ptr84)[u32(unconst_u32(33))], (*ptr84)[u32(unconst_u32(33))], (*ptr84)[u32(unconst_u32(33))], (*ptr84)[u32(unconst_u32(33))], (*ptr84)[u32(unconst_u32(33))], (*ptr84)[u32(unconst_u32(33))], (*ptr84)[u32(unconst_u32(33))], (*ptr84)[u32(unconst_u32(33))], (*ptr84)[u32(unconst_u32(33))], (*ptr84)[u32(unconst_u32(33))], (*ptr84)[u32(unconst_u32(33))]);
+  vp9.f49 *= vec4i(i32((*ptr85)[u32(unconst_u32(434))][u32(unconst_u32(272))]));
+  out -= mat2x2f(f32((*&buffer189)[u32(unconst_u32(74))][0][1]), f32((*&buffer189)[u32(unconst_u32(74))][0][1]), f32((*&buffer189)[u32(unconst_u32(74))][0][1]), f32((*&buffer189)[u32(unconst_u32(74))][0][1]));
+  let ptr86: ptr<storage, f16, read> = &buffer189[arrayLength(&buffer189)][0][1];
+  vp11 <<= vec2u(bitcast<u32>(vp9.f49[u32(unconst_u32(152))]));
+  var vf391: u32 = arrayLength(&buffer189);
+  var vf392: vec3i = max(vec3i(unconst_i32(343), unconst_i32(46), unconst_i32(33)), vec3i(unconst_i32(-118), unconst_i32(221), unconst_i32(46)));
+  vp11 = vec2u(u32((*&buffer189)[arrayLength(&(*&buffer189))][0][1]));
+  vp11 >>= vec2u(bitcast<u32>(vf390[u32(unconst_u32(33))]));
+  let ptr87: ptr<storage, f16, read> = &buffer189[u32(unconst_u32(74))][0][u32(unconst_u32(14))];
+  let ptr88: ptr<storage, f16, read> = &buffer189[u32(unconst_u32(397))][u32(unconst_u32(18))][u32(buffer189[arrayLength(&buffer189)][u32(unconst_u32(137))][u32(unconst_u32(295))])];
+  vf392 = vec3i(i32(buffer189[u32(unconst_u32(153))][u32(unconst_u32(7))][1]));
+  let ptr89: ptr<storage, f16, read> = &buffer189[arrayLength(&buffer189)][0][1];
+  vp9 = VertexOutput13(vec4f(vp9.f49), vp9.f49);
+  vp9 = VertexOutput13(vec4f(f32((*&buffer189)[i32(unconst_i32(27))][0][1])), vec4i(i32((*&buffer189)[i32(unconst_i32(27))][0][1])));
+  return out;
+}
+
+fn fn1() -> array<vec2i, 1> {
+  var out: array<vec2i, 1>;
+  let ptr90: ptr<private, VertexOutput13> = &vp9;
+  fn0();
+  var vf393 = fn0();
+  return out;
+}
+
+fn fn2() -> VertexOutput13 {
+  var out: VertexOutput13;
+  out.f48 = vec4f(f32(buffer189[u32((*&buffer189)[arrayLength(&(*&buffer189))][0][pack4x8unorm(ldexp(vec4f(unconst_f32(0.00475), unconst_f32(0.02808), unconst_f32(0.2626), unconst_f32(0.1199)), vec4i(unconst_i32(68), unconst_i32(-134), unconst_i32(233), unconst_i32(232))))])][0][u32(unconst_u32(18))]));
+  out.f48 += bitcast<vec4f>(vp9.f49);
+  fn0();
+  let ptr91: ptr<storage, array<array<array<f16, 2>, 1>>, read> = &buffer189;
+  vp10[u32(unconst_u32(14))] = mat3x4h((*ptr91)[arrayLength(&(*ptr91))][0][1], (*ptr91)[arrayLength(&(*ptr91))][0][1], (*ptr91)[arrayLength(&(*ptr91))][0][1], (*ptr91)[arrayLength(&(*ptr91))][0][1], (*ptr91)[arrayLength(&(*ptr91))][0][1], (*ptr91)[arrayLength(&(*ptr91))][0][1], (*ptr91)[arrayLength(&(*ptr91))][0][1], (*ptr91)[arrayLength(&(*ptr91))][0][1], (*ptr91)[arrayLength(&(*ptr91))][0][1], (*ptr91)[arrayLength(&(*ptr91))][0][1], (*ptr91)[arrayLength(&(*ptr91))][0][1], (*ptr91)[arrayLength(&(*ptr91))][0][1]);
+  vp9.f49 = vec4i(i32((*&buffer189)[arrayLength(&(*&buffer189))][u32(unconst_u32(101))][1]));
+  vp9 = VertexOutput13(vec4f(f32((*&buffer189)[u32(unconst_u32(8))][0][1])), vec4i(i32((*&buffer189)[u32(unconst_u32(8))][0][1])));
+  return out;
+}
+
+var<workgroup> vw48: atomic<u32>;
+
+var<workgroup> vw49: vec2<bool>;
+
+var<private> vp9: VertexOutput13 = VertexOutput13(vec4f(0.06839, 0.09258, 0.4495, 0.1733), vec4i(292, 733, 403, 77));
+
+var<private> vp10: array<mat3x4h, 1> = array(mat3x4h(4676.8, 2916.3, 22553.9, 11783.0, -472.3, 22222.2, 1888.4, 23047.6, 5606.0, 3530.4, 1057.5, 1553.7));
+
+var<private> vp11: vec2u = vec2u(378, 21);
+
+@vertex
+fn vertex15() -> VertexOutput13 {
+  var out: VertexOutput13;
+  var vf394 = fn0();
+  out.f49 = vec4i(i32(buffer189[arrayLength(&buffer189)][u32(unconst_u32(79))][u32(unconst_u32(48))]));
+  fn1();
+  vp9.f48 *= vec4f(f32(buffer189[arrayLength(&buffer189)][0][u32(unconst_u32(37))]));
+  vp10[u32(unconst_u32(785))] = mat3x4h((*&buffer189)[u32(unconst_u32(26))][u32(unconst_u32(151))][u32(unconst_u32(690))], (*&buffer189)[u32(unconst_u32(26))][u32(unconst_u32(151))][u32(unconst_u32(690))], (*&buffer189)[u32(unconst_u32(26))][u32(unconst_u32(151))][u32(unconst_u32(690))], (*&buffer189)[u32(unconst_u32(26))][u32(unconst_u32(151))][u32(unconst_u32(690))], (*&buffer189)[u32(unconst_u32(26))][u32(unconst_u32(151))][u32(unconst_u32(690))], (*&buffer189)[u32(unconst_u32(26))][u32(unconst_u32(151))][u32(unconst_u32(690))], (*&buffer189)[u32(unconst_u32(26))][u32(unconst_u32(151))][u32(unconst_u32(690))], (*&buffer189)[u32(unconst_u32(26))][u32(unconst_u32(151))][u32(unconst_u32(690))], (*&buffer189)[u32(unconst_u32(26))][u32(unconst_u32(151))][u32(unconst_u32(690))], (*&buffer189)[u32(unconst_u32(26))][u32(unconst_u32(151))][u32(unconst_u32(690))], (*&buffer189)[u32(unconst_u32(26))][u32(unconst_u32(151))][u32(unconst_u32(690))], (*&buffer189)[u32(unconst_u32(26))][u32(unconst_u32(151))][u32(unconst_u32(690))]);
+  fn0();
+  vp9.f48 += vec4f(f32(buffer189[arrayLength(&buffer189)][0][1]));
+  out.f48 *= vec4f(f32(buffer189[u32(unconst_u32(167))][0][1]));
+  vp10[u32(unconst_u32(20))] = mat3x4h(buffer189[arrayLength(&buffer189)][u32(unconst_u32(21))][1], buffer189[arrayLength(&buffer189)][u32(unconst_u32(21))][1], buffer189[arrayLength(&buffer189)][u32(unconst_u32(21))][1], buffer189[arrayLength(&buffer189)][u32(unconst_u32(21))][1], buffer189[arrayLength(&buffer189)][u32(unconst_u32(21))][1], buffer189[arrayLength(&buffer189)][u32(unconst_u32(21))][1], buffer189[arrayLength(&buffer189)][u32(unconst_u32(21))][1], buffer189[arrayLength(&buffer189)][u32(unconst_u32(21))][1], buffer189[arrayLength(&buffer189)][u32(unconst_u32(21))][1], buffer189[arrayLength(&buffer189)][u32(unconst_u32(21))][1], buffer189[arrayLength(&buffer189)][u32(unconst_u32(21))][1], buffer189[arrayLength(&buffer189)][u32(unconst_u32(21))][1]);
+  let ptr92: ptr<private, vec4i> = &vp9.f49;
+  vp10[u32(unconst_u32(81))] = mat3x4h(buffer189[arrayLength(&buffer189)][0][1], buffer189[arrayLength(&buffer189)][0][1], buffer189[arrayLength(&buffer189)][0][1], buffer189[arrayLength(&buffer189)][0][1], buffer189[arrayLength(&buffer189)][0][1], buffer189[arrayLength(&buffer189)][0][1], buffer189[arrayLength(&buffer189)][0][1], buffer189[arrayLength(&buffer189)][0][1], buffer189[arrayLength(&buffer189)][0][1], buffer189[arrayLength(&buffer189)][0][1], buffer189[arrayLength(&buffer189)][0][1], buffer189[arrayLength(&buffer189)][0][1]);
+  out.f48 *= vec4f(f32(buffer189[u32(buffer189[i32(unconst_i32(159))][0][1])][u32(unconst_u32(19))][1]));
+  var vf395 = fn0();
+  var vf396 = fn0();
+  var vf397 = fn0();
+  var vf398 = fn0();
+  var vf399 = fn1();
+  return out;
+}
+
+@fragment
+fn fragment15() -> FragmentOutput12 {
+  var out: FragmentOutput12;
+  vp11 |= vec2u(arrayLength(&(*&buffer189)));
+  out.f1 -= vec4i(i32(buffer189[arrayLength(&buffer189)][0][1]));
+  out.f0 -= f32((*&buffer189)[u32(unconst_u32(351))][0][1]);
+  var vf400 = fn0();
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 3)
+fn compute11(@builtin(num_workgroups) a0: vec3u) {
+  let ptr93: ptr<workgroup, atomic<u32>> = &vw48;
+  var vf401 = fn0();
+  let vf402: vec4h = vp10[0][u32(buffer189[u32(unconst_u32(23))][0][1])];
+  let ptr94: ptr<storage, f16, read> = &buffer189[u32(unconst_u32(28))][u32(unconst_u32(265))][1];
+  vf401 -= mat2x2f(bitcast<vec2f>(vp10[0][u32((*&buffer189)[arrayLength(&(*&buffer189))][u32(unconst_u32(7))][1])]), bitcast<vec2f>(vp10[0][u32((*&buffer189)[arrayLength(&(*&buffer189))][u32(unconst_u32(7))][1])]));
+  vp10[u32(unconst_u32(20))] += vp10[0];
+  vw49 = vec2<bool>(bool((*ptr94)));
+  atomicCompareExchangeWeak(&vw48, unconst_u32(73), unconst_u32(154));
+  let vf403: vec4h = vf402;
+  fn0();
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup149 = device0.createBindGroup({layout: bindGroupLayout23, entries: [{binding: 175, resource: externalTexture5}]});
+let sampler181 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 26.81,
+  lodMaxClamp: 50.34,
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder170.setBindGroup(2, bindGroup41);
+} catch {}
+try {
+computePassEncoder187.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder72.setBindGroup(3, bindGroup107, new Uint32Array(5896), 46, 0);
+} catch {}
+try {
+renderPassEncoder74.setViewport(0.7760761764907693, 0.9680859419750746, 0.8244292277508152, 0.006591966861660217, 0.24044967696023012, 0.8156496206938678);
+} catch {}
+try {
+renderPassEncoder55.setIndexBuffer(buffer33, 'uint16', 818, 2_110);
+} catch {}
+try {
+renderPassEncoder79.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder69.setVertexBuffer(5, buffer98, 388, 1_292);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let bindGroupLayout36 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 357,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 6,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 85,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 252,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8unorm', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 217,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 20,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 262,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 351,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 184,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d' },
+    },
+    {
+      binding: 861,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8unorm', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 75,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16uint', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 418,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 157,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 276,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 62,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 53,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let texture284 = device0.createTexture({
+  size: {width: 8, height: 5, depthOrArrayLayers: 570},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView245 = texture94.createView({arrayLayerCount: 1});
+try {
+computePassEncoder36.setBindGroup(0, bindGroup23, new Uint32Array(2695), 1_455, 0);
+} catch {}
+try {
+renderPassEncoder90.setBindGroup(1, bindGroup87, new Uint32Array(1814), 111, 0);
+} catch {}
+try {
+renderPassEncoder65.setVertexBuffer(2, buffer132, 196, 299);
+} catch {}
+try {
+buffer110.unmap();
+} catch {}
+try {
+renderPassEncoder74.pushDebugGroup('\u094d');
+} catch {}
+try {
+renderPassEncoder74.popDebugGroup();
+} catch {}
+let textureView246 = texture284.createView({});
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup45, new Uint32Array(1584), 827, 0);
+} catch {}
+try {
+buffer123.unmap();
+} catch {}
+let texture285 = device0.createTexture({
+  size: [256],
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler182 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 73.37,
+  lodMaxClamp: 90.53,
+  maxAnisotropy: 15,
+});
+try {
+renderPassEncoder30.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder99.insertDebugMarker('\u98d9');
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let buffer190 = device0.createBuffer({size: 6975, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView247 = texture285.createView({label: '\u{1f8f5}\ud433\uea08\u{1fe74}\u0aab'});
+try {
+renderPassEncoder62.setBindGroup(2, bindGroup86, new Uint32Array(175), 4, 0);
+} catch {}
+let videoFrame54 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte240m', primaries: 'bt709', transfer: 'bt709'} });
+let commandEncoder266 = device0.createCommandEncoder({label: '\u5e78\u0dc9\u6f8c\u00e7\u6ce1\u007f\u0a15'});
+let texture286 = device0.createTexture({size: {width: 4}, dimension: '1d', format: 'r16sint', usage: GPUTextureUsage.COPY_SRC});
+try {
+computePassEncoder136.setBindGroup(2, bindGroup127);
+} catch {}
+try {
+computePassEncoder82.setBindGroup(0, bindGroup85, new Uint32Array(831), 117, 0);
+} catch {}
+try {
+renderPassEncoder75.setBindGroup(1, bindGroup52);
+} catch {}
+try {
+commandEncoder266.copyBufferToBuffer(buffer70, 17316, buffer167, 5856, 1112);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+await gc();
+let renderPassEncoder106 = commandEncoder266.beginRenderPass({
+  colorAttachments: [{
+  view: textureView234,
+  clearValue: { r: 22.56, g: -625.2, b: 495.4, a: 511.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let sampler183 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 86.23,
+  lodMaxClamp: 99.30,
+  maxAnisotropy: 3,
+});
+try {
+renderPassEncoder85.setVertexBuffer(3, buffer53, 292, 98);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer66, 3100, new Float32Array(4246), 139, 676);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture75,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(11_209).fill(74), /* required buffer size: 11_209 */
+{offset: 4, bytesPerRow: 135, rowsPerImage: 41}, {width: 0, height: 2, depthOrArrayLayers: 3});
+} catch {}
+await gc();
+let commandEncoder267 = device0.createCommandEncoder({label: '\u0439\u35ff\ud873\u07b1\ub09b\ue7c0\u7f2c\u0ddd\u0f9f'});
+let texture287 = device0.createTexture({
+  size: [2, 1, 1],
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder188 = commandEncoder267.beginComputePass({});
+try {
+computePassEncoder188.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle5]);
+} catch {}
+try {
+renderPassEncoder100.setStencilReference(1517);
+} catch {}
+try {
+renderPassEncoder51.setVertexBuffer(4, buffer62);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup150 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [
+    {binding: 93, resource: {buffer: buffer118, offset: 1536, size: 964}},
+    {binding: 62, resource: textureView41},
+    {binding: 24, resource: {buffer: buffer134, offset: 0, size: 75}},
+  ],
+});
+let commandEncoder268 = device0.createCommandEncoder({});
+let texture288 = gpuCanvasContext0.getCurrentTexture();
+try {
+computePassEncoder150.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder49.executeBundles([renderBundle16]);
+} catch {}
+try {
+commandEncoder268.copyTextureToBuffer({
+  texture: texture207,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4344 */
+  offset: 4344,
+  bytesPerRow: 4608,
+  buffer: buffer10,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+globalThis.someLabel = renderBundleEncoder4.label;
+} catch {}
+let commandEncoder269 = device0.createCommandEncoder();
+let texture289 = device0.createTexture({
+  size: {width: 16, height: 10, depthOrArrayLayers: 242},
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler184 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 89.96,
+  lodMaxClamp: 93.86,
+});
+try {
+computePassEncoder104.setBindGroup(3, bindGroup62, new Uint32Array(3235), 78, 0);
+} catch {}
+try {
+commandEncoder268.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2716 */
+  offset: 924,
+  bytesPerRow: 1792,
+  buffer: buffer38,
+}, {
+  texture: texture141,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 13},
+  aspect: 'all',
+}, {width: 0, height: 2, depthOrArrayLayers: 1});
+} catch {}
+try {
+renderPassEncoder77.setBindGroup(0, bindGroup73);
+} catch {}
+try {
+commandEncoder268.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1496 */
+  offset: 1496,
+  bytesPerRow: 1536,
+  buffer: buffer111,
+}, {
+  texture: texture170,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let buffer191 = device0.createBuffer({
+  size: 62,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder270 = device0.createCommandEncoder({});
+try {
+computePassEncoder106.pushDebugGroup('\ue081');
+} catch {}
+try {
+computePassEncoder106.popDebugGroup();
+} catch {}
+let querySet37 = device0.createQuerySet({type: 'occlusion', count: 361});
+let renderPassEncoder107 = commandEncoder268.beginRenderPass({
+  colorAttachments: [{
+  view: textureView205,
+  depthSlice: 22,
+  clearValue: { r: 911.8, g: 740.3, b: 408.5, a: 142.1, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet31,
+  maxDrawCount: 457393106,
+});
+try {
+computePassEncoder121.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(1, bindGroup86);
+} catch {}
+try {
+renderPassEncoder44.setVertexBuffer(1, buffer97);
+} catch {}
+try {
+commandEncoder270.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1496 */
+  offset: 1496,
+  bytesPerRow: 0,
+  buffer: buffer161,
+}, {
+  texture: texture260,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame55 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-ncl', primaries: 'smpte170m', transfer: 'gamma22curve'} });
+let bindGroup151 = device0.createBindGroup({layout: bindGroupLayout33, entries: [{binding: 144, resource: sampler164}]});
+let textureView248 = texture285.createView({dimension: '1d', aspect: 'all', arrayLayerCount: 1});
+let texture290 = device0.createTexture({
+  size: [8, 5, 1],
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder189 = commandEncoder270.beginComputePass({label: '\uccd7\u{1fac4}'});
+let renderPassEncoder108 = commandEncoder269.beginRenderPass({
+  colorAttachments: [{
+  view: textureView234,
+  clearValue: { r: -128.0, g: -527.0, b: 668.0, a: 721.1, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let sampler185 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 68.00,
+  lodMaxClamp: 71.75,
+});
+try {
+computePassEncoder149.setBindGroup(2, bindGroup137);
+} catch {}
+try {
+computePassEncoder189.setPipeline(pipeline2);
+} catch {}
+let commandEncoder271 = device0.createCommandEncoder({});
+let computePassEncoder190 = commandEncoder271.beginComputePass({});
+try {
+renderPassEncoder58.executeBundles([renderBundle9, renderBundle7]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 5, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame30,
+  origin: { x: 0, y: 1 },
+  flipY: false,
+}, {
+  texture: texture244,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder167.setBindGroup(1, bindGroup30, new Uint32Array(1914), 39, 0);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup126);
+} catch {}
+try {
+device0.queue.submit([commandBuffer15]);
+} catch {}
+let buffer192 = device0.createBuffer({
+  label: '\u0676\ue78f\u39eb\u015f\u0700\u0c69\u099d\u0fd2',
+  size: 28007,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let sampler186 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 32.01,
+  lodMaxClamp: 64.78,
+});
+try {
+computePassEncoder87.setBindGroup(0, bindGroup36);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer104, 'uint16', 132, 1_662);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(2, buffer27, 0, 494);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(195).fill(50), /* required buffer size: 195 */
+{offset: 195}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+globalThis.someLabel = externalTexture4.label;
+} catch {}
+let bindGroup152 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 121, resource: externalTexture6},
+    {binding: 420, resource: textureView186},
+    {binding: 218, resource: textureView102},
+  ],
+});
+let texture291 = device0.createTexture({
+  size: [16, 10, 1],
+  mipLevelCount: 1,
+  dimension: '2d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup112);
+} catch {}
+try {
+computePassEncoder150.setBindGroup(3, bindGroup81, new Uint32Array(62), 6, 0);
+} catch {}
+try {
+computePassEncoder190.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(0, bindGroup91);
+} catch {}
+try {
+gpuCanvasContext6.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.COPY_DST});
+} catch {}
+let promise24 = device0.queue.onSubmittedWorkDone();
+let texture292 = device0.createTexture({
+  size: [4, 2, 1],
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView249 = texture212.createView({aspect: 'all', baseMipLevel: 0});
+try {
+computePassEncoder136.setBindGroup(2, bindGroup124);
+} catch {}
+try {
+renderPassEncoder88.executeBundles([renderBundle44, renderBundle44]);
+} catch {}
+try {
+renderPassEncoder83.setIndexBuffer(buffer88, 'uint32', 244, 543);
+} catch {}
+try {
+renderPassEncoder62.setVertexBuffer(7, undefined, 147_043_171);
+} catch {}
+let textureView250 = texture217.createView({
+  label: '\u7971\u0eab\u04a3\u0aa2\u3a4a\u{1f961}\u0c3a\u04b6\u0ea9\u0c4e',
+  dimension: '2d-array',
+  mipLevelCount: 1,
+});
+let sampler187 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 95.41,
+  lodMaxClamp: 99.36,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder146.setBindGroup(2, bindGroup141, new Uint32Array(878), 50, 0);
+} catch {}
+try {
+renderPassEncoder107.setBindGroup(1, bindGroup59);
+} catch {}
+try {
+renderPassEncoder41.setViewport(250.46552007389377, 38.05002015706077, 4.60731711396637, 67.59812641671871, 0.5767258569519795, 0.6197038534197146);
+} catch {}
+try {
+renderPassEncoder44.setVertexBuffer(7, buffer94, 0, 82);
+} catch {}
+let imageData32 = new ImageData(56, 60);
+try {
+adapter0.label = '\u9eb9\u02f7\u000f\u7168\u1a66\u{1fe4f}\u{1fd40}';
+} catch {}
+let bindGroup153 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [{binding: 5, resource: textureView152}, {binding: 146, resource: textureView18}],
+});
+let texture293 = device0.createTexture({
+  size: {width: 4, height: 2, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  dimension: '2d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView251 = texture133.createView({format: 'r8uint', mipLevelCount: 1});
+try {
+computePassEncoder158.setBindGroup(3, bindGroup111, new Uint32Array(479), 25, 0);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(2, bindGroup141);
+} catch {}
+try {
+renderPassEncoder73.setBindGroup(3, bindGroup147, new Uint32Array(4591), 731, 0);
+} catch {}
+try {
+renderPassEncoder19.setViewport(0.925286600336999, 0.5522291542353964, 0.5996137993068058, 0.17178785121423368, 0.4451021788090931, 0.7277357704765107);
+} catch {}
+let arrayBuffer30 = buffer46.getMappedRange(80, 16);
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+computePassEncoder156.setBindGroup(1, bindGroup39, new Uint32Array(109), 58, 0);
+} catch {}
+try {
+renderPassEncoder52.executeBundles([renderBundle4]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 5, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData6,
+  origin: { x: 1, y: 0 },
+  flipY: false,
+}, {
+  texture: texture134,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+try {
+renderPassEncoder16.setBindGroup(3, bindGroup133);
+} catch {}
+try {
+renderPassEncoder103.setBindGroup(1, bindGroup85, new Uint32Array(2000), 213, 0);
+} catch {}
+try {
+renderPassEncoder50.setPipeline(pipeline1);
+} catch {}
+try {
+querySet19.destroy();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup154 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [
+    {binding: 62, resource: textureView41},
+    {binding: 24, resource: {buffer: buffer66, offset: 3072, size: 1423}},
+    {binding: 93, resource: {buffer: buffer57, offset: 256, size: 244}},
+  ],
+});
+let texture294 = device0.createTexture({
+  size: [16, 10, 1],
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView252 = texture251.createView({});
+try {
+computePassEncoder148.setBindGroup(1, bindGroup87, new Uint32Array(688), 553, 0);
+} catch {}
+try {
+renderPassEncoder102.setIndexBuffer(buffer179, 'uint16', 612, 814);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline8);
+} catch {}
+let bindGroup155 = device0.createBindGroup({layout: bindGroupLayout17, entries: [{binding: 162, resource: textureView208}]});
+let texture295 = device0.createTexture({
+  size: {width: 8, height: 5, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView253 = texture212.createView({});
+let sampler188 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 35.02,
+  lodMaxClamp: 45.02,
+  maxAnisotropy: 5,
+});
+try {
+renderPassEncoder36.drawIndexedIndirect(buffer133, 544);
+} catch {}
+try {
+computePassEncoder47.insertDebugMarker('\u{1f750}');
+} catch {}
+try {
+renderPassEncoder42.insertDebugMarker('\u007f');
+} catch {}
+try {
+  await promise24;
+} catch {}
+try {
+globalThis.someLabel = externalTexture16.label;
+} catch {}
+let texture296 = device0.createTexture({size: [8, 5, 1], format: 'r16sint', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING});
+try {
+renderPassEncoder1.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder47.setVertexBuffer(5, buffer88);
+} catch {}
+try {
+buffer82.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 11, y: 28, z: 7},
+  aspect: 'all',
+}, new Uint8Array(5_027).fill(46), /* required buffer size: 5_027 */
+{offset: 12, bytesPerRow: 30, rowsPerImage: 151}, {width: 5, height: 17, depthOrArrayLayers: 2});
+} catch {}
+document.body.append(img5);
+try {
+renderPassEncoder55.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderPassEncoder36.draw(571, 204, 1_124_593, 1_107_899_010);
+} catch {}
+try {
+renderPassEncoder36.drawIndexed(10, 120, 30, 738_162_348, 1_146_795_460);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(6, undefined, 403_950_839);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer67, 440, new BigUint64Array(10984), 8396, 44);
+} catch {}
+let promise25 = device0.queue.onSubmittedWorkDone();
+let imageData33 = new ImageData(128, 132);
+let videoFrame56 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'film', transfer: 'gamma22curve'} });
+let buffer193 = device0.createBuffer({
+  size: 11251,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let externalTexture42 = device0.importExternalTexture({source: videoFrame33});
+try {
+computePassEncoder70.setBindGroup(1, bindGroup43);
+} catch {}
+try {
+computePassEncoder9.setBindGroup(2, bindGroup59, new Uint32Array(140), 4, 0);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer145, 'uint16', 704, 622);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer124, 1104, new BigUint64Array(11381), 1428, 28);
+} catch {}
+let canvas5 = document.createElement('canvas');
+try {
+computePassEncoder51.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder84.setBindGroup(3, bindGroup124, new Uint32Array(1965), 488, 0);
+} catch {}
+try {
+renderPassEncoder36.end();
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer191, 0);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(0, buffer21, 0, 25);
+} catch {}
+let arrayBuffer31 = buffer112.getMappedRange(10456, 156);
+try {
+commandEncoder109.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 3151 */
+  offset: 3151,
+  bytesPerRow: 5888,
+  buffer: buffer192,
+}, {
+  texture: texture294,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext8 = canvas5.getContext('webgpu');
+let texture297 = device0.createTexture({
+  size: [256, 256, 15],
+  mipLevelCount: 2,
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView254 = texture160.createView({format: 'r16float'});
+let computePassEncoder191 = commandEncoder109.beginComputePass({});
+try {
+computePassEncoder135.setBindGroup(3, bindGroup52);
+} catch {}
+try {
+computePassEncoder128.setBindGroup(1, bindGroup101, new Uint32Array(997), 20, 0);
+} catch {}
+try {
+computePassEncoder79.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder61.setBindGroup(1, bindGroup146);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline4);
+} catch {}
+let videoFrame57 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'bt709', transfer: 'gamma28curve'} });
+let buffer194 = device0.createBuffer({size: 11288, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView255 = texture96.createView({
+  label: '\u9e73\u4826\u6930\u06b8\u2757\u280c\u2d32\u9a33\ueb1a\u5760\u6c3e',
+  format: 'r16float',
+  baseArrayLayer: 0,
+  arrayLayerCount: 1,
+});
+let sampler189 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 68.71,
+  lodMaxClamp: 94.68,
+});
+try {
+computePassEncoder191.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder83.end();
+} catch {}
+try {
+renderPassEncoder94.setVertexBuffer(0, buffer145);
+} catch {}
+let texture298 = device0.createTexture({
+  size: {width: 8, height: 5, depthOrArrayLayers: 1},
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let computePassEncoder192 = commandEncoder220.beginComputePass({});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup114, new Uint32Array(367), 190, 0);
+} catch {}
+try {
+renderPassEncoder27.executeBundles([renderBundle38]);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer133, 1_328);
+} catch {}
+let sampler190 = device0.createSampler({
+  label: '\u0da0\u0570\ub892',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 82.78,
+  lodMaxClamp: 83.57,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder79.setBindGroup(2, bindGroup67, new Uint32Array(91), 3, 0);
+} catch {}
+try {
+renderPassEncoder55.executeBundles([renderBundle12, renderBundle20, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(10, 18, 12, 764_396_477, 229_994_558);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer191, 0);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer66, 588);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let texture299 = device0.createTexture({size: [2, 1, 1], format: 'r16float', usage: GPUTextureUsage.COPY_DST, viewFormats: []});
+try {
+computePassEncoder99.setBindGroup(1, bindGroup56);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder51); computePassEncoder51.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder192.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup152);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup30, new Uint32Array(1418), 119, 0);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(1, 37, 7, -2_047_853_367, 538_550_211);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer105, 816);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer133, 3_220);
+} catch {}
+try {
+renderPassEncoder45.setVertexBuffer(4, buffer141, 0, 223);
+} catch {}
+try {
+computePassEncoder48.setBindGroup(1, bindGroup21, new Uint32Array(343), 27, 0);
+} catch {}
+try {
+renderPassEncoder1.draw(319, 352, 1_606_017_346, 495_778_669);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(5, 9, 2, 154_511_313, 58_332_058);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer75, 'uint32', 956, 1_829);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(5, buffer193, 368, 2_347);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder51); computePassEncoder51.dispatchWorkgroupsIndirect(buffer10, 4_204); };
+} catch {}
+try {
+renderPassEncoder20.setBlendConstant({ r: 106.2, g: -947.9, b: 638.6, a: -49.16, });
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(0, 122, 10, 92_429_181, 6_273_659);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer157, 352);
+} catch {}
+try {
+renderPassEncoder48.setVertexBuffer(4, buffer161);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let videoFrame58 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'unspecified', transfer: 'gamma28curve'} });
+let sampler191 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 74.99,
+  lodMaxClamp: 81.16,
+});
+try {
+renderPassEncoder79.setViewport(1.6836106820811563, 0.4565612906620363, 0.1455115263440195, 0.3822676145477905, 0.5962956373015748, 0.6356309981093834);
+} catch {}
+try {
+renderPassEncoder79.setIndexBuffer(buffer135, 'uint32', 3_548, 788);
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(4, buffer55, 0, 925);
+} catch {}
+let buffer195 = device0.createBuffer({
+  size: 3213,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let texture300 = device0.createTexture({
+  size: [256, 256, 15],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView256 = texture104.createView({label: '\uc502\uff00\u040e\u002b\u05f4\ud4bf', arrayLayerCount: 1});
+try {
+renderPassEncoder62.executeBundles([renderBundle34]);
+} catch {}
+try {
+renderPassEncoder1.draw(8, 34, 573_699_416, 996_615_846);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer15, 8);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 5, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData22,
+  origin: { x: 1, y: 2 },
+  flipY: true,
+}, {
+  texture: texture262,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let sampler192 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 17.70,
+  lodMaxClamp: 45.41,
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder51.end();
+} catch {}
+try {
+renderPassEncoder106.setBindGroup(2, bindGroup28);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer100, 116);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer60, 160);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(5, buffer55, 0, 9_674);
+} catch {}
+let videoFrame59 = new VideoFrame(canvas4, {timestamp: 0});
+try {
+renderPassEncoder1.draw(120, 59, 428_433_215, 754_712_066);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer24, 'uint16', 654, 1_685);
+} catch {}
+try {
+renderPassEncoder67.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder77.setVertexBuffer(2, buffer162, 320, 1_287);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+let bindGroup156 = device0.createBindGroup({
+  label: '\u4069\u0667\u{1fb41}\ua92e\u0324\u{1fdab}\ub06d\u{1fd89}',
+  layout: bindGroupLayout12,
+  entries: [
+    {binding: 112, resource: textureView81},
+    {binding: 497, resource: externalTexture7},
+    {binding: 232, resource: sampler116},
+  ],
+});
+let textureView257 = texture194.createView({});
+let sampler193 = device0.createSampler({
+  label: '\u{1fbc8}\u07d0\uce77\u4b92\u0f1c\u9993\u0477\u4d0d\u09db\u0ea3',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 61.13,
+  lodMaxClamp: 85.77,
+});
+try {
+renderPassEncoder1.draw(7, 255, 1_431_842_637, 4_294_967_295);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(1, 154, 31, 93_054_616, 100_478_967);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer52, 196);
+} catch {}
+try {
+renderPassEncoder84.setIndexBuffer(buffer135, 'uint32', 1_212, 638);
+} catch {}
+try {
+commandEncoder73.clearBuffer(buffer88, 408, 1484);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+});
+} catch {}
+let imageBitmap7 = await createImageBitmap(imageData2);
+let bindGroup157 = device0.createBindGroup({
+  layout: bindGroupLayout12,
+  entries: [
+    {binding: 232, resource: sampler62},
+    {binding: 497, resource: externalTexture22},
+    {binding: 112, resource: textureView168},
+  ],
+});
+let texture301 = device0.createTexture({
+  label: '\u{1f863}\uc265\u083b\u9bfc\u07c2\ucd88\u{1ff4b}\u09e7\u8ad7\u0a50\u{1fe2d}',
+  size: {width: 8, height: 5, depthOrArrayLayers: 1},
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder109 = commandEncoder73.beginRenderPass({
+  colorAttachments: [{
+  view: textureView249,
+  clearValue: { r: -18.58, g: 128.2, b: -180.9, a: 935.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet34,
+});
+try {
+computePassEncoder118.setBindGroup(0, bindGroup65, new Uint32Array(38), 4, 0);
+} catch {}
+try {
+renderPassEncoder28.setBlendConstant({ r: 194.7, g: 965.3, b: 749.0, a: -330.5, });
+} catch {}
+try {
+  await promise25;
+} catch {}
+document.body.append(canvas0);
+let renderBundleEncoder53 = device0.createRenderBundleEncoder({colorFormats: ['r16float'], stencilReadOnly: true});
+try {
+renderPassEncoder16.setViewport(0.2189987134639022, 1.3953411807271487, 1.5822183175899525, 0.18708234095828302, 0.4037994214847528, 0.7325935693544656);
+} catch {}
+try {
+renderPassEncoder81.setIndexBuffer(buffer156, 'uint32', 7_868, 1_277);
+} catch {}
+try {
+renderBundleEncoder53.setBindGroup(0, bindGroup56);
+} catch {}
+try {
+renderBundleEncoder53.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder53.setVertexBuffer(2, buffer59, 0, 2_725);
+} catch {}
+let promise26 = device0.queue.onSubmittedWorkDone();
+let textureView258 = texture284.createView({format: 'rgba8unorm'});
+let texture302 = device0.createTexture({size: [2], dimension: '1d', format: 'r16sint', usage: GPUTextureUsage.COPY_DST});
+let renderBundle53 = renderBundleEncoder53.finish({});
+try {
+renderPassEncoder1.draw(178, 177, 90_874_315, 240_503_709);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer15, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 42}
+*/
+{
+  source: imageData31,
+  origin: { x: 29, y: 1 },
+  flipY: false,
+}, {
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 15},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+globalThis.someLabel = externalTexture40.label;
+} catch {}
+let textureView259 = texture101.createView({dimension: '3d', mipLevelCount: 1});
+try {
+computePassEncoder40.setBindGroup(1, bindGroup91);
+} catch {}
+try {
+computePassEncoder102.setBindGroup(1, bindGroup9, new Uint32Array(601), 63, 0);
+} catch {}
+try {
+renderPassEncoder64.setBindGroup(3, bindGroup77);
+} catch {}
+try {
+renderPassEncoder103.setBindGroup(0, bindGroup84, new Uint32Array(1661), 196, 0);
+} catch {}
+try {
+renderPassEncoder1.draw(230, 170, 301_248_369, 471_927_144);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer62, 6_664);
+} catch {}
+try {
+renderPassEncoder106.setVertexBuffer(3, buffer53, 780);
+} catch {}
+try {
+buffer55.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 4, height: 2, depthOrArrayLayers: 67}
+*/
+{
+  source: imageData30,
+  origin: { x: 6, y: 5 },
+  flipY: true,
+}, {
+  texture: texture199,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+texture301.label = '\u0a3e\u4d0e\u07c0';
+} catch {}
+let bindGroupLayout37 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 175,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 172,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let buffer196 = device0.createBuffer({
+  size: 3332,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder95.setBindGroup(3, bindGroup95, []);
+} catch {}
+try {
+renderPassEncoder65.setBindGroup(1, bindGroup19, new Uint32Array(3156), 346, 0);
+} catch {}
+try {
+renderPassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder57.setIndexBuffer(buffer13, 'uint32', 3_512, 2_660);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline8);
+} catch {}
+try {
+buffer77.unmap();
+} catch {}
+let imageData34 = new ImageData(24, 20);
+let texture303 = device0.createTexture({size: [16, 10, 1], format: 'r16float', usage: GPUTextureUsage.TEXTURE_BINDING});
+let renderPassEncoder110 = commandEncoder15.beginRenderPass({
+  colorAttachments: [{
+  view: textureView253,
+  clearValue: { r: 653.4, g: 439.6, b: -725.3, a: 875.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 259865474,
+});
+try {
+renderPassEncoder107.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder71.setPipeline(pipeline8);
+} catch {}
+let promise27 = device0.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let bindGroup158 = device0.createBindGroup({
+  layout: bindGroupLayout20,
+  entries: [{binding: 557, resource: {buffer: buffer167, offset: 3328, size: 989}}],
+});
+let buffer197 = device0.createBuffer({
+  label: '\u16d2\u{1fd92}\u179f\u0894\u7525\ue429\u6a0d',
+  size: 16718,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let texture304 = device0.createTexture({
+  size: {width: 2, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView260 = texture113.createView({dimension: '2d-array'});
+let renderBundleEncoder54 = device0.createRenderBundleEncoder({colorFormats: ['r16float'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder94.setBindGroup(3, bindGroup137, new Uint32Array(177), 92, 0);
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let offscreenCanvas5 = new OffscreenCanvas(375, 8);
+let renderBundle54 = renderBundleEncoder54.finish({});
+try {
+computePassEncoder127.setBindGroup(2, bindGroup20);
+} catch {}
+try {
+renderPassEncoder85.setBindGroup(2, bindGroup135, new Uint32Array(999), 354, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer173, 72, new DataView(new ArrayBuffer(2365)), 180, 224);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 64, height: 64, depthOrArrayLayers: 3}
+*/
+{
+  source: videoFrame10,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture245,
+  mipLevel: 2,
+  origin: {x: 3, y: 12, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas0);
+let textureView261 = texture138.createView({});
+try {
+renderPassEncoder74.setBindGroup(3, bindGroup87, []);
+} catch {}
+let querySet38 = device0.createQuerySet({label: '\u{1f95a}\u{1fc28}\u0aa9\ud049\u0f60\u0cb7\ucdd1\u0e1b\ua453', type: 'occlusion', count: 2013});
+try {
+computePassEncoder87.setBindGroup(1, bindGroup115);
+} catch {}
+try {
+renderPassEncoder59.setBindGroup(1, bindGroup100, new Uint32Array(3864), 302, 0);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer179, 'uint32', 892, 164);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(7, buffer132, 872, 1_085);
+} catch {}
+let texture305 = device0.createTexture({
+  size: {width: 4, height: 2, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler194 = device0.createSampler({
+  label: '\ue523\u959b\uc790\u0eba\u082b\u00ad\u0ee2\u{1f97a}\uf0c3\ueb01\u006d',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 82.72,
+  lodMaxClamp: 93.15,
+  compare: 'greater',
+});
+try {
+computePassEncoder9.setBindGroup(0, bindGroup144);
+} catch {}
+try {
+computePassEncoder145.end();
+} catch {}
+try {
+renderPassEncoder69.setPipeline(pipeline9);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let renderPassEncoder111 = commandEncoder206.beginRenderPass({
+  colorAttachments: [{
+  view: textureView249,
+  clearValue: { r: -28.61, g: -669.1, b: -208.6, a: 204.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let sampler195 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 70.30,
+  lodMaxClamp: 82.97,
+});
+try {
+if (!arrayBuffer22.detached) { new Uint8Array(arrayBuffer22).fill(0x55); };
+} catch {}
+let bindGroup159 = device0.createBindGroup({
+  label: '\u178c\u572d\u704f\u05a4\u0116\u{1f807}\u0cae\u0fc9',
+  layout: bindGroupLayout7,
+  entries: [{binding: 13, resource: externalTexture15}],
+});
+let buffer198 = device0.createBuffer({size: 11983, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+let externalTexture43 = device0.importExternalTexture({source: videoFrame15});
+try {
+renderPassEncoder97.setIndexBuffer(buffer61, 'uint16', 1_486, 3_622);
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline8);
+} catch {}
+let videoFrame60 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'fcc', primaries: 'smpteSt4281', transfer: 'iec61966-2-1'} });
+try {
+renderPassEncoder10.beginOcclusionQuery(9);
+} catch {}
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(6, buffer127, 176, 260);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup160 = device0.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [{binding: 26, resource: textureView215}, {binding: 294, resource: textureView117}],
+});
+document.body.prepend(img0);
+let imageData35 = new ImageData(68, 24);
+let texture306 = device0.createTexture({
+  size: [2],
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let sampler196 = device0.createSampler({
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 10.07,
+  lodMaxClamp: 21.33,
+});
+try {
+computePassEncoder148.setBindGroup(3, bindGroup142, new Uint32Array(439), 91, 0);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer89, 'uint32', 716, 77);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(2, buffer88, 0);
+} catch {}
+let imageData36 = new ImageData(8, 24);
+let bindGroup161 = device0.createBindGroup({
+  layout: bindGroupLayout36,
+  entries: [
+    {binding: 861, resource: textureView248},
+    {binding: 262, resource: {buffer: buffer128, offset: 3840, size: 2768}},
+    {binding: 184, resource: textureView54},
+    {binding: 252, resource: textureView246},
+    {binding: 85, resource: sampler179},
+    {binding: 351, resource: textureView81},
+    {binding: 6, resource: textureView3},
+    {binding: 217, resource: sampler168},
+    {binding: 418, resource: textureView190},
+    {binding: 20, resource: {buffer: buffer17, offset: 256, size: 296}},
+    {binding: 75, resource: textureView147},
+    {binding: 276, resource: textureView56},
+    {binding: 357, resource: textureView199},
+    {binding: 53, resource: textureView95},
+    {binding: 157, resource: {buffer: buffer134, offset: 0, size: 364}},
+    {binding: 62, resource: textureView168},
+  ],
+});
+let textureView262 = texture305.createView({});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 5, depthOrArrayLayers: 134}
+*/
+{
+  source: videoFrame26,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture199,
+  mipLevel: 0,
+  origin: {x: 5, y: 1, z: 15},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer199 = device0.createBuffer({
+  size: 6922,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let texture307 = device0.createTexture({
+  label: '\ua07a\u0aa6\ud517\u8694',
+  size: [16, 10, 1],
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView263 = texture194.createView({});
+try {
+computePassEncoder35.pushDebugGroup('\u0374');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 5, depthOrArrayLayers: 134}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 13, y: 6 },
+  flipY: true,
+}, {
+  texture: texture199,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 18},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img0);
+let bindGroup162 = device0.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [{binding: 294, resource: textureView189}, {binding: 26, resource: textureView211}],
+});
+try {
+renderPassEncoder16.setBindGroup(3, bindGroup15);
+} catch {}
+try {
+renderPassEncoder76.setPipeline(pipeline0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+adapter0.label = '\u31c9\ua736\ub5af\ue3e7\u{1fc00}\u{1fc20}\u208a';
+} catch {}
+try {
+computePassEncoder181.label = '\u055d\u{1fd7f}\ub22f\u01f7\ua513';
+} catch {}
+try {
+computePassEncoder100.setBindGroup(0, bindGroup71);
+} catch {}
+try {
+computePassEncoder141.setBindGroup(1, bindGroup135, new Uint32Array(855), 124, 0);
+} catch {}
+try {
+renderPassEncoder89.setBindGroup(0, bindGroup45);
+} catch {}
+try {
+computePassEncoder35.popDebugGroup();
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+  await promise26;
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let texture308 = device0.createTexture({
+  size: {width: 16, height: 10, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler197 = device0.createSampler({
+  label: '\u{1fd5b}\u0d1c\u0def\u0a6f\u6073\u4e59\u{1fa03}',
+  addressModeU: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 61.48,
+  lodMaxClamp: 73.74,
+  compare: 'never',
+});
+try {
+computePassEncoder71.setBindGroup(0, bindGroup145, []);
+} catch {}
+try {
+renderPassEncoder13.setViewport(1.3391108648117669, 1.2582747185523986, 0.4236389571068304, 0.4163035614963213, 0.884905857785287, 0.9512625937508099);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer110, 'uint16', 790, 1_565);
+} catch {}
+try {
+  await buffer190.mapAsync(GPUMapMode.READ, 1008, 880);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture167,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(122).fill(154), /* required buffer size: 122 */
+{offset: 122}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup163 = device0.createBindGroup({
+  layout: bindGroupLayout12,
+  entries: [
+    {binding: 232, resource: sampler121},
+    {binding: 112, resource: textureView168},
+    {binding: 497, resource: externalTexture6},
+  ],
+});
+try {
+computePassEncoder36.setBindGroup(3, bindGroup22);
+} catch {}
+try {
+renderPassEncoder85.setStencilReference(334);
+} catch {}
+try {
+renderPassEncoder25.setViewport(3.783603983531422, 0.16866139548346903, 0.0036865539810388096, 1.1798113685332192, 0.7956916058640842, 0.9337027272996116);
+} catch {}
+try {
+renderPassEncoder106.setIndexBuffer(buffer52, 'uint16', 1_020, 118);
+} catch {}
+try {
+renderPassEncoder61.setPipeline(pipeline8);
+} catch {}
+let canvas6 = document.createElement('canvas');
+let pipelineLayout23 = device0.createPipelineLayout({bindGroupLayouts: []});
+let texture309 = device0.createTexture({
+  size: [2],
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler198 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', magFilter: 'nearest', lodMaxClamp: 94.23});
+try {
+renderPassEncoder10.setIndexBuffer(buffer125, 'uint32', 56, 12);
+} catch {}
+try {
+renderPassEncoder75.setPipeline(pipeline12);
+} catch {}
+let bindGroup164 = device0.createBindGroup({
+  layout: bindGroupLayout31,
+  entries: [
+    {binding: 152, resource: textureView7},
+    {binding: 69, resource: {buffer: buffer163, offset: 0, size: 2633}},
+  ],
+});
+let buffer200 = device0.createBuffer({
+  label: '\u60e6\ufdb3\u{1ff9b}\uc59e\u0d55\u8f96\u07c4',
+  size: 2036,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture310 = device0.createTexture({size: [8], dimension: '1d', format: 'r16float', usage: GPUTextureUsage.TEXTURE_BINDING});
+let buffer201 = device0.createBuffer({
+  size: 13928,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let sampler199 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 61.13,
+  lodMaxClamp: 64.57,
+});
+try {
+computePassEncoder101.setBindGroup(0, bindGroup130, new Uint32Array(4013), 822, 0);
+} catch {}
+try {
+renderPassEncoder58.setBindGroup(3, bindGroup134, new Uint32Array(4364), 2_271, 0);
+} catch {}
+try {
+renderPassEncoder96.setVertexBuffer(4, buffer12, 4_540, 127);
+} catch {}
+try {
+globalThis.someLabel = querySet36.label;
+} catch {}
+let bindGroup165 = device0.createBindGroup({layout: bindGroupLayout20, entries: [{binding: 557, resource: {buffer: buffer171, offset: 7424}}]});
+try {
+computePassEncoder66.setBindGroup(1, bindGroup100);
+} catch {}
+try {
+computePassEncoder124.setBindGroup(0, bindGroup112, new Uint32Array(1828), 351, 0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup72);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture107,
+  mipLevel: 0,
+  origin: {x: 24, y: 6, z: 5},
+  aspect: 'all',
+}, new Uint8Array(221_496).fill(211), /* required buffer size: 221_496 */
+{offset: 137, bytesPerRow: 200, rowsPerImage: 68}, {width: 159, height: 19, depthOrArrayLayers: 17});
+} catch {}
+try {
+computePassEncoder24.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder77.setBindGroup(0, bindGroup162);
+} catch {}
+try {
+renderPassEncoder65.beginOcclusionQuery(7);
+} catch {}
+try {
+renderPassEncoder94.executeBundles([renderBundle45, renderBundle50]);
+} catch {}
+try {
+renderPassEncoder85.setScissorRect(0, 0, 2, 0);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(5, buffer76, 4, 70);
+} catch {}
+let promise28 = device0.queue.onSubmittedWorkDone();
+document.body.append(canvas1);
+let texture311 = device0.createTexture({
+  size: [4, 2, 1],
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder88.setBindGroup(1, bindGroup68, new Uint32Array(3017), 0, 0);
+} catch {}
+try {
+renderPassEncoder65.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline1);
+} catch {}
+let imageData37 = new ImageData(44, 28);
+let texture312 = device0.createTexture({
+  size: [4, 2, 1],
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+device0.queue.writeBuffer(buffer91, 508, new Int16Array(31377), 1381, 144);
+} catch {}
+let shaderModule17 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(22) var tex21: texture_depth_2d;
+
+@group(0) @binding(62) var<uniform> buffer202: vec4h;
+
+@group(0) @binding(103) var tex23: texture_2d<u32>;
+
+@group(0) @binding(132) var sam5: sampler;
+
+@group(0) @binding(236) var st6: texture_storage_2d<rg32float, read>;
+
+struct T0 {
+  f0: vec4h,
+}
+
+struct T1 {
+  f0: array<i32, 2>,
+}
+
+struct T2 {
+  @align(8) @size(8) f0: array<atomic<i32>>,
+}
+
+struct FragmentOutput13 {
+  @location(0) @interpolate(linear) f0: vec4f,
+}
+
+var<workgroup> vw50: FragmentOutput13;
+
+@fragment
+fn fragment16() -> FragmentOutput13 {
+  var out: FragmentOutput13;
+  out.f0 *= unpack4x8snorm(textureNumLevels(tex23));
+  var vf404: f32 = exp2(bitcast<f32>(refract(vec2h(unconst_f16(14505.9), unconst_f16(9043.5)), vec2h(unconst_f16(2381.4), unconst_f16(29057.9)), f16(unconst_f16(55650.1)))));
+  var vf405: vec2u = textureDimensions(st6);
+  out.f0 = vec4f(textureDimensions(tex23).yxxx);
+  vf404 = bitcast<f32>(pack4xU8(textureGather(355 % 4, tex23, sam5, vec2f(unconst_f32(0.04519), unconst_f32(0.3036)), clamp(vec2i(96, 60), vec2i(-8), vec2i(7)))));
+  out.f0 -= vec4f(exp2(f32(unconst_f32(0.7474))));
+  out = FragmentOutput13(vec4f(reverseBits(vec3u(unconst_u32(431), unconst_u32(11), unconst_u32(49))).rbgg));
+  vf405 ^= vec2u(bitcast<u32>(exp2(f32(unconst_f32(0.1050)))));
+  var vf406: u32 = textureNumLevels(tex23);
+  vf405 = textureGather(257 % 4, tex23, sam5, vec2f(unconst_f32(0.01404), unconst_f32(0.3611))).zz;
+  out.f0 += bitcast<vec4f>(vf405.xxxx);
+  var vf407: vec4u = textureGather(252 % 4, tex23, sam5, vec2f(unconst_f32(0.2026), unconst_f32(0.4506)), clamp(vec2i(665, -129), vec2i(-8), vec2i(7)));
+  out.f0 = vec4f(textureGather(226 % 4, tex23, sam5, vec2f(unconst_f32(0.2855), unconst_f32(0.00885))));
+  let ptr95: ptr<function, vec4u> = &vf407;
+  let vf408: vec4u = textureGather(62 % 4, tex23, sam5, vec2f(unconst_f32(0.02899), unconst_f32(0.1167)));
+  vf406 -= textureDimensions(tex23).g;
+  let vf409: vec2h = refract(vec2h(unconst_f16(17628.6), unconst_f16(2646.6)), vec2h(unconst_f16(2185.5), unconst_f16(1341.9)), f16(unconst_f16(24556.6)));
+  let vf410: f16 = (*&buffer202)[(*ptr95)[u32(unconst_u32(242))]];
+  vf406 = textureLoad(tex23, vec2i(unconst_i32(200), unconst_i32(167)), i32(unconst_i32(78))).z;
+  return out;
+}
+
+@compute @workgroup_size(3, 1, 1)
+fn compute12(@builtin(global_invocation_id) a0: vec3u) {
+  vw50.f0 += vec4f((*&buffer202));
+  vw50 = FragmentOutput13(unpack2x16snorm(u32(unconst_u32(346))).rggr);
+  workgroupBarrier();
+  var vf411: f16 = buffer202[u32(unconst_u32(127))];
+  let vf412: vec2u = textureDimensions(tex23);
+  vf411 = f16(mix(clamp(vec4f(unconst_f32(0.07624), unconst_f32(0.1953), unconst_f32(0.1409), unconst_f32(0.06938)), vec4f(unconst_f32(0.2101), unconst_f32(0.6232), unconst_f32(0.03121), unconst_f32(0.4087)), vec4f(unconst_f32(0.1751), unconst_f32(0.3021), unconst_f32(0.4269), unconst_f32(0.07930))), vec4f(unconst_f32(0.1794), unconst_f32(0.01087), unconst_f32(0.04168), unconst_f32(0.1291)), vec4f(unconst_f32(0.3949), unconst_f32(0.2743), unconst_f32(0.2904), unconst_f32(0.1572)))[2]);
+  vf411 += vec2h(unpack2x16float(u32(unconst_u32(40))))[1];
+  let ptr96: ptr<uniform, vec4h> = &(*&buffer202);
+  var vf413: vec2i = countOneBits(vec2i(unconst_i32(32), unconst_i32(531)));
+  let vf414: f32 = (*&vw50).f0[u32(unconst_u32(214))];
+  let vf415: f32 = vw50.f0[u32(unconst_u32(3))];
+  let vf416: vec3h = acosh(vec3h(unconst_f16(2292.7), unconst_f16(4002.7), unconst_f16(-42467.9)));
+  var vf417: vec2u = textureDimensions(tex21);
+  var vf418: FragmentOutput13 = workgroupUniformLoad(&vw50);
+  let ptr97: ptr<workgroup, vec4f> = &vw50.f0;
+  var vf419: i32 = vf413[u32(unconst_u32(102))];
+  var vf420: vec2f = unpack2x16snorm(u32(unconst_u32(189)));
+  let vf421: f16 = (*ptr96)[u32(unconst_u32(193))];
+}`,
+  hints: {},
+});
+let bindGroupLayout38 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 162,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d' },
+    },
+    {
+      binding: 286,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba32sint', access: 'write-only', viewDimension: '1d' },
+    },
+  ],
+});
+let texture313 = device0.createTexture({
+  size: [2],
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder107.setBindGroup(3, bindGroup146);
+} catch {}
+try {
+computePassEncoder150.setBindGroup(0, bindGroup150, new Uint32Array(913), 31, 0);
+} catch {}
+try {
+renderPassEncoder59.setBindGroup(3, bindGroup56);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer157, 'uint32', 920, 12);
+} catch {}
+try {
+renderPassEncoder76.setPipeline(pipeline0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline13 = await device0.createComputePipelineAsync({label: '\u1326\u{1fbee}', layout: pipelineLayout6, compute: {module: shaderModule8, constants: {}}});
+let bindGroup166 = device0.createBindGroup({
+  layout: bindGroupLayout18,
+  entries: [{binding: 97, resource: {buffer: buffer45, offset: 1024, size: 368}}],
+});
+let textureView264 = texture313.createView({aspect: 'all'});
+let externalTexture44 = device0.importExternalTexture({source: videoFrame10});
+try {
+computePassEncoder138.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+computePassEncoder109.setBindGroup(0, bindGroup8, new Uint32Array(3803), 147, 0);
+} catch {}
+try {
+renderPassEncoder57.setPipeline(pipeline1);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(img5);
+try {
+offscreenCanvas5.getContext('webgl2');
+} catch {}
+let bindGroupLayout39 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 82,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+let buffer203 = device0.createBuffer({
+  label: '\u0ae9\uef6c\u{1faa2}\ud535\ueb11\u6193\u{1f730}\u0bd5\uf384',
+  size: 25321,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let sampler200 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 31.59,
+  maxAnisotropy: 14,
+});
+try {
+renderPassEncoder50.setIndexBuffer(buffer110, 'uint16', 1_434, 985);
+} catch {}
+try {
+renderPassEncoder53.setVertexBuffer(0, buffer99, 284, 31);
+} catch {}
+let gpuCanvasContext9 = canvas6.getContext('webgpu');
+try {
+externalTexture24.label = '\u{1feaa}\u579d\ua148\u{1fb9a}\u0d06\ued8b\u0c64\u{1fdaa}\u9032\u1444\u003b';
+} catch {}
+try {
+computePassEncoder75.setBindGroup(0, bindGroup163, new Uint32Array(4130), 917, 0);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(1, bindGroup82, new Uint32Array(1864), 293, 0);
+} catch {}
+try {
+renderPassEncoder28.executeBundles([renderBundle49, renderBundle38]);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer110, 'uint32', 1_284, 379);
+} catch {}
+try {
+renderPassEncoder51.setVertexBuffer(7, buffer17, 0, 102);
+} catch {}
+try {
+adapter0.label = '\u1d57\ua557\u94ac\ud01b';
+} catch {}
+let bindGroup167 = device0.createBindGroup({
+  layout: bindGroupLayout24,
+  entries: [{binding: 172, resource: textureView140}, {binding: 468, resource: {buffer: buffer196, offset: 256}}],
+});
+try {
+renderPassEncoder55.setVertexBuffer(0, buffer20, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer147, 2724, new DataView(new ArrayBuffer(1152)), 59, 356);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView265 = texture8.createView({mipLevelCount: 1});
+try {
+renderPassEncoder29.setBindGroup(3, bindGroup114);
+} catch {}
+await gc();
+let textureView266 = texture193.createView({dimension: '3d'});
+try {
+renderPassEncoder74.setBindGroup(2, bindGroup101, new Uint32Array(2003), 624, 0);
+} catch {}
+try {
+renderPassEncoder39.setViewport(1.430499531830729, 0.26522668261805393, 0.3400188585957082, 0.25088158226090157, 0.5086408270236479, 0.5818421731208941);
+} catch {}
+try {
+renderPassEncoder86.setIndexBuffer(buffer145, 'uint32', 360, 144);
+} catch {}
+try {
+renderPassEncoder69.setVertexBuffer(0, buffer200, 156, 394);
+} catch {}
+try {
+buffer21.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture227,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(178).fill(249), /* required buffer size: 178 */
+{offset: 178, bytesPerRow: 8}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView267 = texture103.createView({dimension: '3d', baseMipLevel: 0, mipLevelCount: 1, arrayLayerCount: 1});
+try {
+renderPassEncoder50.setBindGroup(0, bindGroup79, new Uint32Array(375), 9, 0);
+} catch {}
+try {
+renderPassEncoder85.setIndexBuffer(buffer184, 'uint16', 5_006, 584);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(4, buffer67);
+} catch {}
+let pipeline14 = await device0.createComputePipelineAsync({layout: pipelineLayout6, compute: {module: shaderModule2}});
+try {
+  await promise27;
+} catch {}
+try {
+renderPassEncoder89.executeBundles([renderBundle50, renderBundle44]);
+} catch {}
+let pipeline15 = await device0.createComputePipelineAsync({
+  label: '\u8df3\ubcd0\u{1fdc9}\ufefe\u14d6\u84d7\u0b11\u0625\uc04f',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule9},
+});
+let buffer204 = device0.createBuffer({size: 18313, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+try {
+renderPassEncoder59.setBindGroup(2, bindGroup160);
+} catch {}
+try {
+renderPassEncoder97.executeBundles([renderBundle8]);
+} catch {}
+try {
+renderPassEncoder93.setVertexBuffer(3, buffer53, 0, 1_945);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let texture314 = device0.createTexture({
+  label: '\u{1fdc1}\u1b98\u561b\ufb34\u3600\u04f7\u8393\u3092',
+  size: [16, 10, 229],
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+computePassEncoder17.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder109.setBindGroup(0, bindGroup138, new Uint32Array(2033), 337, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+await gc();
+let canvas7 = document.createElement('canvas');
+let buffer205 = device0.createBuffer({size: 12063, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView268 = texture10.createView({
+  dimension: 'cube',
+  aspect: 'all',
+  baseMipLevel: 0,
+  mipLevelCount: 1,
+  baseArrayLayer: 2,
+  arrayLayerCount: 6,
+});
+try {
+computePassEncoder14.setBindGroup(1, bindGroup92, new Uint32Array(1354), 205, 0);
+} catch {}
+try {
+renderPassEncoder93.setPipeline(pipeline0);
+} catch {}
+let videoFrame61 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'smpte240m', transfer: 'hlg'} });
+let buffer206 = device0.createBuffer({
+  label: '\ufc7b\u67ae\uf533\uea82\u06d4\u71fb\u0817\u{1f77b}\u0372\ud594',
+  size: 6677,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView269 = texture22.createView({});
+let sampler201 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 27.39,
+  lodMaxClamp: 53.83,
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder92.setBindGroup(2, bindGroup115, new Uint32Array(2261), 459, 0);
+} catch {}
+try {
+renderPassEncoder100.setBindGroup(2, bindGroup146);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(0, bindGroup81, new Uint32Array(3872), 42, 0);
+} catch {}
+try {
+renderPassEncoder19.setScissorRect(0, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder62.setIndexBuffer(buffer82, 'uint16', 388, 1_690);
+} catch {}
+try {
+renderPassEncoder66.setPipeline(pipeline8);
+} catch {}
+let textureView270 = texture2.createView({});
+try {
+if (!arrayBuffer28.detached) { new Uint8Array(arrayBuffer28).fill(0x55); };
+} catch {}
+let videoFrame62 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'jedecP22Phosphors', transfer: 'pq'} });
+let bindGroup168 = device0.createBindGroup({
+  layout: bindGroupLayout34,
+  entries: [
+    {binding: 259, resource: {buffer: buffer2, offset: 1024, size: 320}},
+    {binding: 128, resource: {buffer: buffer171, offset: 5120}},
+    {binding: 139, resource: {buffer: buffer94, offset: 256, size: 37}},
+    {binding: 169, resource: {buffer: buffer167, offset: 1792, size: 1324}},
+  ],
+});
+let sampler202 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 16.22,
+  lodMaxClamp: 24.01,
+});
+let externalTexture45 = device0.importExternalTexture({source: videoFrame1});
+try {
+renderPassEncoder44.setVertexBuffer(7, buffer9, 0, 412);
+} catch {}
+let gpuCanvasContext10 = canvas7.getContext('webgpu');
+try {
+globalThis.someLabel = externalTexture39.label;
+} catch {}
+let shaderModule18 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(296) var et10: texture_external;
+
+@group(0) @binding(460) var tex24: texture_2d_array<f32>;
+
+struct T0 {
+  f0: array<i32, 1>,
+}
+
+struct T1 {
+  @size(52) f0: array<T0, 1>,
+}
+
+struct FragmentOutput14 {
+  @location(4) @interpolate(linear, sample) f0: vec2f,
+  @location(0) f1: vec4f,
+}
+
+alias vec3b = vec3<bool>;
+
+var<workgroup> vw51: T1;
+
+var<workgroup> vw52: atomic<u32>;
+
+var<workgroup> vw53: mat2x2f;
+
+var<workgroup> vw54: vec2f;
+
+var<workgroup> vw55: atomic<i32>;
+
+var<private> vp12: f16 = f16(9067.3);
+
+var<private> vp13: mat2x4f = mat2x4f(0.00218, 0.2968, 0.02472, 0.04929, 0.03496, 0.1427, -0.5517, 0.01636);
+
+var<private> vp14: T1 = T1(array<T0, 1>());
+
+var<private> vp15 = modf(vec3h(40444.8, 4180.4, -28191.1));
+
+@fragment
+fn fragment17() -> FragmentOutput14 {
+  var out: FragmentOutput14;
+  var vf422: vec2u = textureDimensions(tex24, i32(unconst_i32(24)));
+  var vf423: vec2h = acosh(vec2h(unconst_f16(7926.0), unconst_f16(2561.1)));
+  vp12 = f16(countTrailingZeros(i32(unconst_i32(235))));
+  vp15.whole = vec3h(f16(firstLeadingBit(u32(unconst_u32(34)))));
+  vp15 = modf(ceil(vec3h(unconst_f16(6736.9), unconst_f16(9240.8), unconst_f16(9046.5))));
+  out.f0 = vec2f(textureDimensions(tex24, i32(unconst_i32(223))));
+  var vf424: vec3h = ceil(vec3h(unconst_f16(1189.3), unconst_f16(2423.0), unconst_f16(18944.5)));
+  vp13 += mat2x4f(vec4f(vp15.fract.rbrb), vec4f(vp15.fract.bbgg));
+  var vf425: vec2u = textureDimensions(tex24, i32(unconst_i32(103)));
+  var vf426: vec4f = log(vec4f(unconst_f32(0.03168), unconst_f32(0.03190), unconst_f32(0.01240), unconst_f32(0.1483)));
+  let ptr98: ptr<private, array<T0, 1>> = &vp14.f0;
+  out.f1 += unpack2x16snorm(u32(unconst_u32(213))).rgrg;
+  let ptr99: ptr<private, array<i32, 1>> = &(*ptr98)[0].f0;
+  let ptr100: ptr<private, f16> = &vp12;
+  let ptr101: ptr<private, i32> = &(*ptr98)[0].f0[0];
+  vf424 = vec3h(f16(countTrailingZeros(i32(unconst_i32(12)))));
+  let vf427: vec2f = faceForward(vec2f(unconst_f32(0.02364), unconst_f32(0.3673)), vec2f(unconst_f32(0.1518), unconst_f32(0.1543)), vec2f(unconst_f32(0.6722), unconst_f32(-0.1405)));
+  let ptr102: ptr<private, i32> = &vp14.f0[u32(unconst_u32(10))].f0[0];
+  vf424 += vec3h(f16((*ptr98)[0].f0[0]));
+  let ptr103: ptr<private, T0> = &(*ptr98)[u32(unconst_u32(52))];
+  vf424 = vec3h(f16(vp14.f0[u32(unconst_u32(11))].f0[0]));
+  vf426 = vp13[unconst_i32(0)];
+  return out;
+}
+
+@compute @workgroup_size(2, 1, 1)
+fn compute13() {
+  vp15 = modf(vec3h(f16(vw51.f0[0].f0[0])));
+  let ptr104: ptr<private, mat2x4f> = &vp13;
+  atomicCompareExchangeWeak(&vw55, unconst_i32(127), unconst_i32(710));
+  let ptr105: ptr<workgroup, i32> = &vw51.f0[u32(unconst_u32(2))].f0[0];
+  atomicOr(&vw52, u32(unconst_u32(104)));
+  vw51 = T1(array<T0, 1>(T0(array<i32, 1>(vw51.f0[0].f0[0]))));
+  vp13 = mat2x4f(unpack2x16snorm(u32(unconst_u32(144))).grgg, unpack2x16snorm(u32(unconst_u32(144))).rgrg);
+  let ptr106: ptr<workgroup, array<i32, 1>> = &(*&vw51).f0[u32(unconst_u32(205))].f0;
+  atomicExchange(&vw52, u32(unconst_u32(839)));
+  atomicCompareExchangeWeak(&vw52, unconst_u32(116), unconst_u32(96));
+  let ptr107: ptr<workgroup, array<T0, 1>> = &vw51.f0;
+  vw51 = T1(array<T0, 1>(T0(array<i32, 1>(bitcast<i32>(unpack2x16snorm(u32(unconst_u32(604))).g)))));
+  let ptr108 = &vp15;
+  let ptr109: ptr<workgroup, i32> = &vw51.f0[0].f0[u32(unconst_u32(184))];
+  let ptr110: ptr<private, array<i32, 1>> = &vp14.f0[0].f0;
+  let ptr111: ptr<workgroup, i32> = &(*ptr105);
+  let ptr112: ptr<workgroup, i32> = &(*&vw51).f0[u32(unconst_u32(187))].f0[0];
+  let ptr113: ptr<workgroup, array<i32, 1>> = &vw51.f0[0].f0;
+  let ptr114: ptr<private, i32> = &(*ptr110)[u32(unconst_u32(62))];
+  let ptr115: ptr<workgroup, T0> = &(*ptr107)[0];
+  vp14.f0[u32(unconst_u32(55))] = T0(array<i32, 1>((*ptr107)[u32(unconst_u32(15))].f0[0]));
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let texture315 = device0.createTexture({size: [4, 2, 1], format: 'r8uint', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC});
+let textureView271 = texture231.createView({dimension: '2d-array'});
+try {
+renderPassEncoder66.setBindGroup(0, bindGroup5, new Uint32Array(906), 48, 0);
+} catch {}
+try {
+renderPassEncoder19.beginOcclusionQuery(51);
+} catch {}
+try {
+renderPassEncoder19.endOcclusionQuery();
+} catch {}
+let textureView272 = texture2.createView({mipLevelCount: 1});
+try {
+computePassEncoder13.setBindGroup(2, bindGroup10, new Uint32Array(191), 17, 0);
+} catch {}
+try {
+renderPassEncoder66.draw(16, 153, 251_467_680, 397_810_843);
+} catch {}
+try {
+renderPassEncoder78.setIndexBuffer(buffer24, 'uint16', 368, 7_996);
+} catch {}
+try {
+renderPassEncoder58.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder66.draw(424, 93, 283_049_635, 389_292_369);
+} catch {}
+try {
+renderPassEncoder66.drawIndirect(buffer139, 1_368);
+} catch {}
+try {
+renderPassEncoder89.setVertexBuffer(5, buffer88);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder151.setBindGroup(0, bindGroup84);
+} catch {}
+try {
+computePassEncoder135.setBindGroup(1, bindGroup42, new Uint32Array(3151), 982, 0);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(3, bindGroup80);
+} catch {}
+try {
+renderPassEncoder66.drawIndirect(buffer22, 1_268);
+} catch {}
+try {
+renderPassEncoder93.setPipeline(pipeline8);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture158,
+  mipLevel: 0,
+  origin: {x: 5, y: 354, z: 0},
+  aspect: 'all',
+}, new Uint8Array(516).fill(123), /* required buffer size: 516 */
+{offset: 516, bytesPerRow: 473}, {width: 54, height: 292, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise28;
+} catch {}
+let buffer207 = device0.createBuffer({
+  size: 9492,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup160);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(2, bindGroup131, new Uint32Array(24), 6, 0);
+} catch {}
+try {
+renderPassEncoder66.draw(71, 23, 914_347_426, 595_726_688);
+} catch {}
+try {
+computePassEncoder138.setBindGroup(2, bindGroup36);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle19]);
+} catch {}
+try {
+renderPassEncoder66.draw(827, 5, 97_089_564, 2_954_063_327);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer71, 'uint16', 286, 3_911);
+} catch {}
+try {
+renderPassEncoder64.setVertexBuffer(3, buffer196, 520, 532);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer127, 8, new DataView(new ArrayBuffer(6182)), 540, 572);
+} catch {}
+let bindGroup169 = device0.createBindGroup({
+  label: '\u7c26\u{1fc28}\uc6d9\ufde3\ucab5\u01dd\u1da3\u07c1\ub3f2\u0cda',
+  layout: bindGroupLayout27,
+  entries: [{binding: 27, resource: {buffer: buffer206, offset: 1536, size: 364}}],
+});
+try {
+computePassEncoder54.setBindGroup(2, bindGroup82);
+} catch {}
+try {
+renderPassEncoder89.setBindGroup(3, bindGroup166, new Uint32Array(4154), 985, 0);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline5);
+} catch {}
+let canvas8 = document.createElement('canvas');
+let imageData38 = new ImageData(36, 8);
+let videoFrame63 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'jedecP22Phosphors', transfer: 'smpteSt4281'} });
+let texture316 = device0.createTexture({
+  label: '\ueaa0\u02a7\u1640',
+  size: {width: 8, height: 5, depthOrArrayLayers: 781},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder137.setBindGroup(1, bindGroup73);
+} catch {}
+try {
+renderPassEncoder90.setBindGroup(3, bindGroup21);
+} catch {}
+try {
+renderPassEncoder73.beginOcclusionQuery(72);
+} catch {}
+try {
+renderPassEncoder59.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(2, buffer175, 0, 731);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let bindGroup170 = device0.createBindGroup({
+  layout: bindGroupLayout13,
+  entries: [
+    {binding: 314, resource: textureView240},
+    {binding: 286, resource: externalTexture41},
+    {binding: 153, resource: textureView84},
+    {binding: 21, resource: externalTexture12},
+  ],
+});
+let buffer208 = device0.createBuffer({
+  size: 8073,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let querySet39 = device0.createQuerySet({type: 'occlusion', count: 1407});
+try {
+computePassEncoder39.setBindGroup(3, bindGroup107, new Uint32Array(973), 72, 0);
+} catch {}
+try {
+renderPassEncoder66.draw(128, 134, 667_662_838, 471_964_816);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline4);
+} catch {}
+let bindGroupLayout40 = device0.createBindGroupLayout({
+  label: '\u0777\u{1f7af}\u0d5e\u0c8a',
+  entries: [
+    {
+      binding: 217,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16sint', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 55,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 197,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 32,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 62, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {
+      binding: 70,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {binding: 107, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let buffer209 = device0.createBuffer({size: 7999, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC});
+let querySet40 = device0.createQuerySet({type: 'occlusion', count: 2136});
+let textureView273 = texture180.createView({label: '\uee76\u6129\u0eee\u{1f988}\u2ae5\u{1fffd}\u097d\u085c\u9ea2\uc019\u{1fe41}'});
+try {
+computePassEncoder126.setBindGroup(0, bindGroup0, new Uint32Array(59), 6, 0);
+} catch {}
+try {
+renderPassEncoder44.executeBundles([renderBundle29, renderBundle19, renderBundle12]);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(6, buffer200, 0, 130);
+} catch {}
+let arrayBuffer32 = buffer8.getMappedRange(4608, 12);
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 10, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame49,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture200,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame5.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame22.close();
+videoFrame23.close();
+videoFrame24.close();
+videoFrame25.close();
+videoFrame26.close();
+videoFrame27.close();
+videoFrame28.close();
+videoFrame29.close();
+videoFrame30.close();
+videoFrame31.close();
+videoFrame32.close();
+videoFrame33.close();
+videoFrame34.close();
+videoFrame36.close();
+videoFrame37.close();
+videoFrame38.close();
+videoFrame40.close();
+videoFrame41.close();
+videoFrame42.close();
+videoFrame44.close();
+videoFrame45.close();
+videoFrame46.close();
+videoFrame47.close();
+videoFrame48.close();
+videoFrame49.close();
+videoFrame50.close();
+videoFrame51.close();
+videoFrame54.close();
+videoFrame55.close();
+videoFrame56.close();
+videoFrame57.close();
+videoFrame58.close();
+videoFrame59.close();
+videoFrame60.close();
+videoFrame62.close();
+videoFrame63.close();
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/BindGroup.h
+++ b/Source/WebGPU/WebGPU/BindGroup.h
@@ -101,6 +101,7 @@ public:
     uint32_t dynamicOffset(uint32_t bindingIndex, const Vector<uint32_t>*) const;
     void rebindSamplersIfNeeded() const;
     bool updateExternalTextures(const ExternalTexture&);
+    bool makeSubmitInvalid(ShaderStage) const;
 
 private:
     BindGroup(id<MTLBuffer> vertexArgumentBuffer, id<MTLBuffer> fragmentArgumentBuffer, id<MTLBuffer> computeArgumentBuffer, Vector<BindableResources>&&, const BindGroupLayout&, DynamicBuffersContainer&&, SamplersContainer&&, ShaderStageArray<ExternalTextureIndices>&&, Device&);

--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -994,7 +994,13 @@ Ref<BindGroup> Device::createBindGroup(const WGPUBindGroupDescriptor& descriptor
                 }
                 Ref apiBuffer = WebGPU::protectedFromAPI(entry.buffer);
                 id<MTLBuffer> buffer = apiBuffer->buffer();
-                auto entryOffset = apiBuffer->isDestroyed() ? 0 : entry.offset;
+                bool isDestroyed = apiBuffer->isDestroyed();
+                if (isDestroyed) {
+                    argumentEncoder[stage] = nil;
+                    argumentBuffer[stage] = nil;
+                }
+
+                auto entryOffset = isDestroyed ? 0 : entry.offset;
                 auto bufferLengthMinusOffset = buffer.length > entryOffset ? (buffer.length - entryOffset) : 0;
                 auto entrySize = entry.size == WGPU_WHOLE_MAP_SIZE ? bufferLengthMinusOffset : entry.size;
                 if (layoutBinding->hasDynamicOffset && !appendedBufferToDynamicBuffers) {
@@ -1003,7 +1009,7 @@ Ref<BindGroup> Device::createBindGroup(const WGPUBindGroupDescriptor& descriptor
                 }
 
                 if (!apiBuffer->isValid() || &apiBuffer->device() != this) {
-                    if (!apiBuffer->isDestroyed())
+                    if (!isDestroyed)
                         VALIDATION_ERROR(@"Buffer is invalid or created from a different device");
                     return BindGroup::createInvalid(*this);
                 }
@@ -1048,7 +1054,8 @@ Ref<BindGroup> Device::createBindGroup(const WGPUBindGroupDescriptor& descriptor
                     [argumentEncoder[stage] setBuffer:buffer offset:entryOffset atIndex:index];
                     if (bufferSizeArgumentBufferIndex) {
                         argumentIndices[stage].remove(*bufferSizeArgumentBufferIndex);
-                        *(uint32_t*)[argumentEncoder[stage] constantDataAtIndex:*bufferSizeArgumentBufferIndex] = std::min<uint32_t>(entrySize, buffer.length);
+                        if (auto* lengthAddress = (uint32_t*)[argumentEncoder[stage] constantDataAtIndex:*bufferSizeArgumentBufferIndex])
+                            *lengthAddress = std::min<uint32_t>(entrySize, buffer.length);
                     }
                 }
                 if (buffer) {
@@ -1132,6 +1139,9 @@ Ref<BindGroup> Device::createBindGroup(const WGPUBindGroupDescriptor& descriptor
                         VALIDATION_ERROR(@"Can not create bind group with filterable 32bpp floating point texture as float32-filterable feature is not enabled");
                         return BindGroup::createInvalid(*this);
                     }
+                } else {
+                    argumentEncoder[stage] = nil;
+                    argumentBuffer[stage] = nil;
                 }
 
                 if (stage != ShaderStage::Undefined) {
@@ -1175,12 +1185,12 @@ Ref<BindGroup> Device::createBindGroup(const WGPUBindGroupDescriptor& descriptor
                     [argumentEncoder[stage] setTexture:texture1 atIndex:index++];
 
                     argumentIndices[stage].remove(index);
-                    auto* uvRemapAddress = static_cast<simd::float3x2*>([argumentEncoder[stage] constantDataAtIndex:index++]);
-                    *uvRemapAddress = textureData.uvRemappingMatrix;
+                    if (auto* uvRemapAddress = static_cast<simd::float3x2*>([argumentEncoder[stage] constantDataAtIndex:index++]))
+                        *uvRemapAddress = textureData.uvRemappingMatrix;
 
                     argumentIndices[stage].remove(index);
-                    auto* cscMatrixAddress = static_cast<simd::float4x3*>([argumentEncoder[stage] constantDataAtIndex:index++]);
-                    *cscMatrixAddress = textureData.colorSpaceConversionMatrix;
+                    if (auto* cscMatrixAddress = static_cast<simd::float4x3*>([argumentEncoder[stage] constantDataAtIndex:index++]))
+                        *cscMatrixAddress = textureData.colorSpaceConversionMatrix;
                 }
             }
         }
@@ -1389,6 +1399,25 @@ bool BindGroup::updateExternalTextures(const ExternalTexture& externalTexture)
 
         auto* cscMatrixAddress = static_cast<simd::float4x3*>([argumentEncoder constantDataAtIndex:index++]);
         *cscMatrixAddress = textureData.colorSpaceConversionMatrix;
+    }
+
+    return true;
+}
+
+bool BindGroup::makeSubmitInvalid(ShaderStage stage) const
+{
+    if (!m_bindGroupLayout)
+        return true;
+
+    switch (stage) {
+    case ShaderStage::Vertex:
+        return m_bindGroupLayout->encodedLength(ShaderStage::Vertex) != m_vertexArgumentBuffer.length;
+    case ShaderStage::Fragment:
+        return m_bindGroupLayout->encodedLength(ShaderStage::Fragment) != m_fragmentArgumentBuffer.length;
+    case ShaderStage::Compute:
+        return m_bindGroupLayout->encodedLength(ShaderStage::Compute) != m_computeArgumentBuffer.length;
+    case ShaderStage::Undefined:
+        return true;
     }
 
     return true;

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.mm
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.mm
@@ -184,6 +184,11 @@ void ComputePassEncoder::executePreDispatchCommands(const Buffer* indirectBuffer
             return;
         }
         auto group = kvp.value;
+        if (group->makeSubmitInvalid(ShaderStage::Compute)) {
+            protectedParentEncoder()->makeSubmitInvalid();
+            return;
+        }
+
         group->rebindSamplersIfNeeded();
         const Vector<uint32_t>* dynamicOffsets = nullptr;
         if (auto it = m_bindGroupDynamicOffsets.find(bindGroupIndex); it != m_bindGroupDynamicOffsets.end())

--- a/Source/WebGPU/WebGPU/RenderBundle.h
+++ b/Source/WebGPU/WebGPU/RenderBundle.h
@@ -63,9 +63,9 @@ class RenderBundle : public WGPURenderBundleImpl, public RefCounted<RenderBundle
 public:
     using MinVertexCountsContainer = HashMap<uint64_t, IndexBufferAndIndexData, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>>;
     using ResourcesContainer = NSMapTable<id<MTLResource>, ResourceUsageAndRenderStage*>;
-    static Ref<RenderBundle> create(NSArray<RenderBundleICBWithResources*> *resources, RefPtr<WebGPU::RenderBundleEncoder> encoder, const WGPURenderBundleEncoderDescriptor& descriptor, uint64_t commandCount, Device& device)
+    static Ref<RenderBundle> create(NSArray<RenderBundleICBWithResources*> *resources, RefPtr<WebGPU::RenderBundleEncoder> encoder, const WGPURenderBundleEncoderDescriptor& descriptor, uint64_t commandCount, bool makeSubmitInvalid, Device& device)
     {
-        return adoptRef(*new RenderBundle(resources, encoder, descriptor, commandCount, device));
+        return adoptRef(*new RenderBundle(resources, encoder, descriptor, commandCount, makeSubmitInvalid, device));
     }
     static Ref<RenderBundle> createInvalid(Device& device, NSString* errorString)
     {
@@ -88,9 +88,10 @@ public:
     uint64_t drawCount() const;
     NSString* lastError() const;
     bool requiresCommandReplay() const;
+    bool makeSubmitInvalid() const;
 
 private:
-    RenderBundle(NSArray<RenderBundleICBWithResources*> *, RefPtr<RenderBundleEncoder>, const WGPURenderBundleEncoderDescriptor&, uint64_t, Device&);
+    RenderBundle(NSArray<RenderBundleICBWithResources*> *, RefPtr<RenderBundleEncoder>, const WGPURenderBundleEncoderDescriptor&, uint64_t, bool makeSubmitInvalid, Device&);
     RenderBundle(Device&, NSString*);
 
     const Ref<Device> m_device;
@@ -103,6 +104,7 @@ private:
     uint64_t m_commandCount { 0 };
     float m_minDepth { 0.f };
     float m_maxDepth { 1.f };
+    bool m_makeSubmitInvalid { false };
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/RenderBundle.mm
+++ b/Source/WebGPU/WebGPU/RenderBundle.mm
@@ -49,13 +49,14 @@ namespace WebGPU {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderBundle);
 
-RenderBundle::RenderBundle(NSArray<RenderBundleICBWithResources*> *resources, RefPtr<RenderBundleEncoder> encoder, const WGPURenderBundleEncoderDescriptor& descriptor, uint64_t commandCount, Device& device)
+RenderBundle::RenderBundle(NSArray<RenderBundleICBWithResources*> *resources, RefPtr<RenderBundleEncoder> encoder, const WGPURenderBundleEncoderDescriptor& descriptor, uint64_t commandCount, bool makeSubmitInvalid, Device& device)
     : m_device(device)
     , m_renderBundleEncoder(encoder)
     , m_renderBundlesResources(resources)
     , m_descriptor(descriptor)
     , m_descriptorColorFormats(descriptor.colorFormats ? Vector<WGPUTextureFormat>(std::span { descriptor.colorFormats, descriptor.colorFormatCount }) : Vector<WGPUTextureFormat>())
     , m_commandCount(commandCount)
+    , m_makeSubmitInvalid(makeSubmitInvalid)
 {
     if (m_descriptorColorFormats.size())
         m_descriptor.colorFormats = &m_descriptorColorFormats[0];
@@ -168,6 +169,11 @@ bool RenderBundle::validatePipeline(const RenderPipeline*)
 NSString* RenderBundle::lastError() const
 {
     return m_lastErrorString;
+}
+
+bool RenderBundle::makeSubmitInvalid() const
+{
+    return m_makeSubmitInvalid;
 }
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.h
@@ -197,6 +197,7 @@ private:
     bool m_requiresCommandReplay { false };
     bool m_finished { false };
     uint32_t m_sampleMask { defaultSampleMask };
+    bool m_makeSubmitInvalid { false };
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -560,6 +560,10 @@ bool RenderPassEncoder::executePreDrawCommands(uint32_t firstInstance, uint32_t 
             makeInvalid(error);
             return false;
         }
+        if (group->makeSubmitInvalid(ShaderStage::Vertex) || group->makeSubmitInvalid(ShaderStage::Fragment)) {
+            protectedParentEncoder()->makeSubmitInvalid();
+            return false;
+        }
         [commandEncoder setVertexBuffer:group->vertexArgumentBuffer() offset:0 atIndex:m_device->vertexBufferIndexForBindGroup(groupIndex)];
         [commandEncoder setFragmentBuffer:group->fragmentArgumentBuffer() offset:0 atIndex:groupIndex];
     }
@@ -1035,6 +1039,11 @@ void RenderPassEncoder::executeBundles(Vector<Ref<RenderBundle>>&& bundles)
     for (auto bundle : bundles) {
         if (!isValidToUseWith(bundle, *this)) {
             makeInvalid([NSString stringWithFormat:@"executeBundles: render bundle is not valid, reason = %@", bundle->lastError()]);
+            return;
+        }
+
+        if (bundle->makeSubmitInvalid()) {
+            protectedParentEncoder()->makeSubmitInvalid();
             return;
         }
 


### PR DESCRIPTION
#### 36df2c80190b88669bc1c38a663cb5368bb040cd
<pre>
[WebGPU] BindGroups with destroyed resources should result in dropping the command buffer submission
<a href="https://bugs.webkit.org/show_bug.cgi?id=283943">https://bugs.webkit.org/show_bug.cgi?id=283943</a>
<a href="https://rdar.apple.com/140802614">rdar://140802614</a>

Reviewed by Dan Glastonbury.

Bind groups are supposed to successfully be created, without validation error and resulting
in a valid bind group, even when the resources contained within the bind group are destroyed.

However, submitting any work to the driver via GPUQueue.submit(...) should still result in
a validation error at that time when the bind group contains a destroyed resource.

* LayoutTests/fast/webgpu/nocrash/fuzz-283943-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-283943.html: Added.
Add regression tests.

* Source/WebGPU/WebGPU/BindGroup.h:
* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::Device::createBindGroup):
(WebGPU::BindGroup::makeSubmitInvalid const):
* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::ComputePassEncoder::executePreDispatchCommands):
* Source/WebGPU/WebGPU/RenderBundle.h:
(WebGPU::RenderBundle::create):
* Source/WebGPU/WebGPU/RenderBundle.mm:
(WebGPU::RenderBundle::RenderBundle):
(WebGPU::m_makeSubmitInvalid):
(WebGPU::RenderBundle::makeSubmitInvalid const):
(WebGPU::m_commandCount): Deleted.
* Source/WebGPU/WebGPU/RenderBundleEncoder.h:
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::executePreDrawCommands):
(WebGPU::RenderBundleEncoder::finish):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::executePreDrawCommands):
(WebGPU::RenderPassEncoder::executeBundles):

Canonical link: <a href="https://commits.webkit.org/287331@main">https://commits.webkit.org/287331@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1304cea2ebb424f1c62cdd62872dee2dc0effb4c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58232 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32575 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83826 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30380 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67324 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6500 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61960 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19870 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82270 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52019 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72170 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42265 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49367 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26312 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28760 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70480 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26739 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85221 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6504 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4506 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70202 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6667 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68042 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69451 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17316 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13508 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12323 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6459 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6391 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9854 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8183 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->