### PR TITLE
[WebGPU] onSubmittedWorkDone hangs when the device is destroyed

### DIFF
--- a/LayoutTests/fast/webgpu/regression/repro_284053-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_284053-expected.txt
@@ -1,0 +1,5 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/repro_284053.html
+++ b/LayoutTests/fast/webgpu/regression/repro_284053.html
@@ -1,0 +1,18 @@
+<script>
+async function run() {
+    let adapter1 = await navigator.gpu.requestAdapter();
+    let device0 = await adapter1.requestDevice({ requiredLimits: { maxTextureDimension1D: 10000 } });
+    let texture0 = device0.createTexture({ size: [10000], dimension: '1d', format: 'rg11b10ufloat', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC });
+    let buffer1 = device0.createBuffer({ size: 39589, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX, });
+    let commandEncoder3 = device0.createCommandEncoder();
+    commandEncoder3.copyTextureToBuffer(
+        { texture: texture0 },
+        { buffer: buffer1 },
+        { width: 2146, height: 1 },
+    )
+    await device0.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
+}
+globalThis.testRunner?.waitUntilDone();
+run();
+</script>

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -245,7 +245,7 @@ Ref<Device> Device::create(id<MTLDevice> device, String&& deviceLabel, HardwareC
 
 Device::Device(id<MTLDevice> device, id<MTLCommandQueue> defaultQueue, HardwareCapabilities&& capabilities, Adapter& adapter)
     : m_device(device)
-    , m_defaultQueue(Queue::create(defaultQueue, *this))
+    , m_defaultQueue(Queue::create(defaultQueue, adapter, *this))
     , m_xrSubImage(XRSubImage::create(*this))
     , m_capabilities(WTFMove(capabilities))
     , m_adapter(adapter)
@@ -309,7 +309,7 @@ Device::Device(id<MTLDevice> device, id<MTLCommandQueue> defaultQueue, HardwareC
 }
 
 Device::Device(Adapter& adapter)
-    : m_defaultQueue(Queue::createInvalid(*this))
+    : m_defaultQueue(Queue::createInvalid(adapter, *this))
     , m_adapter(adapter)
     , m_instance(adapter.weakInstance())
 {

--- a/Source/WebGPU/WebGPU/Queue.h
+++ b/Source/WebGPU/WebGPU/Queue.h
@@ -53,13 +53,13 @@ class TextureView;
 class Queue : public WGPUQueueImpl, public ThreadSafeRefCounted<Queue> {
     WTF_MAKE_TZONE_ALLOCATED(Queue);
 public:
-    static Ref<Queue> create(id<MTLCommandQueue> commandQueue, Device& device)
+    static Ref<Queue> create(id<MTLCommandQueue> commandQueue, Adapter& adapter, Device& device)
     {
-        return adoptRef(*new Queue(commandQueue, device));
+        return adoptRef(*new Queue(commandQueue, adapter, device));
     }
-    static Ref<Queue> createInvalid(Device& device)
+    static Ref<Queue> createInvalid(Adapter& adapter, Device& device)
     {
-        return adoptRef(*new Queue(device));
+        return adoptRef(*new Queue(adapter, device));
     }
 
     ~Queue();
@@ -94,8 +94,8 @@ public:
     // This can be called on a background thread.
     void scheduleWork(Instance::WorkItem&&);
 private:
-    Queue(id<MTLCommandQueue>, Device&);
-    Queue(Device&);
+    Queue(id<MTLCommandQueue>, Adapter&, Device&);
+    Queue(Adapter&, Device&);
 
     NSString* errorValidatingSubmit(const Vector<Ref<WebGPU::CommandBuffer>>&) const;
     bool validateWriteBuffer(const Buffer&, uint64_t bufferOffset, size_t) const;
@@ -122,6 +122,7 @@ private:
     HashMap<uint64_t, OnSubmittedWorkDoneCallbacks, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_onSubmittedWorkDoneCallbacks;
     NSMutableOrderedSet<id<MTLCommandBuffer>> *m_createdNotCommittedBuffers { nil };
     NSMapTable<id<MTLCommandBuffer>, id<MTLCommandEncoder>> *m_openCommandEncoders;
+    const ThreadSafeWeakPtr<Instance> m_instance;
 } SWIFT_SHARED_REFERENCE(refQueue, derefQueue);
 
 } // namespace WebGPU


### PR DESCRIPTION
#### 9977d02fa8cf6ef8c9511ce7e460b4b29d3660ec
<pre>
[WebGPU] onSubmittedWorkDone hangs when the device is destroyed
<a href="https://rdar.apple.com/140888787">rdar://140888787</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=284053">https://bugs.webkit.org/show_bug.cgi?id=284053</a>

Reviewed by Cameron McCormack.

There was a race with the command buffer completion handler returning
and the device being destroyed.

We were using the Device to get to the Instance to schedule work on the
WebGPU main thread, but if the device was destroyed then we would not
schedule the callback.

Avoid this by storing Instance in Queue.

* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::Device::Device):
* Source/WebGPU/WebGPU/Queue.h:
(WebGPU::Queue::create):
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::Queue):
(WebGPU::Queue::onSubmittedWorkDone):
(WebGPU::Queue::commitMTLCommandBuffer):
(WebGPU::Queue::scheduleWork):

Canonical link: <a href="https://commits.webkit.org/287402@main">https://commits.webkit.org/287402@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eca633de490c256536c321eb6b5c701468d1683f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79386 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58413 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32760 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83993 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30519 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67476 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6674 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62092 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19972 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82453 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52151 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72327 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42401 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49502 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26513 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28923 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70614 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26961 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85399 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6659 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4644 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70344 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6824 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68203 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69591 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17372 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13636 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12503 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6611 "Built successfully") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6528 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9999 "Built successfully") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8327 "") | | | 
<!--EWS-Status-Bubble-End-->