### PR TITLE
Web Inspector: Crash when opening the web inspector for the first time

### DIFF
--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp
@@ -97,7 +97,7 @@ void WebInspectorUI::updateConnection()
     m_backendConnection = IPC::Connection::createServerConnection(connectionIdentifiers->server);
     m_backendConnection->open(*this);
 
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebInspectorUIProxy::SetFrontendConnection(WTFMove(connectionIdentifiers->client)), *m_inspectedPageIdentifier);
+    sendToParentProcess(Messages::WebInspectorUIProxy::SetFrontendConnection(WTFMove(connectionIdentifiers->client)));
 }
 
 void WebInspectorUI::windowObjectCleared()
@@ -119,14 +119,14 @@ void WebInspectorUI::frontendLoaded()
     setDockSide(m_dockSide);
     setIsVisible(m_isVisible);
 
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebInspectorUIProxy::FrontendLoaded(), *m_inspectedPageIdentifier);
+    sendToParentProcess(Messages::WebInspectorUIProxy::FrontendLoaded());
 
     bringToFront();
 }
 
 void WebInspectorUI::startWindowDrag()
 {
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebInspectorUIProxy::StartWindowDrag(), *m_inspectedPageIdentifier);
+    sendToParentProcess(Messages::WebInspectorUIProxy::StartWindowDrag());
 }
 
 void WebInspectorUI::moveWindowBy(float x, float y)
@@ -138,12 +138,12 @@ void WebInspectorUI::moveWindowBy(float x, float y)
 
 void WebInspectorUI::bringToFront()
 {
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebInspectorUIProxy::BringToFront(), *m_inspectedPageIdentifier);
+    sendToParentProcess(Messages::WebInspectorUIProxy::BringToFront());
 }
 
 void WebInspectorUI::closeWindow()
 {
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebInspectorUIProxy::DidClose(), *m_inspectedPageIdentifier);
+    sendToParentProcess(Messages::WebInspectorUIProxy::DidClose());
 
     if (m_backendConnection) {
         m_backendConnection->invalidate();
@@ -166,22 +166,22 @@ void WebInspectorUI::closeWindow()
 
 void WebInspectorUI::reopen()
 {
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebInspectorUIProxy::Reopen(), *m_inspectedPageIdentifier);
+    sendToParentProcess(Messages::WebInspectorUIProxy::Reopen());
 }
 
 void WebInspectorUI::resetState()
 {
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebInspectorUIProxy::ResetState(), *m_inspectedPageIdentifier);
+    sendToParentProcess(Messages::WebInspectorUIProxy::ResetState());
 }
 
 void WebInspectorUI::setForcedAppearance(WebCore::InspectorFrontendClient::Appearance appearance)
 {
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebInspectorUIProxy::SetForcedAppearance(appearance), *m_inspectedPageIdentifier);
+    sendToParentProcess(Messages::WebInspectorUIProxy::SetForcedAppearance(appearance));
 }
 
 void WebInspectorUI::effectiveAppearanceDidChange(WebCore::InspectorFrontendClient::Appearance appearance)
 {
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebInspectorUIProxy::EffectiveAppearanceDidChange(appearance), *m_inspectedPageIdentifier);
+    sendToParentProcess(Messages::WebInspectorUIProxy::EffectiveAppearanceDidChange(appearance));
 }
 
 WebCore::UserInterfaceLayoutDirection WebInspectorUI::userInterfaceLayoutDirection() const
@@ -205,19 +205,18 @@ bool WebInspectorUI::supportsDockSide(DockSide dockSide)
 
 void WebInspectorUI::requestSetDockSide(DockSide dockSide)
 {
-    Ref webProcess = WebProcess::singleton();
     switch (dockSide) {
     case DockSide::Undocked:
-        webProcess->protectedParentProcessConnection()->send(Messages::WebInspectorUIProxy::Detach(), *m_inspectedPageIdentifier);
+        sendToParentProcess(Messages::WebInspectorUIProxy::Detach());
         break;
     case DockSide::Right:
-        webProcess->protectedParentProcessConnection()->send(Messages::WebInspectorUIProxy::AttachRight(), *m_inspectedPageIdentifier);
+        sendToParentProcess(Messages::WebInspectorUIProxy::AttachRight());
         break;
     case DockSide::Left:
-        webProcess->protectedParentProcessConnection()->send(Messages::WebInspectorUIProxy::AttachLeft(), *m_inspectedPageIdentifier);
+        sendToParentProcess(Messages::WebInspectorUIProxy::AttachLeft());
         break;
     case DockSide::Bottom:
-        webProcess->protectedParentProcessConnection()->send(Messages::WebInspectorUIProxy::AttachBottom(), *m_inspectedPageIdentifier);
+        sendToParentProcess(Messages::WebInspectorUIProxy::AttachBottom());
         break;
     }
 }
@@ -270,57 +269,57 @@ void WebInspectorUI::updateFindString(const String& findString)
 
 void WebInspectorUI::changeAttachedWindowHeight(unsigned height)
 {
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebInspectorUIProxy::SetAttachedWindowHeight(height), *m_inspectedPageIdentifier);
+    sendToParentProcess(Messages::WebInspectorUIProxy::SetAttachedWindowHeight(height));
 }
 
 void WebInspectorUI::changeAttachedWindowWidth(unsigned width)
 {
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebInspectorUIProxy::SetAttachedWindowWidth(width), *m_inspectedPageIdentifier);
+    sendToParentProcess(Messages::WebInspectorUIProxy::SetAttachedWindowWidth(width));
 }
 
 void WebInspectorUI::changeSheetRect(const FloatRect& rect)
 {
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebInspectorUIProxy::SetSheetRect(rect), *m_inspectedPageIdentifier);
+    sendToParentProcess(Messages::WebInspectorUIProxy::SetSheetRect(rect));
 }
 
 void WebInspectorUI::openURLExternally(const String& url)
 {
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebInspectorUIProxy::OpenURLExternally(url), *m_inspectedPageIdentifier);
+    sendToParentProcess(Messages::WebInspectorUIProxy::OpenURLExternally(url));
 }
 
 void WebInspectorUI::revealFileExternally(const String& path)
 {
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebInspectorUIProxy::RevealFileExternally(path), *m_inspectedPageIdentifier);
+    sendToParentProcess(Messages::WebInspectorUIProxy::RevealFileExternally(path));
 }
 
 void WebInspectorUI::save(Vector<InspectorFrontendClient::SaveData>&& saveDatas, bool forceSaveAs)
 {
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebInspectorUIProxy::Save(WTFMove(saveDatas), forceSaveAs), *m_inspectedPageIdentifier);
+    sendToParentProcess(Messages::WebInspectorUIProxy::Save(WTFMove(saveDatas), forceSaveAs));
 }
 
 void WebInspectorUI::load(const WTF::String& path, CompletionHandler<void(const String&)>&& completionHandler)
 {
-    WebProcess::singleton().parentProcessConnection()->sendWithAsyncReply(Messages::WebInspectorUIProxy::Load(path), WTFMove(completionHandler), *m_inspectedPageIdentifier);
+    sendToParentProcessWithAsyncReply(Messages::WebInspectorUIProxy::Load(path), WTFMove(completionHandler));
 }
 
 void WebInspectorUI::pickColorFromScreen(CompletionHandler<void(const std::optional<WebCore::Color>&)>&& completionHandler)
 {
-    WebProcess::singleton().parentProcessConnection()->sendWithAsyncReply(Messages::WebInspectorUIProxy::PickColorFromScreen(), WTFMove(completionHandler), *m_inspectedPageIdentifier);
+    sendToParentProcessWithAsyncReply(Messages::WebInspectorUIProxy::PickColorFromScreen(), WTFMove(completionHandler));
 }
 
 void WebInspectorUI::inspectedURLChanged(const String& urlString)
 {
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebInspectorUIProxy::InspectedURLChanged(urlString), *m_inspectedPageIdentifier);
+    sendToParentProcess(Messages::WebInspectorUIProxy::InspectedURLChanged(urlString));
 }
 
 void WebInspectorUI::showCertificate(const CertificateInfo& certificateInfo)
 {
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebInspectorUIProxy::ShowCertificate(certificateInfo), *m_inspectedPageIdentifier);
+    sendToParentProcess(Messages::WebInspectorUIProxy::ShowCertificate(certificateInfo));
 }
 
 void WebInspectorUI::setInspectorPageDeveloperExtrasEnabled(bool enabled)
 {
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebInspectorUIProxy::SetInspectorPageDeveloperExtrasEnabled(enabled), *m_inspectedPageIdentifier);
+    sendToParentProcess(Messages::WebInspectorUIProxy::SetInspectorPageDeveloperExtrasEnabled(enabled));
 }
 
 #if ENABLE(INSPECTOR_TELEMETRY)
@@ -432,7 +431,7 @@ void WebInspectorUI::pageUnpaused()
 
 void WebInspectorUI::sendMessageToBackend(const String& message)
 {
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebInspectorUIProxy::SendMessageToBackend(message), *m_inspectedPageIdentifier);
+    sendToParentProcess(Messages::WebInspectorUIProxy::SendMessageToBackend(message));
 }
 
 String WebInspectorUI::targetPlatformName() const

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUI.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUI.h
@@ -28,6 +28,7 @@
 #include "Connection.h"
 #include "DebuggableInfoData.h"
 #include "WebPageProxyIdentifier.h"
+#include "WebProcess.h"
 #include <WebCore/Color.h>
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/InspectorDebuggableType.h>
@@ -184,6 +185,18 @@ private:
     explicit WebInspectorUI(WebPage&);
 
     void didEstablishConnection();
+
+    template<typename T>
+    IPC::Error sendToParentProcess(T&& message)
+    {
+        return WebProcess::singleton().parentProcessConnection()->send(std::forward<T>(message), m_inspectedPageIdentifier ? m_inspectedPageIdentifier->toUInt64() : 0);
+    }
+
+    template<typename T, typename C>
+    std::optional<IPC::AsyncReplyID> sendToParentProcessWithAsyncReply(T&& message, C&& completionHandler)
+    {
+        return WebProcess::singleton().parentProcessConnection()->sendWithAsyncReply(std::forward<T>(message), std::forward<C>(completionHandler), m_inspectedPageIdentifier ? m_inspectedPageIdentifier->toUInt64() : 0);
+    }
 
     WeakRef<WebPage> m_page;
     Ref<WebCore::InspectorFrontendAPIDispatcher> m_frontendAPIDispatcher;


### PR DESCRIPTION
#### d60bec76831e181ddffbf50cbc80a709d821ec37
<pre>
Web Inspector: Crash when opening the web inspector for the first time
<a href="https://bugs.webkit.org/show_bug.cgi?id=283874">https://bugs.webkit.org/show_bug.cgi?id=283874</a>
<a href="https://rdar.apple.com/140796551">rdar://140796551</a>

Reviewed by Devin Rousso.

In 284749@main, I made WebInspectorUI::m_inspectedPageIdentifier a std::optional,
as part of making ObjectIdentifier non-nullable. Whenever m_inspectedPageIdentifier
was using to send IPC, I started dereferencing m_inspectedPageIdentifier, expecting
the identifier to always be valid when sending IPC. However, this assumption turned
out to be incorrect and it would cause us to dereference std::nullopt when opening
WebInspector on an empty tab (no page loaded).

To restore the pre-284749@main behavior, I now null-check m_inspectedPageIdentifier
and use 0 as identifier for sending the IPC if m_inspectedPageIdentifier is std::nullopt.
This behaves exactly like prior to 284749@main. I have verified locally that it makes
the crash go away and Web Inspector correctly opens up on the empty page.

* Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp:
(WebKit::WebInspectorUI::updateConnection):
(WebKit::WebInspectorUI::frontendLoaded):
(WebKit::WebInspectorUI::startWindowDrag):
(WebKit::WebInspectorUI::bringToFront):
(WebKit::WebInspectorUI::closeWindow):
(WebKit::WebInspectorUI::reopen):
(WebKit::WebInspectorUI::resetState):
(WebKit::WebInspectorUI::setForcedAppearance):
(WebKit::WebInspectorUI::effectiveAppearanceDidChange):
(WebKit::WebInspectorUI::requestSetDockSide):
(WebKit::WebInspectorUI::changeAttachedWindowHeight):
(WebKit::WebInspectorUI::changeAttachedWindowWidth):
(WebKit::WebInspectorUI::changeSheetRect):
(WebKit::WebInspectorUI::openURLExternally):
(WebKit::WebInspectorUI::revealFileExternally):
(WebKit::WebInspectorUI::save):
(WebKit::WebInspectorUI::load):
(WebKit::WebInspectorUI::pickColorFromScreen):
(WebKit::WebInspectorUI::inspectedURLChanged):
(WebKit::WebInspectorUI::showCertificate):
(WebKit::WebInspectorUI::setInspectorPageDeveloperExtrasEnabled):
(WebKit::WebInspectorUI::sendMessageToBackend):
* Source/WebKit/WebProcess/Inspector/WebInspectorUI.h:

Canonical link: <a href="https://commits.webkit.org/287282@main">https://commits.webkit.org/287282@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81e97983d6a11ba82b6b8f4d097d3ada8798c107

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79051 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58087 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32428 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83691 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30266 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67196 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6357 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61874 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19791 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82118 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51914 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72056 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42177 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49265 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28630 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70380 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26572 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85077 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6376 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4406 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70112 "Found 5 new test failures: transitions/interrupted-transition-hardware.html webanimations/accelerated-animation-addition-lower-in-effect-stack.html webanimations/accelerated-animation-after-forward-filling-animation.html webanimations/accelerated-animation-renderer-change.html webanimations/accelerated-translate-animation-with-transform.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6540 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67928 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69361 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17281 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13407 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12186 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6327 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6288 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9739 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8080 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->