### PR TITLE
[block-step-sizing] Extra space to distribute for boxes with outer size of 0 is the specified step size.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/zero-outer-size-rounded-up-to-block-step-size-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/zero-outer-size-rounded-up-to-block-step-size-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/zero-outer-size-rounded-up-to-block-step-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/zero-outer-size-rounded-up-to-block-step-size.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Box with an outer size of 0 is rounded up to the specified block-step-size">
+<style>
+.container {
+  display: flow-root;
+  width: 100px;
+  background-color: green;
+}
+.block-step {
+  display: block;
+  block-step-size: 100px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div class="container">
+  <div id="test" class="block-step"></div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -98,6 +98,9 @@ static LayoutUnit computeExtraSpace(LayoutUnit stepSize, LayoutUnit boxOuterSize
     if (!stepSize)
         return { };
 
+    if (!boxOuterSize)
+        return stepSize;
+
     if (auto remainder = intMod(boxOuterSize, stepSize))
         return stepSize - remainder;
     return { };


### PR DESCRIPTION
#### 5af6cc050847fdf815c01e26e9a09d1b80286cdb
<pre>
[block-step-sizing] Extra space to distribute for boxes with outer size of 0 is the specified step size.
<a href="https://bugs.webkit.org/show_bug.cgi?id=284005">https://bugs.webkit.org/show_bug.cgi?id=284005</a>
<a href="https://rdar.apple.com/140879691">rdar://140879691</a>

Reviewed by Alan Baradlay and Tim Nguyen.

If a box with block-step-sizing has an outer size of 0, then that means
the extra space needed to round it up to the size specified in
block-step-size is just that value. When we compute the extra space
let&apos;s check if the outer size is 0 and return the step size value
directly.

* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/zero-outer-size-rounded-up-to-block-step-size-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/zero-outer-size-rounded-up-to-block-step-size.html: Added.
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::BlockStepSizing::computeExtraSpace):

Canonical link: <a href="https://commits.webkit.org/287328@main">https://commits.webkit.org/287328@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d44ffdc988b7d1092434b21cb1e554fe52dcefe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79167 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58196 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32539 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83792 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30356 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81300 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67290 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6464 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61938 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19850 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82234 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51989 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72140 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42243 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49339 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26267 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28730 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70456 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26692 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85185 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6469 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4479 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70181 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6632 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68012 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69429 "Found 4 new API test failures: /TestWebKit:WebKit.HitTestResultNodeHandle, /TestWebKit:WebKit.LoadAlternateHTMLStringWithEmptyBaseURL, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/test-page-list, /TestWebKit:WebKit.ParentFrame (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17311 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13481 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12289 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6425 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6367 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9829 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8159 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->