### PR TITLE
Stop using WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/crypto/

### DIFF
--- a/Source/WTF/wtf/CryptographicUtilities.cpp
+++ b/Source/WTF/wtf/CryptographicUtilities.cpp
@@ -25,21 +25,18 @@
 
 #include "config.h"
 #include <wtf/CryptographicUtilities.h>
+#include <wtf/ZippedRange.h>
 
 namespace WTF {
 
 #if !HAVE(TIMINGSAFE_BCMP)
-NEVER_INLINE int constantTimeMemcmp(const void* voidA, const void* voidB, size_t length)
+NEVER_INLINE int constantTimeMemcmp(std::span<const uint8_t> a, std::span<const uint8_t> b)
 {
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    const uint8_t* a = static_cast<const uint8_t*>(voidA);
-    const uint8_t* b = static_cast<const uint8_t*>(voidB);
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    RELEASE_ASSERT(a.size() == b.size());
 
     uint8_t result = 0;
-    for (size_t i = 0; i < length; ++i)
-        result |= a[i] ^ b[i];
-
+    for (auto [value1, value2] : zippedRange(a, b))
+        result |= value1 ^ value2;
     return result;
 }
 #endif

--- a/Source/WTF/wtf/CryptographicUtilities.h
+++ b/Source/WTF/wtf/CryptographicUtilities.h
@@ -25,18 +25,20 @@
 
 #pragma once
 
+#include <span>
 #include <string>
 
 namespace WTF {
 
 // Returns zero if arrays are equal, and non-zero otherwise. Execution time does not depend on array contents.
 #if HAVE(TIMINGSAFE_BCMP)
-inline int constantTimeMemcmp(const void* voidA, const void* voidB, size_t length)
+inline int constantTimeMemcmp(std::span<const uint8_t> a, std::span<const uint8_t> b)
 {
-    return timingsafe_bcmp(voidA, voidB, length);
+    RELEASE_ASSERT(a.size() == b.size());
+    return timingsafe_bcmp(a.data(), b.data(), b.size());
 }
 #else
-WTF_EXPORT_PRIVATE int constantTimeMemcmp(const void*, const void*, size_t length);
+WTF_EXPORT_PRIVATE int constantTimeMemcmp(std::span<const uint8_t>, std::span<const uint8_t>);
 #endif
 
 }

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESGCM.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESGCM.cpp
@@ -30,9 +30,9 @@
 #include "CryptoAlgorithmAesKeyParams.h"
 #include "CryptoKeyAES.h"
 #include "ScriptExecutionContext.h"
+#include <algorithm>
+#include <ranges>
 #include <wtf/CrossThreadCopier.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 
@@ -43,7 +43,7 @@ static constexpr auto ALG256 = "A256GCM"_s;
 #if CPU(ADDRESS64)
 static const uint64_t PlainTextMaxLength = 549755813632ULL; // 2^39 - 256
 #endif
-static const uint8_t ValidTagLengths[] = { 32, 64, 96, 104, 112, 120, 128 };
+static constexpr std::array<uint8_t, 7> validTagLengths { 32, 64, 96, 104, 112, 120, 128 };
 }
 
 static inline bool usagesAreInvalidForCryptoAlgorithmAESGCM(CryptoKeyUsageBitmap usages)
@@ -54,11 +54,7 @@ static inline bool usagesAreInvalidForCryptoAlgorithmAESGCM(CryptoKeyUsageBitmap
 static inline bool tagLengthIsValid(uint8_t tagLength)
 {
     using namespace CryptoAlgorithmAESGCMInternal;
-    for (size_t i = 0; i < sizeof(ValidTagLengths); i++) {
-        if (tagLength == ValidTagLengths[i])
-            return true;
-    }
-    return false;
+    return std::ranges::find(validTagLengths, tagLength) != std::ranges::end(validTagLengths);
 }
 
 Ref<CryptoAlgorithm> CryptoAlgorithmAESGCM::create()
@@ -243,5 +239,3 @@ ExceptionOr<std::optional<size_t>> CryptoAlgorithmAESGCM::getKeyLength(const Cry
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.cpp
@@ -108,7 +108,7 @@ void CryptoAlgorithmX25519::deriveBits(const CryptoAlgorithmParameters& paramete
         // https://datatracker.ietf.org/doc/html/rfc7748#section-6.1
         constexpr auto expectedOutputSize = 32;
         constexpr std::array<uint8_t, expectedOutputSize> zeros { };
-        if (derivedKey->size() != expectedOutputSize || !constantTimeMemcmp(derivedKey->data(), zeros.data(), expectedOutputSize)) {
+        if (derivedKey->size() != expectedOutputSize || !constantTimeMemcmp(derivedKey->span(), zeros)) {
             exceptionCallback(ExceptionCode::OperationError);
             return;
         }

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESCBCMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESCBCMac.cpp
@@ -30,8 +30,6 @@
 #include "CryptoKeyAES.h"
 #include <CommonCrypto/CommonCrypto.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 static ExceptionOr<Vector<uint8_t>> transformAESCBC(CCOperation operation, const Vector<uint8_t>& iv, const Vector<uint8_t>& key, const Vector<uint8_t>& data, CryptoAlgorithmAESCBC::Padding padding)
@@ -49,16 +47,15 @@ static ExceptionOr<Vector<uint8_t>> transformAESCBC(CCOperation operation, const
     if (status)
         return Exception { ExceptionCode::OperationError };
 
-    uint8_t* p = result.data() + bytesWritten;
+    auto p = result.mutableSpan().subspan(bytesWritten);
     if (padding == CryptoAlgorithmAESCBC::Padding::Yes) {
-        status = CCCryptorFinal(cryptor, p, result.end() - p, &bytesWritten);
-        p += bytesWritten;
+        status = CCCryptorFinal(cryptor, p.data(), p.size(), &bytesWritten);
+        p = p.subspan(bytesWritten);
         if (status)
             return Exception { ExceptionCode::OperationError };
     }
 
-    ASSERT(p <= result.end());
-    result.shrink(p - result.begin());
+    result.shrink(result.size() - p.size());
 
     CCCryptorRelease(cryptor);
 
@@ -96,5 +93,3 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESCBC::platformDecrypt(const Crypto
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESCFBMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESCFBMac.cpp
@@ -30,8 +30,6 @@
 #include "CryptoKeyAES.h"
 #include <CommonCrypto/CommonCrypto.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 static ExceptionOr<Vector<uint8_t>> transformAESCFB(CCOperation operation, const Vector<uint8_t>& iv, const Vector<uint8_t>& key, const Vector<uint8_t>& data)
@@ -48,14 +46,13 @@ static ExceptionOr<Vector<uint8_t>> transformAESCFB(CCOperation operation, const
     if (status)
         return Exception { ExceptionCode::OperationError };
 
-    uint8_t* p = result.data() + bytesWritten;
-    status = CCCryptorFinal(cryptor, p, result.end() - p, &bytesWritten);
-    p += bytesWritten;
+    auto p = result.mutableSpan().subspan(bytesWritten);
+    status = CCCryptorFinal(cryptor, p.data(), p.size(), &bytesWritten);
+    p = p.subspan(bytesWritten);
     if (status)
         return Exception { ExceptionCode::OperationError };
 
-    ASSERT(p <= result.end());
-    result.shrink(p - result.begin());
+    result.shrink(result.size() - p.size());
 
     CCCryptorRelease(cryptor);
 
@@ -75,5 +72,3 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESCFB::platformDecrypt(const Crypto
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESGCMMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESGCMMac.cpp
@@ -29,12 +29,12 @@
 #include "CommonCryptoUtilities.h"
 #include "CryptoAlgorithmAesGcmParams.h"
 #include "CryptoKeyAES.h"
+#include <wtf/CryptographicUtilities.h>
+#include <wtf/StdLibExtras.h>
+
 #if HAVE(SWIFT_CPP_INTEROP)
 #include <pal/PALSwift.h>
 #endif
-#include <wtf/CryptographicUtilities.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 
@@ -49,7 +49,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 ALLOW_DEPRECATED_DECLARATIONS_END
     if (status)
         return Exception { ExceptionCode::OperationError };
-    memcpy(cipherText.data() + plainText.size(), tag.data(), desiredTagLengthInBytes);
+    memcpySpan(cipherText.mutableSpan().subspan(plainText.size()), tag.span());
 
     return WTFMove(cipherText);
 }
@@ -76,7 +76,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return Exception { ExceptionCode::OperationError };
 
     // Using a constant time comparison to prevent timing attacks.
-    if (constantTimeMemcmp(tag.data(), cipherText.data() + offset, desiredTagLengthInBytes))
+    if (constantTimeMemcmp(tag.span(), cipherText.subspan(offset)))
         return Exception { ExceptionCode::OperationError };
 
     plainText.shrink(offset);
@@ -100,5 +100,3 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESGCM::platformDecrypt(const Crypto
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSAMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSAMac.cpp
@@ -31,11 +31,11 @@
 #include "CryptoAlgorithmEcdsaParams.h"
 #include "CryptoDigestAlgorithm.h"
 #include "CryptoKeyEC.h"
+#include <wtf/StdLibExtras.h>
+
 #if HAVE(SWIFT_CPP_INTEROP)
 #include <pal/PALSwiftUtils.h>
 #endif
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 #if HAVE(SWIFT_CPP_INTEROP)
@@ -107,7 +107,7 @@ static ExceptionOr<Vector<uint8_t>> signECDSA(CryptoAlgorithmIdentifier hash, co
     if (signature[offset] < keyLengthInBytes) {
         size_t pos = newSignature.size();
         newSignature.resize(pos + keyLengthInBytes - signature[offset]);
-        memset(newSignature.data() + pos, InitialOctet, keyLengthInBytes - signature[offset]);
+        memsetSpan(newSignature.mutableSpan().subspan(pos), InitialOctet);
         bytesToCopy = signature[offset];
     } else if (signature[offset] > keyLengthInBytes) // Otherwise skip the leading 0s of s.
         offset += signature[offset] - keyLengthInBytes;
@@ -198,5 +198,3 @@ ExceptionOr<bool> CryptoAlgorithmECDSA::platformVerify(const CryptoAlgorithmEcds
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmHMACMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmHMACMac.cpp
@@ -86,7 +86,7 @@ static ExceptionOr<bool> platformVerifyCC(const CryptoKeyHMAC& key, const Vector
 
     auto expectedSignature = calculateHMACSignature(*algorithm, key.key(), data.span());
     // Using a constant time comparison to prevent timing attacks.
-    return signature.size() == expectedSignature.size() && !constantTimeMemcmp(expectedSignature.data(), signature.data(), expectedSignature.size());
+    return signature.size() == expectedSignature.size() && !constantTimeMemcmp(expectedSignature.span(), signature.span());
 }
 
 ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHMAC::platformSign(const CryptoKeyHMAC& key, const Vector<uint8_t>& data)

--- a/Source/WebCore/crypto/cocoa/CryptoKeyECMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoKeyECMac.cpp
@@ -33,8 +33,6 @@
 #endif
 #include <wtf/text/Base64.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 static const unsigned char InitialOctetEC = 0x04; // Per Section 2.3.3 of http://www.secg.org/sec1-v2.pdf
@@ -327,7 +325,8 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportSpki(CryptoAlgorithmIdentifier id
 #else
     ++index;
     CCECCryptorRef ccPublicKey = nullptr;
-    if (CCECCryptorImportKey(kCCImportKeyCompact, keyData.data() + index, keyData.size() - index, ccECKeyPublic, &ccPublicKey))
+    auto dataAfterIndex = keyData.subspan(index);
+    if (CCECCryptorImportKey(kCCImportKeyCompact, dataAfterIndex.data(), dataAfterIndex.size(), ccECKeyPublic, &ccPublicKey))
         return nullptr;
     return create(identifier, curve, CryptoKeyType::Public, PlatformECKeyContainer(ccPublicKey), extractable, usages);
 #endif
@@ -503,5 +502,3 @@ Vector<uint8_t> CryptoKeyEC::platformExportPkcs8() const
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/crypto/cocoa/CryptoKeyOKPCocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoKeyOKPCocoa.cpp
@@ -36,8 +36,6 @@
 #endif
 #include <pal/spi/cocoa/CoreCryptoSPI.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 bool CryptoKeyOKP::supportsNamedCurve()
@@ -475,5 +473,3 @@ Vector<uint8_t> CryptoKeyOKP::platformExportRaw() const
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/crypto/cocoa/CryptoKeyRSAMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoKeyRSAMac.cpp
@@ -37,8 +37,6 @@
 #include <JavaScriptCore/JSGenericTypedArrayViewInlines.h>
 #include <wtf/MainThread.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 // OID rsaEncryption: 1.2.840.113549.1.1.1. Per https://tools.ietf.org/html/rfc3279#section-2.3.1
@@ -322,7 +320,8 @@ RefPtr<CryptoKeyRSA> CryptoKeyRSA::importSpki(CryptoAlgorithmIdentifier identifi
     headerSize += bytesUsedToEncodedLength(keyData[headerSize]) + sizeof(InitialOctet);
 
     CCRSACryptorRef ccPublicKey = nullptr;
-    if (CCRSACryptorImport(keyData.data() + headerSize, keyData.size() - headerSize, &ccPublicKey))
+    auto dataAfterHeader = keyData.subspan(headerSize);
+    if (CCRSACryptorImport(dataAfterHeader.data(), dataAfterHeader.size(), &ccPublicKey))
         return nullptr;
 
     // Notice: CryptoAlgorithmIdentifier::SHA_1 is just a placeholder. It should not have any effect if hash is std::nullopt.
@@ -379,7 +378,8 @@ RefPtr<CryptoKeyRSA> CryptoKeyRSA::importPkcs8(CryptoAlgorithmIdentifier identif
     headerSize += bytesUsedToEncodedLength(keyData[headerSize]);
 
     CCRSACryptorRef ccPrivateKey = nullptr;
-    if (CCRSACryptorImport(keyData.data() + headerSize, keyData.size() - headerSize, &ccPrivateKey))
+    auto dataAfterHeader = keyData.subspan(headerSize);
+    if (CCRSACryptorImport(dataAfterHeader.data(), dataAfterHeader.size(), &ccPrivateKey))
         return nullptr;
 
     // Notice: CryptoAlgorithmIdentifier::SHA_1 is just a placeholder. It should not have any effect if hash is std::nullopt.
@@ -421,5 +421,3 @@ ExceptionOr<Vector<uint8_t>> CryptoKeyRSA::exportPkcs8() const
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/crypto/cocoa/SerializedCryptoKeyWrapMac.mm
+++ b/Source/WebCore/crypto/cocoa/SerializedCryptoKeyWrapMac.mm
@@ -325,7 +325,7 @@ std::optional<Vector<uint8_t>> unwrapCryptoKey(const Vector<uint8_t>& masterKey,
     kek.shrink(kekSize);
 
     size_t tagLength = expectedTagLengthAES;
-    uint8_t actualTag[expectedTagLengthAES] = { 0 };
+    std::array<uint8_t, expectedTagLengthAES> actualTag { };
 
     Vector<uint8_t> key(encryptedKey.size());
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
@@ -334,14 +334,14 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         nullptr, 0, // auth data
         encryptedKey.data(), encryptedKey.size(),
         key.data(),
-        actualTag, &tagLength);
+        actualTag.data(), &tagLength);
 ALLOW_DEPRECATED_DECLARATIONS_END
 
     if (status != kCCSuccess)
         return std::nullopt;
     RELEASE_ASSERT(tagLength == expectedTagLengthAES);
 
-    if (constantTimeMemcmp(tag.data(), actualTag, tagLength))
+    if (constantTimeMemcmp(tag, actualTag))
         return std::nullopt;
 
     return key;

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESGCMGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESGCMGCrypt.cpp
@@ -170,7 +170,7 @@ static std::optional<Vector<uint8_t>> gcryptDecrypt(const Vector<uint8_t>& key, 
             return std::nullopt;
         }
 
-        if (constantTimeMemcmp(tag.data(), cipherText.subspan(cipherLength).data(), tagLength))
+        if (constantTimeMemcmp(tag.span(), cipherText.subspan(cipherLength)))
             return std::nullopt;
     }
 

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmHMACGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmHMACGCrypt.cpp
@@ -102,7 +102,7 @@ ExceptionOr<bool> CryptoAlgorithmHMAC::platformVerify(const CryptoKeyHMAC& key, 
     if (!expectedSignature)
         return Exception { ExceptionCode::OperationError };
     // Using a constant time comparison to prevent timing attacks.
-    return signature.size() == expectedSignature->size() && !constantTimeMemcmp(expectedSignature->data(), signature.data(), expectedSignature->size());
+    return signature.size() == expectedSignature->size() && !constantTimeMemcmp(expectedSignature->span(), signature.span());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/openssl/CryptoAlgorithmHMACOpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoAlgorithmHMACOpenSSL.cpp
@@ -79,7 +79,7 @@ ExceptionOr<bool> CryptoAlgorithmHMAC::platformVerify(const CryptoKeyHMAC& key, 
     if (!expectedSignature)
         return Exception { ExceptionCode::OperationError };
     // Using a constant time comparison to prevent timing attacks.
-    return signature.size() == expectedSignature->size() && !constantTimeMemcmp(expectedSignature->data(), signature.data(), expectedSignature->size());
+    return signature.size() == expectedSignature->size() && !constantTimeMemcmp(expectedSignature->span(), signature.span());
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 490f610d13ba000918520c7bb501a7c458b93142
<pre>
Stop using WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/crypto/
<a href="https://bugs.webkit.org/show_bug.cgi?id=284018">https://bugs.webkit.org/show_bug.cgi?id=284018</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/CryptographicUtilities.cpp:
(WTF::constantTimeMemcmp):
* Source/WTF/wtf/CryptographicUtilities.h:
(WTF::constantTimeMemcmp):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCTR.cpp:
(WebCore::parametersAreValid):
(WebCore::CryptoAlgorithmAESCTR::CounterBlockHelper::CounterBlockHelper):
(WebCore::CryptoAlgorithmAESCTR::CounterBlockHelper::counterVectorAfterOverflow const):
(WebCore::CryptoAlgorithmAESCTR::CounterBlockHelper::CounterBlockBits::set):
(WebCore::CryptoAlgorithmAESCTR::CounterBlockHelper::CounterBlockBits::all const):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmAESGCM.cpp:
(WebCore::tagLengthIsValid):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.cpp:
(WebCore::CryptoAlgorithmX25519::deriveBits):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmAESCBCMac.cpp:
(WebCore::transformAESCBC):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmAESCFBMac.cpp:
(WebCore::transformAESCFB):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmAESGCMMac.cpp:
(WebCore::decyptAESGCM):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSAMac.cpp:
* Source/WebCore/crypto/cocoa/CryptoAlgorithmHMACMac.cpp:
(WebCore::platformVerifyCC):
* Source/WebCore/crypto/cocoa/CryptoKeyECMac.cpp:
* Source/WebCore/crypto/cocoa/CryptoKeyOKPCocoa.cpp:
* Source/WebCore/crypto/cocoa/CryptoKeyRSAMac.cpp:
(WebCore::CryptoKeyRSA::importSpki):
(WebCore::CryptoKeyRSA::importPkcs8):
* Source/WebCore/crypto/cocoa/CryptoUtilitiesCocoa.cpp:
(WebCore::transformAESCTR):
* Source/WebCore/crypto/cocoa/SerializedCryptoKeyWrapMac.mm:
(WebCore::unwrapCryptoKey):
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESGCMGCrypt.cpp:
(WebCore::gcryptDecrypt):
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmHMACGCrypt.cpp:
(WebCore::CryptoAlgorithmHMAC::platformVerify):
* Source/WebCore/crypto/openssl/CryptoAlgorithmHMACOpenSSL.cpp:
(WebCore::CryptoAlgorithmHMAC::platformVerify):

Canonical link: <a href="https://commits.webkit.org/287365@main">https://commits.webkit.org/287365@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81da59be51095a654e8cc28d171b54a824d054dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79336 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58364 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32707 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83951 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30485 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81469 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67439 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6626 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62055 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19952 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82403 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52121 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72286 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42362 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49465 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26468 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28883 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/72431 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70578 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26913 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85351 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/78533 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6620 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4604 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70305 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6784 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68160 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69552 "Found 6 new API test failures: /TestWebKit:WebKit.DownloadDecideDestinationCrash, /TestWebKit:WebKit.FrameMIMETypePNG, /TestWebKit:WebKit.EvaluateJavaScriptThatThrowsAnException, /TestWebKit:WebKit.GeolocationBasicWithHighAccuracy, /TestWebKit:WebKit2UserMessageRoundTripTest.WKString, /TestWebKit:WebKit.ParentFrame (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13607 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12469 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/100867 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12251 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6572 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/24609 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6491 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9964 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8287 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->