### PR TITLE
[iPad] docs.google.com: Clicking on “NO THANKS” or “GET THE APP” using trackpad does nothing

### DIFF
--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -715,7 +715,7 @@ public:
 
     virtual void callAfterPendingSyntheticClick(CompletionHandler<void(SyntheticClickResult)>&& completion) { completion(SyntheticClickResult::Failed); }
 
-    virtual void didSwallowClickEvent(const PlatformMouseEvent&, Node&) { }
+    virtual void didDispatchClickEvent(const PlatformMouseEvent&, Node&) { }
 
     WEBCORE_EXPORT virtual ~ChromeClient();
 

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -2325,13 +2325,12 @@ bool EventHandler::swallowAnyClickEvent(const PlatformMouseEvent& platformMouseE
     // The click event should only be fired for the primary pointer button.
 
     auto& eventName = isPrimaryPointerButton ? eventNames().clickEvent : eventNames().auxclickEvent;
-    if (dispatchMouseEvent(eventName, nodeToClick.get(), m_clickCount, platformMouseEvent, FireMouseOverOut::Yes))
-        return false;
+    bool swallowed = !dispatchMouseEvent(eventName, nodeToClick.get(), m_clickCount, platformMouseEvent, FireMouseOverOut::Yes);
 
     if (RefPtr page = m_frame->protectedPage())
-        page->chrome().client().didSwallowClickEvent(platformMouseEvent, *nodeToClick);
+        page->chrome().client().didDispatchClickEvent(platformMouseEvent, *nodeToClick);
 
-    return true;
+    return swallowed;
 }
 
 HandleUserInputEventResult EventHandler::handleMouseReleaseEvent(const PlatformMouseEvent& platformMouseEvent)

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -225,7 +225,7 @@ public:
 
 #if PLATFORM(IOS_FAMILY)
     WEBCORE_EXPORT bool shouldIgnoreContentObservationForClick(const Node&) const;
-    WEBCORE_EXPORT bool shouldSynthesizeTouchEventsAfterNonSyntheticClick(const Node&) const;
+    WEBCORE_EXPORT bool shouldSynthesizeTouchEventsAfterNonSyntheticClick(const Element&) const;
 #endif
 
     bool needsMozillaFileTypeForDataTransfer() const;
@@ -249,8 +249,10 @@ private:
     bool isSpotifyPlayer() const;
 
     bool isAmazon() const;
+    bool isCBSSports() const;
     bool isESPN() const;
     bool isGoogleMaps() const;
+    bool isGoogleDocs() const;
     bool isNetflix() const;
     bool isSoundCloud() const;
     bool isVimeo() const;

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -29,7 +29,9 @@ namespace WebCore {
 
 struct WEBCORE_EXPORT QuirksData {
     std::optional<bool> isAmazon;
+    std::optional<bool> isCBSSports;
     std::optional<bool> isESPN;
+    std::optional<bool> isGoogleDocs;
     std::optional<bool> isGoogleMaps;
     std::optional<bool> isNetflix;
     std::optional<bool> isSoundCloud;
@@ -69,7 +71,6 @@ struct WEBCORE_EXPORT QuirksData {
 
 #if PLATFORM(IOS_FAMILY)
     std::optional<bool> mayNeedToIgnoreContentObservation;
-    std::optional<bool> needsDeferKeyDownAndKeyPressTimersUntilNextEditingCommandQuirk;
     std::optional<bool> needsFullscreenDisplayNoneQuirk;
     std::optional<bool> needsFullscreenObjectFitQuirk;
     std::optional<bool> needsGMailOverflowScrollQuirk;
@@ -81,8 +82,6 @@ struct WEBCORE_EXPORT QuirksData {
     std::optional<bool> shouldEnableApplicationCacheQuirk;
     std::optional<bool> shouldIgnoreAriaForFastPathContentObservationCheckQuirk;
     std::optional<bool> shouldNavigatorPluginsBeEmpty;
-    std::optional<bool> shouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreasQuirk;
-    std::optional<bool> shouldSynthesizeTouchEventsAfterNonSyntheticClickQuirk;
 #endif
 
 #if PLATFORM(IOS) || PLATFORM(VISION)
@@ -97,7 +96,6 @@ struct WEBCORE_EXPORT QuirksData {
 
 #if PLATFORM(MAC)
     std::optional<bool> isNeverRichlyEditableForTouchBarQuirk;
-    std::optional<bool> isTouchBarUpdateSuppressedForHiddenContentEditableQuirk;
     std::optional<bool> needsFormControlToBeMouseFocusableQuirk;
     std::optional<bool> needsPrimeVideoUserSelectNoneQuirk;
 #endif

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1986,9 +1986,9 @@ void WebChromeClient::callAfterPendingSyntheticClick(CompletionHandler<void(Synt
     protectedPage()->callAfterPendingSyntheticClick(WTFMove(completion));
 }
 
-void WebChromeClient::didSwallowClickEvent(const PlatformMouseEvent& event, Node& node)
+void WebChromeClient::didDispatchClickEvent(const PlatformMouseEvent& event, Node& node)
 {
-    protectedPage()->didSwallowClickEvent(event, node);
+    protectedPage()->didDispatchClickEvent(event, node);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -548,7 +548,7 @@ private:
 
     void callAfterPendingSyntheticClick(CompletionHandler<void(WebCore::SyntheticClickResult)>&&) final;
 
-    void didSwallowClickEvent(const WebCore::PlatformMouseEvent&, WebCore::Node&) final;
+    void didDispatchClickEvent(const WebCore::PlatformMouseEvent&, WebCore::Node&) final;
 
     mutable bool m_cachedMainFrameHasHorizontalScrollbar { false };
     mutable bool m_cachedMainFrameHasVerticalScrollbar { false };

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1867,7 +1867,7 @@ public:
 
     void callAfterPendingSyntheticClick(CompletionHandler<void(WebCore::SyntheticClickResult)>&&);
 
-    void didSwallowClickEvent(const WebCore::PlatformMouseEvent&, WebCore::Node&);
+    void didDispatchClickEvent(const WebCore::PlatformMouseEvent&, WebCore::Node&);
 
 private:
     WebPage(WebCore::PageIdentifier, WebPageCreationParameters&&);
@@ -2960,7 +2960,7 @@ inline void WebPage::prepareToRunModalJavaScriptDialog() { }
 #endif
 
 #if !ENABLE(IOS_TOUCH_EVENTS)
-inline void WebPage::didSwallowClickEvent(const WebCore::PlatformMouseEvent&, WebCore::Node&) { }
+inline void WebPage::didDispatchClickEvent(const WebCore::PlatformMouseEvent&, WebCore::Node&) { }
 #endif
 
 #if !PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -5783,7 +5783,7 @@ void WebPage::callAfterPendingSyntheticClick(CompletionHandler<void(SyntheticCli
 
 #if ENABLE(IOS_TOUCH_EVENTS)
 
-void WebPage::didSwallowClickEvent(const PlatformMouseEvent& event, Node& node)
+void WebPage::didDispatchClickEvent(const PlatformMouseEvent& event, Node& node)
 {
     if (!m_userIsInteracting)
         return;
@@ -5794,16 +5794,16 @@ void WebPage::didSwallowClickEvent(const PlatformMouseEvent& event, Node& node)
     if (event.syntheticClickType() != SyntheticClickType::NoTap)
         return;
 
-    RefPtr element = dynamicDowncast<Element>(node);
+    RefPtr element = dynamicDowncast<Element>(node) ?: node.parentElementInComposedTree();
     if (!element)
         return;
 
     Ref document = node.document();
-    if (!document->quirks().shouldSynthesizeTouchEventsAfterNonSyntheticClick(node))
+    if (!document->quirks().shouldSynthesizeTouchEventsAfterNonSyntheticClick(*element))
         return;
 
     bool isReplaced = false;
-    auto bounds = node.absoluteBoundingRect(&isReplaced);
+    auto bounds = element->absoluteBoundingRect(&isReplaced);
     if (bounds.isEmpty())
         return;
 


### PR DESCRIPTION
#### a01c92ffd71c327f774bd1edb452a10558e8d71b
<pre>
[iPad] docs.google.com: Clicking on “NO THANKS” or “GET THE APP” using trackpad does nothing
<a href="https://bugs.webkit.org/show_bug.cgi?id=284056">https://bugs.webkit.org/show_bug.cgi?id=284056</a>
<a href="https://rdar.apple.com/139903194">rdar://139903194</a>

Reviewed by Abrar Rahman Protyasha.

The App Store promo UI on docs.google.com currently only responds to touch events, and does nothing
when clicked using a trackpad on iPad. Fix this by extending the existing quirk for cbssports.com,
`shouldSynthesizeTouchEventsAfterNonSyntheticClick`, such that we dispatch touch events when
clicking with a trackpad over these buttons.

* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::didDispatchClickEvent):
(WebCore::ChromeClient::didSwallowClickEvent): Deleted.

Rename this client method to `didDispatchClickEvent`, now that it&apos;s dispatched even when the event
is not swallowed by the event handler (e.g. through `stopPropagation()` or `preventDefault()`).

* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::swallowAnyClickEvent):

Adjust this so that it calls into `didDispatchClickEvent` on the chrome client regardless of whether
`dispatchMouseEvent` returns `true` or `false`. This is necessary in order for the quirk to work on
Google Docs.

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::isTouchBarUpdateSuppressedForHiddenContentEditable const):
(WebCore::Quirks::shouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreas const):

Refactor to call the new `isFoo()` helper methods.

(WebCore::Quirks::isCBSSports const):

Add a new helper method to check if the current top domain is cbssports.com, and cache the result.

(WebCore::Quirks::isGoogleDocs const):

Add a new helper method to check if the top host is docs.google.com, and cache the result.

(WebCore::Quirks::needsDeferKeyDownAndKeyPressTimersUntilNextEditingCommand const):
(WebCore::Quirks::shouldSynthesizeTouchEventsAfterNonSyntheticClick const):

Implement the new quirk here — look for a parent of the click target that contains the class name
`docs-ml-promotion-action-container`.

* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:

Add new cached state for `isGoogleDocs` and `isCBSSports`, and remove the now-unnecessary flags for
the other individual quirk behaviors.

* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::didDispatchClickEvent):
(WebKit::WebChromeClient::didSwallowClickEvent): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
(WebKit::WebPage::didDispatchClickEvent):
(WebKit::WebPage::didSwallowClickEvent): Deleted.
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::didDispatchClickEvent):
(WebKit::WebPage::didSwallowClickEvent): Deleted.

Canonical link: <a href="https://commits.webkit.org/287359@main">https://commits.webkit.org/287359@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00641bae3701f76ce4cd798e5eba118e68809b45

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79332 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58360 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32703 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83948 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/30482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81465 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67436 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6623 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62056 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/30482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82399 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52117 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72280 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42363 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/49461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26461 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28880 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/70573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26906 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85347 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6617 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70304 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6781 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68154 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/69551 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17331 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13601 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12461 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6569 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/6488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9961 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8284 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->