### PR TITLE
WIP: View transitions pseudos always create RenderBlockFlow.

### DIFF
--- a/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
@@ -137,6 +137,13 @@ RenderDeprecatedFlexibleBox::RenderDeprecatedFlexibleBox(Element& element, Rende
     m_stretchingChildren = false;
 }
 
+RenderDeprecatedFlexibleBox::RenderDeprecatedFlexibleBox(Document& document, RenderStyle&& style)
+    : RenderBlock(RenderObject::Type::DeprecatedFlexibleBox, document, WTFMove(style), { })
+{
+    setChildrenInline(false); // All of our children must be block-level
+    m_stretchingChildren = false;
+}
+
 RenderDeprecatedFlexibleBox::~RenderDeprecatedFlexibleBox() = default;
 
 static LayoutUnit marginWidthForChild(RenderBox* child)

--- a/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.h
@@ -33,6 +33,7 @@ class RenderDeprecatedFlexibleBox final : public RenderBlock {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderDeprecatedFlexibleBox);
 public:
     RenderDeprecatedFlexibleBox(Element&, RenderStyle&&);
+    RenderDeprecatedFlexibleBox(Document&, RenderStyle&&);
     virtual ~RenderDeprecatedFlexibleBox();
 
     Element& element() const { return downcast<Element>(nodeForNonAnonymous()); }

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -59,7 +59,7 @@ public:
         ListItem         = 1 << 1,
         TableOrTablePart = 1 << 2
     };
-    static RenderPtr<RenderElement> createFor(Element&, RenderStyle&&, OptionSet<ConstructBlockLevelRendererFor> = { });
+    static RenderPtr<RenderElement> createFor(Element&, RenderStyle&&, OptionSet<ConstructBlockLevelRendererFor> = { }, bool anonymous = false);
 
     bool hasInitializedStyle() const { return m_hasInitializedStyle; }
 
@@ -365,6 +365,9 @@ private:
     RenderObject* lastChildSlow() const final { return lastChild(); }
 
     RenderElement* rendererForPseudoStyleAcrossShadowBoundary() const;
+
+    template<typename T>
+    static RenderPtr<RenderElement> createForInternal(T&, RenderStyle&&, OptionSet<ConstructBlockLevelRendererFor>);
 
     // Called when an object that was floating or positioned becomes a normal flow object
     // again.  We have to make sure the render tree updates as needed to accommodate the new

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -61,6 +61,17 @@ RenderGrid::RenderGrid(Element& element, RenderStyle&& style)
     setChildrenInline(false);
 }
 
+RenderGrid::RenderGrid(Document& document, RenderStyle&& style)
+    : RenderBlock(Type::Grid, document, WTFMove(style), { })
+    , m_grid(*this)
+    , m_trackSizingAlgorithm(this, currentGrid())
+    , m_masonryLayout(*this)
+{
+    ASSERT(isRenderGrid());
+    // All of our children must be block level.
+    setChildrenInline(false);
+}
+
 RenderGrid::~RenderGrid() = default;
 
 StyleSelfAlignmentData RenderGrid::selfAlignmentForGridItem(GridAxis axis, const RenderBox& gridItem, const RenderStyle* gridStyle) const

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -51,6 +51,7 @@ class RenderGrid final : public RenderBlock {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderGrid);
 public:
     RenderGrid(Element&, RenderStyle&&);
+    RenderGrid(Document&, RenderStyle&&);
     virtual ~RenderGrid();
 
     Element& element() const { return downcast<Element>(nodeForNonAnonymous()); }

--- a/Source/WebCore/rendering/RenderListItem.cpp
+++ b/Source/WebCore/rendering/RenderListItem.cpp
@@ -56,6 +56,13 @@ RenderListItem::RenderListItem(Element& element, RenderStyle&& style)
     setInline(false);
 }
 
+RenderListItem::RenderListItem(Document& document, RenderStyle&& style)
+    : RenderBlockFlow(Type::ListItem, document, WTFMove(style))
+{
+    ASSERT(isRenderListItem());
+    setInline(false);
+}
+
 RenderListItem::~RenderListItem()
 {
     // Do not add any code here. Add it to willBeDestroyed() instead.

--- a/Source/WebCore/rendering/RenderListItem.h
+++ b/Source/WebCore/rendering/RenderListItem.h
@@ -34,6 +34,7 @@ class RenderListItem final : public RenderBlockFlow {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderListItem);
 public:
     RenderListItem(Element&, RenderStyle&&);
+    RenderListItem(Document&, RenderStyle&&);
     virtual ~RenderListItem();
 
     Element& element() const { return downcast<Element>(nodeForNonAnonymous()); }

--- a/Source/WebCore/rendering/RenderTableCaption.cpp
+++ b/Source/WebCore/rendering/RenderTableCaption.cpp
@@ -35,6 +35,12 @@ RenderTableCaption::RenderTableCaption(Element& element, RenderStyle&& style)
     ASSERT(isRenderTableCaption());
 }
 
+RenderTableCaption::RenderTableCaption(Document& document, RenderStyle&& style)
+    : RenderBlockFlow(Type::TableCaption, document, WTFMove(style))
+{
+    ASSERT(isRenderTableCaption());
+}
+
 RenderTableCaption::~RenderTableCaption() = default;
 
 void RenderTableCaption::insertedIntoTree()

--- a/Source/WebCore/rendering/RenderTableCaption.h
+++ b/Source/WebCore/rendering/RenderTableCaption.h
@@ -30,6 +30,7 @@ class RenderTableCaption final : public RenderBlockFlow {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderTableCaption);
 public:
     RenderTableCaption(Element&, RenderStyle&&);
+    RenderTableCaption(Document&, RenderStyle&&);
     virtual ~RenderTableCaption();
 
     Element& element() const { return downcast<Element>(nodeForNonAnonymous()); }


### PR DESCRIPTION
#### cc8e3f6e60d572e7f41a222106d4f95e5e0e2267
<pre>
WIP: View transitions pseudos always create RenderBlockFlow.
<a href="https://bugs.webkit.org/show_bug.cgi?id=284016">https://bugs.webkit.org/show_bug.cgi?id=284016</a>
&lt;<a href="https://rdar.apple.com/140888963">rdar://140888963</a>&gt;

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp:
(WebCore::RenderDeprecatedFlexibleBox::RenderDeprecatedFlexibleBox):
* Source/WebCore/rendering/RenderDeprecatedFlexibleBox.h:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::createFor):
(WebCore::RenderElement::createForInternal):
* Source/WebCore/rendering/RenderElement.h:
(WebCore::RenderElement::createFor):
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::RenderGrid):
(WebCore::m_masonryLayout):
* Source/WebCore/rendering/RenderGrid.h:
* Source/WebCore/rendering/RenderListItem.cpp:
(WebCore::RenderListItem::RenderListItem):
* Source/WebCore/rendering/RenderListItem.h:
* Source/WebCore/rendering/RenderTableCaption.cpp:
(WebCore::RenderTableCaption::RenderTableCaption):
* Source/WebCore/rendering/RenderTableCaption.h:
* Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.cpp:
(WebCore::RenderTreeUpdater::ViewTransition::updatePseudoElementTree):
(WebCore::createRendererIfNeeded):
(WebCore::RenderTreeUpdater::ViewTransition::updatePseudoElementGroup):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc8e3f6e60d572e7f41a222106d4f95e5e0e2267

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80375 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59381 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33892 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84896 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31357 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82486 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68443 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7684 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62827 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20634 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83444 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52899 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73185 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43131 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50215 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27340 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29816 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71354 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27857 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86330 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7600 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5377 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71109 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7775 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69023 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70350 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14340 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13284 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7562 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13082 "Found 2 new failures in rendering/updating/RenderTreeUpdaterViewTransition.cpp") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7401 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10921 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9207 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->