### PR TITLE
[JSC] Implement `Array.prototype.toReversed` in C++

### DIFF
--- a/JSTests/microbenchmarks/array-prototype-toReversed-double.js
+++ b/JSTests/microbenchmarks/array-prototype-toReversed-double.js
@@ -1,0 +1,13 @@
+const arr = [];
+for (let i = 0; i < 1024; i++) {
+    arr.push(i + 0.5);
+}
+
+function test() {
+    arr.toReversed();
+}
+noInline(test);
+
+for (let i = 0; i < 1e4; i++) {
+    test();
+}

--- a/JSTests/microbenchmarks/array-prototype-toReversed-int32.js
+++ b/JSTests/microbenchmarks/array-prototype-toReversed-int32.js
@@ -1,0 +1,13 @@
+const arr = [];
+for (let i = 0; i < 1024; i++) {
+    arr.push(i);
+}
+
+function test() {
+    arr.toReversed();
+}
+noInline(test);
+
+for (let i = 0; i < 1e4; i++) {
+    test();
+}

--- a/JSTests/microbenchmarks/array-prototype-toReversed-object.js
+++ b/JSTests/microbenchmarks/array-prototype-toReversed-object.js
@@ -1,0 +1,13 @@
+const arr = [];
+for (let i = 0; i < 1024; i++) {
+    arr.push({ i });
+}
+
+function test() {
+    arr.toReversed();
+}
+noInline(test);
+
+for (let i = 0; i < 1e4; i++) {
+    test();
+}

--- a/JSTests/microbenchmarks/array-prototype-toReversed-storage.js
+++ b/JSTests/microbenchmarks/array-prototype-toReversed-storage.js
@@ -1,0 +1,15 @@
+const arr = [];
+for (let i = 0; i < 1024; i++) {
+    arr.push({ i });
+}
+arr.length = 1000000000;
+arr.length = 1024;
+
+function test() {
+    arr.toReversed();
+}
+noInline(test);
+
+for (let i = 0; i < 1e4; i++) {
+    test();
+}

--- a/JSTests/microbenchmarks/array-prototype-toReversed-string.js
+++ b/JSTests/microbenchmarks/array-prototype-toReversed-string.js
@@ -1,0 +1,14 @@
+const characters = "abcdefghijklmnopqrstuvwxyz";
+const arr = [];
+for (let i = 0; i < 1024; i++) {
+    arr.push(characters[i % 26]);
+}
+
+function test() {
+    arr.toReversed();
+}
+noInline(test);
+
+for (let i = 0; i < 1e4; i++) {
+    test();
+}

--- a/JSTests/stress/array-prototype-toReversed-contiguous.js
+++ b/JSTests/stress/array-prototype-toReversed-contiguous.js
@@ -1,0 +1,16 @@
+function sameArray(a, b) {
+    if (a.length !== b.length)
+        throw new Error(`Expected array length ${b.length} but got ${a.length}`);
+    for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i])
+            throw new Error(`Expected ${b[i]} but got ${a[i]} (${i})`);
+    }
+}
+const arr = [];
+for (let i = 0; i < 10; i++) {
+    arr.push({ i });
+}
+
+const result = arr.toReversed();
+
+sameArray(result, [arr[9], arr[8], arr[7], arr[6], arr[5], arr[4], arr[3], arr[2], arr[1], arr[0]]);

--- a/JSTests/stress/array-prototype-toReversed-double.js
+++ b/JSTests/stress/array-prototype-toReversed-double.js
@@ -1,0 +1,16 @@
+function sameArray(a, b) {
+    if (a.length !== b.length)
+        throw new Error(`Expected array length ${b.length} but got ${a.length}`);
+    for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i])
+            throw new Error(`Expected ${b[i]} but got ${a[i]} (${i})`);
+    }
+}
+
+
+const arr = [];
+for (let i = 0; i < 10; i++) {
+    arr.push(i + 0.5);
+}
+const result = arr.toReversed();
+sameArray(result, [9.5, 8.5, 7.5, 6.5, 5.5, 4.5, 3.5, 2.5, 1.5, 0.5]);

--- a/JSTests/stress/array-prototype-toReversed-int32.js
+++ b/JSTests/stress/array-prototype-toReversed-int32.js
@@ -1,0 +1,16 @@
+function sameArray(a, b) {
+    if (a.length !== b.length)
+        throw new Error(`Expected array length ${b.length} but got ${a.length}`);
+    for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i])
+            throw new Error(`Expected ${b[i]} but got ${a[i]} (${i})`);
+    }
+}
+
+
+const arr = [];
+for (let i = 0; i < 10; i++) {
+    arr.push(i);
+}
+const result = arr.toReversed();
+sameArray(result, [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]);

--- a/JSTests/stress/array-prototype-toReversed-storage.js
+++ b/JSTests/stress/array-prototype-toReversed-storage.js
@@ -1,0 +1,48 @@
+function sameArray(a, b) {
+    if (a.length !== b.length)
+        throw new Error(`Expected array length ${b.length} but got ${a.length}`);
+    for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i])
+            throw new Error(`Expected ${b[i]} but got ${a[i]} (${i})`);
+    }
+}
+
+
+{
+    const arr = [];
+    for (let i = 0; i < 5; i++) {
+        arr.push(i);
+    }
+    arr.length = 1000000000;
+    arr.length = 5;
+
+    const result = arr.toReversed();
+
+    sameArray(result, [4, 3, 2, 1, 0]);
+}
+
+{
+    const arr = [];
+    for (let i = 0; i < 5; i++) {
+        arr.push(i + 0.5);
+    }
+    arr.length = 1000000000;
+    arr.length = 5;
+
+    const result = arr.toReversed();
+
+    sameArray(result, [4.5, 3.5, 2.5, 1.5, 0.5]);
+}
+
+{
+    const arr = [];
+    for (let i = 0; i < 5; i++) {
+        arr.push({ i });
+    }
+    arr.length = 1000000000;
+    arr.length = 5;
+
+    const result = arr.toReversed();
+
+    sameArray(result, [arr[4], arr[3], arr[2], arr[1], arr[0]]);
+}

--- a/Source/JavaScriptCore/builtins/ArrayPrototype.js
+++ b/Source/JavaScriptCore/builtins/ArrayPrototype.js
@@ -455,28 +455,6 @@ function at(index)
     return (k >= 0 && k < length) ? array[k] : @undefined;
 }
 
-function toReversed()
-{
-    "use strict";
-
-    // Step 1.
-    var array = @toObject(this, "Array.prototype.toReversed requires that |this| not be null or undefined");
-
-    // Step 2.
-    var length = @toLength(array.length);
-
-    // Step 3.
-    var result = @newArrayWithSize(length);
-
-    // Step 4-5.
-    for (var k = 0; k < length; k++) {
-        var fromValue = array[length - k - 1];
-        @putByValDirect(result, k, fromValue);
-    }
-
-    return result;
-}
-
 function toSorted(comparator)
 {
     "use strict";

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -65,6 +65,7 @@ static JSC_DECLARE_HOST_FUNCTION(arrayProtoFuncIndexOf);
 static JSC_DECLARE_HOST_FUNCTION(arrayProtoFuncLastIndexOf);
 static JSC_DECLARE_HOST_FUNCTION(arrayProtoFuncConcat);
 static JSC_DECLARE_HOST_FUNCTION(arrayProtoFuncFill);
+static JSC_DECLARE_HOST_FUNCTION(arrayProtoFuncToReversed);
 
 // ------------------------------ ArrayPrototype ----------------------------
 
@@ -125,7 +126,7 @@ void ArrayPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().includesPublicName(), arrayPrototypeIncludesCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().copyWithinPublicName(), arrayPrototypeCopyWithinCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().atPublicName(), arrayPrototypeAtCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
-    JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().toReversedPublicName(), arrayPrototypeToReversedCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->toReversed, arrayProtoFuncToReversed, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().toSortedPublicName(), arrayPrototypeToSortedCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().toSplicedPublicName(), arrayPrototypeToSplicedCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().withPublicName(), arrayPrototypeWithCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
@@ -153,7 +154,7 @@ void ArrayPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
         &vm.propertyNames->builtinNames().flatMapPublicName(),
         &vm.propertyNames->builtinNames().includesPublicName(),
         &vm.propertyNames->builtinNames().keysPublicName(),
-        &vm.propertyNames->builtinNames().toReversedPublicName(),
+        &vm.propertyNames->toReversed,
         &vm.propertyNames->builtinNames().toSortedPublicName(),
         &vm.propertyNames->builtinNames().toSplicedPublicName(),
         &vm.propertyNames->builtinNames().valuesPublicName()
@@ -207,26 +208,6 @@ inline bool canUseFastJoin(const JSObject* thisObject)
 inline bool holesMustForwardToPrototype(JSObject* object)
 {
     return object->structure()->holesMustForwardToPrototype(object);
-}
-
-inline bool isHole(double value)
-{
-    return std::isnan(value);
-}
-
-inline bool isHole(const WriteBarrier<Unknown>& value)
-{
-    return !value;
-}
-
-template<typename T>
-inline bool containsHole(T* data, unsigned length)
-{
-    for (unsigned i = 0; i < length; ++i) {
-        if (isHole(data[i]))
-            return true;
-    }
-    return false;
 }
 
 inline JSValue fastJoin(JSGlobalObject* globalObject, JSObject* thisObject, StringView separator, unsigned length, bool& sawHoles, bool& genericCase)
@@ -1940,6 +1921,49 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncFill, (JSGlobalObject* globalObject, Call
     }
 
     return JSValue::encode(thisObject);
+}
+
+JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncToReversed, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto thisValue = callFrame->thisValue().toThis(globalObject, ECMAMode::strict());
+    RETURN_IF_EXCEPTION(scope, { });
+    if (UNLIKELY(thisValue.isUndefinedOrNull()))
+        return throwVMTypeError(globalObject, scope, "Array.prototype.fill requires that |this| not be null or undefined"_s);
+    auto* thisObject = thisValue.toObject(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    uint64_t length = toLength(globalObject, thisObject);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    if (UNLIKELY(length > std::numeric_limits<uint32_t>::max())) {
+        throwRangeError(globalObject, scope, "Array length must be a positive integer of safe magnitude."_s);
+        return { };
+    }
+
+    if (isJSArray(thisObject)) {
+        JSArray* thisArray = jsCast<JSArray*>(thisObject);
+        auto fastResult = thisArray->fastToReversed(globalObject, length);
+        if (fastResult)
+            return JSValue::encode(fastResult);
+    }
+
+    JSArray* result = JSArray::tryCreate(vm, globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithUndecided), length);
+    if (UNLIKELY(!result)) {
+        throwOutOfMemoryError(globalObject, scope);
+        return { };
+    }
+
+    for (unsigned k = 0; k < length; k++) {
+        auto fromValue = thisObject->getIndex(globalObject, length - k - 1);
+        RETURN_IF_EXCEPTION(scope, { });
+        result->putDirectIndex(globalObject, k, fromValue, 0, PutDirectIndexShouldThrow);
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+
+    return JSValue::encode(result);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/CommonIdentifiers.h
+++ b/Source/JavaScriptCore/runtime/CommonIdentifiers.h
@@ -285,6 +285,7 @@
     macro(toJSON) \
     macro(toLocaleString) \
     macro(toPrecision) \
+    macro(toReversed) \
     macro(toString) \
     macro(toTemporalInstant) \
     macro(toWellFormed) \

--- a/Source/JavaScriptCore/runtime/JSArray.cpp
+++ b/Source/JavaScriptCore/runtime/JSArray.cpp
@@ -555,6 +555,87 @@ bool JSArray::fastFill(VM& vm, unsigned startIndex, unsigned endIndex, JSValue v
     return true;
 }
 
+JSArray* JSArray::fastToReversed(JSGlobalObject* globalObject, uint64_t length)
+{
+    ASSERT(length <= std::numeric_limits<uint32_t>::max());
+
+    VM& vm = globalObject->vm();
+
+    auto type = indexingType();
+    switch (type) {
+    case ArrayWithInt32:
+    case ArrayWithContiguous:
+    case ArrayWithDouble: {
+        if (length > this->butterfly()->vectorLength())
+            return nullptr;
+        Structure* resultStructure = globalObject->arrayStructureForIndexingTypeDuringAllocation(type);
+        IndexingType indexingType = resultStructure->indexingType();
+        if (UNLIKELY(hasAnyArrayStorage(indexingType)))
+            return nullptr;
+        ASSERT(!globalObject->isHavingABadTime());
+
+        auto srcData = this->butterfly()->contiguous().data();
+
+        if (hasDouble(indexingType)) {
+            if (holesMustForwardToPrototype() && containsHole(this->butterfly()->contiguousDouble().data(), static_cast<uint32_t>(length)))
+                return nullptr;
+        } else if (holesMustForwardToPrototype() && containsHole(srcData, static_cast<uint32_t>(length)))
+            return nullptr;
+
+        auto vectorLength = Butterfly::optimalContiguousVectorLength(resultStructure, length);
+        void* memory = vm.auxiliarySpace().allocate(
+            vm,
+            Butterfly::totalSize(0, 0, true, vectorLength * sizeof(EncodedJSValue)),
+            nullptr, AllocationFailureMode::ReturnNull);
+        if (UNLIKELY(!memory))
+            return nullptr;
+        auto* butterfly = Butterfly::fromBase(memory, 0, 0);
+        butterfly->setVectorLength(vectorLength);
+        butterfly->setPublicLength(length);
+
+        auto resultData = butterfly->contiguous().data();
+        memcpy(resultData, srcData, sizeof(JSValue) * length);
+
+        if (hasDouble(indexingType)) {
+            auto data = butterfly->contiguousDouble().data();
+            std::reverse(data, data + length);
+        } else
+            std::reverse(resultData, resultData + length);
+
+        return createWithButterfly(vm, nullptr, resultStructure, butterfly);
+    }
+    case ArrayWithArrayStorage: {
+        auto& storage = *this->butterfly()->arrayStorage();
+        if (storage.m_sparseMap.get())
+            return nullptr;
+        if (length > storage.vectorLength())
+            return nullptr;
+        if (storage.hasHoles() && holesMustForwardToPrototype())
+            return nullptr;
+
+        Structure* resultStructure = globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous);
+        if (UNLIKELY(hasAnyArrayStorage(resultStructure->indexingType())))
+            return nullptr;
+
+        ASSERT(!globalObject->isHavingABadTime());
+        ObjectInitializationScope scope(vm);
+        JSArray* resultArray = JSArray::tryCreateUninitializedRestricted(scope, resultStructure, length);
+        if (UNLIKELY(!resultArray))
+            return nullptr;
+        gcSafeMemcpy(resultArray->butterfly()->contiguous().data(), this->butterfly()->arrayStorage()->m_vector, sizeof(JSValue) * static_cast<uint32_t>(length));
+        ASSERT(resultArray->butterfly()->publicLength() == length);
+
+        auto data = resultArray->butterfly()->contiguous().data();
+        std::reverse(data, data + length);
+        vm.writeBarrier(resultArray);
+
+        return resultArray;
+    }
+    default:
+        return nullptr;
+    }
+}
+
 bool JSArray::appendMemcpy(JSGlobalObject* globalObject, VM& vm, unsigned startIndex, IndexingType otherType, std::span<const EncodedJSValue> values)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);

--- a/Source/JavaScriptCore/runtime/JSArray.h
+++ b/Source/JavaScriptCore/runtime/JSArray.h
@@ -120,6 +120,8 @@ public:
 
     bool fastFill(VM&, unsigned startIndex, unsigned endIndex, JSValue);
 
+    JSArray* fastToReversed(JSGlobalObject*, uint64_t length);
+
     ALWAYS_INLINE bool definitelyNegativeOneMiss() const;
 
     enum ShiftCountMode {
@@ -409,6 +411,11 @@ ALWAYS_INLINE uint64_t toLength(JSGlobalObject*, JSObject*);
 
 template<ArrayFillMode fillMode>
 JSArray* tryCloneArrayFromFast(JSGlobalObject*, JSValue arrayValue);
+
+ALWAYS_INLINE bool isHole(double value);
+ALWAYS_INLINE bool isHole(const WriteBarrier<Unknown>& value);
+template<typename T>
+ALWAYS_INLINE bool containsHole(const T* data, unsigned length);
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/runtime/JSArrayInlines.h
+++ b/Source/JavaScriptCore/runtime/JSArrayInlines.h
@@ -335,6 +335,26 @@ ALWAYS_INLINE JSValue getProperty(JSGlobalObject* globalObject, JSObject* object
     return object->getIfPropertyExists(globalObject, index);
 }
 
+ALWAYS_INLINE bool isHole(double value)
+{
+    return std::isnan(value);
+}
+
+ALWAYS_INLINE bool isHole(const WriteBarrier<Unknown>& value)
+{
+    return !value;
+}
+
+template<typename T>
+ALWAYS_INLINE bool containsHole(const T* data, unsigned length)
+{
+    for (unsigned i = 0; i < length; ++i) {
+        if (isHole(data[i]))
+            return true;
+    }
+    return false;
+}
+
 } // namespace JSC
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### 053d9a84ec27095cb583274daaf41ef796c80633
<pre>
[JSC] Implement `Array.prototype.toReversed` in C++
<a href="https://bugs.webkit.org/show_bug.cgi?id=284030">https://bugs.webkit.org/show_bug.cgi?id=284030</a>

Reviewed by Yusuke Suzuki.

This patch implements `Array.prototype.toReversed` in C++ based on the
implementation of `Array.prototype.reverse` and `Array.prototype.slice`

                                            TipOfTree                  Patched

array-prototype-toReversed-string        14.6644+-0.0761     ^      7.8187+-0.3245        ^ definitely 1.8756x faster
array-prototype-toReversed-int32         11.6161+-0.0813     ^      7.5432+-0.2219        ^ definitely 1.5399x faster
array-prototype-toReversed-storage       13.7082+-0.1773     ^      9.2512+-0.5436        ^ definitely 1.4818x faster
array-prototype-toReversed-double        11.7221+-0.1975     ^      6.4701+-0.4021        ^ definitely 1.8117x faster
array-prototype-toReversed-object        15.2418+-1.2822     ^      7.6469+-0.2071        ^ definitely 1.9932x faster

* JSTests/microbenchmarks/array-prototype-toReversed-double.js: Added.
(test):
* JSTests/microbenchmarks/array-prototype-toReversed-int32.js: Added.
(test):
* JSTests/microbenchmarks/array-prototype-toReversed-object.js: Added.
(test):
* JSTests/microbenchmarks/array-prototype-toReversed-storage.js: Added.
(test):
* JSTests/microbenchmarks/array-prototype-toReversed-string.js: Added.
(test):
* JSTests/stress/array-prototype-toReversed-contiguous.js: Added.
(sameArray):
* JSTests/stress/array-prototype-toReversed-double.js: Added.
(sameArray):
* JSTests/stress/array-prototype-toReversed-int32.js: Added.
(sameArray):
* JSTests/stress/array-prototype-toReversed-storage.js: Added.
(sameArray):
* Source/JavaScriptCore/builtins/ArrayPrototype.js:
(toReversed): Deleted.
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::ArrayPrototype::finishCreation):
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::holesMustForwardToPrototype): Deleted.
(JSC::isHole): Deleted.
(JSC::containsHole): Deleted.
* Source/JavaScriptCore/runtime/CommonIdentifiers.h:
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::JSArray::fastToReversed):
* Source/JavaScriptCore/runtime/JSArray.h:
* Source/JavaScriptCore/runtime/JSArrayInlines.h:
(JSC::holesMustForwardToPrototype):
(JSC::isHole):
(JSC::containsHole):

Canonical link: <a href="https://commits.webkit.org/287431@main">https://commits.webkit.org/287431@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f800390deb1d939111554d734d59387335bb919b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79721 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58716 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33111 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84252 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30735 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67794 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7008 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/62308 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/20151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82789 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52361 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72597 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42616 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/49703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26749 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29173 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/72754 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/70839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27214 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85675 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/78845 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6958 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/70563 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7128 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68443 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/69804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17393 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13816 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12726 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/101188 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6912 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/24680 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6781 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10284 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/8584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->