### PR TITLE
UnifiedPDF: Add support for multithreaded paint with WebKit tiling

### DIFF
--- a/Source/WTF/wtf/WorkQueue.cpp
+++ b/Source/WTF/wtf/WorkQueue.cpp
@@ -40,21 +40,6 @@
 
 namespace WTF {
 
-WorkQueueBase::WorkQueueBase(ASCIILiteral name, Type type, QOS qos)
-{
-    platformInitialize(name, type, qos);
-}
-
-WorkQueueBase::~WorkQueueBase()
-{
-    platformInvalidate();
-}
-
-Ref<ConcurrentWorkQueue> ConcurrentWorkQueue::create(ASCIILiteral name, QOS qos)
-{
-    return adoptRef(*new ConcurrentWorkQueue(name, qos));
-}
-
 void ConcurrentWorkQueue::dispatch(Function<void()>&& function)
 {
     WorkQueueBase::dispatch(WTFMove(function));
@@ -183,16 +168,6 @@ WorkQueue& WorkQueue::main()
     return *mainWorkQueue.get();
 }
 
-Ref<WorkQueue> WorkQueue::create(ASCIILiteral name, QOS qos)
-{
-    return adoptRef(*new WorkQueue(name, qos));
-}
-
-WorkQueue::WorkQueue(ASCIILiteral name, QOS qos)
-    : WorkQueueBase(name, Type::Serial, qos)
-{
-}
-
 void WorkQueue::dispatch(Function<void()>&& function)
 {
     WorkQueueBase::dispatch(WTFMove(function));
@@ -201,11 +176,6 @@ void WorkQueue::dispatch(Function<void()>&& function)
 bool WorkQueue::isCurrent() const
 {
     return currentSequence() == m_threadID;
-}
-
-ConcurrentWorkQueue::ConcurrentWorkQueue(ASCIILiteral name, QOS qos)
-    : WorkQueueBase(name, Type::Concurrent, qos)
-{
 }
 
 }

--- a/Source/WebCore/platform/graphics/GraphicsLayerClient.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayerClient.h
@@ -142,6 +142,8 @@ public:
 
     virtual bool layerNeedsPlatformContext(const GraphicsLayer*) const { return false; }
 
+    virtual bool layerSupportsConcurrentPaintContents(const GraphicsLayer*) const { return false; }
+
 #ifndef NDEBUG
     // RenderLayerBacking overrides this to verify that it is not
     // currently painting contents. An ASSERT fails, if it is.

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -2042,6 +2042,11 @@ bool GraphicsLayerCA::platformCALayerNeedsPlatformContext(const PlatformCALayer*
     return client().layerNeedsPlatformContext(this);
 }
 
+bool GraphicsLayerCA::platformCALayerSupportsConcurrentPaintContents(const PlatformCALayer*) const
+{
+    return client().layerSupportsConcurrentPaintContents(this);
+}
+
 void GraphicsLayerCA::commitLayerTypeChangesBeforeSublayers(CommitState&, float pageScaleFactor, bool& layerTypeChanged)
 {
     SetForScope committingChangesChange(m_isCommittingChanges, true);

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -251,6 +251,7 @@ private:
     WEBCORE_EXPORT bool platformCALayerCSSUnprefixedBackdropFilterEnabled() const override;
     WEBCORE_EXPORT void platformCALayerLogFilledVisibleFreshTile(unsigned) override;
     WEBCORE_EXPORT bool platformCALayerNeedsPlatformContext(const PlatformCALayer*) const override;
+    WEBCORE_EXPORT bool platformCALayerSupportsConcurrentPaintContents(const PlatformCALayer*) const override;
     bool platformCALayerContainsBitmapOnly(const PlatformCALayer*) const override { return client().layerContainsBitmapOnly(this); }
     bool platformCALayerShouldPaintUsingCompositeCopy() const override { return shouldPaintUsingCompositeCopy(); }
 

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.mm
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.mm
@@ -69,6 +69,9 @@ bool PlatformCALayer::canHaveBackingStore() const
 
 void PlatformCALayer::drawRepaintIndicator(GraphicsContext& graphicsContext, PlatformCALayer* platformCALayer, int repaintCount, Color customBackgroundColor)
 {
+    // Currently font system does not support work queues.
+    if (platformCALayer->owner()->platformCALayerSupportsConcurrentPaintContents(platformCALayer))
+        return;
     const float verticalMargin = 2.5;
     const float horizontalMargin = 5;
     const unsigned fontSize = 22;

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayerClient.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayerClient.h
@@ -45,6 +45,7 @@ public:
     virtual void platformCALayerAnimationStarted(const String& /*animationKey*/, MonotonicTime) { }
     virtual void platformCALayerAnimationEnded(const String& /*animationKey*/) { }
     virtual GraphicsLayer::CompositingCoordinatesOrientation platformCALayerContentsOrientation() const { return GraphicsLayer::CompositingCoordinatesOrientation::TopDown; }
+    virtual bool platformCALayerSupportsConcurrentPaintContents(const PlatformCALayer*) const { return false; }
     virtual void platformCALayerPaintContents(PlatformCALayer*, GraphicsContext&, const FloatRect& inClip, OptionSet<GraphicsLayerPaintBehavior>) = 0;
     virtual bool platformCALayerShowDebugBorders() const { return false; }
     virtual bool platformCALayerShowRepaintCounter(PlatformCALayer*) const { return false; }

--- a/Source/WebCore/platform/graphics/ca/TileGrid.h
+++ b/Source/WebCore/platform/graphics/ca/TileGrid.h
@@ -146,6 +146,7 @@ private:
 
     // PlatformCALayerClient
     PlatformLayerIdentifier platformCALayerIdentifier() const override;
+    bool platformCALayerSupportsConcurrentPaintContents(const PlatformCALayer*) const override;
     void platformCALayerPaintContents(PlatformCALayer*, GraphicsContext&, const FloatRect&, OptionSet<GraphicsLayerPaintBehavior>) override;
     bool platformCALayerShowDebugBorders() const override;
     bool platformCALayerShowRepaintCounter(PlatformCALayer*) const override;
@@ -156,6 +157,7 @@ private:
     float platformCALayerDeviceScaleFactor() const override;
     bool isUsingDisplayListDrawing(PlatformCALayer*) const override;
     bool platformCALayerNeedsPlatformContext(const PlatformCALayer*) const override;
+    void platformCALayerLayerDidDisplay(PlatformCALayer*) override;
 
     TileGridIdentifier m_identifier;
     CheckedRef<TileController> m_controller;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
@@ -129,11 +129,11 @@ public:
 
     bool performDelegatedLayerDisplay();
 
-    void paintContents();
     virtual void prepareToDisplay() = 0;
-    virtual void createContextAndPaintContents() = 0;
+    void paintContents();
+    void flushContents();
+    virtual void clearBackingStore() = 0;
 
-    virtual std::unique_ptr<ThreadSafeImageBufferSetFlusher> createFlusher(ThreadSafeImageBufferSetFlusher::FlushType = ThreadSafeImageBufferSetFlusher::FlushType::BackendHandlesAndDrawing) = 0;
 
     WebCore::FloatSize size() const { return m_parameters.size; }
     float scale() const { return m_parameters.scale; }
@@ -170,8 +170,6 @@ public:
 
     MonotonicTime lastDisplayTime() const { return m_lastDisplayTime; }
 
-    virtual void clearBackingStore() = 0;
-
     virtual std::optional<ImageBufferBackendHandle> frontBufferHandle() const = 0;
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
     virtual std::optional<ImageBufferBackendHandle> displayListHandle() const  { return std::nullopt; }
@@ -185,9 +183,12 @@ public:
     void markFrontBufferVolatileForTesting();
 
 protected:
+    virtual WebCore::GraphicsContext* contextForPaintContents() = 0;
+    virtual std::unique_ptr<ThreadSafeImageBufferSetFlusher> flushContextForPaintContents(ThreadSafeImageBufferSetFlusher::FlushType = ThreadSafeImageBufferSetFlusher::FlushType::BackendHandlesAndDrawing) = 0;
+
     RemoteLayerBackingStoreCollection* backingStoreCollection() const;
 
-    void drawInContext(WebCore::GraphicsContext&);
+    void drawInContext(PlatformCALayerRemote&, WebCore::GraphicsContext&, OptionSet<WebCore::GraphicsLayerPaintBehavior>);
 
     void dirtyRepaintCounterIfNecessary();
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h
@@ -74,8 +74,9 @@ public:
     bool backingStoreWillBeDisplayedWithRenderingSuppression(RemoteLayerBackingStore&);
     void backingStoreBecameUnreachable(RemoteLayerBackingStore&);
 
-    virtual void prepareBackingStoresForDisplay(RemoteLayerTreeTransaction&);
-    virtual bool paintReachableBackingStoreContents();
+    void prepareBackingStoresForDisplay(RemoteLayerTreeTransaction&);
+    bool paintReachableBackingStores();
+    void flushReachableBackingStores();
 
     void willFlushLayers();
     void willBuildTransaction();

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
@@ -117,7 +117,7 @@ void RemoteLayerBackingStoreCollection::prepareBackingStoresForDisplay(RemoteLay
     }
 }
 
-bool RemoteLayerBackingStoreCollection::paintReachableBackingStoreContents()
+bool RemoteLayerBackingStoreCollection::paintReachableBackingStores()
 {
     bool anyNonEmptyDirtyRegion = false;
     for (auto& backingStore : m_backingStoresNeedingDisplay) {
@@ -126,6 +126,12 @@ bool RemoteLayerBackingStoreCollection::paintReachableBackingStoreContents()
         backingStore.paintContents();
     }
     return anyNonEmptyDirtyRegion;
+}
+
+void RemoteLayerBackingStoreCollection::flushReachableBackingStores()
+{
+    for (auto& backingStore : m_backingStoresNeedingDisplay)
+        backingStore.flushContents();
 }
 
 void RemoteLayerBackingStoreCollection::willFlushLayers()

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.h
@@ -42,8 +42,6 @@ public:
     ProcessModel processModel() const final { return ProcessModel::InProcess; }
 
     void prepareToDisplay() final;
-    void createContextAndPaintContents() final;
-    std::unique_ptr<ThreadSafeImageBufferSetFlusher> createFlusher(ThreadSafeImageBufferSetFlusher::FlushType) final;
 
     void clearBackingStore() final;
 
@@ -62,6 +60,8 @@ private:
     void ensureFrontBuffer();
     bool hasFrontBuffer() const final;
     bool frontBufferMayBeVolatile() const final;
+    WebCore::GraphicsContext* contextForPaintContents() final;
+    std::unique_ptr<ThreadSafeImageBufferSetFlusher> flushContextForPaintContents(ThreadSafeImageBufferSetFlusher::FlushType) final;
 
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
     WebCore::DynamicContentScalingResourceCache ensureDynamicContentScalingResourceCache();

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
@@ -101,11 +101,11 @@ DynamicContentScalingResourceCache RemoteLayerWithInProcessRenderingBackingStore
 }
 #endif
 
-void RemoteLayerWithInProcessRenderingBackingStore::createContextAndPaintContents()
+GraphicsContext* RemoteLayerWithInProcessRenderingBackingStore::contextForPaintContents()
 {
     if (!m_bufferSet.m_frontBuffer) {
-        ASSERT(m_layer->owner()->platformCALayerDelegatesDisplay(m_layer.ptr()));
-        return;
+        ASSERT_NOT_REACHED();
+        return nullptr;
     }
 
     GraphicsContext& context = m_bufferSet.m_frontBuffer->context();
@@ -113,7 +113,7 @@ void RemoteLayerWithInProcessRenderingBackingStore::createContextAndPaintContent
     WebCore::FloatRect layerBounds { { }, m_parameters.size };
 
     m_bufferSet.prepareBufferForDisplay(layerBounds, m_dirtyRegion, m_paintingRects, drawingRequiresClearedPixels());
-    drawInContext(m_bufferSet.m_frontBuffer->context());
+    return &m_bufferSet.m_frontBuffer->context();
 }
 
 class ImageBufferBackingStoreFlusher final : public ThreadSafeImageBufferSetFlusher {
@@ -139,7 +139,7 @@ private:
     std::unique_ptr<WebCore::ThreadSafeImageBufferFlusher> m_imageBufferFlusher;
 };
 
-std::unique_ptr<ThreadSafeImageBufferSetFlusher> RemoteLayerWithInProcessRenderingBackingStore::createFlusher(ThreadSafeImageBufferSetFlusher::FlushType flushType)
+std::unique_ptr<ThreadSafeImageBufferSetFlusher> RemoteLayerWithInProcessRenderingBackingStore::flushContextForPaintContents(ThreadSafeImageBufferSetFlusher::FlushType flushType)
 {
     if (flushType == ThreadSafeImageBufferSetFlusher::FlushType::BackendHandlesOnly)
         return nullptr;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.h
@@ -45,11 +45,9 @@ public:
 
     void prepareToDisplay() final;
     void clearBackingStore() final;
-    void createContextAndPaintContents() final;
 
     RefPtr<RemoteImageBufferSetProxy> protectedBufferSet() { return m_bufferSet; }
 
-    std::unique_ptr<ThreadSafeImageBufferSetFlusher> createFlusher(ThreadSafeImageBufferSetFlusher::FlushType) final;
     std::optional<ImageBufferBackendHandle> frontBufferHandle() const final { return std::exchange(const_cast<RemoteLayerWithRemoteRenderingBackingStore*>(this)->m_backendHandle, std::nullopt); }
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
     std::optional<ImageBufferBackendHandle> displayListHandle() const final;
@@ -72,6 +70,9 @@ public:
 
     void dump(WTF::TextStream&) const final;
 private:
+    WebCore::GraphicsContext* contextForPaintContents() final;
+    std::unique_ptr<ThreadSafeImageBufferSetFlusher> flushContextForPaintContents(ThreadSafeImageBufferSetFlusher::FlushType) final;
+
     RefPtr<RemoteImageBufferSetProxy> m_bufferSet;
     BufferIdentifierSet m_bufferCacheIdentifiers;
     std::optional<ImageBufferBackendHandle> m_backendHandle;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
@@ -82,26 +82,26 @@ void RemoteLayerWithRemoteRenderingBackingStore::clearBackingStore()
     m_cleared = true;
 }
 
-std::unique_ptr<ThreadSafeImageBufferSetFlusher> RemoteLayerWithRemoteRenderingBackingStore::createFlusher(ThreadSafeImageBufferSetFlusher::FlushType flushType)
+std::unique_ptr<ThreadSafeImageBufferSetFlusher> RemoteLayerWithRemoteRenderingBackingStore::flushContextForPaintContents(ThreadSafeImageBufferSetFlusher::FlushType flushType)
 {
     if (!m_bufferSet)
         return { };
     return m_bufferSet->flushFrontBufferAsync(flushType);
 }
 
-void RemoteLayerWithRemoteRenderingBackingStore::createContextAndPaintContents()
+GraphicsContext* RemoteLayerWithRemoteRenderingBackingStore::contextForPaintContents()
 {
     auto bufferSet = protectedBufferSet();
     if (!bufferSet)
-        return;
+        return nullptr;
 
     if (!bufferSet->hasContext()) {
         // The platform layer delegates display or bufferSet does not have a working connection to GPUP anymore.
-        return;
+        return nullptr;
     }
 
-    drawInContext(bufferSet->context());
     m_cleared = false;
+    return &bufferSet->context();
 }
 
 void RemoteLayerWithRemoteRenderingBackingStore::ensureBackingStore(const Parameters& parameters)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -714,8 +714,9 @@ void PDFPlugin::updatePageAndDeviceScaleFactors()
         [m_pdfLayerController setDeviceScaleFactor:newScaleFactor];
 }
 
-void PDFPlugin::deviceScaleFactorChanged(float)
+void PDFPlugin::deviceScaleFactorChanged(float deviceScaleFactor)
 {
+    PDFPluginBase::deviceScaleFactorChanged(deviceScaleFactor);
     updatePageAndDeviceScaleFactors();
 }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -146,7 +146,7 @@ public:
 
     virtual bool geometryDidChange(const WebCore::IntSize& pluginSize, const WebCore::AffineTransform& pluginToRootViewTransform);
     virtual void visibilityDidChange(bool);
-    virtual void deviceScaleFactorChanged(float) { }
+    virtual void deviceScaleFactorChanged(float);
 
     bool handlesPageScaleFactor() const;
     virtual void didBeginMagnificationGesture() { }
@@ -444,6 +444,9 @@ protected:
     CompletionHandler<void(const String&, const URL&, std::span<const uint8_t>)> m_pendingSaveCompletionHandler;
     CompletionHandler<void(const String&, FrameInfoData&&, std::span<const uint8_t>, const String&)> m_pendingOpenCompletionHandler;
 #endif
+    // Page scale factor is stored so that it can be queried during off-thread painting.
+    // This info is not available from the GraphicsLayer tree at the moment.
+    float m_pageDeviceScaleFactor { 1.0f };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -118,6 +118,8 @@ PDFPluginBase::PDFPluginBase(HTMLPlugInElement& element)
     , m_incrementalPDFLoadingEnabled(element.document().settings().incrementalPDFLoadingEnabled())
 #endif
 {
+    if (RefPtr page = this->page())
+        m_pageDeviceScaleFactor = page->deviceScaleFactor();
 }
 
 PDFPluginBase::~PDFPluginBase()
@@ -642,6 +644,11 @@ void PDFPluginBase::visibilityDidChange(bool)
 #endif
 }
 
+void PDFPluginBase::deviceScaleFactorChanged(float deviceScaleFactor)
+{
+    m_pageDeviceScaleFactor = deviceScaleFactor;
+}
+
 FloatSize PDFPluginBase::pdfDocumentSizeForPrinting() const
 {
     return FloatSize { [[m_pdfDocument pageAtIndex:0] boundsForBox:kPDFDisplayBoxCropBox].size };
@@ -799,9 +806,7 @@ IntSize PDFPluginBase::overhangAmount() const
 
 float PDFPluginBase::deviceScaleFactor() const
 {
-    if (RefPtr page = this->page())
-        return page->deviceScaleFactor();
-    return 1;
+    return m_pageDeviceScaleFactor;
 }
 
 void PDFPluginBase::scrollbarStyleChanged(ScrollbarStyle style, bool forceUpdate)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.h
@@ -85,6 +85,7 @@ private:
     float deviceScaleFactor() const override;
     std::optional<float> customContentsScale(const WebCore::GraphicsLayer*) const override;
     bool layerNeedsPlatformContext(const WebCore::GraphicsLayer*) const override;
+    bool layerSupportsConcurrentPaintContents(const WebCore::GraphicsLayer*) const override;
     void tiledBackingUsageChanged(const WebCore::GraphicsLayer*, bool /*usingTiledBacking*/) override;
     void paintContents(const WebCore::GraphicsLayer*, WebCore::GraphicsContext&, const WebCore::FloatRect&, OptionSet<WebCore::GraphicsLayerPaintBehavior>) override;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
@@ -177,11 +177,9 @@ void PDFScrollingPresentationController::setupLayers(GraphicsLayer& scrolledCont
 void PDFScrollingPresentationController::updateLayersOnLayoutChange(FloatSize documentSize, FloatSize centeringOffset, double scaleFactor)
 {
     m_contentsLayer->setSize(documentSize);
-    m_contentsLayer->setNeedsDisplay();
 
 #if ENABLE(UNIFIED_PDF_SELECTION_LAYER)
     m_selectionLayer->setSize(documentSize);
-    m_selectionLayer->setNeedsDisplay();
 #endif
 
     TransformationMatrix transform;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
@@ -153,11 +153,13 @@ void PDFScrollingPresentationController::setupLayers(GraphicsLayer& scrolledCont
         m_contentsLayer = createGraphicsLayer("PDF contents"_s, m_plugin->isFullMainFramePlugin() ? GraphicsLayer::Type::PageTiledBacking : GraphicsLayer::Type::TiledBacking);
         m_contentsLayer->setAnchorPoint({ });
         m_contentsLayer->setDrawsContent(true);
-        m_contentsLayer->setAcceleratesDrawing(m_plugin->canPaintSelectionIntoOwnedLayer());
+        bool useAsyncRenderer = false; // Set this to false when developing without AsyncPDFRenderer.
+        if (useAsyncRenderer)
+            m_contentsLayer->setAcceleratesDrawing(m_plugin->canPaintSelectionIntoOwnedLayer());
         scrolledContentsLayer.addChild(*m_contentsLayer);
 
-        // This is the call that enables async rendering.
-        asyncRenderer()->startTrackingLayer(*m_contentsLayer);
+        if (useAsyncRenderer)
+            asyncRenderer()->startTrackingLayer(*m_contentsLayer);
     }
 
 #if ENABLE(UNIFIED_PDF_SELECTION_LAYER)
@@ -423,7 +425,7 @@ bool PDFScrollingPresentationController::layerNeedsPlatformContext(const Graphic
     // We need a platform context if the plugin can not paint selections into its own layer,
     // since we would then have to vend a platform context that PDFKit can paint into.
     // However, this constraint only applies for the contents layer. No other layer needs to be WP-backed.
-    return layer == m_contentsLayer.get() && !m_plugin->canPaintSelectionIntoOwnedLayer();
+    return layer == m_contentsLayer.get() && !(m_plugin->canPaintSelectionIntoOwnedLayer() && asyncRendererIfExists());
 }
 
 void PDFScrollingPresentationController::tiledBackingUsageChanged(const GraphicsLayer* layer, bool usingTiledBacking)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
@@ -426,6 +426,11 @@ bool PDFScrollingPresentationController::layerNeedsPlatformContext(const Graphic
     return layer == m_contentsLayer.get() && !(m_plugin->canPaintSelectionIntoOwnedLayer() && asyncRendererIfExists());
 }
 
+bool PDFScrollingPresentationController::layerSupportsConcurrentPaintContents(const GraphicsLayer* layer) const
+{
+    return layer == m_contentsLayer.get() && !asyncRendererIfExists();
+}
+
 void PDFScrollingPresentationController::tiledBackingUsageChanged(const GraphicsLayer* layer, bool usingTiledBacking)
 {
     if (usingTiledBacking)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -171,8 +171,7 @@ public:
 
     void scheduleRenderingUpdate(OptionSet<WebCore::RenderingUpdateStep> = WebCore::RenderingUpdateStep::LayerFlush);
     RefPtr<WebCore::GraphicsLayer> createGraphicsLayer(WebCore::GraphicsLayerClient&); // Why public?
-    float deviceScaleFactor() const override;
-
+    using PDFPluginBase::deviceScaleFactor;
     WebCore::FloatRect rectForSelectionInMainFrameContentsSpace(PDFSelection *) const;
 
     /*
@@ -557,8 +556,6 @@ private:
 
     bool isTaggedPDF() const;
 
-    bool shouldShowDebugIndicators() const;
-
     float scaleForPagePreviews() const;
 
     void createPasswordEntryForm();
@@ -597,6 +594,10 @@ private:
     bool m_didAttachScrollingTreeNode { false };
     bool m_didScrollToFragment { false };
     bool m_didLayoutWithValidDocument { false };
+    // Visiblility, activity status is stored so that it can be queried during
+    // off-thread painting. This info is not available from the GraphicsLayer tree,
+    // at the momemnt.
+    bool m_pageIsVisibleAndActive { false };
 
     ShouldUpdateAutoSizeScale m_shouldUpdateAutoSizeScale { ShouldUpdateAutoSizeScale::Yes };
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
@@ -38,6 +38,7 @@
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
+#include <wtf/WorkQueue.h>
 
 namespace WebKit {
 
@@ -58,6 +59,7 @@ public:
 
     ~RemoteLayerTreeContext();
 
+    Ref<ConcurrentWorkQueue> paintQueue();
     void layerDidEnterContext(PlatformCALayerRemote&, WebCore::PlatformCALayer::LayerType);
 #if HAVE(AVKIT)
     void layerDidEnterContext(PlatformCALayerRemote&, WebCore::PlatformCALayer::LayerType, WebCore::HTMLVideoElement&);
@@ -131,6 +133,7 @@ private:
 
     WebCore::LayerPool m_layerPool;
 
+    RefPtr<ConcurrentWorkQueue> m_paintQueue;
     CheckedPtr<RemoteLayerTreeTransaction> m_currentTransaction;
 
     bool m_nextRenderingUpdateRequiresSynchronousImageDecoding { false };


### PR DESCRIPTION
#### 7ed76f8feeab70f4dc5bcac0102dce1f8b516366
<pre>
UnifiedPDF: Add support for multithreaded paint with WebKit tiling
<a href="https://bugs.webkit.org/show_bug.cgi?id=284033">https://bugs.webkit.org/show_bug.cgi?id=284033</a>
<a href="https://rdar.apple.com/140909501">rdar://140909501</a>

Reviewed by NOBODY (OOPS!).

Add rudimentary capablity to paint RemoteLayerBackingStores
concurrently. Currently the only useful implementation is such that
use the platform context, since WebKit GraphicsContext -related
objects like Fonts and such are not thread-safe.

Start the paint for all RemoteLayerBackingStores in the frame
transaction, and wait until they are finished, before committing the
transaction.

For UnifiedPDF scrolled PDFs, cache window activity status and
page device scale factor. Those cannot be accessed via page, as
the page navigated to using weak ptrs that will assert from non-creator
thread.

* Source/WTF/wtf/WorkQueue.cpp:
(WTF::WorkQueueBase::WorkQueueBase): Deleted.
(WTF::WorkQueueBase::~WorkQueueBase): Deleted.
(WTF::ConcurrentWorkQueue::create): Deleted.
(WTF::WorkQueue::create): Deleted.
(WTF::WorkQueue::WorkQueue): Deleted.
(WTF::ConcurrentWorkQueue::ConcurrentWorkQueue): Deleted.
* Source/WTF/wtf/WorkQueue.h:
* Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp:
(WTF::WorkQueueBase::WorkQueueBase):
(WTF::createSerialDispatchQueue):
(WTF::WorkQueue::create):
(WTF::WorkQueue::WorkQueue):
(WTF::ConcurrentWorkQueue::create):
(WTF::ConcurrentWorkQueue::createToGlobal):
(WTF::ConcurrentWorkQueue::dispatchBarrierSync):
(WTF::WorkQueueBase::platformInitialize): Deleted.
(WTF::WorkQueueBase::platformInvalidate): Deleted.
* Source/WTF/wtf/generic/WorkQueueGeneric.cpp:
(WTF::createQueueRunLoop):
(WTF::WorkQueue::WorkQueueBase):
(WTF::WorkQueueBase::~WorkQueueBase):
(WTF::WorkQueue::create):
(WTF::ConcurrentWorkQueue::create):
(WTF::ConcurrentWorkQueue::createToDefault):
(WTF::ConcurrentWorkQueue::dispatchBarrierSync):
(WTF::WorkQueueBase::WorkQueueBase): Deleted.
(WTF::WorkQueueBase::platformInitialize): Deleted.
(WTF::WorkQueueBase::platformInvalidate): Deleted.
(WTF::WorkQueue::WorkQueue): Deleted.

Implement missing features for using ConcurrentWorkQueue correctly:
ConcurrentWorkQueue must always be constructed with some global queue
as the target, otherwise thread count explosion slows the execution.

ConcurrentWorkQueue tasks must always be ordered in some consistent way.
Add sync barrier support for ordering needed for the WebKit compositor.

* Source/WebCore/platform/graphics/GraphicsLayerClient.h:
(WebCore::GraphicsLayerClient::layerSupportsConcurrentPaintContents const):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::platformCALayerSupportsConcurrentPaintContents const):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/platform/graphics/ca/PlatformCALayer.mm:
(WebCore::PlatformCALayer::drawRepaintIndicator):
* Source/WebCore/platform/graphics/ca/PlatformCALayerClient.h:
(WebCore::PlatformCALayerClient::platformCALayerSupportsConcurrentPaintContents const):
* Source/WebCore/platform/graphics/ca/TileGrid.cpp:
(WebCore::TileGrid::setTileNeedsDisplayInRect):
(WebCore::TileGrid::platformCALayerSupportsConcurrentPaintContents const):
(WebCore::TileGrid::platformCALayerPaintContents):
(WebCore::TileGrid::platformCALayerLayerDidDisplay):
* Source/WebCore/platform/graphics/ca/TileGrid.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::paintContents):
(WebKit::RemoteLayerBackingStore::drawInContext):
(WebKit::RemoteLayerBackingStore::flushContents):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm:
(WebKit::RemoteLayerBackingStoreCollection::paintReachableBackingStores):
(WebKit::RemoteLayerBackingStoreCollection::flushReachableBackingStores):
(WebKit::RemoteLayerBackingStoreCollection::paintReachableBackingStoreContents): Deleted.
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm:
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::contextForPaintContents):
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::flushContextForPaintContents):
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::createContextAndPaintContents): Deleted.
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::createFlusher): Deleted.
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm:
(WebKit::RemoteLayerWithRemoteRenderingBackingStore::flushContextForPaintContents):
(WebKit::RemoteLayerWithRemoteRenderingBackingStore::contextForPaintContents):
(WebKit::RemoteLayerWithRemoteRenderingBackingStore::createFlusher): Deleted.
(WebKit::RemoteLayerWithRemoteRenderingBackingStore::createContextAndPaintContents): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::deviceScaleFactorChanged):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::deviceScaleFactorChanged): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::PDFPluginBase):
(WebKit::PDFPluginBase::deviceScaleFactorChanged):
(WebKit::PDFPluginBase::deviceScaleFactor const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm:
(WebKit::PDFScrollingPresentationController::layerSupportsConcurrentPaintContents const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::didChangeSettings):
(WebKit::UnifiedPDFPlugin::windowActivityDidChange):
(WebKit::UnifiedPDFPlugin::paintPDFContent):
(WebKit::UnifiedPDFPlugin::paintPDFSelection):
(WebKit::UnifiedPDFPlugin::shouldShowDebugIndicators const): Deleted.
(WebKit::UnifiedPDFPlugin::deviceScaleFactor const): Deleted.
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm:
(WebKit::RemoteLayerTreeContext::paintQueue):
(WebKit::RemoteLayerTreeContext::buildTransaction):
</pre>
----------------------------------------------------------------------
#### f70c9892133c2a65ddf91c74e8b1c87a774ae3c1
<pre>
UnifiedPDF:  Scrolling PDFs update tiles during zoom
<a href="https://bugs.webkit.org/show_bug.cgi?id=283821">https://bugs.webkit.org/show_bug.cgi?id=283821</a>
<a href="https://rdar.apple.com/140693097">rdar://140693097</a>

Reviewed by NOBODY (OOPS!).

Zooming the PDF is a bit janky due to layer backing store contents being
invalidated for each zoom scale change.

PDFScrollingPresentationController::updateLayersOnLayoutChange updates
only WebKit compositor properties. The compositor is able to figure out
when the backing store is invalid and issue new display.

This is work towards being able to use WebKit tiling instead of
AsyncPDFRenderer.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm:
(WebKit::PDFScrollingPresentationController::updateLayersOnLayoutChange):
</pre>
----------------------------------------------------------------------
#### 34441fc730eb99f3aff2f626522c728d0e4d2290
<pre>
UnifiedPDF: Scrolling PDFs do not work with In process backing stores
<a href="https://bugs.webkit.org/show_bug.cgi?id=283822">https://bugs.webkit.org/show_bug.cgi?id=283822</a>
<a href="https://rdar.apple.com/140693454">rdar://140693454</a>

Reviewed by NOBODY (OOPS!).

Add a bool flag to use to turn on WebKit tiling with in-process backing
stores.

This is work towards removing AsyncPDFRenderer and using normal WebKit
tiling.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm:
(WebKit::PDFScrollingPresentationController::setupLayers):
(WebKit::PDFScrollingPresentationController::layerNeedsPlatformContext const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ed76f8feeab70f4dc5bcac0102dce1f8b516366

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79257 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58285 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32629 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83880 "Hash 7ed76f8f for PR 37423 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30424 "Hash 7ed76f8f for PR 37423 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81390 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67377 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6556 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/83880 "Hash 7ed76f8f for PR 37423 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/30424 "Hash 7ed76f8f for PR 37423 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82324 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52066 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72214 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/83880 "Hash 7ed76f8f for PR 37423 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49411 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26381 "Passed tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28812 "Hash 7ed76f8f for PR 37423 does not build (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/72371 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70524 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26823 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85274 "Hash 7ed76f8f for PR 37423 does not build (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/78465 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6555 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4554 "Found 1 new test failure: pdf/pdf-in-iframe-with-text-annotation.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/85274 "Hash 7ed76f8f for PR 37423 does not build (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6718 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68085 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/85274 "Hash 7ed76f8f for PR 37423 does not build (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13548 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12390 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-multicol/crashtests/interleaved-bfc-crash.html imported/w3c/web-platform-tests/css/css-tables/crashtests/textarea-intrinsic-size-crash.html (failure)") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/100793 "Hash 7ed76f8f for PR 37423 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6512 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12278 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/100793 "Hash 7ed76f8f for PR 37423 does not build (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6434 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9901 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8226 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->