### PR TITLE
generate-serializers.py: Use more f-strings

### DIFF
--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -67,11 +67,11 @@ class Template(object):
 
     def forward_declaration(self):
         if self.enum_storage:
-            return self.type + ' ' + self.name + ' : ' + self.enum_storage + ';'
-        return self.type + ' ' + self.name + ';'
+            return f'{self.type} {self.name} : {self.enum_storage};'
+        return f'{self.type} {self.name};'
 
     def specialization(self):
-        return self.namespace + '::' + self.name
+        return f'{self.namespace}::{self.name}'
 
 
 class SerializedType(object):
@@ -158,36 +158,36 @@ class SerializedType(object):
 
     def namespace_and_name(self):
         if self.cf_type is not None:
-            return self.cf_type + "Ref"
+            return f'{self.cf_type}Ref'
         if self.namespace is None:
             return self.name
-        return self.namespace + '::' + self.cpp_struct_or_class_name()
+        return f'{self.namespace}::{self.cpp_struct_or_class_name()}'
 
     def namespace_if_not_wtf_and_name(self):
         if self.namespace == 'WTF':
             return self.name
         if self.namespace is None:
             return self.name
-        return self.namespace + '::' + self.cpp_struct_or_class_name()
+        return f'{self.namespace}::{self.cpp_struct_or_class_name()}'
 
     def namespace_and_name_for_construction(self, specialization):
         fulltype = None
         if self.construct_subclass:
-            fulltype = self.namespace + '::' + self.construct_subclass
+            fulltype = f'{self.namespace}::{self.construct_subclass}'
         elif self.generic_wrapper is not None:
             fulltype = self.generic_wrapper
         else:
             fulltype = self.namespace_and_name()
         if specialization:
-            fulltype = fulltype + '<' + specialization + '>'
+            fulltype = f'{fulltype}<{specialization}>'
         return fulltype
 
     def cf_wrapper_type(self):
-        return self.namespace + '::' + self.name
+        return f'{self.namespace}::{self.name}'
 
     def name_declaration_for_serialized_type_info(self):
         if self.cf_type is not None:
-            return self.cf_type + 'Ref'
+            return f'{self.cf_type}Ref'
         if self.namespace == 'WTF':
             if self.name != "UUID":
                 return self.name
@@ -197,7 +197,7 @@ class SerializedType(object):
         result = ""
         if self.namespace:
             result += self.namespace + "_"
-        return result + self.name + "_Subclass"
+        return f'{result}{self.name}_Subclass'
 
     def function_name_for_enum(self):
         return 'isValidEnum'
@@ -236,7 +236,7 @@ class SerializedType(object):
 
     def cpp_struct_or_class_name(self):
         if self.is_webkit_secure_coding_type():
-            return 'CoreIPC' + self.name
+            return f'CoreIPC{self.name}'
         return self.name
 
     def is_webkit_secure_coding_type(self):
@@ -262,7 +262,7 @@ class SerializedEnum(object):
     def namespace_and_name(self):
         if self.namespace is None:
             return self.name
-        return self.namespace + '::' + self.name
+        return f'{self.namespace}::{self.name}'
 
     def function_name(self):
         if self.is_option_set():
@@ -276,7 +276,7 @@ class SerializedEnum(object):
 
     def parameter(self):
         if self.is_option_set():
-            return 'OptionSet<' + self.namespace_and_name() + '>'
+            return f'OptionSet<{self.namespace_and_name()}>'
         return self.underlying_type
 
     def is_option_set(self):
@@ -291,8 +291,8 @@ class SerializedEnum(object):
 
 class MemberVariable(object):
     def __init__(self, type, name, condition, attributes, namespace=None, is_subclass=False):
-        assert type == type.strip(), "MemberVariable(" + type + " " + name + ") has invalid type '" + type + "'"
-        assert name == name.strip(), "MemberVariable(" + type + " " + name + ") has invalid name '" + name + "'"
+        assert type == type.strip(), f"MemberVariable({type} {name}) has invalid type '{type}'"
+        assert name == name.strip(), f"MemberVariable({type} {name}) has invalid name '{name}'"
         self.type = type
         self.name = name
         self.condition = condition
@@ -383,13 +383,13 @@ class MemberVariable(object):
         value = self.ns_type()
         if value == 'SecTrustRef':
             return value
-        return value + ' *'
+        return f'{value} *'
 
     def type_check(self):
         value = self.ns_type()
         if value == 'SecTrustRef':
-            return '(m_' + self.type + ' && CFGetTypeID((CFTypeRef)m_' + self.type + '.get()) == SecTrustGetTypeID())'
-        return '[m_' + self.type + ' isKindOfClass:IPC::getClass<' + value + '>()]'
+            return f'(m_{self.type} && CFGetTypeID((CFTypeRef)m_{self.type}.get()) == SecTrustGetTypeID())'
+        return f'[m_{self.type} isKindOfClass:IPC::getClass<{value}>()]'
 
     def id_cast(self):
         value = self.ns_type()
@@ -401,10 +401,10 @@ class MemberVariable(object):
         prefix = 'std::optional<' if self.value_is_optional() else ''
         suffix = '>' if self.value_is_optional() else ''
         if self.array_contents() is not None:
-            return prefix + 'Vector<RetainPtr<' + self.array_contents() + '>>' + suffix
+            return f'{prefix}Vector<RetainPtr<{self.array_contents()}>>{suffix}'
         if self.dictionary_contents() is not None:
-            return prefix + 'Vector<std::pair<String, RetainPtr<' + self.dictionary_contents() + '>>>' + suffix
-        return 'RetainPtr<' + self.ns_type() + '>'
+            return f'{prefix}Vector<std::pair<String, RetainPtr<{self.dictionary_contents()}>>>{suffix}'
+        return f'RetainPtr<{self.ns_type()}>'
 
     def value_is_optional(self):
         return self.name.endswith('?')
@@ -503,19 +503,19 @@ def one_argument_coder_declaration_cf(type):
     result = []
     result.append('')
     if type.condition is not None:
-        result.append('#if ' + type.condition)
+        result.append(f'#if {type.condition}')
     name_with_template = type.namespace_and_name()
-    result.append('template<> struct ArgumentCoder<' + name_with_template + '> {')
+    result.append(f'template<> struct ArgumentCoder<{name_with_template}> {{')
     for encoder in type.encoders:
-        result.append('    static void encode(' + encoder + '&, ' + name_with_template + ');')
+        result.append(f'    static void encode({encoder}&, {name_with_template});')
     result.append('};')
-    result.append('template<> struct ArgumentCoder<RetainPtr<' + name_with_template + '>> {')
+    result.append(f'template<> struct ArgumentCoder<RetainPtr<{name_with_template}>> {{')
     for encoder in type.encoders:
-        result.append('    static void encode(' + encoder + '& encoder, const RetainPtr<' + name_with_template + '>& retainPtr)')
+        result.append(f'    static void encode({encoder}& encoder, const RetainPtr<{name_with_template}>& retainPtr)')
         result.append('    {')
-        result.append('        ArgumentCoder<' + name_with_template + '>::encode(encoder, retainPtr.get());')
+        result.append(f'        ArgumentCoder<{name_with_template}>::encode(encoder, retainPtr.get());')
         result.append('    }')
-    result.append('    static std::optional<RetainPtr<' + name_with_template + '>> decode(Decoder&);')
+    result.append(f'    static std::optional<RetainPtr<{name_with_template}>> decode(Decoder&);')
     result.append('};')
     if type.condition is not None:
         result.append('#endif')
@@ -528,20 +528,20 @@ def one_argument_coder_declaration(type, template_argument):
     result = []
     result.append('')
     if type.condition is not None:
-        result.append('#if ' + type.condition)
+        result.append(f'#if {type.condition}')
     name_with_template = type.namespace_and_name()
     if template_argument is not None:
-        name_with_template = name_with_template + '<' + template_argument.namespace + '::' + template_argument.name + '>'
-    result.append('template<> struct ArgumentCoder<' + name_with_template + '> {')
+        name_with_template = f'{name_with_template}<{template_argument.namespace}::{template_argument.name}>'
+    result.append(f'template<> struct ArgumentCoder<{name_with_template}> {{')
     for encoder in type.encoders:
         if type.rvalue:
-            result.append('    static void encode(' + encoder + '&, ' + name_with_template + '&&);')
+            result.append(f'    static void encode({encoder}&, {name_with_template}&&);')
         else:
-            result.append('    static void encode(' + encoder + '&, const ' + name_with_template + '&);')
+            result.append(f'    static void encode({encoder}&, const {name_with_template}&);')
     if type.return_ref:
-        result.append('    static std::optional<Ref<' + name_with_template + '>> decode(Decoder&);')
+        result.append(f'    static std::optional<Ref<{name_with_template}>> decode(Decoder&);')
     else:
-        result.append('    static std::optional<' + name_with_template + '> decode(Decoder&);')
+        result.append(f'    static std::optional<{name_with_template}> decode(Decoder&);')
     result.append('};')
     if type.condition is not None:
         result.append('#endif')
@@ -623,23 +623,23 @@ def generate_forward_declarations(serialized_types, serialized_enums, additional
     all_namespaces = all_namespaces.union(set(template_types_by_namespace.keys()))
     for namespace in sorted(all_namespaces, key=lambda x: (x is None, x)):
         if namespace is not None:
-            result.append('namespace ' + namespace + ' {')
+            result.append(f'namespace {namespace} {{')
         for enum in serialized_enums_by_namespace.get(namespace, []):
             if enum.condition is not None:
-                result.append('#if ' + enum.condition)
-            result.append('enum class ' + enum.name + ' : ' + enum.underlying_type + ';')
+                result.append(f'#if {enum.condition}')
+            result.append(f'enum class {enum.name} : {enum.underlying_type};')
             if enum.condition is not None:
                 result.append('#endif')
         for type in serialized_types_by_namespace.get(namespace, []):
             if type.condition is not None:
-                result.append('#if ' + type.condition)
+                result.append(f'#if {type.condition}')
             if type.cf_type is None and type.alias is None:
                 name = type.cpp_struct_or_class_name()
                 less_than_index = name.find('<')
                 if less_than_index == -1:
-                    result.append(type.cpp_type_from_struct_or_class() + ' ' + name + ';')
+                    result.append(f'{type.cpp_type_from_struct_or_class()} {name};')
                 else:
-                    result.append('template<typename> ' + type.cpp_type_from_struct_or_class() + ' ' + name[:less_than_index] + ';')
+                    result.append(f'template<typename> {type.cpp_type_from_struct_or_class()} {name[:less_than_index]};')
             if type.condition is not None:
                 result.append('#endif')
         for template in template_types_by_namespace.get(namespace, []):
@@ -649,7 +649,7 @@ def generate_forward_declarations(serialized_types, serialized_enums, additional
         result.append('')
     for declaration in additional_forward_declarations:
         if declaration.condition is not None:
-            result.append('#if ' + declaration.condition)
+            result.append(f'#if {declaration.condition}')
         result.append(declaration.declaration + ';')
         if declaration.condition is not None:
             result.append('#endif')
@@ -657,13 +657,13 @@ def generate_forward_declarations(serialized_types, serialized_enums, additional
         for type in serialized_types_by_namespace.get(namespace, []):
             if type.alias is not None:
                 if type.condition is not None:
-                    result.append('#if ' + type.condition)
+                    result.append(f'#if {type.condition}')
                 if namespace is not None:
-                    result.append('namespace ' + namespace + ' {')
+                    result.append(f'namespace {namespace} {{')
 
                 if namespace is None or get_alias_namespace(type.alias) is None or get_alias_namespace(type.alias) == type.namespace:
-                    result.append('template<' + typenames(type.alias) + '> ' + alias_struct_or_class(type.alias) + ' ' + remove_template_parameters(type.alias) + ';')
-                result.append('using ' + type.name + ' = ' + remove_alias_struct_or_class(type.alias) + ';')
+                    result.append(f'template<{typenames(type.alias)}> {alias_struct_or_class(type.alias)} {remove_template_parameters(type.alias)};')
+                result.append(f'using {type.name} = {remove_alias_struct_or_class(type.alias)};')
 
                 if namespace is not None:
                     result.append('}')
@@ -678,7 +678,7 @@ def generate_header(serialized_types, serialized_enums, additional_forward_decla
     result.append('#pragma once')
     result.append('')
     for header in ['<wtf/ArgumentCoder.h>', '<wtf/OptionSet.h>', '<wtf/Ref.h>', '<wtf/RetainPtr.h>']:
-        result.append('#include ' + header)
+        result.append(f'#include {header}')
 
     result += generate_forward_declarations(serialized_types, serialized_enums, additional_forward_declarations)
     result.append('')
@@ -699,8 +699,8 @@ def generate_header(serialized_types, serialized_enums, additional_forward_decla
         if enum.underlying_type == 'bool':
             continue
         if enum.condition is not None:
-            result.append('#if ' + enum.condition)
-        result.append('template<> bool ' + enum.function_name() + '<' + enum.namespace_and_name() + enum.additional_template_parameter() + '>(' + enum.parameter() + ');')
+            result.append(f'#if {enum.condition}')
+        result.append(f'template<> bool {enum.function_name()}<{enum.namespace_and_name() + enum.additional_template_parameter()}>({enum.parameter()});')
         if enum.condition is not None:
             result.append('#endif')
     result.append('')
@@ -727,51 +727,51 @@ def check_type_members(type, checking_parent_class):
         result = check_type_members(type.parent_class, True)
     for member in type.members:
         if member.condition is not None:
-            result.append('#if ' + member.condition)
-        result.append('    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.' + member.name + ')>, ' + member.type + '>);')
+            result.append(f'#if {member.condition}')
+        result.append(f'    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.{member.name})>, {member.type}>);')
         if member.condition is not None:
             result.append('#endif')
     for member in type.dictionary_members:
-        result.append('    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.m_' + member.type + ')>, ' + member.dictionary_type() + '>);')
+        result.append(f'    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.m_{member.type})>, {member.dictionary_type()}>);')
     if type.can_assert_member_order_is_correct():
         # FIXME: Add this check for types with parent classes, too.
         if type.parent_class is None and not checking_parent_class:
-            result.append('    struct ShouldBeSameSizeAs' + type.name_as_identifier() + ' : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<' + type.namespace_and_name() + '>, ' + ('true' if type.return_ref else 'false') + '> {')
+            result.append(f'    struct ShouldBeSameSizeAs{type.name_as_identifier()} : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<{type.namespace_and_name()}>, {"true" if type.return_ref else "false"}> {{')
             for member in type.members:
                 if member.condition is not None:
-                    result.append('#if ' + member.condition)
-                result.append('        ' + member.type + ' ' + member.name + (' : 1' if 'BitField' in member.attributes else '') + ';')
+                    result.append(f'#if {member.condition}')
+                result.append(f'        {member.type} {member.name}{" : 1" if "BitField" in member.attributes else ""};')
                 if member.condition is not None:
                     result.append('#endif')
             for member in type.dictionary_members:
-                result.append('        ' + member.dictionary_type() + ' ' + member.type + ';')
+                result.append(f'        {member.dictionary_type()} {member.type};')
             result.append('    };')
-            result.append('    static_assert(sizeof(ShouldBeSameSizeAs' + type.name_as_identifier() + ') == sizeof(' + type.namespace_and_name() + '));')
+            result.append(f'    static_assert(sizeof(ShouldBeSameSizeAs{type.name_as_identifier()}) == sizeof({type.namespace_and_name()}));')
         result.append('    static_assert(MembersInCorrectOrder < 0')
         for member in type.members:
             if 'BitField' in member.attributes:
                 continue
             if member.condition is not None:
-                result.append('#if ' + member.condition)
-            result.append('        , offsetof(' + type.namespace_and_name() + ', ' + member.name + ')')
+                result.append(f'#if {member.condition}')
+            result.append(f'        , offsetof({type.namespace_and_name()}, {member.name})')
             if member.condition is not None:
                 result.append('#endif')
         for member in type.dictionary_members:
-            result.append('        , offsetof(' + type.namespace_and_name() + ', m_' + member.type + ')')
-        result.append('    >::value);')
+            result.append(f'        , offsetof({type.namespace_and_name()}, m_{member.type})')
+        result.append(f'    >::value);')
     if type.has_optional_tuple_bits():
         serialized_members = type.serialized_members()
         optional_tuple_state = None
         for i in range(len(serialized_members)):
             member = serialized_members[i]
             if member.optional_tuple_bits():
-                result.append('    static_assert(static_cast<uint64_t>(' + serialized_members[i + 1].optional_tuple_bit() + ') == 1);')
+                result.append(f'    static_assert(static_cast<uint64_t>({serialized_members[i + 1].optional_tuple_bit()}) == 1);')
                 result.append('    static_assert(BitsInIncreasingOrder<')
                 optional_tuple_state = 'begin'
             elif member.optional_tuple_bit():
                 if member.condition is not None:
-                    result.append('#if ' + member.condition)
-                result.append('        ' + (', ' if optional_tuple_state == 'middle' else '') + 'static_cast<uint64_t>(' + member.optional_tuple_bit() + ')')
+                    result.append(f'#if {member.condition}')
+                result.append(f'        {", " if optional_tuple_state == "middle" else ""}static_cast<uint64_t>({member.optional_tuple_bit()})')
                 if member.condition is not None:
                     result.append('#endif')
                 optional_tuple_state = 'middle'
@@ -788,9 +788,9 @@ def check_type_members(type, checking_parent_class):
 def encode_cf_type(type):
     result = []
     if type.from_cf_method is not None:
-        result.append('    encoder << ' + type.from_cf_method + '(instance);')
+        result.append(f'    encoder << {type.from_cf_method}(instance);')
     else:
-        result.append('    encoder << ' + type.cf_wrapper_type() + ' { instance };')
+        result.append(f'    encoder << {type.cf_wrapper_type()} {{ instance }};')
     return result
 
 
@@ -802,10 +802,10 @@ def encode_type(type):
         result = result + encode_type(type.parent_class)
     for member in type.serialized_members():
         if member.condition is not None:
-            result.append('#if ' + member.condition)
+            result.append(f'#if {member.condition}')
         if member.is_subclass:
-            result.append('    if (auto* subclass = dynamicDowncast<' + member.namespace + "::" + member.name + '>(instance)) {')
-            result.append('        encoder << ' + type.subclass_enum_name() + "::" + member.name + ";")
+            result.append(f'    if (auto* subclass = dynamicDowncast<{member.namespace}::{member.name}>(instance)) {{')
+            result.append(f'        encoder << {type.subclass_enum_name()}::{member.name};')
             if type.rvalue:
                 result.append('        encoder << WTFMove(*subclass);')
             else:
@@ -813,37 +813,37 @@ def encode_type(type):
             result.append('        return;')
             result.append('    }')
         elif member.optional_tuple_bits():
-            result.append('    encoder << instance.' + member.name + ';')
+            result.append(f'    encoder << instance.{member.name};')
             bits_variable_name = member.name
         elif member.optional_tuple_bit() is not None:
-            result.append('    if (instance.' + bits_variable_name + ' & ' + member.optional_tuple_bit() + ')')
-            result.append('        encoder << instance.' + member.name + ';')
+            result.append(f'    if (instance.{bits_variable_name} & {member.optional_tuple_bit()})')
+            result.append(f'        encoder << instance.{member.name};')
         else:
             if type.rvalue and '()' not in member.name:
                 if 'EncodeRequestBody' in member.attributes:
-                    result.append('    RefPtr ' + member.name + 'Body = instance.' + member.name + '.httpBody();')
-                result.append('    encoder << WTFMove(instance.' + member.name + ');')
+                    result.append(f'    RefPtr {member.name}Body = instance.{member.name}.httpBody();')
+                result.append(f'    encoder << WTFMove(instance.{member.name});')
                 if 'EncodeRequestBody' in member.attributes:
-                    result.append('    encoder << IPC::FormDataReference { WTFMove(' + member.name + 'Body) };')
+                    result.append(f'    encoder << IPC::FormDataReference {{ WTFMove({member.name}Body) }};')
             else:
-                result.append('    encoder << instance.' + member.name + ';')
+                result.append(f'    encoder << instance.{member.name};')
                 if 'EncodeRequestBody' in member.attributes:
-                    result.append('    encoder << IPC::FormDataReference { instance.' + member.name + '.httpBody() };')
+                    result.append(f'    encoder << IPC::FormDataReference {{ instance.{member.name}.httpBody() }};')
         if member.condition is not None:
             result.append('#endif')
     for member in type.dictionary_members:
-        result.append('    encoder << instance.m_' + member.type + ';')
+        result.append(f'    encoder << instance.m_{member.type};')
 
     return result
 
 
 def decode_cf_type(type):
     result = []
-    result.append('    auto result = decoder.decode<' + type.cf_wrapper_type() + '>();')
+    result.append(f'    auto result = decoder.decode<{type.cf_wrapper_type()}>();')
     result.append('    if (UNLIKELY(!decoder.isValid()))')
     result.append('        return std::nullopt;')
     if type.to_cf_method is not None:
-        result.append('    return ' + type.to_cf_method + ';')
+        result.append(f'    return {type.to_cf_method};')
     else:
         result.append('    return result->toCF();')
     return result
@@ -857,21 +857,21 @@ def decode_type(type):
         result = result + decode_type(type.parent_class)
 
     if type.members_are_subclasses:
-        result.append('    auto type = decoder.decode<' + type.subclass_enum_name() + '>();')
+        result.append(f'    auto type = decoder.decode<{type.subclass_enum_name()}>();')
         result.append('    UNUSED_PARAM(type);')
         result.append('    if (UNLIKELY(!decoder.isValid()))')
         result.append('        return std::nullopt;')
         result.append('')
 
     if type.has_optional_tuple_bits() and type.populate_from_empty_constructor:
-        result.append('    ' + type.namespace_and_name() + ' result;')
+        result.append(f'    {type.namespace_and_name()} result;')
 
     for i in range(len(type.serialized_members())):
         member = type.serialized_members()[i]
         if member.condition is not None:
-            result.append('#if ' + member.condition)
+            result.append(f'#if {member.condition}')
         sanitized_variable_name = sanitize_string_for_variable_name(member.name)
-        r = re.compile("SecureCodingAllowed=\\[(.*)\\]")
+        r = re.compile(r'SecureCodingAllowed=\[(.*)\]')
         decodable_classes = [r.match(m).groups()[0] for m in list(filter(r.match, member.attributes))]
         if len(decodable_classes) == 1:
             match = re.search("RetainPtr<(.*)>", member.type)
@@ -880,56 +880,56 @@ def decode_type(type):
                 precondition = re.search(r'Precondition=\'(.*)\'', attribute)
                 if precondition:
                     condition, = precondition.groups()
-                    result.append('    if (!(' + condition + '))')
+                    result.append(f'    if (!({condition}))')
                     result.append('        return std::nullopt;')
                     break
                 else:
                     condition = re.search(r'Precondition', attribute)
                     assert not condition
-            result.append('    auto ' + sanitized_variable_name + ' = decoder.decodeWithAllowedClasses<' + match.groups()[0] + '>({ ' + decodable_classes[0] + ' });')
+            result.append(f'    auto {sanitized_variable_name} = decoder.decodeWithAllowedClasses<{match.groups()[0]}>({{ {decodable_classes[0]} }});')
         elif member.is_subclass:
-            result.append('    if (type == ' + type.subclass_enum_name() + "::" + member.name + ') {')
-            typename = member.namespace + "::" + member.name
-            result.append('        auto result = decoder.decode<Ref<' + typename + '>>();')
+            result.append(f'    if (type == {type.subclass_enum_name()}::{member.name}) {{')
+            typename = f'{member.namespace}::{member.name}'
+            result.append(f'        auto result = decoder.decode<Ref<{typename}>>();')
             result.append('        if (UNLIKELY(!decoder.isValid()))')
             result.append('            return std::nullopt;')
             result.append('        return WTFMove(*result);')
             result.append('    }')
         elif member.optional_tuple_bits():
             bits_name = sanitized_variable_name
-            result.append('    auto ' + bits_name + ' = decoder.decode<' + member.type + '>();')
-            result.append('    if (!' + bits_name + ')')
+            result.append(f'    auto {bits_name} = decoder.decode<{member.type}>();')
+            result.append(f'    if (!{bits_name})')
             result.append('        return std::nullopt;')
             if type.populate_from_empty_constructor:
-                result.append('    result.' + member.name + ' = *' + bits_name + ';')
+                result.append(f'    result.{member.name} = *{bits_name};')
         elif member.optional_tuple_bit() is not None:
             if type.populate_from_empty_constructor:
-                result.append('    if (*' + bits_name + ' & ' + member.optional_tuple_bit() + ') {')
-                result.append('        if (auto deserialized = decoder.decode<' + member.type + '>())')
-                result.append('            result.' + sanitized_variable_name + ' = WTFMove(*deserialized);')
+                result.append(f'    if (*{bits_name} & {member.optional_tuple_bit()}) {{')
+                result.append(f'        if (auto deserialized = decoder.decode<{member.type}>())')
+                result.append(f'            result.{sanitized_variable_name} = WTFMove(*deserialized);')
                 result.append('        else')
                 result.append('            return std::nullopt;')
                 result.append('    }')
             else:
                 result.append('')
-                result.append('    ' + member.type + ' ' + sanitized_variable_name + ' { };')
-                result.append('    if (*' + bits_name + ' & ' + member.optional_tuple_bit() + ') {')
-                result.append('        if (auto deserialized = decoder.decode<' + member.type + '>())')
-                result.append('            ' + sanitized_variable_name + ' = WTFMove(*deserialized);')
+                result.append(f'    {member.type} {sanitized_variable_name} {{ }};')
+                result.append(f'    if (*{bits_name} & {member.optional_tuple_bit()}) {{')
+                result.append(f'        if (auto deserialized = decoder.decode<{member.type}>())')
+                result.append(f'            {sanitized_variable_name} = WTFMove(*deserialized);')
                 result.append('        else')
                 result.append('            return std::nullopt;')
                 result.append('    }')
         else:
             assert len(decodable_classes) == 0
-            result.append('    auto ' + sanitized_variable_name + ' = decoder.decode<' + member.type + '>();')
+            result.append(f'    auto {sanitized_variable_name} = decoder.decode<{member.type}>();')
             if 'EncodeRequestBody' in member.attributes:
-                result.append('    if (' + sanitized_variable_name + ') {')
-                result.append('        if (auto ' + sanitized_variable_name + 'Body = decoder.decode<IPC::FormDataReference>())')
-                result.append('            ' + sanitized_variable_name + '->setHTTPBody(' + sanitized_variable_name + 'Body->takeData());')
+                result.append(f'    if ({sanitized_variable_name}) {{')
+                result.append(f'        if (auto {sanitized_variable_name}Body = decoder.decode<IPC::FormDataReference>())')
+                result.append(f'            {sanitized_variable_name}->setHTTPBody({sanitized_variable_name}Body->takeData());')
                 result.append('    }')
             if type.debug_decoding_failure:
-                result.append('    if (UNLIKELY(!' + sanitized_variable_name + '))')
-                result.append('        decoder.setIndexOfDecodingFailure(' + str(i) + ');')
+                result.append(f'    if (UNLIKELY(!{sanitized_variable_name}))')
+                result.append(f'        decoder.setIndexOfDecodingFailure({str(i)});')
         for attribute in member.attributes:
             match = re.search(r'Validator=\'(.*)\'', attribute)
             if match:
@@ -937,7 +937,7 @@ def decode_type(type):
                 result.append('    if (UNLIKELY(!decoder.isValid()))')
                 result.append('        return std::nullopt;')
                 result.append('')
-                result.append('    if (!(' + validator + '))')
+                result.append(f'    if (!({validator}))')
                 result.append('        return std::nullopt;')
                 continue
             else:
@@ -947,12 +947,12 @@ def decode_type(type):
             result.append('#endif')
 
     for member in type.dictionary_members:
-        result.append('    auto ' + member.type + ' = decoder.decode<' + member.dictionary_type() + '>();')
-        result.append('    if (!' + member.type + ')')
+        result.append(f'    auto {member.type} = decoder.decode<{member.dictionary_type()}>();')
+        result.append(f'    if (!{member.type})')
         result.append('        return std::nullopt;')
         # FIXME: Add question marks to the serialization.in files and add these checks here:
         # if not member.value_is_optional() and member.array_contents() is None and member.dictionary_contents() is None:
-        #    result.append('    if (!*' + member.type + ')')
+        #    result.append('    if (!*{member.type})')
         #    result.append('        return std::nullopt;')
         result.append('')
 
@@ -967,11 +967,11 @@ def construct_type(type, specialization, indentation):
     result = []
     fulltype = type.namespace_and_name_for_construction(specialization)
     if type.create_using:
-        result.append(indent(indentation) + fulltype + '::' + type.create_using + '(')
+        result.append(f'{indent(indentation)}{fulltype}::{type.create_using}(')
     elif type.return_ref:
-        result.append(indent(indentation) + fulltype + '::create(')
+        result.append(f'{indent(indentation)}{fulltype}::create(')
     else:
-        result.append(indent(indentation) + fulltype + ' {')
+        result.append(f'{indent(indentation)}{fulltype} {{')
     if type.parent_class is not None:
         result = result + construct_type(type.parent_class, specialization, indentation + 1)
         if len(type.members) != 0:
@@ -980,13 +980,13 @@ def construct_type(type, specialization, indentation):
     for i in range(len(serialized_members)):
         member = serialized_members[i]
         if member.condition is not None:
-            result.append('#if ' + member.condition)
-        result.append(indent(indentation + 1) + 'WTFMove(' + ('' if member.optional_tuple_bit() else '*') + sanitize_string_for_variable_name(member.name) + ')' + ('' if i == len(serialized_members) - 1 else ','))
+            result.append(f'#if {member.condition}')
+        result.append(f'{indent(indentation + 1)}WTFMove({"" if member.optional_tuple_bit() else "*"}{sanitize_string_for_variable_name(member.name)}){"" if i == len(serialized_members) - 1 else ","}')
         if member.condition is not None:
             result.append('#endif')
     for i in range(len(type.dictionary_members)):
         member = type.dictionary_members[i]
-        result.append(indent(indentation + 1) + 'WTFMove(*' + member.type + ')' + (',' if i < len(type.dictionary_members) - 1 else ''))
+        result.append(f'{indent(indentation + 1)}WTFMove(*{member.type}){"," if i < len(type.dictionary_members) - 1 else ""}')
     if type.create_using or type.return_ref:
         result.append(indent(indentation) + ')')
     else:
@@ -998,20 +998,20 @@ def generate_one_impl(type, template_argument):
     result = []
     name_with_template = type.namespace_and_name()
     if template_argument is not None:
-        name_with_template = name_with_template + '<' + template_argument.namespace + '::' + template_argument.name + '>'
+        name_with_template = f'{name_with_template}<{template_argument.namespace}::{template_argument.name}>'
     if type.condition is not None:
-        result.append('#if ' + type.condition)
+        result.append(f'#if {type.condition}')
 
     if type.members_are_subclasses:
-        result.append('enum class ' + type.subclass_enum_name() + " : IPC::EncodedVariantIndex {")
+        result.append(f'enum class {type.subclass_enum_name()} : IPC::EncodedVariantIndex {{')
         for idx in range(0, len(type.members)):
             member = type.members[idx]
             if member.condition is not None:
-                result.append('#if ' + member.condition)
+                result.append(f'#if {member.condition}')
             if idx == 0:
-                result.append('    ' + member.name)
+                result.append(f'    {member.name}')
             else:
-                result.append('    , ' + member.name)
+                result.append(f'    , {member.name}')
             if member.condition is not None:
                 result.append('#endif')
         result.append('};')
@@ -1044,11 +1044,11 @@ def generate_one_impl(type, template_argument):
             result.append('IGNORE_WARNINGS_END')
         result.append('')
     if type.cf_type is not None:
-        result.append('std::optional<RetainPtr<' + name_with_template + '>> ArgumentCoder<RetainPtr<' + name_with_template + '>>::decode(Decoder& decoder)')
+        result.append(f'std::optional<RetainPtr<{name_with_template}>> ArgumentCoder<RetainPtr<{name_with_template}>>::decode(Decoder& decoder)')
     elif type.return_ref:
-        result.append('std::optional<Ref<' + name_with_template + '>> ArgumentCoder<' + name_with_template + '>::decode(Decoder& decoder)')
+        result.append(f'std::optional<Ref<{name_with_template}>> ArgumentCoder<{name_with_template}>::decode(Decoder& decoder)')
     else:
-        result.append('std::optional<' + name_with_template + '> ArgumentCoder<' + name_with_template + '>::decode(Decoder& decoder)')
+        result.append(f'std::optional<{name_with_template}> ArgumentCoder<{name_with_template}>::decode(Decoder& decoder)')
     result.append('{')
     result = result + decode_type(type)
     if type.cf_type is None:
@@ -1056,11 +1056,11 @@ def generate_one_impl(type, template_argument):
             result.append('    if (UNLIKELY(!decoder.isValid()))')
             result.append('        return std::nullopt;')
             if type.populate_from_empty_constructor and not type.has_optional_tuple_bits():
-                result.append('    ' + name_with_template + ' result;')
+                result.append(f'    {name_with_template} result;')
                 for member in type.serialized_members():
                     if member.condition is not None:
-                        result.append('#if ' + member.condition)
-                    result.append('    result.' + member.name + ' = WTFMove(*' + member.name + ');')
+                        result.append(f'#if {member.condition}')
+                    result.append(f'    result.{member.name} = WTFMove(*{member.name});')
                     if member.condition is not None:
                         result.append('#endif')
                 result.append('    return { WTFMove(result) };')
@@ -1095,8 +1095,8 @@ def generate_impl(serialized_types, serialized_enums, headers, generating_webkit
         if header.webkit_platform != generating_webkit_platform_impl:
             continue
         if header.condition is not None:
-            result.append('#if ' + header.condition)
-        result.append('#include ' + header.header)
+            result.append(f'#if {header.condition}')
+        result.append(f'#include {header.header}')
         if header.condition is not None:
             result.append('#endif')
     result.append('')
@@ -1135,21 +1135,21 @@ def generate_impl(serialized_types, serialized_enums, headers, generating_webkit
 
     for type in objc_wrapped_types:
         if type.condition is not None:
-            result.append('#if ' + type.condition)
-        result.append('template<> void encodeObjectDirectly<' + type.ns_type + '>(IPC::Encoder& encoder, ' + type.ns_type + ' *instance)')
+            result.append(f'#if {type.condition}')
+        result.append(f'template<> void encodeObjectDirectly<{type.ns_type}>(IPC::Encoder& encoder, {type.ns_type} *instance)')
         result.append('{')
-        result.append('    encoder << (instance ? std::optional(WebKit::' + type.wrapper + '(instance)) : std::nullopt);')
+        result.append(f'    encoder << (instance ? std::optional(WebKit::{type.wrapper}(instance)) : std::nullopt);')
         result.append('}')
         result.append('')
-        result.append('template<> std::optional<RetainPtr<id>> decodeObjectDirectlyRequiringAllowedClasses<' + type.ns_type + '>(IPC::Decoder& decoder)')
+        result.append(f'template<> std::optional<RetainPtr<id>> decodeObjectDirectlyRequiringAllowedClasses<{type.ns_type}>(IPC::Decoder& decoder)')
         result.append('{')
-        result.append('    auto result = decoder.decode<std::optional<WebKit::' + type.wrapper + '>>();')
+        result.append(f'    auto result = decoder.decode<std::optional<WebKit::{type.wrapper}>>();')
         result.append('    if (!result)')
         result.append('        return std::nullopt;')
         result.append('    return *result ? (*result)->toID() : nullptr;')
         result.append('}')
         if type.condition is not None:
-            result.append('#endif // ' + type.condition)
+            result.append(f'#endif // {type.condition}')
         result.append('')
 
     if not generating_webkit_platform_impl:
@@ -1173,15 +1173,15 @@ def generate_impl(serialized_types, serialized_enums, headers, generating_webkit
             continue
         result.append('')
         if type.condition is not None:
-            result.append('#if ' + type.condition)
-        result.append('template<> bool ' + type.function_name_for_enum() + '<IPC::' + type.subclass_enum_name() + ', void>(IPC::EncodedVariantIndex value)')
+            result.append(f'#if {type.condition}')
+        result.append(f'template<> bool {type.function_name_for_enum()}<IPC::{type.subclass_enum_name()}, void>(IPC::EncodedVariantIndex value)')
         result.append('{')
         result.append('IGNORE_WARNINGS_BEGIN("switch-unreachable")')
-        result.append('    switch (static_cast<IPC::' + type.subclass_enum_name() + '>(value)) {')
+        result.append(f'    switch (static_cast<IPC::{type.subclass_enum_name()}>(value)) {{')
         for member in type.members:
             if member.condition is not None:
-                result.append('#if ' + member.condition)
-            result.append('    case IPC::' + type.subclass_enum_name() + '::' + member.name + ':')
+                result.append(f'#if {member.condition}')
+            result.append(f'    case IPC::{type.subclass_enum_name()}::{member.name}:')
             if member.condition is not None:
                 result.append('#endif')
         result.append('        return true;')
@@ -1199,26 +1199,26 @@ def generate_impl(serialized_types, serialized_enums, headers, generating_webkit
             continue
         result.append('')
         if enum.condition is not None:
-            result.append('#if ' + enum.condition)
-        result.append('template<> bool ' + enum.function_name() + '<' + enum.namespace_and_name() + enum.additional_template_parameter() + '>(' + enum.parameter() + ' value)')
+            result.append(f'#if {enum.condition}')
+        result.append(f'template<> bool {enum.function_name()}<{enum.namespace_and_name()}{enum.additional_template_parameter()}>({enum.parameter()} value)')
         result.append('{')
         if enum.is_option_set():
-            result.append('    constexpr ' + enum.underlying_type + ' allValidBitsValue = 0')
+            result.append(f'    constexpr {enum.underlying_type} allValidBitsValue = 0')
             for i in range(0, len(enum.valid_values)):
                 valid_value = enum.valid_values[i]
                 if valid_value.condition is not None:
-                    result.append('#if ' + valid_value.condition)
-                result.append('        | static_cast<' + enum.underlying_type + '>(' + enum.namespace_and_name() + '::' + valid_value.name + ')')
+                    result.append(f'#if {valid_value.condition}')
+                result.append(f'        | static_cast<{enum.underlying_type}>({enum.namespace_and_name()}::{valid_value.name})')
                 if valid_value.condition is not None:
                     result.append('#endif')
             result.append('        | 0;')
             result.append('    return (value.toRaw() | allValidBitsValue) == allValidBitsValue;')
         else:
-            result.append('    switch (static_cast<' + enum.namespace_and_name() + '>(value)) {')
+            result.append(f'    switch (static_cast<{enum.namespace_and_name()}>(value)) {{')
             for valid_value in enum.valid_values:
                 if valid_value.condition is not None:
-                    result.append('#if ' + valid_value.condition)
-                result.append('    case ' + enum.namespace_and_name() + '::' + valid_value.name + ':')
+                    result.append(f'#if {valid_value.condition}')
+                result.append(f'    case {enum.namespace_and_name()}::{valid_value.name}:')
                 if valid_value.condition is not None:
                     result.append('#endif')
             result.append('        return true;')
@@ -1244,8 +1244,8 @@ def generate_optional_tuple_type_info(type):
     for i in range(1, len(serialized_members)):
         member = serialized_members[i]
         if member.condition is not None:
-            result.append('#if ' + member.condition)
-        result.append('                    "' + (', ' if i > 1 else '') + member.type + '"')
+            result.append(f'#if {member.condition}')
+        result.append(f'                    "{", " if i > 1 else ""}{member.type}"')
         if member.condition is not None:
             result.append('#endif')
     result.append('                ">"_s,')
@@ -1257,43 +1257,43 @@ def generate_optional_tuple_type_info(type):
 def generate_one_serialized_type_info(type):
     result = []
     if type.condition is not None:
-        result.append('#if ' + type.condition)
-    result.append('        { "' + type.name_declaration_for_serialized_type_info() + '"_s, {')
+        result.append(f'#if {type.condition}')
+    result.append(f'        {{ "{type.name_declaration_for_serialized_type_info()}"_s, {{')
     if type.members_are_subclasses:
         result.append('            { "std::variant<"')
         for i in range(len(type.members)):
             member = type.members[i]
             if member.condition is not None:
-                result.append('#if ' + member.condition)
-            result.append('                "' + ('' if i == 0 else ', ') + member.namespace + '::' + member.name + '"')
+                result.append(f'#if {member.condition}')
+            result.append(f'                "{"" if i == 0 else ", "}{member.namespace}::{member.name}"')
             if member.condition is not None:
                 result.append('#endif')
         result.append('            ">"_s, "subclasses"_s }')
         result.append('        } },')
         if type.condition is not None:
-            result.append('#endif // ' + type.condition)
+            result.append(f'#endif // {type.condition}')
         return result
 
     if type.cf_type is not None:
-        result.append('            { "' + type.namespace_if_not_wtf_and_name() + '"_s, "wrapper"_s }')
+        result.append(f'            {{ "{type.namespace_if_not_wtf_and_name()}"_s, "wrapper"_s }}')
         result.append('        } },')
         if type.condition is not None:
-            result.append('#endif // ' + type.condition)
+            result.append(f'#endif // {type.condition}')
         return result
 
     if type.is_webkit_secure_coding_type():
         for member in type.dictionary_members:
             if member.condition is not None:
-                result.append('#if ' + member.condition)
-            result.append('            { "' + member.dictionary_type() + '"_s , "' + member.type + '"_s },')
+                result.append(f'#if {member.condition}')
+            result.append(f'            {{ "{member.dictionary_type()}"_s , "{member.type}"_s }},')
             if member.condition is not None:
-                result.append('#endif // ' + member.condition)
+                result.append(f'#endif // {member.condition}')
         result.append('        } },')
-        result.append('        { "' + type.name + '"_s, {')
-        result.append('            { "' + type.namespace_if_not_wtf_and_name() + '"_s, "wrapper"_s }')
+        result.append(f'        {{ "{type.name}"_s, {{')
+        result.append(f'            {{ "{type.namespace_if_not_wtf_and_name()}"_s, "wrapper"_s }}')
         result.append('        } },')
         if type.condition is not None:
-            result.append('#endif // ' + type.condition)
+            result.append(f'#endif // {type.condition}')
         return result
 
     serialized_members = type.members_for_serialized_type_info()
@@ -1305,13 +1305,13 @@ def generate_one_serialized_type_info(type):
     optional_tuple_state = None
     for member in serialized_members:
         if member.condition is not None:
-            result.append('#if ' + member.condition)
+            result.append(f'#if {member.condition}')
         if member.optional_tuple_bits():
             result.append('            {')
             result.append('                "OptionalTuple<"')
             optional_tuple_state = 'begin'
         elif member.optional_tuple_bit():
-            result.append('                    "' + ('' if optional_tuple_state == 'begin' else ', ') + member.type + '"')
+            result.append(f'                    "{"" if optional_tuple_state == "begin" else ", "}{member.type}"')
             optional_tuple_state = 'middle'
         else:
             if optional_tuple_state == 'middle':
@@ -1320,8 +1320,8 @@ def generate_one_serialized_type_info(type):
                 result.append('            },')
                 optional_tuple_state = None
             result.append('            {')
-            result.append('                "' + member.type + '"_s,')
-            result.append('                "' + member.name + '"_s')
+            result.append(f'                "{member.type}"_s,')
+            result.append(f'                "{member.name}"_s')
             result.append('            },')
             optional_tuple_state = None
         if 'EncodeRequestBody' in member.attributes:
@@ -1337,7 +1337,7 @@ def generate_one_serialized_type_info(type):
         result.append('            },')
     result.append('        } },')
     if type.condition is not None:
-        result.append('#endif // ' + type.condition)
+        result.append(f'#endif // {type.condition}')
     return result
 
 
@@ -1345,8 +1345,8 @@ def output_sorted_headers(sorted_headers):
     result = []
     for header in sorted_headers:
         if header.condition is not None:
-            result.append('#if ' + header.condition)
-        result.append('#include ' + header.header)
+            result.append(f'#if {header.condition}')
+        result.append(f'#include {header.header}')
         if header.condition is not None:
             result.append('#endif')
     return result
@@ -1367,8 +1367,8 @@ def generate_serialized_type_info(serialized_types, serialized_enums, headers, u
     result.append('')
     for using_statement in using_statements:
         if using_statement.condition is not None:
-            result.append('#if ' + using_statement.condition)
-        result.append('static_assert(std::is_same_v<' + using_statement.name + ', ' + using_statement.alias + '>);')
+            result.append(f'#if {using_statement.condition}')
+        result.append(f'static_assert(std::is_same_v<{using_statement.name}, {using_statement.alias}>);')
         if using_statement.condition is not None:
             result.append('#endif')
 
@@ -1390,17 +1390,17 @@ def generate_serialized_type_info(serialized_types, serialized_enums, headers, u
 
     for type in objc_wrapped_types:
         if type.condition is not None:
-            result.append('#if ' + type.condition)
-        result.append('        { "' + type.ns_type + '"_s, {')
-        result.append('            { "WebKit::' + type.wrapper + '"_s, "wrapper"_s }')
+            result.append(f'#if {type.condition}')
+        result.append(f'        {{ "{type.ns_type}"_s, {{')
+        result.append(f'            {{ "WebKit::{type.wrapper}"_s, "wrapper"_s }}')
         result.append('        } },')
         if type.condition is not None:
-            result.append('#endif // ' + type.condition)
+            result.append(f'#endif // {type.condition}')
     for using_statement in using_statements:
         if using_statement.condition is not None:
-            result.append('#if ' + using_statement.condition)
-        result.append('        { "' + using_statement.name + '"_s, {')
-        result.append('            { "' + using_statement.alias + '"_s, "alias"_s }')
+            result.append(f'#if {using_statement.condition}')
+        result.append(f'        {{ "{using_statement.name}"_s, {{')
+        result.append(f'            {{ "{using_statement.alias}"_s, "alias"_s }}')
         result.append('        } },')
         if using_statement.condition is not None:
             result.append('#endif')
@@ -1412,15 +1412,15 @@ def generate_serialized_type_info(serialized_types, serialized_enums, headers, u
     result.append('    return {')
     for enum in serialized_enums:
         if enum.condition is not None:
-            result.append('#if ' + enum.condition)
-        result.append('        { "' + enum.namespace_and_name() + '"_s, sizeof(' + enum.namespace_and_name() + '), ' + ('true' if enum.is_option_set() else 'false') + ', {')
+            result.append(f'#if {enum.condition}')
+        result.append(f'        {{ "{enum.namespace_and_name()}"_s, sizeof({enum.namespace_and_name()}), {"true" if enum.is_option_set() else "false"}, {{')
         if enum.underlying_type == 'bool':
             result.append('            0, 1')
         else:
             for valid_value in enum.valid_values:
                 if valid_value.condition is not None:
-                    result.append('#if ' + valid_value.condition)
-                result.append('            enumValueForIPCTestAPI(' + enum.namespace_and_name() + '::' + valid_value.name + '),')
+                    result.append(f'#if {valid_value.condition}')
+                result.append(f'            enumValueForIPCTestAPI({enum.namespace_and_name()}::{valid_value.name}),')
                 if valid_value.condition is not None:
                     result.append('#endif')
         result.append('        } },')
@@ -1519,13 +1519,13 @@ def parse_serialized_types(file):
                 serialized_types.append(type)
                 if namespace is not None and (attributes is None or ('CustomHeader' not in attributes and 'Nested' not in attributes)):
                     if namespace == 'WebKit' or namespace == 'WebKit::WebPushD':
-                        headers.append(ConditionalHeader('"' + name + '.h"', type_condition))
+                        headers.append(ConditionalHeader(f'"{name}.h"', type_condition))
                     elif namespace == 'WTF':
-                        headers.append(ConditionalHeader('<wtf/' + name + '.h>', type_condition))
+                        headers.append(ConditionalHeader(f'<wtf/{name}.h>', type_condition))
                     elif namespace == 'WebKit::WebGPU':
-                        headers.append(ConditionalHeader('"WebGPU' + name + '.h"', type_condition))
+                        headers.append(ConditionalHeader(f'"WebGPU{name}.h"', type_condition))
                     else:
-                        headers.append(ConditionalHeader('<' + namespace + '/' + name + '.h>', type_condition))
+                        headers.append(ConditionalHeader(f'<{namespace}/{name}.h>', type_condition))
             attributes = None
             namespace = None
             name = None
@@ -1786,20 +1786,20 @@ def generate_webkit_secure_coding_impl(serialized_types, headers):
         if not type.is_webkit_secure_coding_type():
             continue
         if type.condition is not None:
-            result.append('#if ' + type.condition)
+            result.append(f'#if {type.condition}')
 
-        result.append(type.cpp_struct_or_class_name() + '::' + type.cpp_struct_or_class_name() + '(')
+        result.append(f'{type.cpp_struct_or_class_name()}::{type.cpp_struct_or_class_name()}(')
         for i in range(len(type.dictionary_members)):
             member = type.dictionary_members[i]
-            result.append('    ' + member.dictionary_type() + '&& ' + member.type + (',' if i < len(type.dictionary_members) - 1 else ''))
+            result.append(f'    {member.dictionary_type()}&& {member.type}{"," if i < len(type.dictionary_members) - 1 else ""}')
         result.append(')')
         for i in range(len(type.dictionary_members)):
             member = type.dictionary_members[i]
-            result.append('    ' + (':' if i == 0 else ',') + ' m_' + member.type + '(WTFMove(' + member.type + '))')
+            result.append(f'    {":" if i == 0 else ","} m_{member.type}(WTFMove({member.type}))')
         result.append('{')
         result.append('}')
         result.append('')
-        result.append(type.cpp_struct_or_class_name() + '::' + type.cpp_struct_or_class_name() + '(' + type.name + ' *object)')
+        result.append(f'{type.cpp_struct_or_class_name()}::{type.cpp_struct_or_class_name()}({type.name} *object)')
         result.append('{')
         useWKKeyedCoderOnly = type.support_wkkeyedcoder and type.custom_secure_coding_class is None
         if useWKKeyedCoderOnly:
@@ -1810,57 +1810,57 @@ def generate_webkit_secure_coding_impl(serialized_types, headers):
             if member.has_container_contents():
                 if member.value_is_optional():
                     if member.dictionary_contents() is not None:
-                        result.append('    m_' + member.type + ' = optionalVectorFromDictionary<' + member.dictionary_contents() + '>((' + member.ns_type_pointer() + ')[dictionary objectForKey:@"' + member.type + '"]);')
+                        result.append(f'    m_{member.type} = optionalVectorFromDictionary<{member.dictionary_contents()}>(({member.ns_type_pointer()})[dictionary objectForKey:@"{member.type}"]);')
                     if member.array_contents() is not None:
-                        result.append('    m_' + member.type + ' = optionalVectorFromArray<' + member.array_contents() + '>((' + member.ns_type_pointer() + ')[dictionary objectForKey:@"' + member.type + '"]);')
+                        result.append(f'    m_{member.type} = optionalVectorFromArray<{member.array_contents()}>(({member.ns_type_pointer()})[dictionary objectForKey:@"{member.type}"]);')
                 else:
                     if member.dictionary_contents() is not None:
-                        result.append('    m_' + member.type + ' = vectorFromDictionary<' + member.dictionary_contents() + '>((' + member.ns_type_pointer() + ')[dictionary objectForKey:@"' + member.type + '"]);')
+                        result.append(f'    m_{member.type} = vectorFromDictionary<{member.dictionary_contents()}>(({member.ns_type_pointer()})[dictionary objectForKey:@"{member.type}"]);')
                     if member.array_contents() is not None:
-                        result.append('    m_' + member.type + ' = vectorFromArray<' + member.array_contents() + '>((' + member.ns_type_pointer() + ')[dictionary objectForKey:@"' + member.type + '"]);')
+                        result.append(f'    m_{member.type} = vectorFromArray<{member.array_contents()}>(({member.ns_type_pointer()})[dictionary objectForKey:@"{member.type}"]);')
             else:
-                result.append('    m_' + member.type + ' = (' + member.ns_type_pointer() + ')[dictionary objectForKey:@"' + member.type + '"];')
-                result.append('    if (!' + member.type_check() + ')')
-                result.append('        m_' + member.type + ' = nullptr;')
+                result.append(f'    m_{member.type} = ({member.ns_type_pointer()})[dictionary objectForKey:@"{member.type}"];')
+                result.append(f'    if (!{member.type_check()})')
+                result.append(f'        m_{member.type} = nullptr;')
                 # FIXME: We ought to be able to ASSERT_NOT_REACHED() here once all the question marks are in the right places.
                 result.append('')
         result.append('}')
         result.append('')
-        result.append('RetainPtr<id> ' + type.cpp_struct_or_class_name() + '::toID() const')
+        result.append(f'RetainPtr<id> {type.cpp_struct_or_class_name()}::toID() const')
         result.append('{')
-        result.append('    auto propertyList = [NSMutableDictionary dictionaryWithCapacity:' + str(len(type.dictionary_members)) + '];')
+        result.append(f'    auto propertyList = [NSMutableDictionary dictionaryWithCapacity:{str(len(type.dictionary_members))}];')
         for member in type.dictionary_members:
             if not member.has_container_contents():
-                result.append('    if (m_' + member.type + ')')
-                result.append('        propertyList[@"' + member.type + '"] = ' + member.id_cast() + 'm_' + member.type + '.get();')
+                result.append(f'    if (m_{member.type})')
+                result.append(f'        propertyList[@"{member.type}"] = {member.id_cast()}m_{member.type}.get();')
         for member in type.dictionary_members:
             if member.value_is_optional():
                 if member.dictionary_contents() is not None:
-                    result.append('    if (auto dictionary = dictionaryFromOptionalVector(m_' + member.type + '))')
-                    result.append('        propertyList[@"' + member.type + '"] = dictionary.get();')
+                    result.append(f'    if (auto dictionary = dictionaryFromOptionalVector(m_{member.type}))')
+                    result.append(f'        propertyList[@"{member.type}"] = dictionary.get();')
                 if member.array_contents() is not None:
-                    result.append('    if (auto array = arrayFromOptionalVector(m_' + member.type + '))')
-                    result.append('        propertyList[@"' + member.type + '"] = array.get();')
+                    result.append(f'    if (auto array = arrayFromOptionalVector(m_{member.type}))')
+                    result.append(f'        propertyList[@"{member.type}"] = array.get();')
             else:
                 if member.dictionary_contents() is not None:
-                    result.append('    propertyList[@"' + member.type + '"] = dictionaryFromVector(m_' + member.type + ').get();')
+                    result.append(f'    propertyList[@"{member.type}"] = dictionaryFromVector(m_{member.type}).get();')
                 if member.array_contents() is not None:
-                    result.append('    propertyList[@"' + member.type + '"] = arrayFromVector(m_' + member.type + ').get();')
+                    result.append(f'    propertyList[@"{member.type}"] = arrayFromVector(m_{member.type}).get();')
         type_name = type.name
         if type.custom_secure_coding_class is not None:
             type_name = type.custom_secure_coding_class
         if not type.support_wkkeyedcoder:
-            result.append('    RELEASE_ASSERT([' + type_name + ' instancesRespondToSelector:@selector(_initWithWebKitPropertyListData:)]);')
+            result.append(f'    RELEASE_ASSERT([{type_name} instancesRespondToSelector:@selector(_initWithWebKitPropertyListData:)]);')
         if not useWKKeyedCoderOnly:
-            result.append('    if ([' + type_name + ' instancesRespondToSelector:@selector(_initWithWebKitPropertyListData:)])')
-            result.append('        return adoptNS([[' + type_name + ' alloc] _initWithWebKitPropertyListData:propertyList]);')
+            result.append(f'    if ([{type_name} instancesRespondToSelector:@selector(_initWithWebKitPropertyListData:)])')
+            result.append(f'        return adoptNS([[{type_name} alloc] _initWithWebKitPropertyListData:propertyList]);')
         result.append('')
         result.append('    auto unarchiver = adoptNS([[WKKeyedCoder alloc] initWithDictionary:propertyList]);')
-        result.append('    return adoptNS([[' + type_name + ' alloc] initWithCoder:unarchiver.get()]);')
+        result.append(f'    return adoptNS([[{type_name} alloc] initWithCoder:unarchiver.get()]);')
         result.append('}')
 
         if type.condition is not None:
-            result.append('#endif // ' + type.condition)
+            result.append(f'#endif // {type.condition}')
         result.append('')
     result.append('} // namespace WebKit')
     result.append('')
@@ -1881,8 +1881,8 @@ def generate_webkit_secure_coding_header(serialized_types):
         if not type.is_webkit_secure_coding_type():
             continue
         if type.condition is not None:
-            result.append('#if ' + type.condition)
-        result.append('OBJC_CLASS ' + type.name + ';')
+            result.append(f'#if {type.condition}')
+        result.append(f'OBJC_CLASS {type.name};')
         if type.condition is not None:
             result.append('#endif')
 
@@ -1893,26 +1893,26 @@ def generate_webkit_secure_coding_header(serialized_types):
             continue
         result.append('')
         if type.condition is not None:
-            result.append('#if ' + type.condition)
-        result.append('class ' + type.cpp_struct_or_class_name() + ' {')
+            result.append(f'#if {type.condition}')
+        result.append(f'class {type.cpp_struct_or_class_name()} {{')
         result.append('public:')
-        result.append('    ' + type.cpp_struct_or_class_name() + '(' + type.name + ' *);')
-        result.append('    ' + type.cpp_struct_or_class_name() + '(const RetainPtr<' + type.name + '>& object)')
-        result.append('        : ' + type.cpp_struct_or_class_name() + '(object.get()) { }')
+        result.append(f'    {type.cpp_struct_or_class_name()}({type.name} *);')
+        result.append(f'    {type.cpp_struct_or_class_name()}(const RetainPtr<{type.name}>& object)')
+        result.append(f'        : {type.cpp_struct_or_class_name()}(object.get()) {{ }}')
         result.append('')
         result.append('    RetainPtr<id> toID() const;')
         result.append('')
         result.append('private:')
-        result.append('    friend struct IPC::ArgumentCoder<' + type.cpp_struct_or_class_name() + ', void>;')
+        result.append(f'    friend struct IPC::ArgumentCoder<{type.cpp_struct_or_class_name()}, void>;')
         result.append('')
-        result.append('    ' + type.cpp_struct_or_class_name() + '(')
+        result.append(f'    {type.cpp_struct_or_class_name()}(')
         for i in range(len(type.dictionary_members)):
             member = type.dictionary_members[i]
-            result.append('        ' + member.dictionary_type() + '&&' + (',' if i < len(type.dictionary_members) - 1 else ''))
+            result.append(f'        {member.dictionary_type()}&&{"," if i < len(type.dictionary_members) - 1 else ""}')
         result.append('    );')
         result.append('')
         for member in type.dictionary_members:
-            result.append('    ' + member.dictionary_type() + ' m_' + member.type + ';')
+            result.append(f'    {member.dictionary_type()} m_{member.type};')
         result.append('};')
         if type.condition is not None:
             result.append('#endif')


### PR DESCRIPTION
#### d9fa83910b5b66881ba812309cfc5acd3c7de10d
<pre>
generate-serializers.py: Use more f-strings
<a href="https://bugs.webkit.org/show_bug.cgi?id=283960">https://bugs.webkit.org/show_bug.cgi?id=283960</a>

Reviewed by Alex Christensen.

Use more f-strings to concatenate strings and variables.
&lt;<a href="https://docs.python.org/3.9/reference/lexical_analysis.html#formatted-string-literals">https://docs.python.org/3.9/reference/lexical_analysis.html#formatted-string-literals</a>&gt;

`{` and `}` have to be encoded as `{{` and `}}`.

* Source/WebKit/Scripts/generate-serializers.py:
(Template.forward_declaration):
(Template.specialization):
(SerializedType.namespace_and_name):
(SerializedType.namespace_if_not_wtf_and_name):
(SerializedType.namespace_and_name_for_construction):
(SerializedType.cf_wrapper_type):
(SerializedType.name_declaration_for_serialized_type_info):
(SerializedType.subclass_enum_name):
(SerializedType.cpp_struct_or_class_name):
(SerializedEnum.namespace_and_name):
(SerializedEnum.parameter):
(MemberVariable.__init__):
(MemberVariable.ns_type_pointer):
(MemberVariable.type_check):
(MemberVariable.dictionary_type):
(one_argument_coder_declaration_cf):
(one_argument_coder_declaration):
(generate_forward_declarations):
(generate_header):
(check_type_members):
(check_type_members.is):
(encode_cf_type):
(encode_type):
(decode_cf_type):
(decode_type):
(construct_type):
(generate_one_impl):
(generate_impl):
(generate_optional_tuple_type_info):
(generate_one_serialized_type_info):
(output_sorted_headers):
(generate_serialized_type_info):
(parse_serialized_types):
(generate_webkit_secure_coding_impl):
(generate_webkit_secure_coding_header):

Canonical link: <a href="https://commits.webkit.org/287306@main">https://commits.webkit.org/287306@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6b5652b90c2dddd9a253deaaa89ea8c944e3e70

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79023 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58059 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32400 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83663 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30238 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67168 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6329 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61850 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19766 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82090 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51889 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72030 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42154 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/78533 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49240 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28603 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70355 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26528 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85049 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6348 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4383 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70083 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6512 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67903 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69333 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13381 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12147 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12214 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6300 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12142 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6260 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9712 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8052 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->