### PR TITLE
Extend AudioSampleBufferCompressor capabilities to allow for any CMSampleBuffer conversion

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp
@@ -36,6 +36,7 @@
 #include "AudioFileReader.h"
 #include "AudioSampleDataSource.h"
 #include "AudioTrackPrivateWebM.h"
+#include "CMUtilities.h"
 #include "FloatConversion.h"
 #include "InbandTextTrackPrivate.h"
 #include "Logging.h"
@@ -275,31 +276,6 @@ static OSStatus passthroughInputDataCallback(AudioConverterRef, UInt32* numDataP
     userData->m_index++;
 
     return noErr;
-}
-
-Vector<AudioStreamPacketDescription> AudioFileReader::getPacketDescriptions(CMSampleBufferRef sampleBuffer) const
-{
-    size_t packetDescriptionsSize;
-    if (PAL::CMSampleBufferGetAudioStreamPacketDescriptions(sampleBuffer, 0, nullptr, &packetDescriptionsSize) != noErr) {
-        RELEASE_LOG_FAULT(WebAudio, "Unable to get packet description list size");
-        return { };
-    }
-    size_t numDescriptions = packetDescriptionsSize / sizeof(AudioStreamPacketDescription);
-    if (!numDescriptions) {
-        RELEASE_LOG_FAULT(WebAudio, "No packet description found.");
-        return { };
-    }
-    Vector<AudioStreamPacketDescription> descriptions(numDescriptions);
-    if (PAL::CMSampleBufferGetAudioStreamPacketDescriptions(sampleBuffer, packetDescriptionsSize, descriptions.data(), nullptr) != noErr) {
-        RELEASE_LOG_FAULT(WebAudio, "Unable to get packet description list");
-        return { };
-    }
-    auto numPackets = PAL::CMSampleBufferGetNumSamples(sampleBuffer);
-    if (numDescriptions != size_t(numPackets)) {
-        RELEASE_LOG_FAULT(WebAudio, "Unhandled CMSampleBuffer structure");
-        return { };
-    }
-    return descriptions;
 }
 
 std::optional<size_t> AudioFileReader::decodeWebMData(AudioBufferList& bufferList, size_t numberOfFrames, const AudioStreamBasicDescription& inFormat, const AudioStreamBasicDescription& outFormat) const

--- a/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.h
@@ -73,7 +73,6 @@ private:
 #if ENABLE(MEDIA_SOURCE)
     bool isMaybeWebM(std::span<const uint8_t>) const;
     std::unique_ptr<AudioFileReaderWebMData> demuxWebMData(std::span<const uint8_t>) const;
-    Vector<AudioStreamPacketDescription> getPacketDescriptions(CMSampleBufferRef) const;
     std::optional<size_t> decodeWebMData(AudioBufferList&, size_t numberOfFrames, const AudioStreamBasicDescription& inFormat, const AudioStreamBasicDescription& outFormat) const;
 #endif
     static OSStatus readProc(void* clientData, SInt64 position, UInt32 requestCount, void* buffer, UInt32* actualCount);

--- a/Source/WebCore/platform/graphics/cocoa/CMUtilities.h
+++ b/Source/WebCore/platform/graphics/cocoa/CMUtilities.h
@@ -27,6 +27,7 @@
 
 #if PLATFORM(COCOA)
 
+#include <CoreAudio/CoreAudioTypes.h>
 #include <memory>
 #include <wtf/Expected.h>
 #include <wtf/RetainPtr.h>
@@ -74,6 +75,8 @@ private:
     uint32_t m_lastVorbisBlockSize { 0 };
     bool m_isValid { false };
 };
+
+Vector<AudioStreamPacketDescription> getPacketDescriptions(CMSampleBufferRef);
 
 }
 

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp
@@ -317,15 +317,18 @@ void MediaRecorderPrivateEncoder::audioSamplesDescriptionChanged(const AudioStre
         m_formatChangedOccurred = true;
     }
 
-    m_audioCompressor = AudioSampleBufferCompressor::create(compressedAudioOutputBufferCallback, this, m_audioCodec, *m_originalOutputDescription);
+    AudioSampleBufferCompressor::Options options = {
+        .format = m_audioCodec,
+        .description = m_originalOutputDescription,
+        .outputBitRate = m_audioBitsPerSecond ? std::optional { m_audioBitsPerSecond } : std::nullopt,
+        .generateTimestamp = true
+    };
+    m_audioCompressor = AudioSampleBufferCompressor::create(compressedAudioOutputBufferCallback, this, options);
     if (!m_audioCompressor) {
         RELEASE_LOG_ERROR(MediaStream, "MediaRecorderPrivateEncoder::audioSamplesDescriptionChanged: creation of compressor failed");
         m_hadError = true;
         return;
     }
-
-    if (m_audioBitsPerSecond)
-        audioCompressor()->setBitsPerSecond(m_audioBitsPerSecond);
 
     updateCurrentRingBufferIfNeeded();
 }


### PR DESCRIPTION
#### 10ea3bdfd9009b070aa95cb6e46e7948f0b1b7f6
<pre>
Extend AudioSampleBufferCompressor capabilities to allow for any CMSampleBuffer conversion
<a href="https://bugs.webkit.org/show_bug.cgi?id=283905">https://bugs.webkit.org/show_bug.cgi?id=283905</a>
<a href="https://rdar.apple.com/140782536">rdar://140782536</a>

Reviewed by Youenn Fablet.

We extend the class to be able to decode various format into PCM as required by the WebCodec&apos;s AudioDecoderCocoa class
(WebCodec&apos;s AudioEncoderCocoa).
We also rewrite the AudioConverterComplexInputDataProc used by processSample using
the available CoreMedia methods and how we create a CMSampleBuffer. This new version is significantly
smaller and less complex while being able to handle more format (in particular, in can now handle any planar formats and not a maximum of two).

The addSampleBuffer method now returns a GenericPromise which is resolved
once the sampleBuffer has been fulled decoded and all data has been returned
to the callback.
Decoding or Encoding errors are now reported back to the consumer/

We add a new mode where the converter will now longer generate the timestamps but
instead set the timestamp of the input to be the same as the one on the input
(this is an AudioDecoder requirement)

This change will be fully tested in a follow-up commit where we introduce AudioDecoderCocoa.
For now, there&apos;s no impact on its only consumer: MediaRecorderPrivateEncoder
which is covered by existing tests.

Fly-By: change use of `auto` for explicit `int` when reporting error as it causes compilation error when using OSStatus.

* Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp:
(WebCore::AudioFileReader::getPacketDescriptions const): Deleted.
* Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.h:
* Source/WebCore/platform/graphics/cocoa/CMUtilities.h: Extract getPacketDescriptions method from AudioFileReaderCocoa.
* Source/WebCore/platform/graphics/cocoa/CMUtilities.mm:
(WebCore::getPacketDescriptions):
* Source/WebCore/platform/mediarecorder/cocoa/AudioSampleBufferCompressor.h:
(WebCore::AudioSampleBufferCompressor::isPCM const):
* Source/WebCore/platform/mediarecorder/cocoa/AudioSampleBufferCompressor.mm:
(WebCore::AudioSampleBufferCompressor::flushInternal):
(WebCore::AudioSampleBufferCompressor::setGenerateTimestamp):
(WebCore::AudioSampleBufferCompressor::initAudioConverterForSourceFormatDescription):
(WebCore::AudioSampleBufferCompressor::gradualDecoderRefreshCount):
(WebCore::AudioSampleBufferCompressor::sampleBuffer):
(WebCore::AudioSampleBufferCompressor::provideSourceDataNumOutputPackets):
(WebCore::AudioSampleBufferCompressor::setTimeFromSample):
(WebCore::AudioSampleBufferCompressor::processSampleBuffers):
(WebCore::AudioSampleBufferCompressor::addSampleBuffer):

Canonical link: <a href="https://commits.webkit.org/287362@main">https://commits.webkit.org/287362@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a235662c03cdb39258662f7628384b5321b4c54a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79264 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58293 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32636 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83890 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30430 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81397 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67384 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6563 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62012 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19909 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82331 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52071 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72226 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42315 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49415 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26398 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28819 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70529 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26832 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85281 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6562 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4559 "Found 1 new test failure: fast/css/value-list-out-of-bounds-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70253 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6725 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68096 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69501 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17332 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13551 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12400 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6519 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12283 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6441 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9908 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8233 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->