### PR TITLE
Rename AudioSampleBufferCompressor to AudioSampleBufferConverter

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1544,6 +1544,7 @@ platform/audio/Reverb.cpp
 platform/audio/ReverbConvolver.cpp
 platform/audio/cocoa/AudioDestinationCocoa.cpp
 platform/audio/cocoa/AudioFileReaderCocoa.cpp
+platform/audio/cocoa/AudioSampleBufferConverter.mm
 platform/audio/cocoa/AudioSampleDataSource.mm
 platform/audio/cocoa/AudioSessionCocoa.mm
 platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -1677,7 +1678,6 @@ platform/mac/VideoPresentationInterfaceMac.mm
 platform/mediarecorder/MediaRecorderPrivate.h
 platform/mediarecorder/MediaRecorderPrivateAVFImpl.cpp
 platform/mediarecorder/MediaRecorderPrivateMock.cpp
-platform/mediarecorder/cocoa/AudioSampleBufferCompressor.mm
 platform/mediastream/MediaStreamTrackDataHolder.cpp
 platform/mediastream/MediaStreamTrackPrivate.cpp
 platform/mediastream/RealtimeMediaSourceCenter.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -352,6 +352,7 @@ page/scrolling/ThreadedScrollingTree.cpp
 page/scrolling/mac/ScrollingTreeMac.mm
 platform/ScrollView.cpp
 platform/animation/AcceleratedEffect.cpp
+platform/audio/cocoa/AudioSampleBufferConverter.mm
 platform/encryptedmedia/CDMProxy.cpp
 platform/graphics/FontCascadeFonts.cpp
 platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
@@ -361,7 +362,6 @@ platform/graphics/ca/GraphicsLayerCA.cpp
 platform/graphics/cg/GradientCG.cpp
 platform/graphics/cocoa/WebCoreDecompressionSession.mm
 platform/graphics/filters/FilterOperation.cpp
-platform/mediarecorder/cocoa/AudioSampleBufferCompressor.mm
 platform/mediastream/RealtimeVideoCaptureSource.cpp
 platform/mediastream/mac/AVVideoCaptureSource.mm
 platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -268,6 +268,7 @@ platform/audio/cocoa/AudioDestinationCocoa.cpp
 platform/audio/cocoa/AudioFileReaderCocoa.cpp
 platform/audio/cocoa/AudioOutputUnitAdaptor.cpp
 platform/audio/cocoa/AudioSampleBufferList.cpp
+platform/audio/cocoa/AudioSampleBufferConverter.mm
 platform/audio/cocoa/AudioSampleDataConverter.mm
 platform/audio/cocoa/AudioSampleDataSource.mm
 platform/audio/cocoa/AudioUtilitiesCocoa.cpp
@@ -630,7 +631,6 @@ platform/mac/WebPlaybackControlsManager.mm
 platform/mac/WidgetMac.mm
 platform/mediarecorder/MediaRecorderPrivateAVFImpl.cpp
 platform/mediarecorder/MediaRecorderPrivateEncoder.cpp
-platform/mediarecorder/cocoa/AudioSampleBufferCompressor.mm
 platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.mm
 platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.cpp
 platform/mediastream/cocoa/AudioMediaStreamTrackRendererCocoa.cpp

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h
@@ -45,7 +45,7 @@ typedef struct opaqueCMBufferQueueTriggerToken *CMBufferQueueTriggerToken;
 
 namespace WebCore {
 
-class AudioSampleBufferCompressor;
+class AudioSampleBufferConverter;
 class InProcessCARingBuffer;
 class FragmentedSharedBuffer;
 struct MediaRecorderPrivateOptions;
@@ -104,7 +104,7 @@ private:
 
     void audioSamplesDescriptionChanged(const AudioStreamBasicDescription&);
     void audioSamplesAvailable(const MediaTime&, size_t, size_t);
-    RefPtr<AudioSampleBufferCompressor> audioCompressor() const;
+    RefPtr<AudioSampleBufferConverter> audioConverter() const;
     void enqueueCompressedAudioSampleBuffers();
 
     void appendVideoFrame(const MediaTime&, Ref<VideoFrame>&&);
@@ -145,7 +145,7 @@ private:
     std::optional<uint8_t> m_audioTrackIndex WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     RetainPtr<CMFormatDescriptionRef> m_audioFormatDescription WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     RetainPtr<CMFormatDescriptionRef> m_audioCompressedFormatDescription WTF_GUARDED_BY_CAPABILITY(queueSingleton());
-    RefPtr<AudioSampleBufferCompressor> m_audioCompressor WTF_GUARDED_BY_CAPABILITY(queueSingleton());
+    RefPtr<AudioSampleBufferConverter> m_audioConverter WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     bool m_formatChangedOccurred WTF_GUARDED_BY_CAPABILITY(queueSingleton()) { false };
     std::optional<AudioStreamBasicDescription> m_originalOutputDescription WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     Deque<Ref<MediaSample>> m_encodedAudioFrames WTF_GUARDED_BY_CAPABILITY(queueSingleton());

--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.mm
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.mm
@@ -36,6 +36,7 @@
 #import <pal/spi/cocoa/AVAssetWriterSPI.h>
 #import <wtf/BlockObjCExceptions.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/NativePromise.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/cocoa/SpanCocoa.h>
 


### PR DESCRIPTION
#### dd7be7cc4f5081536c5972699c0c80f9a6f17566
<pre>
Rename AudioSampleBufferCompressor to AudioSampleBufferConverter
<a href="https://bugs.webkit.org/show_bug.cgi?id=284024">https://bugs.webkit.org/show_bug.cgi?id=284024</a>
<a href="https://rdar.apple.com/140898346">rdar://140898346</a>

Reviewed by Youenn Fablet.

Rename file and move it to WebCore/platforms/audio/cocoa as it will no longer
be used just with MediaRecorder

No observable change.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/audio/cocoa/AudioSampleBufferConverter.h: Renamed from Source/WebCore/platform/mediarecorder/cocoa/AudioSampleBufferCompressor.h.
(WebCore::AudioSampleBufferConverter::finish):
(WebCore::AudioSampleBufferConverter::flush):
(WebCore::AudioSampleBufferConverter::queue const):
(WebCore::AudioSampleBufferConverter::WTF_GUARDED_BY_CAPABILITY):
* Source/WebCore/platform/audio/cocoa/AudioSampleBufferConverter.mm: Renamed from Source/WebCore/platform/mediarecorder/cocoa/AudioSampleBufferCompressor.mm.
(WebCore::AudioSampleBufferConverter::create):
(WebCore::AudioSampleBufferConverter::AudioSampleBufferConverter):
(WebCore::m_generateTimestamp):
(WebCore::AudioSampleBufferConverter::~AudioSampleBufferConverter):
(WebCore::AudioSampleBufferConverter::initialize):
(WebCore::AudioSampleBufferConverter::drain):
(WebCore::AudioSampleBufferConverter::flushInternal):
(WebCore::AudioSampleBufferConverter::defaultOutputBitRate const):
(WebCore::AudioSampleBufferConverter::initAudioConverterForSourceFormatDescription):
(WebCore::AudioSampleBufferConverter::attachPrimingTrimsIfNeeded):
(WebCore::AudioSampleBufferConverter::gradualDecoderRefreshCount):
(WebCore::AudioSampleBufferConverter::sampleBuffer):
(WebCore::AudioSampleBufferConverter::audioConverterComplexInputDataProc):
(WebCore::AudioSampleBufferConverter::provideSourceDataNumOutputPackets):
(WebCore::AudioSampleBufferConverter::isPCM const):
(WebCore::AudioSampleBufferConverter::setTimeFromSample):
(WebCore::AudioSampleBufferConverter::processSampleBuffers):
(WebCore::AudioSampleBufferConverter::processSampleBuffer):
(WebCore::AudioSampleBufferConverter::addSampleBuffer):
(WebCore::AudioSampleBufferConverter::getOutputSampleBuffer const):
(WebCore::AudioSampleBufferConverter::takeOutputSampleBuffer):
(WebCore::AudioSampleBufferConverter::bitRate const):
(WebCore::AudioSampleBufferConverter::isEmpty const):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp:
(WebCore::MediaRecorderPrivateEncoder::audioSamplesDescriptionChanged):
(WebCore::MediaRecorderPrivateEncoder::audioSamplesAvailable):
(WebCore::MediaRecorderPrivateEncoder::enqueueCompressedAudioSampleBuffers):
(WebCore::MediaRecorderPrivateEncoder::waitForMatchingAudio):
(WebCore::MediaRecorderPrivateEncoder::stopRecording):
(WebCore::MediaRecorderPrivateEncoder::flushPendingData):
(WebCore::MediaRecorderPrivateEncoder::audioConverter const):
(WebCore::MediaRecorderPrivateEncoder::audioCompressor const): Deleted.
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h:

Canonical link: <a href="https://commits.webkit.org/287382@main">https://commits.webkit.org/287382@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23347a9e960b2c67d02d77ea8c7445f5b4e2530e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79387 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58414 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32761 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83994 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30520 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81520 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67477 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6675 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62093 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19973 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82454 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52147 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72328 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42402 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/49542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26514 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28924 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/70608 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26962 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85400 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6660 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4643 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70343 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6825 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68204 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69590 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/17361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13637 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12504 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6612 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6527 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10001 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8328 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->