### PR TITLE
Add support for documentId in webNavigation.

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionFrameParameters.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionFrameParameters.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,6 +28,7 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #include <wtf/URL.h>
+#include <wtf/UUID.h>
 
 namespace WebKit {
 
@@ -36,6 +37,7 @@ struct WebExtensionFrameParameters {
     std::optional<URL> url;
     WebKit::WebExtensionFrameIdentifier parentFrameIdentifier;
     std::optional<WebKit::WebExtensionFrameIdentifier> frameIdentifier;
+    Markable<WTF::UUID> documentIdentifier;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Extensions/WebExtensionFrameParameters.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionFrameParameters.serialization.in
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Apple Inc. All rights reserved.
+# Copyright (C) 2023-2024 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -27,6 +27,7 @@ struct WebKit::WebExtensionFrameParameters {
     std::optional<URL> url;
     WebKit::WebExtensionFrameIdentifier parentFrameIdentifier;
     std::optional<WebKit::WebExtensionFrameIdentifier> frameIdentifier;
+    Markable<WTF::UUID> documentIdentifier;
 };
 
 #endif

--- a/Source/WebKit/Shared/FrameInfoData.h
+++ b/Source/WebKit/Shared/FrameInfoData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,6 +28,7 @@
 #include "WebFrameMetrics.h"
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/ResourceRequest.h>
+#include <WebCore/ScriptExecutionContextIdentifier.h>
 #include <WebCore/SecurityOriginData.h>
 #include <wtf/ProcessID.h>
 
@@ -43,6 +44,7 @@ struct FrameInfoData {
     String frameName;
     Markable<WebCore::FrameIdentifier> frameID;
     Markable<WebCore::FrameIdentifier> parentFrameID;
+    Markable<WebCore::ScriptExecutionContextIdentifier> documentID;
     ProcessID processID;
     bool isFocused { false };
     bool errorOccurred { false };

--- a/Source/WebKit/Shared/FrameInfoData.serialization.in
+++ b/Source/WebKit/Shared/FrameInfoData.serialization.in
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 Apple Inc. All rights reserved.
+# Copyright (C) 2022-2024 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -25,15 +25,16 @@ headers: "FrameInfoData.h" "WebCoreArgumentCoders.h"
 enum class WebKit::FrameType : bool
 
 struct WebKit::FrameInfoData {
-    bool isMainFrame
-    WebKit::FrameType frameType
-    WebCore::ResourceRequest request
-    WebCore::SecurityOriginData securityOrigin
-    String frameName
-    Markable<WebCore::FrameIdentifier> frameID
-    Markable<WebCore::FrameIdentifier> parentFrameID
-    WTF::ProcessID processID
-    bool isFocused
-    bool errorOccurred
-    WebKit::WebFrameMetrics frameMetrics
+    bool isMainFrame;
+    WebKit::FrameType frameType;
+    WebCore::ResourceRequest request;
+    WebCore::SecurityOriginData securityOrigin;
+    String frameName;
+    Markable<WebCore::FrameIdentifier> frameID;
+    Markable<WebCore::FrameIdentifier> parentFrameID;
+    Markable<WebCore::ScriptExecutionContextIdentifier> documentID;
+    WTF::ProcessID processID;
+    bool isFocused;
+    bool errorOccurred;
+    WebKit::WebFrameMetrics frameMetrics;
 }

--- a/Source/WebKit/UIProcess/API/APIFrameInfo.h
+++ b/Source/WebKit/UIProcess/API/APIFrameInfo.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -56,6 +56,7 @@ public:
     Ref<FrameHandle> handle() const;
     WebKit::WebPageProxy* page() { return m_page.get(); }
     RefPtr<FrameHandle> parentFrameHandle() const;
+    Markable<WebCore::ScriptExecutionContextIdentifier> documentID() const { return m_data.documentID; }
     ProcessID processID() const { return m_data.processID; }
     bool isFocused() const { return m_data.isFocused; }
     bool errorOccurred() const { return m_data.errorOccurred; }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -99,6 +99,11 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 - (_WKFrameHandle *)_parentFrameHandle
 {
     return wrapper(_frameInfo->parentFrameHandle()).autorelease();
+}
+
+- (NSUUID *)_documentIdentifier
+{
+    return _frameInfo->documentID()->object();
 }
 
 - (pid_t)_processIdentifier

--- a/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfoPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfoPrivate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,6 +31,7 @@
 
 @property (nonatomic, readonly, copy, nonnull) _WKFrameHandle *_handle WK_API_AVAILABLE(macos(10.12), ios(10.0));
 @property (nonatomic, readonly, copy, nullable) _WKFrameHandle *_parentFrameHandle WK_API_AVAILABLE(macos(11.0), ios(14.0));
+@property (nonatomic, readonly, copy, nullable) NSUUID *_documentIdentifier WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 @property (nonatomic, readonly) pid_t _processIdentifier WK_API_AVAILABLE(macos(13.3), ios(16.4));
 @property (nonatomic, readonly) BOOL _isLocalFrame WK_API_AVAILABLE(macos(14.0), ios(17.0));
 @property (nonatomic, readonly) BOOL _isFocused WK_API_AVAILABLE(macos(14.4), ios(17.4), visionos(1.1));

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -1310,7 +1310,7 @@ void UIDelegate::UIClient::callDisplayCapturePermissionDelegate(WebPageProxy& pa
     std::optional<WebCore::FrameIdentifier> mainFrameID;
     if (auto* mainFrame = frame.page() ? frame.page()->mainFrame() : nullptr)
         mainFrameID = mainFrame->frameID();
-    FrameInfoData frameInfo { frame.isMainFrame(), FrameType::Local, { }, userMediaOrigin.securityOrigin(), { }, frame.frameID(), mainFrameID, frame.process().processID(), frame.isFocused() };
+    FrameInfoData frameInfo { frame.isMainFrame(), FrameType::Local, { }, userMediaOrigin.securityOrigin(), { }, frame.frameID(), mainFrameID, std::nullopt, frame.process().processID(), frame.isFocused() };
     RetainPtr<WKFrameInfo> frameInfoWrapper = wrapper(API::FrameInfo::create(WTFMove(frameInfo), frame.page()));
 
     BOOL requestSystemAudio = !!request.requiresDisplayCaptureWithAudio();
@@ -1382,7 +1382,7 @@ void UIDelegate::UIClient::decidePolicyForUserMediaPermissionRequest(WebPageProx
         std::optional<WebCore::FrameIdentifier> mainFrameID;
         if (auto* mainFrame = frame.page() ? frame.page()->mainFrame() : nullptr)
             mainFrameID = mainFrame->frameID();
-        FrameInfoData frameInfo { frame.isMainFrame(), FrameType::Local, { }, userMediaOrigin.securityOrigin(), { }, frame.frameID(), mainFrameID, frame.process().processID(), frame.isFocused() };
+        FrameInfoData frameInfo { frame.isMainFrame(), FrameType::Local, { }, userMediaOrigin.securityOrigin(), { }, frame.frameID(), mainFrameID, std::nullopt, frame.process().processID(), frame.isFocused() };
         RetainPtr<WKFrameInfo> frameInfoWrapper = wrapper(API::FrameInfo::create(WTFMove(frameInfo), frame.page()));
 
         WKMediaCaptureType type = WKMediaCaptureTypeCamera;
@@ -1459,7 +1459,7 @@ void UIDelegate::UIClient::decidePolicyForScreenCaptureUnmuting(WebPageProxy& pa
     std::optional<WebCore::FrameIdentifier> mainFrameID;
     if (auto* mainFrame = frame.page() ? frame.page()->mainFrame() : nullptr)
         mainFrameID = mainFrame->frameID();
-    FrameInfoData frameInfo { frame.isMainFrame(), FrameType::Local, { }, userMediaOrigin.securityOrigin(), { }, frame.frameID(), mainFrameID, frame.process().processID(), frame.isFocused() };
+    FrameInfoData frameInfo { frame.isMainFrame(), FrameType::Local, { }, userMediaOrigin.securityOrigin(), { }, frame.frameID(), mainFrameID, std::nullopt, frame.process().processID(), frame.isFocused() };
     RetainPtr<WKFrameInfo> frameInfoWrapper = wrapper(API::FrameInfo::create(WTFMove(frameInfo), frame.page()));
 
     [delegate _webView:uiDelegate->m_webView.get().get() decidePolicyForScreenCaptureUnmutingForOrigin:wrapper(topLevelOrigin) initiatedByFrame:frameInfoWrapper.get() decisionHandler:decisionHandler.get()];

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWebNavigationCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWebNavigationCocoa.mm
@@ -47,13 +47,14 @@ namespace WebKit {
 static WebExtensionFrameParameters frameParametersForFrame(_WKFrameTreeNode *frame, _WKFrameTreeNode *parentFrame, WebExtensionTab* tab, WebExtensionContext* extensionContext, bool includeFrameIdentifier)
 {
     auto *frameInfo = frame.info;
-    auto *frameURL = frameInfo.request.URL;
+    auto frameURL = URL { frameInfo.request.URL };
 
     return {
-        static_cast<bool>(frameInfo._errorOccurred),
-        extensionContext->hasPermission(frameURL, tab) ? std::optional(frameURL) : std::nullopt,
-        parentFrame ? toWebExtensionFrameIdentifier(parentFrame.info) : WebExtensionFrameConstants::NoneIdentifier,
-        includeFrameIdentifier ? std::optional(toWebExtensionFrameIdentifier(frameInfo)) : std::nullopt
+        .errorOccurred = static_cast<bool>(frameInfo._errorOccurred),
+        .url = extensionContext->hasPermission(frameURL, tab) ? std::optional { frameURL } : std::nullopt,
+        .parentFrameIdentifier = parentFrame ? toWebExtensionFrameIdentifier(parentFrame.info) : WebExtensionFrameConstants::NoneIdentifier,
+        .frameIdentifier = includeFrameIdentifier ? std::optional { toWebExtensionFrameIdentifier(frameInfo) } : std::nullopt,
+        .documentIdentifier = WTF::UUID::fromNSUUID(frameInfo._documentIdentifier)
     };
 }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -590,28 +590,28 @@ void WebExtensionController::addItemsToContextMenu(WebPageProxy& page, const Con
 
 // MARK: webNavigation
 
-void WebExtensionController::didStartProvisionalLoadForFrame(WebPageProxyIdentifier pageID, WebExtensionFrameIdentifier frameID, WebExtensionFrameIdentifier parentFrameID, const URL& targetURL, WallTime timestamp)
+void WebExtensionController::didStartProvisionalLoadForFrame(WebPageProxyIdentifier pageID, const WebExtensionFrameParameters& frameParameters, WallTime timestamp)
 {
     for (Ref context : m_extensionContexts)
-        context->didStartProvisionalLoadForFrame(pageID, frameID, parentFrameID, targetURL, timestamp);
+        context->didStartProvisionalLoadForFrame(pageID, frameParameters, timestamp);
 }
 
-void WebExtensionController::didCommitLoadForFrame(WebPageProxyIdentifier pageID, WebExtensionFrameIdentifier frameID, WebExtensionFrameIdentifier parentFrameID, const URL& frameURL, WallTime timestamp)
+void WebExtensionController::didCommitLoadForFrame(WebPageProxyIdentifier pageID, const WebExtensionFrameParameters& frameParameters, WallTime timestamp)
 {
     for (Ref context : m_extensionContexts)
-        context->didCommitLoadForFrame(pageID, frameID, parentFrameID, frameURL, timestamp);
+        context->didCommitLoadForFrame(pageID, frameParameters, timestamp);
 }
 
-void WebExtensionController::didFinishLoadForFrame(WebPageProxyIdentifier pageID, WebExtensionFrameIdentifier frameID, WebExtensionFrameIdentifier parentFrameID, const URL& frameURL, WallTime timestamp)
+void WebExtensionController::didFinishLoadForFrame(WebPageProxyIdentifier pageID, const WebExtensionFrameParameters& frameParameters, WallTime timestamp)
 {
     for (Ref context : m_extensionContexts)
-        context->didFinishLoadForFrame(pageID, frameID, parentFrameID, frameURL, timestamp);
+        context->didFinishLoadForFrame(pageID, frameParameters, timestamp);
 }
 
-void WebExtensionController::didFailLoadForFrame(WebPageProxyIdentifier pageID, WebExtensionFrameIdentifier frameID, WebExtensionFrameIdentifier parentFrameID, const URL& frameURL, WallTime timestamp)
+void WebExtensionController::didFailLoadForFrame(WebPageProxyIdentifier pageID, const WebExtensionFrameParameters& frameParameters, WallTime timestamp)
 {
     for (Ref context : m_extensionContexts)
-        context->didFailLoadForFrame(pageID, frameID, parentFrameID, frameURL, timestamp);
+        context->didFailLoadForFrame(pageID, frameParameters, timestamp);
 }
 
 // MARK: declarativeNetRequest

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -443,10 +443,10 @@ public:
     void didReplaceTab(WebExtensionTab& oldTab, WebExtensionTab& newTab, SuppressEvents = SuppressEvents::No);
     void didChangeTabProperties(WebExtensionTab&, OptionSet<WebExtensionTab::ChangedProperties> = { });
 
-    void didStartProvisionalLoadForFrame(WebPageProxyIdentifier, WebExtensionFrameIdentifier, WebExtensionFrameIdentifier parentFrameID, const URL&, WallTime);
-    void didCommitLoadForFrame(WebPageProxyIdentifier, WebExtensionFrameIdentifier, WebExtensionFrameIdentifier parentFrameID, const URL&, WallTime);
-    void didFinishLoadForFrame(WebPageProxyIdentifier, WebExtensionFrameIdentifier, WebExtensionFrameIdentifier parentFrameID, const URL&, WallTime);
-    void didFailLoadForFrame(WebPageProxyIdentifier, WebExtensionFrameIdentifier, WebExtensionFrameIdentifier parentFrameID, const URL&, WallTime);
+    void didStartProvisionalLoadForFrame(WebPageProxyIdentifier, const WebExtensionFrameParameters&, WallTime);
+    void didCommitLoadForFrame(WebPageProxyIdentifier, const WebExtensionFrameParameters&, WallTime);
+    void didFinishLoadForFrame(WebPageProxyIdentifier, const WebExtensionFrameParameters&, WallTime);
+    void didFailLoadForFrame(WebPageProxyIdentifier, const WebExtensionFrameParameters&, WallTime);
 
     void resourceLoadDidSendRequest(WebPageProxyIdentifier, const ResourceLoadInfo&, const WebCore::ResourceRequest&);
     void resourceLoadDidPerformHTTPRedirection(WebPageProxyIdentifier, const ResourceLoadInfo&, const WebCore::ResourceResponse&, const WebCore::ResourceRequest&);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -73,6 +73,7 @@ class WebPageProxy;
 class WebProcessPool;
 class WebsiteDataStore;
 struct WebExtensionControllerParameters;
+struct WebExtensionFrameParameters;
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
 class WebInspectorUIProxy;
@@ -210,10 +211,10 @@ private:
     String stateFilePath(const String& uniqueIdentifier) const;
     _WKWebExtensionStorageSQLiteStore* sqliteStore(const String& storageDirectory, WebExtensionDataType, RefPtr<WebExtensionContext>);
 
-    void didStartProvisionalLoadForFrame(WebPageProxyIdentifier, WebExtensionFrameIdentifier, WebExtensionFrameIdentifier parentFrameID, const URL&, WallTime);
-    void didCommitLoadForFrame(WebPageProxyIdentifier, WebExtensionFrameIdentifier, WebExtensionFrameIdentifier parentFrameID, const URL&, WallTime);
-    void didFinishLoadForFrame(WebPageProxyIdentifier, WebExtensionFrameIdentifier, WebExtensionFrameIdentifier parentFrameID, const URL&, WallTime);
-    void didFailLoadForFrame(WebPageProxyIdentifier, WebExtensionFrameIdentifier, WebExtensionFrameIdentifier parentFrameID, const URL&, WallTime);
+    void didStartProvisionalLoadForFrame(WebPageProxyIdentifier, const WebExtensionFrameParameters&, WallTime);
+    void didCommitLoadForFrame(WebPageProxyIdentifier, const WebExtensionFrameParameters&, WallTime);
+    void didFinishLoadForFrame(WebPageProxyIdentifier, const WebExtensionFrameParameters&, WallTime);
+    void didFailLoadForFrame(WebPageProxyIdentifier, const WebExtensionFrameParameters&, WallTime);
 
     void purgeOldMatchedRules();
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.messages.in
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,10 +26,10 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 messages -> WebExtensionController {
-    [Validator=hasLoadedContexts] DidStartProvisionalLoadForFrame(WebKit::WebPageProxyIdentifier pageID, WebKit::WebExtensionFrameIdentifier frameID, WebKit::WebExtensionFrameIdentifier parentFrameID, URL targetURL, WallTime timestamp)
-    [Validator=hasLoadedContexts] DidCommitLoadForFrame(WebKit::WebPageProxyIdentifier pageID, WebKit::WebExtensionFrameIdentifier frameID, WebKit::WebExtensionFrameIdentifier parentFrameID, URL targetURL, WallTime timestamp)
-    [Validator=hasLoadedContexts] DidFinishLoadForFrame(WebKit::WebPageProxyIdentifier pageID, WebKit::WebExtensionFrameIdentifier frameID, WebKit::WebExtensionFrameIdentifier parentFrameID, URL targetURL, WallTime timestamp)
-    [Validator=hasLoadedContexts] DidFailLoadForFrame(WebKit::WebPageProxyIdentifier pageID, WebKit::WebExtensionFrameIdentifier frameID, WebKit::WebExtensionFrameIdentifier parentFrameID, URL targetURL, WallTime timestamp)
+    [Validator=hasLoadedContexts] DidStartProvisionalLoadForFrame(WebKit::WebPageProxyIdentifier pageID, struct WebKit::WebExtensionFrameParameters frameParameters, WallTime timestamp)
+    [Validator=hasLoadedContexts] DidCommitLoadForFrame(WebKit::WebPageProxyIdentifier pageID, struct WebKit::WebExtensionFrameParameters frameParameters, WallTime timestamp)
+    [Validator=hasLoadedContexts] DidFinishLoadForFrame(WebKit::WebPageProxyIdentifier pageID, struct WebKit::WebExtensionFrameParameters frameParameters, WallTime timestamp)
+    [Validator=hasLoadedContexts] DidFailLoadForFrame(WebKit::WebPageProxyIdentifier pageID, struct WebKit::WebExtensionFrameParameters frameParameters, WallTime timestamp)
 
     // Test APIs
     [Validator=inTestingMode] TestResult(bool result, String message, String sourceURL, unsigned lineNumber)

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -233,6 +233,7 @@ void ProvisionalPageProxy::cancel()
         SecurityOriginData::fromURLWithoutStrictOpaqueness(m_request.url()),
         { },
         m_mainFrame->frameID(),
+        std::nullopt,
         std::nullopt,
         m_mainFrame->processID(),
         m_mainFrame->isFocused(),

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -50,6 +50,7 @@ class WebExtensionMatchPattern;
 class WebFrame;
 
 struct WebExtensionAlarmParameters;
+struct WebExtensionFrameParameters;
 struct WebExtensionTabParameters;
 struct WebExtensionWindowParameters;
 
@@ -203,7 +204,7 @@ private:
     void dispatchTabsRemovedEvent(WebExtensionTabIdentifier, WebExtensionWindowIdentifier, WebExtensionContext::WindowIsClosing);
 
     // Web Navigation
-    void dispatchWebNavigationEvent(WebExtensionEventListenerType, WebExtensionTabIdentifier, WebExtensionFrameIdentifier, WebExtensionFrameIdentifier parentFrameID, const URL&, WallTime);
+    void dispatchWebNavigationEvent(WebExtensionEventListenerType, WebExtensionTabIdentifier, const WebExtensionFrameParameters&, WallTime);
 
     // Web Request
     void resourceLoadDidSendRequest(WebExtensionTabIdentifier, WebExtensionWindowIdentifier, const WebCore::ResourceRequest&, const ResourceLoadInfo&);

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
@@ -87,7 +87,7 @@ messages -> WebExtensionContextProxy {
     DispatchTabsRemovedEvent(WebKit::WebExtensionTabIdentifier tabIdentifier, WebKit::WebExtensionWindowIdentifier windowIdentifier, WebKit::WebExtensionContext::WindowIsClosing windowIsClosing)
 
     // Web Navigation
-    DispatchWebNavigationEvent(WebKit::WebExtensionEventListenerType type, WebKit::WebExtensionTabIdentifier tabID, WebKit::WebExtensionFrameIdentifier frameID, WebKit::WebExtensionFrameIdentifier parentFrameID, URL targetURL, WallTime timestamp)
+    DispatchWebNavigationEvent(WebKit::WebExtensionEventListenerType type, WebKit::WebExtensionTabIdentifier tabID, struct WebKit::WebExtensionFrameParameters frameParamaters, WallTime timestamp)
 
     // Web Request
     ResourceLoadDidSendRequest(WebKit::WebExtensionTabIdentifier tabIdentifier, WebKit::WebExtensionWindowIdentifier windowIdentifier, WebCore::ResourceRequest request, struct WebKit::ResourceLoadInfo resourceLoadInfo)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -96,6 +96,9 @@ std::optional<NavigationActionData> WebFrameLoaderClient::navigationActionData(c
     if (auto parentFrame = requestingFrame ? requestingFrame->parentFrame() : nullptr)
         parentFrameID = parentFrame->frameID();
 
+    RefPtr coreLocalFrame = m_frame->coreLocalFrame();
+    RefPtr document = coreLocalFrame ? coreLocalFrame->document() : nullptr;
+
     FrameInfoData originatingFrameInfoData {
         navigationAction.initiatedByMainFrame() == InitiatedByMainFrame::Yes,
         FrameType::Local,
@@ -104,6 +107,7 @@ std::optional<NavigationActionData> WebFrameLoaderClient::navigationActionData(c
         { },
         WTFMove(originatingFrameID),
         WTFMove(parentFrameID),
+        document ? std::optional { document->identifier() } : std::nullopt,
         getCurrentProcessID(),
         requestingFrame ? requestingFrame->isFocused() : false
     };

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWebNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWebNavigation.mm
@@ -37,54 +37,52 @@ namespace TestWebKitAPI {
 
 static auto *webNavigationManifest = @{ @"manifest_version": @3, @"permissions": @[ @"webNavigation" ], @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO } };
 
-TEST(WKWebExtensionAPIWebNavigation, EventListenerTest)
+TEST(WKWebExtensionAPIWebNavigation, EventListenerRegistration)
 {
     auto *backgroundScript = Util::constructScript(@[
-        // Setup
         @"function listener() { browser.test.notifyFail('This listener should not have been called') }",
         @"browser.test.assertFalse(browser.webNavigation.onBeforeNavigate.hasListener(listener), 'Should not have listener')",
 
-        // Test
         @"browser.webNavigation.onBeforeNavigate.addListener(listener)",
         @"browser.test.assertTrue(browser.webNavigation.onBeforeNavigate.hasListener(listener), 'Should have listener')",
+
         @"browser.webNavigation.onBeforeNavigate.removeListener(listener)",
         @"browser.test.assertFalse(browser.webNavigation.onBeforeNavigate.hasListener(listener), 'Should not have listener')",
 
-        // Finish
         @"browser.test.notifyPass()"
     ]);
 
     Util::loadAndRunExtension(webNavigationManifest, @{ @"background.js": backgroundScript });
 }
 
-TEST(WKWebExtensionAPIWebNavigation, EventFiringTest)
+TEST(WKWebExtensionAPIWebNavigation, BeforeNavigateEvent)
 {
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
     auto *backgroundScript = Util::constructScript(@[
-        // Setup
-        @"function passListener(details) {",
+        @"browser.webNavigation.onBeforeNavigate.addListener((details) => {",
+        @"    browser.test.assertEq(details?.frameId, 0, 'details.frameId should be:')",
+        @"    browser.test.assertEq(details?.parentFrameId, -1, 'details.parentFrameId should be:')",
 
-        // This event was fired on a main frame load, so the frameId should be 0 and we shouldn't have a parent frame.
-        @"  browser.test.assertEq(details.frameId, 0)",
-        @"  browser.test.assertEq(details.parentFrameId, -1)",
+        @"    browser.test.assertEq(typeof details?.url, 'string', 'details.url should be:')",
+        @"    browser.test.assertTrue(details?.url?.includes('localhost'), 'details.url should include localhost')",
 
-        @"  browser.test.notifyPass()",
-        @"}",
+        @"    browser.test.assertEq(typeof details?.tabId, 'number', 'details.tabId should be:')",
+        @"    browser.test.assertEq(typeof details?.timeStamp, 'number', 'details.timeStamp should be:')",
 
-        // The passListener firing will consider the test passed.
-        @"browser.webNavigation.onCommitted.addListener(passListener)",
+        @"    browser.test.assertEq(details?.documentId, undefined, 'details.documentId should be:')",
 
-        // Yield after creating the listener so we can load a tab.
+        @"    browser.test.notifyPass()",
+        @"})",
+
         @"browser.test.yield('Load Tab')"
     ]);
 
     auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:webNavigationManifest resources:@{ @"background.js": backgroundScript }]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    // Grant the webNavigation permission.
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
 
     auto *urlRequest = server.requestWithLocalhost();
@@ -99,27 +97,152 @@ TEST(WKWebExtensionAPIWebNavigation, EventFiringTest)
     [manager run];
 }
 
-TEST(WKWebExtensionAPIWebNavigation, AllowedFilterTest)
+TEST(WKWebExtensionAPIWebNavigation, CommittedEvent)
 {
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
     auto *backgroundScript = Util::constructScript(@[
-        // Setup
+        @"browser.webNavigation.onCommitted.addListener((details) => {",
+        @"    browser.test.assertEq(details?.frameId, 0, 'details.frameId should be:')",
+        @"    browser.test.assertEq(details?.parentFrameId, -1, 'details.parentFrameId should be:')",
+
+        @"    browser.test.assertEq(typeof details?.url, 'string', 'details.url should be:')",
+        @"    browser.test.assertTrue(details?.url?.includes('localhost'), 'details.url should include localhost')",
+
+        @"    browser.test.assertEq(typeof details?.tabId, 'number', 'details.tabId should be:')",
+        @"    browser.test.assertEq(typeof details?.timeStamp, 'number', 'details.timeStamp should be:')",
+
+        @"    browser.test.assertEq(typeof details?.documentId, 'string', 'details.documentId should be:')",
+        @"    browser.test.assertEq(details?.documentId?.length, 36, 'details.documentId.length should be:')",
+
+        @"    browser.test.notifyPass()",
+        @"})",
+
+        @"browser.test.yield('Load Tab')"
+    ]);
+
+    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:webNavigationManifest resources:@{ @"background.js": backgroundScript }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
+
+    auto *urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+
+    [manager loadAndRun];
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
+
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
+
+    [manager run];
+}
+
+TEST(WKWebExtensionAPIWebNavigation, DOMContentLoadedEvent)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.webNavigation.onDOMContentLoaded.addListener((details) => {",
+        @"    browser.test.assertEq(details?.frameId, 0, 'details.frameId should be:')",
+        @"    browser.test.assertEq(details?.parentFrameId, -1, 'details.parentFrameId should be:')",
+
+        @"    browser.test.assertEq(typeof details?.url, 'string', 'details.url should be:')",
+        @"    browser.test.assertTrue(details?.url?.includes('localhost'), 'details.url should include localhost')",
+
+        @"    browser.test.assertEq(typeof details?.tabId, 'number', 'details.tabId should be:')",
+        @"    browser.test.assertEq(typeof details?.timeStamp, 'number', 'details.timeStamp should be:')",
+
+        @"    browser.test.assertEq(typeof details?.documentId, 'string', 'details.documentId should be:')",
+        @"    browser.test.assertEq(details?.documentId?.length, 36, 'details.documentId.length should be:')",
+
+        @"    browser.test.notifyPass()",
+        @"})",
+
+        @"browser.test.yield('Load Tab')"
+    ]);
+
+    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:webNavigationManifest resources:@{ @"background.js": backgroundScript }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
+
+    auto *urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+
+    [manager loadAndRun];
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
+
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
+
+    [manager run];
+}
+
+TEST(WKWebExtensionAPIWebNavigation, CompletedEvent)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.webNavigation.onCompleted.addListener((details) => {",
+        @"    browser.test.assertEq(details?.frameId, 0, 'details.frameId should be:')",
+        @"    browser.test.assertEq(details?.parentFrameId, -1, 'details.parentFrameId should be:')",
+
+        @"    browser.test.assertEq(typeof details?.url, 'string', 'details.url should be:')",
+        @"    browser.test.assertTrue(details?.url?.includes('localhost'), 'details.url should include localhost')",
+
+        @"    browser.test.assertEq(typeof details?.tabId, 'number', 'details.tabId should be:')",
+        @"    browser.test.assertEq(typeof details?.timeStamp, 'number', 'details.timeStamp should be:')",
+
+        @"    browser.test.assertEq(typeof details?.documentId, 'string', 'details.documentId should be:')",
+        @"    browser.test.assertEq(details?.documentId?.length, 36, 'details.documentId.length should be:')",
+
+        @"    browser.test.notifyPass()",
+        @"})",
+
+        @"browser.test.yield('Load Tab')"
+    ]);
+
+    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:webNavigationManifest resources:@{ @"background.js": backgroundScript }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
+
+    auto *urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+
+    [manager loadAndRun];
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
+
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
+
+    [manager run];
+}
+
+TEST(WKWebExtensionAPIWebNavigation, AllowedFilter)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *backgroundScript = Util::constructScript(@[
         @"function passListener() { browser.test.notifyPass() }",
 
-        // The passListener firing will consider the test passed.
         @"browser.webNavigation.onCommitted.addListener(passListener, { 'url': [ {'hostContains': 'localhost'} ] })",
 
-        // Yield after creating the listener so we can load a tab.
         @"browser.test.yield('Load Tab')"
     ]);
 
     auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:webNavigationManifest resources:@{ @"background.js": backgroundScript }]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    // Grant the webNavigation permission.
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
 
     auto *urlRequest = server.requestWithLocalhost();
@@ -134,29 +257,25 @@ TEST(WKWebExtensionAPIWebNavigation, AllowedFilterTest)
     [manager run];
 }
 
-TEST(WKWebExtensionAPIWebNavigation, DeniedFilterTest)
+TEST(WKWebExtensionAPIWebNavigation, DeniedFilter)
 {
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
     auto *backgroundScript = Util::constructScript(@[
-        // Setup
         @"function passListener() { browser.test.notifyPass() }",
         @"function failListener() { browser.test.notifyFail('This listener should not have been called') }",
 
-        // The passListener firing (but not the failListener) will consider the test passed.
         @"browser.webNavigation.onCommitted.addListener(failListener, { 'url': [ {'hostContains': 'example'} ] })",
         @"browser.webNavigation.onCommitted.addListener(passListener)",
 
-        // Yield after creating the listener so we can load a tab.
         @"browser.test.yield('Load Tab')"
     ]);
 
     auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:webNavigationManifest resources:@{ @"background.js": backgroundScript }]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    // Grant the webNavigation permission.
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
 
     auto *urlRequest = server.requestWithLocalhost();
@@ -171,24 +290,26 @@ TEST(WKWebExtensionAPIWebNavigation, DeniedFilterTest)
     [manager run];
 }
 
-TEST(WKWebExtensionAPIWebNavigation, AllEventsFiredTest)
+TEST(WKWebExtensionAPIWebNavigation, AllEventsFired)
 {
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
     auto *backgroundScript = Util::constructScript(@[
-        // Setup
         @"let beforeNavigateEventFired = false",
         @"let onCommittedEventFired = false",
         @"let onDOMContentLoadedEventFired = false",
+
         @"function beforeNavigateHandler() { beforeNavigateEventFired = true }",
         @"function onCommittedHandler() { onCommittedEventFired = true }",
         @"function onDOMContentLoadedHandler() { onDOMContentLoadedEventFired = true }",
+
         @"function onCompletedHandler() {",
         @"  browser.test.assertTrue(beforeNavigateEventFired)",
         @"  browser.test.assertTrue(onCommittedEventFired)",
         @"  browser.test.assertTrue(onDOMContentLoadedEventFired)",
+
         @"  browser.test.notifyPass()",
         @"}",
 
@@ -197,14 +318,12 @@ TEST(WKWebExtensionAPIWebNavigation, AllEventsFiredTest)
         @"browser.webNavigation.onDOMContentLoaded.addListener(onDOMContentLoadedHandler)",
         @"browser.webNavigation.onCompleted.addListener(onCompletedHandler)",
 
-        // Yield after creating the listener so we can load a tab.
         @"browser.test.yield('Load Tab')"
     ]);
 
     auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:webNavigationManifest resources:@{ @"background.js": backgroundScript }]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    // Grant the webNavigation permission.
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
 
     auto *urlRequest = server.requestWithLocalhost();
@@ -256,7 +375,7 @@ TEST(WKWebExtensionAPIWebNavigation, RemoveListenerDuringEvent)
     [manager run];
 }
 
-TEST(WKWebExtensionAPIWebNavigation, OnErrorOccurredProvisionalLoadEvent)
+TEST(WKWebExtensionAPIWebNavigation, ErrorOccurredEventDuringProvisionalLoad)
 {
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<iframe src='/frame.html'></iframe>"_s } },
@@ -264,28 +383,23 @@ TEST(WKWebExtensionAPIWebNavigation, OnErrorOccurredProvisionalLoadEvent)
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
     auto *backgroundScript = Util::constructScript(@[
-        // Setup
         @"function errorListener(details) {",
-        // This should be a subframe
-        @"  browser.test.assertTrue(details.frameId != 0)",
+        @"  browser.test.assertTrue(details?.frameId != 0)",
 
-        // The URL of the frame that failed loading should include localhost and frame.
-        @"  browser.test.assertTrue(details.url.includes('localhost'))",
-        @"  browser.test.assertTrue(details.url.includes('frame'))",
+        @"  browser.test.assertTrue(details?.url.includes('localhost'))",
+        @"  browser.test.assertTrue(details?.url.includes('frame'))",
+
         @"  browser.test.notifyPass()",
         @"}",
 
-        // The passListener firing will consider the test passed.
         @"browser.webNavigation.onErrorOccurred.addListener(errorListener)",
 
-        // Yield after creating the listener so we can load a tab.
         @"browser.test.yield('Load Tab')"
     ]);
 
     auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:webNavigationManifest resources:@{ @"background.js": backgroundScript }]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    // Grant the webNavigation permission.
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
 
     auto *urlRequest = server.requestWithLocalhost();
@@ -309,7 +423,7 @@ String longString(LChar c)
     return vector.span();
 }
 
-TEST(WKWebExtensionAPIWebNavigation, OnErrorOccurredDuringLoadEvent)
+TEST(WKWebExtensionAPIWebNavigation, ErrorOccurredEventDuringLoad)
 {
     TestWebKitAPI::HTTPServer server(TestWebKitAPI::HTTPServer::UseCoroutines::Yes, [&](auto connection) -> TestWebKitAPI::Task {
         while (1) {
@@ -343,7 +457,6 @@ TEST(WKWebExtensionAPIWebNavigation, OnErrorOccurredDuringLoadEvent)
     });
 
     auto *backgroundScript = Util::constructScript(@[
-        // Setup
         @"async function errorListener(details) {",
         // This should be a subframe
         @"  browser.test.assertTrue(details.frameId != 0)",
@@ -373,7 +486,6 @@ TEST(WKWebExtensionAPIWebNavigation, OnErrorOccurredDuringLoadEvent)
     auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:webNavigationManifest resources:@{ @"background.js": backgroundScript }]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    // Grant the webNavigation permission.
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
 
     auto *urlRequest = server.requestWithLocalhost();
@@ -390,7 +502,7 @@ TEST(WKWebExtensionAPIWebNavigation, OnErrorOccurredDuringLoadEvent)
     [manager run];
 }
 
-TEST(WKWebExtensionAPIWebNavigation, GetMainFrame)
+TEST(WKWebExtensionAPIWebNavigation, GetFrameWithMainFrame)
 {
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<iframe src='/frame.html'></iframe>"_s } },
@@ -398,31 +510,29 @@ TEST(WKWebExtensionAPIWebNavigation, GetMainFrame)
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
     auto *backgroundScript = Util::constructScript(@[
-        // Setup
         @"function completedListener(details) {",
-        // Only listen for when the main frame loads so we don't call this method more than once.
-        @"  if (details.frameId !== 0)",
+        @"  if (details?.frameId !== 0)",
         @"    return",
-        @"  browser.webNavigation.getFrame({ tabId: details.tabId, frameId: 0 }, function(frame) {",
-        // Main frame
-        @"    browser.test.assertEq(frame.parentFrameId, -1)",
-        @"    browser.test.assertTrue(frame.url.includes('localhost'))",
-        @"    browser.test.assertFalse(frame.url.includes('frame'))",
+
+        @"  browser.webNavigation.getFrame({ tabId: details?.tabId, frameId: 0 }, (frame) => {",
+        @"    browser.test.assertEq(frame?.parentFrameId, -1)",
+        @"    browser.test.assertTrue(frame?.url?.includes('localhost'))",
+        @"    browser.test.assertFalse(frame?.url?.includes('frame'))",
+        @"    browser.test.assertEq(typeof frame?.documentId, 'string', 'frame.documentId should be')",
+        @"    browser.test.assertEq(frame?.documentId?.length, 36, 'frame.documentId.length should be')",
+
         @"    browser.test.notifyPass()",
         @"  })",
         @"}",
 
-        // The passListener firing will consider the test passed.
         @"browser.webNavigation.onCompleted.addListener(completedListener)",
 
-        // Yield after creating the listener so we can load a tab.
         @"browser.test.yield('Load Tab')"
     ]);
 
     auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:webNavigationManifest resources:@{ @"background.js": backgroundScript }]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    // Grant the webNavigation permission.
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
 
     auto *urlRequest = server.requestWithLocalhost();
@@ -439,7 +549,7 @@ TEST(WKWebExtensionAPIWebNavigation, GetMainFrame)
     [manager run];
 }
 
-TEST(WKWebExtensionAPIWebNavigation, GetSubframe)
+TEST(WKWebExtensionAPIWebNavigation, GetFrameWithSubframe)
 {
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<iframe src='/frame.html'></iframe>"_s } },
@@ -447,31 +557,29 @@ TEST(WKWebExtensionAPIWebNavigation, GetSubframe)
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
     auto *backgroundScript = Util::constructScript(@[
-        // Setup
         @"function completedListener(details) {",
-        // Only listen for when the subframe loads. We need its frameId to be able to look it up.
-        @"  if (details.frameId === 0)",
+        @"  if (details?.frameId === 0)",
         @"    return",
-        @"  browser.webNavigation.getFrame({ tabId: details.tabId, frameId: details.frameId }, function(frame) {",
-        // Main frame
+
+        @"  browser.webNavigation.getFrame({ tabId: details?.tabId, frameId: details?.frameId }, (frame) => {",
         @"    browser.test.assertEq(frame.parentFrameId, 0)",
         @"    browser.test.assertTrue(frame.url.includes('localhost'))",
         @"    browser.test.assertTrue(frame.url.includes('frame'))",
+        @"    browser.test.assertEq(typeof frame?.documentId, 'string', 'frame.documentId should be')",
+        @"    browser.test.assertEq(frame?.documentId?.length, 36, 'frame.documentId.length should be')",
+
         @"    browser.test.notifyPass()",
         @"  })",
         @"}",
 
-        // The passListener firing will consider the test passed.
         @"browser.webNavigation.onCompleted.addListener(completedListener)",
 
-        // Yield after creating the listener so we can load a tab.
         @"browser.test.yield('Load Tab')"
     ]);
 
     auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:webNavigationManifest resources:@{ @"background.js": backgroundScript }]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    // Grant the webNavigation permission.
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
 
     auto *urlRequest = server.requestWithLocalhost();
@@ -496,41 +604,40 @@ TEST(WKWebExtensionAPIWebNavigation, GetAllFrames)
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
     auto *backgroundScript = Util::constructScript(@[
-        // Setup
         @"function completedListener(details) {",
-        // Only listen for when the main frame loads so we don't call this method more than once.
         @"  if (details.frameId !== 0)",
         @"    return",
-        @"  browser.webNavigation.getAllFrames({ tabId: details.tabId }, function(frames) {",
-        @"    browser.test.assertEq(frames.length, 2)",
+
+        @"  browser.webNavigation.getAllFrames({ tabId: details?.tabId }, (frames) => {",
+        @"    browser.test.assertEq(frames?.length, 2)",
+
         @"    for (let frame of frames) {",
-        @"      if (frame.frameId === 0) {",
-        // Main frame
-        @"        browser.test.assertEq(frame.parentFrameId, -1)",
-        @"        browser.test.assertTrue(frame.url.includes('localhost'))",
-        @"        browser.test.assertFalse(frame.url.includes('frame'))",
+        @"      if (frame?.frameId === 0) {",
+        @"        browser.test.assertEq(frame?.parentFrameId, -1)",
+        @"        browser.test.assertTrue(frame?.url.includes('localhost'))",
+        @"        browser.test.assertFalse(frame?.url.includes('frame'))",
         @"      } else {",
-        // Subframe
-        @"        browser.test.assertEq(frame.parentFrameId, 0)",
-        @"        browser.test.assertTrue(frame.url.includes('localhost'))",
-        @"        browser.test.assertTrue(frame.url.includes('frame'))",
+        @"        browser.test.assertEq(frame?.parentFrameId, 0)",
+        @"        browser.test.assertTrue(frame?.url.includes('localhost'))",
+        @"        browser.test.assertTrue(frame?.url.includes('frame'))",
         @"      }",
+
+        @"      browser.test.assertEq(typeof frame?.documentId, 'string', 'frame.documentId should be')",
+        @"      browser.test.assertEq(frame?.documentId?.length, 36, 'frame.documentId.length should be')",
         @"    }",
+
         @"    browser.test.notifyPass()",
         @"  })",
         @"}",
 
-        // The passListener firing will consider the test passed.
         @"browser.webNavigation.onCompleted.addListener(completedListener)",
 
-        // Yield after creating the listener so we can load a tab.
         @"browser.test.yield('Load Tab')"
     ]);
 
     auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:webNavigationManifest resources:@{ @"background.js": backgroundScript }]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    // Grant the webNavigation permission.
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
 
     auto *urlRequest = server.requestWithLocalhost();
@@ -555,7 +662,6 @@ TEST(WKWebExtensionAPIWebNavigation, ErrorOccurred)
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
     auto *backgroundScript = Util::constructScript(@[
-        // Setup
         @"function errorListener(details) {",
         // A subframe should have been the one to have the error.
         @"  browser.test.assertFalse(details.frameId == 0)",
@@ -583,7 +689,6 @@ TEST(WKWebExtensionAPIWebNavigation, ErrorOccurred)
     auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:webNavigationManifest resources:@{ @"background.js": backgroundScript }]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    // Grant the webNavigation permission.
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
 
     auto *urlRequest = server.requestWithLocalhost();
@@ -608,7 +713,6 @@ TEST(WKWebExtensionAPIWebNavigation, Errors)
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
     auto *backgroundScript = Util::constructScript(@[
-        // Setup
         @"async function completedListener(details) {",
         // Only listen for when the main frame loads so we don't call this method more than once.
         @"  if (details.frameId !== 0)",
@@ -630,7 +734,6 @@ TEST(WKWebExtensionAPIWebNavigation, Errors)
     auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:webNavigationManifest resources:@{ @"background.js": backgroundScript }]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    // Grant the webNavigation permission.
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
 
     auto *urlRequest = server.requestWithLocalhost();


### PR DESCRIPTION
#### 8ba952548dde7918046052c0507aa6e0b0dda508
<pre>
Add support for documentId in webNavigation.
<a href="https://webkit.org/b/281085">https://webkit.org/b/281085</a>
<a href="https://rdar.apple.com/problem/137532909">rdar://problem/137532909</a>

Reviewed by Brian Weinstein.

Add support for `documentId` in `getFrame()` and `getAllFrames()` as well as
the `onCommitted`, `onDOMContentLoaded`, and `onCompleted`.

* Source/WebKit/Shared/Extensions/WebExtensionFrameParameters.h:
* Source/WebKit/Shared/Extensions/WebExtensionFrameParameters.serialization.in:
* Source/WebKit/Shared/FrameInfoData.h:
* Source/WebKit/Shared/FrameInfoData.serialization.in:
* Source/WebKit/UIProcess/API/APIFrameInfo.h:
* Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm:
(-[WKFrameInfo _documentIdentifier]): Added.
* Source/WebKit/UIProcess/API/Cocoa/WKFrameInfoPrivate.h:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::UIClient::callDisplayCapturePermissionDelegate):
(WebKit::UIDelegate::UIClient::decidePolicyForUserMediaPermissionRequest):
(WebKit::UIDelegate::UIClient::decidePolicyForScreenCaptureUnmuting):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWebNavigationCocoa.mm:
(WebKit::frameParametersForFrame):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::permissionState):
(WebKit::WebExtensionContext::didStartProvisionalLoadForFrame):
(WebKit::WebExtensionContext::didCommitLoadForFrame):
(WebKit::WebExtensionContext::didFinishLoadForFrame):
(WebKit::WebExtensionContext::didFailLoadForFrame):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::didStartProvisionalLoadForFrame):
(WebKit::WebExtensionController::didCommitLoadForFrame):
(WebKit::WebExtensionController::didFinishLoadForFrame):
(WebKit::WebExtensionController::didFailLoadForFrame):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionController.messages.in:
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::cancel):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationCocoa.mm:
(WebKit::toWebAPI):
(WebKit::WebExtensionContextProxy::dispatchWebNavigationEvent):
* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm:
(WebKit::toFrameParameters): Added.
(WebKit::WebExtensionControllerProxy::didStartProvisionalLoadForFrame):
(WebKit::WebExtensionControllerProxy::didCommitLoadForFrame):
(WebKit::WebExtensionControllerProxy::didFinishLoadForFrame):
(WebKit::WebExtensionControllerProxy::didFailLoadForFrame):
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::navigationActionData const):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::info const):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWebNavigation.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIWebNavigation, EventListenerRegistration)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebNavigation, BeforeNavigateEvent)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebNavigation, CommittedEvent)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebNavigation, DOMContentLoadedEvent)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebNavigation, CompletedEvent)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebNavigation, AllowedFilter)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebNavigation, DeniedFilter)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebNavigation, AllEventsFired)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebNavigation, ErrorOccurredEventDuringProvisionalLoad)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebNavigation, ErrorOccurredEventDuringLoad)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebNavigation, GetFrameWithMainFrame)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebNavigation, GetFrameWithSubframe)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebNavigation, GetAllFrames)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebNavigation, ErrorOccurred)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebNavigation, Errors)):

Canonical link: <a href="https://commits.webkit.org/287408@main">https://commits.webkit.org/287408@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d24399f6c2d2da20b6c26fe5339d2a8a18ddcf84

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79456 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58466 "") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32829 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84039 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30556 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81581 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67537 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6742 "") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62130 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19994 "Passed tests") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82521 "Failed to checkout and rebase branch from PR 37466") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52192 "Failed to checkout and rebase branch from PR 37466") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72376 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42440 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49535 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26551 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28969 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70646 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27006 "") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85450 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6721 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/6742 "") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70379 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6883 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68251 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69622 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13661 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12546 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12287 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6675 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12383 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6571 "Built successfully") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10055 "Failed to checkout and rebase branch from PR 37466") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8372 "") | | | 
<!--EWS-Status-Bubble-End-->