### PR TITLE
Explicitly destroy the render tree in WebPage::close

### DIFF
--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -348,6 +348,7 @@ public:
     std::optional<PageIdentifier> identifier() const { return m_identifier; }
 
     WEBCORE_EXPORT uint64_t renderTreeSize() const;
+    WEBCORE_EXPORT void destroyRenderTrees();
 
     WEBCORE_EXPORT void setNeedsRecalcStyleInAllFrames();
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1924,6 +1924,8 @@ void WebPage::close()
         protectedDrawingArea()->unregisterScrollingTree();
 #endif
 
+    m_page->destroyRenderTrees();
+
     m_drawingArea = nullptr;
     m_webPageTesting = nullptr;
     m_page = nullptr;


### PR DESCRIPTION
#### 1eba2ca13db0a4949ad07a1053cb29a5152bbbb0
<pre>
Explicitly destroy the render tree in WebPage::close
<a href="https://bugs.webkit.org/show_bug.cgi?id=283992">https://bugs.webkit.org/show_bug.cgi?id=283992</a>
<a href="https://rdar.apple.com/140868579">rdar://140868579</a>

Reviewed by Simon Fraser.

This should fix some crashes I&apos;m seeing with site isolation enabled,
particularly after <a href="https://github.com/WebKit/WebKit/pull/37381">https://github.com/WebKit/WebKit/pull/37381</a> introduces
more uses of WebPage::close in normal browsing.  The crash was a null
dereference with this stack trace:

WebCore::Page::WeakValueType* WTF::WeakPtrImplBase&lt;WTF::DefaultWeakPtrImpl&gt;::get&lt;WebCore::Page&gt;() + 0 (WeakPtrImpl.h:48) [inlined]
WTF::WeakPtr&lt;WebCore::Page, WTF::DefaultWeakPtrImpl, WTF::RawPtrTraits&lt;WTF::DefaultWeakPtrImpl&gt;&gt;::get() const + 4 (WeakPtr.h:95) [inlined]
WebCore::Frame::page() const + 4 (Page.h:1686) [inlined]
WebCore::RenderObject::page() const + 28 (RenderObject.h:1356) [inlined]
WebCore::RenderLayerCompositor::page() const + 32 (RenderLayerCompositor.cpp:5934) [inlined]
WebCore::RenderLayerCompositor::scheduleRenderingUpdate() + 32 (RenderLayerCompositor.cpp:780) [inlined]
WebCore::RenderLayerCompositor::notifyFlushRequired(WebCore::GraphicsLayer const*) + 32 (RenderLayerCompositor.cpp:773)
WebCore::ThreadTimers::sharedTimerFiredInternal() + 264 (ThreadTimers.cpp:128)
WebCore::timerFired(__CFRunLoopTimer*, void*) + 32 (MainThreadSharedTimerCF.cpp:85)
__CFRUNLOOP_IS_CALLING_OUT_TO_A_TIMER_CALLBACK_FUNCTION__ + 32

* Source/WebCore/history/BackForwardCache.cpp:
(WebCore::BackForwardCache::trySuspendPage):
(WebCore::destroyRenderTree): Deleted.
* Source/WebCore/page/Page.cpp:
(WebCore::Page::destroyRenderTrees):
* Source/WebCore/page/Page.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::close):

Canonical link: <a href="https://commits.webkit.org/287329@main">https://commits.webkit.org/287329@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f268155d0b212372f872d5ebd7b01dcd48066198

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79109 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58145 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32486 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83747 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30319 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81242 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67251 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6414 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61907 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19827 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82176 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51956 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72107 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42211 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49307 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26223 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28686 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70423 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26645 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85134 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6430 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4485 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70155 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-transforms/individual-transform/animation/individual-transform-combine.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6593 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67978 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69403 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13447 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12253 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12227 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6382 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12194 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6335 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9792 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8127 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->