### PR TITLE
[IFC][SVG text] Layout and paint using IFC

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7773,6 +7773,19 @@ UseGiantTiles:
     WebCore:
       default: false
 
+UseIFCForSVGText:
+  type: bool
+  status: internal
+  humanReadableName: "Use IFC for SVG text"
+  humanReadableDescription: "Use IFC for SVG text rendering"
+  defaultValue:
+    WebCore:
+      default: false
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+
 UseImageDocumentForSubframePDF:
   type: bool
   status: embedder

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2586,6 +2586,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     rendering/svg/legacy/LegacyRenderSVGModelObject.h
     rendering/svg/RenderSVGModelObject.h
     rendering/svg/SVGBoundingBoxComputation.h
+    rendering/svg/SVGInlineTextBox.h
     rendering/svg/SVGRenderSupport.h
 
     storage/Storage.h

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
@@ -424,6 +424,11 @@ Layout::ConstraintsForInlineContent BoxGeometryUpdater::formattingContextConstra
     auto& rootRenderer = this->rootRenderer();
     auto writingMode = this->writingMode();
 
+    if (rootRenderer.isRenderSVGText()) {
+        auto horizontalConstraints = Layout::HorizontalConstraints { 0_lu, LayoutUnit::max() };
+        return { { horizontalConstraints, 0_lu }, 0_lu };
+    }
+
     auto padding = logicalPadding(rootRenderer, availableWidth, writingMode);
     auto border = logicalBorder(rootRenderer, writingMode);
     if (writingMode.isVertical() && !writingMode.isBlockFlipped()) {

--- a/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
@@ -286,7 +286,9 @@ static void printLegacyFlexReasons()
 
 bool canUseForLineLayout(const RenderBlockFlow& rootContainer)
 {
-    return !is<RenderSVGBlock>(rootContainer) || rootContainer.isRenderOrLegacyRenderSVGForeignObject();
+    if (is<RenderSVGBlock>(rootContainer) && !rootContainer.isRenderOrLegacyRenderSVGForeignObject())
+        return rootContainer.document().settings().useIFCForSVGText();
+    return true;
 }
 
 bool canUseForPreferredWidthComputation(const RenderBlockFlow& blockContainer)

--- a/Source/WebCore/layout/integration/inline/InlineIteratorBoxLegacyPath.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorBoxLegacyPath.h
@@ -28,6 +28,7 @@
 #include "LegacyInlineTextBox.h"
 #include "LegacyRootInlineBox.h"
 #include "RenderText.h"
+#include "SVGInlineTextBox.h"
 #include "TextBoxSelectableRange.h"
 #include <wtf/Vector.h>
 
@@ -170,9 +171,15 @@ public:
         m_inlineBox = parent ? parent->nextOnLine() : nullptr;
     }
 
+    const Vector<SVGTextFragment>& svgTextFragments() const
+    {
+        return svgInlineTextBox()->textFragments();
+    }
+
 private:
     const LegacyInlineTextBox* inlineTextBox() const { return downcast<LegacyInlineTextBox>(m_inlineBox); }
     const LegacyInlineFlowBox* inlineFlowBox() const { return downcast<LegacyInlineFlowBox>(m_inlineBox); }
+    const SVGInlineTextBox* svgInlineTextBox() const { return downcast<SVGInlineTextBox>(m_inlineBox); }
 
     const LegacyInlineBox* m_inlineBox { nullptr };
 };

--- a/Source/WebCore/layout/integration/inline/InlineIteratorSVGTextBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorSVGTextBox.h
@@ -68,6 +68,7 @@ private:
 SVGTextBoxIterator firstSVGTextBoxFor(const RenderSVGInlineText&);
 BoxRange<SVGTextBoxIterator> svgTextBoxesFor(const RenderSVGInlineText&);
 SVGTextBoxIterator svgTextBoxFor(const SVGInlineTextBox*);
+SVGTextBoxIterator svgTextBoxFor(const LayoutIntegration::InlineContent&, size_t boxIndex);
 
 BoxRange<BoxIterator> boxesFor(const RenderSVGText&);
 

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.cpp
@@ -169,6 +169,12 @@ const Vector<size_t>& InlineContent::nonRootInlineBoxIndexesForLayoutBox(const L
     return it->value;
 }
 
+const Vector<SVGTextFragment>& InlineContent::svgTextFragments(size_t index) const
+{
+    RELEASE_ASSERT(m_svgTextFragmentsForBoxes.size() > index);
+    return m_svgTextFragmentsForBoxes[index];
+}
+
 void InlineContent::releaseCaches()
 {
     m_firstBoxIndexCache = { };

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h
@@ -47,6 +47,7 @@ namespace WebCore {
 
 class RenderBlockFlow;
 class RenderObject;
+struct SVGTextFragment;
 
 namespace Layout {
 class Box;
@@ -98,6 +99,9 @@ struct InlineContent : public CanMakeWeakPtr<InlineContent> {
     std::optional<size_t> firstBoxIndexForLayoutBox(const Layout::Box&) const;
     const Vector<size_t>& nonRootInlineBoxIndexesForLayoutBox(const Layout::Box&) const;
 
+    const Vector<SVGTextFragment>& svgTextFragments(size_t boxIndex) const;
+    Vector<Vector<SVGTextFragment>>& svgTextFragmentsForBoxes() { return m_svgTextFragmentsForBoxes; }
+
     void releaseCaches();
 
 private:
@@ -110,6 +114,8 @@ private:
     using InlineBoxIndexCache = UncheckedKeyHashMap<CheckedRef<const Layout::Box>, Vector<size_t>>;
     mutable std::unique_ptr<InlineBoxIndexCache> m_inlineBoxIndexCache;
     bool m_hasVisualOverflow { false };
+
+    Vector<Vector<SVGTextFragment>> m_svgTextFragmentsForBoxes;
 };
 
 template<typename Function> void InlineContent::traverseNonRootInlineBoxes(const Layout::Box& layoutBox, Function&& function)

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -667,6 +667,26 @@ void LineLayout::updateRenderTreePositions(const Vector<LineAdjustment>& lineAdj
     }
 }
 
+void LineLayout::applySVGTextFragments(SVGTextFragmentMap&& fragmentMap)
+{
+    auto& boxes = m_inlineContent->displayContent().boxes;
+    auto& fragments = m_inlineContent->svgTextFragmentsForBoxes();
+    fragments.resize(m_inlineContent->displayContent().boxes.size());
+
+    for (size_t i = 0; i < boxes.size(); ++i) {
+        auto textBox = InlineIterator::svgTextBoxFor(*m_inlineContent, i);
+        if (!textBox)
+            continue;
+
+        auto it = fragmentMap.find(makeKey(*textBox));
+        if (it != fragmentMap.end())
+            fragments[i] = WTFMove(it->value);
+
+        auto boundaries = textBox->calculateBoundariesIncludingSVGTransform();
+        boxes[i].setRect(boundaries, boundaries);
+    }
+}
+
 void LineLayout::preparePlacedFloats()
 {
     auto& placedFloats = m_blockFormattingState.placedFloats();

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h
@@ -37,6 +37,7 @@
 #include "LayoutPoint.h"
 #include "LayoutState.h"
 #include "RenderObjectEnums.h"
+#include "SVGTextChunk.h"
 #include <wtf/CheckedPtr.h>
 
 namespace WebCore {
@@ -137,6 +138,8 @@ public:
 #ifndef NDEBUG
     bool hasDetachedContent() const { return m_lineDamage && m_lineDamage->hasDetachedContent(); }
 #endif
+
+    void applySVGTextFragments(SVGTextFragmentMap&&);
 
 private:
     void preparePlacedFloats();

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -462,10 +462,23 @@ void RenderSVGText::computePerCharacterLayoutInformation()
     // Perform SVG text layout phase three (see SVGTextChunkBuilder for details).
     auto fragmentMap = characterLayout.finishLayout();
 
-    // Perform SVG text layout phase four
-    // Position & resize all SVGInlineText/FlowBoxes in the inline box tree, resize the root box as well as the RenderSVGText parent block.
-    auto childRect = layoutChildBoxes(legacyRootBox(), fragmentMap);
-    layoutRootBox(childRect);
+    if (legacyRootBox()) {
+        // Perform SVG text layout phase four
+        // Position & resize all SVGInlineText/FlowBoxes in the inline box tree, resize the root box as well as the RenderSVGText parent block.
+        auto childRect = layoutChildBoxes(legacyRootBox(), fragmentMap);
+        layoutRootBox(childRect);
+        return;
+    }
+
+    if (inlineLayout()) {
+        inlineLayout()->applySVGTextFragments(WTFMove(fragmentMap));
+
+        FloatRect childRect;
+        for (auto& box : InlineIterator::boxesFor(*this))
+            childRect.unite(box.visualRectIgnoringBlockDirection());
+
+        updatePositionAndOverflow(childRect);
+    }
 }
 
 void RenderSVGText::layoutCharactersInTextBoxes(const InlineIterator::InlineBoxIterator& parent, SVGTextLayoutEngine& characterLayout)
@@ -862,6 +875,9 @@ void RenderSVGText::paintInlineChildren(PaintInfo& paintInfo, const LayoutPoint&
                 if (textBox->legacyInlineBox()) {
                     LegacySVGTextBoxPainter painter(*textBox->legacyInlineBox(), paintInfo, paintOffset);
                     painter.paintSelectionBackground();
+                } else {
+                    ModernSVGTextBoxPainter painter(textBox->modernPath().inlineContent(), textBox->modernPath().boxIndex(), paintInfo, paintOffset);
+                    painter.paintSelectionBackground();
                 }
             }
         }
@@ -876,6 +892,9 @@ void RenderSVGText::paintInlineChildren(PaintInfo& paintInfo, const LayoutPoint&
         if (auto* textBox = dynamicDowncast<InlineIterator::SVGTextBox>(*box)) {
             if (textBox->legacyInlineBox()) {
                 LegacySVGTextBoxPainter painter(*textBox->legacyInlineBox(), paintInfo, paintOffset);
+                painter.paint();
+            } else {
+                ModernSVGTextBoxPainter painter(textBox->modernPath().inlineContent(), textBox->modernPath().boxIndex(), paintInfo, paintOffset);
                 painter.paint();
             }
         } else {

--- a/Source/WebCore/rendering/svg/SVGInlineTextBox.cpp
+++ b/Source/WebCore/rendering/svg/SVGInlineTextBox.cpp
@@ -43,6 +43,7 @@
 #include "SVGRenderingContext.h"
 #include "SVGResourcesCache.h"
 #include "SVGRootInlineBox.h"
+#include "SVGTextFragment.h"
 #include "TextBoxSelectableRange.h"
 #include <wtf/TZoneMallocInlines.h>
 
@@ -213,6 +214,11 @@ FloatRect SVGInlineTextBox::calculateBoundaries() const
     }
 
     return textRect;
+}
+
+void SVGInlineTextBox::setTextFragments(Vector<SVGTextFragment>&& fragments)
+{
+    m_textFragments = WTFMove(fragments);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/SVGInlineTextBox.h
+++ b/Source/WebCore/rendering/svg/SVGInlineTextBox.h
@@ -23,14 +23,12 @@
 #pragma once
 
 #include "LegacyInlineTextBox.h"
-#include "LegacyRenderSVGResource.h"
-#include "SVGTextFragment.h"
 
 namespace WebCore {
 
-class LegacyRenderSVGResource;
 class RenderSVGInlineText;
 class SVGRootInlineBox;
+struct SVGTextFragment;
 
 class SVGInlineTextBox final : public LegacyInlineTextBox {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(SVGInlineTextBox);
@@ -49,7 +47,7 @@ public:
     FloatRect calculateBoundaries() const;
 
     const Vector<SVGTextFragment>& textFragments() const { return m_textFragments; }
-    void setTextFragments(Vector<SVGTextFragment>&& fragments) { m_textFragments = WTFMove(fragments); }
+    void setTextFragments(Vector<SVGTextFragment>&&);
 
     void dirtyOwnLineBoxes() override;
     void dirtyLineBoxes() override;

--- a/Source/WebCore/rendering/svg/SVGTextBoxPainter.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextBoxPainter.cpp
@@ -46,6 +46,13 @@ LegacySVGTextBoxPainter::LegacySVGTextBoxPainter(const SVGInlineTextBox& textBox
 {
 }
 
+
+ModernSVGTextBoxPainter::ModernSVGTextBoxPainter(const LayoutIntegration::InlineContent& inlineContent, size_t boxIndex, PaintInfo& paintInfo, const LayoutPoint& paintOffset)
+    : SVGTextBoxPainter(InlineIterator::BoxModernPath { inlineContent, boxIndex }, paintInfo, paintOffset)
+{
+}
+
+
 template<typename TextBoxPath>
 SVGTextBoxPainter<TextBoxPath>::SVGTextBoxPainter(TextBoxPath&& textBox, PaintInfo& paintInfo, const LayoutPoint& paintOffset)
     : m_textBox(WTFMove(textBox))

--- a/Source/WebCore/rendering/svg/SVGTextBoxPainter.h
+++ b/Source/WebCore/rendering/svg/SVGTextBoxPainter.h
@@ -86,4 +86,9 @@ public:
     LegacySVGTextBoxPainter(const SVGInlineTextBox&, PaintInfo&, const LayoutPoint& paintOffset);
 };
 
+class ModernSVGTextBoxPainter : public SVGTextBoxPainter<InlineIterator::BoxModernPath> {
+public:
+    ModernSVGTextBoxPainter(const LayoutIntegration::InlineContent&, size_t boxIndex, PaintInfo&, const LayoutPoint& paintOffset);
+};
+
 }


### PR DESCRIPTION
#### d451c7bd69057a86cd6e4bd733ac94fc215ed915
<pre>
[IFC][SVG text] Layout and paint using IFC
<a href="https://bugs.webkit.org/show_bug.cgi?id=284031">https://bugs.webkit.org/show_bug.cgi?id=284031</a>
<a href="https://rdar.apple.com/140907758">rdar://140907758</a>

Reviewed by Alan Baradlay.

Also add a setting. It is not enabled yet.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp:
(WebCore::LayoutIntegration::BoxGeometryUpdater::formattingContextConstraints):

No horizontal constraint, everything is on a single line.

* Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp:
(WebCore::LayoutIntegration::canUseForLineLayout):
* Source/WebCore/layout/integration/inline/InlineIteratorBoxLegacyPath.h:
(WebCore::InlineIterator::BoxLegacyPath::svgTextFragments const):
(WebCore::InlineIterator::BoxLegacyPath::svgInlineTextBox const):
* Source/WebCore/layout/integration/inline/InlineIteratorBoxModernPath.h:
(WebCore::InlineIterator::BoxModernPath::traverseNextBoxOnLineSkippingChildren):
(WebCore::InlineIterator::BoxModernPath::svgTextFragments const):
(WebCore::InlineIterator::BoxModernPath::boxIndex const):
(WebCore::InlineIterator::BoxModernPath::isWithinInlineBox):

Root inline boxes have the block box as a layout box. Only bail after testing.

* Source/WebCore/layout/integration/inline/InlineIteratorSVGTextBox.cpp:
(WebCore::InlineIterator::SVGTextBox::calculateBoundariesIncludingSVGTransform const):

Copy from the legacy inline box.

(WebCore::InlineIterator::SVGTextBox::textFragments const):
(WebCore::InlineIterator::svgTextBoxFor):
* Source/WebCore/layout/integration/inline/InlineIteratorSVGTextBox.h:

Save SVG text fragments per-box to a vector in InlineContent.

* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::applySVGTextFragments):

Apply the computed fragments to InlineContent.

* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h:
* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::RenderSVGText::computePerCharacterLayoutInformation):

Apply the fragments and compute box position and size after layout.

(WebCore::RenderSVGText::paintInlineChildren):

Paint IFC boxes with the painter.

* Source/WebCore/rendering/svg/SVGInlineTextBox.cpp:
(WebCore::SVGInlineTextBox::setTextFragments):
* Source/WebCore/rendering/svg/SVGInlineTextBox.h:
* Source/WebCore/rendering/svg/SVGTextBoxPainter.cpp:
(WebCore::ModernSVGTextBoxPainter::ModernSVGTextBoxPainter):
* Source/WebCore/rendering/svg/SVGTextBoxPainter.h:

Canonical link: <a href="https://commits.webkit.org/287350@main">https://commits.webkit.org/287350@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abb110d5d28b566b546954d04a5f980644359f18

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79292 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58321 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32664 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83916 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30457 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81425 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67411 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6591 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/62030 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19933 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82359 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52096 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/72252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42337 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49440 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/26427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28848 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/72402 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/70552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26867 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85309 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/78501 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6590 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70279 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6754 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68124 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69526 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17325 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13579 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/12434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/100828 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/6546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/24600 "Found 2 new JSC stress test failures: wasm.yaml/wasm/stress/struct-new_default-small-members.js.default-wasm, wasm.yaml/wasm/stress/struct-new_default-small-members.js.wasm-collect-continuously (failure)") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/6466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9935 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8260 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->