### PR TITLE
imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-javascript-url-navigation.html is failing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-javascript-url-navigation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-javascript-url-navigation-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL entries() after navigation to a javascript: URL assert_equals: expected 2 but got 3
+PASS entries() after navigation to a javascript: URL
 

--- a/Source/WebCore/bindings/js/ScriptController.h
+++ b/Source/WebCore/bindings/js/ScriptController.h
@@ -62,6 +62,7 @@ class HTMLPlugInElement;
 class LoadableModuleScript;
 class LocalFrame;
 class ModuleFetchParameters;
+class NavigationAction;
 class ScriptSourceCode;
 class SecurityOrigin;
 class Widget;
@@ -111,8 +112,7 @@ public:
     JSC::JSValue evaluateInWorldIgnoringException(const ScriptSourceCode&, DOMWrapperWorld&);
 
     // This asserts that URL argument is a JavaScript URL.
-    void executeJavaScriptURL(const URL&, RefPtr<SecurityOrigin>, ShouldReplaceDocumentIfJavaScriptURL, bool& didReplaceDocument);
-    void executeJavaScriptURL(const URL&, RefPtr<SecurityOrigin> = nullptr, ShouldReplaceDocumentIfJavaScriptURL = ReplaceDocumentIfJavaScriptURL);
+    void executeJavaScriptURL(const URL&, const NavigationAction&, bool& didReplaceDocument);
 
     static void initializeMainThread();
 

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3927,7 +3927,7 @@ void FrameLoader::executeJavaScriptURL(const URL& url, const NavigationAction& a
         if (RefPtr document = m_frame->document())
             document->addConsoleMessage(MessageSource::Security, MessageLevel::Error, makeString("Blocked script execution in '"_s, action.requester()->url.stringCenterEllipsizedToLength(), "' because the document's frame is sandboxed and the 'allow-scripts' permission is not set."_s));
     } else
-        protectedFrame()->checkedScript()->executeJavaScriptURL(url, action.requester() ? action.requester()->securityOrigin.ptr() : nullptr, action.shouldReplaceDocumentIfJavaScriptURL(), didReplaceDocument);
+        protectedFrame()->checkedScript()->executeJavaScriptURL(url, action, didReplaceDocument);
 
     // We need to communicate that a load happened, even if the JavaScript URL execution didn't end up replacing the document.
     if (RefPtr document = m_frame->document(); isFirstNavigationInFrame && !didReplaceDocument)


### PR DESCRIPTION
#### cda0ce0dcbd3537524f86dff14fed9efe368a23d
<pre>
imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-javascript-url-navigation.html is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=284011">https://bugs.webkit.org/show_bug.cgi?id=284011</a>

Reviewed by Rob Buis.

When setting an iframe&apos;s src to a javascript URL and the js returns a String, we
replace the document with that String, which counts as a &quot;Replace&quot; navigation
(navigation which replaces the current HistoryItem). The test in question is
expecting this since it expects `navigation.entries` to have 2 entries before
AND after the JS URL navigation.

The logic in FrameLoader::loadURL() was properly setting the NavigationAction&apos;s
navigationType to `NavigationNavigationType::Replace`. However, before we would
end up calling executeJavaScriptURL() instead of doing a proper navigation, we
would not end up setting the NavigationAction object as the DocumentLoader&apos;s
triggeringAction. The navigationType is supposed to get passed to
Navigation::initializeForNewWindow() to make sure it replaces the current entry
instead of creating a new one in this case. However, initializeForNewWindow() is
called from FrameLoader::didBeginDocument() which gets it from the DocumentLoader&apos;s
triggeringAction.

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-javascript-url-navigation-expected.txt:
* Source/WebCore/bindings/js/ScriptController.cpp:
(WebCore::ScriptController::executeJavaScriptURL):
* Source/WebCore/bindings/js/ScriptController.h:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::executeJavaScriptURL):

Canonical link: <a href="https://commits.webkit.org/287344@main">https://commits.webkit.org/287344@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73cbedcd0a92e89cf60499213e400f4d5652ab78

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79274 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58304 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83898 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30439 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81407 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67395 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6574 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62018 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19922 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82341 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52079 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72233 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42322 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49424 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26406 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28830 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70538 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26842 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85291 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6572 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4568 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70266 "Found 48 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-update-001.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-update-005.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-update-006.html imported/w3c/web-platform-tests/css/css-backgrounds/background-attachment-local/attachment-local-positioning-5.html imported/w3c/web-platform-tests/css/css-backgrounds/background-color-body-propagation-006.html imported/w3c/web-platform-tests/css/css-backgrounds/background-color-root-propagation-002.html imported/w3c/web-platform-tests/css/css-images/object-fit-contain-png-002i.html imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-descendant-text-mutated-001.html imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-position-under-left-001.xht imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-position-under-right-001.xht ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6736 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68106 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69511 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/17322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13561 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12408 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12237 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6530 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6451 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9917 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8242 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->