### PR TITLE
Implement New Wasm Exception Spec in IPInt

### DIFF
--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.h
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.h
@@ -29,10 +29,15 @@
 
 #include "WasmCallee.h"
 
-extern "C" void ipint_entry();
-extern "C" void ipint_entry_simd();
-extern "C" void ipint_catch_entry();
-extern "C" void ipint_catch_all_entry();
+extern "C" void SYSV_ABI ipint_entry();
+extern "C" void SYSV_ABI ipint_entry_simd();
+extern "C" void SYSV_ABI ipint_catch_entry();
+extern "C" void SYSV_ABI ipint_catch_all_entry();
+
+extern "C" void SYSV_ABI ipint_table_catch_entry();
+extern "C" void SYSV_ABI ipint_table_catch_ref_entry();
+extern "C" void SYSV_ABI ipint_table_catch_all_entry();
+extern "C" void SYSV_ABI ipint_table_catch_allref_entry();
 
 #define IPINT_VALIDATE_DEFINE_FUNCTION(opcode, name) \
     extern "C" void ipint_ ## name ## _validate() REFERENCED_FROM_ASM WTF_INTERNAL NO_REORDER;
@@ -48,7 +53,7 @@ extern "C" void ipint_catch_all_entry();
     m(0x07, catch) \
     m(0x08, throw) \
     m(0x09, rethrow) \
-    m(0x0a, reserved_0xa) \
+    m(0x0a, throw_ref) \
     m(0x0b, end) \
     m(0x0c, br) \
     m(0x0d, br_if) \
@@ -69,7 +74,7 @@ extern "C" void ipint_catch_all_entry();
     m(0x1c, select_t) \
     m(0x1d, reserved_0x1d) \
     m(0x1e, reserved_0x1e) \
-    m(0x1f, reserved_0x1f) \
+    m(0x1f, try_table) \
     m(0x20, local_get) \
     m(0x21, local_set) \
     m(0x22, local_tee) \

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter32_64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter32_64.asm
@@ -175,7 +175,7 @@ unimplementedInstruction(_try)
 unimplementedInstruction(_catch)
 unimplementedInstruction(_throw)
 unimplementedInstruction(_rethrow)
-reservedOpcode(0xa)
+unimplementedInstruction(_throw_ref)
 
 
 macro uintDispatch()
@@ -221,7 +221,7 @@ unimplementedInstruction(_select)
 unimplementedInstruction(_select_t)
 reservedOpcode(0x1d)
 reservedOpcode(0x1e)
-reservedOpcode(0x1f)
+unimplementedInstruction(_try_table)
 
     ###################################
     # 0x20 - 0x26: get and set values #

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -244,7 +244,28 @@ IPIntCallee::IPIntCallee(FunctionIPIntMetadataGenerator& generator, FunctionSpac
         for (size_t i = 0; i < count; i++) {
             const UnlinkedHandlerInfo& unlinkedHandler = generator.m_exceptionHandlers[i];
             HandlerInfo& handler = m_exceptionHandlers[i];
-            void* ptr = reinterpret_cast<void*>(unlinkedHandler.m_type == HandlerType::Catch ? ipint_catch_entry : ipint_catch_all_entry);
+            void* ptr = nullptr;
+            switch (unlinkedHandler.m_type) {
+            case HandlerType::Catch:
+                ptr = reinterpret_cast<void*>(ipint_catch_entry);
+                break;
+            case HandlerType::CatchAll:
+            case HandlerType::Delegate:
+                ptr = reinterpret_cast<void*>(ipint_catch_all_entry);
+                break;
+            case HandlerType::TryTableCatch:
+                ptr = reinterpret_cast<void*>(ipint_table_catch_entry);
+                break;
+            case HandlerType::TryTableCatchRef:
+                ptr = reinterpret_cast<void*>(ipint_table_catch_ref_entry);
+                break;
+            case HandlerType::TryTableCatchAll:
+                ptr = reinterpret_cast<void*>(ipint_table_catch_all_entry);
+                break;
+            case HandlerType::TryTableCatchAllRef:
+                ptr = reinterpret_cast<void*>(ipint_table_catch_allref_entry);
+                break;
+            }
             void* untagged = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).untaggedPtr();
             void* retagged = nullptr;
 #if ENABLE(JIT_CAGE)

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
@@ -40,13 +40,13 @@ class JSWebAssemblyInstance;
 namespace IPInt {
 
 #define WASM_IPINT_EXTERN_CPP_DECL(name, ...) \
-    extern "C" UGPRPair ipint_extern_##name(JSWebAssemblyInstance* instance, __VA_ARGS__)
+    extern "C" UGPRPair SYSV_ABI ipint_extern_##name(JSWebAssemblyInstance* instance, __VA_ARGS__)
 
 #define WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(name, ...) \
     WASM_IPINT_EXTERN_CPP_DECL(name, __VA_ARGS__) REFERENCED_FROM_ASM WTF_INTERNAL
 
 #define WASM_IPINT_EXTERN_CPP_DECL_1P(name) \
-    extern "C" UGPRPair ipint_extern_##name(JSWebAssemblyInstance* instance)
+    extern "C" UGPRPair SYSV_ABI ipint_extern_##name(JSWebAssemblyInstance* instance)
 
 #define WASM_IPINT_EXTERN_CPP_HIDDEN_DECL_1P(name) \
     WASM_IPINT_EXTERN_CPP_DECL_1P(name) REFERENCED_FROM_ASM WTF_INTERNAL
@@ -58,8 +58,11 @@ WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(epilogue_osr, CallFrame* callFrame);
 #endif
 
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(retrieve_and_clear_exception, CallFrame*, IPIntStackEntry* stack, IPIntLocal* pl);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(retrieve_clear_and_push_exception, CallFrame*, IPIntStackEntry* stack, IPIntLocal* pl);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(retrieve_clear_and_push_exception_and_arguments, CallFrame*, IPIntStackEntry* stack, IPIntLocal* pl);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(throw_exception, CallFrame*, IPIntStackEntry* arguments, unsigned exceptionIndex);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(rethrow_exception, CallFrame*, uint64_t* pl, unsigned tryDepth);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(rethrow_exception, CallFrame*, IPIntStackEntry* pl, unsigned tryDepth);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(throw_ref, CallFrame* callFrame, EncodedJSValue exnref);
 
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(ref_func, unsigned index);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_get, unsigned, unsigned);

--- a/Tools/lldb/debug_ipint.py
+++ b/Tools/lldb/debug_ipint.py
@@ -20,9 +20,9 @@ if ARCH == 'arm64':
 
 IPINT_INSTRUCTIONS = [
     'unreachable', 'nop', 'block', 'loop', 'if', 'else', 'try', 'catch', 'throw',
-    'rethrow', 'end', 'br', 'br_if', 'br_table', 'return', 'call', 'call_indirect',
+    'rethrow', 'throw_ref', 'end', 'br', 'br_if', 'br_table', 'return', 'call', 'call_indirect',
     'return_call', 'return_call_indirect', 'call_ref', 'return_call_ref', 'delegate',
-    'catch_all', 'drop', 'select', 'select_t', 'local_get', 'local_set', 'local_tee',
+    'catch_all', 'drop', 'select', 'select_t', 'try_table', 'local_get', 'local_set', 'local_tee',
     'global_get', 'global_set', 'table_get', 'table_set', 'i32_load_mem', 'i64_load_mem',
     'f32_load_mem', 'f64_load_mem', 'i32_load8s_mem', 'i32_load8u_mem', 'i32_load16s_mem',
     'i32_load16u_mem', 'i64_load8s_mem', 'i64_load8u_mem', 'i64_load16s_mem',


### PR DESCRIPTION
#### cabec25e5dd20b315e71c24f42e4d7445140982f
<pre>
Implement New Wasm Exception Spec in IPInt
<a href="https://bugs.webkit.org/show_bug.cgi?id=284061">https://bugs.webkit.org/show_bug.cgi?id=284061</a>
<a href="https://rdar.apple.com/140935975">rdar://140935975</a>

Reviewed by Yusuke Suzuki.

To achieve feature parity with LLInt, we need to implement the
new exception spec (try_table) in IPInt.

* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/llint/InPlaceInterpreter.h:
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::IPIntCallee::IPIntCallee):
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntControlType::isTryTable):
(JSC::Wasm::IPIntGenerator::addTryTable):
(JSC::Wasm::IPIntGenerator::addThrowRef):
(JSC::Wasm::IPIntGenerator::endTryTable):
(JSC::Wasm::IPIntGenerator::addEndToUnreachable):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h:
* Tools/lldb/debug_ipint.py:

Canonical link: <a href="https://commits.webkit.org/287562@main">https://commits.webkit.org/287562@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b30130a015f912e4a9ad84c2f61794dee0efa007

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79647 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58645 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33040 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84190 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30688 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81757 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67736 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6933 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62259 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20108 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82713 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52315 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72542 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42567 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49658 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26694 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29118 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/72686 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70797 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27152 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85604 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/78775 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6897 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4809 "Found 2 new test failures: media/media-vp8-hiddenframes.html media/video-canvas-createPattern.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70505 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-transforms/animation/transform-percent-with-width-and-height-separate.html imported/w3c/web-platform-tests/css/css-transforms/animation/translate-percent-with-width-and-height-separate.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7066 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68387 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69750 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17460 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13766 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12681 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/101116 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6846 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/24675 "Found 5 new JSC stress test failures: stress/json-stringify-inspector-check.js.no-llint, stress/substring-global-atom-cache.js.lockdown, wasm.yaml/wasm/stress/cc-int-to-int-cross-module-with-exception.js.default-wasm, wasm.yaml/wasm/stress/struct-new_default-small-members.js.default-wasm, wasm.yaml/wasm/stress/struct-new_default-small-members.js.wasm-eager-jettison (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6734 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10229 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8532 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->