### PR TITLE
Implement WebTransport datagrams and outgoing streams network interface

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h
@@ -145,11 +145,10 @@ bool nw_resolver_set_update_handler(nw_resolver_t, dispatch_queue_t, nw_resolver
 bool nw_resolver_cancel(nw_resolver_t);
 void nw_context_set_privacy_level(nw_context_t, nw_context_privacy_level_t);
 void nw_parameters_set_context(nw_parameters_t, nw_context_t);
+
 nw_context_t nw_context_create(const char *);
 size_t nw_array_get_count(nw_array_t);
 nw_object_t nw_array_get_object_at_index(nw_array_t, size_t);
-nw_parameters_t nw_parameters_create_quic_stream(nw_parameters_configure_protocol_block_t, nw_parameters_configure_protocol_block_t);
-sec_protocol_options_t nw_quic_connection_copy_sec_protocol_options(nw_protocol_options_t);
 #ifdef __cplusplus
 }
 #endif

--- a/Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h
@@ -58,6 +58,13 @@ nw_interface_t nw_path_copy_interface(nw_path_t);
 
 bool nw_settings_get_unified_http_enabled(void);
 
+void nw_parameters_set_server_mode(nw_parameters_t, bool);
+nw_parameters_t nw_parameters_create_webtransport_http(nw_parameters_configure_protocol_block_t, nw_parameters_configure_protocol_block_t, nw_parameters_configure_protocol_block_t, nw_parameters_configure_protocol_block_t);
+nw_protocol_options_t nw_webtransport_create_options(void);
+bool nw_protocol_options_is_webtransport(nw_protocol_options_t);
+void nw_webtransport_options_set_is_unidirectional(nw_protocol_options_t, bool);
+void nw_webtransport_options_set_is_datagram(nw_protocol_options_t, bool);
+void nw_webtransport_options_set_connection_max_sessions(nw_protocol_options_t, uint64_t);
 WTF_EXTERN_C_END
 
 #endif // USE(APPLE_INTERNAL_SDK)

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp
@@ -64,16 +64,14 @@ void NetworkTransportSession::sendDatagram(std::span<const uint8_t>, CompletionH
 
 void NetworkTransportSession::sendStreamSendBytes(WebTransportStreamIdentifier identifier, std::span<const uint8_t> bytes, bool withFin, CompletionHandler<void()>&& completionHandler)
 {
-    if (RefPtr stream = m_sendStreams.get(identifier))
+    if (RefPtr stream = m_streams.get(identifier))
         stream->sendBytes(bytes, withFin);
     completionHandler();
 }
 
 void NetworkTransportSession::streamSendBytes(WebTransportStreamIdentifier identifier, std::span<const uint8_t> bytes, bool withFin, CompletionHandler<void()>&& completionHandler)
 {
-    if (RefPtr stream = m_bidirectionalStreams.get(identifier))
-        stream->sendBytes(bytes, withFin);
-    else if (RefPtr stream = m_sendStreams.get(identifier))
+    if (RefPtr stream = m_streams.get(identifier))
         stream->sendBytes(bytes, withFin);
     completionHandler();
 }
@@ -92,14 +90,14 @@ void NetworkTransportSession::createBidirectionalStream(CompletionHandler<void(s
 
 void NetworkTransportSession::destroyOutgoingUnidirectionalStream(WebTransportStreamIdentifier identifier)
 {
-    ASSERT(m_sendStreams.contains(identifier));
-    m_sendStreams.remove(identifier);
+    ASSERT(m_streams.contains(identifier));
+    m_streams.remove(identifier);
 }
 
 void NetworkTransportSession::destroyBidirectionalStream(WebTransportStreamIdentifier identifier)
 {
-    ASSERT(m_bidirectionalStreams.contains(identifier));
-    m_bidirectionalStreams.remove(identifier);
+    ASSERT(m_streams.contains(identifier));
+    m_streams.remove(identifier);
 }
 
 void NetworkTransportSession::terminate(uint32_t, CString&&)

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
@@ -41,6 +41,7 @@ namespace WebKit {
 
 class NetworkConnectionToWebProcess;
 class NetworkTransportStream;
+enum class NetworkTransportStreamType : uint8_t;
 
 struct SharedPreferencesForWebProcess;
 struct WebTransportSessionIdentifierType;
@@ -83,15 +84,18 @@ private:
 
     IPC::Connection* messageSenderConnection() const final;
     uint64_t messageSenderDestinationID() const final;
+    void setupConnectionHandler();
+    void setupDatagramConnection(CompletionHandler<void(RefPtr<NetworkTransportSession>&&)>&&);
+    void receiveDatagramLoop();
+    void createStream(NetworkTransportStreamType, CompletionHandler<void(std::optional<WebTransportStreamIdentifier>)>&&);
 
-    HashMap<WebTransportStreamIdentifier, Ref<NetworkTransportStream>> m_bidirectionalStreams;
-    HashMap<WebTransportStreamIdentifier, Ref<NetworkTransportStream>> m_receiveStreams;
-    HashMap<WebTransportStreamIdentifier, Ref<NetworkTransportStream>> m_sendStreams;
+    HashMap<WebTransportStreamIdentifier, Ref<NetworkTransportStream>> m_streams;
     WeakPtr<NetworkConnectionToWebProcess> m_connectionToWebProcess;
 
 #if PLATFORM(COCOA)
     const RetainPtr<nw_connection_group_t> m_connectionGroup;
     const RetainPtr<nw_endpoint_t> m_endpoint;
+    RetainPtr<nw_connection_t> m_datagramConnection;
 #endif
 };
 

--- a/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
@@ -28,7 +28,7 @@
 
 #import "NetworkConnectionToWebProcess.h"
 #import "NetworkTransportStream.h"
-#import <pal/spi/cf/CFNetworkSPI.h>
+#import <pal/spi/cocoa/NetworkSPI.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/CompletionHandler.h>
 #import <wtf/RetainPtr.h>
@@ -42,96 +42,90 @@ NetworkTransportSession::NetworkTransportSession(NetworkConnectionToWebProcess& 
     , m_connectionGroup(connectionGroup)
     , m_endpoint(endpoint)
 {
-    constexpr uint32_t maximumMessageSize { std::numeric_limits<uint32_t>::max() };
-    constexpr bool rejectOversizedMessages { false };
-    nw_connection_group_set_receive_handler(connectionGroup, maximumMessageSize, rejectOversizedMessages, makeBlockPtr([weakThis = WeakPtr { *this }] (dispatch_data_t datagram, nw_content_context_t, bool) {
-        RefPtr strongThis = weakThis.get();
-        if (!strongThis)
-            return;
-
-        // FIXME: Not only is this an unnecessary string copy, but it's also something that should probably be in WTF or FragmentedSharedBuffer.
-        auto vectorFromData = [](dispatch_data_t content) {
-            ASSERT(content);
-            Vector<uint8_t> request;
-            dispatch_data_apply_span(content, [&](std::span<const uint8_t> data) {
-                request.append(data);
-                return true;
-            });
-            return request;
-        };
-
-        strongThis->receiveDatagram(vectorFromData(datagram).span());
-    }).get());
-
-    // FIXME: Use nw_connection_group_set_new_connection_handler to receive incoming connections.
+    setupConnectionHandler();
 }
 
-void NetworkTransportSession::initialize(NetworkConnectionToWebProcess& connectionToWebProcess, URL&& url, CompletionHandler<void(RefPtr<NetworkTransportSession>&&)>&& completionHandler)
+#if HAVE(WEB_TRANSPORT)
+static RetainPtr<nw_parameters_t> createParameters()
 {
-    // FIXME: Use nw_endpoint_create_url to support all URLs on systems where rdar://135036170 is fixed.
-    auto port = url.port() ? url.port() : defaultPortForProtocol(url.protocol());
-    if (!port)
-        return completionHandler(nullptr);
-
-    RetainPtr endpoint = adoptNS(nw_endpoint_create_host(url.host().utf8().data(), makeString(*port).utf8().data()));
-    if (!endpoint) {
-        ASSERT_NOT_REACHED();
-        return completionHandler(nullptr);
-    }
-
-    RetainPtr descriptor = adoptNS(nw_group_descriptor_create_multiplex(endpoint.get()));
-    if (!descriptor) {
-        ASSERT_NOT_REACHED();
-        return completionHandler(nullptr);
-    }
+    auto configureWebTransport = [](nw_protocol_options_t options) {
+        nw_webtransport_options_set_is_unidirectional(options, false);
+        nw_webtransport_options_set_is_datagram(options, true);
+    };
 
     auto configureTLS = [](nw_protocol_options_t options) {
-        RetainPtr securityOptions = adoptNS(nw_quic_connection_copy_sec_protocol_options(options));
+        RetainPtr securityOptions = adoptNS(nw_tls_copy_sec_protocol_options(options));
         sec_protocol_options_set_peer_authentication_required(securityOptions.get(), true);
         sec_protocol_options_set_verify_block(securityOptions.get(), makeBlockPtr([](sec_protocol_metadata_t metadata, sec_trust_t trust, sec_protocol_verify_complete_t completion) {
             // FIXME: Hook this up with WKNavigationDelegate.didReceiveChallenge.
             completion(true);
         }).get(), dispatch_get_main_queue());
         // FIXME: Pipe client cert auth into this too, probably.
-        sec_protocol_options_add_tls_application_protocol(securityOptions.get(), "h3");
     };
 
-    RetainPtr parameters = adoptNS(nw_parameters_create_quic_stream(NW_PARAMETERS_DEFAULT_CONFIGURATION, configureTLS));
+    auto configureQUIC = [](nw_protocol_options_t options) {
+        nw_quic_set_initial_max_streams_bidirectional(options, std::numeric_limits<uint32_t>::max());
+        nw_quic_set_initial_max_streams_unidirectional(options, std::numeric_limits<uint32_t>::max());
+        nw_quic_set_max_datagram_frame_size(options, std::numeric_limits<uint16_t>::max());
+    };
 
+    return adoptNS(nw_parameters_create_webtransport_http(configureWebTransport, configureTLS, configureQUIC, NW_PARAMETERS_DEFAULT_CONFIGURATION));
+}
+#endif // HAVE(WEB_TRANSPORT)
+
+void NetworkTransportSession::initialize(NetworkConnectionToWebProcess& connectionToWebProcess, URL&& url, CompletionHandler<void(RefPtr<NetworkTransportSession>&&)>&& completionHandler)
+{
+#if HAVE(WEB_TRANSPORT)
+    RetainPtr endpoint = adoptNS(nw_endpoint_create_url(url.string().utf8().data()));
+    if (!endpoint) {
+        ASSERT_NOT_REACHED();
+        return completionHandler(nullptr);
+    }
+
+    RetainPtr parameters = createParameters();
     if (!parameters) {
         ASSERT_NOT_REACHED();
         return completionHandler(nullptr);
     }
 
-    RetainPtr connectionGroup = adoptNS(nw_connection_group_create(descriptor.get(), parameters.get()));
+    RetainPtr groupDescriptor = adoptNS(nw_group_descriptor_create_multiplex(endpoint.get()));
+    if (!groupDescriptor) {
+        ASSERT_NOT_REACHED();
+        return completionHandler(nullptr);
+    }
+
+    RetainPtr connectionGroup = adoptNS(nw_connection_group_create(groupDescriptor.get(), parameters.get()));
     if (!connectionGroup) {
         ASSERT_NOT_REACHED();
         return completionHandler(nullptr);
     }
 
     Ref networkTransportSession = NetworkTransportSession::create(connectionToWebProcess, connectionGroup.get(), endpoint.get());
-    WeakPtr weakNetworkTransportSession { networkTransportSession };
-    auto creationCompletionHandler = [completionHandler = WTFMove(completionHandler)] (RefPtr<NetworkTransportSession>&& session) mutable {
-        if (completionHandler)
-            completionHandler(WTFMove(session));
+
+    auto creationCompletionHandler = [
+        completionHandler = WTFMove(completionHandler)
+    ] (RefPtr<NetworkTransportSession>&& session) mutable {
+        if (!completionHandler)
+            return;
+        if (!session)
+            completionHandler(nullptr);
+        session->setupDatagramConnection(WTFMove(completionHandler));
     };
+
     nw_connection_group_set_state_changed_handler(connectionGroup.get(), makeBlockPtr([
         networkTransportSession = WTFMove(networkTransportSession),
-        weakNetworkTransportSession = WTFMove(weakNetworkTransportSession),
         creationCompletionHandler = WTFMove(creationCompletionHandler)
     ] (nw_connection_group_state_t state, nw_error_t error) mutable {
         if (error)
             return creationCompletionHandler(nullptr);
         switch (state) {
-        case nw_connection_group_state_invalid:
-            return creationCompletionHandler(nullptr);
         case nw_connection_group_state_waiting:
             return; // We will get another callback with another state change.
         case nw_connection_group_state_ready:
             return creationCompletionHandler(WTFMove(networkTransportSession));
         case nw_connection_group_state_failed:
         case nw_connection_group_state_cancelled:
-            // FIXME: Use weakNetworkTransportSession to pipe the failure to JS.
+        case nw_connection_group_state_invalid:
             return creationCompletionHandler(nullptr);
         }
         RELEASE_ASSERT_NOT_REACHED();
@@ -139,19 +133,113 @@ void NetworkTransportSession::initialize(NetworkConnectionToWebProcess& connecti
 
     nw_connection_group_set_queue(connectionGroup.get(), dispatch_get_main_queue());
     nw_connection_group_start(connectionGroup.get());
-}
-
-void NetworkTransportSession::sendDatagram(std::span<const uint8_t> data, CompletionHandler<void()>&& completionHandler)
-{
-    nw_connection_group_send_message(m_connectionGroup.get(), makeDispatchData(Vector(data)).get(), m_endpoint.get(), NW_CONNECTION_DEFAULT_MESSAGE_CONTEXT, makeBlockPtr([completionHandler = WTFMove(completionHandler)] (nw_error_t error) mutable {
-        // FIXME: Pass any error through to JS.
-        completionHandler();
-    }).get());
+#else
+    completionHandler(nullptr);
+#endif // HAVE(WEB_TRANSPORT)
 }
 
 void NetworkTransportSession::createBidirectionalStream(CompletionHandler<void(std::optional<WebTransportStreamIdentifier>)>&& completionHandler)
 {
-    RetainPtr connection = adoptNS(nw_connection_group_extract_connection(m_connectionGroup.get(), m_endpoint.get(), nullptr));
+    createStream(NetworkTransportStreamType::Bidirectional, WTFMove(completionHandler));
+}
+
+void NetworkTransportSession::createOutgoingUnidirectionalStream(CompletionHandler<void(std::optional<WebTransportStreamIdentifier>)>&& completionHandler)
+{
+    createStream(NetworkTransportStreamType::OutgoingUnidirectional, WTFMove(completionHandler));
+}
+
+void NetworkTransportSession::setupDatagramConnection(CompletionHandler<void(RefPtr<NetworkTransportSession>&&)>&& completionHandler)
+{
+#if HAVE(WEB_TRANSPORT)
+    ASSERT(!m_datagramConnection);
+    ASSERT(completionHandler);
+
+    RetainPtr webtransportOptions = adoptNS(nw_webtransport_create_options());
+    if (!webtransportOptions) {
+        ASSERT_NOT_REACHED();
+        return completionHandler(nullptr);
+    }
+    nw_webtransport_options_set_is_unidirectional(webtransportOptions.get(), false);
+    nw_webtransport_options_set_is_datagram(webtransportOptions.get(), true);
+
+    m_datagramConnection = adoptNS(nw_connection_group_extract_connection(m_connectionGroup.get(), nil, webtransportOptions.get()));
+    if (!m_datagramConnection) {
+        ASSERT_NOT_REACHED();
+        return completionHandler(nullptr);
+    }
+
+    nw_connection_set_state_changed_handler(m_datagramConnection.get(), makeBlockPtr([
+        protectedThis = RefPtr { this },
+        completionHandler = WTFMove(completionHandler)
+    ] (nw_connection_state_t state, nw_error_t error) mutable {
+        if (!protectedThis)
+            return completionHandler(nullptr);
+        if (error) {
+            protectedThis = nullptr;
+            return completionHandler(nullptr); // FIXME: Pipe the failure to JS
+        }
+        switch (state) {
+        case nw_connection_state_waiting:
+        case nw_connection_state_preparing: {
+            return; // We will get another callback with another state change.
+        }
+        case nw_connection_state_ready: {
+            protectedThis->receiveDatagramLoop();
+            return completionHandler(std::exchange(protectedThis, nullptr));
+        }
+        case nw_connection_state_invalid:
+        case nw_connection_state_failed:
+        case nw_connection_state_cancelled: {
+            protectedThis = nullptr;
+            return completionHandler(nullptr); // FIXME: Pipe the failure to JS
+        }
+        }
+        RELEASE_ASSERT_NOT_REACHED();
+    }).get());
+    nw_connection_set_queue(m_datagramConnection.get(), dispatch_get_main_queue());
+    nw_connection_start(m_datagramConnection.get());
+#else
+    completionHandler(nullptr);
+#endif // HAVE(WEB_TRANSPORT)
+}
+
+void NetworkTransportSession::sendDatagram(std::span<const uint8_t> data, CompletionHandler<void()>&& completionHandler)
+{
+#if HAVE(WEB_TRANSPORT)
+    ASSERT(m_datagramConnection);
+    nw_connection_send(m_datagramConnection.get(), makeDispatchData(Vector(data)).get(), NW_CONNECTION_DEFAULT_MESSAGE_CONTEXT, true, makeBlockPtr([completionHandler = WTFMove(completionHandler)] (nw_error_t error) mutable {
+        ASSERT(!error);
+        // FIXME: Pass any error through to JS.
+        completionHandler();
+    }).get());
+#else
+    completionHandler();
+#endif // HAVE(WEB_TRANSPORT)
+}
+
+void NetworkTransportSession::setupConnectionHandler()
+{
+#if HAVE(WEB_TRANSPORT)
+    nw_connection_group_set_new_connection_handler(m_connectionGroup.get(), makeBlockPtr([weakThis = WeakPtr { *this }] (nw_connection_t inboundConnection) mutable {
+        ASSERT_UNUSED(weakThis, weakThis);
+        // FIXME: Implement incoming connection handler
+    }).get());
+#endif // HAVE(WEB_TRANSPORT)
+}
+
+void NetworkTransportSession::createStream(NetworkTransportStreamType streamType, CompletionHandler<void(std::optional<WebTransportStreamIdentifier>)>&& completionHandler)
+{
+#if HAVE(WEB_TRANSPORT)
+    ASSERT(streamType != NetworkTransportStreamType::IncomingUnidirectional);
+    RetainPtr webtransportOptions = adoptNS(nw_webtransport_create_options());
+    if (!webtransportOptions) {
+        ASSERT_NOT_REACHED();
+        return completionHandler(std::nullopt);
+    }
+    nw_webtransport_options_set_is_unidirectional(webtransportOptions.get(), streamType != NetworkTransportStreamType::Bidirectional);
+    nw_webtransport_options_set_is_datagram(webtransportOptions.get(), false);
+
+    RetainPtr connection = adoptNS(nw_connection_group_extract_connection(m_connectionGroup.get(), nil, webtransportOptions.get()));
     if (!connection) {
         ASSERT_NOT_REACHED();
         return completionHandler(std::nullopt);
@@ -167,12 +255,12 @@ void NetworkTransportSession::createBidirectionalStream(CompletionHandler<void(s
         if (!strongThis || !stream)
             return completionHandler(std::nullopt);
         auto identifier = stream->identifier();
-        ASSERT(!strongThis->m_bidirectionalStreams.contains(identifier));
-        strongThis->m_bidirectionalStreams.set(identifier, stream.releaseNonNull());
+        ASSERT(!strongThis->m_streams.contains(identifier));
+        strongThis->m_streams.set(identifier, stream.releaseNonNull());
         completionHandler(identifier);
     };
 
-    Ref stream = NetworkTransportStream::create(*this, connection.get(), NetworkTransportStreamType::Bidirectional);
+    Ref stream = NetworkTransportStream::create(*this, connection.get(), streamType);
 
     nw_connection_set_state_changed_handler(connection.get(), makeBlockPtr([
         creationCompletionHandler = WTFMove(creationCompletionHandler),
@@ -196,12 +284,36 @@ void NetworkTransportSession::createBidirectionalStream(CompletionHandler<void(s
     }).get());
     nw_connection_set_queue(connection.get(), dispatch_get_main_queue());
     nw_connection_start(connection.get());
-}
-
-void NetworkTransportSession::createOutgoingUnidirectionalStream(CompletionHandler<void(std::optional<WebTransportStreamIdentifier>)>&& completionHandler)
-{
-    // FIXME: Call nw_connection_group_extract_connection and make a NetworkTransportStream and add to m_sendStreams like NetworkTransportSession::createBidirectionalStream.
+#else
     completionHandler(std::nullopt);
+#endif // HAVE(WEB_TRANSPORT)
 }
 
+void NetworkTransportSession::receiveDatagramLoop()
+{
+#if HAVE(WEB_TRANSPORT)
+    ASSERT(m_datagramConnection);
+    nw_connection_receive(m_datagramConnection.get(), 1, std::numeric_limits<uint32_t>::max(), makeBlockPtr([weakThis = WeakPtr { *this }] (dispatch_data_t content, nw_content_context_t, bool withFin, nw_error_t error) {
+        RefPtr strongThis = weakThis.get();
+        if (!strongThis)
+            return;
+        if (error)
+            return; // FIXME: Pipe this error to JS.
+
+        // FIXME: Not only is this an unnecessary string copy, but it's also something that should probably be in WTF or FragmentedSharedBuffer.
+        auto vectorFromData = [](dispatch_data_t content) {
+            ASSERT(content);
+            Vector<uint8_t> request;
+            dispatch_data_apply_span(content, [&](std::span<const uint8_t> buffer) {
+                request.append(buffer);
+                return true;
+            });
+            return request;
+        };
+
+        strongThis->receiveDatagram(vectorFromData(content).span());
+        strongThis->receiveDatagramLoop();
+    }).get());
+#endif // HAVE(WEB_TRANSPORT)
+}
 }

--- a/Source/WebKit/WebProcess/Network/WebTransportSession.cpp
+++ b/Source/WebKit/WebProcess/Network/WebTransportSession.cpp
@@ -85,6 +85,8 @@ void WebTransportSession::receiveDatagram(std::span<const uint8_t> datagram)
     ASSERT(RunLoop::isMain());
     if (auto strongClient = m_client.get())
         strongClient->receiveDatagram(datagram);
+    else
+        ASSERT_NOT_REACHED();
 }
 
 void WebTransportSession::receiveIncomingUnidirectionalStream(WebTransportStreamIdentifier)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm
@@ -35,6 +35,7 @@
 
 namespace TestWebKitAPI {
 
+#if HAVE(WEB_TRANSPORT)
 static void enableWebTransport(WKWebViewConfiguration *configuration)
 {
     auto preferences = [configuration preferences];
@@ -46,7 +47,8 @@ static void enableWebTransport(WKWebViewConfiguration *configuration)
     }
 }
 
-TEST(WebTransport, Basic)
+// FIXME: Re-enable these tests once rdar://141009498 is available in OS builds.
+TEST(WebTransport, DISABLED_ClientBidirectional)
 {
     WebTransportServer echoServer([] (Connection connection) -> Task {
         while (1) {
@@ -78,4 +80,36 @@ TEST(WebTransport, Basic)
     EXPECT_WK_STREQ([webView _test_waitForAlert], "successfully read abc");
 }
 
+TEST(WebTransport, DISABLED_Datagram)
+{
+    WebTransportServer echoServer([] (Connection connection) -> Task {
+        while (1) {
+            auto request = co_await connection.awaitableReceiveBytes();
+            co_await connection.awaitableSend(WTFMove(request));
+        }
+    });
+
+    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    enableWebTransport(configuration.get());
+    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+
+    NSString *html = [NSString stringWithFormat:@""
+        "<script>async function test() {"
+        "  try {"
+        "    let t = new WebTransport('https://127.0.0.1:%d/');"
+        "    await t.ready;"
+        "    let w = t.datagrams.writable.getWriter();"
+        "    await w.write(new TextEncoder().encode('abc'));"
+        "    let r = t.datagrams.readable.getReader();"
+        "    const { value, done } = await r.read();"
+        "    alert('successfully read ' + new TextDecoder().decode(value));"
+        "  } catch (e) { alert('caught ' + e); }"
+        "}; test();"
+        "</script>",
+        echoServer.port()];
+    [webView loadHTMLString:html baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "successfully read abc");
+}
+
+#endif // HAVE(WEB_TRANSPORT)
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 18fc2c8a829238a023b22f9c584ce09756d4b757
<pre>
Implement WebTransport datagrams and outgoing streams network interface
<a href="https://bugs.webkit.org/show_bug.cgi?id=284069">https://bugs.webkit.org/show_bug.cgi?id=284069</a>
<a href="https://rdar.apple.com/136262968">rdar://136262968</a>

Reviewed by Alex Christensen.

WebTransport streams are hooked up with nw_connection_t for outgoing bidirectional streams, unidirectional streams, and datagrams.
They can now send and receive data.

One test is added, WebTransport.Datagram, and the existing WebTransport.Basic test is now WebTransport.Bidirectional to validate the added changes.
A test for unidirectional stream will be added with the handling of incoming streams.

* Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp:
(WebKit::NetworkTransportSession::sendStreamSendBytes):
(WebKit::NetworkTransportSession::streamSendBytes):
(WebKit::NetworkTransportSession::destroyOutgoingUnidirectionalStream):
(WebKit::NetworkTransportSession::destroyBidirectionalStream):
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h:
* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm:
(WebKit::NetworkTransportSession::NetworkTransportSession):
(WebKit::createDatagramParameters):
(WebKit::NetworkTransportSession::initialize):
(WebKit::NetworkTransportSession::sendDatagram):
(WebKit::NetworkTransportSession::createBidirectionalStream):
(WebKit::NetworkTransportSession::createOutgoingUnidirectionalStream):
(WebKit::NetworkTransportSession::setupListenerConnectionHandler):
(WebKit::NetworkTransportSession::createParameters):
(WebKit::NetworkTransportSession::receiveDatagramLoop):
(WebKit::NetworkTransportSession::createStream):
* Source/WebKit/WebProcess/Network/WebTransportSession.cpp:
(WebKit::WebTransportSession::receiveDatagram):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm:
(TestWebKitAPI::TEST(WebTransport, ClientBidirectional)):
(TestWebKitAPI::TEST(WebTransport, Datagram)):
(TestWebKitAPI::TEST(WebTransport, Basic)): Deleted.
* Tools/TestWebKitAPI/WebTransportServer.mm:
(TestWebKitAPI::WebTransportServer::WebTransportServer):

Canonical link: <a href="https://commits.webkit.org/287714@main">https://commits.webkit.org/287714@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f3197f6261171b093a60975448baa510a800e8f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80573 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59580 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34506 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85100 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31555 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82684 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68641 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7885 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62947 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20749 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83642 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/53057 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73345 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43252 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50352 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27503 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30014 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71498 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28026 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86528 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7799 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5503 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71235 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7974 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69182 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70476 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14486 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12481 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7761 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/13280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7600 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11119 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9405 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->