### PR TITLE
Add primitive routines to perform Audio Sample format conversion.

### DIFF
--- a/Source/WebCore/platform/AudioSampleFormat.h
+++ b/Source/WebCore/platform/AudioSampleFormat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2023 Igalia S.L
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,6 +26,9 @@
 
 #pragma once
 
+#include <algorithm>
+#include <limits>
+
 namespace WebCore {
 
 enum class AudioSampleFormat {
@@ -39,4 +42,123 @@ enum class AudioSampleFormat {
     F32Planar,
 };
 
+namespace detail {
+
+// Utility methods to convert one data type to another.
+template <typename T>
+constexpr float maxAsFloat()
+{
+    return static_cast<float>(std::numeric_limits<T>::max());
 }
+
+template <typename T>
+constexpr float maxPlus1AsFloat()
+{
+    return -static_cast<float>(std::numeric_limits<T>::lowest());
+}
+
+template <typename T>
+constexpr float lowestAsFloat()
+{
+    return static_cast<float>(std::numeric_limits<T>::lowest());
+}
+
+// The bias value for an audio sample type is the value that often corresponds to the middle of the range
+// (but for ints, this range is not symmetrical). An audio buffer comprised only of values equal to the bias value is silent.
+// Operation clips the values to be between [-1, 1] inclusive.
+// The operation is done in such a way that the value of +1 can be achieved from an int. e.g the lowest representable int will be converted to -1, and the maximum to 1.
+template <typename T, typename TExtreme = T>
+inline float divideWithBiasAndClamp(T value, auto bias)
+{
+    return std::clamp((static_cast<float>(value) - bias) / ((value < bias) ? maxPlus1AsFloat<TExtreme>() : maxAsFloat<TExtreme>()), -1.0f, 1.0f);
+}
+
+template <typename T>
+inline T floatToAudioSample(float value)
+{
+    if constexpr (std::is_same_v<float, T>)
+        return value;
+    else if constexpr (std::is_same_v<T, uint8_t>)
+        return static_cast<T>(std::clamp((value + 1.0f) * 128.0f, lowestAsFloat<T>(), maxAsFloat<T>()));
+    else if constexpr (std::is_same_v<T, int16_t>)
+        return static_cast<T>(std::clamp(value * maxPlus1AsFloat<T>(), lowestAsFloat<T>(), maxAsFloat<T>()));
+    else if constexpr (std::is_same_v<T, int32_t>) {
+        // We can't use divideWithBiasAndClamp here as a float32 only have 24 bits mantissa and rounding conversion causes error.
+        // So we need to handle this case slightly differently than the others.
+        if (value >= 0.0f) {
+            if (value >= 1.0f)
+                return std::numeric_limits<T>::max();
+            // A 32-bits float can't represent int32_max (causing compilation error), so extend to a double
+            constexpr double max = static_cast<double>(std::numeric_limits<T>::max());
+            return static_cast<T>(value * max);
+        }
+        if (value <= -1.0f)
+            return std::numeric_limits<T>::lowest();
+        // A float32 would do here, but as in the positive case we upconvert to a double first, to maintain consistency, upconvert to a double first too.
+        constexpr double magnitudeNeg = -1.0f * std::numeric_limits<T>::lowest();
+        return static_cast<T>(value * magnitudeNeg);
+    }
+}
+
+template <typename T>
+inline T uint8ToAudioSample(uint8_t value)
+{
+    // uint8_t audio has a range of [0, 255] with a bias value of 128
+    // https://w3c.github.io/webcodecs/#bias-value
+    if constexpr (std::is_same_v<T, uint8_t>)
+        return value;
+    else if constexpr (std::is_same_v<T, int16_t>)
+        return static_cast<int16_t>((value << 8) - (1 << 15));
+    else if constexpr (std::is_same_v<T, int32_t>)
+        return static_cast<int32_t>((value << 24) - (1 << 31));
+    else if constexpr (std::is_same_v<T, float>)
+        return divideWithBiasAndClamp<uint8_t, int8_t>(value, 128);
+}
+
+template <typename T>
+inline T int16ToAudioSample(int16_t value)
+{
+    if constexpr (std::is_same_v<T, uint8_t>)
+        return static_cast<uint8_t>((value >> 8) + 128);
+    else if constexpr (std::is_same_v<T, int16_t>)
+        return value;
+    else if constexpr (std::is_same_v<T, int32_t>)
+        return value << 16;
+    else if constexpr (std::is_same_v<T, float>)
+        return divideWithBiasAndClamp(value, 0);
+}
+
+template <typename T>
+inline T int32ToAudioSample(int32_t value)
+{
+    if constexpr (std::is_same_v<T, uint8_t>)
+        return static_cast<uint8_t>((value >> 24) + 128);
+    else if constexpr (std::is_same_v<T, int16_t>)
+        return value >> 16;
+    else if constexpr (std::is_same_v<T, int32_t>)
+        return value;
+    else if constexpr (std::is_same_v<T, float>)
+        return divideWithBiasAndClamp(value, 0);
+}
+
+} // namespace detail
+
+template <typename D, typename S>
+inline D convertAudioSample(S source)
+{
+    if constexpr (std::is_same_v<S, D> && std::is_same_v<D, float>)
+        return std::clamp(source, -1.0f, 1.0f);
+    if constexpr (std::is_same_v<S, D>)
+        return source;
+    else if constexpr (std::is_same_v<S, uint8_t>)
+        return detail::uint8ToAudioSample<D>(source);
+    else if constexpr (std::is_same_v<S, int16_t>)
+        return detail::int16ToAudioSample<D>(source);
+    else if constexpr (std::is_same_v<S, int32_t>)
+        return detail::int32ToAudioSample<D>(source);
+    else if constexpr (std::is_same_v<S, float>)
+        return detail::floatToAudioSample<D>(source);
+    // This doesn't return anything on purpose. It will cause a compilation error if used with unsupported types.
+}
+
+} // namespace WebCore

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -189,6 +189,7 @@ if (ENABLE_WEBCORE)
         Utilities.cpp
 
         Tests/WebCore/AffineTransform.cpp
+        Tests/WebCore/AudioSampleFormat.cpp
         Tests/WebCore/CSSParser.cpp
         Tests/WebCore/CSSTokenizerTests.cpp
         Tests/WebCore/ColorTests.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -215,6 +215,7 @@
 		5159F267260D43E300B2DA3C /* NowPlayingInfoTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5159F266260D43E300B2DA3C /* NowPlayingInfoTests.cpp */; };
 		516281252325C18000BB7E42 /* TestPDFDocument.mm in Sources */ = {isa = PBXBuildFile; fileRef = 516281242325C17B00BB7E42 /* TestPDFDocument.mm */; };
 		516404382AB1D9BC0042B1C3 /* NativePromise.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 516404372AB1D9BB0042B1C3 /* NativePromise.cpp */; };
+		516B289E2CFEA5BC003C544C /* AudioSampleFormat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 516B289D2CFEA5BC003C544C /* AudioSampleFormat.cpp */; };
 		5175C7A226F876230003AF5C /* BundlePageConsoleMessage.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5175C7A126F876230003AF5C /* BundlePageConsoleMessage.mm */; };
 		51820A4D22F4EE7F00DF0A01 /* JavascriptURLNavigation.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51820A4C22F4EE7700DF0A01 /* JavascriptURLNavigation.mm */; };
 		518EE51920A78CE500E024F3 /* DoubleDefersLoadingPlugin.mm in Sources */ = {isa = PBXBuildFile; fileRef = 518EE51720A78CDF00E024F3 /* DoubleDefersLoadingPlugin.mm */; };
@@ -2645,6 +2646,7 @@
 		516281282325C45400BB7E42 /* PDFKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PDFKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library/Frameworks/PDFKit.framework; sourceTree = DEVELOPER_DIR; };
 		516404372AB1D9BB0042B1C3 /* NativePromise.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NativePromise.cpp; sourceTree = "<group>"; };
 		5165FE03201EE617009F7EC3 /* MessagePortProviders.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MessagePortProviders.mm; sourceTree = "<group>"; };
+		516B289D2CFEA5BC003C544C /* AudioSampleFormat.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = AudioSampleFormat.cpp; sourceTree = "<group>"; };
 		51714EB21CF8C761004723C4 /* WebProcessKillIDBCleanup-1.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "WebProcessKillIDBCleanup-1.html"; sourceTree = "<group>"; };
 		51714EB31CF8C761004723C4 /* WebProcessKillIDBCleanup-2.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "WebProcessKillIDBCleanup-2.html"; sourceTree = "<group>"; };
 		51714EB61CF8C7A4004723C4 /* WebProcessKillIDBCleanup.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebProcessKillIDBCleanup.mm; sourceTree = "<group>"; };
@@ -4648,6 +4650,7 @@
 				6354F4D01F7C3AB500D89DF3 /* ApplicationManifestParser.cpp */,
 				DF6580922722168900B3F1C1 /* ASN1Utilities.cpp */,
 				DF6580932722168900B3F1C1 /* ASN1Utilities.h */,
+				516B289D2CFEA5BC003C544C /* AudioSampleFormat.cpp */,
 				07C046C91E42573E007201E7 /* CARingBufferTest.cpp */,
 				57303BC220071E2200355965 /* CBORReaderTest.cpp */,
 				57303BAC2006C56000355965 /* CBORValueTest.cpp */,
@@ -6882,6 +6885,7 @@
 				7CCE7EB41A411A7E00447C4C /* AttributedString.mm in Sources */,
 				F4FA2A4F24D1F05700618A46 /* AttributedSubstringForProposedRange.mm in Sources */,
 				A17C57E12C9A5365009DD0B5 /* AttributedSubstringForProposedRangeWithImage.mm in Sources */,
+				516B289E2CFEA5BC003C544C /* AudioSampleFormat.cpp in Sources */,
 				CDC8E48D1BC5CB4500594FEC /* AudioSessionCategoryIOS.mm in Sources */,
 				7BE876032919457B00B15289 /* AudioStreamDescriptionCocoa.mm in Sources */,
 				F42D634422A1729F00D2FB3A /* AutocorrectionTestsIOS.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebCore/AudioSampleFormat.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/AudioSampleFormat.cpp
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "Test.h"
+
+#include <WebCore/AudioSampleFormat.h>
+#include <cstdint>
+#include <wtf/Vector.h>
+
+namespace TestWebKitAPI {
+
+using namespace WebCore;
+using namespace WTF;
+
+#define AUDIO_SAMPLE_WITH_MORE_TESTS 1
+
+TEST(AudioSampleFormat, U8)
+{
+    auto testVectorUint8 = Vector<uint8_t>::from(0, INT8_MAX / 2, 128, INT8_MAX / 2 + 128, UINT8_MAX);
+    Vector<float> testVectorFloatFromUint8(testVectorUint8.size(), [&](auto index) {
+        return convertAudioSample<float>(testVectorUint8[index]);
+    });
+    Vector<uint8_t> testVectorUint8FromFloat(testVectorFloatFromUint8.size(), [&](auto index) {
+        return convertAudioSample<uint8_t>(testVectorFloatFromUint8[index]);
+    });
+    for (size_t i = 0; i < testVectorUint8.size(); i++)
+        EXPECT_EQ(testVectorUint8[i], testVectorUint8FromFloat[i]);
+
+    // Test that the min and max of the [-1, 1] range can be reached and that BIAS value gets converted to 0.
+    EXPECT_EQ(-1.0f, convertAudioSample<float>(static_cast<uint8_t>(0)));
+    EXPECT_EQ(0.0f, convertAudioSample<float>(static_cast<uint8_t>(128)));
+    EXPECT_EQ(1.0f, convertAudioSample<float>(static_cast<uint8_t>(255)));
+
+    // Test that conversion to float and back is lossless.
+    for (uint8_t i = 0; i < 255; i++)
+        EXPECT_EQ(i, convertAudioSample<uint8_t>(convertAudioSample<float>(i)));
+}
+
+TEST(AudioSampleFormat, S16)
+{
+    auto testVectorInt16 = Vector<int16_t>::from(INT16_MIN, 0, INT16_MIN / 2, INT16_MAX / 2, INT16_MAX);
+    Vector<float> testVectorFloatFromInt16(testVectorInt16.size(), [&](auto index) {
+        return convertAudioSample<float>(testVectorInt16[index]);
+    });
+    Vector<int16_t> testVectorInt16FromFloat(testVectorFloatFromInt16.size(), [&](auto index) {
+        return convertAudioSample<int16_t>(testVectorFloatFromInt16[index]);
+    });
+    for (size_t i = 0; i < testVectorInt16.size(); i++)
+        EXPECT_EQ(testVectorInt16[i], testVectorInt16FromFloat[i]);
+
+    // Test that the min and max of the [-1, 1] range can be reached and that silence stays silent.
+    EXPECT_EQ(-1.0f, convertAudioSample<float>(static_cast<int16_t>(INT16_MIN)));
+    EXPECT_EQ(0.0f, convertAudioSample<float>(static_cast<int16_t>(0)));
+    EXPECT_EQ(1.0f, convertAudioSample<float>(static_cast<int16_t>(INT16_MAX)));
+}
+
+TEST(AudioSampleFormat, S16toU8)
+{
+    EXPECT_EQ(0, convertAudioSample<uint8_t>(static_cast<int16_t>(INT16_MIN)));
+    EXPECT_EQ(128, convertAudioSample<uint8_t>(static_cast<int16_t>(0)));
+    EXPECT_EQ(255, convertAudioSample<uint8_t>(static_cast<int16_t>(INT16_MAX)));
+}
+
+TEST(AudioSampleFormat, S16toS32)
+{
+    // Conversion from S16 to S32 and back is lossless.
+    auto testVectorInt16 = Vector<int16_t>::from(INT16_MIN, 0, INT16_MIN / 2, INT16_MAX / 2, INT16_MAX);
+    Vector<int32_t> testVectorInt32FromInt16(testVectorInt16.size(), [&](auto index) {
+        return convertAudioSample<int32_t>(testVectorInt16[index]);
+    });
+    Vector<int16_t> testVectorInt16FromInt32(testVectorInt32FromInt16.size(), [&](auto index) {
+        return convertAudioSample<int16_t>(testVectorInt32FromInt16[index]);
+    });
+    for (size_t i = 0; i < testVectorInt16.size(); i++)
+        EXPECT_EQ(testVectorInt16[i], testVectorInt16FromInt32[i]);
+
+    EXPECT_GE(INT32_MAX / 2, convertAudioSample<int32_t>(static_cast<int16_t>(INT16_MAX / 2)));
+    EXPECT_LE(INT32_MIN / 2, convertAudioSample<int32_t>(static_cast<int16_t>(INT16_MIN / 2)));
+
+#if AUDIO_SAMPLE_WITH_MORE_TESTS
+    // May be too slow to enable all the time.
+    for (int32_t i = std::numeric_limits<int16_t>::lowest(); i <= std::numeric_limits<int16_t>::lowest(); i++)
+        EXPECT_EQ(i, convertAudioSample<int16_t>(convertAudioSample<int32_t, int16_t>(i)));
+#endif
+}
+
+TEST(AudioSampleFormat, S32)
+{
+    auto testVectorInt32 = Vector<int32_t>::from(INT32_MIN, 0, INT32_MIN / 2, INT32_MAX / 2, INT32_MAX);
+    Vector<float> testVectorFloatFromInt32(testVectorInt32.size(), [&](auto index) {
+        return convertAudioSample<float>(testVectorInt32[index]);
+    });
+    Vector<int32_t> testVectorInt32FromFloat(testVectorFloatFromInt32.size(), [&](auto index) {
+        return convertAudioSample<int32_t>(testVectorFloatFromInt32[index]);
+    });
+    // S32 provides greater accuracy than a 32 bits float (it only has a 24 bits mantissa). So the conversion back and forth may not be lossless.
+    // At the most it will be off by one.
+    for (size_t i = 0; i < testVectorInt32.size(); i++)
+        EXPECT_LE(std::abs(testVectorInt32[i] - testVectorInt32FromFloat[i]), 1);
+
+    // Test that the min and max of the [-1, 1] range can be reached.
+    EXPECT_EQ(-1.0f, convertAudioSample<float>(static_cast<int32_t>(INT32_MIN)));
+    EXPECT_EQ(0.0f, convertAudioSample<float>(static_cast<int32_t>(0)));
+    EXPECT_EQ(1.0f, convertAudioSample<float>(static_cast<int32_t>(INT32_MAX)));
+}
+
+TEST(AudioSampleFormat, S32toS16)
+{
+    EXPECT_EQ(INT16_MIN, convertAudioSample<int16_t>(static_cast<int32_t>(INT32_MIN)));
+    EXPECT_EQ(INT16_MAX, convertAudioSample<int16_t>(static_cast<int32_t>(INT32_MAX)));
+    EXPECT_GE(INT16_MAX / 2, convertAudioSample<int16_t>(static_cast<int32_t>(INT32_MAX / 2)));
+    EXPECT_LE(INT16_MIN / 2, convertAudioSample<int16_t>(static_cast<int32_t>(INT32_MIN / 2)));
+}
+
+TEST(AudioSampleFormat, F32)
+{
+    auto testVectorFloat = Vector<float>::from(-1.0, -.75, -0.5, -0.3, -0.1, 0.0, 0.1, 0.3, 0.5, 0.75, 1.0);
+    Vector<int32_t> testVectorInt32FromFloat(testVectorFloat.size(), [&](auto index) {
+        return convertAudioSample<int32_t>(testVectorFloat[index]);
+    });
+    Vector<float> testVectorFloatFromInt32(testVectorInt32FromFloat.size(), [&](auto index) {
+        return convertAudioSample<float>(testVectorInt32FromFloat[index]);
+    });
+    for (size_t i = 0; i < testVectorFloat.size(); i++)
+        EXPECT_EQ(testVectorFloat[i], testVectorFloatFromInt32[i]);
+
+    // Test that clipping is properly done.
+    EXPECT_EQ(1.0f, convertAudioSample<float>(1.1f));
+    EXPECT_EQ(-1.0f, convertAudioSample<float>(-1.1f));
+    EXPECT_EQ(1.0f, convertAudioSample<float>(convertAudioSample<int32_t>(1.1f)));
+    EXPECT_EQ(-1.0f, convertAudioSample<float>(convertAudioSample<int32_t>(-1.1f)));
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### bf54b5a538ebd488a067445fef3a72c7067051bc
<pre>
Add primitive routines to perform Audio Sample format conversion.
<a href="https://bugs.webkit.org/show_bug.cgi?id=283902">https://bugs.webkit.org/show_bug.cgi?id=283902</a>
<a href="https://rdar.apple.com/140782221">rdar://140782221</a>

Reviewed by Gerald Squelart.

Add convertAudioSample method to convert uint8_t, int16_t, int32_t, float audio sample formats.

Float Audio samples use a float range of [-1.0, 1.0] inclusive.

This method will be used with the WebCodec&apos;s AudioData API.
The conversion had two requirements to fullfill the WebCodec&apos;s AudioData wpt:
 1- The conversion is symmetric between int and float.
 2- +1.0 can be mapped to std::numeric_limits&lt;T&gt;::max().

Requirement 2) was removed in later WebCodec&apos;s wpt, but for the version currently in the tree, it is required.

Float conversion accuracy has been given preferential treatment over speed.

Add API tests.
* Source/WebCore/platform/AudioSampleFormat.h:
(WebCore::detail::maxAsFloat):
(WebCore::detail::maxPlus1AsFloat):
(WebCore::detail::lowestAsFloat):
(WebCore::detail::divideWithBiasAndClamp):
(WebCore::detail::uint8ToAudioSample):
(WebCore::detail::int16ToAudioSample):
(WebCore::detail::int32ToAudioSample):
(WebCore::detail::floatToAudioSample):
(WebCore::convertAudioSample):
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/AudioSampleFormat.cpp: Added.
(TestWebKitAPI::TEST(AudioSampleFormat, U8)):
(TestWebKitAPI::TEST(AudioSampleFormat, U8toS16)):
(TestWebKitAPI::TEST(AudioSampleFormat, S16)):
(TestWebKitAPI::TEST(AudioSampleFormat, S16toS32)):
(TestWebKitAPI::TEST(AudioSampleFormat, S32)):
(TestWebKitAPI::TEST(AudioSampleFormat, F32)):

Canonical link: <a href="https://commits.webkit.org/287327@main">https://commits.webkit.org/287327@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb64017d1a9b41f1e5aaec8e1802ba9880ce9c35

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79043 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58079 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32420 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83683 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30258 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81176 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67188 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6349 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61867 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19786 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82110 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51906 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72049 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42170 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49257 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26143 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28622 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70372 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26561 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85069 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6368 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4400 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70105 "Found 1 new test failure: webanimations/accelerated-animation-addition-lower-in-effect-stack.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6532 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67921 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69355 "Found 10 new API test failures: /TestWebKit:WebKit.DownloadDecideDestinationCrash, /TestWebKit:WebKit.DocumentStartUserScriptAlertCrashTest, /TestWebKit:WebKit.EvaluateJavaScriptThatCreatesBlob, /TestWebKit:WebKit.InjectedBundleFrameHitTest, /TestWebKit:WebKit.HitTestResultNodeHandle, /TestWebKit:WebKit.LoadCanceledNoServerRedirectCallback, /TestWebKit:WebKit.FrameMIMETypePNG, /TestWebKit:WebKit.FocusedFrameAfterCrash, /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginShouldNotBeDispatchedForAlreadyFocusedField, /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginAndEndEditingEvents (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17312 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13400 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12176 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6319 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12155 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6280 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9731 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8072 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->