### PR TITLE
[JSC] Track # of active JITPlan for compiler thread suspension

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -2557,7 +2557,7 @@ bool CodeBlock::checkIfOptimizationThresholdReached()
 {
 #if ENABLE(DFG_JIT)
     if (JITWorklist* worklist = JITWorklist::existingGlobalWorklistOrNull()) {
-        if (worklist->compilationState(JITCompilationKey(this, JITCompilationMode::DFG)) == JITWorklist::Compiled) {
+        if (worklist->compilationState(*m_vm, JITCompilationKey(this, JITCompilationMode::DFG)) == JITWorklist::Compiled) {
             optimizeNextInvocation();
             return true;
         }

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -711,7 +711,7 @@ private:
     Ticket requestCollection(GCRequest);
     void waitForCollection(Ticket);
     
-    void suspendCompilerThreads();
+    bool suspendCompilerThreads();
     void willStartCollection();
     void prepareForMarking();
     
@@ -946,6 +946,7 @@ private:
     bool m_mutatorDidRun { true };
     bool m_didDeferGCWork { false };
     bool m_shouldStopCollectingContinuously { false };
+    bool m_isCompilerThreadsSuspended { false };
 
     uint64_t m_mutatorExecutionVersion { 0 };
     uint64_t m_phaseVersion { 0 };

--- a/Source/JavaScriptCore/jit/JITPlan.cpp
+++ b/Source/JavaScriptCore/jit/JITPlan.cpp
@@ -52,6 +52,13 @@ JITPlan::JITPlan(JITCompilationMode mode, CodeBlock* codeBlock)
     , m_vm(&codeBlock->vm())
     , m_codeBlock(codeBlock)
 {
+    m_vm->changeNumberOfActiveJITPlans(1);
+}
+
+JITPlan::~JITPlan()
+{
+    if (m_vm)
+        m_vm->changeNumberOfActiveJITPlans(-1);
 }
 
 void JITPlan::cancel()
@@ -59,6 +66,7 @@ void JITPlan::cancel()
     RELEASE_ASSERT(m_stage != JITPlanStage::Canceled);
     RELEASE_ASSERT(!safepointKeepsDependenciesLive());
     ASSERT(m_vm);
+    m_vm->changeNumberOfActiveJITPlans(-1);
     m_stage = JITPlanStage::Canceled;
     m_vm = nullptr;
     m_codeBlock = nullptr;

--- a/Source/JavaScriptCore/jit/JITPlan.h
+++ b/Source/JavaScriptCore/jit/JITPlan.h
@@ -48,7 +48,7 @@ protected:
     JITPlan(JITCompilationMode, CodeBlock*);
 
 public:
-    virtual ~JITPlan() { }
+    virtual ~JITPlan();
 
     VM* vm() const { return m_vm; }
     CodeBlock* codeBlock() const { return m_codeBlock; }

--- a/Source/JavaScriptCore/jit/JITWorklist.cpp
+++ b/Source/JavaScriptCore/jit/JITWorklist.cpp
@@ -141,8 +141,11 @@ void JITWorklist::resumeAllThreads() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
     m_suspensionLock.unlock();
 }
 
-auto JITWorklist::compilationState(JITCompilationKey key) -> State
+auto JITWorklist::compilationState(VM& vm, JITCompilationKey key) -> State
 {
+    if (!vm.numberOfActiveJITPlans())
+        return NotKnown;
+
     Locker locker { *m_lock };
     const auto& iter = m_plans.find(key);
     if (iter == m_plans.end())
@@ -152,6 +155,9 @@ auto JITWorklist::compilationState(JITCompilationKey key) -> State
 
 auto JITWorklist::completeAllReadyPlansForVM(VM& vm, JITCompilationKey requestedKey) -> State
 {
+    if (!vm.numberOfActiveJITPlans())
+        return NotKnown;
+
     DeferGC deferGC(vm);
 
     Vector<RefPtr<JITPlan>, 8> myReadyPlans;
@@ -210,6 +216,9 @@ void JITWorklist::waitUntilAllPlansForVMAreReady(VM& vm)
 
 void JITWorklist::completeAllPlansForVM(VM& vm)
 {
+    if (!vm.numberOfActiveJITPlans())
+        return;
+
     DeferGC deferGC(vm);
     waitUntilAllPlansForVMAreReady(vm);
     completeAllReadyPlansForVM(vm);
@@ -217,6 +226,9 @@ void JITWorklist::completeAllPlansForVM(VM& vm)
 
 void JITWorklist::cancelAllPlansForVM(VM& vm)
 {
+    if (!vm.numberOfActiveJITPlans())
+        return;
+
     removeMatchingPlansForVM(vm, [&](JITPlan& plan) {
         return plan.stage() != JITPlanStage::Compiling;
     });
@@ -229,6 +241,9 @@ void JITWorklist::cancelAllPlansForVM(VM& vm)
 
 void JITWorklist::removeDeadPlans(VM& vm)
 {
+    if (!vm.numberOfActiveJITPlans())
+        return;
+
     removeMatchingPlansForVM(vm, [&](JITPlan& plan) {
         if (!plan.isKnownToBeLiveAfterGC())
             return true;

--- a/Source/JavaScriptCore/jit/JITWorklist.h
+++ b/Source/JavaScriptCore/jit/JITWorklist.h
@@ -60,11 +60,9 @@ public:
     void resumeAllThreads();
 
     enum State { NotKnown, Compiling, Compiled };
-    State compilationState(JITCompilationKey);
+    State compilationState(VM&, JITCompilationKey);
 
     State completeAllReadyPlansForVM(VM&, JITCompilationKey = JITCompilationKey());
-
-    void waitUntilAllPlansForVMAreReady(VM&);
 
     // This is equivalent to:
     // worklist->waitUntilAllPlansForVMAreReady(vm);
@@ -91,6 +89,8 @@ private:
     JITWorklist();
 
     size_t queueLength(const AbstractLocker&) const;
+
+    void waitUntilAllPlansForVMAreReady(VM&);
 
     template<typename MatchFunction>
     void removeMatchingPlansForVM(VM&, const MatchFunction&);

--- a/Source/JavaScriptCore/jit/JITWorklistInlines.h
+++ b/Source/JavaScriptCore/jit/JITWorklistInlines.h
@@ -34,6 +34,9 @@ namespace JSC {
 template<typename Visitor>
 void JITWorklist::iterateCodeBlocksForGC(Visitor& visitor, VM& vm, const Function<void(CodeBlock*)>& func)
 {
+    if (!vm.numberOfActiveJITPlans())
+        return;
+
     Locker locker { *m_lock };
     for (auto& entry : m_plans) {
         if (entry.value->vm() != &vm)

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -1007,6 +1007,13 @@ public:
     template<typename Func>
     void forEachDebugger(const Func&);
 
+    void changeNumberOfActiveJITPlans(int64_t value)
+    {
+        m_numberOfActiveJITPlans.fetch_add(value, std::memory_order_relaxed);
+    }
+
+    int64_t numberOfActiveJITPlans() const { return m_numberOfActiveJITPlans.load(std::memory_order_relaxed); }
+
     Ref<Waiter> syncWaiter();
 
     void notifyDebuggerHookInjected() { m_isDebuggerHookInjected = true; }
@@ -1134,6 +1141,8 @@ private:
     UncheckedKeyHashMap<const JSInstruction*, std::pair<unsigned, std::unique_ptr<uintptr_t>>> m_loopHintExecutionCounts;
 
     Ref<Waiter> m_syncWaiter;
+
+    std::atomic<int64_t> m_numberOfActiveJITPlans { 0 };
 
     Vector<Function<void()>> m_didPopListeners;
 


### PR DESCRIPTION
#### ac3edb570f403e4e1e47bee55f610a99f9d46c38
<pre>
[JSC] Track # of active JITPlan for compiler thread suspension
<a href="https://bugs.webkit.org/show_bug.cgi?id=284046">https://bugs.webkit.org/show_bug.cgi?id=284046</a>
<a href="https://rdar.apple.com/140920747">rdar://140920747</a>

Reviewed by Keith Miller.

JITWorklist is global data structure and shared by all VMs.
When GC runs on one VM, we need to suspend compiler threads in
JITWorklist since it can touch GC-managed objects. But it is possible
that no JITPlan is scheduled for GC-ing VM if there are many VMs.
In that case, we do not need to suspend and resume compiler threads.

This patch tracks # of active JITPlans for a VM. And we avoid suspending
and resuming compiler threads when we know that VM does not have any
active JITPlans.

* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::checkIfOptimizationThresholdReached):
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::stopThePeriphery):
(JSC::Heap::resumeThePeriphery):
(JSC::Heap::suspendCompilerThreads):
(JSC::Heap::resumeCompilerThreads):
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/jit/JITPlan.cpp:
(JSC::JITPlan::JITPlan):
(JSC::JITPlan::~JITPlan):
(JSC::JITPlan::cancel):
* Source/JavaScriptCore/jit/JITPlan.h:
(JSC::JITPlan::~JITPlan): Deleted.
* Source/JavaScriptCore/jit/JITWorklist.cpp:
(JSC::JITWorklist::compilationState):
(JSC::JITWorklist::completeAllReadyPlansForVM):
(JSC::JITWorklist::completeAllPlansForVM):
(JSC::JITWorklist::cancelAllPlansForVM):
(JSC::JITWorklist::removeDeadPlans):
* Source/JavaScriptCore/jit/JITWorklist.h:
* Source/JavaScriptCore/jit/JITWorklistInlines.h:
(JSC::JITWorklist::iterateCodeBlocksForGC):
* Source/JavaScriptCore/runtime/VM.h:
(JSC::VM::changeNumberOfActiveJITPlans):
(JSC::VM::numberOfActiveJITPlans const):

Canonical link: <a href="https://commits.webkit.org/287355@main">https://commits.webkit.org/287355@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c95008e7ff814fc50f3a10450a5f8491f797f4eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79305 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58333 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32677 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83927 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30466 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67420 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6603 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/62045 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19940 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82372 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52102 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72258 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42352 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49446 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26435 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28859 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/72411 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70558 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26878 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85322 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/78511 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6600 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70289 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6764 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68132 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69537 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13588 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12440 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/100838 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12241 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6553 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/24605 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/struct-new_default-small-members.js.wasm-eager (failure)") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/6473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9945 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8269 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->