### PR TITLE
Move BlockStepSizing code to its own file

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2753,6 +2753,7 @@ rendering/AutoTableLayout.cpp
 rendering/BackgroundPainter.cpp
 rendering/BaselineAlignment.cpp
 rendering/BidiRun.cpp
+rendering/BlockStepSizing.cpp
 rendering/BorderEdge.cpp
 rendering/BorderPainter.cpp
 rendering/BorderShape.cpp

--- a/Source/WebCore/rendering/BlockStepSizing.cpp
+++ b/Source/WebCore/rendering/BlockStepSizing.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "BlockStepSizing.h"
+
+#include "RenderBox.h"
+#include "RenderStyleInlines.h"
+
+namespace WebCore {
+
+namespace BlockStepSizing {
+
+bool childHasSupportedStyle(const RenderStyle& childStyle)
+{
+    return childStyle.blockStepInsert() == BlockStepInsert::MarginBox
+        && childStyle.blockStepAlign() == BlockStepAlign::Auto
+        && childStyle.blockStepRound() == BlockStepRound::Up;
+}
+
+LayoutUnit computeExtraSpace(LayoutUnit stepSize, LayoutUnit boxOuterSize)
+{
+    if (!stepSize)
+        return { };
+
+    if (!boxOuterSize)
+        return stepSize;
+
+    if (auto remainder = intMod(boxOuterSize, stepSize))
+        return stepSize - remainder;
+    return { };
+}
+
+void distributeExtraSpaceToChildMargins(RenderBox& child, LayoutUnit extraSpace, WritingMode containingBlockWritingMode)
+{
+    auto halfExtraSpace = extraSpace / 2;
+    child.setMarginBefore(child.marginBefore(containingBlockWritingMode) + halfExtraSpace);
+    child.setMarginAfter(child.marginAfter(containingBlockWritingMode) + halfExtraSpace);
+}
+
+NO_RETURN_DUE_TO_ASSERT void distributeExtraSpaceToChildPadding(RenderBox& /* child */, LayoutUnit /* extraSpace */, WritingMode /* containingBlockWritingMode */)
+{
+    ASSERT_NOT_IMPLEMENTED_YET();
+}
+
+NO_RETURN_DUE_TO_ASSERT void distributeExtraSpaceToChildContentArea(RenderBox& /* child */, LayoutUnit /* extraSpace */, WritingMode /* containingBlockWritingMode */)
+{
+    ASSERT_NOT_IMPLEMENTED_YET();
+}
+
+} // namespace BlockStepSizing
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/BlockStepSizing.h
+++ b/Source/WebCore/rendering/BlockStepSizing.h
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+class LayoutUnit;
+class RenderBox;
+class RenderStyle;
+class WritingMode;
+
+namespace BlockStepSizing {
+
+bool childHasSupportedStyle(const RenderStyle& childStyle);
+
+LayoutUnit computeExtraSpace(LayoutUnit stepSize, LayoutUnit boxOuterSize);
+
+void distributeExtraSpaceToChildMargins(RenderBox& child, LayoutUnit extraSpace, WritingMode containingBlockWritingMode);
+void distributeExtraSpaceToChildPadding(RenderBox& /* child */, LayoutUnit /* extraSpace */, WritingMode /* containingBlockWritingMode */);
+void distributeExtraSpaceToChildContentArea(RenderBox& /* child */, LayoutUnit /* extraSpace */, WritingMode /* containingBlockWritingMode */);
+
+} // namespace BlockStepSizing
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -25,6 +25,7 @@
 #include "config.h"
 #include "RenderBlockFlow.h"
 
+#include "BlockStepSizing.h"
 #include "Editor.h"
 #include "ElementInlines.h"
 #include "FloatingObjects.h"
@@ -90,47 +91,6 @@ struct SameSizeAsMarginInfo {
 
 static_assert(sizeof(MarginValues) == sizeof(LayoutUnit[4]), "MarginValues should stay small");
 static_assert(sizeof(RenderBlockFlow::MarginInfo) == sizeof(SameSizeAsMarginInfo), "MarginInfo should stay small");
-
-namespace BlockStepSizing {
-
-static bool childHasSupportedStyle(const RenderStyle& childStyle)
-{
-    return childStyle.blockStepInsert() == BlockStepInsert::MarginBox
-        && childStyle.blockStepAlign() == BlockStepAlign::Auto
-        && childStyle.blockStepRound() == BlockStepRound::Up;
-}
-
-static LayoutUnit computeExtraSpace(LayoutUnit stepSize, LayoutUnit boxOuterSize)
-{
-    if (!stepSize)
-        return { };
-
-    if (!boxOuterSize)
-        return stepSize;
-
-    if (auto remainder = intMod(boxOuterSize, stepSize))
-        return stepSize - remainder;
-    return { };
-}
-
-static void distributeExtraSpaceToChildMargins(RenderBox& child, LayoutUnit extraSpace, WritingMode containingBlockWritingMode)
-{
-    auto halfExtraSpace = extraSpace / 2;
-    child.setMarginBefore(child.marginBefore(containingBlockWritingMode) + halfExtraSpace);
-    child.setMarginAfter(child.marginAfter(containingBlockWritingMode) + halfExtraSpace);
-}
-
-NO_RETURN_DUE_TO_ASSERT static void distributeExtraSpaceToChildPadding(RenderBox& /* child */, LayoutUnit /* extraSpace */, WritingMode /* containingBlockWritingMode */)
-{
-    ASSERT_NOT_IMPLEMENTED_YET();
-}
-
-NO_RETURN_DUE_TO_ASSERT static void distributeExtraSpaceToChildContentArea(RenderBox& /* child */, LayoutUnit /* extraSpace */, WritingMode /* containingBlockWritingMode */)
-{
-    ASSERT_NOT_IMPLEMENTED_YET();
-}
-
-};
 
 RenderBlockFlowRareData::RenderBlockFlowRareData(const RenderBlockFlow& block)
     : m_margins(positiveMarginBeforeDefault(block), negativeMarginBeforeDefault(block), positiveMarginAfterDefault(block), negativeMarginAfterDefault(block))


### PR DESCRIPTION
#### 45cf77d8f25bdccbb56bf765a6bac7bc0893e7e3
<pre>
Move BlockStepSizing code to its own file
<a href="https://rdar.apple.com/140923146">rdar://140923146</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=284049">https://bugs.webkit.org/show_bug.cgi?id=284049</a>

Reviewed by Tim Nguyen.

These functions don&apos;t have to live on RenderBlockFlow so lets move them
to their own set of files.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/rendering/BlockStepSizing.cpp: Added.
(WebCore::BlockStepSizing::childHasSupportedStyle):
(WebCore::BlockStepSizing::computeExtraSpace):
(WebCore::BlockStepSizing::distributeExtraSpaceToChildMargins):
(WebCore::BlockStepSizing::distributeExtraSpaceToChildPadding):
(WebCore::BlockStepSizing::distributeExtraSpaceToChildContentArea):
* Source/WebCore/rendering/BlockStepSizing.h: Added.
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::BlockStepSizing::childHasSupportedStyle): Deleted.
(WebCore::BlockStepSizing::computeExtraSpace): Deleted.
(WebCore::BlockStepSizing::distributeExtraSpaceToChildMargins): Deleted.
(WebCore::BlockStepSizing::distributeExtraSpaceToChildPadding): Deleted.
(WebCore::BlockStepSizing::distributeExtraSpaceToChildContentArea): Deleted.

Canonical link: <a href="https://commits.webkit.org/287371@main">https://commits.webkit.org/287371@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/150123c088a8b92b86c01c420fe1e6934580d84e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79344 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58372 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32721 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83958 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30491 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81477 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67446 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6633 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62064 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19951 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82411 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52119 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72295 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42372 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49463 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26482 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28890 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70575 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26928 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85358 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6627 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4612 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70318 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6791 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68172 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69565 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17337 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13606 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12476 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6579 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6497 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9971 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8294 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->