### PR TITLE
resolveForDocument() should explicitly set the FontCascade on the style

### DIFF
--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -147,6 +147,7 @@ bool FontCascade::isCurrent(const FontSelector& fontSelector) const
 
 void FontCascade::updateFonts(Ref<FontCascadeFonts>&& fonts) const
 {
+    // FIXME: Ideally we'd only update m_generation if the fonts changed.
     m_fonts = WTFMove(fonts);
     m_generation = ++lastFontCascadeGeneration;
 }

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.h
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.h
@@ -18,8 +18,7 @@
  *
  */
 
-#ifndef FontCascadeFonts_h
-#define FontCascadeFonts_h
+#pragma once
 
 #include "Font.h"
 #include "FontCascadeDescription.h"
@@ -126,8 +125,8 @@ private:
 
     WidthCache m_widthCache;
 
-    unsigned m_fontSelectorVersion;
-    unsigned short m_generation;
+    unsigned m_fontSelectorVersion { 0 };
+    unsigned short m_generation { 0 };
     Pitch m_pitch { UnknownPitch };
     bool m_isForPlatformFont { false };
     TriState m_canTakeFixedPitchFastContentMeasuring : 2 { TriState::Indeterminate };
@@ -178,5 +177,3 @@ inline const Font& FontCascadeFonts::primaryFont(const FontCascadeDescription& d
 WTF::TextStream& operator<<(WTF::TextStream&, const FontCascadeFonts&);
 
 } // namespace WebCore
-
-#endif

--- a/Source/WebCore/platform/graphics/FontRanges.cpp
+++ b/Source/WebCore/platform/graphics/FontRanges.cpp
@@ -40,8 +40,8 @@ const Font* FontRanges::Range::font(ExternalResourceDownloadPolicy policy) const
 }
 
 FontRanges::FontRanges(FontRanges&& other, IsGenericFontFamily isGenericFontFamily)
-: m_ranges { WTFMove(other.m_ranges) }
-, m_isGenericFontFamily { isGenericFontFamily }
+    : m_ranges { WTFMove(other.m_ranges) }
+    , m_isGenericFontFamily { isGenericFontFamily }
 {
 }
 

--- a/Source/WebCore/platform/graphics/FontRanges.h
+++ b/Source/WebCore/platform/graphics/FontRanges.h
@@ -23,8 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
-#ifndef FontRanges_h
-#define FontRanges_h
+#pragma once
 
 #include "Font.h"
 #include <wtf/Vector.h>
@@ -53,13 +52,7 @@ public:
         {
         }
 
-        Range(const Range& range)
-            : m_from(range.m_from)
-            , m_to(range.m_to)
-            , m_fontAccessor(range.m_fontAccessor.copyRef())
-        {
-        }
-
+        Range(const Range&) = default;
         Range(Range&&) = default;
         Range& operator=(const Range&) = delete;
         Range& operator=(Range&&) = default;
@@ -103,5 +96,3 @@ private:
 };
 
 }
-
-#endif

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2759,6 +2759,14 @@ TextAutospace RenderStyle::textAutospace() const
     return fontDescription().textAutospace();
 }
 
+void RenderStyle::setFontCascade(FontCascade&& fontCascade)
+{
+    if (fontCascade == this->fontCascade())
+        return;
+
+    m_inheritedData.access().fontCascade = fontCascade;
+}
+
 bool RenderStyle::setFontDescription(FontCascadeDescription&& description)
 {
     if (fontDescription() == description)

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -1268,6 +1268,7 @@ public:
 
     void setFieldSizing(FieldSizing);
 
+    void setFontCascade(FontCascade&&);
     WEBCORE_EXPORT bool setFontDescription(FontCascadeDescription&&);
 
     // Only used for blending font sizes when animating, for MathML anonymous blocks, and for text autosizing.

--- a/Source/WebCore/style/StyleResolveForDocument.cpp
+++ b/Source/WebCore/style/StyleResolveForDocument.cpp
@@ -100,7 +100,9 @@ RenderStyle resolveForDocument(const Document& document)
 
     documentStyle.setFontDescription(WTFMove(fontDescription));
 
-    documentStyle.fontCascade().update(&const_cast<Document&>(document).fontSelector());
+    auto fontCascade = documentStyle.fontCascade();
+    fontCascade.update(&const_cast<Document&>(document).fontSelector());
+    documentStyle.setFontCascade(WTFMove(fontCascade));
 
     return documentStyle;
 }


### PR DESCRIPTION
#### c731586091b5ad7bf44d6da8e0412c84187a310c
<pre>
resolveForDocument() should explicitly set the FontCascade on the style
<a href="https://bugs.webkit.org/show_bug.cgi?id=284001">https://bugs.webkit.org/show_bug.cgi?id=284001</a>
<a href="https://rdar.apple.com/140876951">rdar://140876951</a>

Reviewed by Alan Baradlay.

Currently, resolveForDocument () does:
  documentStyle.fontCascade().update(&amp;const_cast&lt;Document&amp;&gt;(document).fontSelector())

This updates the FontCascade in situ, which means that that the object shared by existing
RenderStyles, and any newly created styles will be the same even when there is a change
that should have prompted style diffs.

Fix it to set the FontCascade, which invokes `access()` which clones the `m_inheritedData`
when necessary.

Minor tidy up in FontRanges and FontCascadeFonts, and a FIXME in `FontCascade::updateFonts()`
where we should compare the old and new, but `FontCascadeFonts` has no equality operator.

* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::updateFonts const):
* Source/WebCore/platform/graphics/FontCascadeFonts.h:
* Source/WebCore/platform/graphics/FontRanges.cpp:
(WebCore::FontRanges::FontRanges):
* Source/WebCore/platform/graphics/FontRanges.h:
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::setFontCascade):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/style/StyleResolveForDocument.cpp:
(WebCore::Style::resolveForDocument):

Canonical link: <a href="https://commits.webkit.org/287326@main">https://commits.webkit.org/287326@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d8d2f92c76fc494eb95d21ff25fb9f78f9d5596

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79152 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32527 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83783 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30350 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81285 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67283 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6450 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61934 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19844 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82219 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51986 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72135 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42239 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49337 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26260 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28723 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70454 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26684 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85173 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6462 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4475 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70183 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6625 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68006 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69432 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17308 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13472 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12283 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6416 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6363 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9823 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8155 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->