### PR TITLE
Stop taking unbounded network assertion in host app for downloads

### DIFF
--- a/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
@@ -224,6 +224,8 @@ void Download::startUpdatingProgress()
     auto *progress = (WKModernDownloadProgress *)m_progress;
     [progress startUpdatingDownloadProgress];
 
+    send(Messages::DownloadProxy::DidStartUpdatingProgress());
+
     // If we have a download task, progress is updated by observing this task. See startUpdatingDownloadProgress method.
     if (m_downloadTask)
         return;

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
@@ -34,6 +34,7 @@
 #include "FrameInfoData.h"
 #include "NetworkProcessMessages.h"
 #include "NetworkProcessProxy.h"
+#include "ProcessAssertion.h"
 #include "WebPageProxy.h"
 #include "WebProcessMessages.h"
 #include "WebProtectionSpace.h"
@@ -62,6 +63,9 @@ DownloadProxy::DownloadProxy(DownloadProxyMap& downloadProxyMap, WebsiteDataStor
     , m_request(resourceRequest)
     , m_originatingPage(originatingPage)
     , m_frameInfo(API::FrameInfo::create(FrameInfoData { frameInfoData }, originatingPage))
+#if HAVE(MODERN_DOWNLOADPROGRESS)
+    , m_assertion(ProcessAssertion::create(getCurrentProcessID(), "WebKit DownloadProxy DecideDestination"_s, ProcessAssertionType::FinishTaskInterruptable))
+#endif
 {
 }
 

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
@@ -56,6 +56,7 @@ class ResourceResponse;
 namespace WebKit {
 
 class DownloadProxyMap;
+class ProcessAssertion;
 class WebPageProxy;
 
 enum class AllowOverwrite : bool;
@@ -124,6 +125,7 @@ public:
 #if HAVE(MODERN_DOWNLOADPROGRESS)
     void didReceivePlaceholderURL(const URL&, std::span<const uint8_t> bookmarkData, WebKit::SandboxExtensionHandle&&, CompletionHandler<void()>&&);
     void didReceiveFinalURL(const URL&, std::span<const uint8_t> bookmarkData, WebKit::SandboxExtensionHandle&&);
+    void didStartUpdatingProgress();
 #endif
     void willSendRequest(WebCore::ResourceRequest&& redirectRequest, const WebCore::ResourceResponse& redirectResponse, CompletionHandler<void(WebCore::ResourceRequest&&)>&&);
     void decideDestinationWithSuggestedFilename(const WebCore::ResourceResponse&, String&& suggestedFilename, DecideDestinationCallback&&);
@@ -159,6 +161,9 @@ private:
     CompletionHandler<void(DownloadProxy*)> m_didStartCallback;
 #if PLATFORM(COCOA)
     RetainPtr<NSProgress> m_progress;
+#endif
+#if HAVE(MODERN_DOWNLOADPROGRESS)
+    RefPtr<ProcessAssertion> m_assertion;
 #endif
 };
 

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.messages.in
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.messages.in
@@ -32,5 +32,6 @@ messages -> DownloadProxy {
 #if HAVE(MODERN_DOWNLOADPROGRESS)
     DidReceivePlaceholderURL(URL placeholderURL, std::span<const uint8_t> bookmarkData, WebKit::SandboxExtensionHandle handle) -> ()
     DidReceiveFinalURL(URL finalURL, std::span<const uint8_t> bookmarkData, WebKit::SandboxExtensionHandle handle)
+    DidStartUpdatingProgress()
 #endif
 }

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxyCocoa.mm
@@ -78,6 +78,11 @@ void DownloadProxy::didReceiveFinalURL(const URL& finalURL, std::span<const uint
     m_client->didReceiveFinalURL(*this, finalURL, bookmarkData);
 }
 
+void DownloadProxy::didStartUpdatingProgress()
+{
+    m_assertion = nullptr;
+}
+
 Vector<uint8_t> DownloadProxy::bookmarkDataForURL(const URL& url)
 {
     RetainPtr localURL = adoptNS([[NSURL alloc] initFileURLWithPath:url.fileSystemPath() relativeToURL:nil]);

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxyMap.cpp
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxyMap.cpp
@@ -49,7 +49,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(DownloadProxyMap);
 
 DownloadProxyMap::DownloadProxyMap(NetworkProcessProxy& process)
     : m_process(process)
-#if PLATFORM(COCOA)
+#if PLATFORM(COCOA) && !HAVE(MODERN_DOWNLOADPROGRESS)
     , m_shouldTakeAssertion(WTF::processHasEntitlement("com.apple.multitasking.systemappassertions"_s))
 #endif
 {


### PR DESCRIPTION
#### ed142da66dbff90e39c31856eabb53af5ff9318d
<pre>
Stop taking unbounded network assertion in host app for downloads
<a href="https://bugs.webkit.org/show_bug.cgi?id=284052">https://bugs.webkit.org/show_bug.cgi?id=284052</a>
<a href="https://rdar.apple.com/140156066">rdar://140156066</a>

Reviewed by Per Arne Vollan.

Now that we&apos;ve moved assertion management for downloads to dasd (284764@main), we should also remove
the unbounded networking assertion for the host app. Instead we should keep the host app running
only long enough until it starts receiving progress updates, at which point it should be safe to
suspend the host app.

* Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm:
(WebKit::Download::startUpdatingProgress):
* Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp:
(WebKit::m_assertion):
* Source/WebKit/UIProcess/Downloads/DownloadProxy.h:
* Source/WebKit/UIProcess/Downloads/DownloadProxy.messages.in:
* Source/WebKit/UIProcess/Downloads/DownloadProxyCocoa.mm:
(WebKit::DownloadProxy::startUpdatingProgress):
* Source/WebKit/UIProcess/Downloads/DownloadProxyMap.cpp:
(WebKit::DownloadProxyMap::DownloadProxyMap):

Canonical link: <a href="https://commits.webkit.org/287370@main">https://commits.webkit.org/287370@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7386343e1649c1ae068f627e5f34822d24db0f53

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79323 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58352 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32718 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83942 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30478 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67432 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6617 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62050 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19946 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82390 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52111 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72297 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42357 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49455 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28874 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70567 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26927 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85338 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6613 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4600 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70301 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6777 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68171 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69549 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17335 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13600 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12475 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6565 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6484 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9957 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8280 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->