### PR TITLE
[TextureMapper] Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE from TextureMapper

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
@@ -73,8 +73,8 @@ public:
     bool didModifyStencil { false };
     GLint previousScissorState { 0 };
     GLint previousDepthState { 0 };
-    GLint viewport[4] { 0, };
-    GLint previousScissor[4] { 0, };
+    std::array<GLint, 4> viewport { };
+    std::array<GLint, 4> previousScissor { };
     double zNear { 0 };
     double zFar { 0 };
     RefPtr<BitmapTexture> currentSurface;
@@ -214,11 +214,9 @@ void TextureMapper::beginPainting(FlipY flipY, BitmapTexture* surface)
     glDepthFunc(GL_LEQUAL);
     glEnable(GL_SCISSOR_TEST);
     data().didModifyStencil = false;
-    glGetIntegerv(GL_VIEWPORT, data().viewport);
-    glGetIntegerv(GL_SCISSOR_BOX, data().previousScissor);
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib/Win port
+    glGetIntegerv(GL_VIEWPORT, data().viewport.data());
+    glGetIntegerv(GL_SCISSOR_BOX, data().previousScissor.data());
     m_clipStack.reset(IntRect(0, 0, data().viewport[2], data().viewport[3]), flipY == FlipY::Yes ? ClipStack::YAxisMode::Default : ClipStack::YAxisMode::Inverted);
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     glGetIntegerv(GL_FRAMEBUFFER_BINDING, &data().targetFrameBuffer);
     data().flipY = flipY;
     bindSurface(surface);
@@ -234,9 +232,7 @@ void TextureMapper::endPainting()
 
     glUseProgram(data().previousProgram);
 
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib/Win port
     glScissor(data().previousScissor[0], data().previousScissor[1], data().previousScissor[2], data().previousScissor[3]);
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     if (data().previousScissorState)
         glEnable(GL_SCISSOR_TEST);
     else


### PR DESCRIPTION
#### 2f2968229e34603da4a065b8df59f5d44c40503b
<pre>
[TextureMapper] Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE from TextureMapper
<a href="https://bugs.webkit.org/show_bug.cgi?id=283975">https://bugs.webkit.org/show_bug.cgi?id=283975</a>

Reviewed by Michael Catanzaro.

* Source/WebCore/platform/graphics/texmap/TextureMapper.cpp:
(WebCore::TextureMapper::beginPainting):
(WebCore::TextureMapper::endPainting):

Canonical link: <a href="https://commits.webkit.org/287283@main">https://commits.webkit.org/287283@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72c6823bc1009d75e7d50b197544ba7b19f49151

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79058 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58094 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32435 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83698 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30273 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81191 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67203 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6364 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61878 "Found 1 new test failure: media/modern-media-controls/css/transformed-media-crash.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19797 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82125 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51916 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72060 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42181 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49267 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26160 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28637 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70382 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26578 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85084 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6383 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4410 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70115 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6547 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67932 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69364 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13409 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12192 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12199 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6334 "Built successfully") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6294 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9746 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8087 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->