### PR TITLE
getUserMedia for video only should not trigger exposure of microphone (and vice versa)

### DIFF
--- a/LayoutTests/fast/mediastream/device-change-event-3-expected.txt
+++ b/LayoutTests/fast/mediastream/device-change-event-3-expected.txt
@@ -1,0 +1,3 @@
+
+PASS 'devicechange' event fired when getUserMedia is called with microphone and then with camera
+

--- a/LayoutTests/fast/mediastream/device-change-event-3.html
+++ b/LayoutTests/fast/mediastream/device-change-event-3.html
@@ -1,0 +1,56 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Testing 'devicechange' event is fired correctly.</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+    <script>
+    promise_test(async (test) => {
+        let promise;
+        const devices1 = await navigator.mediaDevices.enumerateDevices();
+
+        promise = new Promise(resolve => {
+            navigator.mediaDevices.ondevicechange = resolve;
+        });
+        await navigator.mediaDevices.getUserMedia({ audio:true, video:false });
+
+        await promise;
+        const devices2 = await navigator.mediaDevices.enumerateDevices();
+
+        promise = new Promise(resolve => {
+            navigator.mediaDevices.ondevicechange = resolve;
+        });
+        await navigator.mediaDevices.getUserMedia({ audio:false, video:true });
+        await promise;
+
+        await promise;
+        const devices3 = await navigator.mediaDevices.enumerateDevices();
+
+        assert_equals(devices1.length, 2, "devices1 length");
+        assert_equals(devices1[0].label, "", "devices1 first label");
+        assert_equals(devices1[1].label, "", "devices1 second label");
+        assert_equals(devices1[0].kind, "audioinput", "devices1 first kind");
+        assert_equals(devices1[1].kind, "videoinput", "devices1 second kind");
+
+        assert_greater_than(devices2.length, devices1.length);
+        assert_greater_than(devices3.length, devices2.length);
+
+        assert_not_equals(devices2[0].label, "");
+        let hasCamera = false;
+        for (let device of devices2) {
+           if (device.kind === "videoinput") {
+               hasCamera = true;
+               assert_equals(device.label, "", "empty camera in devices2");
+           }
+        }
+        assert_true(hasCamera, "hasCamera");
+
+        for (let device of devices3)
+            assert_not_equals(device.label, "", "devices3");
+    }, "'devicechange' event fired when getUserMedia is called with microphone and then with camera");
+    </script>
+</head>
+<body>
+</body>
+</html>

--- a/LayoutTests/fast/mediastream/device-change-event-4-expected.txt
+++ b/LayoutTests/fast/mediastream/device-change-event-4-expected.txt
@@ -1,0 +1,3 @@
+
+PASS 'devicechange' event fired when getUserMedia is called with camera and then with microphone
+

--- a/LayoutTests/fast/mediastream/device-change-event-4.html
+++ b/LayoutTests/fast/mediastream/device-change-event-4.html
@@ -1,0 +1,48 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <meta charset="utf-8">
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+    <script>
+    promise_test(async (test) => {
+        let promise;
+        const devices1 = await navigator.mediaDevices.enumerateDevices();
+
+        promise = new Promise(resolve => {
+            navigator.mediaDevices.ondevicechange = resolve;
+        });
+        await navigator.mediaDevices.getUserMedia({ audio:false, video:true });
+
+        await promise;
+        const devices2 = await navigator.mediaDevices.enumerateDevices();
+
+        promise = new Promise(resolve => {
+            navigator.mediaDevices.ondevicechange = resolve;
+        });
+        await navigator.mediaDevices.getUserMedia({ audio:true, video:false });
+        await promise;
+
+        await promise;
+        const devices3 = await navigator.mediaDevices.enumerateDevices();
+
+        assert_equals(devices1.length, 2, "devices1 length");
+        assert_equals(devices1[0].label, "", "devices1 first label");
+        assert_equals(devices1[1].label, "", "devices1 second label");
+        assert_equals(devices1[0].kind, "audioinput", "devices1 first kind");
+        assert_equals(devices1[1].kind, "videoinput", "devices1 second kind");
+
+        assert_greater_than(devices2.length, devices1.length);
+        assert_greater_than(devices3.length, devices2.length);
+
+        assert_equals(devices2[0].label, "", "devices2 first label");
+        assert_equals(devices2[0].kind, "audioinput", "devices2 first kind");
+
+        for (let device of devices3)
+            assert_not_equals(device.label, "", "devices3");
+    }, "'devicechange' event fired when getUserMedia is called with camera and then with microphone");
+    </script>
+</head>
+<body>
+</body>
+</html>

--- a/LayoutTests/fast/mediastream/media-devices-enumerate-devices.html
+++ b/LayoutTests/fast/mediastream/media-devices-enumerate-devices.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ ExposeSpeakersEnabled=false ] -->
 <html>
     <head>
         <meta charset="utf-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaDevices-enumerateDevices.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaDevices-enumerateDevices.https-expected.txt
@@ -4,7 +4,7 @@ This test checks for the presence of the navigator.mediaDevices.enumerateDevices
 
 
 PASS mediaDevices.enumerateDevices() is present and working - before capture
-FAIL mediaDevices.enumerateDevices() is working - after video capture assert_equals: audio deviceId should be empty. expected 0 but got 40
+PASS mediaDevices.enumerateDevices() is working - after video capture
 PASS mediaDevices.enumerateDevices() is working - after video then audio capture
 PASS InputDeviceInfo is supported
 

--- a/Source/WebCore/Modules/mediastream/MediaDevices.h
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.h
@@ -97,6 +97,8 @@ public:
     String deviceIdToPersistentId(const String& deviceId) const { return m_audioOutputDeviceIdToPersistentId.get(deviceId); }
     String hashedGroupId(const String& groupId);
 
+    void willStartMediaCapture(bool microphone, bool camera);
+
 private:
     explicit MediaDevices(Document&);
 
@@ -137,6 +139,9 @@ private:
 
     MemoryCompactRobinHoodHashMap<String, String> m_audioOutputDeviceIdToPersistentId;
     String m_audioOutputDeviceId;
+
+    bool m_hasRestrictedCameraDevices { true };
+    bool m_hasRestrictedMicrophoneDevices { true };
 };
 
 } // namespace WebCore

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h
@@ -174,8 +174,10 @@ private:
     RequestAction getRequestAction(const UserMediaPermissionRequestProxy&);
 
     bool wasGrantedVideoOrAudioAccess(WebCore::FrameIdentifier);
+    bool wasGrantedAudioAccess(WebCore::FrameIdentifier);
+    bool wasGrantedVideoAccess(WebCore::FrameIdentifier);
 
-    void computeFilteredDeviceList(bool revealIdsAndLabels, CompletionHandler<void(Vector<WebCore::CaptureDeviceWithCapabilities>&&)>&&);
+    void computeFilteredDeviceList(WebCore::FrameIdentifier, bool revealIdsAndLabels, CompletionHandler<void(Vector<WebCore::CaptureDeviceWithCapabilities>&&)>&&);
     void platformGetMediaStreamDevices(bool revealIdsAndLabels, CompletionHandler<void(Vector<WebCore::CaptureDeviceWithCapabilities>&&)>&&);
 
     void processUserMediaPermissionRequest();
@@ -220,13 +222,13 @@ private:
     Ref<const Logger> m_logger;
     const uint64_t m_logIdentifier;
 #endif
-    bool m_hasFilteredDeviceList { false };
 #if PLATFORM(COCOA)
     bool m_hasCreatedSandboxExtensionForTCCD { false };
 #endif
     uint64_t m_hasPendingCapture { 0 };
     std::optional<bool> m_mockDevicesEnabledOverride;
-    HashSet<WebCore::FrameIdentifier> m_grantedFrames;
+    HashSet<WebCore::FrameIdentifier> m_grantedAudioFrames;
+    HashSet<WebCore::FrameIdentifier> m_grantedVideoFrames;
 #if PLATFORM(COCOA)
     HashCountedSet<String> m_monitoredDeviceIds;
     RetainPtr<WKRotationCoordinatorObserver> m_objcObserver;


### PR DESCRIPTION
#### 07f45d308dc38d21221c9f066bf430d7c650ef7a
<pre>
getUserMedia for video only should not trigger exposure of microphone (and vice versa)
<a href="https://rdar.apple.com/140917408">rdar://140917408</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=284043">https://bugs.webkit.org/show_bug.cgi?id=284043</a>

Reviewed by Eric Carlson.

MediaDevices is now responsible to fire devicechange events when:
- camera devices were not exposed before and getUserMedia for camera will start.
- microphone devices were not exposed before and getUserMedia for microphone will start.

Update UserMediaPermissionRequestManagerProxy to filter camera and microphone differently.
We thus keep track of frames granted for audio and video separately.

* LayoutTests/fast/mediastream/device-change-event-3-expected.txt: Added.
* LayoutTests/fast/mediastream/device-change-event-3.html: Added.
* LayoutTests/fast/mediastream/device-change-event-4-expected.txt: Added.
* LayoutTests/fast/mediastream/device-change-event-4.html: Added.
* LayoutTests/fast/mediastream/media-devices-enumerate-devices.html:
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaDevices-enumerateDevices.https-expected.txt:
* Source/WebCore/Modules/mediastream/MediaDevices.cpp:
(WebCore::MediaDevices::exposeDevices):
(WebCore::MediaDevices::willStartMediaCapture):
* Source/WebCore/Modules/mediastream/MediaDevices.h:
* Source/WebCore/Modules/mediastream/UserMediaRequest.cpp:
(WebCore::UserMediaRequest::~UserMediaRequest):
(WebCore::UserMediaRequest::allow):
(WebCore::UserMediaRequest::stop):
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp:
(WebKit::UserMediaPermissionRequestManagerProxy::grantRequest):
(WebKit::UserMediaPermissionRequestManagerProxy::finishGrantingRequest):
(WebKit::UserMediaPermissionRequestManagerProxy::resetAccess):
(WebKit::UserMediaPermissionRequestManagerProxy::updateStoredRequests):
(WebKit::UserMediaPermissionRequestManagerProxy::wasGrantedVideoOrAudioAccess):
(WebKit::UserMediaPermissionRequestManagerProxy::wasGrantedAudioAccess):
(WebKit::UserMediaPermissionRequestManagerProxy::wasGrantedVideoAccess):
(WebKit::UserMediaPermissionRequestManagerProxy::computeFilteredDeviceList):
(WebKit::UserMediaPermissionRequestManagerProxy::enumerateMediaDevicesForFrame):
(WebKit::UserMediaPermissionRequestManagerProxy::watchdogTimerFired):
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h:

Canonical link: <a href="https://commits.webkit.org/287629@main">https://commits.webkit.org/287629@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ebda257034fcc2264edb99e6e0a758c040d95a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80312 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59318 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33738 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84833 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31294 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82423 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68380 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7618 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62786 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/20598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83381 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52848 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73132 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43089 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50171 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27288 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29753 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71308 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27802 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86267 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7537 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71064 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7712 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68969 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70304 "Found 4 new API test failures: /TestWebKit:WebKit.DOMWindowExtensionCrashOnReload, /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidEndShouldBeDispatchedForRemovedFocusField, /TestWebKit:WebKit.FocusedFrameAfterCrash, /TestWebKit:WebKit.DocumentStartUserScriptAlertCrashTest (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17509 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14306 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13242 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7499 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/13019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7338 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10858 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9144 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->