### PR TITLE
Crash at API::getContentRuleListSourceFromMappedFile().

### DIFF
--- a/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
+++ b/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
@@ -46,6 +46,7 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RunLoop.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/WeakRandom.h>
 #include <wtf/WorkQueue.h>
 #include <wtf/persistence/PersistentDecoder.h>
 #include <wtf/persistence/PersistentEncoder.h>
@@ -445,26 +446,38 @@ static WTF::String getContentRuleListSourceFromMappedFile(const MappedData& mapp
     ASSERT(!RunLoop::isMain());
 
     if (mappedData.metaData.version < 9) {
-        // Older versions cannot recover the original JSON source from disk.
+        WTFLogAlways("Content Rule List source recovery failed: Version is too old to recover the original JSON source from disk.");
         return { };
     }
 
-    if (!mappedData.metaData.sourceSize)
+    auto sourceSizeBytes = mappedData.metaData.sourceSize;
+    if (!sourceSizeBytes) {
+        WTFLogAlways("Content Rule List source recovery failed: No source size specified; cannot retrieve content.");
         return { };
+    }
 
+    auto dataSpan = mappedData.data.span();
     auto headerSizeBytes = headerSize(mappedData.metaData.version);
-    bool is8Bit = mappedData.data.span()[headerSizeBytes];
+
+    if (dataSpan.size() < headerSizeBytes + sourceSizeBytes) {
+        WTFLogAlways("Content Rule List source recovery failed: Data size is smaller than the header and source size; data is invalid.");
+        return { };
+    }
+
+    bool is8Bit = dataSpan[headerSizeBytes];
     size_t start = headerSizeBytes + sizeof(bool);
-    size_t length = mappedData.metaData.sourceSize - sizeof(bool);
+    size_t length = sourceSizeBytes - sizeof(bool);
+
     if (is8Bit)
-        return mappedData.data.span().subspan(start, length);
+        return dataSpan.subspan(start, length);
 
     if (length % sizeof(UChar)) {
         ASSERT_NOT_REACHED();
+        WTFLogAlways("Content Rule List source recovery failed: Length is not a multiple of UChar size; data is corrupted.");
         return { };
     }
 
-    return spanReinterpretCast<const UChar>(mappedData.data.span().subspan(start, length));
+    return spanReinterpretCast<const UChar>(dataSpan.subspan(start, length));
 }
 
 void ContentRuleListStore::lookupContentRuleList(WTF::String&& identifier, CompletionHandler<void(RefPtr<API::ContentRuleList>, std::error_code)> completionHandler)
@@ -486,7 +499,10 @@ void ContentRuleListStore::lookupContentRuleListFile(WTF::String&& filePath, WTF
             return;
         }
 
-        if (contentRuleList->metaData.version != ContentRuleListStore::CurrentContentRuleListFileVersion) {
+        bool versionMismatch = contentRuleList->metaData.version != ContentRuleListStore::CurrentContentRuleListFileVersion;
+        bool fileSizeMismatch = contentRuleList->metaData.fileSize() != contentRuleList->data.size();
+
+        if (versionMismatch || fileSizeMismatch) {
             if (auto sourceFromOldVersion = getContentRuleListSourceFromMappedFile(*contentRuleList); !sourceFromOldVersion.isEmpty()) {
                 RunLoop::main().dispatch([protectedThis = WTFMove(protectedThis), sourceFromOldVersion = WTFMove(sourceFromOldVersion).isolatedCopy(), identifier = WTFMove(identifier).isolatedCopy(), completionHandler = WTFMove(completionHandler)] () mutable {
                     protectedThis->compileContentRuleList(WTFMove(identifier), WTFMove(sourceFromOldVersion), WTFMove(completionHandler));
@@ -494,8 +510,8 @@ void ContentRuleListStore::lookupContentRuleListFile(WTF::String&& filePath, WTF
                 return;
             }
 
-            RunLoop::main().dispatch([protectedThis = WTFMove(protectedThis), completionHandler = WTFMove(completionHandler)] () mutable {
-                completionHandler(nullptr, Error::VersionMismatch);
+            RunLoop::main().dispatch([versionMismatch, protectedThis = WTFMove(protectedThis), completionHandler = WTFMove(completionHandler)] () mutable {
+                completionHandler(nullptr, versionMismatch ? Error::VersionMismatch : Error::LookupFailed);
             });
             return;
         }
@@ -587,13 +603,47 @@ void ContentRuleListStore::synchronousRemoveAllContentRuleLists()
 
 void ContentRuleListStore::invalidateContentRuleListVersion(const WTF::String& identifier)
 {
-    auto file = openFile(constructedPath(m_storePath, identifier), FileOpenMode::Truncate);
+    auto file = openFile(constructedPath(m_storePath, identifier), FileOpenMode::ReadWrite);
     if (file == invalidPlatformFileHandle)
         return;
 
-    ContentRuleListMetaData invalidHeader = {0, 0, 0, 0, 0, 0};
+    ContentRuleListMetaData header;
+
+    auto bytesRead = readFromFile(file, asMutableByteSpan(header));
+    if (bytesRead != sizeof(header)) {
+        closeFile(file);
+        return;
+    }
+
+    // Invalidate the version by setting it to one less than the current version.
+    header.version = CurrentContentRuleListFileVersion - 1;
+
+    if (seekFile(file, 0, FileSeekOrigin::Beginning) == -1) {
+        closeFile(file);
+        return;
+    }
+
+    auto bytesWritten = writeToFile(file, asByteSpan(header));
+    ASSERT_UNUSED(bytesWritten, bytesWritten == sizeof(header));
+
+    closeFile(file);
+}
+
+void ContentRuleListStore::corruptContentRuleList(const WTF::String& identifier, bool usingCurrentVersion)
+{
+    auto file = openFile(constructedPath(m_storePath, identifier), FileOpenMode::ReadWrite);
+    if (file == invalidPlatformFileHandle)
+        return;
+
+    static WeakRandom random;
+
+    ContentRuleListMetaData invalidHeader = { CurrentContentRuleListFileVersion - 1, random.getUint64(), random.getUint64(), random.getUint64(), random.getUint64(), random.getUint64() };
+    if (usingCurrentVersion)
+        invalidHeader.version = CurrentContentRuleListFileVersion;
+
     auto bytesWritten = writeToFile(file, asByteSpan(invalidHeader));
     ASSERT_UNUSED(bytesWritten, bytesWritten == sizeof(invalidHeader));
+
     closeFile(file);
 }
 

--- a/Source/WebKit/UIProcess/API/APIContentRuleListStore.h
+++ b/Source/WebKit/UIProcess/API/APIContentRuleListStore.h
@@ -76,6 +76,7 @@ public:
     // For testing only.
     void synchronousRemoveAllContentRuleLists();
     void invalidateContentRuleListVersion(const WTF::String& identifier);
+    void corruptContentRuleList(const WTF::String& identifier, bool usingCurrentVersion);
     void getContentRuleListSource(WTF::String&& identifier, CompletionHandler<void(WTF::String)>);
 
 private:

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm
@@ -169,6 +169,13 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 #endif
 }
 
+- (void)_corruptContentRuleListForIdentifier:(NSString *)identifier usingCurrentVersion:(BOOL)usingCurrentVersion
+{
+#if ENABLE(CONTENT_EXTENSIONS)
+    _contentRuleListStore->corruptContentRuleList(identifier, usingCurrentVersion);
+#endif
+}
+
 - (void)_getContentRuleListSourceForIdentifier:(NSString *)identifier completionHandler:(void (^)(NSString*))completionHandler
 {
 #if ENABLE(CONTENT_EXTENSIONS)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStorePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStorePrivate.h
@@ -30,6 +30,7 @@
 // For testing only.
 - (void)_removeAllContentRuleLists;
 - (void)_invalidateContentRuleListVersionForIdentifier:(NSString *)identifier;
+- (void)_corruptContentRuleListForIdentifier:(NSString *)identifier usingCurrentVersion:(BOOL)usingCurrentVersion;
 - (void)_getContentRuleListSourceForIdentifier:(NSString *)identifier completionHandler:(void (^)(NSString *))completionHandler;
 
 + (instancetype)defaultStoreWithLegacyFilename;


### PR DESCRIPTION
#### fa5d8d81450ba9d0a3f29ddc100b7f2e80c1420b
<pre>
Crash at API::getContentRuleListSourceFromMappedFile().
<a href="https://webkit.org/b/283996">https://webkit.org/b/283996</a>
<a href="https://rdar.apple.com/140450689">rdar://140450689</a>

Reviewed by Alex Christensen.

Make the handling of getContentRuleListSourceFromMappedFile() more robust by checking header sizes
to the mapped data size. This was failing when the version got bumped and fallback to recompiling
from the original source was needed.

Improved mismatch version testing by dropping the version by one and keeping all the compiled data
the same to test proper version upgrades from the original source.

Added two corrupt size tests to error on invalid data sizes or empty data (missing source).

* Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp:
(API::getContentRuleListSourceFromMappedFile): Added logging and size checks.
(API::ContentRuleListStore::lookupContentRuleListFile): Check fileSize() against the mapped data.
(API::ContentRuleListStore::invalidateContentRuleListVersion): Changed to set the version back by one.
(API::ContentRuleListStore::corruptContentRuleListHeader): Added.
* Source/WebKit/UIProcess/API/APIContentRuleListStore.h:
* Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm:
(-[WKContentRuleListStore _corruptContentRuleListHeaderForIdentifier:usingCurrentVersion:]): Added.
* Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStorePrivate.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm:
(TEST_F(WKContentRuleListStoreTest, VersionMismatch)): Updated expectations since source is preserved now.
(TEST_F(WKContentRuleListStoreTest, CorruptHeaderEmpty)): Added.
(TEST_F(WKContentRuleListStoreTest, CorruptHeaderRandom)): Added.

Canonical link: <a href="https://commits.webkit.org/287319@main">https://commits.webkit.org/287319@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/483da79b00b9891bde34681253bf17c4e980a9b1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79141 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58173 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32516 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83772 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30341 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81274 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67273 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6439 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61923 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19839 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82208 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51970 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72117 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42227 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49321 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26237 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28712 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70437 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26662 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85162 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6452 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4466 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70170 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6615 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67989 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69418 "Found 1 new API test failure: /TestWebKit:WebKit.EvaluateJavaScriptThatCreatesBlob (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13463 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12221 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6405 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6354 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9814 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8146 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->