### PR TITLE
[WebGPU] 'auto' GPUBindGroupLayout creation allows for mixing bind groups at different locations

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-283998-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-283998-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-283998.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-283998.html
@@ -1,0 +1,7934 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = console.log;
+
+async function gc() {
+  await 0;
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUComputePassEncoder} computePassEncoder
+ */
+function clearResourceUsages(device, computePassEncoder) {
+  let code = `@compute @workgroup_size(1) fn c() {}`;
+  let module = device.createShaderModule({code});
+  computePassEncoder.setPipeline(device.createComputePipeline(
+    {
+      layout: 'auto',
+      compute: {module},
+    }));
+  computePassEncoder.dispatchWorkgroups(1);
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+const videoUrls = [
+
+];
+
+/**
+ * @param {number} index
+ * @returns {Promise<HTMLVideoElement>}
+ */
+function videoWithData(index) {
+  let video = document.createElement('video');
+  video.src = videoUrls[index % videoUrls.length];
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+/**
+ * @param {string} payload
+ * @returns {string}
+ */
+function toBlobUrl(payload) {
+  let blob = new Blob([payload], {type: 'text/javascript'});
+  return URL.createObjectURL(blob);
+}
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+let promise0 = navigator.gpu.requestAdapter();
+let adapter0 = await promise0;
+let adapter1 = await navigator.gpu.requestAdapter({});
+let device0 = await adapter0.requestDevice({
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxColorAttachmentBytesPerSample: 32,
+    maxUniformBufferBindingSize: 220235206,
+    maxStorageBufferBindingSize: 142707703,
+  },
+});
+let texture0 = device0.createTexture({
+  size: [54, 15, 2],
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let buffer0 = device0.createBuffer({
+  size: 5624,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let textureView0 = texture0.createView({label: '\uc670\uacbb\u{1f6cf}', dimension: '2d', aspect: 'all', format: 'depth32float-stencil8'});
+let texture1 = device0.createTexture({
+  size: {width: 54, height: 15, depthOrArrayLayers: 2},
+  dimension: '2d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+device0.queue.writeBuffer(buffer0, 2108, new Int16Array(4105), 393, 64);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer1 = device0.createBuffer({
+  size: 13563,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let commandEncoder0 = device0.createCommandEncoder({});
+let textureView1 = texture0.createView({dimension: '2d', mipLevelCount: 1});
+let commandEncoder1 = device0.createCommandEncoder({});
+let textureView2 = texture0.createView({dimension: '2d', aspect: 'stencil-only'});
+let computePassEncoder0 = commandEncoder0.beginComputePass({label: 'p'});
+let sampler0 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'mirror-repeat'});
+try {
+commandEncoder1.copyTextureToBuffer({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 54 widthInBlocks: 54 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1108 */
+  offset: 1108,
+  bytesPerRow: 3328,
+  buffer: buffer1,
+}, {width: 54, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let texture2 = device0.createTexture({
+  size: {width: 8},
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let sampler1 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  lodMaxClamp: 99.98,
+  compare: 'less',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder0.pushDebugGroup('\u0695');
+} catch {}
+let buffer2 = device0.createBuffer({
+  size: 7448,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture3 = device0.createTexture({
+  size: {width: 432, height: 120, depthOrArrayLayers: 2},
+  dimension: '2d',
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder1 = commandEncoder1.beginComputePass({label: 'q'});
+try {
+buffer2.unmap();
+} catch {}
+try {
+computePassEncoder0.insertDebugMarker('\u4521');
+} catch {}
+let commandEncoder2 = device0.createCommandEncoder({});
+let texture4 = device0.createTexture({
+  size: [216, 60, 2],
+  sampleCount: 1,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder2 = commandEncoder2.beginComputePass({label: 'r'});
+let textureView3 = texture4.createView({dimension: '2d-array', arrayLayerCount: 1});
+let texture5 = device0.createTexture({
+  size: {width: 216},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView4 = texture1.createView({format: 'rgba16float', baseArrayLayer: 0, arrayLayerCount: 1});
+try {
+computePassEncoder0.popDebugGroup();
+} catch {}
+let commandEncoder3 = device0.createCommandEncoder({});
+let textureView5 = texture3.createView({dimension: '2d', baseMipLevel: 0});
+let textureView6 = texture0.createView({arrayLayerCount: 1});
+let computePassEncoder3 = commandEncoder3.beginComputePass({label: 's'});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({colorFormats: ['r8sint'], stencilReadOnly: true});
+try {
+renderBundleEncoder0.setIndexBuffer(buffer2, 'uint32', 72, 553);
+} catch {}
+let texture6 = device0.createTexture({
+  size: {width: 108},
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+buffer1.unmap();
+} catch {}
+await gc();
+let commandEncoder4 = device0.createCommandEncoder({});
+let texture7 = device0.createTexture({
+  size: {width: 432},
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView7 = texture3.createView({dimension: '2d', mipLevelCount: 1});
+let computePassEncoder4 = commandEncoder4.beginComputePass({label: 't'});
+let renderBundle0 = renderBundleEncoder0.finish({});
+let textureView8 = texture7.createView({baseMipLevel: 0});
+let textureView9 = texture4.createView({arrayLayerCount: 1});
+let sampler2 = device0.createSampler({addressModeV: 'repeat', minFilter: 'linear', lodMaxClamp: 47.16});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture8 = device0.createTexture({
+  size: [8, 8, 22],
+  format: 'rg16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(49).fill(190), /* required buffer size: 49 */
+{offset: 49}, {width: 106, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let commandEncoder5 = device0.createCommandEncoder({});
+let sampler3 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 62.80, compare: 'less'});
+let texture9 = device0.createTexture({
+  size: [216, 60, 22],
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView10 = texture1.createView({baseMipLevel: 0, mipLevelCount: 1, arrayLayerCount: 1});
+let veryExplicitBindGroupLayout0 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 30,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d-array' },
+    },
+    {
+      binding: 138,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 176,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 18, hasDynamicOffset: false },
+    },
+    {
+      binding: 237,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '1d' },
+    },
+    {binding: 473, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }},
+  ],
+});
+let buffer3 = device0.createBuffer({
+  size: 23308,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture10 = device0.createTexture({
+  size: [108, 30, 2],
+  mipLevelCount: 2,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder5 = commandEncoder5.beginComputePass({label: 'u'});
+let promise1 = device0.queue.onSubmittedWorkDone();
+let veryExplicitBindGroupLayout1 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 32,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 165,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let buffer4 = device0.createBuffer({size: 3688, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let commandEncoder6 = device0.createCommandEncoder({});
+let texture11 = device0.createTexture({
+  size: {width: 8, height: 8, depthOrArrayLayers: 22},
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder6 = commandEncoder6.beginComputePass({label: 'v'});
+try {
+  await promise1;
+} catch {}
+let textureView11 = texture10.createView({dimension: '2d', mipLevelCount: 1});
+let sampler4 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 45.31,
+  maxAnisotropy: 7,
+});
+let commandEncoder7 = device0.createCommandEncoder({});
+let computePassEncoder7 = commandEncoder7.beginComputePass({label: 'w'});
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(79).fill(144), /* required buffer size: 79 */
+{offset: 79}, {width: 35, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder8 = device0.createCommandEncoder({});
+let textureView12 = texture10.createView({mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder8 = commandEncoder8.beginComputePass({label: 'x'});
+let canvas0 = document.createElement('canvas');
+let pipelineLayout0 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout1]});
+let commandEncoder9 = device0.createCommandEncoder({});
+let computePassEncoder9 = commandEncoder9.beginComputePass({label: 'y'});
+let sampler5 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 93.56,
+  compare: 'not-equal',
+});
+try {
+device0.queue.writeBuffer(buffer0, 900, new Int16Array(2303), 420, 468);
+} catch {}
+let imageData0 = new ImageData(4, 64);
+let bindGroup0 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 165, resource: textureView0}, {binding: 32, resource: {buffer: buffer2, offset: 768}}],
+});
+let buffer5 = device0.createBuffer({size: 1670, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+let commandEncoder10 = device0.createCommandEncoder();
+let textureView13 = texture11.createView({dimension: 'cube', baseArrayLayer: 1});
+try {
+buffer5.unmap();
+} catch {}
+let bindGroup1 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [
+    {binding: 30, resource: textureView3},
+    {binding: 138, resource: textureView11},
+    {binding: 473, resource: sampler0},
+    {binding: 176, resource: {buffer: buffer2, offset: 4096}},
+    {binding: 237, resource: textureView8},
+  ],
+});
+let pipelineLayout1 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout1]});
+let texture12 = device0.createTexture({
+  size: {width: 432},
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder10 = commandEncoder10.beginComputePass({label: 'z'});
+try {
+computePassEncoder9.insertDebugMarker('\u0476');
+} catch {}
+let pipelineLayout2 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let commandEncoder11 = device0.createCommandEncoder({});
+let textureView14 = texture11.createView({dimension: '2d-array', baseArrayLayer: 1, arrayLayerCount: 8});
+let texture13 = device0.createTexture({
+  label: '\u08f0\u{1f743}\uc892\u1598\u7a30\u097c\u{1fcbe}\u5d75\u{1f773}\uda7a',
+  size: [108, 30, 2],
+  sampleCount: 1,
+  format: 'r8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView15 = texture12.createView({});
+let computePassEncoder11 = commandEncoder11.beginComputePass({label: '1'});
+let videoFrame0 = new VideoFrame(canvas0, {timestamp: 0});
+let commandEncoder12 = device0.createCommandEncoder({});
+let textureView16 = texture3.createView({arrayLayerCount: 1});
+let computePassEncoder12 = commandEncoder12.beginComputePass({label: '2'});
+let sampler6 = device0.createSampler({addressModeV: 'repeat', lodMaxClamp: 98.32, maxAnisotropy: 1});
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 42, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(235).fill(55), /* required buffer size: 235 */
+{offset: 235}, {width: 123, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas0);
+let veryExplicitBindGroupLayout2 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 23,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba8snorm', access: 'write-only', viewDimension: '2d' },
+    },
+  ],
+});
+let bindGroup2 = device0.createBindGroup({layout: veryExplicitBindGroupLayout2, entries: [{binding: 23, resource: textureView5}]});
+let buffer6 = device0.createBuffer({
+  size: 38551,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let commandEncoder13 = device0.createCommandEncoder({});
+let texture14 = device0.createTexture({
+  size: [216, 60, 41],
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder7.setBindGroup(3, bindGroup2, new Uint32Array(3579), 300, 0);
+} catch {}
+try {
+commandEncoder13.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 848 */
+  offset: 848,
+  buffer: buffer2,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup3 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 32, resource: {buffer: buffer2, offset: 0}}, {binding: 165, resource: textureView0}],
+});
+let buffer7 = device0.createBuffer({size: 10899, usage: GPUBufferUsage.MAP_READ});
+let commandEncoder14 = device0.createCommandEncoder({});
+let texture15 = device0.createTexture({size: [8], dimension: '1d', format: 'r8sint', usage: GPUTextureUsage.COPY_DST});
+let computePassEncoder13 = commandEncoder14.beginComputePass({label: '3'});
+let buffer8 = device0.createBuffer({size: 17282, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+let textureView17 = texture15.createView({});
+let computePassEncoder14 = commandEncoder13.beginComputePass({label: '4'});
+try {
+computePassEncoder12.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+adapter1.label = '\u1707\u0886\u{1f838}\u02fd\u039f';
+} catch {}
+try {
+device0.label = '\ufae5\u00d2\u7437\u{1f85c}';
+} catch {}
+let bindGroup4 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 32, resource: {buffer: buffer3, offset: 256}}, {binding: 165, resource: textureView1}],
+});
+let buffer9 = device0.createBuffer({
+  size: 1196,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder15 = device0.createCommandEncoder();
+let computePassEncoder15 = commandEncoder15.beginComputePass({label: '5'});
+try {
+device0.queue.writeBuffer(buffer2, 2992, new BigUint64Array(9733), 2767, 100);
+} catch {}
+document.body.append(canvas0);
+let bindGroup5 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 32, resource: {buffer: buffer2, offset: 256}}, {binding: 165, resource: textureView0}],
+});
+let sampler7 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 74.41});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup2);
+} catch {}
+let commandEncoder16 = device0.createCommandEncoder({});
+document.body.prepend(canvas0);
+try {
+globalThis.someLabel = sampler5.label;
+} catch {}
+let buffer10 = device0.createBuffer({
+  size: 3761,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let computePassEncoder16 = commandEncoder16.beginComputePass({label: '6'});
+try {
+buffer6.unmap();
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let bindGroup6 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 32, resource: {buffer: buffer3, offset: 512}}, {binding: 165, resource: textureView1}],
+});
+let buffer11 = device0.createBuffer({size: 14394, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder17 = device0.createCommandEncoder({});
+let texture16 = device0.createTexture({
+  size: [8, 8, 22],
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder17 = commandEncoder17.beginComputePass({label: '7'});
+try {
+computePassEncoder12.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+buffer6.label = '\u{1fecb}\ue19b\ubf59\ufa0f\u2bce\u0e96\u{1fbcb}\u{1fd74}\u0b53\u7d1f';
+} catch {}
+let bindGroup7 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [
+    {binding: 176, resource: {buffer: buffer2, offset: 1024}},
+    {binding: 30, resource: textureView3},
+    {binding: 138, resource: textureView11},
+    {binding: 237, resource: textureView8},
+    {binding: 473, resource: sampler7},
+  ],
+});
+let buffer12 = device0.createBuffer({size: 6330, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let commandEncoder18 = device0.createCommandEncoder();
+let computePassEncoder18 = commandEncoder18.beginComputePass({label: '8'});
+let sampler8 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 1,
+});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder5.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+computePassEncoder2.setBindGroup(0, bindGroup2, new Uint32Array(295), 14, 0);
+} catch {}
+let img0 = await imageWithData(13, 60, '#10101010', '#20202020');
+let buffer13 = device0.createBuffer({
+  label: '\u08d8\u0539\ubd49\u0c08\ub241',
+  size: 18019,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let textureView18 = texture10.createView({dimension: '2d-array', mipLevelCount: 1, arrayLayerCount: 1});
+let gpuCanvasContext0 = canvas0.getContext('webgpu');
+document.body.append(img0);
+let imageData1 = new ImageData(24, 132);
+let texture17 = device0.createTexture({
+  size: [54, 15, 106],
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r8sint'],
+});
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let textureView19 = texture15.createView({dimension: '1d'});
+let sampler9 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 95.68,
+  compare: 'equal',
+  maxAnisotropy: 1,
+});
+let videoFrame1 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'unspecified', primaries: 'smpte240m', transfer: 'gamma28curve'} });
+let texture18 = device0.createTexture({
+  size: [432, 120, 2],
+  mipLevelCount: 2,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView20 = texture18.createView({mipLevelCount: 1, baseArrayLayer: 0, arrayLayerCount: 1});
+try {
+computePassEncoder6.setBindGroup(3, bindGroup3);
+} catch {}
+let imageBitmap0 = await createImageBitmap(canvas0);
+let buffer14 = device0.createBuffer({
+  size: 12332,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT,
+});
+let textureView21 = texture8.createView({dimension: '2d'});
+let shaderModule0 = device0.createShaderModule({
+  code: `
+requires pointer_composite_access;
+
+enable f16;
+
+struct VertexOutput0 {
+  @location(4) @interpolate(flat, sample) f0: vec4u,
+  @location(5) f1: u32,
+  @builtin(position) f2: vec4f,
+}
+
+var<workgroup> vw2: vec4u;
+
+fn fn0() -> mat3x2h {
+  var out: mat3x2h;
+  var vf0: f16 = override1;
+  vf0 = vec4h(unpack4x8unorm(u32(unconst_u32(31))))[2];
+  var vf1: f32 = override0;
+  var vf2: f32 = determinant(mat3x3f());
+  let vf3: vec3f = pow(vec3f(unconst_f32(0.2374), unconst_f32(0.1532), unconst_f32(0.3473)), vec3f(unconst_f32(0.02667), unconst_f32(0.01867), unconst_f32(-0.1301)));
+  var vf4: vec3f = inverseSqrt(vec3f(unconst_f32(0.1464), unconst_f32(0.1135), unconst_f32(0.02580)));
+  return out;
+  _ = override0;
+  _ = override1;
+}
+
+override override1: f16 = 6329.0;
+
+var<workgroup> vw0: array<atomic<u32>, 1>;
+
+var<private> vp0 = modf(f32(0.02298));
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+override override2 = true;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<workgroup> vw3: atomic<i32>;
+
+var<workgroup> vw1: atomic<u32>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct VertexOutput1 {
+  @builtin(position) f3: vec4f,
+}
+
+@id(30730) override override0 = 0.1647;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct T0 {
+  @align(256) @size(256) f0: mat3x2h,
+  @size(512) f1: mat2x2f,
+  @align(32) @size(2560) f2: array<array<atomic<i32>, 128>>,
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  var out: VertexOutput0;
+  out.f1 += bitcast<u32>(vp0.whole);
+  vp0.fract = f32(determinant(mat3x3h(unconst_f16(-18482.5), unconst_f16(4360.1), unconst_f16(-23.35), unconst_f16(4838.0), unconst_f16(36054.3), unconst_f16(6093.2), unconst_f16(11974.1), unconst_f16(-737.0), unconst_f16(6422.1))));
+  out.f1 = bitcast<u32>(cosh(vec2h(unconst_f16(11129.8), unconst_f16(9042.5))));
+  let vf5: vec3h = cross(vec3h(unconst_f16(14639.0), unconst_f16(27385.8), unconst_f16(10796.0)), vec3h(f16(pack2x16float(vec2f(unconst_f32(0.01911), unconst_f32(-0.09891))))));
+  vp0 = modf(f32(fma(f16(unconst_f16(-8819.0)), f16(unconst_f16(6819.2)), min(f16(unconst_f16(27334.1)), f16(unconst_f16(7938.7))))));
+  out.f2 -= vec4f(f32(override2));
+  out.f2 = vec4f(f32(fma(f16(unconst_f16(34516.8)), f16(unconst_f16(21100.0)), f16(unconst_f16(2049.2)))));
+  out.f0 = vec4u(sinh(vec2h(unconst_f16(11020.8), unconst_f16(-4239.3))).yxyy);
+  out.f0 <<= unpack4xU8(pack2x16float(vec2f(unconst_f32(0.7654), unconst_f32(0.06718))));
+  let vf6: vec2h = refract(vec2h(unconst_f16(47337.3), unconst_f16(3075.6)), vec2h(unconst_f16(6266.1), unconst_f16(6823.0)), fma(f16(unconst_f16(2224.4)), f16(unconst_f16(25479.9)), f16(unconst_f16(3751.8))));
+  out.f0 = bitcast<vec4u>(firstTrailingBit(vec3i(unconst_i32(45), unconst_i32(-157), unconst_i32(457))).zxzx);
+  vp0 = modf(vp0.fract);
+  out.f2 = vec4f(f32(override1));
+  out.f1 = pack2x16unorm(unpack2x16unorm(u32(unconst_u32(116))));
+  return out;
+  _ = override2;
+  _ = override1;
+}
+
+@vertex
+fn vertex1(@location(2) a0: vec2i, @location(13) a1: i32, @location(6) a2: vec2h) -> VertexOutput1 {
+  var out: VertexOutput1;
+  var vf7 = fn0();
+  let vf8: f16 = vf7[u32(unconst_u32(45))][u32(dot4I8Packed(u32(unconst_u32(194)), u32(unconst_u32(45))))];
+  var vf9 = fn0();
+  out.f3 = vec4f(vf9[u32(unconst_u32(137))].ggrg);
+  var vf10: f16 = exp2(f16(unconst_f16(8953.8)));
+  fn0();
+  out = VertexOutput1(vec4f(override0));
+  var vf11: f16 = vf9[u32(firstLeadingBit(i32(unconst_i32(189))))][u32(unconst_u32(223))];
+  vf9 += mat3x2h(f16(firstLeadingBit(firstLeadingBit(i32(unconst_i32(40))))), f16(firstLeadingBit(firstLeadingBit(i32(unconst_i32(40))))), f16(firstLeadingBit(firstLeadingBit(i32(unconst_i32(40))))), f16(firstLeadingBit(firstLeadingBit(i32(unconst_i32(40))))), f16(firstLeadingBit(firstLeadingBit(i32(unconst_i32(40))))), f16(firstLeadingBit(firstLeadingBit(i32(unconst_i32(40))))));
+  let ptr0: ptr<function, f16> = &vf10;
+  fn0();
+  out.f3 -= vec4f(vf7[u32(unconst_u32(705))].grrr);
+  return out;
+  _ = override1;
+  _ = override0;
+}`,
+});
+let commandEncoder19 = device0.createCommandEncoder();
+let texture19 = device0.createTexture({
+  size: [54],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView22 = texture5.createView({dimension: '1d', baseArrayLayer: 0});
+let sampler10 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+});
+try {
+computePassEncoder5.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let buffer17 = device0.createBuffer({size: 2187, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+let textureView23 = texture4.createView({arrayLayerCount: 1});
+let texture20 = device0.createTexture({
+  size: [8, 8, 22],
+  sampleCount: 1,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView24 = texture15.createView({});
+let computePassEncoder19 = commandEncoder19.beginComputePass({label: '9'});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup2, new Uint32Array(2345), 367, 0);
+} catch {}
+let commandEncoder20 = device0.createCommandEncoder({});
+let sampler11 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMinClamp: 33.08,
+  lodMaxClamp: 42.85,
+});
+try {
+computePassEncoder2.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+computePassEncoder1.setBindGroup(3, bindGroup3, new Uint32Array(1268), 74, 0);
+} catch {}
+try {
+commandEncoder20.copyBufferToBuffer(buffer12, 2932, buffer13, 444, 208);
+} catch {}
+let commandEncoder21 = device0.createCommandEncoder({});
+let computePassEncoder20 = commandEncoder21.beginComputePass({label: '10'});
+try {
+computePassEncoder6.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+commandEncoder20.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 16 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1074 */
+  offset: 1074,
+  buffer: buffer6,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 64, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 16, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas1 = document.createElement('canvas');
+let imageData2 = new ImageData(24, 96);
+let computePassEncoder21 = commandEncoder20.beginComputePass({label: '11'});
+let sampler12 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 95.03,
+});
+try {
+computePassEncoder20.setBindGroup(0, bindGroup2, new Uint32Array(1256), 36, 0);
+} catch {}
+document.body.append(canvas1);
+let imageData3 = new ImageData(16, 28);
+let commandEncoder22 = device0.createCommandEncoder({});
+let textureView25 = texture3.createView({arrayLayerCount: 1});
+let computePassEncoder22 = commandEncoder22.beginComputePass({label: '12'});
+let videoFrame2 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'smpte170m', transfer: 'linear'} });
+let bindGroup8 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [
+    {binding: 473, resource: sampler6},
+    {binding: 30, resource: textureView3},
+    {binding: 176, resource: {buffer: buffer10, offset: 0, size: 308}},
+    {binding: 237, resource: textureView8},
+    {binding: 138, resource: textureView21},
+  ],
+});
+let commandEncoder23 = device0.createCommandEncoder({});
+let textureView26 = texture19.createView({mipLevelCount: 1});
+let sampler13 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 92.23,
+});
+let texture21 = device0.createTexture({
+  size: [432, 120, 3],
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+try {
+commandEncoder23.copyTextureToTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(9).fill(246), /* required buffer size: 9 */
+{offset: 9, rowsPerImage: 0}, {width: 22, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext1 = canvas1.getContext('webgpu');
+await gc();
+let commandEncoder24 = device0.createCommandEncoder({});
+let querySet0 = device0.createQuerySet({type: 'occlusion', count: 961});
+let texture22 = device0.createTexture({
+  size: {width: 108, height: 30, depthOrArrayLayers: 2},
+  mipLevelCount: 3,
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView27 = texture7.createView({});
+let computePassEncoder23 = commandEncoder23.beginComputePass({label: '13'});
+try {
+commandEncoder24.copyTextureToBuffer({
+  texture: texture10,
+  mipLevel: 1,
+  origin: {x: 7, y: 1, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 88 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1192 */
+  offset: 1192,
+  bytesPerRow: 11776,
+  buffer: buffer11,
+}, {width: 11, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let bindGroup9 = device0.createBindGroup({layout: veryExplicitBindGroupLayout2, entries: [{binding: 23, resource: textureView7}]});
+let buffer18 = device0.createBuffer({
+  size: 9114,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder25 = device0.createCommandEncoder({});
+try {
+computePassEncoder23.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+commandEncoder25.clearBuffer(buffer1, 564, 284);
+} catch {}
+let texture23 = device0.createTexture({
+  size: {width: 108, height: 30, depthOrArrayLayers: 671},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let computePassEncoder24 = commandEncoder25.beginComputePass({label: '14'});
+let sampler14 = device0.createSampler({
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 85.68,
+  maxAnisotropy: 14,
+});
+try {
+commandEncoder24.insertDebugMarker('\u40a6');
+} catch {}
+let computePassEncoder25 = commandEncoder24.beginComputePass({label: '14'});
+let sampler15 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'repeat', magFilter: 'nearest', maxAnisotropy: 1});
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 4588, new Int16Array(12884), 4637, 224);
+} catch {}
+let imageBitmap1 = await createImageBitmap(videoFrame0);
+let bindGroup10 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [
+    {binding: 32, resource: {buffer: buffer18, offset: 768, size: 656}},
+    {binding: 165, resource: textureView0},
+  ],
+});
+let pipelineLayout3 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let texture24 = device0.createTexture({
+  size: [108, 30, 2],
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView28 = texture9.createView({});
+let bindGroup11 = device0.createBindGroup({layout: veryExplicitBindGroupLayout2, entries: [{binding: 23, resource: textureView7}]});
+let texture25 = device0.createTexture({size: [108, 30, 2], mipLevelCount: 1, format: 'r8sint', usage: GPUTextureUsage.COPY_DST});
+try {
+computePassEncoder22.setBindGroup(3, bindGroup3, new Uint32Array(1802), 424, 0);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+let videoFrame3 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'unspecified', transfer: 'smpteSt4281'} });
+let texture26 = device0.createTexture({
+  size: {width: 54, height: 15, depthOrArrayLayers: 2},
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let commandEncoder26 = device0.createCommandEncoder({});
+let textureView29 = texture19.createView({baseArrayLayer: 0});
+let computePassEncoder26 = commandEncoder26.beginComputePass({label: '15'});
+let videoFrame4 = videoFrame2.clone();
+try {
+computePassEncoder4.setBindGroup(1, bindGroup9);
+} catch {}
+let bindGroup12 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [
+    {binding: 30, resource: textureView9},
+    {binding: 176, resource: {buffer: buffer3, offset: 256}},
+    {binding: 473, resource: sampler6},
+    {binding: 237, resource: textureView15},
+    {binding: 138, resource: textureView11},
+  ],
+});
+let buffer19 = device0.createBuffer({
+  size: 2578,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false,
+});
+let sampler16 = device0.createSampler({
+  addressModeU: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.90,
+  maxAnisotropy: 11,
+});
+try {
+buffer5.unmap();
+} catch {}
+document.body.prepend(canvas1);
+let veryExplicitBindGroupLayout3 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 110,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+try {
+device0.pushErrorScope('internal');
+} catch {}
+document.body.prepend(canvas1);
+let imageData4 = new ImageData(8, 16);
+let buffer20 = device0.createBuffer({
+  size: 9881,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder27 = device0.createCommandEncoder({});
+let querySet1 = device0.createQuerySet({type: 'occlusion', count: 1332});
+let computePassEncoder27 = commandEncoder27.beginComputePass({label: '16'});
+try {
+computePassEncoder22.setBindGroup(2, bindGroup2);
+} catch {}
+let shaderModule1 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+enable f16;
+
+fn fn1() -> VertexOutput2 {
+  var out: VertexOutput2;
+  var vf19: u32 = pack4x8snorm(vec4f(unconst_f32(0.06026), unconst_f32(0.03551), unconst_f32(0.1696), unconst_f32(0.1234)));
+  var vf20: vec2f = radians(vec2f(unconst_f32(0.1542), unconst_f32(0.04247)));
+  let vf21: vec2h = smoothstep(vec2h(unconst_f16(28381.0), unconst_f16(-8629.0)), vec2h(unconst_f16(17154.8), unconst_f16(13965.7)), vec2h(unconst_f16(-661.7), unconst_f16(31656.8)));
+  var vf22: mat4x2h = transpose(mat2x4h());
+  return out;
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn fn0(a0: ptr<storage, mat2x3f, read_write>) -> array<array<mat2x2h, 1>, 1> {
+  var out: array<array<mat2x2h, 1>, 1>;
+  var vf12: vec3f = log2(vec3f(unconst_f32(0.3003), unconst_f32(0.4018), unconst_f32(0.06239)));
+  vp1 = modf(vec3f(asin(vec4h(unconst_f16(22317.7), unconst_f16(4996.3), unconst_f16(2276.8), unconst_f16(3339.8))).zxw));
+  vp1 = modf(vec3f(f32(smoothstep(f16(unconst_f16(22527.7)), f16(unconst_f16(10440.1)), f16(unconst_f16(6122.0))))));
+  var vf13: vec2h = ceil(vec2h(unconst_f16(7881.2), unconst_f16(8788.7)));
+  (*a0) = mat2x3f(f32(smoothstep(f16(unconst_f16(3786.4)), f16(unconst_f16(26666.0)), f16(unconst_f16(18870.4)))), f32(smoothstep(f16(unconst_f16(3786.4)), f16(unconst_f16(26666.0)), f16(unconst_f16(18870.4)))), f32(smoothstep(f16(unconst_f16(3786.4)), f16(unconst_f16(26666.0)), f16(unconst_f16(18870.4)))), f32(smoothstep(f16(unconst_f16(3786.4)), f16(unconst_f16(26666.0)), f16(unconst_f16(18870.4)))), f32(smoothstep(f16(unconst_f16(3786.4)), f16(unconst_f16(26666.0)), f16(unconst_f16(18870.4)))), f32(smoothstep(f16(unconst_f16(3786.4)), f16(unconst_f16(26666.0)), f16(unconst_f16(18870.4)))));
+  let ptr1: ptr<function, vec2h> = &vf13;
+  let vf14: f16 = override5;
+  let vf15: f32 = override3;
+  var vf16: vec2h = exp(vec2h(unconst_f16(13342.5), unconst_f16(22131.1)));
+  var vf17: f16 = asinh(f16(unconst_f16(9146.2)));
+  let vf18: f16 = vf14;
+  return out;
+  _ = override3;
+  _ = override5;
+}
+
+override override4: u32;
+
+@group(0) @binding(176) var<storage, read_write> buffer21: array<array<array<array<array<array<array<array<array<f16, 1>, 1>, 1>, 3>, 1>, 3>, 1>, 1>>;
+
+var<private> vp1 = modf(vec3f(0.1172, 0.1601, 0.05554));
+
+struct VertexOutput2 {
+  @location(9) @interpolate(flat) f4: vec2i,
+  @location(0) @interpolate(perspective, sample) f5: vec2h,
+  @location(8) f6: vec4u,
+  @location(6) @interpolate(perspective, centroid) f7: vec4h,
+  @builtin(position) f8: vec4f,
+  @location(14) f9: f16,
+}
+
+var<workgroup> vw4: atomic<u32>;
+
+fn fn2() -> array<VertexOutput2, 1> {
+  var out: array<VertexOutput2, 1>;
+  var vf23 = fn1();
+  let ptr2: ptr<storage, array<f16, 1>, read_write> = &(*&buffer21)[u32(unconst_u32(38))][0][0][u32(unconst_u32(377))][0][2][0][u32(unconst_u32(26))];
+  out[u32(unconst_u32(164))] = VertexOutput2(vec2i(i32((*&buffer21)[u32(unconst_u32(173))][u32(unconst_u32(212))][u32(unconst_u32(133))][u32(unconst_u32(34))][0][2][0][0][0])), vec2h((*&buffer21)[u32(unconst_u32(173))][u32(unconst_u32(212))][u32(unconst_u32(133))][u32(unconst_u32(34))][0][2][0][0][0]), vec4u(u32((*&buffer21)[u32(unconst_u32(173))][u32(unconst_u32(212))][u32(unconst_u32(133))][u32(unconst_u32(34))][0][2][0][0][0])), vec4h((*&buffer21)[u32(unconst_u32(173))][u32(unconst_u32(212))][u32(unconst_u32(133))][u32(unconst_u32(34))][0][2][0][0][0]), vec4f(f32((*&buffer21)[u32(unconst_u32(173))][u32(unconst_u32(212))][u32(unconst_u32(133))][u32(unconst_u32(34))][0][2][0][0][0])), (*&buffer21)[u32(unconst_u32(173))][u32(unconst_u32(212))][u32(unconst_u32(133))][u32(unconst_u32(34))][0][2][0][0][0]);
+  var vf24 = fn1();
+  let ptr3: ptr<storage, f16, read_write> = &(*&buffer21)[u32(unconst_u32(170))][u32(unconst_u32(93))][0][2][u32(unconst_u32(33))][2][0][0][0];
+  vf24 = VertexOutput2(vec2i(i32(buffer21[arrayLength(&buffer21)][u32(unconst_u32(231))][0][u32(unconst_u32(33))][0][u32(unconst_u32(240))][0][0][0])), vec2h(buffer21[arrayLength(&buffer21)][u32(unconst_u32(231))][0][u32(unconst_u32(33))][0][u32(unconst_u32(240))][0][0][0]), vec4u(u32(buffer21[arrayLength(&buffer21)][u32(unconst_u32(231))][0][u32(unconst_u32(33))][0][u32(unconst_u32(240))][0][0][0])), vec4h(buffer21[arrayLength(&buffer21)][u32(unconst_u32(231))][0][u32(unconst_u32(33))][0][u32(unconst_u32(240))][0][0][0]), vec4f(f32(buffer21[arrayLength(&buffer21)][u32(unconst_u32(231))][0][u32(unconst_u32(33))][0][u32(unconst_u32(240))][0][0][0])), buffer21[arrayLength(&buffer21)][u32(unconst_u32(231))][0][u32(unconst_u32(33))][0][u32(unconst_u32(240))][0][0][0]);
+  buffer22[u32(unconst_u32(463))][u32(unconst_u32(7))][u32(unconst_u32(327))][u32(unconst_u32(307))][u32(unconst_u32(51))][u32(unconst_u32(3))][u32((*&buffer21)[arrayLength(&(*&buffer21))][u32(unconst_u32(291))][0][u32(unconst_u32(84))][0][2][0][0][0])] -= buffer21[u32(unconst_u32(5))][0][u32(unconst_u32(34))][u32(unconst_u32(55))][u32(unconst_u32(121))][2][0][u32(unconst_u32(8))][0];
+  buffer22[u32(unconst_u32(41))][u32(unconst_u32(297))][u32(unconst_u32(2))][u32(unconst_u32(200))][u32(unconst_u32(430))][u32(unconst_u32(119))][u32(unconst_u32(11))] -= buffer21[arrayLength(&buffer21)][0][u32(unconst_u32(41))][2][u32(unconst_u32(129))][u32((*&buffer21)[arrayLength(&(*&buffer21))][0][u32(unconst_u32(207))][2][0][u32(unconst_u32(66))][0][0][0])][0][0][0];
+  let ptr4: ptr<storage, array<array<array<f16, 1>, 3>, 1>, read_write> = &(*&buffer22)[u32(buffer22[u32(unconst_u32(16))][0][0][2][u32(unconst_u32(20))][u32(unconst_u32(40))][0])][u32(unconst_u32(221))][u32(unconst_u32(257))][2];
+  vf24 = VertexOutput2(vec2i(i32((*&buffer21)[arrayLength(&(*&buffer21))][0][u32(unconst_u32(26))][2][u32(unconst_u32(250))][2][0][0][0])), vec2h((*&buffer21)[arrayLength(&(*&buffer21))][0][u32(unconst_u32(26))][2][u32(unconst_u32(250))][2][0][0][0]), vec4u(u32((*&buffer21)[arrayLength(&(*&buffer21))][0][u32(unconst_u32(26))][2][u32(unconst_u32(250))][2][0][0][0])), vec4h((*&buffer21)[arrayLength(&(*&buffer21))][0][u32(unconst_u32(26))][2][u32(unconst_u32(250))][2][0][0][0]), vec4f(f32((*&buffer21)[arrayLength(&(*&buffer21))][0][u32(unconst_u32(26))][2][u32(unconst_u32(250))][2][0][0][0])), (*&buffer21)[arrayLength(&(*&buffer21))][0][u32(unconst_u32(26))][2][u32(unconst_u32(250))][2][0][0][0]);
+  let ptr5: ptr<storage, array<array<f16, 1>, 3>, read_write> = &buffer22[u32((*&buffer21)[u32(unconst_u32(177))][u32(unconst_u32(116))][0][u32(buffer22[0][u32(unconst_u32(64))][u32(unconst_u32(378))][u32(unconst_u32(136))][u32((*&buffer21)[u32(unconst_u32(308))][0][0][2][u32(unconst_u32(180))][2][0][u32(unconst_u32(394))][0])][2][0])][0][2][u32(unconst_u32(413))][u32(unconst_u32(205))][u32(unconst_u32(50))])][0][u32(buffer21[arrayLength(&buffer21)][u32(unconst_u32(31))][0][2][u32(unconst_u32(1000))][u32(unconst_u32(26))][u32((*&buffer21)[u32(unconst_u32(330))][0][u32(unconst_u32(55))][u32(unconst_u32(248))][u32(unconst_u32(83))][u32(buffer22[u32(unconst_u32(188))][u32(buffer21[arrayLength(&buffer21)][0][u32(unconst_u32(53))][u32(unconst_u32(22))][u32(unconst_u32(145))][u32(unconst_u32(627))][u32(unconst_u32(234))][u32(unconst_u32(102))][0])][u32(unconst_u32(170))][2][u32(unconst_u32(48))][2][0])][u32(unconst_u32(0))][0][u32(unconst_u32(1))])][0][0])][2][u32(unconst_u32(250))];
+  let ptr6: ptr<storage, array<f16, 1>, read_write> = &buffer21[u32(unconst_u32(1000))][u32(unconst_u32(36))][0][u32(unconst_u32(358))][0][2][0][u32(unconst_u32(25))];
+  vf24 = VertexOutput2(vec2i(i32((*&buffer21)[u32(buffer21[u32(unconst_u32(54))][u32(unconst_u32(260))][u32((*&buffer21)[u32(unconst_u32(357))][u32(unconst_u32(255))][u32(unconst_u32(256))][2][u32(unconst_u32(183))][u32(unconst_u32(118))][u32(unconst_u32(636))][u32(buffer21[arrayLength(&buffer21)][0][0][2][u32(unconst_u32(898))][2][0][0][0])][0])][u32(unconst_u32(330))][0][u32(unconst_u32(0))][0][u32(unconst_u32(222))][u32(unconst_u32(61))])][0][u32(unconst_u32(128))][u32(unconst_u32(69))][u32(unconst_u32(113))][2][0][0][0])), vec2h((*&buffer21)[u32(buffer21[u32(unconst_u32(54))][u32(unconst_u32(260))][u32((*&buffer21)[u32(unconst_u32(357))][u32(unconst_u32(255))][u32(unconst_u32(256))][2][u32(unconst_u32(183))][u32(unconst_u32(118))][u32(unconst_u32(636))][u32(buffer21[arrayLength(&buffer21)][0][0][2][u32(unconst_u32(898))][2][0][0][0])][0])][u32(unconst_u32(330))][0][u32(unconst_u32(0))][0][u32(unconst_u32(222))][u32(unconst_u32(61))])][0][u32(unconst_u32(128))][u32(unconst_u32(69))][u32(unconst_u32(113))][2][0][0][0]), vec4u(u32((*&buffer21)[u32(buffer21[u32(unconst_u32(54))][u32(unconst_u32(260))][u32((*&buffer21)[u32(unconst_u32(357))][u32(unconst_u32(255))][u32(unconst_u32(256))][2][u32(unconst_u32(183))][u32(unconst_u32(118))][u32(unconst_u32(636))][u32(buffer21[arrayLength(&buffer21)][0][0][2][u32(unconst_u32(898))][2][0][0][0])][0])][u32(unconst_u32(330))][0][u32(unconst_u32(0))][0][u32(unconst_u32(222))][u32(unconst_u32(61))])][0][u32(unconst_u32(128))][u32(unconst_u32(69))][u32(unconst_u32(113))][2][0][0][0])), vec4h((*&buffer21)[u32(buffer21[u32(unconst_u32(54))][u32(unconst_u32(260))][u32((*&buffer21)[u32(unconst_u32(357))][u32(unconst_u32(255))][u32(unconst_u32(256))][2][u32(unconst_u32(183))][u32(unconst_u32(118))][u32(unconst_u32(636))][u32(buffer21[arrayLength(&buffer21)][0][0][2][u32(unconst_u32(898))][2][0][0][0])][0])][u32(unconst_u32(330))][0][u32(unconst_u32(0))][0][u32(unconst_u32(222))][u32(unconst_u32(61))])][0][u32(unconst_u32(128))][u32(unconst_u32(69))][u32(unconst_u32(113))][2][0][0][0]), vec4f(f32((*&buffer21)[u32(buffer21[u32(unconst_u32(54))][u32(unconst_u32(260))][u32((*&buffer21)[u32(unconst_u32(357))][u32(unconst_u32(255))][u32(unconst_u32(256))][2][u32(unconst_u32(183))][u32(unconst_u32(118))][u32(unconst_u32(636))][u32(buffer21[arrayLength(&buffer21)][0][0][2][u32(unconst_u32(898))][2][0][0][0])][0])][u32(unconst_u32(330))][0][u32(unconst_u32(0))][0][u32(unconst_u32(222))][u32(unconst_u32(61))])][0][u32(unconst_u32(128))][u32(unconst_u32(69))][u32(unconst_u32(113))][2][0][0][0])), (*&buffer21)[u32(buffer21[u32(unconst_u32(54))][u32(unconst_u32(260))][u32((*&buffer21)[u32(unconst_u32(357))][u32(unconst_u32(255))][u32(unconst_u32(256))][2][u32(unconst_u32(183))][u32(unconst_u32(118))][u32(unconst_u32(636))][u32(buffer21[arrayLength(&buffer21)][0][0][2][u32(unconst_u32(898))][2][0][0][0])][0])][u32(unconst_u32(330))][0][u32(unconst_u32(0))][0][u32(unconst_u32(222))][u32(unconst_u32(61))])][0][u32(unconst_u32(128))][u32(unconst_u32(69))][u32(unconst_u32(113))][2][0][0][0]);
+  let ptr7: ptr<storage, array<f16, 1>, read_write> = &(*&buffer22)[0][0][0][2][u32(unconst_u32(47))][u32(unconst_u32(307))];
+  let ptr8: ptr<storage, f16, read_write> = &buffer21[arrayLength(&buffer21)][0][0][u32(unconst_u32(183))][0][2][u32(unconst_u32(376))][u32(unconst_u32(31))][u32(unconst_u32(45))];
+  return out;
+  _ = buffer21;
+  _ = buffer22;
+}
+
+var<workgroup> vw5: atomic<u32>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw7: T0;
+
+@group(0) @binding(30) var st4: texture_storage_2d_array<r32sint, read_write>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct T0 {
+  @size(20) f0: atomic<i32>,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@group(1) @binding(176) var<storage, read_write> buffer22: array<array<array<array<array<array<array<f16, 1>, 3>, 1>, 3>, 1>, 1>, 1>;
+
+override override3: f32;
+
+override override5: f16 = 1750.4;
+
+var<workgroup> vw6: atomic<u32>;
+
+@vertex
+fn vertex2(@location(12) a0: vec4f, @location(10) @interpolate(flat, center) a1: vec2f) -> VertexOutput2 {
+  var out: VertexOutput2;
+  out.f4 |= vec2i(i32(max(f16(unconst_f16(16086.8)), f16(unconst_f16(454.6)))));
+  out = VertexOutput2(vec2i(i32(override5)), vec2h(override5), vec4u(u32(override5)), vec4h(override5), vec4f(f32(override5)), override5);
+  let vf25: f32 = override3;
+  fn1();
+  var vf26: f32 = override3;
+  out.f4 = vec2i(a0.rr);
+  out.f9 = f16(vf26);
+  let vf27: f16 = override5;
+  out.f5 += vec2h(vf27);
+  out.f8 += vec4f(vf25);
+  out.f9 = f16(distance(f32(unconst_f32(0.01306)), f32(unconst_f32(0.05123))));
+  out.f9 *= f16(max(u32(unconst_u32(25)), u32(unconst_u32(97))));
+  fn1();
+  out.f7 = vec4h(vp1.whole.brgb);
+  fn1();
+  var vf28: vec4f = degrees(vec4f(unconst_f32(0.1495), unconst_f32(0.4155), unconst_f32(0.04995), unconst_f32(0.01255)));
+  out.f5 *= bitcast<vec2h>(override4);
+  var vf29: vec2f = a1;
+  vf28 = vec4f(f32(override4));
+  vp1 = modf(degrees(vec4f(unconst_f32(0.1522), unconst_f32(-0.1716), unconst_f32(0.1763), unconst_f32(0.06170))).ggb);
+  let vf30: vec4f = degrees(vec4f(unconst_f32(0.06329), unconst_f32(0.1390), unconst_f32(0.4450), unconst_f32(0.1006)));
+  vf28 = vec4f(sqrt(vec4h(unconst_f16(7175.0), unconst_f16(17757.3), unconst_f16(1052.3), unconst_f16(1806.3))));
+  return out;
+  _ = override5;
+  _ = override3;
+  _ = override4;
+}
+
+@compute @workgroup_size(2, 1, 1)
+fn compute0(@builtin(workgroup_id) a0: vec3u) {
+  var vf31 = fn1();
+  vf31 = VertexOutput2(vec2i(i32((*&buffer21)[u32(unconst_u32(72))][0][0][u32(unconst_u32(294))][u32(unconst_u32(276))][2][0][u32(unconst_u32(145))][u32(unconst_u32(115))])), vec2h((*&buffer21)[u32(unconst_u32(72))][0][0][u32(unconst_u32(294))][u32(unconst_u32(276))][2][0][u32(unconst_u32(145))][u32(unconst_u32(115))]), vec4u(u32((*&buffer21)[u32(unconst_u32(72))][0][0][u32(unconst_u32(294))][u32(unconst_u32(276))][2][0][u32(unconst_u32(145))][u32(unconst_u32(115))])), vec4h((*&buffer21)[u32(unconst_u32(72))][0][0][u32(unconst_u32(294))][u32(unconst_u32(276))][2][0][u32(unconst_u32(145))][u32(unconst_u32(115))]), vec4f(f32((*&buffer21)[u32(unconst_u32(72))][0][0][u32(unconst_u32(294))][u32(unconst_u32(276))][2][0][u32(unconst_u32(145))][u32(unconst_u32(115))])), (*&buffer21)[u32(unconst_u32(72))][0][0][u32(unconst_u32(294))][u32(unconst_u32(276))][2][0][u32(unconst_u32(145))][u32(unconst_u32(115))]);
+  atomicOr(&vw7.f0, i32(unconst_i32(103)));
+  textureStore(st4, vec2i(unconst_i32(173), unconst_i32(-2)), i32(unconst_i32(6)), vec4i(vec4i(unconst_i32(77), unconst_i32(11), unconst_i32(93), unconst_i32(-165))));
+  atomicOr(&vw6, u32(unconst_u32(6)));
+  let ptr9: ptr<storage, f16, read_write> = &buffer22[u32(unconst_u32(22))][u32(unconst_u32(155))][u32((*&buffer22)[0][0][u32(unconst_u32(54))][2][0][2][0])][2][0][u32(unconst_u32(55))][0];
+  atomicStore(&vw4, u32(unconst_u32(7)));
+  _ = buffer22;
+  _ = buffer21;
+  _ = st4;
+}`,
+});
+let commandEncoder28 = device0.createCommandEncoder({});
+let textureView30 = texture4.createView({dimension: '2d'});
+let computePassEncoder28 = commandEncoder28.beginComputePass({label: '17'});
+try {
+device0.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 3, y: 4, z: 0},
+  aspect: 'all',
+}, new Uint8Array(30).fill(172), /* required buffer size: 30 */
+{offset: 30, bytesPerRow: 60}, {width: 36, height: 10, depthOrArrayLayers: 0});
+} catch {}
+let buffer23 = device0.createBuffer({
+  size: 8209,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder23.setBindGroup(1, bindGroup9);
+} catch {}
+let shaderModule2 = device0.createShaderModule({
+  code: `
+requires packed_4x8_integer_dot_product;
+
+enable f16;
+
+@id(3639) override override9: u32 = 169;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@id(39313) override override6: f32;
+
+@group(1) @binding(176) var<storage, read_write> buffer25: array<f16, 9>;
+
+var<workgroup> vw8: array<atomic<u32>, 25>;
+
+var<workgroup> vw9: T2;
+
+fn fn1() -> mat3x2f {
+  var out: mat3x2f;
+  let vf44: f16 = override8;
+  out = mat3x2f(faceForward(vec4f(unconst_f32(0.02208), unconst_f32(0.05099), unconst_f32(0.1718), unconst_f32(0.7557)), vec4f(unconst_f32(0.02071), unconst_f32(0.01709), unconst_f32(0.02877), unconst_f32(0.1264)), vec4f(unconst_f32(0.1122), unconst_f32(0.01308), unconst_f32(0.4596), unconst_f32(0.6711))).ga, faceForward(vec4f(unconst_f32(0.02208), unconst_f32(0.05099), unconst_f32(0.1718), unconst_f32(0.7557)), vec4f(unconst_f32(0.02071), unconst_f32(0.01709), unconst_f32(0.02877), unconst_f32(0.1264)), vec4f(unconst_f32(0.1122), unconst_f32(0.01308), unconst_f32(0.4596), unconst_f32(0.6711))).zy, faceForward(vec4f(unconst_f32(0.02208), unconst_f32(0.05099), unconst_f32(0.1718), unconst_f32(0.7557)), vec4f(unconst_f32(0.02071), unconst_f32(0.01709), unconst_f32(0.02877), unconst_f32(0.1264)), vec4f(unconst_f32(0.1122), unconst_f32(0.01308), unconst_f32(0.4596), unconst_f32(0.6711))).aa);
+  var vf45: vec4f = faceForward(vec4f(unconst_f32(0.04739), unconst_f32(0.1409), unconst_f32(0.02161), unconst_f32(0.01353)), vec4f(unconst_f32(0.04838), unconst_f32(0.00169), unconst_f32(0.2759), unconst_f32(0.02239)), vec4f(unconst_f32(0.01871), unconst_f32(-0.01171), unconst_f32(0.1286), unconst_f32(0.3579)));
+  out = mat3x2f(vf45.yx, vf45.rr, vf45.gg);
+  vf45 *= unpack4x8snorm(override9);
+  var vf46: vec3f = cross(vec3f(unconst_f32(0.4744), unconst_f32(0.1151), unconst_f32(0.5253)), vec3f(unconst_f32(0.1596), unconst_f32(0.05983), unconst_f32(0.09908)));
+  let vf47: f16 = inverseSqrt(f16(unconst_f16(806.0)));
+  return out;
+  _ = override8;
+  _ = override9;
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@group(1) @binding(237) var st10: texture_storage_1d<r32float, read_write>;
+
+@id(1579) override override8: f16;
+
+var<workgroup> vw10: vec2f;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn fn0() -> vec2h {
+  var out: vec2h;
+  let vf32: u32 = firstTrailingBit(u32(unconst_u32(110)));
+  out += vec2h(dot(vec2h(unconst_f16(275.9), unconst_f16(-15561.4)), vec2h(unconst_f16(-4259.4), unconst_f16(332.9))));
+  let vf33: u32 = pack4xU8(vec4u(unconst_u32(127), unconst_u32(80), unconst_u32(80), unconst_u32(285)));
+  let vf34: vec2h = sqrt(vec2h(unconst_f16(16277.4), unconst_f16(5201.8)));
+  out = bitcast<vec2h>(vf32);
+  let vf35: u32 = override9;
+  let vf36: f16 = dot(vec2h(unconst_f16(8362.3), unconst_f16(2148.1)), vec2h(unconst_f16(1228.1), unconst_f16(6082.3)));
+  var vf37: f32 = override7;
+  vf37 = vf37;
+  var vf38: f16 = vf34[u32(unconst_u32(246))];
+  let vf39: f32 = override7;
+  let vf40: vec2h = vf34;
+  vf38 += f16(override9);
+  vf38 *= cosh(vec2h(unconst_f16(11062.9), unconst_f16(8307.6)))[1];
+  let vf41: f32 = vf39;
+  var vf42: f32 = override7;
+  var vf43: f16 = dot(vec2h(unconst_f16(21015.2), unconst_f16(19485.6)), vec2h(unconst_f16(11947.6), unconst_f16(-1603.7)));
+  return out;
+  _ = override9;
+  _ = override7;
+}
+
+struct T1 {
+  @size(20) f0: array<u32>,
+}
+
+@id(49639) override override7 = -1.000;
+
+struct T3 {
+  @size(20) f0: array<u32>,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct T2 {
+  @size(20) f0: atomic<i32>,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<workgroup> vw13: vec4i;
+
+var<workgroup> vw11: T0;
+
+var<workgroup> vw12: FragmentOutput0;
+
+@group(0) @binding(176) var<storage, read_write> buffer24: array<array<array<array<f16, 1>, 3>, 3>>;
+
+struct T0 {
+  @size(16) f0: array<f32, 1>,
+  f1: array<f16, 1>,
+}
+
+struct FragmentOutput0 {
+  @location(6) f0: vec4u,
+  @location(0) f1: vec2i,
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  buffer25[u32(unconst_u32(384))] = buffer24[u32(unconst_u32(353))][u32(unconst_u32(54))][u32(unconst_u32(74))][u32(unconst_u32(28))];
+  let ptr10: ptr<storage, f16, read_write> = &buffer24[arrayLength(&buffer24)][u32(unconst_u32(315))][u32(unconst_u32(217))][u32(unconst_u32(331))];
+  fn1();
+  out.f1 = vec2i(i32((*&buffer24)[u32(unconst_u32(860))][u32(unconst_u32(22))][u32(unconst_u32(262))][u32(buffer24[textureDimensions(st10)][2][2][u32(buffer24[arrayLength(&buffer24)][u32(unconst_u32(211))][u32(unconst_u32(153))][0])])]));
+  let ptr11: ptr<storage, array<f16, 1>, read_write> = &buffer24[u32(unconst_u32(144))][2][u32(unconst_u32(47))];
+  fn1();
+  var vf48 = fn1();
+  var vf49 = fn1();
+  out.f1 = vec2i(i32((*&buffer24)[u32(unconst_u32(46))][2][2][0]));
+  let ptr12: ptr<storage, array<f16, 1>, read_write> = &buffer24[arrayLength(&buffer24)][2][u32(unconst_u32(220))];
+  textureStore(st10, i32(unconst_i32(37)), vec4f(vec4f(unconst_f32(0.07477), unconst_f32(0.08673), unconst_f32(0.02571), unconst_f32(0.00513))));
+  fn1();
+  let ptr13: ptr<storage, array<array<f16, 1>, 3>, read_write> = &(*&buffer24)[arrayLength(&(*&buffer24))][2];
+  return out;
+  _ = override9;
+  _ = override8;
+  _ = buffer24;
+  _ = st10;
+  _ = buffer25;
+}
+
+@compute @workgroup_size(2, 1, 1)
+fn compute1(@builtin(global_invocation_id) a0: vec3u) {
+  let vf50: i32 = vw12.f1[u32(unconst_u32(443))];
+  vw12.f1 *= vec2i(i32(buffer24[arrayLength(&buffer24)][2][pack2x16float(vw10)][0]));
+  atomicAdd(&vw9.f0, i32(unconst_i32(277)));
+  buffer25[u32(unconst_u32(328))] = (*&buffer24)[arrayLength(&(*&buffer24))][2][2][0];
+  vw11 = T0(array<f32, 1>(f32(buffer24[arrayLength(&buffer24)][u32(unconst_u32(51))][2][u32(unconst_u32(39))])), array<f16, 1>(buffer24[arrayLength(&buffer24)][u32(unconst_u32(51))][2][u32(unconst_u32(39))]));
+  let ptr14: ptr<workgroup, f16> = &vw11.f1[u32(unconst_u32(262))];
+  vw10 = vec2f(f32(buffer24[arrayLength(&buffer24)][2][2][0]));
+  buffer24[u32(unconst_u32(314))][u32(buffer24[u32((*&buffer25)[8])][2][2][u32(buffer24[arrayLength(&buffer24)][2][2][0])])][u32(unconst_u32(126))][u32(unconst_u32(87))] = f16((*&vw11).f0[0]);
+  _ = buffer25;
+  _ = buffer24;
+}`,
+});
+try {
+buffer9.destroy();
+} catch {}
+let pipeline0 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule2, constants: {}}});
+let buffer26 = device0.createBuffer({size: 696, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+let texture27 = device0.createTexture({
+  size: {width: 432, height: 120, depthOrArrayLayers: 2},
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture28 = device0.createTexture({
+  size: [108],
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder23.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+computePassEncoder0.setBindGroup(2, bindGroup11, new Uint32Array(196), 85, 0);
+} catch {}
+let autogeneratedBindGroupLayout0 = pipeline0.getBindGroupLayout(0);
+let sampler17 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 70.27,
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder19.setPipeline(pipeline0);
+} catch {}
+document.body.prepend(img0);
+let autogeneratedBindGroupLayout1 = pipeline0.getBindGroupLayout(1);
+let bindGroup13 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [
+    {binding: 32, resource: {buffer: buffer18, offset: 1280, size: 624}},
+    {binding: 165, resource: textureView0},
+  ],
+});
+try {
+computePassEncoder24.setBindGroup(0, bindGroup3, new Uint32Array(2610), 2_610, 0);
+} catch {}
+let commandEncoder29 = device0.createCommandEncoder({});
+let texture29 = device0.createTexture({
+  size: {width: 432, height: 120, depthOrArrayLayers: 679},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture30 = gpuCanvasContext0.getCurrentTexture();
+let computePassEncoder29 = commandEncoder29.beginComputePass({label: '18'});
+try {
+computePassEncoder27.setBindGroup(2, bindGroup2, new Uint32Array(169), 41, 0);
+} catch {}
+try {
+computePassEncoder12.setBindGroup(3, bindGroup9, new Uint32Array(1439), 1_360, 0);
+} catch {}
+try {
+computePassEncoder26.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder19.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let buffer27 = device0.createBuffer({size: 37641, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+try {
+computePassEncoder29.setBindGroup(3, bindGroup13);
+} catch {}
+let promise2 = shaderModule0.getCompilationInfo();
+try {
+computePassEncoder26.pushDebugGroup('\u{1f867}');
+} catch {}
+try {
+  await promise2;
+} catch {}
+let veryExplicitBindGroupLayout4 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 110,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup14 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [
+    {binding: 176, resource: {buffer: buffer8, offset: 2560, size: 5464}},
+    {binding: 237, resource: textureView8},
+    {binding: 473, resource: sampler15},
+    {binding: 30, resource: textureView9},
+    {binding: 138, resource: textureView21},
+  ],
+});
+let buffer28 = device0.createBuffer({
+  size: 18223,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: false,
+});
+let commandEncoder30 = device0.createCommandEncoder({});
+let texture31 = device0.createTexture({
+  size: [108, 30, 236],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder30 = commandEncoder30.beginComputePass({label: '19'});
+try {
+computePassEncoder17.setPipeline(pipeline0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let pipeline1 = device0.createComputePipeline({label: 'bbb', layout: 'auto', compute: {module: shaderModule2}});
+let commandEncoder31 = device0.createCommandEncoder({});
+let textureView31 = texture13.createView({baseMipLevel: 0, arrayLayerCount: 1});
+try {
+computePassEncoder20.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+computePassEncoder14.setPipeline(pipeline1);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let autogeneratedBindGroupLayout2 = pipeline1.getBindGroupLayout(1);
+let buffer29 = device0.createBuffer({size: 7217, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder32 = device0.createCommandEncoder({});
+let renderPassEncoder0 = commandEncoder32.beginRenderPass({
+  colorAttachments: [{
+  view: textureView31,
+  clearValue: { r: 952.8, g: 181.9, b: -90.56, a: -574.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 133468867,
+});
+let sampler18 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 97.36,
+});
+try {
+commandEncoder31.resolveQuerySet(querySet1, 9, 170, buffer27, 11008);
+} catch {}
+await gc();
+let autogeneratedBindGroupLayout3 = pipeline1.getBindGroupLayout(0);
+let bindGroup15 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [
+    {binding: 237, resource: textureView15},
+    {binding: 176, resource: {buffer: buffer23, offset: 1792, size: 40}},
+    {binding: 138, resource: textureView21},
+    {binding: 473, resource: sampler13},
+    {binding: 30, resource: textureView23},
+  ],
+});
+let commandEncoder33 = device0.createCommandEncoder({label: '\u{1f7a8}\u0866\u{1ff43}\u{1f650}\ub6ab\u0be9\u3d4d\u{1fb97}'});
+let computePassEncoder31 = commandEncoder33.beginComputePass({label: '20'});
+let renderPassEncoder1 = commandEncoder31.beginRenderPass({
+  colorAttachments: [{
+  view: textureView28,
+  depthSlice: 12,
+  clearValue: { r: -539.1, g: 172.1, b: -156.2, a: 870.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet1,
+});
+try {
+computePassEncoder28.end();
+} catch {}
+try {
+computePassEncoder31.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder26.popDebugGroup();
+} catch {}
+let renderPassEncoder2 = commandEncoder28.beginRenderPass({colorAttachments: [{view: textureView28, depthSlice: 18, loadOp: 'clear', storeOp: 'store'}]});
+try {
+computePassEncoder14.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+computePassEncoder9.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(4, buffer1, 448, 241);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+let autogeneratedBindGroupLayout4 = pipeline1.getBindGroupLayout(1);
+let commandEncoder34 = device0.createCommandEncoder({});
+let textureView32 = texture16.createView({baseArrayLayer: 3, arrayLayerCount: 2});
+let texture32 = device0.createTexture({
+  size: {width: 54, height: 15, depthOrArrayLayers: 2},
+  mipLevelCount: 2,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture33 = gpuCanvasContext0.getCurrentTexture();
+let sampler19 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat'});
+try {
+computePassEncoder13.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup10, new Uint32Array(5537), 775, 0);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(13, 2, 25, 11);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(2, buffer1);
+} catch {}
+try {
+commandEncoder34.clearBuffer(buffer13, 2892, 1588);
+} catch {}
+await gc();
+let autogeneratedBindGroupLayout5 = pipeline0.getBindGroupLayout(1);
+let texture34 = device0.createTexture({size: [216, 60, 2], format: 'depth24plus', usage: GPUTextureUsage.TEXTURE_BINDING, viewFormats: []});
+let textureView33 = texture30.createView({});
+let sampler20 = device0.createSampler({addressModeU: 'mirror-repeat', lodMaxClamp: 90.04, compare: 'less'});
+try {
+computePassEncoder29.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+computePassEncoder30.setBindGroup(0, bindGroup13, new Uint32Array(1365), 82, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup14, []);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(297);
+} catch {}
+try {
+commandEncoder34.copyTextureToBuffer({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 40, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 88 widthInBlocks: 88 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 4733 */
+  offset: 4733,
+  bytesPerRow: 7168,
+  buffer: buffer14,
+}, {width: 88, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder34.copyTextureToTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 57, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(21).fill(205), /* required buffer size: 21 */
+{offset: 21, rowsPerImage: 24}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img0);
+let videoFrame5 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'fcc', primaries: 'smpteSt4281', transfer: 'gamma28curve'} });
+let commandEncoder35 = device0.createCommandEncoder();
+let texture35 = device0.createTexture({
+  size: {width: 216},
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup14, new Uint32Array(826), 93, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer2, 'uint32', 500, 2_297);
+} catch {}
+let bindGroup16 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [{binding: 110, resource: {buffer: buffer23, offset: 512, size: 1276}}],
+});
+let commandEncoder36 = device0.createCommandEncoder({});
+try {
+computePassEncoder13.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+computePassEncoder8.setBindGroup(1, bindGroup13, new Uint32Array(1193), 163, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup11, new Uint32Array(295), 8, 0);
+} catch {}
+try {
+commandEncoder35.copyBufferToTexture({
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 4841 */
+  offset: 4841,
+  bytesPerRow: 23040,
+  rowsPerImage: 48,
+  buffer: buffer3,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder36.resolveQuerySet(querySet1, 556, 41, buffer19, 1024);
+} catch {}
+let imageData5 = new ImageData(52, 76);
+let autogeneratedBindGroupLayout6 = pipeline1.getBindGroupLayout(1);
+let querySet2 = device0.createQuerySet({type: 'occlusion', count: 402});
+let textureView34 = texture25.createView({arrayLayerCount: 1});
+let renderPassEncoder3 = commandEncoder34.beginRenderPass({
+  colorAttachments: [{
+  view: textureView31,
+  clearValue: { r: 757.9, g: -797.0, b: -900.0, a: -270.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet2,
+});
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer3, 'uint16', 13_560, 952);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+let buffer30 = device0.createBuffer({size: 6643, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let querySet3 = device0.createQuerySet({type: 'occlusion', count: 1455});
+let textureView35 = texture16.createView({baseArrayLayer: 2, arrayLayerCount: 1});
+let computePassEncoder32 = commandEncoder36.beginComputePass({label: '21'});
+let renderPassEncoder4 = commandEncoder35.beginRenderPass({
+  colorAttachments: [{view: textureView31, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet1,
+  maxDrawCount: 385412712,
+});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(1, undefined);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer17, 84, new BigUint64Array(6996), 1034, 224);
+} catch {}
+await gc();
+let autogeneratedBindGroupLayout7 = pipeline0.getBindGroupLayout(0);
+let buffer31 = device0.createBuffer({
+  size: 752,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let textureView36 = texture29.createView({mipLevelCount: 1});
+try {
+computePassEncoder13.setBindGroup(3, bindGroup2, new Uint32Array(464), 42, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.COPY_DST, colorSpace: 'display-p3'});
+} catch {}
+document.body.prepend(img0);
+let buffer32 = device0.createBuffer({
+  size: 7725,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture36 = gpuCanvasContext1.getCurrentTexture();
+let sampler21 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'repeat', lodMinClamp: 47.74, lodMaxClamp: 99.72});
+try {
+computePassEncoder23.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer10, 'uint16', 294, 122);
+} catch {}
+document.body.append(canvas1);
+let buffer33 = device0.createBuffer({size: 11155, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let textureView37 = texture24.createView({dimension: '2d'});
+let sampler22 = device0.createSampler({addressModeV: 'repeat', lodMinClamp: 54.72, lodMaxClamp: 77.16});
+try {
+computePassEncoder27.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer10, 'uint32', 1_188, 291);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(6, buffer20, 0, 2_392);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+let autogeneratedBindGroupLayout8 = pipeline1.getBindGroupLayout(1);
+try {
+computePassEncoder2.setBindGroup(0, bindGroup8, new Uint32Array(1387), 220, 0);
+} catch {}
+try {
+computePassEncoder7.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup2);
+} catch {}
+let bindGroup17 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout3,
+  entries: [{binding: 110, resource: {buffer: buffer18, offset: 1024, size: 808}}],
+});
+let texture37 = device0.createTexture({size: [54], mipLevelCount: 1, dimension: '1d', format: 'r8sint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let textureView38 = texture20.createView({dimension: 'cube-array', baseMipLevel: 0, baseArrayLayer: 2, arrayLayerCount: 6});
+let externalTexture0 = device0.importExternalTexture({source: videoFrame4, colorSpace: 'srgb'});
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup2, []);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup10, new Uint32Array(1643), 207, 0);
+} catch {}
+let imageData6 = new ImageData(56, 52);
+let buffer34 = device0.createBuffer({
+  size: 3633,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let sampler23 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 92.19,
+  compare: 'not-equal',
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder8.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup2, []);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup15, new Uint32Array(762), 406, 0);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer31, 'uint16', 12, 240);
+} catch {}
+let sampler24 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.34,
+  maxAnisotropy: 3,
+});
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup14, new Uint32Array(1725), 124, 0);
+} catch {}
+let bindGroup18 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout2,
+  entries: [{binding: 176, resource: {buffer: buffer10, offset: 256, size: 588}}],
+});
+let buffer35 = device0.createBuffer({size: 10685, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+let commandEncoder37 = device0.createCommandEncoder({});
+let computePassEncoder33 = commandEncoder37.beginComputePass({label: '22'});
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup11, new Uint32Array(642), 43, 0);
+} catch {}
+try {
+buffer29.unmap();
+} catch {}
+let buffer36 = device0.createBuffer({
+  size: 15547,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView39 = texture20.createView({dimension: 'cube', baseMipLevel: 0, mipLevelCount: 1});
+let sampler25 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.63,
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder13.setBindGroup(2, bindGroup14, new Uint32Array(6066), 947, 0);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder2.setViewport(79.03740968931368, 20.59458476088974, 13.670462720004888, 37.031388198165125, 0.7408286035770237, 0.9480174996841199);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(3, buffer4, 0, 2_022);
+} catch {}
+let bindGroup19 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout6,
+  entries: [{binding: 176, resource: {buffer: buffer10, offset: 0, size: 148}}],
+});
+let commandEncoder38 = device0.createCommandEncoder({});
+let texture38 = device0.createTexture({
+  size: {width: 108},
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder34 = commandEncoder38.beginComputePass({label: '23'});
+try {
+computePassEncoder4.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup13, new Uint32Array(5051), 22, 0);
+} catch {}
+let pipeline2 = await device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule1, constants: {}}});
+await gc();
+let imageData7 = new ImageData(68, 36);
+let bindGroup20 = device0.createBindGroup({layout: veryExplicitBindGroupLayout2, entries: [{binding: 23, resource: textureView5}]});
+let commandEncoder39 = device0.createCommandEncoder({});
+let textureView40 = texture30.createView({dimension: '2d-array', arrayLayerCount: 1});
+let computePassEncoder35 = commandEncoder39.beginComputePass({label: '24'});
+try {
+computePassEncoder22.setBindGroup(0, bindGroup16, new Uint32Array(266), 4, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: -297.7, g: -674.9, b: 11.97, a: -275.6, });
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer10, 'uint32', 120, 573);
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(211, 83);
+let autogeneratedBindGroupLayout9 = pipeline2.getBindGroupLayout(1);
+let buffer37 = device0.createBuffer({
+  size: 1396,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder40 = device0.createCommandEncoder({});
+let texture39 = device0.createTexture({
+  size: [54, 15, 2],
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture40 = device0.createTexture({
+  size: [54],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView41 = texture31.createView({mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder36 = commandEncoder40.beginComputePass({label: '25'});
+try {
+computePassEncoder8.setBindGroup(2, bindGroup3, new Uint32Array(2281), 304, 0);
+} catch {}
+try {
+computePassEncoder24.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(5, buffer32);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 46, y: 10, z: 0},
+  aspect: 'all',
+}, new Uint8Array(5).fill(196), /* required buffer size: 5 */
+{offset: 5}, {width: 13, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let promise3 = device0.queue.onSubmittedWorkDone();
+let pipeline3 = device0.createRenderPipeline({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {1_579: 0},
+  targets: [{format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex1',
+    constants: {override1: 0, 30_730: 0},
+    buffers: [
+      {
+        arrayStride: 504,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32', offset: 112, shaderLocation: 2},
+          {format: 'sint8x4', offset: 56, shaderLocation: 13},
+          {format: 'unorm10-10-10-2', offset: 56, shaderLocation: 6},
+        ],
+      },
+    ],
+  },
+});
+let commandEncoder41 = device0.createCommandEncoder({});
+let textureView42 = texture4.createView({dimension: '2d'});
+let computePassEncoder37 = commandEncoder41.beginComputePass({label: '26'});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup19);
+} catch {}
+try {
+computePassEncoder5.setBindGroup(0, bindGroup13, new Uint32Array(815), 19, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup19, new Uint32Array(693), 15, 0);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(680);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 19, y: 11, z: 0},
+  aspect: 'all',
+}, new Uint8Array(273).fill(90), /* required buffer size: 273 */
+{offset: 273, bytesPerRow: 87}, {width: 49, height: 43, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter0.label = '\ub6ba\u9af1\u{1fc01}\u5876\u{1fa7e}\uc285\u{1fc3f}\u{1fef0}\ubdae\u0397';
+} catch {}
+let autogeneratedBindGroupLayout10 = pipeline0.getBindGroupLayout(0);
+try {
+computePassEncoder2.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer3, 'uint32', 192, 1_883);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(4, buffer32, 2_176, 45);
+} catch {}
+await gc();
+try {
+computePassEncoder2.setBindGroup(0, bindGroup13, new Uint32Array(724), 101, 0);
+} catch {}
+try {
+computePassEncoder33.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer37, 'uint32', 220, 185);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(2, buffer23, 3_360, 515);
+} catch {}
+let gpuCanvasContext2 = offscreenCanvas0.getContext('webgpu');
+let buffer38 = device0.createBuffer({
+  size: 7763,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder42 = device0.createCommandEncoder({});
+let renderPassEncoder5 = commandEncoder42.beginRenderPass({colorAttachments: [{view: textureView28, depthSlice: 0, loadOp: 'clear', storeOp: 'store'}]});
+try {
+computePassEncoder20.setBindGroup(2, bindGroup20, []);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup14, new Uint32Array(2824), 483, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 15, y: 4, z: 0},
+  aspect: 'all',
+}, new Uint8Array(169).fill(122), /* required buffer size: 169 */
+{offset: 169, bytesPerRow: 222}, {width: 14, height: 3, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img0);
+try {
+adapter1.label = '\u52f9\u{1f906}\u{1fb7b}\uca2f\ub9a1\u0c98';
+} catch {}
+let bindGroup21 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout1,
+  entries: [{binding: 176, resource: {buffer: buffer19, offset: 0, size: 208}}],
+});
+let buffer39 = device0.createBuffer({
+  size: 14319,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder43 = device0.createCommandEncoder({});
+let textureView43 = texture20.createView({dimension: '2d', baseArrayLayer: 1});
+let computePassEncoder38 = commandEncoder43.beginComputePass({label: '27'});
+try {
+computePassEncoder36.setBindGroup(1, bindGroup19);
+} catch {}
+try {
+computePassEncoder6.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder1.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer18, 'uint16', 1_624, 187);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline3);
+} catch {}
+document.body.append(canvas1);
+try {
+adapter0.label = '\u35a8\u945a\u09a3\u2e17';
+} catch {}
+let buffer40 = device0.createBuffer({
+  label: '\u974a\ue86a\ubfd3\u001f\u{1f715}\u885e\uf00c\uef2f\udbb2\u{1fd15}',
+  size: 12262,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder18.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle0]);
+} catch {}
+try {
+device0.label = '\u0d13\u8b45\u8dc8\u055d\u0cfc\ube27\u9a99\ue741';
+} catch {}
+try {
+commandEncoder17.label = '\u{1fc24}\u{1fc9e}\u03c8\u31de\u{1f793}\u6049\u5b71\u7248\u9f21';
+} catch {}
+let autogeneratedBindGroupLayout11 = pipeline0.getBindGroupLayout(0);
+let commandEncoder44 = device0.createCommandEncoder();
+let renderPassEncoder6 = commandEncoder44.beginRenderPass({
+  colorAttachments: [{
+  view: textureView41,
+  depthSlice: 167,
+  clearValue: { r: 230.0, g: -6.027, b: -39.97, a: 144.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 156239479,
+});
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup9, new Uint32Array(198), 22, 0);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(2, buffer31);
+} catch {}
+let videoFrame6 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'fcc', primaries: 'smpte170m', transfer: 'bt2020_10bit'} });
+let buffer41 = device0.createBuffer({size: 14304, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+let commandEncoder45 = device0.createCommandEncoder({});
+let computePassEncoder39 = commandEncoder45.beginComputePass({label: '28'});
+try {
+computePassEncoder36.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer2, 'uint32', 332, 3_187);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(6, buffer3, 3_948, 9_340);
+} catch {}
+let shaderModule3 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+var<private> vp3: vec4h = vec4h(28553.6, 2743.7, 3158.0, 7577.9);
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(155) var<uniform> buffer44: array<array<array<mat4x4f, 17>, 1>, 1>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct T0 {
+  @size(36) f0: array<atomic<i32>>,
+}
+
+struct VertexOutput3 {
+  @builtin(position) f10: vec4f,
+  @location(12) f11: f32,
+  @location(6) f12: vec4i,
+  @location(14) f13: vec2i,
+}
+
+struct VertexOutput4 {
+  @invariant @builtin(position) f14: vec4f,
+}
+
+var<workgroup> vw14: array<atomic<i32>, 51>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<workgroup> vw15: array<f16, 1>;
+
+var<private> vp4: VertexOutput4 = VertexOutput4(vec4f(0.1241, 0.1653, 0.05853, 0.3719));
+
+var<workgroup> vw16: vec2<bool>;
+
+@group(0) @binding(78) var<storage, read_write> buffer42: array<atomic<u32>, 2>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@group(0) @binding(218) var st11: texture_storage_1d<r32float, write>;
+
+var<private> vp2: mat2x3f = mat2x3f(0.1719, 0.01088, 0.00765, 0.06545, 0.1017, 0.02412);
+
+var<workgroup> vw17: mat3x4f;
+
+@vertex @must_use
+fn vertex3() -> VertexOutput3 {
+  var out: VertexOutput3;
+  vp4.f14 = vec4f(buffer44[0][0][u32(unconst_u32(182))][u32(unconst_u32(158))][u32(unconst_u32(188))]);
+  out.f11 = buffer44[0][u32(unconst_u32(98))][u32(unconst_u32(1))][u32(unconst_u32(37))][u32(unconst_u32(183))];
+  let ptr15: ptr<uniform, mat4x4f> = &buffer44[u32(unconst_u32(12))][u32(unconst_u32(69))][u32(unconst_u32(256))];
+  out.f11 = (*&buffer44)[u32(unconst_u32(7))][u32(unconst_u32(137))][u32(unconst_u32(713))][unconst_i32(2)].x;
+  return out;
+  _ = buffer44;
+}
+
+@vertex
+fn vertex4(@location(9) @interpolate(flat, center) a0: vec4u, @location(6) @interpolate(linear, center) a1: f32) -> VertexOutput4 {
+  var out: VertexOutput4;
+  let ptr16: ptr<uniform, array<mat4x4f, 17>> = &buffer44[0][u32(unconst_u32(64))];
+  out.f14 -= vec4f(a1);
+  return out;
+  _ = buffer44;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute2() {
+  let ptr17: ptr<private, VertexOutput4> = &vp4;
+  atomicOr(&buffer42[u32(unconst_u32(21))], u32(unconst_u32(74)));
+  textureStore(st11, i32(unconst_i32(140)), vec4f(vec4f(f32(dot4I8Packed(atomicExchange(&(*&buffer42)[1], u32(unconst_u32(214))), u32(unconst_u32(71)))))));
+  vp4 = VertexOutput4(unpack4x8unorm(pack4x8unorm(buffer44[0][u32(unconst_u32(82))][u32(unconst_u32(390))][atomicLoad(&(*&buffer42)[1])])));
+  _ = st11;
+  _ = buffer42;
+  _ = buffer44;
+}`,
+});
+let commandEncoder46 = device0.createCommandEncoder({});
+let renderPassEncoder7 = commandEncoder46.beginRenderPass({
+  colorAttachments: [{view: textureView43, loadOp: 'clear', storeOp: 'store'}],
+  occlusionQuerySet: querySet3,
+});
+try {
+computePassEncoder20.setBindGroup(3, bindGroup18);
+} catch {}
+try {
+computePassEncoder0.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer28, 'uint16', 5_628, 2_741);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let bindGroup22 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout11,
+  entries: [{binding: 176, resource: {buffer: buffer32, offset: 5376, size: 936}}],
+});
+let commandEncoder47 = device0.createCommandEncoder({});
+let texture41 = device0.createTexture({size: [8], dimension: '1d', format: 'r8sint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let computePassEncoder40 = commandEncoder47.beginComputePass({label: '29'});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({colorFormats: ['r8sint'], stencilReadOnly: true});
+let sampler26 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 89.36,
+});
+let externalTexture1 = device0.importExternalTexture({source: videoFrame5});
+try {
+computePassEncoder24.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup11, new Uint32Array(4954), 506, 0);
+} catch {}
+try {
+buffer28.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 43, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(89).fill(89), /* required buffer size: 89 */
+{offset: 89, bytesPerRow: 493}, {width: 61, height: 12, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img0);
+let commandEncoder48 = device0.createCommandEncoder({});
+let computePassEncoder41 = commandEncoder48.beginComputePass({label: '30'});
+let renderBundle1 = renderBundleEncoder1.finish({});
+let sampler27 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 49.80,
+});
+try {
+computePassEncoder37.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup15, new Uint32Array(891), 154, 0);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer14, 1732, new BigUint64Array(14588), 6399, 84);
+} catch {}
+let imageData8 = new ImageData(20, 96);
+let commandEncoder49 = device0.createCommandEncoder({});
+let texture42 = device0.createTexture({
+  size: [216, 60, 2],
+  mipLevelCount: 1,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder39.setBindGroup(2, bindGroup2, new Uint32Array(4038), 499, 0);
+} catch {}
+try {
+computePassEncoder12.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline3);
+} catch {}
+try {
+commandEncoder49.copyBufferToTexture({
+  /* bytesInLastRow: 224 widthInBlocks: 28 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 5232 */
+  offset: 5232,
+  bytesPerRow: 7168,
+  buffer: buffer1,
+}, {
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 3, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 28, height: 6, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder49.resolveQuerySet(querySet2, 58, 16, buffer36, 1792);
+} catch {}
+let promise4 = device0.queue.onSubmittedWorkDone();
+let pipeline4 = await device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule1}});
+try {
+adapter1.label = '\u450c\u0ad5\ue180\u0792\u03fc\u96f4\uc954\u1eae\u4d16';
+} catch {}
+let bindGroup23 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [{binding: 110, resource: {buffer: buffer34, offset: 256, size: 168}}],
+});
+let renderPassEncoder8 = commandEncoder49.beginRenderPass({
+  colorAttachments: [{
+  view: textureView31,
+  clearValue: { r: 868.6, g: -822.5, b: 879.5, a: -879.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 180863908,
+});
+try {
+computePassEncoder11.setBindGroup(2, bindGroup21);
+} catch {}
+let buffer45 = device0.createBuffer({
+  size: 23842,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder50 = device0.createCommandEncoder();
+let textureView44 = texture15.createView({dimension: '1d', aspect: 'all', format: 'r8sint'});
+try {
+computePassEncoder11.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+commandEncoder50.copyBufferToTexture({
+  /* bytesInLastRow: 64 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1392 */
+  offset: 1392,
+  bytesPerRow: 46336,
+  buffer: buffer35,
+}, {
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder50.insertDebugMarker('\uc831');
+} catch {}
+document.body.append(canvas1);
+await gc();
+let autogeneratedBindGroupLayout12 = pipeline4.getBindGroupLayout(0);
+let bindGroup24 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout3,
+  entries: [{binding: 110, resource: {buffer: buffer2, offset: 1024}}],
+});
+let commandEncoder51 = device0.createCommandEncoder({});
+let textureView45 = texture34.createView({dimension: '2d', baseMipLevel: 0});
+let renderPassEncoder9 = commandEncoder51.beginRenderPass({
+  colorAttachments: [{
+  view: textureView28,
+  depthSlice: 6,
+  clearValue: { r: -919.2, g: -758.7, b: -26.81, a: -65.09, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet1,
+  maxDrawCount: 348052055,
+});
+let sampler28 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.06,
+  compare: 'equal',
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder34.setBindGroup(3, bindGroup14, new Uint32Array(481), 226, 0);
+} catch {}
+try {
+computePassEncoder41.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup10, []);
+} catch {}
+let videoFrame7 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'bt2020', transfer: 'iec6196624'} });
+let buffer46 = device0.createBuffer({size: 38419, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let texture43 = device0.createTexture({
+  size: [8, 8, 22],
+  mipLevelCount: 2,
+  format: 'r8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder34.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup14);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer31, 'uint16', 46, 141);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(6, buffer34, 0, 676);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+document.body.append(canvas1);
+let bindGroup25 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout3,
+  entries: [{binding: 176, resource: {buffer: buffer46, offset: 2304, size: 2844}}],
+});
+let commandEncoder52 = device0.createCommandEncoder({});
+let computePassEncoder42 = commandEncoder50.beginComputePass({label: '31'});
+try {
+computePassEncoder41.setBindGroup(3, bindGroup17);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer5, 'uint16', 248, 70);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(2, buffer36, 180, 4_258);
+} catch {}
+try {
+commandEncoder52.copyBufferToBuffer(buffer38, 448, buffer0, 1512, 2064);
+} catch {}
+try {
+commandEncoder52.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 813 */
+  offset: 813,
+  rowsPerImage: 67,
+  buffer: buffer6,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb'],
+});
+} catch {}
+let autogeneratedBindGroupLayout13 = pipeline2.getBindGroupLayout(0);
+let buffer47 = device0.createBuffer({
+  size: 24673,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder53 = device0.createCommandEncoder();
+let computePassEncoder43 = commandEncoder52.beginComputePass({label: '32'});
+let renderPassEncoder10 = commandEncoder53.beginRenderPass({
+  label: '\u0316\u08ba\u1613\u029c\ubc9b\u6a33\u{1f936}\u7459\u9f2b\u5489',
+  colorAttachments: [{
+  view: textureView28,
+  depthSlice: 18,
+  clearValue: { r: 366.1, g: -67.58, b: -367.9, a: 599.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 516220011,
+});
+try {
+computePassEncoder37.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup20, new Uint32Array(3509), 108, 0);
+} catch {}
+try {
+renderPassEncoder7.beginOcclusionQuery(42);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(4, buffer3, 0);
+} catch {}
+let imageData9 = new ImageData(68, 44);
+let videoFrame8 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'smpte170m', transfer: 'linear'} });
+let veryExplicitBindGroupLayout5 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 30,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d-array' },
+    },
+    {
+      binding: 138,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 176,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 18, hasDynamicOffset: false },
+    },
+    {
+      binding: 237,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '1d' },
+    },
+    {binding: 473, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }},
+  ],
+});
+try {
+computePassEncoder24.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+computePassEncoder13.setBindGroup(2, bindGroup13, new Uint32Array(1778), 658, 0);
+} catch {}
+try {
+computePassEncoder35.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer38, 0);
+} catch {}
+let commandEncoder54 = device0.createCommandEncoder({});
+let texture44 = device0.createTexture({
+  size: [216, 60, 2],
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderPassEncoder11 = commandEncoder54.beginRenderPass({
+  colorAttachments: [{view: textureView28, depthSlice: 11, loadOp: 'load', storeOp: 'store'}],
+  maxDrawCount: 153760606,
+});
+let sampler29 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 64.53,
+  compare: 'less',
+});
+try {
+computePassEncoder32.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer14, 'uint16', 7_686, 1_757);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let textureView46 = texture3.createView({dimension: '2d', mipLevelCount: 1});
+try {
+computePassEncoder38.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup17);
+} catch {}
+let autogeneratedBindGroupLayout14 = pipeline3.getBindGroupLayout(1);
+let commandEncoder55 = device0.createCommandEncoder({});
+let texture45 = device0.createTexture({
+  size: [216, 60, 2],
+  mipLevelCount: 2,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder12 = commandEncoder55.beginRenderPass({
+  colorAttachments: [{
+  view: textureView41,
+  depthSlice: 214,
+  clearValue: { r: -909.6, g: 250.2, b: -847.7, a: -618.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let sampler30 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 98.47,
+});
+try {
+computePassEncoder40.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+computePassEncoder42.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline3);
+} catch {}
+let promise5 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise5;
+} catch {}
+let commandEncoder56 = device0.createCommandEncoder({});
+let renderPassEncoder13 = commandEncoder56.beginRenderPass({
+  colorAttachments: [{view: textureView28, depthSlice: 4, loadOp: 'clear', storeOp: 'store'}],
+  occlusionQuerySet: querySet1,
+});
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(2, buffer47);
+} catch {}
+let videoFrame9 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'bt470bg', transfer: 'hlg'} });
+let texture46 = device0.createTexture({
+  size: [432, 120, 2],
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder17.setBindGroup(0, bindGroup21, new Uint32Array(1739), 89, 0);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(0, buffer39);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 428, new Float32Array(14606), 1472, 136);
+} catch {}
+document.body.append(img0);
+let videoFrame10 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte170m', primaries: 'smpte432', transfer: 'bt709'} });
+let bindGroup26 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 138, resource: textureView43},
+    {binding: 473, resource: sampler30},
+    {binding: 30, resource: textureView9},
+    {binding: 176, resource: {buffer: buffer10, offset: 0, size: 272}},
+    {binding: 237, resource: textureView15},
+  ],
+});
+let texture47 = device0.createTexture({
+  size: {width: 8, height: 8, depthOrArrayLayers: 22},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder11.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer40, 'uint32', 7_408, 468);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(6, buffer3);
+} catch {}
+try {
+  await promise3;
+} catch {}
+await gc();
+let bindGroup27 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 473, resource: sampler6},
+    {binding: 176, resource: {buffer: buffer32, offset: 512, size: 660}},
+    {binding: 237, resource: textureView8},
+    {binding: 138, resource: textureView43},
+    {binding: 30, resource: textureView9},
+  ],
+});
+let buffer48 = device0.createBuffer({
+  size: 32615,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let sampler31 = device0.createSampler({magFilter: 'linear', minFilter: 'linear', mipmapFilter: 'linear', lodMinClamp: 22.69, maxAnisotropy: 12});
+try {
+computePassEncoder34.setBindGroup(0, bindGroup17);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup27);
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(52, 8, 105, 0);
+} catch {}
+let buffer49 = device0.createBuffer({size: 21758, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+let textureView47 = texture13.createView({dimension: '2d'});
+try {
+renderPassEncoder12.setIndexBuffer(buffer5, 'uint32', 480, 13);
+} catch {}
+let bindGroup28 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout11,
+  entries: [{binding: 176, resource: {buffer: buffer8, offset: 3072, size: 1204}}],
+});
+let pipelineLayout4 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout5]});
+try {
+computePassEncoder39.setBindGroup(3, bindGroup23);
+} catch {}
+try {
+computePassEncoder43.setBindGroup(1, bindGroup11, new Uint32Array(1321), 520, 0);
+} catch {}
+try {
+computePassEncoder25.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer39, 'uint32', 4_080, 434);
+} catch {}
+let pipeline5 = device0.createRenderPipeline({
+  layout: 'auto',
+  fragment: {module: shaderModule2, entryPoint: 'fragment0', constants: {1_579: 0}, targets: [{format: 'r8sint'}]},
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', constants: {override1: 0}, buffers: []},
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', frontFace: 'cw', cullMode: 'back'},
+});
+document.body.append(canvas1);
+let texture48 = device0.createTexture({
+  size: [8, 8, 22],
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView48 = texture34.createView({aspect: 'depth-only', arrayLayerCount: 1});
+try {
+computePassEncoder9.setBindGroup(2, bindGroup11, new Uint32Array(1843), 641, 0);
+} catch {}
+try {
+computePassEncoder10.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup26, new Uint32Array(798), 1, 0);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer39, 'uint32', 4_680, 4_241);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline3);
+} catch {}
+try {
+  await promise4;
+} catch {}
+let img1 = await imageWithData(300, 47, '#10101010', '#20202020');
+let imageData10 = new ImageData(12, 64);
+let buffer50 = device0.createBuffer({size: 18778, usage: GPUBufferUsage.MAP_WRITE});
+let commandEncoder57 = device0.createCommandEncoder({});
+let computePassEncoder44 = commandEncoder57.beginComputePass({label: '33'});
+try {
+computePassEncoder3.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(3, buffer40);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let textureView49 = texture8.createView({baseArrayLayer: 1, arrayLayerCount: 14});
+try {
+computePassEncoder35.setBindGroup(1, bindGroup25);
+} catch {}
+try {
+computePassEncoder13.setPipeline(pipeline0);
+} catch {}
+let bindGroup29 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout9,
+  entries: [{binding: 176, resource: {buffer: buffer34, offset: 1536, size: 268}}],
+});
+let textureView50 = texture24.createView({aspect: 'depth-only', arrayLayerCount: 1});
+let sampler32 = device0.createSampler({addressModeV: 'clamp-to-edge', lodMinClamp: 88.09, lodMaxClamp: 97.30});
+try {
+renderPassEncoder13.executeBundles([renderBundle0, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(6, buffer18);
+} catch {}
+let pipelineLayout5 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let textureView51 = texture38.createView({});
+try {
+renderPassEncoder9.beginOcclusionQuery(23);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.setStencilReference(22);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer39, 'uint32', 400, 7_720);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(6, buffer3, 332);
+} catch {}
+let pipeline6 = await device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule2, entryPoint: 'compute1'}});
+document.body.prepend(canvas1);
+let bindGroup30 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [
+    {binding: 473, resource: sampler6},
+    {binding: 176, resource: {buffer: buffer8, offset: 256, size: 10980}},
+    {binding: 138, resource: textureView43},
+    {binding: 237, resource: textureView15},
+    {binding: 30, resource: textureView23},
+  ],
+});
+let commandEncoder58 = device0.createCommandEncoder({});
+let computePassEncoder45 = commandEncoder58.beginComputePass({label: '34'});
+let sampler33 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 90.50});
+try {
+computePassEncoder30.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup26, new Uint32Array(3068), 408, 0);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(4, buffer48, 3_384);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 2268, new Int16Array(18004), 8092, 80);
+} catch {}
+await gc();
+let querySet4 = device0.createQuerySet({type: 'occlusion', count: 562});
+let texture49 = device0.createTexture({
+  size: {width: 54, height: 15, depthOrArrayLayers: 291},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView52 = texture32.createView({dimension: '2d', mipLevelCount: 1, arrayLayerCount: 1});
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup30);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup30, new Uint32Array(184), 8, 0);
+} catch {}
+try {
+adapter0.label = '\u3584\u8c2f\u{1f7a4}\u0d43\udaa6\u02ee\ubce1\u0871';
+} catch {}
+let shaderModule4 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+requires readonly_and_readwrite_storage_textures;
+
+enable f16;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@group(0) @binding(88) var<storage, read> buffer52: array<array<array<array<f16, 1>, 8>, 15>>;
+
+fn fn0(a0: array<array<array<array<array<mat3x2f, 1>, 1>, 1>, 1>, 1>, a1: ptr<uniform, mat3x4h>) -> array<array<array<mat2x2h, 1>, 1>, 4> {
+  var out: array<array<array<mat2x2h, 1>, 1>, 4>;
+  out[bitcast<vec2u>(a0[0][0][0][0][0][unconst_i32(1)]).g][0][u32(unconst_u32(81))] += mat2x2h(vec2h(buffer53[1][33].br), vec2h(buffer53[1][33].ww));
+  var vf51: vec2f = a0[u32(unconst_u32(922))][u32(unconst_u32(485))][u32(unconst_u32(45))][0][0][u32(unconst_u32(51))];
+  vf51 *= vec2f(f32(buffer52[u32(unconst_u32(174))][u32(unconst_u32(668))][u32(unconst_u32(217))][0]));
+  let ptr18: ptr<storage, f16, read> = &(*&buffer52)[arrayLength(&(*&buffer52))][u32(unconst_u32(12))][7][u32(unconst_u32(70))];
+  let ptr19: ptr<storage, array<f16, 1>, read> = &(*&buffer52)[arrayLength(&(*&buffer52))][14][7];
+  out[u32(unconst_u32(467))][u32(unconst_u32(110))][u32(unconst_u32(240))] += mat2x2h((*a1)[u32(unconst_u32(49))][u32(unconst_u32(49))], (*a1)[u32(unconst_u32(49))][u32(unconst_u32(49))], (*a1)[u32(unconst_u32(49))][u32(unconst_u32(49))], (*a1)[u32(unconst_u32(49))][u32(unconst_u32(49))]);
+  out[3][u32(unconst_u32(98))][u32(unconst_u32(465))] = mat2x2h((*&buffer52)[u32(unconst_u32(137))][u32(unconst_u32(6))][7][0], (*&buffer52)[u32(unconst_u32(137))][u32(unconst_u32(6))][7][0], (*&buffer52)[u32(unconst_u32(137))][u32(unconst_u32(6))][7][0], (*&buffer52)[u32(unconst_u32(137))][u32(unconst_u32(6))][7][0]);
+  vf51 *= a0[0][0][u32(unconst_u32(459))][u32(unconst_u32(61))][0][unconst_i32(1)];
+  let vf52: vec2f = a0[0][vec4u((*a1)[u32(unconst_u32(112))]).x][u32(unconst_u32(36))][u32(unconst_u32(29))][u32(unconst_u32(32))][u32(unconst_u32(293))];
+  var vf53: f32 = a0[u32(unconst_u32(4))][u32(unconst_u32(159))][u32(unconst_u32(131))][u32(unconst_u32(254))][u32(unconst_u32(216))][u32(unconst_u32(129))][u32(unconst_u32(204))];
+  let ptr20: ptr<storage, array<array<f16, 1>, 8>, read> = &buffer52[arrayLength(&buffer52)][u32(unconst_u32(536))];
+  return out;
+  _ = buffer52;
+  _ = buffer53;
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@group(0) @binding(218) var st12: texture_storage_1d<r32float, write>;
+
+@group(0) @binding(78) var<storage, read_write> buffer51: array<array<f16, 4>>;
+
+var<workgroup> vw19: array<FragmentOutput1, 1>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<workgroup> vw21: atomic<i32>;
+
+struct T0 {
+  @align(16) @size(240) f0: array<i32>,
+}
+
+struct FragmentOutput1 {
+  @location(3) @interpolate(linear, sample) f0: vec4f,
+  @location(2) @interpolate(flat) f1: vec4u,
+  @location(0) @interpolate(flat) f2: i32,
+}
+
+var<workgroup> vw18: FragmentOutput1;
+
+fn fn1() -> vec4h {
+  var out: vec4h;
+  out *= vec4h(buffer53[u32(unconst_u32(367))][u32(unconst_u32(36))]);
+  out -= vec4h(buffer53[u32(unconst_u32(51))][33]);
+  out = vec4h(f16(atan(f32(unconst_f32(0.1049)))));
+  return out;
+  _ = buffer53;
+}
+
+@group(0) @binding(155) var<uniform> buffer53: array<array<vec4f, 34>, 2>;
+
+var<workgroup> vw20: u32;
+
+@vertex
+fn vertex5(@location(3) @interpolate(flat) a0: vec2u) -> @builtin(position) vec4f {
+  var out: vec4f;
+  let ptr21: ptr<uniform, array<vec4f, 34>> = &(*&buffer53)[u32(unconst_u32(64))];
+  out = asin(vec4f(unconst_f32(0.08728), unconst_f32(0.03608), unconst_f32(0.08636), unconst_f32(0.1007)));
+  out = (*&buffer53)[u32(unconst_u32(98))][33];
+  out = vec4f((*&buffer53)[1][u32(unconst_u32(74))][u32(unconst_u32(46))]);
+  var vf54 = fn1();
+  out = degrees(vec2f(unconst_f32(-0.5924), unconst_f32(0.3208))).xxxx;
+  var vf55 = fn1();
+  var vf56 = fn1();
+  fn1();
+  vf54 = vec4h((*ptr21)[33]);
+  let ptr22: ptr<uniform, array<vec4f, 34>> = &(*&buffer53)[1];
+  vf55 *= vec4h(step(vec3f(unconst_f32(0.5977), unconst_f32(0.04327), unconst_f32(-0.03326)), vec3f(unconst_f32(0.04208), unconst_f32(0.2157), unconst_f32(0.02088))).grrb);
+  var vf57 = fn1();
+  var vf58 = fn1();
+  var vf59 = fn1();
+  vf56 -= vec4h(f16((*ptr22)[pack4x8unorm(buffer53[pack4x8unorm((*ptr22)[33])][u32(unconst_u32(0))])][u32(unconst_u32(45))]));
+  var vf60 = fn1();
+  let ptr23: ptr<uniform, vec4f> = &(*ptr22)[33];
+  var vf61 = fn1();
+  return out;
+  _ = buffer53;
+}
+
+@fragment
+fn fragment1(@location(6) @interpolate(flat) a0: vec4i) -> FragmentOutput1 {
+  var out: FragmentOutput1;
+  out.f2 *= i32((*&buffer52)[arrayLength(&(*&buffer52))][14][u32(unconst_u32(2))][u32(unconst_u32(294))]);
+  let ptr24: ptr<storage, f16, read> = &buffer52[u32(unconst_u32(2))][14][7][u32(unconst_u32(211))];
+  out.f2 ^= i32((*&buffer52)[arrayLength(&(*&buffer52))][14][u32(unconst_u32(3))][0]);
+  return out;
+  _ = buffer52;
+}
+
+@compute @workgroup_size(4, 1, 1)
+fn compute3() {
+  vw19[u32(unconst_u32(130))].f2 = bitcast<i32>(pack4xU8(vw18.f1));
+  textureStore(st12, i32(unconst_i32(73)), vec4f(vec4f(unconst_f32(0.03561), unconst_f32(0.1989), unconst_f32(-0.02252), unconst_f32(0.1258))));
+  var vf62 = fn1();
+  var vf63 = fn1();
+  let ptr25: ptr<storage, array<f16, 4>, read_write> = &buffer51[u32(unconst_u32(86))];
+  let ptr26: ptr<storage, f16, read> = &buffer52[arrayLength(&buffer52)][u32(unconst_u32(620))][7][0];
+  textureStore(st12, i32(unconst_i32(1)), vec4f(vec4f(unconst_f32(0.5581), unconst_f32(0.3503), unconst_f32(0.2403), unconst_f32(0.1688))));
+  let ptr27: ptr<storage, f16, read_write> = &(*&buffer51)[u32(unconst_u32(113))][3];
+  let ptr28: ptr<storage, array<array<f16, 1>, 8>, read> = &(*&buffer52)[arrayLength(&(*&buffer52))][14];
+  vf63 = vec4h(buffer52[u32(unconst_u32(24))][14][7][0]);
+  let vf64: f32 = (*&vw19)[0].f0[u32(unconst_u32(24))];
+  var vf65 = fn1();
+  let ptr29: ptr<uniform, array<vec4f, 34>> = &buffer53[1];
+  fn1();
+  textureStore(st12, i32(unconst_i32(-88)), vec4f(vec4f(unconst_f32(0.05522), unconst_f32(-0.00955), unconst_f32(0.1845), unconst_f32(0.04235))));
+  fn1();
+  var vf66 = fn1();
+  fn1();
+  workgroupBarrier();
+  var vf67 = fn1();
+  _ = buffer53;
+  _ = st12;
+  _ = buffer51;
+  _ = buffer52;
+}`,
+});
+let veryExplicitBindGroupLayout6 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 78,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 88,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 155,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 218,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32float', access: 'write-only', viewDimension: '1d' },
+    },
+  ],
+});
+let commandEncoder59 = device0.createCommandEncoder({});
+let texture50 = device0.createTexture({
+  size: [216, 60, 2],
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture51 = device0.createTexture({
+  size: [8, 8, 22],
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder14 = commandEncoder59.beginRenderPass({
+  colorAttachments: [{
+  view: textureView52,
+  clearValue: { r: 846.2, g: 115.3, b: -140.2, a: -536.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet1,
+});
+let sampler34 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 59.00,
+});
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup14);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup23, new Uint32Array(48), 14, 0);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder14.pushDebugGroup('\u0c79');
+} catch {}
+let texture52 = device0.createTexture({
+  size: [8],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler35 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 91.87,
+  compare: 'greater-equal',
+});
+try {
+computePassEncoder33.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline3);
+} catch {}
+try {
+  await shaderModule2.getCompilationInfo();
+} catch {}
+let videoFrame11 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'film', transfer: 'smpteSt4281'} });
+let autogeneratedBindGroupLayout15 = pipeline1.getBindGroupLayout(1);
+let commandEncoder60 = device0.createCommandEncoder({});
+let computePassEncoder46 = commandEncoder60.beginComputePass({label: '35'});
+let sampler36 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 47.55,
+});
+try {
+computePassEncoder24.setBindGroup(2, bindGroup18, new Uint32Array(585), 379, 0);
+} catch {}
+try {
+computePassEncoder43.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(4, buffer20, 52, 116);
+} catch {}
+let commandEncoder61 = device0.createCommandEncoder({});
+let textureView53 = texture20.createView({dimension: 'cube-array', baseArrayLayer: 6, arrayLayerCount: 6});
+let texture53 = device0.createTexture({
+  label: '\u0b3d\u08be\u299b\u0a01\u295d\u0e78',
+  size: {width: 8, height: 8, depthOrArrayLayers: 22},
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView54 = texture25.createView({arrayLayerCount: 1});
+let renderPassEncoder15 = commandEncoder61.beginRenderPass({
+  colorAttachments: [{
+  view: textureView41,
+  depthSlice: 38,
+  clearValue: { r: 319.5, g: 73.75, b: -233.5, a: -465.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder29.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup18);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let imageData11 = new ImageData(52, 28);
+let autogeneratedBindGroupLayout16 = pipeline3.getBindGroupLayout(0);
+let commandEncoder62 = device0.createCommandEncoder({});
+let renderPassEncoder16 = commandEncoder62.beginRenderPass({colorAttachments: [{view: textureView28, depthSlice: 4, loadOp: 'load', storeOp: 'discard'}]});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({colorFormats: ['r8sint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderBundleEncoder2.setPipeline(pipeline3);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let autogeneratedBindGroupLayout17 = pipeline5.getBindGroupLayout(1);
+try {
+computePassEncoder41.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+computePassEncoder46.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder9.beginOcclusionQuery(202);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(39, 15, 3, 1);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer37, 'uint32', 80, 42);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(1, bindGroup22, []);
+} catch {}
+document.body.append(img1);
+let commandEncoder63 = device0.createCommandEncoder({});
+let texture54 = device0.createTexture({
+  size: {width: 432, height: 120, depthOrArrayLayers: 2},
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder47 = commandEncoder63.beginComputePass({label: '36'});
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup10, new Uint32Array(157), 7, 0);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer20, 'uint32', 932, 2_584);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder2.setVertexBuffer(4, buffer40, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer54 = device0.createBuffer({
+  size: 24508,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder64 = device0.createCommandEncoder({});
+let texture55 = gpuCanvasContext1.getCurrentTexture();
+let textureView55 = texture37.createView({});
+let computePassEncoder48 = commandEncoder64.beginComputePass({label: '37'});
+try {
+computePassEncoder36.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup21, new Uint32Array(515), 32, 0);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderBundleEncoder2.setIndexBuffer(buffer39, 'uint32', 2_908, 406);
+} catch {}
+try {
+renderPassEncoder14.popDebugGroup();
+} catch {}
+let autogeneratedBindGroupLayout18 = pipeline5.getBindGroupLayout(1);
+let commandEncoder65 = device0.createCommandEncoder({});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({colorFormats: ['r8sint'], depthReadOnly: true});
+try {
+computePassEncoder48.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup8, new Uint32Array(1246), 360, 0);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(buffer39, 'uint32', 392, 22);
+} catch {}
+try {
+commandEncoder65.copyBufferToTexture({
+  /* bytesInLastRow: 364 widthInBlocks: 91 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1848 */
+  offset: 1848,
+  bytesPerRow: 12288,
+  buffer: buffer3,
+}, {
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 27, y: 24, z: 0},
+  aspect: 'all',
+}, {width: 91, height: 5, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderBundleEncoder3.insertDebugMarker('\u0473');
+} catch {}
+let promise6 = device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule4}});
+await gc();
+let imageBitmap2 = await createImageBitmap(videoFrame5);
+let buffer55 = device0.createBuffer({size: 8345, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder66 = device0.createCommandEncoder({});
+let textureView56 = texture4.createView({arrayLayerCount: 1});
+let computePassEncoder49 = commandEncoder66.beginComputePass({label: '38'});
+let sampler37 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 90.23,
+  compare: 'always',
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder15.setBindGroup(3, bindGroup25);
+} catch {}
+try {
+computePassEncoder24.setBindGroup(1, bindGroup10, new Uint32Array(606), 128, 0);
+} catch {}
+try {
+computePassEncoder22.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(5, buffer46, 12_936, 461);
+} catch {}
+try {
+renderBundleEncoder2.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder2.setVertexBuffer(0, buffer4, 2_040, 89);
+} catch {}
+try {
+buffer30.unmap();
+} catch {}
+let bindGroup31 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout6,
+  entries: [
+    {binding: 218, resource: textureView15},
+    {binding: 155, resource: {buffer: buffer20, offset: 0, size: 1763}},
+    {binding: 78, resource: {buffer: buffer39, offset: 2304, size: 1404}},
+    {binding: 88, resource: {buffer: buffer20, offset: 1024, size: 804}},
+  ],
+});
+let commandEncoder67 = device0.createCommandEncoder({});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({colorFormats: ['r8sint'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle2 = renderBundleEncoder4.finish();
+let sampler38 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 88.66,
+});
+try {
+computePassEncoder21.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer32, 'uint32', 1_960, 268);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(5, buffer32);
+} catch {}
+try {
+buffer27.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer48, 412, new Int16Array(5084), 183, 232);
+} catch {}
+document.body.append(img1);
+let computePassEncoder50 = commandEncoder67.beginComputePass({label: '39'});
+let renderBundle3 = renderBundleEncoder3.finish({});
+let sampler39 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 85.88});
+try {
+computePassEncoder18.setBindGroup(3, bindGroup26, new Uint32Array(469), 117, 0);
+} catch {}
+try {
+computePassEncoder39.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(0, buffer31, 160, 202);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(0, bindGroup17, new Uint32Array(2099), 89, 0);
+} catch {}
+try {
+commandEncoder65.resolveQuerySet(querySet0, 52, 102, buffer32, 0);
+} catch {}
+try {
+renderBundleEncoder2.insertDebugMarker('\uf9ed');
+} catch {}
+document.body.prepend(img1);
+let commandEncoder68 = device0.createCommandEncoder({});
+let computePassEncoder51 = commandEncoder65.beginComputePass({label: '40'});
+let renderPassEncoder17 = commandEncoder68.beginRenderPass({
+  colorAttachments: [{
+  view: textureView43,
+  clearValue: { r: -120.3, g: 541.9, b: 175.6, a: -97.78, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet3,
+});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+computePassEncoder44.setBindGroup(2, bindGroup20, new Uint32Array(661), 25, 0);
+} catch {}
+try {
+computePassEncoder16.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle2, renderBundle3, renderBundle0, renderBundle0, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer5, 'uint16', 96, 120);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer14, 724, new BigUint64Array(19923), 1585, 4);
+} catch {}
+let bindGroup32 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout1,
+  entries: [{binding: 176, resource: {buffer: buffer8, offset: 10240, size: 836}}],
+});
+let commandEncoder69 = device0.createCommandEncoder({});
+let computePassEncoder52 = commandEncoder69.beginComputePass({label: '41'});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup20, new Uint32Array(382), 60, 0);
+} catch {}
+try {
+computePassEncoder51.setPipeline(pipeline4);
+} catch {}
+let autogeneratedBindGroupLayout19 = pipeline1.getBindGroupLayout(1);
+let commandEncoder70 = device0.createCommandEncoder({});
+let textureView57 = texture33.createView({});
+let computePassEncoder53 = commandEncoder70.beginComputePass({label: '42'});
+try {
+computePassEncoder27.setBindGroup(0, bindGroup15, new Uint32Array(253), 82, 0);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer3, 'uint16', 6_008, 6_089);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 32, new BigUint64Array(584));
+} catch {}
+let videoFrame12 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'fcc', primaries: 'film', transfer: 'gamma28curve'} });
+try {
+computePassEncoder45.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder20.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup11, new Uint32Array(4503), 884, 0);
+} catch {}
+try {
+renderBundleEncoder2.setPipeline(pipeline5);
+} catch {}
+try {
+gpuCanvasContext2.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.COPY_SRC});
+} catch {}
+document.body.append(canvas1);
+try {
+globalThis.someLabel = buffer19.label;
+} catch {}
+let commandEncoder71 = device0.createCommandEncoder();
+let textureView58 = texture3.createView({arrayLayerCount: 1});
+let computePassEncoder54 = commandEncoder71.beginComputePass({label: '43'});
+try {
+renderPassEncoder16.setIndexBuffer(buffer40, 'uint16', 1_248, 8_583);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame13 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'unspecified', primaries: 'bt470m', transfer: 'gamma28curve'} });
+let commandEncoder72 = device0.createCommandEncoder({});
+let querySet5 = device0.createQuerySet({type: 'occlusion', count: 374});
+let texture56 = device0.createTexture({size: [8, 8, 151], dimension: '3d', format: 'r8sint', usage: GPUTextureUsage.COPY_SRC});
+let computePassEncoder55 = commandEncoder72.beginComputePass({label: '44'});
+try {
+computePassEncoder45.setBindGroup(1, bindGroup29, new Uint32Array(820), 391, 0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup32, new Uint32Array(26), 7, 0);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(1, buffer39, 1_620, 4_884);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(2, bindGroup19, new Uint32Array(972), 24, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 1,
+  origin: {x: 12, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(13).fill(52), /* required buffer size: 13 */
+{offset: 13, bytesPerRow: 78}, {width: 8, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let imageData12 = new ImageData(12, 60);
+let autogeneratedBindGroupLayout20 = pipeline5.getBindGroupLayout(1);
+let bindGroup33 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout8,
+  entries: [{binding: 176, resource: {buffer: buffer45, offset: 5632, size: 2488}}],
+});
+let commandEncoder73 = device0.createCommandEncoder({});
+let computePassEncoder56 = commandEncoder73.beginComputePass({label: '45'});
+try {
+renderPassEncoder4.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder2.setPipeline(pipeline5);
+} catch {}
+let pipeline7 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule3, constants: {}}});
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let bindGroup34 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout10,
+  entries: [{binding: 176, resource: {buffer: buffer48, offset: 3072, size: 3296}}],
+});
+let buffer56 = device0.createBuffer({size: 6908, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView59 = texture39.createView({dimension: '2d'});
+try {
+renderPassEncoder0.setViewport(1.8364186362947357, 13.775122652543008, 85.73120756660893, 10.89197759727269, 0.9512455715763238, 0.9837505436118698);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(2, buffer20, 0);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(1, bindGroup32);
+} catch {}
+try {
+renderBundleEncoder2.setPipeline(pipeline3);
+} catch {}
+let imageData13 = new ImageData(8, 12);
+try {
+renderPassEncoder13.executeBundles([renderBundle2, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer55, 'uint16', 1_200, 245);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(1, buffer47, 0, 4_797);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder2.setIndexBuffer(buffer55, 'uint16', 844, 993);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let buffer57 = device0.createBuffer({size: 5783, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder74 = device0.createCommandEncoder({});
+let texture57 = device0.createTexture({
+  size: {width: 108},
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder57 = commandEncoder74.beginComputePass({label: '46'});
+try {
+renderBundleEncoder2.setVertexBuffer(2, buffer37, 0, 23);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+});
+} catch {}
+let textureView60 = texture56.createView({});
+let renderBundle4 = renderBundleEncoder2.finish({});
+try {
+computePassEncoder15.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder15.executeBundles([renderBundle1, renderBundle3, renderBundle0, renderBundle0]);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+let buffer58 = device0.createBuffer({
+  size: 1475,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder75 = device0.createCommandEncoder({});
+let texture58 = device0.createTexture({
+  size: {width: 8, height: 8, depthOrArrayLayers: 151},
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture59 = gpuCanvasContext0.getCurrentTexture();
+let renderPassEncoder18 = commandEncoder75.beginRenderPass({
+  colorAttachments: [{
+  view: textureView31,
+  clearValue: { r: -421.6, g: -598.4, b: 986.7, a: -469.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet5,
+  maxDrawCount: 367324139,
+});
+let sampler40 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 88.20});
+let externalTexture2 = device0.importExternalTexture({source: videoFrame3});
+try {
+computePassEncoder9.setBindGroup(1, bindGroup25);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 83, y: 35, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup35 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout10,
+  entries: [{binding: 176, resource: {buffer: buffer2, offset: 3072}}],
+});
+let buffer59 = device0.createBuffer({size: 9766, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder76 = device0.createCommandEncoder();
+let textureView61 = texture27.createView({arrayLayerCount: 1});
+try {
+renderPassEncoder16.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(7, buffer40, 1_016, 3_737);
+} catch {}
+try {
+commandEncoder76.copyBufferToBuffer(buffer37, 72, buffer11, 2092, 412);
+} catch {}
+try {
+commandEncoder76.resolveQuerySet(querySet3, 321, 35, buffer9, 512);
+} catch {}
+await gc();
+let externalTexture3 = device0.importExternalTexture({source: videoFrame4});
+document.body.prepend(img0);
+let commandEncoder77 = device0.createCommandEncoder({});
+let textureView62 = texture8.createView({dimension: 'cube-array', baseArrayLayer: 0, arrayLayerCount: 6});
+let computePassEncoder58 = commandEncoder76.beginComputePass({label: '47'});
+let renderPassEncoder19 = commandEncoder77.beginRenderPass({
+  colorAttachments: [{
+  view: textureView31,
+  clearValue: { r: 432.6, g: -438.0, b: -492.7, a: 468.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet5,
+});
+let sampler41 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.56,
+  compare: 'greater-equal',
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder55.setPipeline(pipeline7);
+} catch {}
+let querySet6 = device0.createQuerySet({type: 'occlusion', count: 360});
+let textureView63 = texture54.createView({arrayLayerCount: 1});
+try {
+computePassEncoder47.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(7, buffer45);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+});
+} catch {}
+let videoFrame14 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'bt470bg', transfer: 'smpte240m'} });
+let bindGroup36 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout4,
+  entries: [{binding: 176, resource: {buffer: buffer20, offset: 2304, size: 2868}}],
+});
+let commandEncoder78 = device0.createCommandEncoder({});
+let texture60 = device0.createTexture({size: [108, 30, 2], format: 'r8sint', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC});
+let computePassEncoder59 = commandEncoder78.beginComputePass({label: '48'});
+try {
+computePassEncoder49.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 8320, new Int16Array(2940), 969, 988);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 5},
+  aspect: 'all',
+}, new Uint8Array(2).fill(173), /* required buffer size: 2 */
+{offset: 2, rowsPerImage: 9}, {width: 3, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline8 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule4}});
+await gc();
+try {
+adapter1.label = '\u029c\ub9df\u76fc';
+} catch {}
+let querySet7 = device0.createQuerySet({type: 'occlusion', count: 611});
+let texture61 = gpuCanvasContext1.getCurrentTexture();
+try {
+computePassEncoder21.setBindGroup(1, bindGroup16, new Uint32Array(2263), 148, 0);
+} catch {}
+try {
+computePassEncoder44.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline3);
+} catch {}
+try {
+buffer17.unmap();
+} catch {}
+try {
+computePassEncoder58.pushDebugGroup('\ucf33');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder79 = device0.createCommandEncoder({});
+let textureView64 = texture32.createView({format: 'r8sint', mipLevelCount: 1, arrayLayerCount: 1});
+let renderPassEncoder20 = commandEncoder79.beginRenderPass({
+  colorAttachments: [{view: textureView31, loadOp: 'load', storeOp: 'discard'}],
+  occlusionQuerySet: querySet6,
+});
+try {
+computePassEncoder21.setBindGroup(3, bindGroup33);
+} catch {}
+try {
+renderPassEncoder20.setBlendConstant({ r: -294.2, g: 796.8, b: -577.6, a: -17.20, });
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer32, 'uint32', 1_424, 1_700);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(0, buffer47, 64, 8_170);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas1,
+  origin: { x: 18, y: 4 },
+  flipY: true,
+}, {
+  texture: texture61,
+  mipLevel: 0,
+  origin: {x: 8, y: 4, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 156, height: 115, depthOrArrayLayers: 0});
+} catch {}
+let veryExplicitBindGroupLayout7 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 23,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba8snorm', access: 'write-only', viewDimension: '2d' },
+    },
+  ],
+});
+let autogeneratedBindGroupLayout21 = pipeline6.getBindGroupLayout(0);
+let texture62 = device0.createTexture({
+  size: {width: 8, height: 8, depthOrArrayLayers: 22},
+  sampleCount: 1,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r8sint'],
+});
+try {
+computePassEncoder50.setBindGroup(2, bindGroup36);
+} catch {}
+try {
+computePassEncoder36.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer2, 'uint32', 1_932, 948);
+} catch {}
+try {
+adapter0.label = '\u0358\u{1f7a4}\u{1fb58}\u0295';
+} catch {}
+let autogeneratedBindGroupLayout22 = pipeline7.getBindGroupLayout(0);
+let buffer60 = device0.createBuffer({
+  size: 6476,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView65 = texture20.createView({dimension: '2d-array', aspect: 'all', baseArrayLayer: 1, arrayLayerCount: 12});
+try {
+computePassEncoder57.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup10, new Uint32Array(349), 1, 0);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline5);
+} catch {}
+let autogeneratedBindGroupLayout23 = pipeline7.getBindGroupLayout(0);
+let commandEncoder80 = device0.createCommandEncoder();
+let texture63 = device0.createTexture({
+  size: {width: 108, height: 30, depthOrArrayLayers: 2},
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let renderPassEncoder21 = commandEncoder80.beginRenderPass({
+  colorAttachments: [{
+  view: textureView41,
+  depthSlice: 19,
+  clearValue: { r: -804.3, g: -864.6, b: -440.0, a: 279.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet0,
+});
+let sampler42 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 8,
+});
+try {
+computePassEncoder19.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+computePassEncoder20.setBindGroup(2, bindGroup32, new Uint32Array(197), 22, 0);
+} catch {}
+try {
+computePassEncoder59.setPipeline(pipeline8);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame14,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 126, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let autogeneratedBindGroupLayout24 = pipeline7.getBindGroupLayout(0);
+let textureView66 = texture33.createView({dimension: '2d', baseArrayLayer: 0, arrayLayerCount: 1});
+try {
+computePassEncoder56.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup22, new Uint32Array(4654), 3_095, 0);
+} catch {}
+try {
+renderPassEncoder14.setBlendConstant({ r: -783.6, g: 2.115, b: 912.5, a: 767.2, });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer60, 1000, new Float32Array(2172), 60, 148);
+} catch {}
+let autogeneratedBindGroupLayout25 = pipeline6.getBindGroupLayout(1);
+let texture64 = device0.createTexture({
+  size: {width: 108, height: 30, depthOrArrayLayers: 2},
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView67 = texture30.createView({});
+try {
+computePassEncoder49.setBindGroup(3, bindGroup18, new Uint32Array(383), 232, 0);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline3);
+} catch {}
+let commandEncoder81 = device0.createCommandEncoder({});
+let texture65 = device0.createTexture({size: [216], dimension: '1d', format: 'r8sint', usage: GPUTextureUsage.COPY_SRC});
+let renderPassEncoder22 = commandEncoder81.beginRenderPass({colorAttachments: [{view: textureView64, loadOp: 'clear', storeOp: 'store'}]});
+try {
+computePassEncoder52.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer40, 'uint16', 1_118, 791);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline3);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder82 = device0.createCommandEncoder({});
+let computePassEncoder60 = commandEncoder82.beginComputePass({label: '49'});
+try {
+computePassEncoder41.setBindGroup(1, bindGroup29);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer38, 'uint32', 2_036, 74);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+await gc();
+let commandEncoder83 = device0.createCommandEncoder({label: '\u3f40\u0b98\u0477\u0037'});
+let computePassEncoder61 = commandEncoder83.beginComputePass({label: '50'});
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+gpuCanvasContext1.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT, alphaMode: 'opaque'});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+}, new Uint8Array(1_134).fill(110), /* required buffer size: 1_134 */
+{offset: 648, bytesPerRow: 54, rowsPerImage: 9}, {width: 0, height: 1, depthOrArrayLayers: 2});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: img0,
+  origin: { x: 0, y: 10 },
+  flipY: false,
+}, {
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 47, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let texture66 = device0.createTexture({size: [108, 30, 2], format: 'r8sint', usage: GPUTextureUsage.COPY_DST});
+let textureView68 = texture5.createView({});
+try {
+computePassEncoder31.setBindGroup(3, bindGroup28);
+} catch {}
+try {
+computePassEncoder27.setBindGroup(2, bindGroup3, new Uint32Array(885), 157, 0);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup32);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle0]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture61,
+  mipLevel: 0,
+  origin: {x: 18, y: 23, z: 0},
+  aspect: 'all',
+}, new Uint8Array(55).fill(201), /* required buffer size: 55 */
+{offset: 55, bytesPerRow: 712, rowsPerImage: 120}, {width: 82, height: 8, depthOrArrayLayers: 0});
+} catch {}
+try {
+globalThis.someLabel = commandEncoder15.label;
+} catch {}
+let commandEncoder84 = device0.createCommandEncoder();
+let texture67 = device0.createTexture({size: [8, 8, 324], dimension: '3d', format: 'r8sint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let computePassEncoder62 = commandEncoder84.beginComputePass({label: '51'});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({colorFormats: ['r8sint']});
+let renderBundle5 = renderBundleEncoder5.finish({});
+try {
+computePassEncoder31.setBindGroup(2, bindGroup16);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup20, new Uint32Array(570), 89, 0);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle5, renderBundle0, renderBundle1, renderBundle2]);
+} catch {}
+let canvas2 = document.createElement('canvas');
+let veryExplicitBindGroupLayout8 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 110,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder85 = device0.createCommandEncoder({});
+let texture68 = gpuCanvasContext2.getCurrentTexture();
+let renderPassEncoder23 = commandEncoder85.beginRenderPass({
+  colorAttachments: [{
+  view: textureView64,
+  clearValue: { r: 328.2, g: -594.1, b: 242.1, a: -196.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder18.setIndexBuffer(buffer58, 'uint32', 8, 5);
+} catch {}
+let textureView69 = texture35.createView({});
+try {
+computePassEncoder62.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(2, buffer45, 2_760, 5_488);
+} catch {}
+let sampler43 = device0.createSampler({
+  addressModeV: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 70.06,
+  lodMaxClamp: 92.84,
+  compare: 'greater-equal',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder47.setBindGroup(2, bindGroup9);
+} catch {}
+try {
+computePassEncoder50.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(3, bindGroup20);
+} catch {}
+try {
+renderPassEncoder13.setScissorRect(135, 11, 7, 34);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline5);
+} catch {}
+let promise7 = shaderModule1.getCompilationInfo();
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(619).fill(130), /* required buffer size: 619 */
+{offset: 59, bytesPerRow: 56}, {width: 7, height: 10, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await promise7;
+} catch {}
+document.body.prepend(canvas2);
+let autogeneratedBindGroupLayout26 = pipeline2.getBindGroupLayout(0);
+let buffer61 = device0.createBuffer({
+  size: 5078,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView70 = texture0.createView({mipLevelCount: 1, arrayLayerCount: 1});
+let sampler44 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 98.53,
+});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+computePassEncoder60.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant({ r: -507.1, g: -217.5, b: -601.2, a: -700.9, });
+} catch {}
+let promise8 = device0.queue.onSubmittedWorkDone();
+let gpuCanvasContext3 = canvas2.getContext('webgpu');
+try {
+  await promise8;
+} catch {}
+let offscreenCanvas1 = new OffscreenCanvas(196, 540);
+let texture69 = device0.createTexture({
+  size: {width: 8, height: 8, depthOrArrayLayers: 22},
+  dimension: '2d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView71 = texture1.createView({arrayLayerCount: 1});
+try {
+computePassEncoder3.setBindGroup(2, bindGroup36);
+} catch {}
+try {
+computePassEncoder5.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline5);
+} catch {}
+let videoFrame15 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte240m', primaries: 'bt470m', transfer: 'gamma22curve'} });
+let shaderModule5 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct T0 {
+  @align(16) @size(240) f0: array<atomic<u32>>,
+}
+
+@group(0) @binding(88) var<storage, read> buffer63: array<array<array<f16, 5>, 4>, 6>;
+
+var<workgroup> vw23: f32;
+
+@group(0) @binding(155) var<uniform> buffer64: array<array<mat2x2f, 34>, 2>;
+
+var<workgroup> vw22: array<atomic<u32>, 1>;
+
+fn fn0(a0: ptr<storage, array<u32>, read_write>) -> array<array<FragmentOutput2, 1>, 1> {
+  var out: array<array<FragmentOutput2, 1>, 1>;
+  var vf68: vec4f = unpack4x8snorm(u32(unconst_u32(37)));
+  (*a0)[u32(unconst_u32(104))] <<= pack4xU8Clamp(unpack4xU8(u32((*&buffer64)[u32(unconst_u32(157))][u32(unconst_u32(802))][u32(unconst_u32(304))][u32(unconst_u32(96))])));
+  vf68 = (*&buffer64)[1][33][u32(unconst_u32(141))].yxyx;
+  var vf69: vec4h = clamp(vec4h(unconst_f16(890.8), unconst_f16(16468.2), unconst_f16(-46138.3), unconst_f16(-4785.8)), vec4h(unconst_f16(-931.1), unconst_f16(-20409.7), unconst_f16(11490.4), unconst_f16(23781.6)), vec4h(unconst_f16(839.9), unconst_f16(2821.5), unconst_f16(13659.2), unconst_f16(18424.8)));
+  return out;
+  _ = buffer64;
+}
+
+fn fn1() -> vec4f {
+  var out: vec4f;
+  out = vec4f((*&buffer64)[u32(unconst_u32(157))][33][u32(unconst_u32(311))][u32(unconst_u32(423))]);
+  var vf70: vec2f = buffer64[1][u32(unconst_u32(445))][u32(unconst_u32(75))];
+  let ptr30: ptr<storage, array<array<f16, 5>, 4>, read> = &(*&buffer63)[u32(unconst_u32(673))];
+  let ptr31: ptr<storage, f16, read> = &(*ptr30)[u32(unconst_u32(10))][u32(unconst_u32(282))];
+  return out;
+  _ = buffer64;
+  _ = buffer63;
+}
+
+struct FragmentOutput2 {
+  @location(2) f0: u32,
+  @location(0) @interpolate(flat) f1: i32,
+  @location(5) f2: vec2f,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@vertex
+fn vertex6(@location(6) a0: vec2u, @location(11) @interpolate(flat) a1: vec2i, @location(2) a2: f32, @location(14) @interpolate(flat) a3: vec2i) -> @builtin(position) vec4f {
+  var out: vec4f;
+  out = (*&buffer64)[u32(unconst_u32(60))][33][unconst_i32(1)].yyxx;
+  var vf71: f16 = trunc(f16(unconst_f16(7495.7)));
+  vf71 = f16((*&buffer64)[1][33][u32(unconst_u32(77))][pack2x16float(buffer64[u32(unconst_u32(219))][33][u32(unconst_u32(53))])]);
+  out = buffer64[u32(unconst_u32(69))][u32(unconst_u32(116))][unconst_i32(1)].rgrr;
+  let ptr32: ptr<uniform, array<mat2x2f, 34>> = &(*&buffer64)[1];
+  var vf72: f32 = (*ptr32)[u32(unconst_u32(65))][u32(unconst_u32(0))][u32(unconst_u32(147))];
+  vf71 = log(vec4h(unconst_f16(35360.3), unconst_f16(923.1), unconst_f16(2523.7), unconst_f16(-2338.7)))[3];
+  out = vec4f(atan(vec2h(unconst_f16(1444.2), unconst_f16(21629.9))).yyyy);
+  vf72 += (*ptr32)[33][unconst_i32(0)][1];
+  var vf73: f32 = length(f32(unconst_f32(0.07762)));
+  vf72 *= bitcast<f32>(a1[u32(unconst_u32(272))]);
+  vf71 += f16(vf72);
+  vf72 += buffer64[1][33][unconst_i32(1)][1];
+  var vf74: vec2i = a1;
+  let ptr33: ptr<uniform, array<mat2x2f, 34>> = &buffer64[1];
+  vf71 = f16((*ptr32)[u32(unconst_u32(160))][a0.y][u32(unconst_u32(202))]);
+  let ptr34: ptr<uniform, mat2x2f> = &buffer64[1][u32(unconst_u32(146))];
+  vf72 = buffer64[1][33][u32(unconst_u32(172))][0];
+  vf74 = bitcast<vec2i>((*ptr32)[33][unconst_i32(0)]);
+  return out;
+  _ = buffer64;
+}
+
+@fragment
+fn fragment2() -> FragmentOutput2 {
+  var out: FragmentOutput2;
+  var vf75 = fn1();
+  fn1();
+  fn1();
+  out = FragmentOutput2(u32((*&buffer63)[5][3][4]), i32((*&buffer63)[5][3][4]), vec2f(f32((*&buffer63)[5][3][4])));
+  fn1();
+  out.f0 >>= u32((*&buffer63)[u32(round(vec4f(unconst_f32(0.02035), unconst_f32(0.03955), unconst_f32(0.2596), unconst_f32(0.1591))).z)][u32(unconst_u32(13))][4]);
+  out.f2 *= vec2f(f32((*&buffer63)[5][3][u32(unconst_u32(79))]));
+  let ptr35: ptr<storage, array<array<f16, 5>, 4>, read> = &buffer63[u32(unconst_u32(145))];
+  out.f1 |= i32((*&buffer63)[5][3][4]);
+  discard;
+  out.f1 = i32((*&buffer63)[u32(unconst_u32(178))][3][4]);
+  out = FragmentOutput2(u32((*&buffer63)[5][3][4]), i32((*&buffer63)[5][3][4]), vec2f(f32((*&buffer63)[5][3][4])));
+  var vf76: vec4f = round(vec4f(unconst_f32(0.1407), unconst_f32(0.03809), unconst_f32(0.3144), unconst_f32(0.3352)));
+  fn1();
+  out.f1 = bitcast<i32>(mix(vec3f(unconst_f32(0.05456), unconst_f32(0.3907), unconst_f32(0.3323)), vec3f(unconst_f32(0.02008), unconst_f32(0.3919), unconst_f32(-0.5181)), f32(unconst_f32(0.3941))).r);
+  out.f0 = bitcast<vec2u>(buffer64[1][u32(unconst_u32(315))][u32(unconst_u32(46))])[0];
+  return out;
+  _ = buffer64;
+  _ = buffer63;
+}
+
+@compute @workgroup_size(2, 1, 2)
+fn compute4(@builtin(local_invocation_id) a0: vec3u) {
+}`,
+});
+let pipelineLayout6 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout1]});
+let buffer65 = device0.createBuffer({size: 2652, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let externalTexture4 = device0.importExternalTexture({source: videoFrame2, colorSpace: 'display-p3'});
+try {
+computePassEncoder53.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(3, bindGroup26, new Uint32Array(1338), 417, 0);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline5);
+} catch {}
+let autogeneratedBindGroupLayout27 = pipeline7.getBindGroupLayout(0);
+let bindGroup37 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout19,
+  entries: [{binding: 176, resource: {buffer: buffer32, offset: 512, size: 700}}],
+});
+let textureView72 = texture62.createView({baseArrayLayer: 4, arrayLayerCount: 2});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({colorFormats: ['r8sint'], depthReadOnly: false, stencilReadOnly: true});
+try {
+renderPassEncoder20.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer14, 'uint32', 2_340, 2_058);
+} catch {}
+try {
+renderBundleEncoder6.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(3, buffer1, 0);
+} catch {}
+await gc();
+try {
+computePassEncoder58.setBindGroup(1, bindGroup17, new Uint32Array(6024), 936, 0);
+} catch {}
+try {
+computePassEncoder20.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder58.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(2, bindGroup14, new Uint32Array(8098), 150, 0);
+} catch {}
+try {
+renderPassEncoder19.setScissorRect(4, 0, 55, 4);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(6, buffer36, 0);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(0, bindGroup19, new Uint32Array(556), 7, 0);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(3, buffer39, 1_052, 29);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 24, new BigUint64Array(2767), 115, 24);
+} catch {}
+let textureView73 = texture46.createView({dimension: '2d-array', arrayLayerCount: 1});
+try {
+computePassEncoder40.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(3, bindGroup32, new Uint32Array(1675), 157, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer49, 1940, new Int16Array(23729), 2576, 4744);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+}, new Uint8Array(4_876).fill(111), /* required buffer size: 4_876 */
+{offset: 164, bytesPerRow: 38, rowsPerImage: 31}, {width: 0, height: 0, depthOrArrayLayers: 5});
+} catch {}
+let img2 = await imageWithData(1, 131, '#10101010', '#20202020');
+let autogeneratedBindGroupLayout28 = pipeline3.getBindGroupLayout(0);
+let bindGroup38 = device0.createBindGroup({layout: veryExplicitBindGroupLayout2, entries: [{binding: 23, resource: textureView7}]});
+try {
+computePassEncoder30.setBindGroup(2, bindGroup9);
+} catch {}
+try {
+computePassEncoder7.setBindGroup(0, bindGroup28, new Uint32Array(220), 34, 0);
+} catch {}
+try {
+computePassEncoder61.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+renderBundleEncoder6.setPipeline(pipeline5);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData13,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture61,
+  mipLevel: 0,
+  origin: {x: 19, y: 5, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext4 = offscreenCanvas1.getContext('webgpu');
+let veryExplicitBindGroupLayout9 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 304,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({colorFormats: ['r8sint'], depthReadOnly: true});
+try {
+computePassEncoder54.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer5, 'uint16', 198, 87);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(2, buffer37, 296);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(3, bindGroup28, new Uint32Array(5875), 210, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let autogeneratedBindGroupLayout29 = pipeline1.getBindGroupLayout(0);
+let bindGroup39 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout27,
+  entries: [
+    {binding: 155, resource: {buffer: buffer33, offset: 2560, size: 7039}},
+    {binding: 218, resource: textureView15},
+    {binding: 78, resource: {buffer: buffer60, offset: 0, size: 464}},
+  ],
+});
+try {
+computePassEncoder46.setBindGroup(3, bindGroup38, new Uint32Array(1063), 497, 0);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle2, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer32, 'uint16', 34, 379);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(5, buffer1, 588, 683);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let buffer66 = device0.createBuffer({
+  size: 3015,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({colorFormats: ['r8sint'], stencilReadOnly: true});
+try {
+computePassEncoder47.setBindGroup(0, bindGroup32);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(0, bindGroup17, []);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(4, buffer40, 6_708);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(0, buffer61);
+} catch {}
+try {
+computePassEncoder58.popDebugGroup();
+} catch {}
+let autogeneratedBindGroupLayout30 = pipeline0.getBindGroupLayout(0);
+let buffer67 = device0.createBuffer({
+  size: 1469,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let sampler45 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 86.16,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder7.setBindGroup(1, bindGroup16, new Uint32Array(1856), 391, 0);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(1, bindGroup29, new Uint32Array(390), 127, 0);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer5, 'uint16', 1_360, 9);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(2, bindGroup19, new Uint32Array(8), 0, 0);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer19, 'uint32', 672, 133);
+} catch {}
+let promise9 = device0.queue.onSubmittedWorkDone();
+let autogeneratedBindGroupLayout31 = pipeline6.getBindGroupLayout(1);
+try {
+computePassEncoder32.setBindGroup(2, bindGroup22, new Uint32Array(1274), 112, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup29, new Uint32Array(1579), 197, 0);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle4, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer3, 'uint16', 270, 285);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(3, buffer66, 0, 284);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(2, bindGroup20, new Uint32Array(1823), 286, 0);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(2, buffer20);
+} catch {}
+try {
+querySet4.destroy();
+} catch {}
+try {
+renderPassEncoder12.pushDebugGroup('\u{1ff3a}');
+} catch {}
+try {
+renderPassEncoder12.popDebugGroup();
+} catch {}
+let pipeline9 = await device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule3}});
+let imageBitmap3 = await createImageBitmap(videoFrame10);
+let imageData14 = new ImageData(40, 12);
+let textureView74 = texture42.createView({arrayLayerCount: 1});
+let renderBundle6 = renderBundleEncoder6.finish({});
+try {
+computePassEncoder61.setBindGroup(0, bindGroup22, new Uint32Array(1893), 110, 0);
+} catch {}
+try {
+renderPassEncoder15.setScissorRect(10, 4, 4, 6);
+} catch {}
+try {
+renderPassEncoder14.setViewport(41.17133278483209, 13.01258588797682, 7.696683188454034, 0.7017917399289394, 0.6716065789241313, 0.7989130962737142);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer66, 'uint32', 3_012, 1);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(5, buffer3, 14_776, 714);
+} catch {}
+let shaderModule6 = device0.createShaderModule({
+  code: `
+requires pointer_composite_access;
+
+enable f16;
+
+requires pointer_composite_access;
+
+requires readonly_and_readwrite_storage_textures;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@id(11640) override override13: u32;
+
+@group(0) @binding(155) var<uniform> buffer70: array<array<mat2x3f, 2>, 17>;
+
+@id(25386) override override14: bool;
+
+var<private> vp5: vec4h = vec4h(7700.9, 34450.8, 5527.8, 3586.5);
+
+@id(60291) override override10: f16;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+override override12: u32;
+
+@id(13019) override override11: f16 = 16405.7;
+
+struct FragmentOutput3 {
+  @location(0) f0: vec4i,
+}
+
+@id(43836) override override15: f16;
+
+@group(0) @binding(78) var<storage, read_write> buffer68: T0;
+
+@group(0) @binding(218) var st14: texture_storage_1d<r32float, write>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<private> vp6 = array(modf(f16(-20004.2)));
+
+struct T0 {
+  @align(8) @size(8) f0: atomic<u32>,
+}
+
+@vertex
+fn vertex7(@location(6) @interpolate(linear) a0: f32, @location(1) @interpolate(linear, center) a1: f32, @location(14) @interpolate(flat, center) a2: vec2i) -> @builtin(position) vec4f {
+  var out: vec4f;
+  vp5 = vec4h(buffer70[u32(unconst_u32(56))][1][unconst_i32(1)].rrgg);
+  let vf77: f32 = buffer70[u32(unconst_u32(246))][1][u32(unconst_u32(53))][u32(vp6[0].whole)];
+  let vf78: f32 = (*&buffer70)[u32(unconst_u32(175))][u32(unconst_u32(102))][u32(unconst_u32(27))][u32(unconst_u32(38))];
+  let ptr36 = &vp6[0];
+  vp5 = vec4h((*&buffer70)[u32(unconst_u32(84))][1][unconst_i32(1)].xyxy);
+  vp6[u32(unconst_u32(10))] = modf(f16((*&buffer70)[u32(unconst_u32(200))][1][unconst_i32(0)].x));
+  let ptr37: ptr<uniform, mat2x3f> = &(*&buffer70)[16][u32(unconst_u32(70))];
+  vp6[u32(unconst_u32(44))] = modf(f16(buffer70[16][1][u32(unconst_u32(26))][2]));
+  let ptr38: ptr<uniform, array<mat2x3f, 2>> = &(*&buffer70)[u32(unconst_u32(111))];
+  vp6[u32(unconst_u32(33))].fract -= vp6[0].whole;
+  let vf79: f32 = vf77;
+  vp6[u32(unconst_u32(61))].whole = vec3h((*&buffer70)[bitcast<u32>((*ptr38)[1][unconst_i32(1)].z)][u32(unconst_u32(326))][unconst_i32(0)]).z;
+  let ptr39: ptr<private, f16> = &(*ptr36).whole;
+  vp5 = vec4h((*&buffer70)[16][1][unconst_i32(0)].xxzx);
+  let ptr40: ptr<uniform, array<array<mat2x3f, 2>, 17>> = &buffer70;
+  let vf80: f32 = (*ptr40)[16][1][u32(unconst_u32(376))][u32(unconst_u32(245))];
+  var vf81: vec3f = buffer70[16][u32(unconst_u32(154))][u32(unconst_u32(255))];
+  vf81 = unpack4x8unorm(u32(unconst_u32(109))).aab;
+  var vf82: f32 = vf79;
+  let vf83: f32 = a1;
+  let vf84: vec3f = (*&buffer70)[u32(unconst_u32(112))][1][u32(unconst_u32(912))];
+  let ptr41: ptr<uniform, mat2x3f> = &(*&buffer70)[u32(unconst_u32(20))][u32(unconst_u32(99))];
+  return out;
+  _ = buffer70;
+}
+
+@fragment
+fn fragment3() -> FragmentOutput3 {
+  var out: FragmentOutput3;
+  var vf85: f32 = (*&buffer70)[16][1][u32(unconst_u32(36))][u32(unconst_u32(24))];
+  let ptr42: ptr<uniform, mat2x3f> = &(*&buffer70)[16][u32(unconst_u32(90))];
+  let vf86: u32 = override13;
+  return out;
+  _ = override13;
+  _ = buffer70;
+}
+
+@compute @workgroup_size(1, 1, 2)
+fn compute5() {
+  let ptr43: ptr<uniform, mat2x3f> = &buffer70[16][u32(unconst_u32(51))];
+  vp6[0] = modf(f16((*&buffer70)[16][1][unconst_i32(1)].y));
+  let ptr44: ptr<uniform, mat2x3f> = &buffer70[u32(unconst_u32(74))][u32(unconst_u32(262))];
+  let vf87: u32 = pack4x8unorm(vec4f(unconst_f32(0.2294), unconst_f32(0.07094), unconst_f32(0.00522), unconst_f32(0.3442)));
+  var vf88: vec3f = buffer70[u32(unconst_u32(43))][u32(unconst_u32(186))][u32(unconst_u32(93))];
+  atomicExchange(&buffer68.f0, bitcast<u32>(step(f32(unconst_f32(0.1465)), f32(unconst_f32(0.05555)))));
+  textureStore(st14, i32(unconst_i32(31)), vec4f(vec4f(unconst_f32(0.2449), unconst_f32(0.1254), unconst_f32(-0.2737), unconst_f32(-0.07110))));
+  textureStore(st14, i32(unconst_i32(113)), vec4f(vec4f(unconst_f32(-0.01515), unconst_f32(0.00036), unconst_f32(0.02583), unconst_f32(0.4434))));
+  var vf89: u32 = override13;
+  _ = override13;
+  _ = st14;
+  _ = buffer68;
+  _ = buffer70;
+}`,
+});
+let buffer71 = device0.createBuffer({size: 650, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({colorFormats: ['r8sint'], depthReadOnly: true});
+try {
+computePassEncoder18.setBindGroup(2, bindGroup19, []);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer14, 'uint16', 1_230, 1_053);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture61,
+  mipLevel: 0,
+  origin: {x: 39, y: 50, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise9;
+} catch {}
+document.body.prepend(img2);
+let videoFrame16 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'smpteRp431', transfer: 'smpte170m'} });
+let texture70 = device0.createTexture({
+  size: {width: 8, height: 8, depthOrArrayLayers: 22},
+  format: 'r8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle7 = renderBundleEncoder9.finish({});
+try {
+computePassEncoder45.setBindGroup(0, bindGroup34);
+} catch {}
+try {
+computePassEncoder40.setBindGroup(1, bindGroup18, new Uint32Array(652), 67, 0);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup17, new Uint32Array(14), 0, 0);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer57, 'uint32', 1_368, 628);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(4, undefined, 0, 277_927_175);
+} catch {}
+let sampler46 = device0.createSampler({addressModeU: 'mirror-repeat', magFilter: 'linear', compare: 'equal'});
+let externalTexture5 = device0.importExternalTexture({source: videoFrame5});
+try {
+computePassEncoder23.setBindGroup(1, bindGroup37);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline5);
+} catch {}
+try {
+buffer61.unmap();
+} catch {}
+try {
+gpuCanvasContext2.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT, viewFormats: []});
+} catch {}
+let texture71 = device0.createTexture({
+  size: {width: 108, height: 30, depthOrArrayLayers: 2},
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle8 = renderBundleEncoder8.finish({});
+let sampler47 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 77.96,
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder6.setBindGroup(3, bindGroup2, new Uint32Array(301), 44, 0);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer19, 'uint16', 276, 116);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(5, buffer36);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(1, bindGroup23);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(0, bindGroup8, new Uint32Array(345), 62, 0);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer58, 'uint16', 34, 160);
+} catch {}
+try {
+buffer47.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 97, y: 60, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer72 = device0.createBuffer({
+  size: 20000,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture72 = device0.createTexture({
+  size: {width: 54, height: 15, depthOrArrayLayers: 2},
+  mipLevelCount: 3,
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView75 = texture19.createView({aspect: 'all'});
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup36);
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(10, 5, 16, 5);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer32, 'uint32', 424, 1_267);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(3, bindGroup15);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(3, buffer48, 0, 18_203);
+} catch {}
+let pipeline10 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule3, entryPoint: 'compute2'}});
+let buffer73 = device0.createBuffer({
+  size: 1115,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder86 = device0.createCommandEncoder();
+let textureView76 = texture33.createView({dimension: '2d-array', baseMipLevel: 0});
+let textureView77 = texture35.createView({baseMipLevel: 0});
+let renderBundle9 = renderBundleEncoder7.finish({});
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup32, new Uint32Array(1602), 284, 0);
+} catch {}
+try {
+renderPassEncoder6.setStencilReference(140);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let querySet8 = device0.createQuerySet({type: 'occlusion', count: 2610});
+let renderPassEncoder24 = commandEncoder86.beginRenderPass({
+  colorAttachments: [{
+  view: textureView28,
+  depthSlice: 6,
+  clearValue: { r: 641.0, g: 51.59, b: -663.6, a: -0.4407, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet6,
+});
+let sampler48 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 52.59,
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder53.setBindGroup(2, bindGroup27);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(1051);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer2, 'uint16', 436, 2_918);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(0, buffer45, 0, 3_103);
+} catch {}
+let autogeneratedBindGroupLayout32 = pipeline9.getBindGroupLayout(0);
+let textureView78 = texture64.createView({arrayLayerCount: 1});
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer3, 'uint16', 6_030, 452);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(7, buffer4, 388, 809);
+} catch {}
+let promise10 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData1,
+  origin: { x: 5, y: 24 },
+  flipY: false,
+}, {
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 27, y: 25, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 49, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame17 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'smpte240m', transfer: 'bt709'} });
+let autogeneratedBindGroupLayout33 = pipeline9.getBindGroupLayout(0);
+let texture73 = device0.createTexture({
+  size: {width: 8, height: 8, depthOrArrayLayers: 22},
+  mipLevelCount: 2,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder16.pushDebugGroup('\u{1fdfb}');
+} catch {}
+try {
+  await promise10;
+} catch {}
+let buffer74 = device0.createBuffer({
+  size: 17446,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder9.setBindGroup(2, bindGroup10, new Uint32Array(551), 12, 0);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer5, 'uint16', 78, 75);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 23, y: 10 },
+  flipY: false,
+}, {
+  texture: texture61,
+  mipLevel: 0,
+  origin: {x: 213, y: 31, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 43, height: 21, depthOrArrayLayers: 0});
+} catch {}
+let veryExplicitBindGroupLayout10 = device0.createBindGroupLayout({
+  label: '\u{1f6d3}\u73cc\ufa72\ue865\u56c2\u12a8\u{1f98d}\u{1ff0d}',
+  entries: [
+    {binding: 378, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform', hasDynamicOffset: false }},
+  ],
+});
+let commandEncoder87 = device0.createCommandEncoder({});
+let textureView79 = texture1.createView({aspect: 'all', arrayLayerCount: 1});
+let computePassEncoder63 = commandEncoder87.beginComputePass({label: '52'});
+let sampler49 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', minFilter: 'linear', lodMaxClamp: 50.10});
+try {
+computePassEncoder57.setBindGroup(1, bindGroup31, new Uint32Array(1829), 1_136, 0);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(1, buffer74, 0, 1_494);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame9,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture61,
+  mipLevel: 0,
+  origin: {x: 65, y: 40, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let autogeneratedBindGroupLayout34 = pipeline6.getBindGroupLayout(0);
+let pipelineLayout7 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout17]});
+let texture74 = device0.createTexture({
+  size: {width: 8, height: 8, depthOrArrayLayers: 128},
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler50 = device0.createSampler({
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 88.18,
+  compare: 'less-equal',
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder41.setBindGroup(0, bindGroup37, new Uint32Array(3160), 191, 0);
+} catch {}
+try {
+computePassEncoder7.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer5, 'uint32', 28, 59);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(5, buffer39, 0, 1_382);
+} catch {}
+let pipeline11 = device0.createRenderPipeline({
+  layout: 'auto',
+  fragment: {module: shaderModule5, constants: {}, targets: [{format: 'r8sint', writeMask: 0}]},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex4',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 944, shaderLocation: 9},
+          {format: 'float16x4', offset: 324, shaderLocation: 6},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let commandEncoder88 = device0.createCommandEncoder();
+let querySet9 = device0.createQuerySet({type: 'occlusion', count: 476});
+let renderPassEncoder25 = commandEncoder88.beginRenderPass({
+  colorAttachments: [{
+  view: textureView28,
+  depthSlice: 13,
+  clearValue: { r: -402.3, g: 697.0, b: -427.2, a: -328.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet5,
+});
+try {
+renderPassEncoder24.setBindGroup(0, bindGroup28);
+} catch {}
+try {
+computePassEncoder16.popDebugGroup();
+} catch {}
+let texture75 = device0.createTexture({
+  size: {width: 216, height: 60, depthOrArrayLayers: 2},
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture76 = device0.createTexture({
+  size: [216, 60, 5],
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder63.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(2, bindGroup19, new Uint32Array(341), 189, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let autogeneratedBindGroupLayout35 = pipeline7.getBindGroupLayout(0);
+let textureView80 = texture75.createView({aspect: 'all', arrayLayerCount: 1});
+let sampler51 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  lodMaxClamp: 67.54,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder3.setBindGroup(1, bindGroup37);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer2, 'uint32', 1_792, 790);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline3);
+} catch {}
+await gc();
+let texture77 = device0.createTexture({
+  size: [54],
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder3.setVertexBuffer(7, buffer38);
+} catch {}
+try {
+renderPassEncoder5.pushDebugGroup('\u{1f617}');
+} catch {}
+let autogeneratedBindGroupLayout36 = pipeline6.getBindGroupLayout(0);
+let commandEncoder89 = device0.createCommandEncoder();
+let textureView81 = texture75.createView({arrayLayerCount: 1});
+try {
+computePassEncoder8.setBindGroup(2, bindGroup31, new Uint32Array(1384), 577, 0);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer58, 'uint16', 24, 183);
+} catch {}
+let bindGroup40 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout26,
+  entries: [
+    {binding: 30, resource: textureView56},
+    {binding: 176, resource: {buffer: buffer34, offset: 1024, size: 1032}},
+  ],
+});
+let textureView82 = texture16.createView({dimension: '2d', baseMipLevel: 0, baseArrayLayer: 8, arrayLayerCount: 1});
+let computePassEncoder64 = commandEncoder89.beginComputePass({label: '53'});
+let sampler52 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 95.85,
+  lodMaxClamp: 98.29,
+});
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup26, []);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup26, new Uint32Array(1370), 229, 0);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(1, buffer61, 0, 73);
+} catch {}
+try {
+buffer72.unmap();
+} catch {}
+try {
+renderPassEncoder5.popDebugGroup();
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(114, 166);
+let commandEncoder90 = device0.createCommandEncoder({});
+let renderPassEncoder26 = commandEncoder90.beginRenderPass({
+  colorAttachments: [{
+  view: textureView28,
+  depthSlice: 17,
+  clearValue: { r: 428.0, g: -481.8, b: 473.5, a: 419.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 96724355,
+});
+try {
+computePassEncoder64.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 1},
+  aspect: 'all',
+}, new Uint8Array(297).fill(149), /* required buffer size: 297 */
+{offset: 297}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let sampler53 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder59.setBindGroup(3, bindGroup29);
+} catch {}
+try {
+computePassEncoder59.setBindGroup(2, bindGroup33, new Uint32Array(2532), 96, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup36, new Uint32Array(3767), 789, 0);
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant({ r: 59.08, g: 175.5, b: -156.6, a: -210.8, });
+} catch {}
+let texture78 = device0.createTexture({size: [108], mipLevelCount: 1, dimension: '1d', format: 'r8sint', usage: GPUTextureUsage.COPY_SRC});
+let sampler54 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'clamp-to-edge', lodMaxClamp: 96.61, compare: 'always'});
+try {
+renderPassEncoder12.setBindGroup(1, bindGroup14, new Uint32Array(440), 246, 0);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle5, renderBundle2, renderBundle3]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame13,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 20, y: 10, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas2);
+let videoFrame18 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'bt470m', transfer: 'gamma28curve'} });
+let bindGroup41 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout31,
+  entries: [{binding: 176, resource: {buffer: buffer65, offset: 0}}],
+});
+let sampler55 = device0.createSampler({addressModeU: 'mirror-repeat', lodMinClamp: 93.20, lodMaxClamp: 97.51, compare: 'greater'});
+try {
+renderPassEncoder3.setBlendConstant({ r: 662.3, g: -866.5, b: 806.6, a: 494.2, });
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+externalTexture5.label = '\u0446\u{1f860}\u093b\u5dd7\u0edc\ud632\u099e\u283c\ud023\u9e84';
+} catch {}
+let bindGroup42 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout18,
+  entries: [
+    {binding: 176, resource: {buffer: buffer35, offset: 1536, size: 340}},
+    {binding: 237, resource: textureView27},
+  ],
+});
+let buffer75 = device0.createBuffer({size: 7009, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder91 = device0.createCommandEncoder();
+let texture79 = device0.createTexture({
+  size: {width: 8},
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView83 = texture76.createView({});
+let renderPassEncoder27 = commandEncoder91.beginRenderPass({
+  colorAttachments: [{
+  view: textureView41,
+  depthSlice: 208,
+  clearValue: { r: -164.3, g: 736.7, b: 489.9, a: -32.72, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet2,
+  maxDrawCount: 372422332,
+});
+let sampler56 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 8.474,
+});
+try {
+computePassEncoder15.setBindGroup(1, bindGroup36, new Uint32Array(2539), 864, 0);
+} catch {}
+try {
+buffer28.unmap();
+} catch {}
+let gpuCanvasContext5 = offscreenCanvas2.getContext('webgpu');
+document.body.prepend(img1);
+let img3 = await imageWithData(20, 49, '#10101010', '#20202020');
+let sampler57 = device0.createSampler({addressModeV: 'mirror-repeat', magFilter: 'linear', lodMaxClamp: 95.17, compare: 'greater-equal'});
+let externalTexture6 = device0.importExternalTexture({source: videoFrame13});
+try {
+computePassEncoder38.setBindGroup(2, bindGroup15, new Uint32Array(1063), 99, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup13, []);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer66, 'uint16', 52, 219);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+}, new Uint8Array(18).fill(211), /* required buffer size: 18 */
+{offset: 18, rowsPerImage: 65}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup43 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout15,
+  entries: [{binding: 176, resource: {buffer: buffer34, offset: 1280, size: 204}}],
+});
+let commandEncoder92 = device0.createCommandEncoder({});
+let renderPassEncoder28 = commandEncoder92.beginRenderPass({
+  colorAttachments: [{
+  view: textureView64,
+  clearValue: { r: -332.2, g: -425.4, b: -429.4, a: 837.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame12,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture61,
+  mipLevel: 0,
+  origin: {x: 108, y: 44, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let buffer76 = device0.createBuffer({size: 14058, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let texture80 = device0.createTexture({
+  size: {width: 432, height: 120, depthOrArrayLayers: 25},
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder19.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle6, renderBundle2, renderBundle6, renderBundle6, renderBundle2]);
+} catch {}
+let commandEncoder93 = device0.createCommandEncoder({});
+let texture81 = device0.createTexture({
+  size: [432, 120, 2],
+  mipLevelCount: 3,
+  sampleCount: 1,
+  format: 'r8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder29 = commandEncoder93.beginRenderPass({
+  colorAttachments: [{
+  view: textureView47,
+  clearValue: { r: -497.7, g: 582.9, b: 199.7, a: -111.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet4,
+});
+try {
+computePassEncoder27.setBindGroup(1, bindGroup18, new Uint32Array(343), 56, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 70, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(84).fill(115), /* required buffer size: 84 */
+{offset: 84, bytesPerRow: 180}, {width: 4, height: 10, depthOrArrayLayers: 0});
+} catch {}
+let pipeline12 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule3}});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let sampler58 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 86.94,
+  compare: 'less',
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+computePassEncoder18.setBindGroup(3, bindGroup26, new Uint32Array(984), 18, 0);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer2, 'uint32', 2_504, 100);
+} catch {}
+try {
+  await buffer49.mapAsync(GPUMapMode.READ, 9952, 3656);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+await gc();
+let autogeneratedBindGroupLayout37 = pipeline9.getBindGroupLayout(0);
+let commandEncoder94 = device0.createCommandEncoder();
+let textureView84 = texture27.createView({dimension: '2d', mipLevelCount: 1, arrayLayerCount: 1});
+let renderPassEncoder30 = commandEncoder94.beginRenderPass({
+  colorAttachments: [{
+  view: textureView47,
+  clearValue: { r: 279.6, g: 630.4, b: 160.4, a: 237.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder7.beginOcclusionQuery(570);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline3);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 10, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(697).fill(151), /* required buffer size: 697 */
+{offset: 697, bytesPerRow: 48}, {width: 28, height: 18, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData10,
+  origin: { x: 1, y: 11 },
+  flipY: true,
+}, {
+  texture: texture61,
+  mipLevel: 0,
+  origin: {x: 85, y: 10, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let autogeneratedBindGroupLayout38 = pipeline6.getBindGroupLayout(1);
+let bindGroup44 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout25,
+  entries: [{binding: 176, resource: {buffer: buffer40, offset: 1536, size: 1004}}],
+});
+let commandEncoder95 = device0.createCommandEncoder();
+try {
+renderPassEncoder15.setBindGroup(1, bindGroup15, new Uint32Array(942), 179, 0);
+} catch {}
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer54, 'uint16', 1_230, 3_955);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(6, buffer38, 3_244, 105);
+} catch {}
+try {
+commandEncoder95.copyTextureToTexture({
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 58, y: 2, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 6, y: 63, z: 0},
+  aspect: 'all',
+},
+{width: 13, height: 14, depthOrArrayLayers: 0});
+} catch {}
+let buffer77 = device0.createBuffer({
+  size: 15736,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder96 = device0.createCommandEncoder({});
+let computePassEncoder65 = commandEncoder96.beginComputePass({label: '54'});
+let sampler59 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 82.64,
+});
+try {
+computePassEncoder58.setPipeline(pipeline7);
+} catch {}
+try {
+computePassEncoder65.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer3, 'uint16', 1_256, 207);
+} catch {}
+try {
+commandEncoder95.copyBufferToBuffer(buffer3, 1668, buffer49, 312, 592);
+} catch {}
+try {
+commandEncoder95.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 156 */
+  offset: 156,
+  buffer: buffer27,
+}, {
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 57, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData15 = new ImageData(32, 96);
+let textureView85 = texture74.createView({format: 'r8sint', arrayLayerCount: 1});
+let computePassEncoder66 = commandEncoder95.beginComputePass({label: '55'});
+try {
+computePassEncoder51.setBindGroup(2, bindGroup30);
+} catch {}
+let autogeneratedBindGroupLayout39 = pipeline1.getBindGroupLayout(1);
+let sampler60 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMinClamp: 33.65,
+  lodMaxClamp: 89.93,
+  compare: 'equal',
+});
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup21, new Uint32Array(3115), 1_432, 0);
+} catch {}
+let promise11 = device0.queue.onSubmittedWorkDone();
+try {
+computePassEncoder66.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline11);
+} catch {}
+try {
+buffer30.unmap();
+} catch {}
+try {
+gpuCanvasContext5.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.TEXTURE_BINDING, colorSpace: 'srgb'});
+} catch {}
+document.body.prepend(canvas1);
+let bindGroup45 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout17,
+  entries: [
+    {binding: 237, resource: textureView8},
+    {binding: 176, resource: {buffer: buffer73, offset: 0, size: 136}},
+  ],
+});
+let pipelineLayout8 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout4]});
+try {
+renderPassEncoder18.setBindGroup(2, bindGroup20, []);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline11);
+} catch {}
+let commandEncoder97 = device0.createCommandEncoder({});
+let sampler61 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 95.84,
+});
+try {
+renderPassEncoder24.setBindGroup(0, bindGroup25);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer37, 0, 477);
+} catch {}
+try {
+commandEncoder97.copyBufferToBuffer(buffer27, 1520, buffer77, 2628, 888);
+} catch {}
+try {
+commandEncoder97.copyTextureToBuffer({
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 14 widthInBlocks: 14 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 3549 */
+  offset: 3549,
+  bytesPerRow: 768,
+  buffer: buffer56,
+}, {width: 14, height: 6, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder97.copyTextureToTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture77,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let bindGroup46 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout21,
+  entries: [{binding: 176, resource: {buffer: buffer38, offset: 512, size: 124}}],
+});
+let textureView86 = texture75.createView({baseMipLevel: 0, mipLevelCount: 1, arrayLayerCount: 1});
+let textureView87 = texture15.createView({});
+let computePassEncoder67 = commandEncoder97.beginComputePass({label: '56'});
+try {
+computePassEncoder67.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup46, new Uint32Array(2649), 37, 0);
+} catch {}
+try {
+renderPassEncoder21.setViewport(87.25510064136263, 6.08207084764535, 9.69775818133272, 17.404829766317082, 0.32941816739161656, 0.6739933041909236);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer58, 'uint16', 66, 423);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer36, 8, new Int16Array(3779), 81, 188);
+} catch {}
+let autogeneratedBindGroupLayout40 = pipeline4.getBindGroupLayout(1);
+let commandEncoder98 = device0.createCommandEncoder({});
+let computePassEncoder68 = commandEncoder98.beginComputePass({label: '57'});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({colorFormats: [], depthStencilFormat: 'depth32float', depthReadOnly: true});
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup32);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle9, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer37, 'uint16', 66, 1_211);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(1, bindGroup37);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(0, bindGroup46, new Uint32Array(434), 66, 0);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer66, 'uint32', 1_436, 127);
+} catch {}
+let bindGroup47 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout31,
+  entries: [{binding: 176, resource: {buffer: buffer60, offset: 256}}],
+});
+let buffer78 = device0.createBuffer({
+  size: 1361,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false,
+});
+let commandEncoder99 = device0.createCommandEncoder();
+let computePassEncoder69 = commandEncoder99.beginComputePass({label: '58'});
+let externalTexture7 = device0.importExternalTexture({source: videoFrame4});
+try {
+computePassEncoder69.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(2, bindGroup46);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(0, buffer40, 0);
+} catch {}
+try {
+gpuCanvasContext2.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.COPY_SRC, colorSpace: 'display-p3'});
+} catch {}
+let querySet10 = device0.createQuerySet({type: 'occlusion', count: 1540});
+try {
+renderPassEncoder12.insertDebugMarker('\u3b47');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer79 = device0.createBuffer({
+  size: 2549,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let renderBundle10 = renderBundleEncoder10.finish({});
+let sampler62 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.20,
+});
+try {
+computePassEncoder7.setBindGroup(2, bindGroup15);
+} catch {}
+try {
+computePassEncoder49.end();
+} catch {}
+try {
+computePassEncoder68.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup28, new Uint32Array(4791), 416, 0);
+} catch {}
+try {
+commandEncoder66.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer37, 332, new Int16Array(3105), 277, 0);
+} catch {}
+let commandEncoder100 = device0.createCommandEncoder();
+let commandBuffer0 = commandEncoder66.finish();
+let computePassEncoder70 = commandEncoder100.beginComputePass({label: '59'});
+try {
+computePassEncoder33.setBindGroup(3, bindGroup15, new Uint32Array(2485), 1_204, 0);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(3, bindGroup23, new Uint32Array(3669), 718, 0);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle7, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder65.pushDebugGroup('\u08e7');
+} catch {}
+let bindGroup48 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout17,
+  entries: [
+    {binding: 237, resource: textureView27},
+    {binding: 176, resource: {buffer: buffer46, offset: 5632, size: 11500}},
+  ],
+});
+let externalTexture8 = device0.importExternalTexture({source: videoFrame10});
+try {
+computePassEncoder67.setBindGroup(3, bindGroup26, new Uint32Array(699), 24, 0);
+} catch {}
+try {
+renderPassEncoder28.executeBundles([renderBundle9, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer54, 'uint32', 1_136, 6_650);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline11);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 85, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(83).fill(55), /* required buffer size: 83 */
+{offset: 83}, {width: 221, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas1);
+let imageData16 = new ImageData(28, 40);
+let shaderModule7 = device0.createShaderModule({
+  label: '\u04d5\u{1f7c6}\u0aa0\u{1fb9b}\u0790\u{1f99a}\u5ba9',
+  code: `
+enable f16;
+
+requires pointer_composite_access;
+
+struct VertexOutput5 {
+  @builtin(position) f15: vec4f,
+  @location(8) f16: vec2u,
+  @location(9) @interpolate(flat, centroid) f17: f32,
+  @location(13) @interpolate(flat, centroid) f18: vec4i,
+  @location(15) f19: vec2i,
+}
+
+struct FragmentOutput4 {
+  @location(0) @interpolate(flat) f0: vec2u,
+  @location(4) @interpolate(flat) f1: vec4u,
+}
+
+struct T0 {
+  @size(20) f0: array<array<array<u32, 1>, 1>>,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct T2 {
+  @size(24) f0: array<vec4h, 2>,
+}
+
+var<workgroup> vw24: array<array<vec2<bool>, 1>, 1>;
+
+override override16: f32;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@group(0) @binding(176) var<storage, read_write> buffer80: array<array<array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>, 9>>;
+
+var<workgroup> vw25: VertexOutput5;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct T3 {
+  @align(16) @size(400) f0: array<array<array<u32, 1>, 1>, 50>,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn fn0() -> vec2h {
+  var out: vec2h;
+  out += vec2h(inverseSqrt(f16(unconst_f16(20510.2))));
+  let vf90: vec4i = extractBits(vec4i(unconst_i32(-103), unconst_i32(-85), unconst_i32(-275), unconst_i32(32)), u32(unconst_u32(213)), u32(unconst_u32(14)));
+  var vf91: vec2i = firstTrailingBit(vec2i(unconst_i32(-86), unconst_i32(275)));
+  vf91 = firstTrailingBit(vec2i(unconst_i32(-10), unconst_i32(68)));
+  var vf92: f16 = inverseSqrt(f16(unconst_f16(2969.9)));
+  out += vec2h(vf92);
+  var vf93: vec2i = firstTrailingBit(vec2i(tan(vec3h(unconst_f16(1344.0), unconst_f16(491.5), unconst_f16(4501.9))).zy));
+  let vf94: u32 = dot4U8Packed(u32(unconst_u32(3)), u32(unconst_u32(11)));
+  vf93 += vec2i(vf90[u32(unconst_u32(548))]);
+  let vf95: f16 = inverseSqrt(f16(unconst_f16(6799.3)));
+  vf92 -= vec2h(vf91)[0];
+  var vf96: u32 = vf94;
+  vf91 &= vf91;
+  let vf97: vec2i = select(vec2i(unconst_i32(44), unconst_i32(108)), vec2i(unconst_i32(487), unconst_i32(37)), vec2<bool>(bool(vf93[u32(unconst_u32(2))])));
+  vf92 += f16(vf90[3]);
+  vf91 |= extractBits(vec4i(unconst_i32(41), unconst_i32(497), unconst_i32(365), unconst_i32(27)), u32(unconst_u32(277)), u32(unconst_u32(69))).ar;
+  var vf98: i32 = vf91[u32(unconst_u32(107))];
+  vf92 *= f16(vf94);
+  let vf99: u32 = vf94;
+  let vf100: vec2i = firstTrailingBit(vec2i(unconst_i32(144), unconst_i32(162)));
+  var vf101: f32 = override16;
+  return out;
+  _ = override16;
+}
+
+struct T1 {
+  f0: u32,
+  @size(16) f1: array<mat3x2h>,
+}
+
+@vertex
+fn vertex8(@location(0) @interpolate(flat, sample) a0: i32) -> VertexOutput5 {
+  var out: VertexOutput5;
+  out.f15 -= vec4f(f32(cos(f16(unpack4x8unorm(bitcast<u32>(a0))[0]))));
+  out.f16 = vec2u(dot4U8Packed(u32(unconst_u32(34)), u32(unconst_u32(64))));
+  fn0();
+  var vf102: vec3f = cross(vec3f(unconst_f32(0.1610), unconst_f32(0.2467), unconst_f32(0.02000)), fract(vec2f(unconst_f32(-0.07339), unconst_f32(0.02255))).rgg);
+  let vf103: f32 = override16;
+  var vf104 = fn0();
+  fn0();
+  out = VertexOutput5(vec4f(vf104.yyxx), vec2u(vf104), bitcast<f32>(vf104), vec4i(vf104.ggrr), vec2i(vf104));
+  fn0();
+  var vf105 = fn0();
+  let vf106: f32 = exp2(f32(unconst_f32(0.7737)));
+  var vf107 = fn0();
+  vf107 = bitcast<vec2h>(vf102[u32(unconst_u32(369))]);
+  var vf108 = fn0();
+  vf102 = vf102;
+  let vf109: f32 = exp2(f32(unconst_f32(0.3087)));
+  fn0();
+  var vf110 = fn0();
+  let vf111: f32 = determinant(mat3x3f());
+  return out;
+  _ = override16;
+}
+
+@fragment
+fn fragment4() -> FragmentOutput4 {
+  var out: FragmentOutput4;
+  let ptr45: ptr<storage, array<f16, 1>, read_write> = &buffer80[u32(unconst_u32(251))][u32(unconst_u32(169))][u32(unconst_u32(808))][0][u32(buffer80[arrayLength(&buffer80)][u32(unconst_u32(249))][0][u32(unconst_u32(27))][0][0][0])][0];
+  let ptr46: ptr<storage, array<array<array<f16, 1>, 1>, 1>, read_write> = &buffer80[u32(unconst_u32(779))][8][u32(unconst_u32(27))][u32((*&buffer80)[arrayLength(&(*&buffer80))][8][u32(unconst_u32(281))][0][u32(unconst_u32(149))][u32(unconst_u32(125))][u32(unconst_u32(92))])];
+  let ptr47: ptr<storage, array<array<f16, 1>, 1>, read_write> = &(*&buffer80)[arrayLength(&(*&buffer80))][8][0][0][0];
+  let ptr48: ptr<storage, array<array<array<f16, 1>, 1>, 1>, read_write> = &(*&buffer80)[u32(buffer80[arrayLength(&buffer80)][8][0][0][0][u32(unconst_u32(1))][u32(unconst_u32(3))])][u32(unconst_u32(46))][0][0];
+  let ptr49: ptr<storage, f16, read_write> = &buffer80[arrayLength(&buffer80)][u32(unconst_u32(12))][u32(unconst_u32(106))][0][u32(unconst_u32(121))][0][0];
+  let vf112: u32 = arrayLength(&(*&buffer80));
+  let ptr50: ptr<storage, f16, read_write> = &(*&buffer80)[arrayLength(&(*&buffer80))][u32(unconst_u32(49))][0][u32((*&buffer80)[arrayLength(&(*&buffer80))][u32(unconst_u32(54))][u32(unconst_u32(22))][u32(unconst_u32(93))][0][0][0])][u32(unconst_u32(102))][0][0];
+  buffer80[u32(unconst_u32(234))][u32(unconst_u32(23))][u32(unconst_u32(274))][u32(unconst_u32(28))][u32(unconst_u32(36))][u32(unconst_u32(120))][u32(unconst_u32(1))] = buffer80[u32(unconst_u32(263))][8][u32(unconst_u32(33))][0][u32(unconst_u32(240))][0][0];
+  out.f1 >>= vec4u(u32((*ptr48)[u32(unconst_u32(273))][0][0]));
+  let ptr51: ptr<storage, f16, read_write> = &(*&buffer80)[u32(unconst_u32(110))][u32(unconst_u32(195))][0][0][0][u32(unconst_u32(107))][0];
+  let ptr52: ptr<storage, array<f16, 1>, read_write> = &(*&buffer80)[arrayLength(&(*&buffer80))][8][u32(unconst_u32(314))][0][0][0];
+  let ptr53: ptr<storage, f16, read_write> = &buffer80[arrayLength(&buffer80)][u32(unconst_u32(3))][0][u32(unconst_u32(103))][u32(unconst_u32(288))][u32(unconst_u32(76))][0];
+  out.f0 ^= vec2u(u32(buffer80[arrayLength(&buffer80)][8][u32(unconst_u32(125))][u32(unconst_u32(291))][u32(unconst_u32(14))][0][0]));
+  let ptr54: ptr<storage, array<array<array<f16, 1>, 1>, 1>, read_write> = &buffer80[u32(unconst_u32(194))][u32(unconst_u32(19))][0][0];
+  let ptr55: ptr<storage, array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>, read_write> = &(*&buffer80)[u32(unconst_u32(83))][u32(unconst_u32(162))];
+  let ptr56: ptr<storage, f16, read_write> = &(*&buffer80)[u32(unconst_u32(33))][8][u32(unconst_u32(46))][0][u32(unconst_u32(21))][0][u32(unconst_u32(189))];
+  out.f1 = vec4u(u32((*&buffer80)[u32(unconst_u32(89))][u32(unconst_u32(33))][u32(unconst_u32(162))][0][0][0][0]));
+  let ptr57: ptr<storage, array<f16, 1>, read_write> = &buffer80[arrayLength(&buffer80)][8][u32(unconst_u32(250))][u32(unconst_u32(91))][0][0];
+  out = FragmentOutput4(vec2u(u32((*&buffer80)[arrayLength(&(*&buffer80))][u32(unconst_u32(1))][0][u32(unconst_u32(24))][0][u32(unconst_u32(207))][0])), vec4u(u32((*&buffer80)[arrayLength(&(*&buffer80))][u32(unconst_u32(1))][0][u32(unconst_u32(24))][0][u32(unconst_u32(207))][0])));
+  return out;
+  _ = buffer80;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute6() {
+  vw24[u32(unconst_u32(348))][0] = vec2<bool>((*&vw24)[u32(unconst_u32(157))][0][u32(unconst_u32(176))]);
+}`,
+});
+let commandEncoder101 = device0.createCommandEncoder({});
+let textureView88 = texture71.createView({format: 'r8sint', arrayLayerCount: 1});
+let sampler63 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 62.64,
+  lodMaxClamp: 95.96,
+});
+try {
+computePassEncoder70.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 2004, new Float32Array(40), 10, 12);
+} catch {}
+let promise12 = device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule3}});
+let shaderModule8 = device0.createShaderModule({
+  code: `
+requires packed_4x8_integer_dot_product;
+
+enable f16;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct T0 {
+  @align(8) f0: array<mat2x2h, 1>,
+}
+
+@group(1) @binding(237) var st22: texture_storage_1d<r32float, read_write>;
+
+struct T2 {
+  @size(20) f0: array<array<atomic<i32>, 1>>,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@id(45279) override override17: f16 = 2671.1;
+
+struct FragmentOutput5 {
+  @location(0) f0: vec2i,
+}
+
+fn fn2() -> array<array<T0, 1>, 2> {
+  var out: array<array<T0, 1>, 2>;
+  vp7 = modf(smoothstep(vec3f(unconst_f32(0.1106), unconst_f32(0.1139), unconst_f32(0.1133)), vec3f(unconst_f32(0.04148), unconst_f32(0.5525), unconst_f32(0.2429)), vec3f(unconst_f32(0.02669), unconst_f32(0.1328), unconst_f32(0.1763))).xzzx);
+  let ptr60: ptr<storage, array<f16, 1>, read_write> = &(*&buffer81)[2][u32(unconst_u32(244))];
+  vp7.fract -= vec4f(f32((*&buffer81)[u32(unconst_u32(238))][2][u32(unconst_u32(27))]));
+  buffer81[u32(unconst_u32(130))][u32(unconst_u32(337))][u32(unconst_u32(170))] *= ceil(f16(unconst_f16(7656.0)));
+  vp7.whole = vec4f(f32(buffer81[u32(unconst_u32(52))][u32(unconst_u32(179))][0]));
+  buffer81[pack4x8snorm(vp7.fract)][u32(unconst_u32(39))][u32(unconst_u32(278))] += buffer81[2][u32(unconst_u32(19))][0];
+  let ptr61: ptr<storage, array<array<f16, 1>, 3>, read_write> = &buffer81[u32(unconst_u32(32))];
+  let ptr62: ptr<storage, array<f16, 1>, read_write> = &(*&buffer81)[u32(unconst_u32(520))][2];
+  buffer81[u32(unconst_u32(59))][u32(unconst_u32(227))][u32(unconst_u32(200))] -= refract(vec3h(unconst_f16(2354.4), unconst_f16(-11053.1), unconst_f16(10073.4)), vec3h(unconst_f16(-35776.8), unconst_f16(3063.3), unconst_f16(17354.6)), f16(unconst_f16(48.83)))[1];
+  let ptr63: ptr<storage, f16, read_write> = &buffer81[u32(buffer81[2][2][u32(unconst_u32(2))])][u32(unconst_u32(50))][u32(unconst_u32(76))];
+  let ptr64: ptr<storage, f16, read_write> = &(*ptr62)[0];
+  vp7 = modf(vec4f(bitcast<f32>(dot4U8Packed(u32(unconst_u32(70)), u32(unconst_u32(7))))));
+  vp7 = modf(vec4f(f32((*&buffer81)[u32(unconst_u32(259))][u32(unconst_u32(81))][u32(unconst_u32(78))])));
+  var vf115: f16 = cosh(f16(unconst_f16(6387.8)));
+  vp7 = modf(vp7.fract);
+  let ptr65: ptr<storage, array<f16, 1>, read_write> = &(*ptr62);
+  return out;
+  _ = buffer81;
+}
+
+var<private> vp7 = modf(vec4f(0.2263, 0.02334, 0.09898, 0.3501));
+
+fn fn1() -> vec4<bool> {
+  var out: vec4<bool>;
+  let vf114: i32 = atomicLoad(&(*&vw28)[0][u32(unconst_u32(76))]);
+  textureBarrier();
+  vw27.f0[u32(unconst_u32(20))] = mat2x2h(f16(atomicLoad(&vw29[62])), f16(atomicLoad(&vw29[62])), f16(atomicLoad(&vw29[62])), f16(atomicLoad(&vw29[62])));
+  buffer81[u32(unconst_u32(334))][u32(unconst_u32(202))][u32((*&buffer81)[u32(unconst_u32(46))][2][0])] = (*&buffer81)[2][2][0];
+  textureStore(st21, vec2i(unconst_i32(289), unconst_i32(379)), i32(unconst_i32(128)), vec4i(vec4i(firstTrailingBit(vec4u(unconst_u32(148), unconst_u32(355), unconst_u32(258), unconst_u32(159))))));
+  storageBarrier();
+  out = vec4<bool>(bool(atomicLoad(&vw29[u32(unconst_u32(286))])));
+  out = vec4<bool>(bool(atomicExchange(&vw28[0][u32(unconst_u32(412))], i32(unconst_i32(11)))));
+  atomicMin(&vw28[u32(unconst_u32(76))][u32(unconst_u32(32))], i32(unconst_i32(237)));
+  return out;
+  _ = buffer81;
+  _ = st21;
+}
+
+var<workgroup> vw27: T0;
+
+fn fn0(a0: ptr<function, vec4<bool>>, a1: ptr<storage, FragmentOutput5, read_write>) {
+  let ptr58: ptr<storage, array<f16, 1>, read_write> = &buffer81[u32(unconst_u32(79))][u32(unconst_u32(210))];
+  (*a1) = FragmentOutput5(vec2i(i32(buffer81[u32(unconst_u32(199))][u32(unconst_u32(107))][bitcast<u32>(smoothstep(vec2h(unconst_f16(12706.7), unconst_f16(9795.6)), vec2h(unconst_f16(-2776.5), unconst_f16(1982.9)), vec2h(unconst_f16(17073.7), unconst_f16(2989.4))))])));
+  let vf113: u32 = pack4x8snorm(vec4f(unconst_f32(-0.00616), unconst_f32(0.2559), unconst_f32(0.07100), unconst_f32(0.06013)));
+  (*a0) = vec4<bool>(bool((*ptr58)[0]));
+  buffer81[u32(unconst_u32(167))][u32(unconst_u32(167))][u32(unconst_u32(46))] *= smoothstep(vec2h(unconst_f16(3355.5), unconst_f16(417.6)), vec2h(unconst_f16(24350.5), unconst_f16(506.8)), vec2h(unconst_f16(15492.9), unconst_f16(12036.0)))[1];
+  buffer81[u32(unconst_u32(4))][2][u32(unconst_u32(11))] *= (*&buffer81)[2][2][u32(unconst_u32(246))];
+  let ptr59: ptr<storage, array<f16, 1>, read_write> = &buffer81[u32(unconst_u32(268))][2];
+  _ = buffer81;
+}
+
+@group(1) @binding(138) var tex8: texture_2d<i32>;
+
+var<workgroup> vw28: array<array<atomic<i32>, 13>, 1>;
+
+struct T3 {
+  @size(24) f0: array<mat2x4h>,
+}
+
+var<workgroup> vw29: array<atomic<u32>, 63>;
+
+struct T1 {
+  @size(20) f0: array<u32>,
+}
+
+struct T4 {
+  @size(24) f0: array<T0>,
+}
+
+@group(0) @binding(30) var st19: texture_storage_2d_array<r32sint, read_write>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@group(0) @binding(237) var st20: texture_storage_1d<r32float, read_write>;
+
+var<workgroup> vw26: vec2h;
+
+struct VertexOutput6 {
+  @builtin(position) f20: vec4f,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@group(1) @binding(176) var<storage, read_write> buffer81: array<array<array<f16, 1>, 3>, 3>;
+
+@group(0) @binding(138) var tex7: texture_2d<i32>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+override override18: u32;
+
+@group(1) @binding(30) var st21: texture_storage_2d_array<r32sint, read_write>;
+
+@vertex
+fn vertex9(@location(10) @interpolate(flat, center) a0: vec4u) -> VertexOutput6 {
+  var out: VertexOutput6;
+  out = VertexOutput6(vec4f(inverseSqrt(vec3f(sqrt(vec3h(unconst_f16(1337.6), unconst_f16(9345.7), unconst_f16(8901.3))))[1])));
+  out = VertexOutput6(unpack2x16unorm(u32(unconst_u32(8))).yyxy);
+  let vf116: vec4h = mix(vec4h(unconst_f16(-5125.1), unconst_f16(45085.9), unconst_f16(1803.5), unconst_f16(28096.3)), vec4h(unconst_f16(-3240.1), unconst_f16(3619.5), unconst_f16(14259.2), unconst_f16(24638.4)), vec4h(unconst_f16(6113.6), unconst_f16(40583.0), unconst_f16(5570.9), unconst_f16(577.7)));
+  var vf117: vec4i = sign(vec4i(unconst_i32(61), unconst_i32(239), unconst_i32(82), unconst_i32(83)));
+  var vf118: vec4f = abs(vec4f(unconst_f32(0.00276), unconst_f32(0.07918), unconst_f32(0.04439), unconst_f32(0.08892)));
+  let vf119: f32 = vf118[u32(unconst_u32(265))];
+  let vf120: vec4i = firstTrailingBit(vec4i(vp7.whole));
+  vf117 = bitcast<vec4i>(a0);
+  vf118 = vp7.whole;
+  vf117 = vec4i(i32(fma(f16(unconst_f16(-5792.4)), f16(unconst_f16(-20038.2)), f16(unconst_f16(1129.0)))));
+  var vf121: f16 = override17;
+  return out;
+  _ = override17;
+}
+
+@fragment
+fn fragment5() -> FragmentOutput5 {
+  var out: FragmentOutput5;
+  buffer81[u32(unconst_u32(2))][u32(unconst_u32(290))][u32(unconst_u32(253))] += (*&buffer81)[2][u32(unconst_u32(28))][u32(unconst_u32(63))];
+  textureStore(st22, i32(unconst_i32(53)), vec4f(vec4f(unconst_f32(0.02747), unconst_f32(0.08018), unconst_f32(0.5365), unconst_f32(0.02545))));
+  var vf122: vec2f = sin(vec2f(f32((*&buffer81)[u32(unconst_u32(192))][u32(unconst_u32(143))][0])));
+  textureStore(st20, i32(unconst_i32(-237)), vec4f(vec4f(unconst_f32(0.01840), unconst_f32(0.01212), unconst_f32(0.3112), unconst_f32(0.08604))));
+  out.f0 += vec2i(log(vec4f(unconst_f32(0.1431), unconst_f32(0.3127), unconst_f32(0.07128), unconst_f32(0.1668))).ar);
+  buffer81[u32(unconst_u32(28))][u32(unconst_u32(34))][u32(unconst_u32(43))] = f16(asinh(vec4f(unconst_f32(0.3563), unconst_f32(0.3430), unconst_f32(0.02306), unconst_f32(0.3779))).z);
+  textureStore(st22, i32(unconst_i32(60)), vec4f(textureLoad(st22, i32(unconst_i32(-31)))));
+  var vf123: vec2u = textureDimensions(tex7);
+  let vf124: vec4i = textureLoad(tex8, vec2i(unconst_i32(404), unconst_i32(178)), i32(unconst_i32(396)));
+  out.f0 ^= vec2i(i32((*&buffer81)[2][2][0]));
+  textureStore(st22, i32(unconst_i32(-327)), vec4f(vec4f(unconst_f32(0.09525), unconst_f32(0.03221), unconst_f32(0.1033), unconst_f32(0.1243))));
+  let ptr66: ptr<storage, array<array<f16, 1>, 3>, read_write> = &(*&buffer81)[2];
+  vf122 += sin(vec2f(vf124.ab));
+  let ptr67: ptr<storage, f16, read_write> = &buffer81[2][2][0];
+  var vf125 = fn2();
+  vp7.fract = vec4f(f32(vf125[u32(unconst_u32(756))][u32(unconst_u32(43))].f0[0][u32(unconst_u32(131))][u32(unconst_u32(261))]));
+  return out;
+  _ = buffer81;
+  _ = st22;
+  _ = tex7;
+  _ = tex8;
+  _ = st20;
+}
+
+@compute @workgroup_size(2, 1, 1)
+fn compute7() {
+  let vf126: u32 = atomicLoad(&vw29[u32((*&buffer81)[2][2][0])]);
+  let ptr68: ptr<storage, f16, read_write> = &(*&buffer81)[2][u32(unconst_u32(371))][0];
+  buffer81[u32(unconst_u32(32))][u32(unconst_u32(156))][u32(unconst_u32(49))] = vec4h(fract(vec4f(unconst_f32(0.2838), unconst_f32(0.06896), unconst_f32(0.2347), unconst_f32(0.08286))))[1];
+  let vf127: vec4i = textureLoad(st19, vec2i(unconst_i32(358), unconst_i32(35)), i32(unconst_i32(404)));
+  vp7.whole = vec4f(select(vec4u(unconst_u32(130), unconst_u32(103), unconst_u32(130), unconst_u32(37)), vec4u(log(vec2h(unconst_f16(2435.6), unconst_f16(9678.1))).yyxx), vec4<bool>(unconst_bool(true), unconst_bool(false), unconst_bool(true), unconst_bool(false))));
+  var vf128 = fn1();
+  textureStore(st21, vec2i(unconst_i32(109), unconst_i32(203)), i32(unconst_i32(221)), vec4i(vec4i(unconst_i32(209), unconst_i32(11), unconst_i32(236), unconst_i32(250))));
+  let ptr69: ptr<workgroup, atomic<i32>> = &vw28[0][12];
+  atomicSub(&vw28[0][u32(unconst_u32(21))], i32(unconst_i32(69)));
+  vw27.f0[u32(unconst_u32(484))] = mat2x2h(buffer81[u32(unconst_u32(250))][u32(unconst_u32(839))][0], buffer81[u32(unconst_u32(250))][u32(unconst_u32(839))][0], buffer81[u32(unconst_u32(250))][u32(unconst_u32(839))][0], buffer81[u32(unconst_u32(250))][u32(unconst_u32(839))][0]);
+  _ = buffer81;
+  _ = st21;
+  _ = st19;
+}`,
+});
+let buffer82 = device0.createBuffer({
+  size: 12976,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let commandEncoder102 = device0.createCommandEncoder();
+let computePassEncoder71 = commandEncoder101.beginComputePass({label: '60'});
+let sampler64 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.03,
+  compare: 'never',
+  maxAnisotropy: 19,
+});
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup8, new Uint32Array(901), 74, 0);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer82, 'uint32', 836, 2_720);
+} catch {}
+let promise13 = device0.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let bindGroup49 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout17,
+  entries: [
+    {binding: 237, resource: textureView27},
+    {binding: 176, resource: {buffer: buffer46, offset: 512, size: 8128}},
+  ],
+});
+let computePassEncoder72 = commandEncoder102.beginComputePass({label: '61'});
+try {
+computePassEncoder48.setBindGroup(2, bindGroup17, new Uint32Array(4381), 833, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup46);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(2, bindGroup22, new Uint32Array(402), 112, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer54, 'uint32', 472, 3_007);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(1, buffer34, 0, 982);
+} catch {}
+try {
+device0.queue.submit([commandBuffer0]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer54, 3908, new BigUint64Array(29096), 19552, 260);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: img3,
+  origin: { x: 1, y: 1 },
+  flipY: true,
+}, {
+  texture: texture61,
+  mipLevel: 0,
+  origin: {x: 1, y: 6, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 4, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img1);
+try {
+renderPassEncoder9.executeBundles([renderBundle9, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(3, buffer3, 252, 1_618);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: img0,
+  origin: { x: 0, y: 8 },
+  flipY: false,
+}, {
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 4, y: 43, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 4, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas2);
+let img4 = await imageWithData(51, 91, '#10101010', '#20202020');
+try {
+computePassEncoder70.setBindGroup(0, bindGroup27);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle8]);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline11);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let videoFrame19 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'bt709', transfer: 'bt1361ExtendedColourGamut'} });
+let autogeneratedBindGroupLayout41 = pipeline10.getBindGroupLayout(0);
+let texture82 = gpuCanvasContext0.getCurrentTexture();
+let textureView89 = texture25.createView({dimension: '2d', baseArrayLayer: 0});
+try {
+computePassEncoder17.setBindGroup(2, bindGroup30);
+} catch {}
+try {
+computePassEncoder14.setBindGroup(1, bindGroup11, new Uint32Array(2533), 1_129, 0);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(5, undefined);
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+try {
+adapter1.label = '\u{1ff08}\ufd35\u000e\u03b6\u0df5\u38e0';
+} catch {}
+let sampler65 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'mirror-repeat'});
+try {
+computePassEncoder72.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup42);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer78, 'uint16', 276, 104);
+} catch {}
+document.body.append(canvas1);
+let videoFrame20 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'smpteRp431', transfer: 'bt2020_10bit'} });
+let commandEncoder103 = device0.createCommandEncoder();
+let texture83 = device0.createTexture({
+  size: [54, 15, 274],
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView90 = texture3.createView({aspect: 'all', arrayLayerCount: 1});
+let computePassEncoder73 = commandEncoder103.beginComputePass({label: '62'});
+try {
+computePassEncoder13.setBindGroup(1, bindGroup36);
+} catch {}
+try {
+computePassEncoder9.setBindGroup(0, bindGroup34, new Uint32Array(2136), 143, 0);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(5, 2, 5, 13);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer31, 'uint16', 96, 102);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline5);
+} catch {}
+try {
+  await buffer30.mapAsync(GPUMapMode.WRITE, 0, 1204);
+} catch {}
+try {
+renderPassEncoder9.insertDebugMarker('\u0ab7');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer60, 2808, new Int16Array(4483), 933, 572);
+} catch {}
+let autogeneratedBindGroupLayout42 = pipeline5.getBindGroupLayout(0);
+let buffer83 = device0.createBuffer({size: 8165, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+let textureView91 = texture83.createView({});
+let textureView92 = texture10.createView({mipLevelCount: 1, arrayLayerCount: 1});
+try {
+computePassEncoder22.setBindGroup(1, bindGroup41, []);
+} catch {}
+try {
+computePassEncoder61.setBindGroup(1, bindGroup30, new Uint32Array(752), 122, 0);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer55, 'uint32', 1_652, 301);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(3, buffer45);
+} catch {}
+let imageData17 = new ImageData(40, 4);
+let autogeneratedBindGroupLayout43 = pipeline8.getBindGroupLayout(0);
+let buffer84 = device0.createBuffer({
+  size: 21452,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder104 = device0.createCommandEncoder({});
+let texture84 = device0.createTexture({
+  size: [108, 30, 2],
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView93 = texture19.createView({});
+let sampler66 = device0.createSampler({
+  addressModeU: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 89.27,
+  compare: 'equal',
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder71.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(6, buffer77);
+} catch {}
+try {
+commandEncoder104.copyBufferToTexture({
+  /* bytesInLastRow: 40 widthInBlocks: 40 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 184 */
+  offset: 184,
+  buffer: buffer31,
+}, {
+  texture: texture77,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 40, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise14 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame11,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas3 = document.createElement('canvas');
+let commandEncoder105 = device0.createCommandEncoder();
+let texture85 = device0.createTexture({
+  size: {width: 432, height: 120, depthOrArrayLayers: 2},
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture86 = device0.createTexture({
+  size: {width: 432, height: 120, depthOrArrayLayers: 2},
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder31 = commandEncoder105.beginRenderPass({
+  colorAttachments: [{
+  view: textureView64,
+  clearValue: { r: 837.0, g: -144.9, b: 305.6, a: -690.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet4,
+});
+try {
+computePassEncoder73.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup34);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(3, bindGroup30, new Uint32Array(3718), 218, 0);
+} catch {}
+try {
+renderPassEncoder20.setViewport(47.59399421445689, 29.640233640582522, 13.650377557879237, 0.06277780497502783, 0.1560381242762463, 0.6662670795190456);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer84, 'uint32', 504, 6_817);
+} catch {}
+try {
+commandEncoder104.copyTextureToTexture({
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 44, y: 4, z: 0},
+  aspect: 'all',
+},
+{width: 59, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder31.insertDebugMarker('\u{1ff19}');
+} catch {}
+let commandEncoder106 = device0.createCommandEncoder({});
+let texture87 = device0.createTexture({
+  size: {width: 54, height: 15, depthOrArrayLayers: 2},
+  format: 'rg16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder32 = commandEncoder104.beginRenderPass({
+  colorAttachments: [{
+  view: textureView85,
+  depthSlice: 30,
+  clearValue: { r: 63.49, g: -447.8, b: 319.5, a: -323.1, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 13145968,
+});
+try {
+computePassEncoder70.setBindGroup(2, bindGroup30, new Uint32Array(745), 141, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup31, new Uint32Array(713), 403, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData5,
+  origin: { x: 11, y: 16 },
+  flipY: true,
+}, {
+  texture: texture61,
+  mipLevel: 0,
+  origin: {x: 169, y: 6, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 30, depthOrArrayLayers: 0});
+} catch {}
+try {
+externalTexture1.label = '\u{1fead}\ud2c0\u3e43\u74c3\u35e8\u8f85\u08e5\u8e36';
+} catch {}
+let veryExplicitBindGroupLayout11 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 4,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d-array' },
+    },
+    {
+      binding: 269,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let texture88 = device0.createTexture({
+  size: {width: 54, height: 15, depthOrArrayLayers: 2},
+  mipLevelCount: 1,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder33 = commandEncoder106.beginRenderPass({
+  colorAttachments: [{
+  view: textureView28,
+  depthSlice: 20,
+  clearValue: { r: 40.26, g: -356.5, b: 243.6, a: 646.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder23.setBindGroup(0, bindGroup32, []);
+} catch {}
+try {
+renderPassEncoder19.beginOcclusionQuery(21);
+} catch {}
+try {
+renderPassEncoder33.executeBundles([renderBundle0, renderBundle5, renderBundle7, renderBundle8, renderBundle9]);
+} catch {}
+let pipeline13 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule2,
+  constants: {1_579: 0},
+  targets: [{format: 'r8sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule7,
+    constants: {override16: 0},
+    buffers: [{arrayStride: 0, attributes: [{format: 'sint16x2', offset: 84, shaderLocation: 0}]}],
+  },
+  primitive: {topology: 'point-list', cullMode: 'back', unclippedDepth: true},
+});
+try {
+  await promise13;
+} catch {}
+await gc();
+let bindGroup50 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout1,
+  entries: [{binding: 176, resource: {buffer: buffer34, offset: 256, size: 1480}}],
+});
+let buffer85 = device0.createBuffer({
+  size: 29623,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder107 = device0.createCommandEncoder();
+let texture89 = device0.createTexture({
+  size: {width: 216, height: 60, depthOrArrayLayers: 2},
+  mipLevelCount: 2,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder2.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(2, bindGroup33, new Uint32Array(1578), 80, 0);
+} catch {}
+try {
+renderPassEncoder19.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer2, 'uint16', 368, 416);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(0, buffer36, 0, 2_348);
+} catch {}
+let commandEncoder108 = device0.createCommandEncoder({});
+let texture90 = device0.createTexture({
+  size: {width: 108, height: 30, depthOrArrayLayers: 2},
+  sampleCount: 1,
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView94 = texture72.createView({dimension: '2d', mipLevelCount: 1});
+let computePassEncoder74 = commandEncoder107.beginComputePass({label: '63'});
+try {
+computePassEncoder74.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup2, new Uint32Array(2330), 36, 0);
+} catch {}
+try {
+renderPassEncoder21.end();
+} catch {}
+try {
+renderPassEncoder30.setScissorRect(9, 1, 20, 2);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer28, 'uint16', 742, 2_633);
+} catch {}
+let gpuCanvasContext6 = canvas3.getContext('webgpu');
+let commandEncoder109 = device0.createCommandEncoder({});
+let texture91 = device0.createTexture({
+  size: [108, 30, 2],
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder75 = commandEncoder108.beginComputePass({label: '\u6be1\u{1fd5e}\ufb76\u28e1\u{1f8bc}\ud7c7\u6c36\u746a\u{1ffb3}'});
+try {
+commandEncoder109.clearBuffer(buffer29, 1600, 452);
+} catch {}
+try {
+gpuCanvasContext3.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.COPY_DST});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData16,
+  origin: { x: 0, y: 2 },
+  flipY: true,
+}, {
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 9, y: 19, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 6, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap4 = await createImageBitmap(img2);
+let texture92 = device0.createTexture({
+  size: [216, 60, 2],
+  mipLevelCount: 1,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView95 = texture1.createView({dimension: '2d-array', aspect: 'all', baseArrayLayer: 0, arrayLayerCount: 1});
+let computePassEncoder76 = commandEncoder80.beginComputePass({label: '64'});
+let sampler67 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 77.58});
+let externalTexture9 = device0.importExternalTexture({source: videoFrame18});
+try {
+computePassEncoder61.setPipeline(pipeline10);
+} catch {}
+try {
+computePassEncoder75.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(1, bindGroup36);
+} catch {}
+try {
+renderPassEncoder24.beginOcclusionQuery(1);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(2, buffer32, 4_268);
+} catch {}
+try {
+commandEncoder109.resolveQuerySet(querySet1, 206, 116, buffer28, 768);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 8, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(302).fill(253), /* required buffer size: 302 */
+{offset: 302}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder110 = device0.createCommandEncoder({});
+let texture93 = device0.createTexture({
+  size: {width: 432, height: 120, depthOrArrayLayers: 2},
+  mipLevelCount: 3,
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture94 = device0.createTexture({
+  size: [216, 60, 2],
+  mipLevelCount: 6,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let texture95 = gpuCanvasContext3.getCurrentTexture();
+try {
+computePassEncoder76.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(3, bindGroup30, new Uint32Array(393), 113, 0);
+} catch {}
+try {
+renderPassEncoder14.insertDebugMarker('\u{1f9ec}');
+} catch {}
+try {
+adapter1.label = '\u02a8\u0704\u0c38\u0e19\uf05e\ue035\uf035\u1a7b\u0f6b';
+} catch {}
+let commandEncoder111 = device0.createCommandEncoder({});
+let commandBuffer1 = commandEncoder110.finish();
+let texture96 = device0.createTexture({
+  size: {width: 432, height: 120, depthOrArrayLayers: 2},
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture97 = device0.createTexture({
+  size: {width: 432, height: 120, depthOrArrayLayers: 2},
+  mipLevelCount: 3,
+  format: 'astc-6x5-unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView96 = texture78.createView({aspect: 'all'});
+try {
+computePassEncoder2.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer10, 'uint32', 216, 1_032);
+} catch {}
+try {
+device0.queue.submit([commandBuffer1]);
+} catch {}
+let bindGroup51 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 30, resource: textureView9},
+    {binding: 176, resource: {buffer: buffer79, offset: 0, size: 560}},
+    {binding: 473, resource: sampler13},
+    {binding: 237, resource: textureView15},
+    {binding: 138, resource: textureView52},
+  ],
+});
+let texture98 = device0.createTexture({
+  size: {width: 8, height: 8, depthOrArrayLayers: 22},
+  format: 'rg8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder77 = commandEncoder111.beginComputePass({label: '65'});
+try {
+computePassEncoder69.setBindGroup(1, bindGroup3, new Uint32Array(1305), 125, 0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup27);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer37, 'uint32', 0, 72);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer20, 0);
+} catch {}
+let bindGroup52 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout9,
+  entries: [{binding: 176, resource: {buffer: buffer47, offset: 2048, size: 456}}],
+});
+let textureView97 = texture98.createView({dimension: 'cube'});
+let texture99 = device0.createTexture({
+  size: [8, 8, 22],
+  mipLevelCount: 1,
+  sampleCount: 1,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder32.setBindGroup(0, bindGroup15, new Uint32Array(566), 123, 0);
+} catch {}
+try {
+computePassEncoder77.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup28, new Uint32Array(386), 76, 0);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(99);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer32, 'uint32', 1_260, 28);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(3, buffer38, 4_428, 196);
+} catch {}
+let arrayBuffer0 = buffer49.getMappedRange(10696, 360);
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append(img2);
+let autogeneratedBindGroupLayout44 = pipeline4.getBindGroupLayout(0);
+let bindGroup53 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout28,
+  entries: [{binding: 176, resource: {buffer: buffer78, offset: 256, size: 116}}],
+});
+let buffer86 = device0.createBuffer({size: 29565, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView98 = texture84.createView({dimension: '2d'});
+let renderPassEncoder34 = commandEncoder109.beginRenderPass({
+  colorAttachments: [{
+  view: textureView52,
+  clearValue: { r: 328.4, g: -196.8, b: -97.25, a: -30.88, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder61.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+computePassEncoder51.setBindGroup(1, bindGroup52, new Uint32Array(388), 28, 0);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(7, buffer18, 324);
+} catch {}
+document.body.prepend(canvas0);
+try {
+externalTexture5.label = '\u0fb4\u4c68\u0c34\u{1fa3c}\u{1fcfb}\uf1b1';
+} catch {}
+let autogeneratedBindGroupLayout45 = pipeline8.getBindGroupLayout(0);
+try {
+computePassEncoder36.setBindGroup(3, bindGroup15);
+} catch {}
+try {
+renderPassEncoder24.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(5, buffer36, 0, 585);
+} catch {}
+let buffer87 = device0.createBuffer({
+  size: 3334,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let texture100 = device0.createTexture({size: [8], mipLevelCount: 1, dimension: '1d', format: 'rg16sint', usage: GPUTextureUsage.COPY_DST});
+try {
+computePassEncoder32.setBindGroup(1, bindGroup17);
+} catch {}
+try {
+renderPassEncoder28.setBlendConstant({ r: 410.6, g: 394.1, b: -963.0, a: -671.0, });
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(2, buffer79, 44, 272);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture61,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(14).fill(164), /* required buffer size: 14 */
+{offset: 14, bytesPerRow: 329, rowsPerImage: 33}, {width: 24, height: 23, depthOrArrayLayers: 0});
+} catch {}
+let canvas4 = document.createElement('canvas');
+let texture101 = device0.createTexture({
+  size: {width: 216, height: 60, depthOrArrayLayers: 2},
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder27.setBindGroup(2, bindGroup10, new Uint32Array(5584), 3_404, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer32, 32, new Int16Array(7170), 1198, 192);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame10,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData18 = new ImageData(16, 36);
+let buffer88 = device0.createBuffer({size: 427, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+try {
+computePassEncoder14.setBindGroup(0, bindGroup48, []);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer73, 'uint32', 108, 163);
+} catch {}
+let arrayBuffer1 = buffer49.getMappedRange(9952, 204);
+try {
+buffer83.unmap();
+} catch {}
+try {
+computePassEncoder18.insertDebugMarker('\u0239');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let autogeneratedBindGroupLayout46 = pipeline8.getBindGroupLayout(0);
+try {
+computePassEncoder61.setBindGroup(0, bindGroup32);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline11);
+} catch {}
+let commandEncoder112 = device0.createCommandEncoder({});
+let computePassEncoder78 = commandEncoder112.beginComputePass({label: '66'});
+try {
+computePassEncoder10.setBindGroup(0, bindGroup33, new Uint32Array(283), 4, 0);
+} catch {}
+try {
+computePassEncoder78.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(0, bindGroup14, new Uint32Array(732), 0, 0);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer18, 'uint16', 2_876, 300);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline11);
+} catch {}
+let texture102 = device0.createTexture({
+  size: {width: 432, height: 120, depthOrArrayLayers: 459},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder30.setBindGroup(1, bindGroup18, new Uint32Array(404), 5, 0);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline5);
+} catch {}
+try {
+computePassEncoder65.popDebugGroup();
+} catch {}
+let commandEncoder113 = device0.createCommandEncoder({});
+try {
+computePassEncoder69.setBindGroup(3, bindGroup25, new Uint32Array(1093), 237, 0);
+} catch {}
+let pipeline14 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule1}});
+let imageData19 = new ImageData(12, 4);
+let bindGroup54 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout31,
+  entries: [{binding: 176, resource: {buffer: buffer20, offset: 512, size: 740}}],
+});
+let textureView99 = texture83.createView({});
+let computePassEncoder79 = commandEncoder113.beginComputePass({label: '67'});
+try {
+renderPassEncoder26.executeBundles([renderBundle7]);
+} catch {}
+try {
+  await shaderModule8.getCompilationInfo();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 1, y: 2, z: 1},
+  aspect: 'all',
+}, new Uint8Array(106_434).fill(73), /* required buffer size: 106_434 */
+{offset: 174, bytesPerRow: 115, rowsPerImage: 12}, {width: 0, height: 0, depthOrArrayLayers: 78});
+} catch {}
+let pipeline15 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  multisample: {count: 4, mask: 0x1d1f7d67},
+  fragment: {
+  module: shaderModule7,
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth16unorm',
+    depthWriteEnabled: true,
+    depthCompare: 'greater-equal',
+    stencilBack: {failOp: 'keep'},
+    stencilReadMask: 1050357281,
+    stencilWriteMask: 1602636735,
+    depthBias: 874913331,
+    depthBiasClamp: 264.3395917191769,
+  },
+  vertex: {
+    module: shaderModule4,
+    buffers: [
+      {
+        arrayStride: 644,
+        stepMode: 'vertex',
+        attributes: [{format: 'uint32', offset: 116, shaderLocation: 3}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+let commandEncoder114 = device0.createCommandEncoder();
+let computePassEncoder80 = commandEncoder114.beginComputePass({label: '68'});
+try {
+computePassEncoder79.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup44, new Uint32Array(883), 16, 0);
+} catch {}
+try {
+renderPassEncoder11.setBlendConstant({ r: 875.0, g: -306.0, b: -635.3, a: -107.4, });
+} catch {}
+try {
+renderPassEncoder24.setViewport(150.9864444626926, 40.048846379796984, 12.336433650152205, 6.069353044002, 0.7583287400622831, 0.9657663515350234);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(6, buffer77, 7_500, 922);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer17, 28, new BigUint64Array(12180), 32, 8);
+} catch {}
+let buffer89 = device0.createBuffer({
+  size: 210,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let textureView100 = texture92.createView({aspect: 'all', arrayLayerCount: 1});
+let sampler68 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 31.14,
+  lodMaxClamp: 44.19,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder65.setBindGroup(3, bindGroup54, new Uint32Array(183), 1, 0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer83, 'uint32', 1_856, 545);
+} catch {}
+let arrayBuffer2 = buffer49.getMappedRange(11264, 248);
+let autogeneratedBindGroupLayout47 = pipeline2.getBindGroupLayout(1);
+let textureView101 = texture52.createView({mipLevelCount: 1});
+try {
+computePassEncoder80.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(1, bindGroup21, new Uint32Array(805), 31, 0);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline13);
+} catch {}
+let textureView102 = texture98.createView({dimension: 'cube', baseArrayLayer: 3});
+let texture103 = device0.createTexture({
+  size: {width: 108, height: 30, depthOrArrayLayers: 2},
+  format: 'rg8uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder10.dispatchWorkgroups(1, 1);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup25, new Uint32Array(316), 10, 0);
+} catch {}
+try {
+renderPassEncoder22.setStencilReference(373);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer84, 'uint32', 448, 3_583);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer56, 436, new Float32Array(209), 107);
+} catch {}
+let texture104 = device0.createTexture({
+  size: {width: 108, height: 30, depthOrArrayLayers: 2},
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView103 = texture63.createView({dimension: '2d'});
+try {
+renderPassEncoder1.setVertexBuffer(5, buffer4, 1_540, 587);
+} catch {}
+try {
+buffer26.unmap();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+  await promise11;
+} catch {}
+let buffer90 = device0.createBuffer({size: 184, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView104 = texture5.createView({});
+let sampler69 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'greater',
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder18.setBindGroup(1, bindGroup18);
+} catch {}
+try {
+renderPassEncoder28.executeBundles([renderBundle5, renderBundle3, renderBundle9, renderBundle1, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline3);
+} catch {}
+let buffer91 = device0.createBuffer({size: 11081, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup53);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder10); computePassEncoder10.dispatchWorkgroupsIndirect(buffer48, 976); };
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer55, 'uint32', 3_836, 29);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline13);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture61,
+  mipLevel: 0,
+  origin: {x: 73, y: 12, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+document.body.prepend(canvas0);
+let videoFrame21 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'jedecP22Phosphors', transfer: 'smpte240m'} });
+try {
+canvas4.getContext('webgl');
+} catch {}
+let autogeneratedBindGroupLayout48 = pipeline13.getBindGroupLayout(0);
+let textureView105 = texture98.createView({dimension: 'cube', mipLevelCount: 1});
+let textureView106 = texture44.createView({dimension: '2d'});
+let sampler70 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'mirror-repeat', magFilter: 'nearest', lodMaxClamp: 94.39});
+try {
+renderPassEncoder23.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+renderPassEncoder25.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline11);
+} catch {}
+try {
+  await promise14;
+} catch {}
+let sampler71 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'mirror-repeat', magFilter: 'nearest'});
+try {
+renderPassEncoder34.setBindGroup(3, bindGroup44);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(1, bindGroup8, new Uint32Array(6624), 2_874, 0);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(6, buffer32, 0, 287);
+} catch {}
+try {
+renderPassEncoder26.insertDebugMarker('\u{1fbd3}');
+} catch {}
+let videoFrame22 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'unspecified', primaries: 'smpte170m', transfer: 'bt709'} });
+let veryExplicitBindGroupLayout12 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 78,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 88,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 155,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 218,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32float', access: 'write-only', viewDimension: '1d' },
+    },
+  ],
+});
+let bindGroup55 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout27,
+  entries: [
+    {binding: 78, resource: {buffer: buffer91, offset: 3072, size: 1108}},
+    {binding: 155, resource: {buffer: buffer47, offset: 768, size: 15293}},
+    {binding: 218, resource: textureView27},
+  ],
+});
+let querySet11 = device0.createQuerySet({type: 'occlusion', count: 1479});
+let textureView107 = texture9.createView({dimension: '3d'});
+try {
+computePassEncoder24.setBindGroup(3, bindGroup45, new Uint32Array(7098), 1_422, 0);
+} catch {}
+let autogeneratedBindGroupLayout49 = pipeline7.getBindGroupLayout(0);
+let bindGroup56 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout11,
+  entries: [
+    {binding: 4, resource: textureView81},
+    {binding: 269, resource: {buffer: buffer8, offset: 2816, size: 736}},
+  ],
+});
+let commandEncoder115 = device0.createCommandEncoder({});
+let computePassEncoder81 = commandEncoder115.beginComputePass({label: '69'});
+let sampler72 = device0.createSampler({addressModeW: 'mirror-repeat', minFilter: 'linear', compare: 'greater-equal'});
+try {
+computePassEncoder81.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup10, new Uint32Array(121), 0, 0);
+} catch {}
+await gc();
+try {
+externalTexture4.label = '\u6686\u{1fb4e}\u49dd\ucfff\ue31c\u9c6a';
+} catch {}
+let veryExplicitBindGroupLayout13 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 78,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 88,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 155,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 218,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32float', access: 'write-only', viewDimension: '1d' },
+    },
+  ],
+});
+let autogeneratedBindGroupLayout50 = pipeline0.getBindGroupLayout(1);
+let bindGroup57 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout10,
+  entries: [{binding: 378, resource: {buffer: buffer2, offset: 512, size: 600}}],
+});
+let commandEncoder116 = device0.createCommandEncoder({});
+let textureView108 = texture101.createView({aspect: 'depth-only', arrayLayerCount: 1});
+let computePassEncoder82 = commandEncoder116.beginComputePass({label: '70'});
+try {
+computePassEncoder82.setPipeline(pipeline8);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 572, new DataView(new ArrayBuffer(16246)), 6802, 4108);
+} catch {}
+let bindGroup58 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout37,
+  entries: [
+    {binding: 155, resource: {buffer: buffer2, offset: 0}},
+    {binding: 218, resource: textureView27},
+    {binding: 78, resource: {buffer: buffer41, offset: 2304}},
+  ],
+});
+let commandEncoder117 = device0.createCommandEncoder();
+let texture105 = device0.createTexture({
+  size: [8, 8, 22],
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture106 = gpuCanvasContext3.getCurrentTexture();
+try {
+computePassEncoder61.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+computePassEncoder6.setBindGroup(2, bindGroup57, new Uint32Array(1243), 230, 0);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer37, 'uint16', 178, 99);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline11);
+} catch {}
+try {
+commandEncoder117.resolveQuerySet(querySet11, 211, 22, buffer67, 0);
+} catch {}
+let veryExplicitBindGroupLayout14 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 19,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 23,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '3d' },
+    },
+    {binding: 94, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'filtering' }},
+    {
+      binding: 97,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 137,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let autogeneratedBindGroupLayout51 = pipeline9.getBindGroupLayout(0);
+let commandEncoder118 = device0.createCommandEncoder();
+try {
+renderPassEncoder8.setIndexBuffer(buffer14, 'uint16', 240, 146);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+commandEncoder118.copyBufferToTexture({
+  /* bytesInLastRow: 242 widthInBlocks: 242 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 6725 */
+  offset: 6725,
+  bytesPerRow: 26624,
+  buffer: buffer2,
+}, {
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 30, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 242, height: 61, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 1352, new Float32Array(4379), 328, 32);
+} catch {}
+let pipeline16 = device0.createRenderPipeline({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {1_579: 0},
+  targets: [{format: 'r8sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule1,
+    constants: {override3: 0, override5: 0, override4: 0},
+    buffers: [
+      {
+        arrayStride: 588,
+        attributes: [
+          {format: 'unorm16x2', offset: 40, shaderLocation: 12},
+          {format: 'unorm8x4', offset: 72, shaderLocation: 10},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', unclippedDepth: true},
+});
+let textureView109 = texture73.createView({mipLevelCount: 1, baseArrayLayer: 9, arrayLayerCount: 1});
+let computePassEncoder83 = commandEncoder118.beginComputePass({label: '71'});
+try {
+computePassEncoder13.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+computePassEncoder83.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(0, bindGroup34, []);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(0, bindGroup30, new Uint32Array(3381), 238, 0);
+} catch {}
+try {
+commandEncoder117.copyBufferToBuffer(buffer38, 2504, buffer13, 5804, 244);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas2,
+  origin: { x: 99, y: 0 },
+  flipY: true,
+}, {
+  texture: texture61,
+  mipLevel: 0,
+  origin: {x: 101, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 6, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let imageData20 = new ImageData(4, 16);
+let autogeneratedBindGroupLayout52 = pipeline5.getBindGroupLayout(1);
+let bindGroup59 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout34,
+  entries: [{binding: 176, resource: {buffer: buffer46, offset: 3072, size: 5204}}],
+});
+let texture107 = device0.createTexture({
+  size: [8, 8, 22],
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView110 = texture33.createView({format: 'rgba8unorm', baseArrayLayer: 0});
+let computePassEncoder84 = commandEncoder117.beginComputePass({label: '72'});
+try {
+computePassEncoder84.setPipeline(pipeline0);
+} catch {}
+let autogeneratedBindGroupLayout53 = pipeline6.getBindGroupLayout(0);
+let commandEncoder119 = device0.createCommandEncoder({});
+let querySet12 = device0.createQuerySet({type: 'occlusion', count: 566});
+let textureView111 = texture47.createView({dimension: '2d', format: 'r8sint', mipLevelCount: 1, baseArrayLayer: 1});
+let computePassEncoder85 = commandEncoder119.beginComputePass({label: '73'});
+try {
+computePassEncoder13.setBindGroup(1, bindGroup53);
+} catch {}
+try {
+computePassEncoder85.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup55);
+} catch {}
+let textureView112 = texture11.createView({baseMipLevel: 0, baseArrayLayer: 1, arrayLayerCount: 5});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({colorFormats: [], depthStencilFormat: 'depth32float', stencilReadOnly: false});
+try {
+renderPassEncoder27.setBlendConstant({ r: -901.0, g: -544.2, b: 415.8, a: 556.4, });
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(3, bindGroup15);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(2, buffer85, 0, 1_564);
+} catch {}
+let commandEncoder120 = device0.createCommandEncoder({});
+let textureView113 = texture6.createView({});
+let renderBundle11 = renderBundleEncoder11.finish({});
+try {
+computePassEncoder77.setBindGroup(1, bindGroup50, new Uint32Array(4494), 82, 0);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(2, buffer32);
+} catch {}
+try {
+commandEncoder120.copyTextureToTexture({
+  texture: texture48,
+  mipLevel: 0,
+  origin: {x: 2, y: 1, z: 8},
+  aspect: 'all',
+},
+{
+  texture: texture77,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer92 = device0.createBuffer({
+  size: 11490,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let textureView114 = texture105.createView({arrayLayerCount: 3});
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup59, []);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup51, new Uint32Array(1186), 274, 0);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(4, undefined, 0, 33_496_071);
+} catch {}
+let texture108 = device0.createTexture({
+  size: {width: 432, height: 120, depthOrArrayLayers: 2},
+  mipLevelCount: 6,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView115 = texture3.createView({arrayLayerCount: 1});
+let computePassEncoder86 = commandEncoder120.beginComputePass({label: '74'});
+try {
+computePassEncoder86.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(3, bindGroup52, new Uint32Array(688), 26, 0);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline16);
+} catch {}
+let autogeneratedBindGroupLayout54 = pipeline9.getBindGroupLayout(0);
+let commandEncoder121 = device0.createCommandEncoder({});
+let renderPassEncoder35 = commandEncoder121.beginRenderPass({
+  colorAttachments: [{view: textureView41, depthSlice: 123, loadOp: 'load', storeOp: 'discard'}],
+  maxDrawCount: 310635653,
+});
+try {
+computePassEncoder69.setBindGroup(0, bindGroup40);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup15, new Uint32Array(619), 101, 0);
+} catch {}
+try {
+renderPassEncoder14.setBlendConstant({ r: -392.4, g: 671.4, b: 292.5, a: 553.6, });
+} catch {}
+let imageData21 = new ImageData(56, 4);
+let commandEncoder122 = device0.createCommandEncoder({});
+try {
+computePassEncoder33.setBindGroup(3, bindGroup38, new Uint32Array(632), 25, 0);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(1, bindGroup39);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup20, new Uint32Array(209), 56, 0);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer5, 'uint32', 280, 258);
+} catch {}
+try {
+adapter0.label = '\uf7e2\u{1fe8b}\udc7b\u{1fd4f}\u0b51\u08e6\u{1f8da}';
+} catch {}
+let texture109 = device0.createTexture({
+  size: [216, 60, 2],
+  mipLevelCount: 3,
+  format: 'astc-12x10-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder87 = commandEncoder122.beginComputePass({label: '75'});
+try {
+computePassEncoder87.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(0, bindGroup49);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup2, new Uint32Array(538), 26, 0);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData19,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 44, y: 9, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let buffer93 = device0.createBuffer({
+  size: 11817,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder123 = device0.createCommandEncoder();
+let computePassEncoder88 = commandEncoder123.beginComputePass({label: '76'});
+try {
+computePassEncoder88.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(370);
+} catch {}
+try {
+renderPassEncoder27.setViewport(52.11128918859228, 12.212237657923351, 35.91668841490431, 5.299611903645637, 0.971727050579545, 0.9829499641997317);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline16);
+} catch {}
+let pipeline17 = await device0.createComputePipelineAsync({layout: pipelineLayout5, compute: {module: shaderModule5}});
+let pipeline18 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule6,
+  constants: {11_640: 0},
+  targets: [{
+  format: 'r8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex1',
+    constants: {30_730: 0},
+    buffers: [
+      {
+        arrayStride: 572,
+        attributes: [
+          {format: 'sint32x4', offset: 24, shaderLocation: 13},
+          {format: 'sint16x4', offset: 84, shaderLocation: 2},
+        ],
+      },
+      {arrayStride: 544, attributes: [{format: 'snorm8x2', offset: 20, shaderLocation: 6}]},
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'front'},
+});
+let buffer94 = device0.createBuffer({
+  size: 17630,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder60.setBindGroup(3, bindGroup52, new Uint32Array(251), 36, 0);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(2, bindGroup40, new Uint32Array(1560), 353, 0);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer74, 'uint16', 4_368, 1_040);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline13);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+let texture110 = device0.createTexture({
+  size: {width: 54, height: 15, depthOrArrayLayers: 2},
+  mipLevelCount: 2,
+  format: 'rg8uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder14.setBindGroup(0, bindGroup56, new Uint32Array(1962), 257, 0);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(3, buffer39, 0, 1_447);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+document.body.prepend(img2);
+let commandEncoder124 = device0.createCommandEncoder();
+let querySet13 = device0.createQuerySet({type: 'occlusion', count: 165});
+let textureView116 = texture85.createView({aspect: 'stencil-only', arrayLayerCount: 1});
+try {
+renderPassEncoder25.setViewport(156.22733329194736, 58.18791727493248, 12.74931798933816, 0.9978337798319644, 0.30348329921584494, 0.5866854012985594);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline5);
+} catch {}
+try {
+buffer34.unmap();
+} catch {}
+try {
+commandEncoder124.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 303 */
+  offset: 303,
+  bytesPerRow: 6656,
+  rowsPerImage: 145,
+  buffer: buffer0,
+}, {
+  texture: texture73,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let promise15 = device0.queue.onSubmittedWorkDone();
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+  await promise15;
+} catch {}
+let renderPassEncoder36 = commandEncoder124.beginRenderPass({
+  colorAttachments: [{
+  view: textureView106,
+  clearValue: { r: -134.3, g: -506.7, b: -171.9, a: -459.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet1,
+});
+try {
+computePassEncoder10.end();
+} catch {}
+
+
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame22.close();
+videoFrame23.close();
+videoFrame24.close();
+videoFrame25.close();
+videoFrame27.close();
+videoFrame28.close();
+videoFrame31.close();
+videoFrame32.close();
+videoFrame33.close();
+videoFrame34.close();
+videoFrame35.close();
+videoFrame37.close();
+videoFrame38.close();
+videoFrame39.close();
+videoFrame40.close();
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/BindGroup.h
+++ b/Source/WebGPU/WebGPU/BindGroup.h
@@ -102,7 +102,7 @@ public:
     uint32_t dynamicOffset(uint32_t bindingIndex, const Vector<uint32_t>*) const;
     void rebindSamplersIfNeeded() const;
     bool updateExternalTextures(const ExternalTexture&);
-    bool makeSubmitInvalid(ShaderStage) const;
+    bool makeSubmitInvalid(ShaderStage, const BindGroupLayout*) const;
 
 private:
     BindGroup(id<MTLBuffer> vertexArgumentBuffer, id<MTLBuffer> fragmentArgumentBuffer, id<MTLBuffer> computeArgumentBuffer, Vector<BindableResources>&&, const BindGroupLayout&, DynamicBuffersContainer&&, SamplersContainer&&, ShaderStageArray<ExternalTextureIndices>&&, Device&);

--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -1404,18 +1404,22 @@ bool BindGroup::updateExternalTextures(const ExternalTexture& externalTexture)
     return true;
 }
 
-bool BindGroup::makeSubmitInvalid(ShaderStage stage) const
+bool BindGroup::makeSubmitInvalid(ShaderStage stage, const BindGroupLayout* pipelineLayout) const
 {
+    if (!pipelineLayout)
+        return false;
+
     if (!m_bindGroupLayout)
         return true;
 
+    Ref pipelineBindGroupLayout = Ref { *pipelineLayout };
     switch (stage) {
     case ShaderStage::Vertex:
-        return protectedBindGroupLayout()->encodedLength(ShaderStage::Vertex) != m_vertexArgumentBuffer.length;
+        return m_vertexArgumentBuffer.length != pipelineBindGroupLayout->encodedLength(stage);
     case ShaderStage::Fragment:
-        return protectedBindGroupLayout()->encodedLength(ShaderStage::Fragment) != m_fragmentArgumentBuffer.length;
+        return m_fragmentArgumentBuffer.length != pipelineBindGroupLayout->encodedLength(stage);
     case ShaderStage::Compute:
-        return protectedBindGroupLayout()->encodedLength(ShaderStage::Compute) != m_computeArgumentBuffer.length;
+        return m_computeArgumentBuffer.length != pipelineBindGroupLayout->encodedLength(stage);
     case ShaderStage::Undefined:
         return true;
     }

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.mm
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.mm
@@ -184,7 +184,7 @@ void ComputePassEncoder::executePreDispatchCommands(const Buffer* indirectBuffer
             return;
         }
         auto group = kvp.value;
-        if (group->makeSubmitInvalid(ShaderStage::Compute)) {
+        if (group->makeSubmitInvalid(ShaderStage::Compute, pipelineLayout->optionalBindGroupLayout(bindGroupIndex))) {
             protectedParentEncoder()->makeSubmitInvalid();
             return;
         }

--- a/Source/WebGPU/WebGPU/PipelineLayout.h
+++ b/Source/WebGPU/WebGPU/PipelineLayout.h
@@ -67,6 +67,7 @@ public:
     bool isAutoLayout() const;
     size_t numberOfBindGroupLayouts() const { return m_bindGroupLayouts ? m_bindGroupLayouts->size() : 0; }
     BindGroupLayout& bindGroupLayout(size_t) const;
+    BindGroupLayout* optionalBindGroupLayout(size_t) const;
 
     Device& device() const { return m_device; }
     void makeInvalid();

--- a/Source/WebGPU/WebGPU/PipelineLayout.mm
+++ b/Source/WebGPU/WebGPU/PipelineLayout.mm
@@ -173,6 +173,14 @@ BindGroupLayout& PipelineLayout::bindGroupLayout(size_t i) const
     return (*m_bindGroupLayouts)[i];
 }
 
+BindGroupLayout* PipelineLayout::optionalBindGroupLayout(size_t i) const
+{
+    if (m_bindGroupLayouts.has_value() && i < m_bindGroupLayouts->size())
+        return (*m_bindGroupLayouts)[i].ptr();
+
+    return nullptr;
+}
+
 void PipelineLayout::makeInvalid()
 {
     m_isValid = false;

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -514,7 +514,8 @@ bool RenderPassEncoder::executePreDrawCommands(uint32_t firstInstance, uint32_t 
         return false;
 
     auto pipeline = m_pipeline;
-    if (NSString* error = pipeline->protectedPipelineLayout()->errorValidatingBindGroupCompatibility(m_bindGroups)) {
+    Ref pipelineLayout = pipeline->protectedPipelineLayout();
+    if (NSString* error = pipelineLayout->errorValidatingBindGroupCompatibility(m_bindGroups)) {
         makeInvalid(error);
         return false;
     }
@@ -560,7 +561,7 @@ bool RenderPassEncoder::executePreDrawCommands(uint32_t firstInstance, uint32_t 
             makeInvalid(error);
             return false;
         }
-        if (group->makeSubmitInvalid(ShaderStage::Vertex) || group->makeSubmitInvalid(ShaderStage::Fragment)) {
+        if (group->makeSubmitInvalid(ShaderStage::Vertex, pipelineLayout->optionalBindGroupLayout(groupIndex)) || group->makeSubmitInvalid(ShaderStage::Fragment, pipelineLayout->optionalBindGroupLayout(groupIndex))) {
             protectedParentEncoder()->makeSubmitInvalid();
             return false;
         }
@@ -581,7 +582,6 @@ bool RenderPassEncoder::executePreDrawCommands(uint32_t firstInstance, uint32_t 
     m_queryBufferIndicesToClear.remove(m_visibilityResultBufferOffset);
 
     for (auto& kvp : m_bindGroupDynamicOffsets) {
-        Ref pipelineLayout = m_pipeline->pipelineLayout();
         auto bindGroupIndex = kvp.key;
 
         auto* pvertexOffsets = pipelineLayout->vertexOffsets(bindGroupIndex, kvp.value);


### PR DESCRIPTION
#### b17d39f2c8ce8c24af4964676ad0cdb5f30ab7ac
<pre>
[WebGPU] &apos;auto&apos; GPUBindGroupLayout creation allows for mixing bind groups at different locations
<a href="https://bugs.webkit.org/show_bug.cgi?id=283998">https://bugs.webkit.org/show_bug.cgi?id=283998</a>
<a href="https://rdar.apple.com/140802793">rdar://140802793</a>

Reviewed by Tadeu Zagallo.

With auto layouts, @group(K) @binding(X) must correspond
to a bind group created from layout K and placed at bind
group X in the call to setBindGroup(bindGroup, index=K)

* Source/WebGPU/WebGPU/BindGroup.h:
* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::BindGroup::makeSubmitInvalid const):
* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::ComputePassEncoder::executePreDispatchCommands):
* Source/WebGPU/WebGPU/PipelineLayout.h:
* Source/WebGPU/WebGPU/PipelineLayout.mm:
(WebGPU::PipelineLayout::optionalBindGroupLayout const):
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::executePreDrawCommands):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::executePreDrawCommands):

Canonical link: <a href="https://commits.webkit.org/287499@main">https://commits.webkit.org/287499@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f720fd4d06c033d1f8fc4e703709768c5526758

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79904 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58902 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33302 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84419 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30879 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67966 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7194 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62444 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20271 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82972 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/52498 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72766 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42755 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49846 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26915 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29341 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70966 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27394 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85851 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7121 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4988 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70716 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7298 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68606 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69958 "68 api tests failed or timed out") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17429 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13955 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12888 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7085 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12627 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6932 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10444 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8736 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->