### PR TITLE
[iPadOS] Unable to two-finger pan image carousels in Amazon app using trackpad

### DIFF
--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -184,6 +184,7 @@ WTF_EXPORT_PRIVATE bool isMimeoPhotoProject();
 
 namespace IOSApplication {
 
+WTF_EXPORT_PRIVATE bool isAmazon();
 WTF_EXPORT_PRIVATE bool isAppleApplication();
 WTF_EXPORT_PRIVATE bool isCardiogram();
 WTF_EXPORT_PRIVATE bool isCrunchyroll();

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
@@ -582,6 +582,12 @@ bool IOSApplication::isHoYoLAB()
     return isHoYoLAB;
 }
 
+bool IOSApplication::isAmazon()
+{
+    static bool isAmazon = applicationBundleIsEqualTo("com.amazon.Amazon"_s);
+    return isAmazon;
+}
+
 bool IOSApplication::isAppleApplication()
 {
     static bool isAppleApplication = applicationBundleStartsWith("com.apple."_s);

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -226,6 +226,7 @@ public:
 #if PLATFORM(IOS_FAMILY)
     WEBCORE_EXPORT bool shouldIgnoreContentObservationForClick(const Node&) const;
     WEBCORE_EXPORT bool shouldSynthesizeTouchEventsAfterNonSyntheticClick(const Element&) const;
+    WEBCORE_EXPORT bool needsPointerTouchCompatibility(const Element&) const;
 #endif
 
     bool needsMozillaFileTypeForDataTransfer() const;

--- a/Source/WebKit/Shared/ios/InteractionInformationAtPosition.h
+++ b/Source/WebKit/Shared/ios/InteractionInformationAtPosition.h
@@ -92,6 +92,7 @@ struct InteractionInformationAtPosition {
 #if ENABLE(SPATIAL_IMAGE_DETECTION)
     bool isSpatialImage { false };
 #endif
+    bool needsPointerTouchCompatibilityQuirk { false };
     WebCore::FloatPoint adjustedPointForNodeRespondingToClickEvents;
     URL url;
     URL imageURL;

--- a/Source/WebKit/Shared/ios/InteractionInformationAtPosition.serialization.in
+++ b/Source/WebKit/Shared/ios/InteractionInformationAtPosition.serialization.in
@@ -67,6 +67,7 @@ struct WebKit::InteractionInformationAtPosition {
 #if ENABLE(SPATIAL_IMAGE_DETECTION)
     bool isSpatialImage;
 #endif
+    bool needsPointerTouchCompatibilityQuirk;
     WebCore::FloatPoint adjustedPointForNodeRespondingToClickEvents;
     URL url;
     URL imageURL;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -452,8 +452,7 @@ static uint32_t convertSystemLayoutDirection(NSUserInterfaceLayoutDirection dire
 #endif
 
 #if PLATFORM(IOS_FAMILY)
-    if (WebKit::PointerTouchCompatibilitySimulator::requiresPointerTouchCompatibility())
-        _pointerTouchCompatibilitySimulator = WTF::makeUnique<WebKit::PointerTouchCompatibilitySimulator>(self);
+    _pointerTouchCompatibilitySimulator = WTF::makeUnique<WebKit::PointerTouchCompatibilitySimulator>(self);
 #endif
 }
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -212,6 +212,7 @@ enum class TapHandlingResult : uint8_t;
 @property (nonatomic, readonly) BOOL _isWindowResizingEnabled;
 #endif
 
+@property (nonatomic, readonly) BOOL _isSimulatingCompatibilityPointerTouches;
 @property (nonatomic, readonly) WKVelocityTrackingScrollView *_scrollViewInternal;
 @property (nonatomic, readonly) CGRect _contentRectForUserInteraction;
 
@@ -223,6 +224,8 @@ enum class TapHandlingResult : uint8_t;
 
 - (void)_overrideZoomScaleParametersWithMinimumZoomScale:(CGFloat)minimumZoomScale maximumZoomScale:(CGFloat)maximumZoomScale allowUserScaling:(BOOL)allowUserScaling;
 - (void)_clearOverrideZoomScaleParameters;
+
+- (void)_setPointerTouchCompatibilitySimulatorEnabled:(BOOL)enabled;
 
 #if ENABLE(PAGE_LOAD_OBSERVER)
 - (void)_updatePageLoadObserverState NS_DIRECT;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -2189,8 +2189,8 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
 
 - (void)scrollView:(WKBaseScrollView *)scrollView handleScrollUpdate:(WKBEScrollViewScrollUpdate *)update completion:(void (^)(BOOL handled))completion
 {
-    if (_pointerTouchCompatibilitySimulator)
-        _pointerTouchCompatibilitySimulator->handleScrollUpdate(scrollView, update);
+    if (_pointerTouchCompatibilitySimulator->handleScrollUpdate(scrollView, update))
+        return completion(YES);
 
     BOOL isHandledByDefault = !scrollView.scrollEnabled;
 
@@ -3816,7 +3816,22 @@ static bool isLockdownModeWarningNeeded()
     [self _scheduleVisibleContentRectUpdate];
 }
 
+- (void)_setPointerTouchCompatibilitySimulatorEnabled:(BOOL)enabled
+{
+    _pointerTouchCompatibilitySimulator->setEnabled(enabled);
+}
+
+- (BOOL)_isSimulatingCompatibilityPointerTouches
+{
+    return _pointerTouchCompatibilitySimulator->isSimulatingTouches();
+}
+
 #pragma mark - WKBaseScrollViewDelegate
+
+- (BOOL)shouldAllowPanGestureRecognizerToReceiveTouchesInScrollView:(WKBaseScrollView *)scrollView
+{
+    return !self._isSimulatingCompatibilityPointerTouches;
+}
 
 - (UIAxis)axesToPreventScrollingForPanGestureInScrollView:(WKBaseScrollView *)scrollView
 {

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -587,6 +587,8 @@ public:
     virtual void handleAsynchronousCancelableScrollEvent(WKBaseScrollView *, WKBEScrollViewScrollUpdate *, void (^completion)(BOOL handled)) = 0;
 #endif
 
+    virtual bool isSimulatingCompatibilityPointerTouches() const = 0;
+
     virtual WebCore::Color contentViewBackgroundColor() = 0;
     virtual WebCore::Color insertionPointColor() = 0;
     virtual bool isScreenBeingCaptured() = 0;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.h
@@ -83,6 +83,7 @@ public:
     void computeActiveTouchActionsForGestureRecognizer(UIGestureRecognizer*);
     void clearActiveTouchActions() { m_activeTouchActions = { }; }
     void cancelPointersForGestureRecognizer(UIGestureRecognizer*);
+    bool shouldAllowPanGestureRecognizerToReceiveTouches() const;
 
     UIScrollView *findActingScrollParent(UIScrollView *);
     WKBaseScrollView *scrollView() const;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -328,6 +328,8 @@ private:
     void handleAsynchronousCancelableScrollEvent(WKBaseScrollView *, WKBEScrollViewScrollUpdate *, void (^completion)(BOOL handled)) final;
 #endif
 
+    bool isSimulatingCompatibilityPointerTouches() const final;
+
     WebCore::Color contentViewBackgroundColor() final;
     WebCore::Color insertionPointColor() final;
     bool isScreenBeingCaptured() final;
@@ -351,9 +353,7 @@ private:
     void didCleanupFullscreen() final;
 #endif
 
-#if PLATFORM(IOS_FAMILY)
     UIViewController *presentingViewController() const final;
-#endif
 
     bool isPotentialTapInProgress() const final;
 

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -1135,6 +1135,11 @@ void PageClientImpl::handleAsynchronousCancelableScrollEvent(WKBaseScrollView *s
 }
 #endif
 
+bool PageClientImpl::isSimulatingCompatibilityPointerTouches() const
+{
+    return [webView() _isSimulatingCompatibilityPointerTouches];
+}
+
 void PageClientImpl::runModalJavaScriptDialog(CompletionHandler<void()>&& callback)
 {
     [contentView() runModalJavaScriptDialog:WTFMove(callback)];

--- a/Source/WebKit/UIProcess/ios/PointerTouchCompatibilitySimulator.h
+++ b/Source/WebKit/UIProcess/ios/PointerTouchCompatibilitySimulator.h
@@ -54,13 +54,14 @@ class PointerTouchCompatibilitySimulator {
     WTF_MAKE_NONCOPYABLE(PointerTouchCompatibilitySimulator);
     WTF_MAKE_TZONE_ALLOCATED(PointerTouchCompatibilitySimulator);
 public:
-    static bool requiresPointerTouchCompatibility();
-
     PointerTouchCompatibilitySimulator(WKWebView *);
 
 #if HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_HANDLING)
-    void handleScrollUpdate(WKBaseScrollView *, WKBEScrollViewScrollUpdate *);
+    bool handleScrollUpdate(WKBaseScrollView *, WKBEScrollViewScrollUpdate *);
 #endif
+
+    bool isSimulatingTouches() const { return !m_touchDelta.isZero(); }
+    void setEnabled(bool);
 
     RetainPtr<WKWebView> view() const { return m_view.get(); }
     RetainPtr<UIWindow> window() const;
@@ -72,7 +73,9 @@ private:
     const WeakObjCPtr<WKWebView> m_view;
     RunLoop::Timer m_stateResetWatchdogTimer;
     WebCore::FloatPoint m_centroid;
-    WebCore::FloatSize m_delta;
+    WebCore::FloatSize m_touchDelta;
+    WebCore::FloatSize m_initialDelta;
+    bool m_isEnabled { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/ios/WKBaseScrollView.h
+++ b/Source/WebKit/UIProcess/ios/WKBaseScrollView.h
@@ -40,6 +40,7 @@
 
 @protocol WKBaseScrollViewDelegate <NSObject>
 
+- (BOOL)shouldAllowPanGestureRecognizerToReceiveTouchesInScrollView:(WKBaseScrollView *)scrollView;
 - (UIAxis)axesToPreventScrollingForPanGestureInScrollView:(WKBaseScrollView *)scrollView;
 
 @end

--- a/Source/WebKit/UIProcess/ios/WKBaseScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKBaseScrollView.mm
@@ -35,6 +35,7 @@
 #import <wtf/RetainPtr.h>
 #import <wtf/RuntimeApplicationChecks.h>
 #import <wtf/SetForScope.h>
+#import <wtf/WeakObjCPtr.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
@@ -214,6 +215,21 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return YES;
 
     return [super gestureRecognizerShouldBegin:gestureRecognizer];
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch
+{
+    if (self.panGestureRecognizer == gestureRecognizer) {
+        RetainPtr delegate = [self baseScrollViewDelegate];
+        if (delegate && ![delegate shouldAllowPanGestureRecognizerToReceiveTouchesInScrollView:self])
+            return NO;
+    }
+
+    static BOOL callIntoSuperclass = [UIScrollView instancesRespondToSelector:@selector(gestureRecognizer:shouldReceiveTouch:)];
+    if (!callIntoSuperclass)
+        return YES;
+
+    return [super gestureRecognizer:gestureRecognizer shouldReceiveTouch:touch];
 }
 
 @end

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -11779,6 +11779,7 @@ static BOOL applicationIsKnownToIgnoreMouseEvents(const char* &warningVersion)
 
     if ([self _currentPositionInformationIsValidForRequest:interactionInformationRequest]) {
         _lastPointerRegion = [self pointerRegionForPositionInformation:_positionInformation point:request.location];
+        [_webView _setPointerTouchCompatibilitySimulatorEnabled:_positionInformation.needsPointerTouchCompatibilityQuirk];
         _pointerInteractionRegionNeedsUpdate = NO;
         return;
     }
@@ -11805,6 +11806,7 @@ static BOOL applicationIsKnownToIgnoreMouseEvents(const char* &warningVersion)
 
         strongSelf->_pointerInteractionRegionNeedsUpdate = NO;
         strongSelf->_lastPointerRegion = [strongSelf pointerRegionForPositionInformation:information point:location];
+        [strongSelf->_webView _setPointerTouchCompatibilitySimulatorEnabled:information.needsPointerTouchCompatibilityQuirk];
         [strongSelf->_pointerInteraction invalidate];
     } forRequest:interactionInformationRequest];
 }

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -3280,6 +3280,7 @@ static void boundsPositionInformation(RenderObject& renderer, InteractionInforma
 
 static void elementPositionInformation(WebPage& page, Element& element, const InteractionInformationRequest& request, const Node* innerNonSharedNode, InteractionInformationAtPosition& info)
 {
+    Ref document = element.document();
     Element* linkElement = nullptr;
     if (element.renderer() && element.renderer()->isRenderImage())
         linkElement = containingLinkAnchorElement(element);
@@ -3298,7 +3299,7 @@ static void elementPositionInformation(WebPage& page, Element& element, const In
 
     if (linkElement && !info.isImageOverlayText) {
         info.isLink = true;
-        info.url = page.applyLinkDecorationFiltering(linkElement->document().completeURL(linkElement->getAttribute(HTMLNames::hrefAttr)), LinkDecorationFilteringTrigger::Unspecified);
+        info.url = page.applyLinkDecorationFiltering(document->completeURL(linkElement->getAttribute(HTMLNames::hrefAttr)), LinkDecorationFilteringTrigger::Unspecified);
 
         linkIndicatorPositionInformation(page, *linkElement, request, info);
 #if ENABLE(DATA_DETECTION)
@@ -3314,6 +3315,8 @@ static void elementPositionInformation(WebPage& page, Element& element, const In
 #endif
     }
 
+    info.needsPointerTouchCompatibilityQuirk = document->quirks().needsPointerTouchCompatibility(element);
+
     if (auto* renderer = element.renderer()) {
         bool shouldCollectImagePositionInformation = renderer->isRenderImage();
         if (shouldCollectImagePositionInformation && info.isImageOverlayText) {
@@ -3321,7 +3324,7 @@ static void elementPositionInformation(WebPage& page, Element& element, const In
             if (request.includeImageData) {
                 if (auto rendererAndImage = imageRendererAndImage(element)) {
                     auto& [renderImage, image] = *rendererAndImage;
-                    info.imageURL = page.applyLinkDecorationFiltering(element.document().completeURL(renderImage.cachedImage()->url().string()), LinkDecorationFilteringTrigger::Unspecified);
+                    info.imageURL = page.applyLinkDecorationFiltering(document->completeURL(renderImage.cachedImage()->url().string()), LinkDecorationFilteringTrigger::Unspecified);
                     info.imageMIMEType = image.mimeType();
                     info.image = createShareableBitmap(renderImage, { screenSize() * page.corePage()->deviceScaleFactor(), AllowAnimatedImages::Yes, UseSnapshotForTransparentImages::Yes });
                 }


### PR DESCRIPTION
#### 5a67b636ca3a3ae0df1e746a4ad9e0c44c2f1ed3
<pre>
[iPadOS] Unable to two-finger pan image carousels in Amazon app using trackpad
<a href="https://bugs.webkit.org/show_bug.cgi?id=284041">https://bugs.webkit.org/show_bug.cgi?id=284041</a>
<a href="https://rdar.apple.com/140800215">rdar://140800215</a>

Reviewed by Abrar Rahman Protyasha.

Make some improvements to the pointer touch compatibility quirk introduced in 286150@main, and
deploy it to fix horizontal swiping over image carousels on product pages in the Amazon app.

-   Only activate the quirk when performing mouse hover over specific DOM subtrees on Amazon/Feedly.
-   Make the simulated touches more responsive by locking in to dispatching simulated touches once
    the hysteresis threshold is met.
-   Fix an issue where the scroll view content offset would sometimes jump when simulating touches.

See below for more information.

* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm:
(WTF::IOSApplication::isAmazon):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::needsPointerTouchCompatibility const):

Add a heuristic that engages this pointer touch compatibility quirk only when hovering over specific
targets in a couple of native iOS apps — Feedly and Amazon.

* Source/WebCore/page/Quirks.h:
* Source/WebKit/Shared/ios/InteractionInformationAtPosition.h:
* Source/WebKit/Shared/ios/InteractionInformationAtPosition.serialization.in:

Add a position information flag that determines whether or not the touch simulation quirk should be
active.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _initializeWithConfiguration:]):

Refactor `PointerTouchCompatibilitySimulator` so that it&apos;s now always instantiated on the web view,
but only intercepts wheel events if the quirk is activated (based on the position information state
above).

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView scrollView:handleScrollUpdate:completion:]):

Make `handleScrollUpdate` return a `bool` result indicating whether the event should be handled, and
prevent dispatching the wheel event if so. Note that the page will always still see the begin/end
wheel events even if the touch simulation quirk kicks in, since we only return `true` from
`handleScrollUpdate` in the case where the wheel event phase is already `Changed`, and we always
reset immediately upon observing the `Ended` phase.

(-[WKWebView _setPointerTouchCompatibilitySimulatorEnabled:]):
(-[WKWebView _isSimulatingCompatibilityPointerTouches]):
(-[WKWebView shouldAllowPanGestureRecognizerToReceiveTouchesInScrollView:]):

Don&apos;t allow simulated touches to trigger scrolling via the scroll view pan gesture; see below for
more detail.

* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm:
(-[WKScrollingNodeScrollViewDelegate shouldAllowPanGestureRecognizerToReceiveTouchesInScrollView:]):
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::shouldAllowPanGestureRecognizerToReceiveTouches const):
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::isSimulatingCompatibilityPointerTouches const):
* Source/WebKit/UIProcess/ios/PointerTouchCompatibilitySimulator.h:
(WebKit::PointerTouchCompatibilitySimulator::isSimulatingTouches const):
* Source/WebKit/UIProcess/ios/PointerTouchCompatibilitySimulator.mm:
(WebKit::hasPredominantHorizontalAxis):
(WebKit::PointerTouchCompatibilitySimulator::handleScrollUpdate):

Rework how touch simulation works:

1.  Accumulate a total wheel delta when beginning a trackpad swipe, and consider the cumulative
    delta when checking for the predominant scrolling axis. This allows a slow-but-steady horizontal
    swipe to reliably trigger the quirk.

2.  Once the quirk is active, intercept all subsequent wheel events and just perform touch event
    simulation. This helps prevent erroneous vertical scroll jittering when swiping horizontally.

3.  Apply the initial touch move delta when beginning the simulated touches, so that we immediately
    dispatch `touchstart` over the centroid and `touchmove` to the centroid offset by the initial
    delta. This prevents the stream of simulated touches from being incorrectly handled as a tap
    gesture, if the touch simulation ends right after it begins.

(WebKit::PointerTouchCompatibilitySimulator::resetState):
(WebKit::PointerTouchCompatibilitySimulator::locationInScreen const):

Rename `m_delta` to `m_touchDelta` to clarify that this tracks the overall touch delta once the
simulated touch event stream begins.

(WebKit::PointerTouchCompatibilitySimulator::setEnabled):

Add a method to enable/disable `PointerTouchCompatibilitySimulator` on the fly, now that we always
create this helper class but only activate it when the user hovers over specific DOM elements in a
couple of targeted native apps.

(WebKit::PointerTouchCompatibilitySimulator::requiresPointerTouchCompatibility): Deleted.

Move this logic into `WebCore::Quirks`, now that it additionally depends on the state of the DOM.

* Source/WebKit/UIProcess/ios/WKBaseScrollView.h:

Add a new delegate method that allows WebKit&apos;s managed scroll views to avoid recognizing pan
gestures due to simulated touches.

* Source/WebKit/UIProcess/ios/WKBaseScrollView.mm:
(-[WKBaseScrollView gestureRecognizer:shouldReceiveTouch:]):

Additionally override `-gestureRecognizer:shouldReceiveTouch:` and return `NO` when pointer touch
compatibility simulator is actively sending touches to avoid unwanted scrolling due to these
simulated touches.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _updateLastPointerRegionIfNeeded:]):

Make this also update the enablement state of `PointerTouchCompatibilitySimulator`, based on
`needsPointerTouchCompatibilityQuirk` in the position information computed based on the cursor
location.

* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::elementPositionInformation):

Populate the new `needsPointerTouchCompatibilityQuirk` member on position information, based the
hit-tested node and new heuristics in `Quirks`.

Canonical link: <a href="https://commits.webkit.org/287368@main">https://commits.webkit.org/287368@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22fb7cde754461f0d53cedee449062f08fa8dbe1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79370 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58397 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32744 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83980 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/30507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81503 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67463 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6659 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/62080 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/30507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82437 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/52140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72314 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42389 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/49484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26501 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28910 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/72456 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/70597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26947 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85384 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/78560 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6646 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6811 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68191 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17333 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13628 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12491 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/100901 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6598 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/24617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/6512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9987 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/8310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->