### PR TITLE
Port WebExtension DeclarativeNetRequest Parsing

### DIFF
--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -499,12 +499,6 @@
 /* Fallback label text for unlabeled email address field. */
 "Email address" = "Email address";
 
-/* WKWebExtensionErrorInvalidDeclarativeNetRequestEntry description for empty JSON path */
-"Empty `declarative_net_request` JSON path." = "Empty `declarative_net_request` JSON path.";
-
-/* WKWebExtensionErrorInvalidDeclarativeNetRequestEntry description for empty ruleset id */
-"Empty `declarative_net_request` ruleset id." = "Empty `declarative_net_request` ruleset id.";
-
 /* WKWebExtensionErrorInvalidManifestEntry description for background */
 "Empty or invalid `background` manifest entry." = "Empty or invalid `background` manifest entry.";
 
@@ -544,6 +538,9 @@
 /* WKWebExtensionErrorInvalidManifestEntry description for icon_variants */
 "Empty or invalid `icon_variants` manifest entry." = "Empty or invalid `icon_variants` manifest entry.";
 
+/* WKWebExtensionErrorInvalidDeclarativeNetRequestEntry description for empty or invalid id in declarative_net_request manifest entry */
+"Empty or invalid `id` in `declarative_net_request` manifest entry." = "Empty or invalid `id` in `declarative_net_request` manifest entry.";
+
 /* WKWebExtensionErrorInvalidManifestEntry description for invalid new tab entry */
 "Empty or invalid `newtab` manifest entry." = "Empty or invalid `newtab` manifest entry.";
 
@@ -552,6 +549,9 @@
 
 /* WKWebExtensionErrorInvalidManifestEntry description for options UI */
 "Empty or invalid `options_ui` manifest entry" = "Empty or invalid `options_ui` manifest entry";
+
+/* WKWebExtensionErrorInvalidDeclarativeNetRequestEntry description for empty or invalid path in declarative_net_request manifest entry */
+"Empty or invalid `path` in `declarative_net_request` manifest entry." = "Empty or invalid `path` in `declarative_net_request` manifest entry.";
 
 /* WKWebExtensionErrorInvalidManifestEntry description for invalid command */
 "Empty or invalid command in the `commands` manifest entry." = "Empty or invalid command in the `commands` manifest entry.";
@@ -1060,6 +1060,9 @@
 /* WKWebExtensionErrorInvalidManifestEntry description for version */
 "Missing or empty `version` manifest entry." = "Missing or empty `version` manifest entry.";
 
+/* WKWebExtensionErrorInvalidDeclarativeNetRequestEntry description for missing enabled boolean */
+"Missing or invalid `enabled` boolean for the `declarative_net_request` manifest entry." = "Missing or invalid `enabled` boolean for the `declarative_net_request` manifest entry.";
+
 /* Media Mute context menu item */
 "Mute" = "Mute";
 
@@ -1338,9 +1341,6 @@
 
 /* Label for the set up with Apple Pay button. */
 "Set up with Apple Pay" = "Set up with Apple Pay";
-
-/* Title for Share context menu item. */
-"Share" = "Share";
 
 /* Default name for the file created for a shared image with no explicit name. */
 "Shared Image" = "Shared Image";
@@ -1627,7 +1627,7 @@
 /* WKWebExtensionErrorResourceNotFound description with invalid file path */
 "Unable to find \"%@\" in the extension’s resources. It is an invalid path." = "Unable to find \"%@\" in the extension’s resources. It is an invalid path.";
 
-/* WKWebExtensionErrorInvalidManifestEntry description for missing default_locale */
+/* Error description for missing default_locale */
 "Unable to find `default_locale` in “_locales” folder." = "Unable to find `default_locale` in “_locales” folder.";
 
 /* WKWebExtensionErrorInvalidDeclarativeNetRequest description */
@@ -1784,7 +1784,7 @@
 "\"%s\" cannot be parsed because the scheme \"%s\" is invalid." = "\"%s\" cannot be parsed because the scheme \"%s\" is invalid.";
 
 /* WKWebExtensionErrorInvalidDeclarativeNetRequestEntry description for duplicate ruleset id */
-"`declarative_net_request` ruleset with id \"%@\" is invalid. Ruleset id must be unique." = "`declarative_net_request` ruleset with id \"%@\" is invalid. Ruleset id must be unique.";
+"`declarative_net_request` ruleset with id \"%s\" is invalid. Ruleset id must be unique." = "`declarative_net_request` ruleset with id \"%s\" is invalid. Ruleset id must be unique.";
 
 /* Verb stating the action that will occur when a text field is selected, as used by accessibility */
 "activate" = "activate";

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -36,7 +36,6 @@
 #import "FoundationSPI.h"
 #import "Logging.h"
 #import "WKWebExtensionInternal.h"
-#import "WebExtensionConstants.h"
 #import "WebExtensionPermission.h"
 #import "WebExtensionUtilities.h"
 #import <CoreFoundation/CFBundle.h>
@@ -64,12 +63,6 @@ namespace WebKit {
 
 static NSString * const generatedBackgroundPageFilename = @"_generated_background_page.html";
 static NSString * const generatedBackgroundServiceWorkerFilename = @"_generated_service_worker.js";
-
-static NSString * const declarativeNetRequestManifestKey = @"declarative_net_request";
-static NSString * const declarativeNetRequestRulesManifestKey = @"rule_resources";
-static NSString * const declarativeNetRequestRulesetIDManifestKey = @"id";
-static NSString * const declarativeNetRequestRuleEnabledManifestKey = @"enabled";
-static NSString * const declarativeNetRequestRulePathManifestKey = @"path";
 
 static String convertChromeExtensionToTemporaryZipFile(const String& inputFilePath)
 {
@@ -584,138 +577,6 @@ RefPtr<WebCore::Icon> WebExtension::bestIconVariant(RefPtr<JSON::Array> variants
 #endif // not USE(APPKIT)
 }
 #endif // ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
-
-std::optional<WebExtension::DeclarativeNetRequestRulesetData> WebExtension::parseDeclarativeNetRequestRulesetDictionary(NSDictionary *rulesetDictionary, RefPtr<API::Error>& error)
-{
-    NSArray *requiredKeysInRulesetDictionary = @[
-        declarativeNetRequestRulesetIDManifestKey,
-        declarativeNetRequestRuleEnabledManifestKey,
-        declarativeNetRequestRulePathManifestKey,
-    ];
-
-    NSDictionary *keyToExpectedValueTypeInRulesetDictionary = @{
-        declarativeNetRequestRulesetIDManifestKey: NSString.class,
-        declarativeNetRequestRuleEnabledManifestKey: @YES.class,
-        declarativeNetRequestRulePathManifestKey: NSString.class,
-    };
-
-    error = nullptr;
-
-    NSString *exceptionString;
-    bool isRulesetDictionaryValid = validateDictionary(rulesetDictionary, nil, requiredKeysInRulesetDictionary, keyToExpectedValueTypeInRulesetDictionary, &exceptionString);
-    if (!isRulesetDictionaryValid) {
-        error = createError(WebExtension::Error::InvalidDeclarativeNetRequest, exceptionString);
-        return std::nullopt;
-    }
-
-    NSString *rulesetID = objectForKey<NSString>(rulesetDictionary, declarativeNetRequestRulesetIDManifestKey);
-    if (!rulesetID.length) {
-        error = createError(WebExtension::Error::InvalidDeclarativeNetRequest, WEB_UI_STRING("Empty `declarative_net_request` ruleset id.", "WKWebExtensionErrorInvalidDeclarativeNetRequestEntry description for empty ruleset id"));
-        return std::nullopt;
-    }
-
-    NSString *jsonPath = objectForKey<NSString>(rulesetDictionary, declarativeNetRequestRulePathManifestKey);
-    if (!jsonPath.length) {
-        error = createError(WebExtension::Error::InvalidDeclarativeNetRequest, WEB_UI_STRING("Empty `declarative_net_request` JSON path.", "WKWebExtensionErrorInvalidDeclarativeNetRequestEntry description for empty JSON path"));
-        return std::nullopt;
-
-    }
-
-    DeclarativeNetRequestRulesetData rulesetData = {
-        rulesetID,
-        (bool)objectForKey<NSNumber>(rulesetDictionary, declarativeNetRequestRuleEnabledManifestKey).boolValue,
-        jsonPath
-    };
-
-    return std::optional { WTFMove(rulesetData) };
-}
-
-void WebExtension::populateDeclarativeNetRequestPropertiesIfNeeded()
-{
-    if (!manifestParsedSuccessfully())
-        return;
-
-    if (m_parsedManifestDeclarativeNetRequestRulesets)
-        return;
-
-    m_parsedManifestDeclarativeNetRequestRulesets = true;
-
-    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/declarative_net_request
-
-    if (!supportedPermissions().contains(WebExtensionPermission::declarativeNetRequest()) && !supportedPermissions().contains(WebExtensionPermission::declarativeNetRequestWithHostAccess())) {
-        recordError(createError(Error::InvalidDeclarativeNetRequest, WEB_UI_STRING("Manifest has no `declarativeNetRequest` permission.", "WKWebExtensionErrorInvalidDeclarativeNetRequestEntry description for missing declarativeNetRequest permission")));
-        return;
-    }
-
-    auto *manifest = manifestDictionary();
-
-    auto *declarativeNetRequestManifestDictionary = objectForKey<NSDictionary>(manifest, declarativeNetRequestManifestKey);
-    if (!declarativeNetRequestManifestDictionary) {
-        if ([manifest objectForKey:declarativeNetRequestManifestKey])
-            recordError(createError(Error::InvalidDeclarativeNetRequest));
-        return;
-    }
-
-    auto *declarativeNetRequestRulesets = objectForKey<NSArray>(declarativeNetRequestManifestDictionary, declarativeNetRequestRulesManifestKey, false, NSDictionary.class);
-    if (!declarativeNetRequestRulesets) {
-        if ([manifest objectForKey:declarativeNetRequestManifestKey])
-            recordError(createError(Error::InvalidDeclarativeNetRequest));
-        return;
-    }
-
-    if (declarativeNetRequestRulesets.count > webExtensionDeclarativeNetRequestMaximumNumberOfStaticRulesets)
-        recordError(createError(Error::InvalidDeclarativeNetRequest, WEB_UI_STRING("Exceeded maximum number of `declarative_net_request` rulesets. Ignoring extra rulesets.", "WKWebExtensionErrorInvalidDeclarativeNetRequestEntry description for too many rulesets")));
-
-    NSUInteger rulesetCount = 0;
-    NSUInteger enabledRulesetCount = 0;
-    bool recordedTooManyRulesetsManifestError = false;
-    HashSet<String> seenRulesetIDs;
-    for (NSDictionary *rulesetDictionary in declarativeNetRequestRulesets) {
-        if (rulesetCount >= webExtensionDeclarativeNetRequestMaximumNumberOfStaticRulesets)
-            continue;
-
-        RefPtr<API::Error> error;
-        auto optionalRuleset = parseDeclarativeNetRequestRulesetDictionary(rulesetDictionary, error);
-        if (!optionalRuleset) {
-            if (error)
-                recordError(createError(Error::InvalidDeclarativeNetRequest, { }, error));
-            continue;
-        }
-
-        auto ruleset = optionalRuleset.value();
-        if (seenRulesetIDs.contains(ruleset.rulesetID)) {
-            recordError(createError(Error::InvalidDeclarativeNetRequest, WEB_UI_FORMAT_STRING("`declarative_net_request` ruleset with id \"%@\" is invalid. Ruleset id must be unique.", "WKWebExtensionErrorInvalidDeclarativeNetRequestEntry description for duplicate ruleset id", (NSString *)ruleset.rulesetID)));
-            continue;
-        }
-
-        if (ruleset.enabled && ++enabledRulesetCount > webExtensionDeclarativeNetRequestMaximumNumberOfEnabledRulesets && !recordedTooManyRulesetsManifestError) {
-            recordError(createError(Error::InvalidDeclarativeNetRequest, WEB_UI_FORMAT_STRING("Exceeded maximum number of enabled `declarative_net_request` static rulesets. The first %lu will be applied, the remaining will be ignored.", "WKWebExtensionErrorInvalidDeclarativeNetRequestEntry description for too many enabled static rulesets", webExtensionDeclarativeNetRequestMaximumNumberOfEnabledRulesets)));
-            recordedTooManyRulesetsManifestError = true;
-            continue;
-        }
-
-        seenRulesetIDs.add(ruleset.rulesetID);
-        ++rulesetCount;
-
-        m_declarativeNetRequestRulesets.append(ruleset);
-    }
-}
-
-const WebExtension::DeclarativeNetRequestRulesetVector& WebExtension::declarativeNetRequestRulesets()
-{
-    populateDeclarativeNetRequestPropertiesIfNeeded();
-    return m_declarativeNetRequestRulesets;
-}
-
-std::optional<WebExtension::DeclarativeNetRequestRulesetData> WebExtension::declarativeNetRequestRuleset(const String& identifier)
-{
-    for (auto& ruleset : declarativeNetRequestRulesets()) {
-        if (ruleset.rulesetID == identifier)
-            return ruleset;
-    }
-
-    return std::nullopt;
-}
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -377,7 +377,7 @@ private:
 
     URL resourceFileURLForPath(const String&);
 
-    std::optional<WebExtension::DeclarativeNetRequestRulesetData> parseDeclarativeNetRequestRulesetDictionary(NSDictionary *, RefPtr<API::Error>&);
+    std::optional<WebExtension::DeclarativeNetRequestRulesetData> parseDeclarativeNetRequestRulesetObject(const JSON::Object&, RefPtr<API::Error>&);
 
     InjectedContentVector m_staticInjectedContents;
     WebAccessibleResourcesVector m_webAccessibleResources;


### PR DESCRIPTION
#### cb007e60679aee6a8af66f54941d1727a618f147
<pre>
Port WebExtension DeclarativeNetRequest Parsing
<a href="https://webkit.org/b/283987">https://webkit.org/b/283987</a>

Reviewed by Timothy Hatcher.

Port DeclarativeNetRequest parsing to C++. This is the last portion of the manifest that must be ported to C++.

* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::parseDeclarativeNetRequestRulesetDictionary): Deleted.
(WebKit::WebExtension::populateDeclarativeNetRequestPropertiesIfNeeded): Deleted.
(WebKit::WebExtension::declarativeNetRequestRulesets): Deleted.
(WebKit::WebExtension::declarativeNetRequestRuleset): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtension.cpp:
(WebKit::WebExtension::parseDeclarativeNetRequestRulesetDictionary):
(WebKit::WebExtension::populateDeclarativeNetRequestPropertiesIfNeeded):
(WebKit::WebExtension::declarativeNetRequestRulesets):
(WebKit::WebExtension::declarativeNetRequestRuleset):
* Source/WebKit/UIProcess/Extensions/WebExtension.h:

Canonical link: <a href="https://commits.webkit.org/287325@main">https://commits.webkit.org/287325@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/baed6530dfd46535f42af1d35dbca153ace78cae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79164 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32537 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83790 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30355 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81297 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6461 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61936 "24 flakes 89 failures") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19849 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82231 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51982 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72142 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42241 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49333 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26270 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28729 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70450 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26694 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85183 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6468 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4478 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70179 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6631 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68014 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69427 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13478 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12290 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12226 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6423 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6366 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9828 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8158 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->