### PR TITLE
[rhythmic-sizing] Add block-step-round to CSS parser

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -39,6 +39,7 @@ PASS block-ellipsis
 PASS block-size
 PASS block-step-align
 PASS block-step-insert
+PASS block-step-round
 PASS block-step-size
 PASS border-block-end-color
 PASS border-block-end-style

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-round-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-round-computed-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Property block-step-round value 'up'
+PASS Property block-step-round value 'down'
+PASS Property block-step-round value 'nearest'
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-round-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-round-computed.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Rhythm: block-step-round computed values</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-round">
+<meta name="assert" content="Checking computed values for block-step-round">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+    test_computed_value("block-step-round", "up");
+    test_computed_value("block-step-round", "down");
+    test_computed_value("block-step-round", "nearest");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-round-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-round-invalid-expected.txt
@@ -1,0 +1,20 @@
+
+PASS e.style['block-step-align'] = "up up" should not set the property value
+PASS e.style['block-step-align'] = "up down" should not set the property value
+PASS e.style['block-step-align'] = "up nearest" should not set the property value
+PASS e.style['block-step-align'] = "down down" should not set the property value
+PASS e.style['block-step-align'] = "down up" should not set the property value
+PASS e.style['block-step-align'] = "down nearest" should not set the property value
+PASS e.style['block-step-align'] = "nearest nearest" should not set the property value
+PASS e.style['block-step-align'] = "nearest up" should not set the property value
+PASS e.style['block-step-align'] = "nearest down" should not set the property value
+PASS e.style['block-step-align'] = "-1px" should not set the property value
+PASS e.style['block-step-align'] = "min-content" should not set the property value
+PASS e.style['block-step-align'] = "10%" should not set the property value
+PASS e.style['block-step-align'] = "20" should not set the property value
+PASS e.style['block-step-align'] = "none" should not set the property value
+PASS e.style['block-step-align'] = "border-box" should not set the property value
+PASS e.style['block-step-align'] = "margin" should not set the property value
+PASS e.style['block-step-align'] = "padding" should not set the property value
+PASS e.style['block-step-align'] = "content" should not set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-round-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-round-invalid.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Rhythm: block-step-round invalid values</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-round">
+<meta name="assert" content="Invalid values for block-step-round should not be parsed">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+    test_invalid_value("block-step-align", "up up");
+    test_invalid_value("block-step-align", "up down");
+    test_invalid_value("block-step-align", "up nearest");
+    test_invalid_value("block-step-align", "down down");
+    test_invalid_value("block-step-align", "down up");
+    test_invalid_value("block-step-align", "down nearest");
+    test_invalid_value("block-step-align", "nearest nearest");
+    test_invalid_value("block-step-align", "nearest up");
+    test_invalid_value("block-step-align", "nearest down");
+    test_invalid_value("block-step-align", "-1px");
+    test_invalid_value("block-step-align", "min-content");
+    test_invalid_value("block-step-align", "10%");
+    test_invalid_value("block-step-align", "20");
+    test_invalid_value("block-step-align", "none");
+    test_invalid_value("block-step-align", "border-box");
+    test_invalid_value('block-step-align', "margin");
+    test_invalid_value("block-step-align", "padding")
+    test_invalid_value("block-step-align", "content")
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-round-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-round-valid-expected.txt
@@ -1,0 +1,5 @@
+
+PASS e.style['block-step-round'] = "up" should set the property value
+PASS e.style['block-step-round'] = "down" should set the property value
+PASS e.style['block-step-round'] = "nearest" should set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-round-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-round-valid.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Rhythm: block-step-round valid values</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-round">
+<meta name="assert" content="Parsing valid values for block-step-round property">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+    test_valid_value("block-step-round", "up");
+    test_valid_value("block-step-round", "down");
+    test_valid_value("block-step-round", "nearest");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-001-expected.txt
@@ -57,6 +57,13 @@ PASS block-step-insert: "content-box" onto "margin-box"
 PASS block-step-insert: "margin-box" onto "content-box"
 PASS block-step-insert: "content-box" onto "padding-box"
 PASS block-step-insert: "padding-box" onto "content-box"
+PASS block-step-round (type: discrete) has testAccumulation function
+PASS block-step-round: "down" onto "up"
+PASS block-step-round: "up" onto "down"
+PASS block-step-round: "nearest" onto "down"
+PASS block-step-round: "down" onto "nearest"
+PASS block-step-round: "up" onto "nearest"
+PASS block-step-round: "nearest" onto "up"
 PASS block-step-size (type: length) has testAccumulation function
 PASS block-step-size: length
 PASS block-step-size: length of rem

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-001-expected.txt
@@ -57,6 +57,13 @@ PASS block-step-insert: "content-box" onto "margin-box"
 PASS block-step-insert: "margin-box" onto "content-box"
 PASS block-step-insert: "content-box" onto "padding-box"
 PASS block-step-insert: "padding-box" onto "content-box"
+PASS block-step-round (type: discrete) has testAddition function
+PASS block-step-round: "down" onto "up"
+PASS block-step-round: "up" onto "down"
+PASS block-step-round: "nearest" onto "down"
+PASS block-step-round: "down" onto "nearest"
+PASS block-step-round: "up" onto "nearest"
+PASS block-step-round: "nearest" onto "up"
 PASS block-step-size (type: length) has testAddition function
 PASS block-step-size: length
 PASS block-step-size: length of rem

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001-expected.txt
@@ -75,6 +75,16 @@ PASS block-step-insert uses discrete animation when animating between "margin-bo
 PASS block-step-insert uses discrete animation when animating between "padding-box" and "content-box" with linear easing
 PASS block-step-insert uses discrete animation when animating between "padding-box" and "content-box" with effect easing
 PASS block-step-insert uses discrete animation when animating between "padding-box" and "content-box" with keyframe easing
+PASS block-step-round (type: discrete) has testInterpolation function
+PASS block-step-round uses discrete animation when animating between "up" and "down" with linear easing
+PASS block-step-round uses discrete animation when animating between "up" and "down" with effect easing
+PASS block-step-round uses discrete animation when animating between "up" and "down" with keyframe easing
+PASS block-step-round uses discrete animation when animating between "down" and "nearest" with linear easing
+PASS block-step-round uses discrete animation when animating between "down" and "nearest" with effect easing
+PASS block-step-round uses discrete animation when animating between "down" and "nearest" with keyframe easing
+PASS block-step-round uses discrete animation when animating between "nearest" and "up" with linear easing
+PASS block-step-round uses discrete animation when animating between "nearest" and "up" with effect easing
+PASS block-step-round uses discrete animation when animating between "nearest" and "up" with keyframe easing
 PASS block-step-size (type: length) has testInterpolation function
 PASS block-step-size supports animating as a length
 PASS block-step-size supports animating as a length of rem

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js
@@ -116,6 +116,12 @@ const gCSSProperties1 = {
       { type: 'discrete', options: [ [ 'margin-box', 'padding-box'], ['margin-box', 'content-box'], ['padding-box', 'content-box'] ] }
     ]
   },
+  'block-step-round': {
+    // https://drafts.csswg.org/css-rhythm/#block-step-round
+    types: [
+      { type: 'discrete', options: [ [ 'up', 'down'], ['down', 'nearest'], ['nearest', 'up'] ] }
+    ]
+  },
   'block-step-size': {
     // https://drafts.csswg.org/css-rhythm/#block-step-size
     types: [ 'length' ]

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -37,6 +37,7 @@ PASS block-size
 PASS block-step-align
 PASS block-step-insert
 PASS block-step-size
+PASS block-step-round
 PASS border-block-end-color
 PASS border-block-end-style
 PASS border-block-end-width

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -39,6 +39,7 @@ PASS block-ellipsis
 PASS block-size
 PASS block-step-align
 PASS block-step-insert
+PASS block-step-round
 PASS block-step-size
 PASS border-block-end-color
 PASS border-block-end-style

--- a/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -37,6 +37,7 @@ PASS block-ellipsis
 PASS block-size
 PASS block-step-align
 PASS block-step-insert
+PASS block-step-round
 PASS block-step-size
 PASS border-block-end-color
 PASS border-block-end-style

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -38,6 +38,7 @@ PASS block-ellipsis
 PASS block-size
 PASS block-step-align
 PASS block-step-insert
+PASS block-step-round
 PASS block-step-size
 PASS border-block-end-color
 PASS border-block-end-style

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -3941,6 +3941,7 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
 
         new DiscretePropertyWrapper<BlockStepAlign>(CSSPropertyBlockStepAlign, &RenderStyle::blockStepAlign, &RenderStyle::setBlockStepAlign),
         new DiscretePropertyWrapper<BlockStepInsert>(CSSPropertyBlockStepInsert, &RenderStyle::blockStepInsert, &RenderStyle::setBlockStepInsert),
+        new DiscretePropertyWrapper<BlockStepRound>(CSSPropertyBlockStepRound, &RenderStyle::blockStepRound, &RenderStyle::setBlockStepRound),
         new OptionalLengthPropertyWrapper(CSSPropertyBlockStepSize, &RenderStyle::blockStepSize, &RenderStyle::setBlockStepSize, { OptionalLengthPropertyWrapper::Flags::NegativeLengthsAreInvalid }),
 
         new ContainIntrinsicLengthPropertyWrapper(CSSPropertyContainIntrinsicWidth, &RenderStyle::containIntrinsicWidth, &RenderStyle::setContainIntrinsicWidth, &RenderStyle::containIntrinsicWidthType, &RenderStyle::setContainIntrinsicWidthType),

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -186,6 +186,12 @@ DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE
 #undef FOR_EACH
 
+#define TYPE BlockStepRound
+#define FOR_EACH(CASE) CASE(Up) CASE(Down) CASE(Nearest)
+DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
+#undef TYPE
+#undef FOR_EACH
+
 
 constexpr CSSValueID toCSSValueID(BorderStyle e)
 {

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -301,6 +301,22 @@
             },
             "status": "in development"
         },
+        "block-step-round": {
+            "values": [
+                "up",
+                "down",
+                "nearest"
+            ],
+            "codegen-properties": {
+                "settings-flag": "cssRhythmicSizingEnabled",
+                "parser-grammar": "<<values>>"
+            },
+            "specification": {
+                "category": "css-rhythm",
+                "url": "https://drafts.csswg.org/css-rhythm/#block-step-round"
+            },
+            "status": "in development"
+        },
         "block-step-size": {
             "codegen-properties": {
                 "settings-flag": "cssRhythmicSizingEnabled",

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -3583,31 +3583,11 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
         }
         return CSSPrimitiveValue::create(CSSValueNone);
     case CSSPropertyBlockStepAlign:
-        switch (style.blockStepAlign()) {
-        case BlockStepAlign::Auto:
-            return CSSPrimitiveValue::create(CSSValueAuto);
-        case BlockStepAlign::Center:
-            return CSSPrimitiveValue::create(CSSValueCenter);
-        case BlockStepAlign::Start:
-            return CSSPrimitiveValue::create(CSSValueStart);
-        case BlockStepAlign::End:
-            return CSSPrimitiveValue::create(CSSValueEnd);
-        default:
-            ASSERT_NOT_REACHED();
-            return CSSPrimitiveValue::create(CSSValueAuto);
-        }
+        return createConvertingToCSSValueID(style.blockStepAlign());
     case CSSPropertyBlockStepInsert:
-        switch (style.blockStepInsert()) {
-        case BlockStepInsert::MarginBox:
-            return CSSPrimitiveValue::create(CSSValueMarginBox);
-        case BlockStepInsert::PaddingBox:
-            return CSSPrimitiveValue::create(CSSValuePaddingBox);
-        case BlockStepInsert::ContentBox:
-            return CSSPrimitiveValue::create(CSSValueContentBox);
-        default:
-            ASSERT_NOT_REACHED();
-            return CSSPrimitiveValue::create(CSSValueMarginBox);
-        }
+        return createConvertingToCSSValueID(style.blockStepInsert());
+    case CSSPropertyBlockStepRound:
+        return createConvertingToCSSValueID(style.blockStepRound());
     case CSSPropertyBlockStepSize: {
         auto blockStepSize = style.blockStepSize();
         if (!blockStepSize)

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -1814,6 +1814,8 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
             changingProperties.m_properties.set(CSSPropertyBlockStepAlign);
         if (first.blockStepInsert != second.blockStepInsert)
             changingProperties.m_properties.set(CSSPropertyBlockStepInsert);
+        if (first.blockStepRound != second.blockStepRound)
+            changingProperties.m_properties.set(CSSPropertyBlockStepRound);
         if (first.blockStepSize != second.blockStepSize)
             changingProperties.m_properties.set(CSSPropertyBlockStepSize);
         if (first.containIntrinsicWidth != second.containIntrinsicWidth || first.containIntrinsicWidthType != second.containIntrinsicWidthType)

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -118,6 +118,7 @@ enum class BlendMode : uint8_t;
 enum class FlowDirection : uint8_t;
 enum class BlockStepAlign : uint8_t;
 enum class BlockStepInsert : uint8_t;
+enum class BlockStepRound : uint8_t;
 enum class BorderCollapse : bool;
 enum class BorderStyle : uint8_t;
 enum class BoxAlignment : uint8_t;
@@ -2263,6 +2264,11 @@ public:
     static constexpr BlockStepInsert initialBlockStepInsert();
     inline BlockStepInsert blockStepInsert() const;
     inline void setBlockStepInsert(BlockStepInsert);
+
+    static constexpr BlockStepRound initialBlockStepRound();
+    inline BlockStepRound blockStepRound() const;
+    inline void setBlockStepRound(BlockStepRound);
+
     bool scrollAnchoringSuppressionStyleDidChange(const RenderStyle*) const;
     bool outOfFlowPositionStyleDidChange(const RenderStyle*) const;
 

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -128,6 +128,16 @@ TextStream& operator<<(TextStream& ts, BlockStepInsert blockStepInsert)
     return ts;
 }
 
+TextStream& operator<<(TextStream& ts, BlockStepRound blockStepRound)
+{
+    switch (blockStepRound) {
+    case BlockStepRound::Up: ts << "up"; break;
+    case BlockStepRound::Down: ts << "down"; break;
+    case BlockStepRound::Nearest: ts << "nearest"; break;
+    }
+    return ts;
+}
+
 TextStream& operator<<(TextStream& ts, BorderCollapse collapse)
 {
     switch (collapse) {

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -1210,6 +1210,12 @@ enum class BlockStepInsert : uint8_t {
     ContentBox
 };
 
+enum class BlockStepRound : uint8_t {
+    Up,
+    Down,
+    Nearest
+};
+
 enum class FieldSizing : bool {
     Fixed,
     Content
@@ -1226,6 +1232,7 @@ WTF::TextStream& operator<<(WTF::TextStream&, AutoRepeatType);
 WTF::TextStream& operator<<(WTF::TextStream&, BackfaceVisibility);
 WTF::TextStream& operator<<(WTF::TextStream&, BlockStepAlign);
 WTF::TextStream& operator<<(WTF::TextStream&, BlockStepInsert);
+WTF::TextStream& operator<<(WTF::TextStream&, BlockStepRound);
 WTF::TextStream& operator<<(WTF::TextStream&, BorderCollapse);
 WTF::TextStream& operator<<(WTF::TextStream&, BorderStyle);
 WTF::TextStream& operator<<(WTF::TextStream&, BoxAlignment);

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -102,6 +102,7 @@ inline const Length& RenderStyle::backgroundYPosition() const { return backgroun
 inline const BlockEllipsis& RenderStyle::blockEllipsis() const { return m_rareInheritedData->blockEllipsis; }
 inline BlockStepAlign RenderStyle::blockStepAlign() const { return static_cast<BlockStepAlign>(m_nonInheritedData->rareData->blockStepAlign); }
 inline BlockStepInsert RenderStyle::blockStepInsert() const { return static_cast<BlockStepInsert>(m_nonInheritedData->rareData->blockStepInsert); }
+inline BlockStepRound RenderStyle::blockStepRound() const { return static_cast<BlockStepRound>(m_nonInheritedData->rareData->blockStepRound); }
 inline std::optional<Length> RenderStyle::blockStepSize() const { return m_nonInheritedData->rareData->blockStepSize; }
 inline const BorderData& RenderStyle::border() const { return m_nonInheritedData->surroundData->border; }
 inline const BorderValue& RenderStyle::borderBottom() const { return border().bottom(); }
@@ -340,6 +341,7 @@ inline Style::Color RenderStyle::initialBackgroundColor() { return Color::transp
 inline BlockEllipsis RenderStyle::initialBlockEllipsis() { return { }; }
 constexpr BlockStepAlign RenderStyle::initialBlockStepAlign() { return BlockStepAlign::Auto; }
 constexpr BlockStepInsert RenderStyle::initialBlockStepInsert() { return BlockStepInsert::MarginBox; }
+constexpr BlockStepRound RenderStyle::initialBlockStepRound() { return BlockStepRound::Up; }
 inline std::optional<Length> RenderStyle::initialBlockStepSize() { return std::nullopt; }
 constexpr BorderCollapse RenderStyle::initialBorderCollapse() { return BorderCollapse::Separate; }
 inline LengthSize RenderStyle::initialBorderRadius() { return { zeroLength(), zeroLength() }; }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -92,6 +92,7 @@ inline void RenderStyle::setBackgroundRepeat(FillRepeatXY fillRepeat) { SET_DOUB
 inline void RenderStyle::setBlockEllipsis(const BlockEllipsis& value) { SET(m_rareInheritedData, blockEllipsis, value); }
 inline void RenderStyle::setBlockStepAlign(BlockStepAlign value) { SET_NESTED(m_nonInheritedData, rareData, blockStepAlign, static_cast<unsigned>(value)); }
 inline void RenderStyle::setBlockStepInsert(BlockStepInsert value) { SET_NESTED(m_nonInheritedData, rareData, blockStepInsert, static_cast<unsigned>(value)); }
+inline void RenderStyle::setBlockStepRound(BlockStepRound value) { SET_NESTED(m_nonInheritedData, rareData, blockStepRound, static_cast<unsigned>(value)); }
 inline void RenderStyle::setBlockStepSize(std::optional<Length> length) { SET_NESTED(m_nonInheritedData, rareData, blockStepSize, WTFMove(length)); }
 inline void RenderStyle::setBorderBottomColor(const Style::Color& value) { SET_NESTED_BORDER_COLOR(m_nonInheritedData, surroundData, border.m_bottom, value); }
 inline void RenderStyle::setBorderBottomLeftRadius(LengthSize&& size) { SET_NESTED(m_nonInheritedData, surroundData, border.m_radii.bottomLeft, WTFMove(size)); }

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
@@ -103,6 +103,7 @@ StyleRareNonInheritedData::StyleRareNonInheritedData()
     , blockStepSize(RenderStyle::initialBlockStepSize())
     , blockStepAlign(static_cast<unsigned>(RenderStyle::initialBlockStepAlign()))
     , blockStepInsert(static_cast<unsigned>(RenderStyle::initialBlockStepInsert()))
+    , blockStepRound(static_cast<unsigned>(RenderStyle::initialBlockStepRound()))
     , overscrollBehaviorX(static_cast<unsigned>(RenderStyle::initialOverscrollBehaviorX()))
     , overscrollBehaviorY(static_cast<unsigned>(RenderStyle::initialOverscrollBehaviorY()))
     , pageSizeType(static_cast<unsigned>(PageSizeType::Auto))
@@ -201,6 +202,7 @@ inline StyleRareNonInheritedData::StyleRareNonInheritedData(const StyleRareNonIn
     , blockStepSize(o.blockStepSize)
     , blockStepAlign(o.blockStepAlign)
     , blockStepInsert(o.blockStepInsert)
+    , blockStepRound(o.blockStepRound)
     , overscrollBehaviorX(o.overscrollBehaviorX)
     , overscrollBehaviorY(o.overscrollBehaviorY)
     , pageSizeType(o.pageSizeType)
@@ -304,6 +306,7 @@ bool StyleRareNonInheritedData::operator==(const StyleRareNonInheritedData& o) c
         && blockStepSize == o.blockStepSize
         && blockStepAlign == o.blockStepAlign
         && blockStepInsert == o.blockStepInsert
+        && blockStepRound == o.blockStepRound
         && overscrollBehaviorX == o.overscrollBehaviorX
         && overscrollBehaviorY == o.overscrollBehaviorY
         && pageSizeType == o.pageSizeType
@@ -456,6 +459,7 @@ void StyleRareNonInheritedData::dumpDifferences(TextStream& ts, const StyleRareN
 
     LOG_IF_DIFFERENT_WITH_CAST(BlockStepAlign, blockStepAlign);
     LOG_IF_DIFFERENT_WITH_CAST(BlockStepInsert, blockStepInsert);
+    LOG_IF_DIFFERENT_WITH_CAST(BlockStepRound, blockStepRound);
 
     LOG_IF_DIFFERENT_WITH_CAST(OverscrollBehavior, overscrollBehaviorX);
     LOG_IF_DIFFERENT_WITH_CAST(OverscrollBehavior, overscrollBehaviorY);

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -215,6 +215,7 @@ public:
     std::optional<Length> blockStepSize;
     unsigned blockStepAlign : 2; // BlockStepAlign
     unsigned blockStepInsert : 2; // BlockStepInsert
+    unsigned blockStepRound : 2; // BlockStepRound
 
     unsigned overscrollBehaviorX : 2; // OverscrollBehavior
     unsigned overscrollBehaviorY : 2; // OverscrollBehavior


### PR DESCRIPTION
#### b0dd16149d4e384b5f3b473274f98030e2c74c78
<pre>
[rhythmic-sizing] Add block-step-round to CSS parser
<a href="https://bugs.webkit.org/show_bug.cgi?id=252208">https://bugs.webkit.org/show_bug.cgi?id=252208</a>
<a href="https://rdar.apple.com/105421820">rdar://105421820</a>

Reviewed by Antti Koivisto.

Parse block-step-round according to: <a href="https://drafts.csswg.org/css-rhythm/#block-step-round">https://drafts.csswg.org/css-rhythm/#block-step-round</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-round-computed-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-round-computed.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-round-invalid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-round-invalid.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-round-valid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-round-valid.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle const):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::conservativelyCollectChangedAnimatableProperties const):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::blockStepRound const):
(WebCore::RenderStyle::initialBlockStepRound):
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setBlockStepRound):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp:
(WebCore::StyleRareNonInheritedData::StyleRareNonInheritedData):
(WebCore::StyleRareNonInheritedData::operator== const):
(WebCore::StyleRareNonInheritedData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:

Canonical link: <a href="https://commits.webkit.org/287285@main">https://commits.webkit.org/287285@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/553bc5f4d6826f9cd38409e22257d72d0f0b996c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79017 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58053 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32394 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83657 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30232 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81150 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67162 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6323 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61847 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19764 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82084 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51883 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72027 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42151 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49234 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26108 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28597 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70348 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26524 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; 22 flakes") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85043 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6342 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4379 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70084 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6506 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67900 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69334 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/17284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13376 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12142 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12201 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6294 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12139 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6254 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9706 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8046 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->