### PR TITLE
Ensure third party frames do not have cookie access from Cookie Store API change listener

### DIFF
--- a/LayoutTests/http/wpt/cookie-store/cookieStore_third_party_iframe_change_listener-expected.txt
+++ b/LayoutTests/http/wpt/cookie-store/cookieStore_third_party_iframe_change_listener-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Third-party iframe does not get change notifications
+

--- a/LayoutTests/http/wpt/cookie-store/cookieStore_third_party_iframe_change_listener.html
+++ b/LayoutTests/http/wpt/cookie-store/cookieStore_third_party_iframe_change_listener.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src='/resources/testharness.js'></script>
+    <script src='/resources/testharnessreport.js'></script>
+    <script src="/common/get-host-info.sub.js"></script>
+</head>
+<body>
+    <script>
+
+const host = get_host_info();
+const notSameSiteBaseURL = host.HTTP_NOTSAMESITE_ORIGIN + window.location.pathname.replace(/\/[^\/]*$/, '/') ;
+
+function with_iframe(url) {
+  return new Promise(function(resolve) {
+      var frame = document.createElement('iframe');
+      frame.src = url;
+      frame.onload = function() { resolve(frame); };
+      document.body.appendChild(frame);
+    });
+}
+
+promise_test(async t => {
+    const iframe = await with_iframe(notSameSiteBaseURL + "/resources/third_party_iframe_change_listener.html");
+
+    var otherWindow = window.open(notSameSiteBaseURL + "/resources/third_party_iframe_change_listener_helper.html");
+
+    await new Promise(resolve => {
+        window.addEventListener('message', event => {
+            assert_equals(event.data, false);
+            resolve();
+        }, { once: true });
+        iframe.contentWindow.postMessage('Check if change event fired', '*');
+    });
+
+}, 'Third-party iframe does not get change notifications');
+
+    </script>
+</body>
+</html>

--- a/LayoutTests/http/wpt/cookie-store/resources/third_party_iframe_change_listener.html
+++ b/LayoutTests/http/wpt/cookie-store/resources/third_party_iframe_change_listener.html
@@ -1,0 +1,13 @@
+<script>
+    var changeEventFired = false;
+
+    onload = () => {
+        cookieStore.addEventListener('change', (event) => {
+            changeEventFired = true;
+        });
+
+        window.addEventListener('message', event => {
+            parent.postMessage(changeEventFired, '*');
+        }, { once: true });
+    }
+</script>

--- a/LayoutTests/http/wpt/cookie-store/resources/third_party_iframe_change_listener_helper.html
+++ b/LayoutTests/http/wpt/cookie-store/resources/third_party_iframe_change_listener_helper.html
@@ -1,0 +1,3 @@
+<script>
+    document.cookie="cookie_name=cookie_value";
+</script>

--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -624,7 +624,7 @@ void CookieStore::eventListenersDidChange()
     Ref cookieJar = page->cookieJar();
     auto host = document->url().host().toString();
     if (m_hasChangeEventListener)
-        cookieJar->addChangeListener(host, *this);
+        cookieJar->addChangeListener(*document, *this);
     else
         cookieJar->removeChangeListener(host, *this);
 #endif

--- a/Source/WebCore/loader/CookieJar.cpp
+++ b/Source/WebCore/loader/CookieJar.cpp
@@ -227,7 +227,7 @@ Ref<StorageSessionProvider> CookieJar::protectedStorageSessionProvider() const
 }
 
 #if HAVE(COOKIE_CHANGE_LISTENER_API)
-void CookieJar::addChangeListener(const String&, const CookieChangeListener&)
+void CookieJar::addChangeListener(const WebCore::Document&, const CookieChangeListener&)
 {
 }
 

--- a/Source/WebCore/loader/CookieJar.h
+++ b/Source/WebCore/loader/CookieJar.h
@@ -71,7 +71,7 @@ public:
     virtual void setCookieAsync(Document&, const URL&, const Cookie&, CompletionHandler<void(bool)>&&) const;
 
 #if HAVE(COOKIE_CHANGE_LISTENER_API)
-    virtual void addChangeListener(const String& host, const CookieChangeListener&);
+    virtual void addChangeListener(const WebCore::Document&, const CookieChangeListener&);
     virtual void removeChangeListener(const String& host, const CookieChangeListener&);
 #endif
 

--- a/Source/WebCore/platform/network/NetworkStorageSession.h
+++ b/Source/WebCore/platform/network/NetworkStorageSession.h
@@ -212,7 +212,7 @@ public:
     WEBCORE_EXPORT Vector<Cookie> domCookiesForHost(const String& host);
 
 #if HAVE(COOKIE_CHANGE_LISTENER_API)
-    WEBCORE_EXPORT void startListeningForCookieChangeNotifications(CookieChangeObserver&, const String& host);
+    WEBCORE_EXPORT bool startListeningForCookieChangeNotifications(CookieChangeObserver&, const URL&, const URL& firstParty, FrameIdentifier, PageIdentifier, ShouldRelaxThirdPartyCookieBlocking);
     WEBCORE_EXPORT void stopListeningForCookieChangeNotifications(CookieChangeObserver&, const HashSet<String>& hosts);
 #endif
     WEBCORE_EXPORT void addCookiesEnabledStateObserver(CookiesEnabledStateObserver&);

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -395,7 +395,7 @@ private:
     void domCookiesForHost(const URL& host, CompletionHandler<void(const Vector<WebCore::Cookie>&)>&&);
 
 #if HAVE(COOKIE_CHANGE_LISTENER_API)
-    void subscribeToCookieChangeNotifications(const String& host);
+    void subscribeToCookieChangeNotifications(const URL&, const URL& firstParty, WebCore::FrameIdentifier, WebCore::PageIdentifier, WebCore::ShouldRelaxThirdPartyCookieBlocking, CompletionHandler<void(bool)>&&);
     void unsubscribeFromCookieChangeNotifications(const String& host);
 
     // WebCore::CookieChangeObserver.

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -56,7 +56,7 @@ messages -> NetworkConnectionToWebProcess WantsDispatchMessage {
     SetCookieFromDOMAsync(URL firstParty, struct WebCore::SameSiteInfo sameSiteInfo, URL url, std::optional<WebCore::FrameIdentifier> frameID, std::optional<WebCore::PageIdentifier> pageID, enum:bool WebCore::ApplyTrackingPrevention applyTrackingPrevention, struct WebCore::Cookie cookie, enum:bool WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking) -> (bool setSuccessfully)
 
 #if HAVE(COOKIE_CHANGE_LISTENER_API)
-    SubscribeToCookieChangeNotifications(String host) AllowedWhenWaitingForSyncReply
+    SubscribeToCookieChangeNotifications(URL url, URL firstParty, WebCore::FrameIdentifier frameID, WebCore::PageIdentifier pageID, enum:bool WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking) -> (bool result) AllowedWhenWaitingForSyncReply
     UnsubscribeFromCookieChangeNotifications(String host) AllowedWhenWaitingForSyncReply
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/WebCookieCache.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieCache.cpp
@@ -72,7 +72,7 @@ String WebCookieCache::cookiesForDOM(const URL& firstParty, const SameSiteInfo& 
         auto host = url.host().toString();
 #if HAVE(COOKIE_CHANGE_LISTENER_API)
         if (!hasCacheForHost)
-            WebProcess::singleton().protectedCookieJar()->addChangeListener(host, *this);
+            WebProcess::singleton().protectedCookieJar()->addChangeListenerWithAccess(url, firstParty, frameID, pageID, ShouldRelaxThirdPartyCookieBlocking::No, *this);
 #endif
         auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection().protectedConnection()->sendSync(Messages::NetworkConnectionToWebProcess::DomCookiesForHost(url), 0);
         if (!sendResult.succeeded())

--- a/Source/WebKit/WebProcess/WebPage/WebCookieJar.h
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieJar.h
@@ -64,7 +64,8 @@ public:
     void setCookieAsync(WebCore::Document&, const URL&, const WebCore::Cookie&, CompletionHandler<void(bool)>&&) const final;
 
 #if HAVE(COOKIE_CHANGE_LISTENER_API)
-    void addChangeListener(const String& host, const WebCore::CookieChangeListener&) final;
+    void addChangeListenerWithAccess(const URL&, const URL& firstParty, WebCore::FrameIdentifier, WebCore::PageIdentifier, WebCore::ShouldRelaxThirdPartyCookieBlocking, const WebCore::CookieChangeListener&);
+    void addChangeListener(const WebCore::Document&, const WebCore::CookieChangeListener&) final;
     void removeChangeListener(const String& host, const WebCore::CookieChangeListener&) final;
 #endif
 


### PR DESCRIPTION
#### 0df5a7c46418c0afa242a7c4d07761a813251e23
<pre>
Ensure third party frames do not have cookie access from Cookie Store API change listener
<a href="https://bugs.webkit.org/show_bug.cgi?id=283985">https://bugs.webkit.org/show_bug.cgi?id=283985</a>
<a href="https://rdar.apple.com/140446608">rdar://140446608</a>

Reviewed by Sihui Liu.

Previously, a third party iframe could register a cookie-change event listener.
Then, if another page set a cookie, the iframe would get a notification about
the cookie change. But third party iframes should not have this cookie access.

The fix: when the iframe tries to register a change listener, a listener won&apos;t
be registered if the iframe&apos;s cookie access should be blocked.

Furthermore, we add allowsFirstPartyForCookies() and shouldBlockCookies() checks
in the Network Process because the Web Process may not have all the information
to know if it should block cookie access. Since it&apos;s possible that the checks
in the Web Process pass and those in the Network Process fail, we refactor the
code so that the Network Process returns a boolean indicating if the checks passed.
So the Web Process will only add the listener to it&apos;s local map of listeners if
the checks in the Network Process pass and the listener is indeed registered.

Since WebCookieCache&apos;s call to add a cookie change listener happens only if it
passes the Web Process&apos; shouldBlockCookies check in WebCookieJar, we don&apos;t need
to do the Web Process check again for it. So we add a new addChangeListenerWithAccess
function that doesn&apos;t do the Web Process check but does still do the Network
Process checks.

* LayoutTests/http/wpt/cookie-store/cookieStore_third_party_iframe_change_listener-expected.txt: Added.
* LayoutTests/http/wpt/cookie-store/cookieStore_third_party_iframe_change_listener.html: Added.
* LayoutTests/http/wpt/cookie-store/resources/third_party_iframe_change_listener.html: Added.
* LayoutTests/http/wpt/cookie-store/resources/third_party_iframe_change_listener_helper.html: Added.
* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::eventListenersDidChange):
* Source/WebCore/loader/CookieJar.cpp:
(WebCore::CookieJar::addChangeListener):
* Source/WebCore/loader/CookieJar.h:
* Source/WebCore/platform/network/NetworkStorageSession.h:
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::NetworkStorageSession::startListeningForCookieChangeNotifications):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::subscribeToCookieChangeNotifications):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:
* Source/WebKit/WebProcess/WebPage/WebCookieCache.cpp:
(WebKit::WebCookieCache::cookiesForDOM):
* Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp:
(WebKit::WebCookieJar::addChangeListenerWithAccess):
(WebKit::WebCookieJar::addChangeListener):
* Source/WebKit/WebProcess/WebPage/WebCookieJar.h:

Canonical link: <a href="https://commits.webkit.org/287462@main">https://commits.webkit.org/287462@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48bd52c94ec7988c79ce3222c7a9275be953439e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79716 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58711 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33106 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84247 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30730 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81824 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67789 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7003 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62302 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20146 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82784 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52352 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72595 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42610 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49695 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26747 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29168 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70831 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27212 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85670 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6953 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4847 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70558 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7123 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68441 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69798 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/17413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13809 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12724 "Passed tests") | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12328 "Failed to push commit to Webkit repository") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6907 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12527 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6776 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10279 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8579 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->