### PR TITLE
[block-step-sizing] Add some tests to verify interaction between block-step-size and margins of various replaced elements.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/computedstyle/block-level-replaced-elements-affected-by-block-step-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/computedstyle/block-level-replaced-elements-affected-by-block-step-size-expected.txt
@@ -1,0 +1,35 @@
+
+
+FAIL .test 1 assert_equals:
+<div class="container test" data-expected-height="100">
+  <img class="block-step test" src="../../support/60x60-green.png" data-expected-margin-top="20" data-expected-margin-bottom="20">
+</div>
+margin-top expected "20" but got "0"
+FAIL .test 2 assert_equals:
+<img class="block-step test" src="../../support/60x60-green.png" data-expected-margin-top="20" data-expected-margin-bottom="20">
+margin-top expected "20" but got "0"
+FAIL .test 3 assert_equals:
+<div class="container test" data-expected-height="100">
+  <canvas width="20" height="20" class="block-step test" data-expected-margin-top="40" data-expected-margin-bottom="40"></canvas>
+</div>
+margin-top expected "40" but got "0"
+FAIL .test 4 assert_equals:
+<canvas width="20" height="20" class="block-step test" data-expected-margin-top="40" data-expected-margin-bottom="40"></canvas>
+margin-top expected "40" but got "0"
+FAIL .test 5 assert_equals:
+<div class="container test" data-expected-height="100">
+  <svg class="block-step test" viewBox="0 0 100 50" data-expected-margin-top="25" data-expected-margin-bottom="25"></svg>
+</div>
+margin-top expected "25" but got "0"
+FAIL .test 6 assert_equals:
+<svg class="block-step test" viewBox="0 0 100 50" data-expected-margin-top="25" data-expected-margin-bottom="25"></svg>
+margin-top expected "25" but got "0"
+PASS .test 7
+PASS .test 8
+PASS .test 9
+PASS .test 10
+PASS .test 11
+PASS .test 12
+PASS .test 13
+PASS .test 14
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/computedstyle/block-level-replaced-elements-affected-by-block-step-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/computedstyle/block-level-replaced-elements-affected-by-block-step-size.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<meta name="assert" content="Checks getComputedStyle for block level replaced margins affected by block-step-size and height of their containers">
+<style>
+.container {
+  display: inline flow-root;
+  width: 100px;
+}
+.block-step {
+  display: block;
+  block-step-size: 100px;
+  visibility: hidden;
+}
+
+iframe {
+  border: 0;
+}
+
+</style>
+</head>
+<body onload="checkLayout('.test')">
+
+<div class="container test" data-expected-height="100">
+  <img class="block-step test" src="../../support/60x60-green.png" data-expected-margin-top="20" data-expected-margin-bottom="20"></img>
+</div>
+
+<div class="container test" data-expected-height="100">
+  <canvas width="20" height="20" class="block-step test" data-expected-margin-top="40" data-expected-margin-bottom="40"></canvas>
+</div>
+
+<div class="container test" data-expected-height="100">
+  <svg class="block-step test" viewBox="0 0 100 50" data-expected-margin-top="25" data-expected-margin-bottom="25"></svg>
+</div>
+
+<div class="container test" data-expected-height="100">
+  <embed type="text/xml" width="20" height="20" class="block-step test" data-expected-margin-top="40" data-expected-margin-bottom="40"></embed>
+</div>
+<div class="container test" data-expected-height="100">
+  <iframe src="" width="20" height="20" class="block-step test" data-expected-margin-top="40" data-expected-margin-bottom="40"></iframe>
+</div>
+
+<div class="container test" data-expected-height="100">
+  <object width="20" height="20" class="block-step test" data-expected-margin-top="40" data-expected-margin-bottom="40"></object>
+</div>
+
+<div class="container test" data-expected-height="100">
+  <video width="20" height="20" class="block-step test" data-expected-margin-top="40" data-expected-margin-bottom="40"></video>
+</div>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/computedstyle/inline-level-replaced-elements-not-affected-by-block-step-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/computedstyle/inline-level-replaced-elements-not-affected-by-block-step-size-expected.txt
@@ -1,0 +1,17 @@
+
+
+PASS .test 1
+PASS .test 2
+PASS .test 3
+PASS .test 4
+PASS .test 5
+PASS .test 6
+PASS .test 7
+PASS .test 8
+PASS .test 9
+PASS .test 10
+PASS .test 11
+PASS .test 12
+PASS .test 13
+PASS .test 14
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/computedstyle/inline-level-replaced-elements-not-affected-by-block-step-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/computedstyle/inline-level-replaced-elements-not-affected-by-block-step-size.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<meta name="assert" content="Check inline level replaced elements are not affected by block-step-size via getComputedStyle">
+<style>
+.container {
+  display: inline flow-root;
+  width: 100px;
+  font-size: 0px;
+}
+.block-step {
+  block-step-size: 100px;
+  visibility: hidden;
+}
+
+iframe {
+  border: 0;
+}
+
+</style>
+</head>
+<body onload="checkLayout('.test')">
+
+<div class="container test" data-expected-height="60">
+  <img class="block-step test" src="../../support/60x60-green.png" data-expected-margin-top="0" data-expected-margin-bottom="0"></img>
+</div>
+
+<div class="container test" data-expected-height="20">
+  <canvas width="20" height="20" class="block-step test" data-expected-margin-top="0" data-expected-margin-bottom="0"></canvas>
+</div>
+
+<div class="container test" data-expected-height="20">
+  <svg class="block-step test" viewBox="0 0 100 20" data-expected-margin-top="0" data-expected-margin-bottom="0"></svg>
+</div>
+
+<div class="container test" data-expected-height="20">
+  <embed type="text/xml" width="20" height="20" class="block-step test" data-expected-margin-top="0" data-expected-margin-bottom="0"></embed>
+</div>
+<div class="container test" data-expected-height="20">
+  <iframe src="" width="20" height="20" class="block-step test" data-expected-margin-top="0" data-expected-margin-bottom="0"></iframe>
+</div>
+
+<div class="container test" data-expected-height="20">
+  <object width="20" height="20" class="block-step test" data-expected-margin-top="0" data-expected-margin-bottom="0"></object>
+</div>
+
+<div class="container test" data-expected-height="20">
+  <video width="20" height="20" class="block-step test" data-expected-margin-top="0" data-expected-margin-bottom="0"></video>
+</div>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-canvas-margins-affected-by-block-step-size-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-canvas-margins-affected-by-block-step-size-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-canvas-margins-affected-by-block-step-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-canvas-margins-affected-by-block-step-size.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Block level canvas is affected by block-step-size">
+<style>
+.container {
+  display: flow-root;
+  width: 100px;
+  background-color: green;
+}
+.block-step {
+  display: block;
+  block-step-size: 100px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div class="container">
+  <canvas width="20" height="20" class="block-step"></canvas>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-embed-margins-affected-by-block-step-size-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-embed-margins-affected-by-block-step-size-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-embed-margins-affected-by-block-step-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-embed-margins-affected-by-block-step-size.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Block level embed is affected by block-step-size">
+<style>
+.container {
+  display: flow-root;
+  width: 100px;
+  background-color: green;
+}
+.block-step {
+  display: block;
+  block-step-size: 100px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div class="container">
+  <embed type="text/xml" width="20" height="20" class="block-step"></embed>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-iframe-margins-affected-by-block-step-size-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-iframe-margins-affected-by-block-step-size-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-iframe-margins-affected-by-block-step-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-iframe-margins-affected-by-block-step-size.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Block level iframe is affected by block-step-size">
+<style>
+.container {
+  display: flow-root;
+  width: 100px;
+  background-color: green;
+}
+.block-step {
+  display: block;
+  block-step-size: 100px;
+  visibility: hidden;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div class="container">
+  <iframe src="" width="20" height="20" class="block-step"></iframe>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-img-margins-affected-by-block-step-size-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-img-margins-affected-by-block-step-size-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-img-margins-affected-by-block-step-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-img-margins-affected-by-block-step-size.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Block level img is affected by block-step-size">
+<style>
+.container {
+  display: flow-root;
+  width: 100px;
+  background-color: green;
+}
+.block-step {
+  block-step-size: 100px;
+  display: block;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div class="container">
+  <img class="block-step" src="../../support/60x60-green.png"></img>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-object-margins-affected-by-block-step-size-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-object-margins-affected-by-block-step-size-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-object-margins-affected-by-block-step-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-object-margins-affected-by-block-step-size.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Block level object is affected by block-step-size">
+<style>
+.container {
+  display: flow-root;
+  width: 100px;
+  background-color: green;
+}
+.block-step {
+  display: block;
+  block-step-size: 100px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div class="container">
+  <object width="20" height="20" class="block-step"></object>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-svg-margins-affected-by-block-step-size-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-svg-margins-affected-by-block-step-size-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-svg-margins-affected-by-block-step-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-svg-margins-affected-by-block-step-size.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Block level SVG is affected by block-step-size">
+<style>
+.container {
+  display: flow-root;
+  background-color: green;
+  width: 100px;
+}
+.block-step {
+  display: block;
+  block-step-size: 100px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div class="container">
+  <svg class="block-step" viewBox="0 0 100 50"></svg>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-video-margins-affected-by-block-step-size-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-video-margins-affected-by-block-step-size-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-video-margins-affected-by-block-step-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-video-margins-affected-by-block-step-size.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Block level video is affected by block-step-size">
+<style>
+.container {
+  display: flow-root;
+  width: 100px;
+  background-color: green;
+}
+.block-step {
+  display: block;
+  block-step-size: 100px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div class="container">
+  <video width="20" height="20" class="block-step"></video>
+</div>
+</body>
+</html>


### PR DESCRIPTION
#### 8066e3f9f8716c5184a9bfa11d7e7a25b28aa372
<pre>
[block-step-sizing] Add some tests to verify interaction between block-step-size and margins of various replaced elements.
<a href="https://bugs.webkit.org/show_bug.cgi?id=284060">https://bugs.webkit.org/show_bug.cgi?id=284060</a>
<a href="https://rdar.apple.com/140931188">rdar://140931188</a>

Reviewed by Alan Baradlay.

block-step-size should be able to adjust the margins of block-level
replaced elements appropriately while not affecting inline-level ones at
all. This patch adds some tests to help verify this behavior.

The block-level-* tests make sure that the extra space is added to the
margins of various block-level replaced elements.

A corresponding test was also added in css-rhythm/computedstyle/block-level-replaced-elements-affected-by-block-step-size.html
to make sure getComputedStyle returns the correct value for the adjusted
margins. This test basically contains the added tests in
css-rhythm/replaced-elements but checks the value of the box&apos;s margins
and the height of the container via getComputedStyle. Some of the tests
subtests are failing even though the box is sized correctly as seen
in the equivalent ref test that was added. This will need to be
investigated, but one theory is that this could be the same underlying
bug as <a href="http://webkit.org/b/283508.">http://webkit.org/b/283508.</a>

css-rhythm/computedstyle/inline-level-replaced-elements-not-affected-by-block-step-size.html
is the counterpart to the above test to make sure that replaced elements
which are inline do not get affected by the property at all.

* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/computedstyle/block-level-replaced-elements-affected-by-block-step-size-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/computedstyle/block-level-replaced-elements-affected-by-block-step-size.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/computedstyle/inline-level-replaced-elements-not-affected-by-block-step-size-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/computedstyle/inline-level-replaced-elements-not-affected-by-block-step-size.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-canvas-margins-affected-by-block-step-size-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-canvas-margins-affected-by-block-step-size.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-embed-margins-affected-by-block-step-size-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-embed-margins-affected-by-block-step-size.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-iframe-margins-affected-by-block-step-size-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-iframe-margins-affected-by-block-step-size.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-img-margins-affected-by-block-step-size-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-img-margins-affected-by-block-step-size.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-object-margins-affected-by-block-step-size-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-object-margins-affected-by-block-step-size.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-svg-margins-affected-by-block-step-size-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-svg-margins-affected-by-block-step-size.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-video-margins-affected-by-block-step-size-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/replaced-elements/block-level-video-margins-affected-by-block-step-size.html: Added.

Canonical link: <a href="https://commits.webkit.org/287379@main">https://commits.webkit.org/287379@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd2cf2d5f234be966b3b448dcae0f073d56632cd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79351 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58378 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32724 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83961 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30494 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6640 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62066 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19954 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82418 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52129 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72293 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42374 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49473 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26480 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28893 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/70607 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26926 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85365 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6630 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4615 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70328 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6794 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68170 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69575 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17348 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13609 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12474 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6582 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6500 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9974 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8297 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->