### PR TITLE
Add site isolation test for iframes with borders

### DIFF
--- a/LayoutTests/http/tests/site-isolation/iframe-with-border-expected.html
+++ b/LayoutTests/http/tests/site-isolation/iframe-with-border-expected.html
@@ -1,0 +1,3 @@
+<body bgcolor=blue>
+<iframe src="http://127.0.0.1:8000/site-isolation/resources/green-background.html" style="border: 20px solid red"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/iframe-with-border.html
+++ b/LayoutTests/http/tests/site-isolation/iframe-with-border.html
@@ -1,0 +1,4 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<body bgcolor=blue>
+<iframe src="http://localhost:8000/site-isolation/resources/green-background.html" style="border: 20px solid red"></iframe>
+</body>


### PR DESCRIPTION
#### a7be137ed4b079541564d299f42a52e8f34d3638
<pre>
Add site isolation test for iframes with borders
<a href="https://bugs.webkit.org/show_bug.cgi?id=284059">https://bugs.webkit.org/show_bug.cgi?id=284059</a>
<a href="https://rdar.apple.com/116921461">rdar://116921461</a>

Reviewed by Charlie Wolfe.

When I first started working on site isolation, the drawing of iframe borders didn&apos;t work
correctly so I started by testing drawing iframes without borders and filed a bug reminding
myself to fix iframes with borders later.  Since then we have fixed iframes with borders,
but I still have that bug in the file.  This adds a test that verifies it works correctly.

* LayoutTests/http/tests/site-isolation/iframe-with-border-expected.html: Added.
* LayoutTests/http/tests/site-isolation/iframe-with-border.html: Added.

Canonical link: <a href="https://commits.webkit.org/287363@main">https://commits.webkit.org/287363@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21bb3f401bd0aa3fec0ee8b1aff7583da30b14aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79340 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58368 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32711 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83954 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/30488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67442 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6629 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62061 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/30488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82407 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/52118 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72289 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42369 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49462 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26472 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28886 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/70574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26917 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85354 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6623 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70310 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6787 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68163 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69557 "Found 2 new API test failures: /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/test-page-list, /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginAndEndEditingEvents (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13605 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12471 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12249 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6575 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12321 "Build is in progress. Recent messages:") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/6494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9967 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8290 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->