### PR TITLE
[WebGPU] onSubmittedWorkDone hangs when no work was submitted

### DIFF
--- a/LayoutTests/fast/webgpu/regression/repro_284053-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_284053-expected.txt
@@ -1,0 +1,5 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/repro_284053.html
+++ b/LayoutTests/fast/webgpu/regression/repro_284053.html
@@ -1,0 +1,18 @@
+<script>
+async function run() {
+    let adapter1 = await navigator.gpu.requestAdapter();
+    let device0 = await adapter1.requestDevice({ requiredLimits: { maxTextureDimension1D: 10000 } });
+    let texture0 = device0.createTexture({ size: [10000], dimension: '1d', format: 'rg11b10ufloat', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC });
+    let buffer1 = device0.createBuffer({ size: 39589, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX, });
+    let commandEncoder3 = device0.createCommandEncoder();
+    commandEncoder3.copyTextureToBuffer(
+        { texture: texture0 },
+        { buffer: buffer1 },
+        { width: 2146, height: 1 },
+    )
+    await device0.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
+}
+globalThis.testRunner?.waitUntilDone();
+run();
+</script>

--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -181,7 +181,7 @@ void Queue::onSubmittedWorkDone(CompletionHandler<void(WGPUQueueWorkDoneStatus)>
 
     finalizeBlitCommandEncoder();
 
-    if (isIdle()) {
+    if (isIdle() || m_submittedCommandBufferCount == m_completedCommandBufferCount) {
         scheduleWork([callback = WTFMove(callback)]() mutable {
             callback(WGPUQueueWorkDoneStatus_Success);
         });


### PR DESCRIPTION
#### 3bee0af9727649da0b4ef130e6a14a895ad6884e
<pre>
[WebGPU] onSubmittedWorkDone hangs when no work was submitted
<a href="https://bugs.webkit.org/show_bug.cgi?id=284053">https://bugs.webkit.org/show_bug.cgi?id=284053</a>
<a href="https://rdar.apple.com/140888787">rdar://140888787</a>

Reviewed by NOBODY (OOPS!).

If the completedCommandBuffer count was equal to the count of command buffers
submitted, i.e., no additional GPUCommandBuffers were submitted to GPUQueue.submit(),
GPUQueue.onSubmittedWorkDone() would appear to hang as its promise was never resolved.

* LayoutTests/ifast/webgpu/regression/repro_284053-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_284053.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::onSubmittedWorkDone):
Immedietly resolve when no work is pending.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3bee0af9727649da0b4ef130e6a14a895ad6884e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79324 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58353 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32694 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83943 "Failed to checkout and rebase branch from PR 37446") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/30479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/67433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/6618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/83943 "Failed to checkout and rebase branch from PR 37446") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/30479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82391 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/67433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/72277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/83943 "Failed to checkout and rebase branch from PR 37446") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/67433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/26457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28875 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/67433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/26901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85339 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/6614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/6618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/70300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/6778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/68152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/69548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/12459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/6566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/6485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/9958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/8281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->