### PR TITLE
Content Security Policy for previous load should not apply to subsequent alternate HTML load

### DIFF
--- a/Source/WebCore/loader/DocumentWriter.cpp
+++ b/Source/WebCore/loader/DocumentWriter.cpp
@@ -222,6 +222,10 @@ bool DocumentWriter::begin(const URL& urlReference, bool dispatch, Document* own
         // https://html.spec.whatwg.org/multipage/origin.html#determining-navigation-params-policy-container
         RefPtr currentHistoryItem = frame->history().currentItem();
 
+        auto isLoadingBrowserControlledHTML = [document] {
+            return document->loader() && document->loader()->substituteData().isValid();
+        };
+
         if (currentHistoryItem && currentHistoryItem->policyContainer()) {
             const auto& policyContainerFromHistory = currentHistoryItem->policyContainer();
             ASSERT(policyContainerFromHistory);
@@ -232,7 +236,7 @@ bool DocumentWriter::begin(const URL& urlReference, bool dispatch, Document* own
                 document->inheritPolicyContainerFrom(parentFrame->document()->policyContainer());
                 document->checkedContentSecurityPolicy()->updateSourceSelf(parentFrame->document()->securityOrigin());
             }
-        } else if (triggeringAction && triggeringAction->requester()) {
+        } else if (triggeringAction && triggeringAction->requester() && !isLoadingBrowserControlledHTML()) {
             document->inheritPolicyContainerFrom(triggeringAction->requester()->policyContainer);
             document->checkedContentSecurityPolicy()->updateSourceSelf(triggeringAction->requester()->securityOrigin);
         }

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebView.cpp
@@ -2015,6 +2015,21 @@ static void testWebViewEnableHTML5Database(WebViewTest* test, gconstpointer)
     g_assert_cmpint(waitForFooChanged(), ==, -1);
 }
 
+static void testWebViewLoadAlternateHTMLFromPageWithCSP(WebViewTest* test, gconstpointer)
+{
+    char html[] = "<html><head><meta http-equiv=\"Content-Security-Policy\" content=\"script-src 'none'\"/></html>";
+    char alternateHTML[] = "<html><head></head><body><script>test=true</script></body></html>";
+    GUniqueOutPtr<GError> error;
+
+    webkit_web_view_load_html(test->m_webView, html, "http://example.com");
+    test->waitUntilLoadFinished();
+
+    webkit_web_view_load_alternate_html(test->m_webView, alternateHTML, "about:error", nullptr);
+    test->waitUntilLoadFinished();
+    test->runJavaScriptAndWaitUntilFinished("test === true", &error.outPtr());
+    g_assert_no_error(error.get());
+}
+
 #if USE(SOUP2)
 static void serverCallback(SoupServer* server, SoupMessage* message, const char* path, GHashTable*, SoupClientContext*, gpointer)
 #else
@@ -2089,6 +2104,7 @@ void beforeAll()
     WebViewTest::add("WebKitWebView", "web-extension-mode", testWebViewWebExtensionMode);
     WebViewTest::add("WebKitWebView", "disable-web-security", testWebViewDisableWebSecurity);
     WebViewTest::add("WebKitWebView", "enable-html5-database", testWebViewEnableHTML5Database);
+    WebViewTest::add("WebKitWebView", "load-alternate-html-from-page-with-csp", testWebViewLoadAlternateHTMLFromPageWithCSP);
 }
 
 void afterAll()


### PR DESCRIPTION
#### a2b811f9d215673ed789980acc598fd86d924e19
<pre>
Content Security Policy for previous load should not apply to subsequent alternate HTML load
<a href="https://bugs.webkit.org/show_bug.cgi?id=264355">https://bugs.webkit.org/show_bug.cgi?id=264355</a>

Reviewed by Ryan Reno.

A substitute data load occurs when WebKit decides to load a URL using
its own web content rather than the website&apos;s usual web content. In
practice, browsers do this when displaying error pages, such as network
error pages or TLS error pages. Since the web content is controlled by
the web browser, it is inappropriate to inherit security policy from the
triggering action.

This fixes error pages in Epiphany after visiting a website that sets
CSP. For example, visit <a href="https://duckduckgo.com/">https://duckduckgo.com/</a> then visit
<a href="https://expired.badssl.com/">https://expired.badssl.com/</a> which should display a TLS error page.
Before this commit, DuckDuckGo&apos;s CSP applies to the error page and
blocks the lock icon. CSP on other websites may also break Epiphany&apos;s
button for bypassing the certificate error, since the button uses
JavaScript.

The new test is written by Patrick Griffis (thank you!).

* Source/WebCore/loader/DocumentWriter.cpp:
(WebCore::DocumentWriter::begin):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebView.cpp:
(testWebViewLoadAlternateHTMLFromPageWithCSP):
(beforeAll):

Canonical link: <a href="https://commits.webkit.org/288026@main">https://commits.webkit.org/288026@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a115105e25d12e3f4b420cfe780cb963d2dfff4b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81699 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1225 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35653 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86243 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32694 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83805 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1258 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9045 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/63745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21467 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84769 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/911 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74354 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/44031 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/810 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28528 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31148 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29130 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87682 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8939 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/72077 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9124 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70173 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71307 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17755 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15392 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/14310 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8890 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/14422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8731 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12254 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10539 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->