### PR TITLE
[XR] Fix a typo in a PlatformXR variable name

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXRInputSource.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRInputSource.cpp
@@ -105,7 +105,7 @@ void WebXRInputSource::update(double timestamp, const PlatformXR::FrameData::Inp
 
 bool WebXRInputSource::requiresInputSourceChange(const InputSource& source)
 {
-    return m_source.handeness != source.handeness
+    return m_source.handedness != source.handedness
         || m_source.targetRayMode != source.targetRayMode
         || m_source.profiles != source.profiles
         || static_cast<bool>(m_gripSpace) != source.gripOrigin.has_value();

--- a/Source/WebCore/Modules/webxr/WebXRInputSource.h
+++ b/Source/WebCore/Modules/webxr/WebXRInputSource.h
@@ -63,7 +63,7 @@ public:
     ~WebXRInputSource();
 
     PlatformXR::InputSourceHandle handle() const { return m_source.handle; }
-    XRHandedness handedness() const { return m_source.handeness; }
+    XRHandedness handedness() const { return m_source.handedness; }
     XRTargetRayMode targetRayMode() const { return m_source.targetRayMode; };
     const WebXRSpace& targetRaySpace() const {return m_targetRaySpace.get(); };
     WebXRSpace* gripSpace() const { return m_gripSpace.get(); }

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -333,7 +333,7 @@ struct FrameData {
 
     struct InputSource {
         InputSourceHandle handle { 0 };
-        XRHandedness handeness { XRHandedness::None };
+        XRHandedness handedness { XRHandedness::None };
         XRTargetRayMode targetRayMode { XRTargetRayMode::Gaze };
         Vector<String> profiles;
         InputSourcePose pointerOrigin;

--- a/Source/WebCore/platform/xr/openxr/OpenXRInput.cpp
+++ b/Source/WebCore/platform/xr/openxr/OpenXRInput.cpp
@@ -51,9 +51,9 @@ XrResult OpenXRInput::initialize()
         XRHandedness::Left, XRHandedness::Right
     };
 
-    for (auto handeness : hands) {
+    for (auto handedness : hands) {
         m_handleIndex++;;
-        if (auto inputSource = OpenXRInputSource::create(m_instance, m_session, handeness, m_handleIndex))
+        if (auto inputSource = OpenXRInputSource::create(m_instance, m_session, handedness, m_handleIndex))
             m_inputSources.append(makeUniqueRefFromNonNullUniquePtr(WTFMove(inputSource)));
     }
 

--- a/Source/WebCore/platform/xr/openxr/OpenXRInputSource.cpp
+++ b/Source/WebCore/platform/xr/openxr/OpenXRInputSource.cpp
@@ -35,18 +35,18 @@ namespace PlatformXR {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(OpenXRInputSource);
 
-std::unique_ptr<OpenXRInputSource> OpenXRInputSource::create(XrInstance instance, XrSession session, XRHandedness handeness, InputSourceHandle handle)
+std::unique_ptr<OpenXRInputSource> OpenXRInputSource::create(XrInstance instance, XrSession session, XRHandedness handedness, InputSourceHandle handle)
 {
-    auto input = std::unique_ptr<OpenXRInputSource>(new OpenXRInputSource(instance, session, handeness, handle));
+    auto input = std::unique_ptr<OpenXRInputSource>(new OpenXRInputSource(instance, session, handedness, handle));
     if (XR_FAILED(input->initialize()))
         return nullptr;
     return input;
 }
 
-OpenXRInputSource::OpenXRInputSource(XrInstance instance, XrSession session, XRHandedness handeness, InputSourceHandle handle)
+OpenXRInputSource::OpenXRInputSource(XrInstance instance, XrSession session, XRHandedness handedness, InputSourceHandle handle)
     : m_instance(instance)
     , m_session(session)
-    , m_handeness(handeness)
+    , m_handedness(handedness)
     , m_handle(handle)
 {
 }
@@ -63,12 +63,12 @@ OpenXRInputSource::~OpenXRInputSource()
 
 XrResult OpenXRInputSource::initialize()
 {
-    String handenessName = handenessToString(m_handeness);
-    m_subactionPathName = makeString(OPENXR_INPUT_HAND_PATH, handenessName);
+    String handednessName = handednessToString(m_handedness);
+    m_subactionPathName = makeString(OPENXR_INPUT_HAND_PATH, handednessName);
     RETURN_RESULT_IF_FAILED(xrStringToPath(m_instance, m_subactionPathName.utf8().data(), &m_subactionPath), m_instance);
 
     // Initialize Action Set.
-    auto prefix = makeString("input_"_s, handenessName);
+    auto prefix = makeString("input_"_s, handednessName);
     auto actionSetName = makeString(prefix, "_action_set"_s);
     auto createInfo =  createStructure<XrActionSetCreateInfo, XR_TYPE_ACTION_SET_CREATE_INFO>();
     std::strncpy(createInfo.actionSetName, actionSetName.utf8().data(), XR_MAX_ACTION_SET_NAME_SIZE - 1);
@@ -107,7 +107,7 @@ XrResult OpenXRInputSource::suggestBindings(SuggestedBindings& bindings) const
         RETURN_RESULT_IF_FAILED(createBinding(profile.path, m_gripAction, makeString(m_subactionPathName, OPENXR_INPUT_GRIP_PATH), bindings), m_instance);
         RETURN_RESULT_IF_FAILED(createBinding(profile.path, m_pointerAction, makeString(m_subactionPathName, OPENXR_INPUT_AIM_PATH), bindings), m_instance);
 
-        for (const auto& button : m_handeness == XRHandedness::Left ? profile.leftButtons : profile.rightButtons) {
+        for (const auto& button : m_handedness == XRHandedness::Left ? profile.leftButtons : profile.rightButtons) {
             const auto& actions = m_buttonActions.get(button.type);
             if (button.press) {
                 ASSERT(actions.press != XR_NULL_HANDLE);
@@ -137,7 +137,7 @@ XrResult OpenXRInputSource::suggestBindings(SuggestedBindings& bindings) const
 std::optional<FrameData::InputSource> OpenXRInputSource::getInputSource(XrSpace localSpace, const XrFrameState& frameState) const
 {
     FrameData::InputSource data;
-    data.handeness = m_handeness;
+    data.handedness = m_handedness;
     data.handle = m_handle;
     data.targetRayMode = XRTargetRayMode::TrackedPointer;
     data.profiles = m_profiles;

--- a/Source/WebCore/platform/xr/openxr/OpenXRInputSource.h
+++ b/Source/WebCore/platform/xr/openxr/OpenXRInputSource.h
@@ -67,7 +67,7 @@ private:
 
     XrInstance m_instance { XR_NULL_HANDLE };
     XrSession m_session { XR_NULL_HANDLE };
-    XRHandedness m_handeness { XRHandedness::Left };
+    XRHandedness m_handedness { XRHandedness::Left };
     InputSourceHandle m_handle { 0 };
     String m_subactionPathName;
     XrPath m_subactionPath { XR_NULL_PATH };

--- a/Source/WebCore/platform/xr/openxr/OpenXRUtils.h
+++ b/Source/WebCore/platform/xr/openxr/OpenXRUtils.h
@@ -116,9 +116,9 @@ inline XrViewConfigurationType toXrViewConfigurationType(SessionMode mode)
     return XR_VIEW_CONFIGURATION_TYPE_PRIMARY_MONO;
 }
 
-inline String handenessToString(XRHandedness handeness)
+inline String handednessToString(XRHandedness handedness)
 {
-    switch (handeness) {
+    switch (handedness) {
     case XRHandedness::Left:
         return "left"_s;
     case XRHandedness::Right:

--- a/Source/WebCore/testing/WebFakeXRInputController.cpp
+++ b/Source/WebCore/testing/WebFakeXRInputController.cpp
@@ -54,7 +54,7 @@ Ref<WebFakeXRInputController> WebFakeXRInputController::create(PlatformXR::Input
 
 WebFakeXRInputController::WebFakeXRInputController(PlatformXR::InputSourceHandle handle, const FakeXRInputSourceInit& init)
     : m_handle(handle)
-    , m_handeness(init.handedness)
+    , m_handedness(init.handedness)
     , m_targetRayMode(init.targetRayMode)
     , m_profiles(init.profiles)
     , m_primarySelected(init.selectionStarted)
@@ -112,7 +112,7 @@ InputSource WebFakeXRInputController::getFrameData()
 {
     InputSource state;
     state.handle = m_handle;
-    state.handeness = m_handeness;
+    state.handedness = m_handedness;
     state.targetRayMode = m_targetRayMode;
     state.profiles = m_profiles;
     state.pointerOrigin = m_pointerOrigin;

--- a/Source/WebCore/testing/WebFakeXRInputController.h
+++ b/Source/WebCore/testing/WebFakeXRInputController.h
@@ -47,7 +47,7 @@ class WebFakeXRInputController final : public RefCounted<WebFakeXRInputControlle
 public:
     static Ref<WebFakeXRInputController> create(PlatformXR::InputSourceHandle, const FakeXRInputSourceInit&);
 
-    void setHandedness(XRHandedness handeness) { m_handeness = handeness; }
+    void setHandedness(XRHandedness handedness) { m_handedness = handedness; }
     void setTargetRayMode(XRTargetRayMode mode) { m_targetRayMode = mode; }
     void setProfiles(Vector<String>&& profiles) { m_profiles = WTFMove(profiles); }
     void setGripOrigin(FakeXRRigidTransformInit gripOrigin, bool emulatedPosition = false);
@@ -78,7 +78,7 @@ private:
     ButtonOrPlaceholder getButtonOrPlaceholder(FakeXRButtonStateInit::Type) const;
 
     PlatformXR::InputSourceHandle m_handle { 0 };
-    XRHandedness m_handeness { XRHandedness::None };
+    XRHandedness m_handedness { XRHandedness::None };
     XRTargetRayMode m_targetRayMode { XRTargetRayMode::Gaze };
     Vector<String> m_profiles;
     PlatformXR::FrameData::InputSourcePose m_pointerOrigin;

--- a/Source/WebKit/Shared/XR/PlatformXR.serialization.in
+++ b/Source/WebKit/Shared/XR/PlatformXR.serialization.in
@@ -175,7 +175,7 @@ header: <WebCore/PlatformXR.h>
 
 [Nested] struct PlatformXR::FrameData::InputSource {
     int handle;
-    PlatformXR::XRHandedness handeness;
+    PlatformXR::XRHandedness handedness;
     PlatformXR::XRTargetRayMode targetRayMode;
     Vector<String> profiles;
     PlatformXR::FrameData::InputSourcePose pointerOrigin;

--- a/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.mm
+++ b/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.mm
@@ -503,7 +503,7 @@ id<WKARPresentationSession> createPresentationSession(ARSession *session, WKARPr
     PlatformXRPose pose(transientAction.pose);
 
     PlatformXR::FrameData::InputSource data;
-    data.handeness = PlatformXR::XRHandedness::None;
+    data.handedness = PlatformXR::XRHandedness::None;
     data.handle = actionIdentifier;
     data.profiles = Vector<String> { "generic-button-invisible"_s, "generic-button"_s };
     data.targetRayMode = PlatformXR::XRTargetRayMode::TransientPointer;


### PR DESCRIPTION
#### 3a09ab3a98f423c6bf0b8a6443885d9780a9e1ed
<pre>
[XR] Fix a typo in a PlatformXR variable name
<a href="https://bugs.webkit.org/show_bug.cgi?id=283963">https://bugs.webkit.org/show_bug.cgi?id=283963</a>

Reviewed by Adrian Perez de Castro.

s/handeness/handedness

* Source/WebCore/Modules/webxr/WebXRInputSource.cpp:
(WebCore::WebXRInputSource::requiresInputSourceChange):
* Source/WebCore/Modules/webxr/WebXRInputSource.h:
(WebCore::WebXRInputSource::handedness const):
* Source/WebCore/platform/xr/PlatformXR.h:
* Source/WebCore/platform/xr/openxr/OpenXRInput.cpp:
(PlatformXR::OpenXRInput::initialize):
* Source/WebCore/platform/xr/openxr/OpenXRInputSource.cpp:
(PlatformXR::OpenXRInputSource::create):
(PlatformXR::OpenXRInputSource::OpenXRInputSource):
(PlatformXR::OpenXRInputSource::initialize):
(PlatformXR::OpenXRInputSource::suggestBindings const):
(PlatformXR::OpenXRInputSource::getInputSource const):
* Source/WebCore/platform/xr/openxr/OpenXRInputSource.h:
* Source/WebCore/platform/xr/openxr/OpenXRUtils.h:
(PlatformXR::handednessToString):
(PlatformXR::handenessToString): Deleted.
* Source/WebCore/testing/WebFakeXRInputController.cpp:
(WebCore::WebFakeXRInputController::WebFakeXRInputController):
(WebCore::WebFakeXRInputController::getFrameData):
* Source/WebCore/testing/WebFakeXRInputController.h:
* Source/WebKit/Shared/XR/PlatformXR.serialization.in:
* Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.mm:
(-[_WKTransientGestureRecognizer _platformXRInputSourceFromTransientAction:actionIdentifier:]):

Canonical link: <a href="https://commits.webkit.org/287276@main">https://commits.webkit.org/287276@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b808d98049afb70173b3953cfc6f7310efed6b76

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79027 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58063 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32404 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83667 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30242 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81160 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67172 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6333 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61853 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19771 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82094 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51892 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72036 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42157 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49243 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26122 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28607 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70358 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26538 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85053 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6352 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4387 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70087 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6516 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67908 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69341 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17278 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13387 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12156 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6304 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6264 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9716 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8056 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->