### PR TITLE
Make WebGPU crashtests more robust

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2241,7 +2241,8 @@ fast/webgpu/regression [ Pass ]
 fast/webgpu/regression/repro_275108.html [ Pass Failure Timeout ]
 
 [ Debug ] fast/webgpu/nocrash [ Skip ]
-[ Release ] fast/webgpu/nocrash [ Pass Failure Timeout ]
+[ Release ] fast/webgpu/nocrash [ Pass Failure ]
+fast/webgpu/nocrash/fuzz-282052.html [ Pass Failure Slow ]
 [ Debug ] fast/webgpu/regression/repro_275624.html [ Skip ]
 [ Debug ] fast/webgpu/texture-supports-blending.html [ Pass Crash ]
 

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-126711484.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-126711484.html
@@ -34,8 +34,10 @@ async function run() {
     await 0;
     gc();
     renderPass.executeBundles([renderBundle]);
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-128396311.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-128396311.html
@@ -12,7 +12,9 @@ async function run() {
     let buffer2 = device.createBuffer({ size: 391719, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE });
     buffer.unmap();
     commandEncoder.copyBufferToBuffer(buffer2, 278668, buffer, 14060, 64684);
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-272863.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-272863.html
@@ -6,7 +6,9 @@ async function run() {
     let commandEncoder = device.createCommandEncoder();
     let querySet = device.createQuerySet({ type: 'occlusion', count: 52 });
     commandEncoder.resolveQuerySet(querySet, 3, 0, buffer, 11264)
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-272903.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-272903.html
@@ -6,7 +6,9 @@ async function run() {
     let querySet = device.createQuerySet({ type: 'occlusion', count: 1 });
     let commandEncoder = device.createCommandEncoder();
     commandEncoder.resolveQuerySet(querySet, 0, 0, buffer, 1280);
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-272911.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-272911.html
@@ -9,7 +9,10 @@ async function run() {
         { texture: texture0 },
         { buffer: buffer1 },
         { width: 2146, height: 1 },
-    )};
+    )
+    await device0.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
+}
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-273017.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-273017.html
@@ -12,7 +12,9 @@ async function run() {
         ],
     });
     renderPassEncoder.end()
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-273021.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-273021.html
@@ -49,19 +49,27 @@ async function run() {
     })
     let texture = device.createTexture({ size: [], format: 'depth24plus-stencil8', usage: GPUTextureUsage.RENDER_ATTACHMENT });
     let textureView = texture.createView({ aspect: 'stencil-only' });
-    let renderPipeline = device.createRenderPipeline({
-        layout: 'auto',
-        vertex: { module: shaderModule },
-        depthStencil: { format: 'stencil8' }
-    });
-    let commandEncoder = device.createCommandEncoder()
-    let renderPass = commandEncoder.beginRenderPass({
-        colorAttachments: [],
-        depthStencilAttachment: { view: textureView, stencilLoadOp: 'clear', stencilStoreOp: 'discard' }
-    });
-    renderPass.setPipeline(renderPipeline);
-    renderPass.drawIndexed(0);
+    let renderPipeline;
+    try {
+        renderPipeline = device.createRenderPipeline({
+            layout: 'auto',
+            vertex: { module: shaderModule },
+            depthStencil: { format: 'stencil8' }
+        });
+    } catch {
+    }
+    if (renderPipeline) {
+        let commandEncoder = device.createCommandEncoder()
+        let renderPass = commandEncoder.beginRenderPass({
+            colorAttachments: [],
+            depthStencilAttachment: { view: textureView, stencilLoadOp: 'clear', stencilStoreOp: 'discard' }
+        });
+        renderPass.setPipeline(renderPipeline);
+        renderPass.drawIndexed(0);
+    }
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-273023.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-273023.html
@@ -10,7 +10,9 @@ async function run() {
         { texture: texture2, origin: { x: 0, y: 0, z: 198 } },
         { width: 1, height: 1 }
     );
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-273323.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-273323.html
@@ -1,20 +1,22 @@
 <script>
 async function run() {
-let adapter = await navigator.gpu.requestAdapter();
-let device = await adapter.requestDevice();
-let texture = device.createTexture({ size: [1, 1], format: 'depth24plus', usage: GPUTextureUsage.RENDER_ATTACHMENT });
-let textureView = texture.createView();
-texture.destroy()
-device.createCommandEncoder().beginRenderPass({
-    colorAttachments: [],
-    depthStencilAttachment: {
-        view: textureView,
-        depthClearValue: 0,
-        depthLoadOp: 'load',
-        depthStoreOp: 'discard',
-    },
-})
+    let adapter = await navigator.gpu.requestAdapter();
+    let device = await adapter.requestDevice();
+    let texture = device.createTexture({ size: [1, 1], format: 'depth24plus', usage: GPUTextureUsage.RENDER_ATTACHMENT });
+    let textureView = texture.createView();
+    texture.destroy()
+    device.createCommandEncoder().beginRenderPass({
+        colorAttachments: [],
+        depthStencilAttachment: {
+            view: textureView,
+            depthClearValue: 0,
+            depthLoadOp: 'load',
+            depthStoreOp: 'discard',
+        },
+    })
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-273503.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-273503.html
@@ -25,7 +25,9 @@ async function run() {
     renderBundleEncoder.setPipeline(pipeline1);
     renderBundleEncoder.setVertexBuffer(0, undefined);
     renderBundleEncoder.setPipeline(pipeline2);
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-273505.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-273505.html
@@ -65,8 +65,10 @@ async function run() {
     renderBundleEncoder.setPipeline(renderPipeline);
     renderBundleEncoder.draw(0);
     renderBundleEncoder.finish();
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-273566.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-273566.html
@@ -53,7 +53,9 @@ async function run() {
     renderBundleEncoder.setPipeline(pipeline);
     renderBundleEncoder.setBindGroup(0, bindGroup);
     renderBundleEncoder.setPipeline(pipeline2);
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-273570.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-273570.html
@@ -12,7 +12,9 @@ async function run() {
         layout: bindGroupLayout,
         entries: [{ binding: 0, resource: textureView }]
     });
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-273573.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-273573.html
@@ -1,22 +1,24 @@
 <script>
 async function run() {
-  let adapter = await navigator.gpu.requestAdapter();
-  let device = await adapter.requestDevice();
-  let texture = device.createTexture({
-      size: { width: 21 },
-      format: 'depth32float',
-      usage: GPUTextureUsage.TEXTURE_BINDING
-  });
-  let textureView = texture.createView();
-  let commandEncoder = device.createCommandEncoder();
-  texture.destroy();
-  commandEncoder.beginRenderPass({
-      colorAttachments: [],
-      depthStencilAttachment: {
-          view: textureView
-      },
-  });
+    let adapter = await navigator.gpu.requestAdapter();
+    let device = await adapter.requestDevice();
+    let texture = device.createTexture({
+        size: { width: 21 },
+        format: 'depth32float',
+        usage: GPUTextureUsage.TEXTURE_BINDING
+    });
+    let textureView = texture.createView();
+    let commandEncoder = device.createCommandEncoder();
+    texture.destroy();
+    commandEncoder.beginRenderPass({
+        colorAttachments: [],
+        depthStencilAttachment: {
+            view: textureView
+        },
+    });
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-273578.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-273578.html
@@ -37,8 +37,10 @@ async function run() {
     });
     let renderBundle = renderBundleEncoder.finish();
     renderPass.executeBundles([renderBundle]);
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-274161.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-274161.html
@@ -8,8 +8,10 @@ async function run() {
     canvas.getContext('webgpu').configure({ device: device, format: 'rgba16float' });
     device.destroy();
     createImageBitmap(canvas);
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-274171.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-274171.html
@@ -1,20 +1,22 @@
 <script>
 async function run() {
-let adapter = await navigator.gpu.requestAdapter();
-let device = await adapter.requestDevice({ requiredFeatures: ['texture-compression-etc2'] });
-let texture = device.createTexture({
-    size: { width: 7904, height: 240, depthOrArrayLayers: 1 },
-    mipLevelCount: 6,
-    format: 'etc2-rgba8unorm-srgb',
-    usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
-});
-device.queue.writeTexture(
-    { texture: texture, mipLevel: 5 },
-    new Int32Array(2318),
-    { offset: 934, bytesPerRow: 824 },
-    { width: 140, height: 8, depthOrArrayLayers: 1 }
-);
+    let adapter = await navigator.gpu.requestAdapter();
+    let device = await adapter.requestDevice({ requiredFeatures: ['texture-compression-etc2'] });
+    let texture = device.createTexture({
+        size: { width: 7904, height: 240, depthOrArrayLayers: 1 },
+        mipLevelCount: 6,
+        format: 'etc2-rgba8unorm-srgb',
+        usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+    });
+    device.queue.writeTexture(
+        { texture: texture, mipLevel: 5 },
+        new Int32Array(2318),
+        { offset: 934, bytesPerRow: 824 },
+        { width: 140, height: 8, depthOrArrayLayers: 1 }
+    );
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-274270.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-274270.html
@@ -7,8 +7,10 @@ async function run() {
     context.configure({ device: device, format: 'rgba16float', viewFormats: ['rgba16float'] });
     new VideoFrame(canvas, { timestamp: 0 });
     context.getCurrentTexture().createView({format : 'rgba16float'});
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-274271.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-274271.html
@@ -43,7 +43,9 @@ async function run() {
     let renderBundle = renderBundleEncoder.finish();
     renderPassEncoder1.executeBundles([renderBundle]);
     renderPassEncoder2.executeBundles([renderBundle]);
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-274275.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-274275.html
@@ -15,7 +15,9 @@ async function run() {
     for (let i = 0; i < 100; i++) {
         commandBuffers.push(device.createCommandEncoder());
     }
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-274290.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-274290.html
@@ -32,7 +32,9 @@ async function run() {
     });
     let renderBundle = renderBundleEncoder.finish();
     renderPassEncoder.executeBundles([renderBundle]);
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-274317.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-274317.html
@@ -45,7 +45,9 @@ async function run() {
     });
     renderPassEncoder.setBindGroup(0, bindGroup, [0]);
     renderPassEncoder.drawIndexed(0);
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-274622.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-274622.html
@@ -6,21 +6,22 @@ globalThis.testRunner?.waitUntilDone();
 const log = globalThis.$vm?.print ?? console.log;
 
 onload = async () => {
-let adapter = await navigator.gpu.requestAdapter({});
-let device = await adapter.requestDevice({});
-let texture = device.createTexture({format: 'r32uint', size: [1, 1, 1], usage: GPUTextureUsage.RENDER_ATTACHMENT});
-let renderPassDescriptor = {
-  colorAttachments: [{
-    view: texture.createView(),
-    clearValue: [0, 0, 0, 0],
-    loadOp: 'clear', storeOp: 'store',
-  }],
-};
-let commandEncoder = device.createCommandEncoder();
-let renderPassEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
-let indexBuffer = device.createBuffer({usage: GPUBufferUsage.INDEX, size: 4});
-renderPassEncoder.setIndexBuffer(indexBuffer, 'uint32');
-renderPassEncoder.drawIndexed(1);
-globalThis.testRunner?.notifyDone();
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    let texture = device.createTexture({format: 'r32uint', size: [1, 1, 1], usage: GPUTextureUsage.RENDER_ATTACHMENT});
+    let renderPassDescriptor = {
+        colorAttachments: [{
+            view: texture.createView(),
+            clearValue: [0, 0, 0, 0],
+            loadOp: 'clear', storeOp: 'store',
+        }],
+    };
+    let commandEncoder = device.createCommandEncoder();
+    let renderPassEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
+    let indexBuffer = device.createBuffer({usage: GPUBufferUsage.INDEX, size: 4});
+    renderPassEncoder.setIndexBuffer(indexBuffer, 'uint32');
+    renderPassEncoder.drawIndexed(1);
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 };
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-275167.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-275167.html
@@ -55,8 +55,10 @@ async function run() {
     renderBundleEncoder.setPipeline(pipeline);
     renderBundleEncoder.drawIndexed(1833);
     renderBundleEncoder.finish();
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-275172.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-275172.html
@@ -40,8 +40,10 @@ async function run() {
     let renderPassEncoder = commandEncoder.beginRenderPass({ colorAttachments: [{ view: textureView, loadOp: 'load', storeOp: 'discard' }] });
     let renderBundle = renderBundleEncoder.finish();
     renderPassEncoder.executeBundles([renderBundle]);
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-275218.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-275218.html
@@ -18,7 +18,9 @@ async function run() {
             { binding: 0, resource: sampler }
         ],
     });
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-275225.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-275225.html
@@ -12,7 +12,9 @@ async function run() {
         depthStencilAttachment: { view: textureView, depthClearValue: 0.6744484791866846, depthLoadOp: 'clear', depthStoreOp: 'store', stencilClearValue: 40696, stencilReadOnly: true },
     });
     renderPassEncoder.end()
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-275228.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-275228.html
@@ -28,7 +28,9 @@ async function run() {
     renderPassEncoder.setVertexBuffer(4, buffer);
     device.destroy();
     renderPassEncoder.drawIndexed(153);
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-275229.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-275229.html
@@ -6,7 +6,9 @@ async function run() {
     let textureView = texture.createView();
     texture.destroy();
     device.createCommandEncoder().beginRenderPass({ colorAttachments: [], depthStencilAttachment: { view: textureView } });
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-275232.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-275232.html
@@ -40,7 +40,9 @@ async function run() {
     });
     let renderBundle = renderBundleEncoder.finish();
     renderPass.executeBundles([renderBundle]);
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-275371.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-275371.html
@@ -33,8 +33,10 @@ async function run() {
     device.destroy();
     renderBundleEncoder.draw(0);
     renderBundleEncoder.finish();
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-276279.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-276279.html
@@ -109,7 +109,9 @@ async function run() {
     renderBundleEncoder.finish();
     let renderBundle = renderBundleEncoder.finish();
     renderPassEncoder.executeBundles([renderBundle]);
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-277017.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-277017.html
@@ -12,7 +12,9 @@ async function run() {
         ],
     });
     renderPassEncoder.end()
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-277557.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-277557.html
@@ -70,7 +70,9 @@ async function run() {
         colorAttachments: [, { view: textureView, depthSlice: 0, loadOp: 'clear', storeOp: 'discard' }]
     });
     renderPassEncoder.executeBundles([renderBundle]);
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 globalThis.testRunner?.waitUntilDone();
-run().then(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-277642.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-277642.html
@@ -29,8 +29,10 @@ async function run() {
     });
     renderPassEncoder.setPipeline(pipeline);
     renderPassEncoder.draw(10530, 519, 4_294_967_295)
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-277864.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-277864.html
@@ -15,7 +15,9 @@ async function run() {
         depthStencilAttachment: { view: textureView }
     });
     renderPassEncoder.end();
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-277928.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-277928.html
@@ -45,8 +45,10 @@ async function run() {
     let renderBundle3 = renderBundleEncoder3.finish();
     let renderBundle2 = renderBundleEncoder2.finish();
     renderPassEncoder.executeBundles([renderBundle2, renderBundle, renderBundle3]);
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-277928b.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-277928b.html
@@ -1,6 +1,5 @@
 <script>
 async function run() {
-// START
     let adapter = await navigator.gpu.requestAdapter();
     let device = await adapter.requestDevice();
     let bindGroupLayout = device.createBindGroupLayout({ entries: [{ binding: 0, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'storage' } }] });
@@ -37,7 +36,9 @@ async function run() {
     let renderBundle2 = renderBundleEncoder2.finish();
     let renderPassEncoder = commandEncoder.beginRenderPass({ colorAttachments: [{ view: textureView, loadOp: 'clear', storeOp: 'store' }] });
     renderPassEncoder.executeBundles([renderBundle2, renderBundle]);
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-278049.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-278049.html
@@ -41,7 +41,9 @@ async function run() {
     renderBundleEncoder.drawIndexed(1);
     renderBundleEncoder.setIndexBuffer(buffer, 'uint32', 3_668);
     renderBundleEncoder.setPipeline(renderPipeline2);
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 globalThis.testRunner?.waitUntilDone();
-run().then(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-278474.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-278474.html
@@ -1,14 +1,16 @@
 <script>
 async function run() {
-  let adapter = await navigator.gpu.requestAdapter();
-  let device = await adapter.requestDevice({ requiredFeatures: ['texture-compression-astc'] });
-  let texture = device.createTexture({
-    size: { width: 64, height: 4 },
-    format: 'astc-4x4-unorm-srgb',
-    usage: GPUTextureUsage.COPY_DST
-  });
-  device.queue.writeTexture({texture : texture}, new Uint8Array(136), {}, { width: 16, height: 4 });
+    let adapter = await navigator.gpu.requestAdapter();
+    let device = await adapter.requestDevice({ requiredFeatures: ['texture-compression-astc'] });
+    let texture = device.createTexture({
+        size: { width: 64, height: 4 },
+        format: 'astc-4x4-unorm-srgb',
+        usage: GPUTextureUsage.COPY_DST
+    });
+    device.queue.writeTexture({texture : texture}, new Uint8Array(136), {}, { width: 16, height: 4 });
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 testRunner?.waitUntilDone();
-run().then(() => testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-279086.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-279086.html
@@ -46,8 +46,10 @@ async function run() {
     });
     renderPassEncoder.setPipeline(renderPipeline);
     renderPassEncoder.draw(3, 1, 4_294_967_295);
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-279449.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-279449.html
@@ -10,8 +10,10 @@ async function run() {
     let externalTexture = device.importExternalTexture({ source: videoFrame });
     device.createBindGroup({ layout: bindGroupLayout, entries: [{ binding: 4, resource: externalTexture }] });
     device.createBindGroup({ layout: bindGroupLayout, entries: [{ binding: 4, resource: externalTexture }] });
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-279453.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-279453.html
@@ -53,8 +53,10 @@ async function run() {
     renderBundleEncoder.draw(0);
     renderBundleEncoder.draw(0);
     renderPassEncoder.executeBundles([renderBundleEncoder.finish()]);
+    await device0.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-279912.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-279912.html
@@ -36,7 +36,9 @@ async function run() {
     renderPassEncoder8.setPipeline(pipeline2)
     renderPassEncoder8.setBindGroup(0, bindGroup17);
     renderPassEncoder8.draw(54, 42, 4_294_967_295)
+    await device0.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => setTimeout(() => globalThis.testRunner?.notifyDone(), 1000));
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-281271.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-281271.html
@@ -6,8 +6,10 @@ async function run() {
     device0.queue.writeTexture({ texture: texture1 }, new Uint8Array(14_980), { bytesPerRow: 130 }, {width: 4, height: 12 });
     await device0.queue.onSubmittedWorkDone();
     device0.queue.writeTexture({ texture: texture1 }, new Uint8Array(202), {}, {width: 48, height: 4 });
+    await device0.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-281272.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-281272.html
@@ -35,8 +35,10 @@ async function run() {
         ]
     });
     renderPassEncoder.executeBundles([renderBundleEncoder.finish()])
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-281539.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-281539.html
@@ -46,8 +46,10 @@ async function run() {
     });
     renderPassEncoder.setPipeline(renderPipeline);
     renderPassEncoder.drawIndexedIndirect(buffer, 2_468);
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => setTimeout(() => globalThis.testRunner?.notifyDone(), 250));
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-281555.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-281555.html
@@ -4,7 +4,9 @@ async function run() {
     let device = await adapter.requestDevice({ requiredFeatures: [ 'texture-compression-etc2' ] })
     let texture = device.createTexture({ size: { width: 400, height: 60 }, mipLevelCount: 2, format: 'etc2-rgb8unorm-srgb', usage: GPUTextureUsage.COPY_DST })
     device.queue.writeTexture({ texture: texture, mipLevel: 1 }, new Uint8Array(186_828), { bytesPerRow: 84 }, { width: 4, height: 32 });
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 globalThis.testRunner?.waitUntilDone();
-run().then(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-281603.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-281603.html
@@ -29,8 +29,10 @@ async function run() {
     renderBundleEncoder.drawIndexedIndirect(buffer, 0);
     let renderBundle = renderBundleEncoder.finish();
     renderPassEncoder.executeBundles([renderBundle]);
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-281614.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-281614.html
@@ -39,8 +39,10 @@ async function run() {
     renderBundleEncoder.setPipeline(renderPipeline);
     let renderBundle = renderBundleEncoder.finish();
     renderPassEncoder.executeBundles([renderBundle]);
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-281778.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-281778.html
@@ -3,9 +3,9 @@ async function run() {
     let adapter = await navigator.gpu.requestAdapter();
     let device = await adapter.requestDevice();
     let bindGroupLayout = device.createBindGroupLayout({
-      entries: [
-        { binding: 0, visibility: GPUShaderStage.VERTEX, externalTexture: {} }
-      ]
+        entries: [
+            { binding: 0, visibility: GPUShaderStage.VERTEX, externalTexture: {} }
+        ]
     });
     let pipelineLayout = device.createPipelineLayout({ bindGroupLayouts : [bindGroupLayout] })
     let shaderModule = device.createShaderModule({ code: ` 
@@ -36,7 +36,9 @@ async function run() {
     renderPass.end()
     let commandBuffer = commandEncoder.finish();
     device.queue.submit([commandBuffer]);
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 globalThis.testRunner?.waitUntilDone();
-run().then(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-282052.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-282052.html
@@ -35,8 +35,10 @@ async function run() {
     renderBundleEncoder.drawIndexedIndirect(buffer2, 0);
     let renderBundle = renderBundleEncoder.finish();
     renderPassEncoder.executeBundles([renderBundle]);
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => setTimeout(() => globalThis.testRunner?.notifyDone(), 1000));
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-282086.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-282086.html
@@ -31,8 +31,10 @@ async function run() {
     computePassEncoder14.end();
     let commandBuffer = commandEncoder.finish();
     device.queue.submit([commandBuffer]);
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-282097.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-282097.html
@@ -74,7 +74,9 @@ async function run() {
     renderPassEncoder.end();
     let commandBuffer = commandEncoder.finish();
     device.queue.submit([commandBuffer])
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 globalThis.testRunner?.waitUntilDone();
-run().then(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-282116.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-282116.html
@@ -1,11 +1,13 @@
 <script>
 async function run() {
-  let adapter = await navigator.gpu.requestAdapter();
-  let device = await adapter.requestDevice();
-  let renderBundleEncoder = device.createRenderBundleEncoder({ colorFormats: ['r8sint'] });
-  renderBundleEncoder.draw(67, 297, 432_754_598, 4_294_967_295);
-  renderBundleEncoder.finish();
+    let adapter = await navigator.gpu.requestAdapter();
+    let device = await adapter.requestDevice();
+    let renderBundleEncoder = device.createRenderBundleEncoder({ colorFormats: ['r8sint'] });
+    renderBundleEncoder.draw(67, 297, 432_754_598, 4_294_967_295);
+    renderBundleEncoder.finish();
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 testRunner?.waitUntilDone();
-run().then(() => testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-282485.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-282485.html
@@ -1,11 +1,10 @@
 <script>
 async function run() {
-  adapter0 = await navigator.gpu.requestAdapter();
-  device0 = await adapter0.requestDevice();
-  buffer4 = device0.createBuffer({size : 1, usage : GPUBufferUsage.VERTEX});
-  pipelineLayout0 = device0.createPipelineLayout({bindGroupLayouts : []});
-  shaderModule1 = device0.createShaderModule({
-    code : `
+    adapter0 = await navigator.gpu.requestAdapter();
+    device0 = await adapter0.requestDevice();
+    buffer4 = device0.createBuffer({size : 1, usage : GPUBufferUsage.VERTEX});
+    pipelineLayout0 = device0.createPipelineLayout({bindGroupLayouts : []});
+    shaderModule1 = device0.createShaderModule({ code : `
 struct FragmentOutput0 {
   @location(0) f2: vec4f,
 }
@@ -30,52 +29,53 @@ fn unconst_u32(v: u32) -> u32 { return v; }
   var out: FragmentOutput0;
   return out;
 }
-`
-  });
-  pipeline0 = await device0.createRenderPipelineAsync({
-    layout : pipelineLayout0,
-    fragment : {
-      module : shaderModule1,
-      entryPoint : 'fragment0',
-      targets : [ {format : 'rgba16float'} ]
-    },
-    vertex : {
-      module : shaderModule1,
-      buffers : [ {
-        arrayStride : 0,
-        attributes : [
-          {format : 'uint16x4', offset : 0, shaderLocation : 0},
-          {format : 'unorm10-10-10-2', offset : 0, shaderLocation : 1}
-        ]
-      } ]
-    }
-  });
-  texture14 = device0.createTexture({
-    size : {width : 1, height : 1, depthOrArrayLayers : 1},
-    dimension : '3d',
-    format : 'rgba16float',
-    usage : GPUTextureUsage.RENDER_ATTACHMENT
-  });
-  textureView16 = texture14.createView();
-  buffer12 = device0.createBuffer({size : 10, usage : GPUBufferUsage.INDEX});
-  commandEncoder29 = device0.createCommandEncoder();
-  renderPassEncoder2 = commandEncoder29.beginRenderPass({
-    colorAttachments : [ {
-      view : textureView16,
-      depthSlice : 0,
-      loadOp : 'clear',
-      storeOp : 'discard'
-    } ],
-  });
-  renderPassEncoder2.setPipeline(pipeline0)
-  renderPassEncoder2.setIndexBuffer(buffer12, 'uint16')
-  renderPassEncoder2.setVertexBuffer(0, buffer4);
-  renderPassEncoder2.drawIndexed(3)
-  renderPassEncoder2.end()
-  commandBuffer3 = commandEncoder29.finish();
-  device0.queue.submit([ commandBuffer3 ])
+  `});
+    pipeline0 = await device0.createRenderPipelineAsync({
+      layout : pipelineLayout0,
+      fragment : {
+        module : shaderModule1,
+        entryPoint : 'fragment0',
+        targets : [ {format : 'rgba16float'} ]
+      },
+      vertex : {
+        module : shaderModule1,
+        buffers : [ {
+          arrayStride : 0,
+          attributes : [
+            {format : 'uint16x4', offset : 0, shaderLocation : 0},
+            {format : 'unorm10-10-10-2', offset : 0, shaderLocation : 1}
+          ]
+        } ]
+      }
+    });
+    texture14 = device0.createTexture({
+      size : {width : 1, height : 1, depthOrArrayLayers : 1},
+      dimension : '3d',
+      format : 'rgba16float',
+      usage : GPUTextureUsage.RENDER_ATTACHMENT
+    });
+    textureView16 = texture14.createView();
+    buffer12 = device0.createBuffer({size : 10, usage : GPUBufferUsage.INDEX});
+    commandEncoder29 = device0.createCommandEncoder();
+    renderPassEncoder2 = commandEncoder29.beginRenderPass({
+      colorAttachments : [ {
+        view : textureView16,
+        depthSlice : 0,
+        loadOp : 'clear',
+        storeOp : 'discard'
+      } ],
+    });
+    renderPassEncoder2.setPipeline(pipeline0)
+    renderPassEncoder2.setIndexBuffer(buffer12, 'uint16')
+    renderPassEncoder2.setVertexBuffer(0, buffer4);
+    renderPassEncoder2.drawIndexed(3)
+    renderPassEncoder2.end()
+    commandBuffer3 = commandEncoder29.finish();
+    device0.queue.submit([ commandBuffer3 ])
+    await device0.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 
 testRunner?.waitUntilDone();
-run().then(() => testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-282499.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-282499.html
@@ -1,19 +1,21 @@
 <script>
 async function run() {
-  let adapter = await navigator.gpu.requestAdapter();
-  let device = await adapter.requestDevice({ requiredFeatures: ['texture-compression-etc2'] });
-  let texture = device.createTexture({
-    size: { width: 660, height: 32 },
-    mipLevelCount: 2,
-    format: 'eac-r11snorm',
-    usage: GPUTextureUsage.COPY_DST
-  });
-  device.queue.writeTexture({
-    texture: texture,
-    mipLevel: 1,
-    origin: { x: 316 }
-  }, new Uint8Array(32), {}, {width: 16, height: 4 });
+    let adapter = await navigator.gpu.requestAdapter();
+    let device = await adapter.requestDevice({ requiredFeatures: ['texture-compression-etc2'] });
+    let texture = device.createTexture({
+        size: { width: 660, height: 32 },
+        mipLevelCount: 2,
+        format: 'eac-r11snorm',
+        usage: GPUTextureUsage.COPY_DST
+    });
+    device.queue.writeTexture({
+        texture: texture,
+        mipLevel: 1,
+        origin: { x: 316 }
+    }, new Uint8Array(32), {}, {width: 16, height: 4 });
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 testRunner?.waitUntilDone();
-run().then(() => testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-282710.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-282710.html
@@ -82,8 +82,10 @@ async function run() {
     renderPassEncoder.end();
     let commandBuffer = commandEncoder.finish();
     device.queue.submit([commandBuffer]);
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-282995.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-282995.html
@@ -16,8 +16,10 @@ async function run() {
         { texture: texture, origin: {}, aspect: 'all' },
         { width: 0, height: 0, depthOrArrayLayers: 0 }
     );
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-283008.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-283008.html
@@ -41,8 +41,10 @@ async function run() {
             { binding: 0, resource: { buffer: buffer, offset: 0, size: 56 } }
         ]
     })
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-283051.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-283051.html
@@ -32,8 +32,10 @@ async function run() {
     renderPassEncoder.end();
     let commandBuffer = commandEncoder.finish();
     device.queue.submit([commandBuffer]);
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-283071.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-283071.html
@@ -34,8 +34,10 @@ async function run() {
     computePassEncoder.end();
     let commandBuffer = commandEncoder.finish();
     device.queue.submit([commandBuffer]);
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
 }
 
 globalThis.testRunner?.waitUntilDone();
-run().finally(() => globalThis.testRunner?.notifyDone());
+run();
 </script>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1597,6 +1597,21 @@ webkit.org/b/263396 css3/color/text.html [ Skip ]
 # skipped outside of macOS Sequoia due to crash in failed allocation
 [ Ventura Sonoma ] fast/webgpu/nocrash/fuzz-279086.html [ Skip ]
 
+# skipped on non-AS due to requiring features unavailable on Intel
+[ x86_64 ] fast/webgpu/nocrash/fuzz-273021.html [ Skip ]
+[ x86_64 ] fast/webgpu/nocrash/fuzz-274171.html [ Skip ]
+[ x86_64 ] fast/webgpu/nocrash/fuzz-276279.html [ Skip ]
+[ x86_64 ] fast/webgpu/nocrash/fuzz-278474.html [ Skip ]
+[ x86_64 ] fast/webgpu/nocrash/fuzz-281271.html [ Skip ]
+[ x86_64 ] fast/webgpu/nocrash/fuzz-281555.html [ Skip ]
+[ x86_64 ] fast/webgpu/nocrash/fuzz-282499.html [ Skip ]
+
+# skipped on Intel due to intermittently timing out due to the workload
+[ x86_64 ] fast/webgpu/nocrash/fuzz-282052.html [ Skip ]
+
+# skipped due to failing when run in stress test mode
+[ Ventura Sonoma ] fast/webgpu/nocrash/RenderBundle_WRITE.html [ Skip ]
+
 [ Release arm64 ] http/tests/webgpu/webgpu/api [ Pass Failure Timeout ]
 [ Release arm64 ] http/tests/webgpu/webgpu/shader [ Pass Failure Timeout ]
 [ Release arm64 ] http/tests/webgpu/webgpu/web_platform [ Pass Failure Timeout ]


### PR DESCRIPTION
#### f96776e9a72272b6ecabdb0c7988fa65c1f4d9eb
<pre>
Make WebGPU crashtests more robust
<a href="https://bugs.webkit.org/show_bug.cgi?id=284007">https://bugs.webkit.org/show_bug.cgi?id=284007</a>
<a href="https://rdar.apple.com/140873189">rdar://140873189</a>

Reviewed by Mike Wyrzykowski.

Many of the shader validation crashtests are timing dependent. Use
`await device.queue.onSubmittedWorkDone()` at the end of the test to
make them more likely to crash before the test has completed.

Remove the finally() call so that unexpected exceptions cause a test
to fail.

Skip a subset of the tests on Intel Macs, which use features or limits
unsupported on that hardware.

* LayoutTests/fast/webgpu/nocrash/fuzz-126711484.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-128396311.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-272863.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-272903.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-272911.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-273017.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-273021.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-273023.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-273323.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-273503.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-273505.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-273566.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-273570.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-273573.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-273578.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-274161.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-274171.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-274270.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-274271.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-274275.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-274290.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-274317.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-274622.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-275167.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-275172.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-275218.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-275225.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-275228.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-275229.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-275232.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-275371.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-276279.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-277017.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-277557.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-277642.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-277864.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-277928.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-277928b.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-278049.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-278474.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-279086.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-279449.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-279453.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-279912.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-281271.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-281272.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-281539.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-281555.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-281603.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-281614.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-281778.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-282052.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-282086.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-282097.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-282116.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-282485.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-282499.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-282710.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-282995.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-283008.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-283051.html:
* LayoutTests/fast/webgpu/nocrash/fuzz-283071.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/287587@main">https://commits.webkit.org/287587@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b099c23b8624932b83bca720ba2f514b9686e65

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80164 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59166 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33577 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84681 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31140 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68227 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7465 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62666 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20486 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83233 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/52739 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73012 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42972 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50069 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27166 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29600 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71198 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27673 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86113 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7384 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5229 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70942 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7559 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68851 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70180 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14177 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13128 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12406 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7348 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7187 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10707 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8992 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->