### PR TITLE
imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-in-new-javascript-url-iframe.html is failing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-in-new-javascript-url-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-in-new-javascript-url-iframe-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL entries() and currentEntry should be set in a new javascript: URL iframe assert_not_equals: got disallowed value null
+PASS entries() and currentEntry should be set in a new javascript: URL iframe
 

--- a/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/Source/WebCore/bindings/js/ScriptController.cpp
@@ -31,6 +31,7 @@
 #include "Event.h"
 #include "FrameLoader.h"
 #include "HTMLPlugInElement.h"
+#include "HistoryController.h"
 #include "InspectorInstrumentation.h"
 #include "JSDOMBindingSecurity.h"
 #include "JSDOMExceptionHandling.h"
@@ -895,6 +896,11 @@ void ScriptController::executeJavaScriptURL(const URL& url, const NavigationActi
 
         // We're still in a frame, so there should be a DocumentLoader.
         ASSERT(documentLoader);
+
+        // If there is no current history item, create one since we're about to commit a document
+        // from the JS URL.
+        if (!m_frame.history().currentItem())
+            m_frame.checkedHistory()->updateForRedirectWithLockedBackForwardList();
 
         // Since we're replacing the document, this JavaScript URL load acts as a "Replace" navigation.
         // Make sure the triggering action get set on the DocumentLoader since some logic in


### PR DESCRIPTION
#### 1e21ed7d927f52cff93c0630ece2b7288114ceee
<pre>
imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-in-new-javascript-url-iframe.html is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=284051">https://bugs.webkit.org/show_bug.cgi?id=284051</a>

Reviewed by Rob Buis.

When an iframe loads a JavaScript URL as first load, we would fail to create
a HistoryItem, even though we do commit a document. As a result,
navigation.entries would remain empty and the test would fail.

Fix this by making sure we create a HistoryItem when committing a JS URL, if
there is no current HistoryItem.

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-in-new-javascript-url-iframe-expected.txt:
* Source/WebCore/bindings/js/ScriptController.cpp:
(WebCore::ScriptController::executeJavaScriptURL):

Canonical link: <a href="https://commits.webkit.org/287448@main">https://commits.webkit.org/287448@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/761af7fb4abdaf94c4b8b7726d07d4cacd78d919

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79313 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58341 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32684 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83933 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30471 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81446 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67425 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6608 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62042 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19942 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82380 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52108 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72266 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42349 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49452 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26444 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28865 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70564 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26887 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85329 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6605 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4595 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70292 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6769 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68141 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69540 "Found 1 new API test failure: /WebKitGTK/TestAuthentication:/webkit/Authentication/authentication-empty-realm (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13594 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12447 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12310 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6558 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12307 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6478 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9950 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8274 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->