### PR TITLE
[GTK] Create IconGtk

### DIFF
--- a/Source/WebCore/SourcesGTK.txt
+++ b/Source/WebCore/SourcesGTK.txt
@@ -79,6 +79,7 @@ platform/graphics/gbm/PlatformDisplayGBM.cpp @no-unify
 platform/graphics/gtk/ColorGtk.cpp
 platform/graphics/gtk/GdkCairoUtilities.cpp
 platform/graphics/gtk/GdkSkiaUtilities.cpp
+platform/graphics/gtk/IconGtk.cpp
 platform/graphics/gtk/ImageAdapterGtk.cpp
 platform/graphics/gtk/SystemFontDatabaseGTK.cpp
 

--- a/Source/WebCore/platform/graphics/Icon.cpp
+++ b/Source/WebCore/platform/graphics/Icon.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "Icon.h"
 
-#if !PLATFORM(IOS_FAMILY) && !PLATFORM(MAC) && !PLATFORM(WIN)
+#if !PLATFORM(GTK) && !PLATFORM(IOS_FAMILY) && !PLATFORM(MAC) && !PLATFORM(WIN)
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/graphics/Icon.h
+++ b/Source/WebCore/platform/graphics/Icon.h
@@ -41,6 +41,11 @@ using CocoaImage = UIImage;
 
 #elif PLATFORM(WIN)
 typedef struct HICON__* HICON;
+
+#elif PLATFORM(GTK)
+#include <wtf/glib/GRefPtr.h>
+
+typedef struct _GIcon GIcon;
 #endif
 
 namespace WebCore {
@@ -59,6 +64,12 @@ public:
 
 #if PLATFORM(WIN)
     static Ref<Icon> create(HICON hIcon) { return adoptRef(*new Icon(hIcon)); }
+#endif
+
+#if PLATFORM(GTK)
+    WEBCORE_EXPORT static RefPtr<Icon> create(GIcon*);
+
+    GIcon* icon() const { return m_icon.get(); };
 #endif
 
 #if PLATFORM(COCOA)
@@ -80,6 +91,9 @@ private:
 #elif PLATFORM(WIN)
     Icon(HICON);
     HICON m_hIcon;
+#elif PLATFORM(GTK)
+    explicit Icon(GIcon*);
+    GRefPtr<GIcon> m_icon;
 #endif
 };
 

--- a/Source/WebCore/platform/graphics/gtk/IconGtk.cpp
+++ b/Source/WebCore/platform/graphics/gtk/IconGtk.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2024 Igalia, S.L.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * 3.  Neither the name of Apple Inc. ("Apple") nor the names of
+ *     its contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "Icon.h"
+
+#include "NotImplemented.h"
+
+#include <gio/gio.h>
+
+namespace WebCore {
+
+Icon::Icon(GIcon* icon)
+    : m_icon(icon)
+{
+}
+
+Icon::~Icon()
+{
+}
+
+RefPtr<Icon> Icon::create(GIcon* icon)
+{
+    if (!icon)
+        return nullptr;
+
+    return adoptRef(new Icon(icon));
+}
+
+void Icon::paint(GraphicsContext&, const FloatRect&)
+{
+    ASSERT_NOT_REACHED();
+}
+
+RefPtr<Icon> Icon::createIconForFiles(const Vector<String>&)
+{
+    notImplemented();
+    return nullptr;
+}
+
+}


### PR DESCRIPTION
#### 6bea61c2af271a604eb1ff146d71781e6206a15b
<pre>
[GTK] Create IconGtk
<a href="https://webkit.org/b/284020">https://webkit.org/b/284020</a>

Reviewed by Michael Catanzaro.

Create a Gtk implementation of WebCore::Icon, for usage in WebExtensions. Right now it&apos;s just a wrapper for GIcon.

* Source/WebCore/SourcesGTK.txt:
* Source/WebCore/platform/graphics/Icon.cpp:
* Source/WebCore/platform/graphics/Icon.h:
(WebCore::Icon::icon const):

Canonical link: <a href="https://commits.webkit.org/287627@main">https://commits.webkit.org/287627@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df427e5ce8e536bac1e9694821db85cc0d1f0dd0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79277 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58307 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32649 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83901 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30442 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81410 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67397 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6577 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62019 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19924 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82344 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52081 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72234 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42323 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49425 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26407 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28833 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70539 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26843 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85294 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6575 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4571 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70267 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6739 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68107 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69512 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17507 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13566 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12409 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6532 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12291 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6453 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9920 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8245 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->