### PR TITLE
[Navigation] Entry state can be lost during traversals

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/same-document-away-and-back-location-api-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/same-document-away-and-back-location-api-expected.txt
@@ -1,10 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_not_equals: got disallowed value undefined
 
-Harness Error (FAIL), message = Unhandled rejection: assert_not_equals: got disallowed value undefined
-
-TIMEOUT entry.getState() behavior after navigating away using a fragment change, then back Test timed out
-
-Harness Error (FAIL), message = Unhandled rejection: assert_not_equals: got disallowed value undefined
-
-TIMEOUT entry.getState() behavior after navigating away using a fragment change, then back Test timed out
+PASS entry.getState() behavior after navigating away using a fragment change, then back
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/same-document-away-and-back-location-api-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/same-document-away-and-back-location-api-expected.txt
@@ -1,10 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: undefined is not an object (evaluating 'entry1.getState().statevar')
 
-Harness Error (FAIL), message = Unhandled rejection: undefined is not an object (evaluating 'entry1.getState().statevar')
-
-TIMEOUT entry.getState() behavior after navigating away using the location API, then back Test timed out
-
-Harness Error (FAIL), message = Unhandled rejection: undefined is not an object (evaluating 'entry1.getState().statevar')
-
-TIMEOUT entry.getState() behavior after navigating away using the location API, then back Test timed out
+PASS entry.getState() behavior after navigating away using the location API, then back
 

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1291,7 +1291,7 @@ void FrameLoader::loadInSameDocument(URL url, RefPtr<SerializedScriptValue> stat
 
     auto navigationType = determineNavigationType(m_loadType, historyHandling);
     if (document->settings().navigationAPIEnabled() && document->domWindow() && m_frame->checkedHistory()->currentItem())
-        document->protectedWindow()->navigation().updateForNavigation(*m_frame->checkedHistory()->currentItem(), navigationType);
+        document->protectedWindow()->navigation().updateForNavigation(*m_frame->checkedHistory()->currentItem(), navigationType, ShouldCopyStateObjectFromCurrentEntry::Yes);
 
     // If we were in the autoscroll/panScroll mode we want to stop it before following the link to the anchor
     if (hashChange)

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -618,7 +618,7 @@ void Navigation::notifyCommittedToEntry(NavigationAPIMethodTracker* apiMethodTra
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#update-the-navigation-api-entries-for-a-same-document-navigation
-void Navigation::updateForNavigation(Ref<HistoryItem>&& item, NavigationNavigationType navigationType)
+void Navigation::updateForNavigation(Ref<HistoryItem>&& item, NavigationNavigationType navigationType, ShouldCopyStateObjectFromCurrentEntry shouldCopyStateObjectFromCurrentEntry)
 {
     if (hasEntriesAndEventsDisabled())
         return;
@@ -641,8 +641,11 @@ void Navigation::updateForNavigation(Ref<HistoryItem>&& item, NavigationNavigati
     } else if (navigationType == NavigationNavigationType::Replace)
         disposedEntries.append(*oldCurrentEntry);
 
-    if (navigationType == NavigationNavigationType::Push || navigationType == NavigationNavigationType::Replace)
+    if (navigationType == NavigationNavigationType::Push || navigationType == NavigationNavigationType::Replace) {
         m_entries[*m_currentEntryIndex] = NavigationHistoryEntry::create(protectedScriptExecutionContext().get(), WTFMove(item));
+        if (shouldCopyStateObjectFromCurrentEntry == ShouldCopyStateObjectFromCurrentEntry::Yes)
+            m_entries[*m_currentEntryIndex]->setState(oldCurrentEntry->state());
+    }
 
     if (m_ongoingAPIMethodTracker)
         notifyCommittedToEntry(m_ongoingAPIMethodTracker.get(), currentEntry(), navigationType);

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -86,6 +86,8 @@ private:
     NavigationAPIMethodTrackerIdentifier identifier;
 };
 
+enum class ShouldCopyStateObjectFromCurrentEntry : bool { No, Yes };
+
 class Navigation final : public RefCounted<Navigation>, public EventTarget, public LocalDOMWindowProperty {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(Navigation);
 public:
@@ -145,7 +147,7 @@ public:
     bool dispatchPushReplaceReloadNavigateEvent(const URL&, NavigationNavigationType, bool isSameDocument, FormState*, SerializedScriptValue* classicHistoryAPIState = nullptr);
     bool dispatchDownloadNavigateEvent(const URL&, const String& downloadFilename);
 
-    void updateForNavigation(Ref<HistoryItem>&&, NavigationNavigationType);
+    void updateForNavigation(Ref<HistoryItem>&&, NavigationNavigationType, ShouldCopyStateObjectFromCurrentEntry = ShouldCopyStateObjectFromCurrentEntry::No);
     void updateForReactivation(Vector<Ref<HistoryItem>>& newHistoryItems, HistoryItem& reactivatedItem);
     void updateForActivation(HistoryItem* previousItem, std::optional<NavigationNavigationType>);
 

--- a/Source/WebCore/page/NavigationHistoryEntry.h
+++ b/Source/WebCore/page/NavigationHistoryEntry.h
@@ -58,6 +58,7 @@ public:
     JSC::JSValue getState(JSDOMGlobalObject&) const;
 
     void setState(RefPtr<SerializedScriptValue>&&);
+    SerializedScriptValue* state() const { return m_state.get(); }
 
     HistoryItem& associatedHistoryItem() const { return m_associatedHistoryItem; }
 


### PR DESCRIPTION
#### 79c78cf13ab46767853da09b1c8d0f7a5efa9981
<pre>
[Navigation] Entry state can be lost during traversals
<a href="https://bugs.webkit.org/show_bug.cgi?id=282627">https://bugs.webkit.org/show_bug.cgi?id=282627</a>
<a href="https://rdar.apple.com/139735948">rdar://139735948</a>

Reviewed by Rob Buis.

As per [1], fragment navigations should maintain the previous NavigationEntry&apos;s
state object. This PR implements this behavior to make the corresponding WPT
tests pass.

[1] <a href="https://html.spec.whatwg.org/#scroll-to-fragid">https://html.spec.whatwg.org/#scroll-to-fragid</a>

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/same-document-away-and-back-location-api-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/same-document-away-and-back-location-api-expected.txt:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadInSameDocument):
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::updateForNavigation):
* Source/WebCore/page/Navigation.h:
* Source/WebCore/page/NavigationHistoryEntry.h:

Canonical link: <a href="https://commits.webkit.org/287401@main">https://commits.webkit.org/287401@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ede01c2838b5f1a803ef5f0ac6f811160c8694b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79392 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58419 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32766 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83998 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30523 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81525 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67480 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6680 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62098 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19976 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82459 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52155 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72333 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42408 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49547 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26519 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28928 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70724 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26967 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85405 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6663 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4740 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70350 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6828 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68209 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69597 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13642 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12507 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12284 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6615 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12360 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6531 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10004 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8333 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->