### PR TITLE
Implement URLPattern matching

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
@@ -1,120 +1,120 @@
 
 PASS Loading data...
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}]
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"]
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}]
+PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}]
+PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}]
 PASS Pattern: [{"protocol":"(café)"}] Inputs: undefined
 PASS Pattern: [{"username":"(café)"}] Inputs: undefined
 PASS Pattern: [{"password":"(café)"}] Inputs: undefined
@@ -129,78 +129,76 @@ FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] assert_equals
 FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/:café" but got "/:caf%C3%A9"
 FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] assert_equals: compiled pattern property 'search' expected ":café" but got ":caf%C3%A9"
 FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] assert_equals: compiled pattern property 'hash' expected ":café" but got ":caf%C3%A9"
-FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
-FAIL Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}] The operation is not supported.
-FAIL Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hostname":":℘"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:℘"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"search":":℘"}] Inputs: [{"search":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hash":":℘"}] Inputs: [{"hash":"foo"}] The operation is not supported.
-FAIL Pattern: [{"protocol":":㐀"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
-FAIL Pattern: [{"username":":㐀"}] Inputs: [{"username":"foo"}] The operation is not supported.
-FAIL Pattern: [{"password":":㐀"}] Inputs: [{"password":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}] The operation is not supported.
+PASS Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}]
+PASS Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}]
+PASS Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}]
+PASS Pattern: [{"hostname":":℘"}] Inputs: [{"hostname":"foo"}]
+PASS Pattern: [{"pathname":"/:℘"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"search":":℘"}] Inputs: [{"search":"foo"}]
+PASS Pattern: [{"hash":":℘"}] Inputs: [{"hash":"foo"}]
+PASS Pattern: [{"protocol":":㐀"}] Inputs: [{"protocol":"foo"}]
+PASS Pattern: [{"username":":㐀"}] Inputs: [{"username":"foo"}]
+PASS Pattern: [{"password":":㐀"}] Inputs: [{"password":"foo"}]
+PASS Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}]
+PASS Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}]
+PASS Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}]
+PASS Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}]
+PASS Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}]
+PASS Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}]
 FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%c3%a9" but got "café"
 FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%c3%a9" but got "café"
-FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: test() result expected true but got false
 FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
-FAIL Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}]
 FAIL Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","port":"80"}] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
-FAIL Pattern: [{"port":"80"}] Inputs: [{"port":"80"}] The operation is not supported.
-FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] The operation is not supported.
+PASS Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"port":"80"}] Inputs: [{"port":"80"}]
+FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] assert_equals: test() result expected false but got true
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}]
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}]
 FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "./foo/bar"
 FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/" but got ""
-FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Initial URLPatternInit input should not contain a base URL string.
 FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/b" but got "b"
-FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
+PASS Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"]
 FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
 FAIL Pattern: [{"pathname":":name.html","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo.html"] assert_equals: compiled pattern property 'pathname' expected "/:name.html" but got ":name.html"
-FAIL Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
-FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] The operation is not supported.
-FAIL Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
-FAIL Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}] The operation is not supported.
-FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] The operation is not supported.
-FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] The operation is not supported.
-FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] The operation is not supported.
+PASS Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}]
+PASS Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}]
+PASS Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}]
+PASS Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}]
+PASS Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}]
+PASS Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}]
+FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] assert_equals: test() result expected true but got false
 PASS Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined
-FAIL Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}] The operation is not supported.
+PASS Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}]
+PASS Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}]
+FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}]
 FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+PASS Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}]
 FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
 FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
-FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}]
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" did not throw
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Not implemented.
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
 FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
@@ -252,13 +250,13 @@ FAIL Pattern: ["(café)://foo"] Inputs: undefined assert_throws_js: URLPattern()
     [native code]
 }" ("TypeError")
 FAIL Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}] Not implemented.
-FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] The operation is not supported.
+FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Type error
 FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Type error
 FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Type error
 FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Type error
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] The operation is not supported.
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"] The operation is not supported.
+FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] assert_equals: test() result expected false but got true
+PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"]
 FAIL Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"] Not implemented.
 FAIL Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"] Not implemented.
 FAIL Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"] Not implemented.
@@ -293,12 +291,12 @@ PASS Pattern: ["/foo",""] Inputs: undefined
 FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
+PASS Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}]
+PASS Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}]
+PASS Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"hostname":"bad hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined
@@ -316,52 +314,52 @@ PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{}] Inputs: ["https://example.com/"] The operation is not supported.
+FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_equals: test() result expected true but got false
 FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
 FAIL Pattern: [] Inputs: [{}] Not implemented.
 FAIL Pattern: [] Inputs: [] Not implemented.
-FAIL Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:foo.."}] Inputs: [{"pathname":"/bar.."}] The operation is not supported.
-FAIL Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
-FAIL Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
+PASS Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}]
+PASS Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}]
+PASS Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}]
+PASS Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}]
+PASS Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}]
+PASS Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}]
+PASS Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}]
+PASS Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}]
+PASS Pattern: [{"pathname":"/:foo.."}] Inputs: [{"pathname":"/bar.."}]
+PASS Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}]
+PASS Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}]
+PASS Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}]
+PASS Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}]
+PASS Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}]
+PASS Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
+PASS Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Not implemented.
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Type error
 PASS Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
-FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] The operation is not supported.
-FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] The operation is not supported.
+FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Initial URLPatternInit input should not contain a base URL string.
 FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Type error
-FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/3"}] The operation is not supported.
+PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}]
+PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}]
+PASS Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}]
+PASS Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/3"}]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
@@ -1,120 +1,120 @@
 
 PASS Loading data...
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}]
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"]
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}]
+PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}]
+PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}]
 PASS Pattern: [{"protocol":"(café)"}] Inputs: undefined
 PASS Pattern: [{"username":"(café)"}] Inputs: undefined
 PASS Pattern: [{"password":"(café)"}] Inputs: undefined
@@ -129,78 +129,76 @@ FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] assert_equals
 FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/:café" but got "/:caf%C3%A9"
 FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] assert_equals: compiled pattern property 'search' expected ":café" but got ":caf%C3%A9"
 FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] assert_equals: compiled pattern property 'hash' expected ":café" but got ":caf%C3%A9"
-FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
-FAIL Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}] The operation is not supported.
-FAIL Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hostname":":℘"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:℘"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"search":":℘"}] Inputs: [{"search":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hash":":℘"}] Inputs: [{"hash":"foo"}] The operation is not supported.
-FAIL Pattern: [{"protocol":":㐀"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
-FAIL Pattern: [{"username":":㐀"}] Inputs: [{"username":"foo"}] The operation is not supported.
-FAIL Pattern: [{"password":":㐀"}] Inputs: [{"password":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}] The operation is not supported.
+PASS Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}]
+PASS Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}]
+PASS Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}]
+PASS Pattern: [{"hostname":":℘"}] Inputs: [{"hostname":"foo"}]
+PASS Pattern: [{"pathname":"/:℘"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"search":":℘"}] Inputs: [{"search":"foo"}]
+PASS Pattern: [{"hash":":℘"}] Inputs: [{"hash":"foo"}]
+PASS Pattern: [{"protocol":":㐀"}] Inputs: [{"protocol":"foo"}]
+PASS Pattern: [{"username":":㐀"}] Inputs: [{"username":"foo"}]
+PASS Pattern: [{"password":":㐀"}] Inputs: [{"password":"foo"}]
+PASS Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}]
+PASS Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}]
+PASS Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}]
+PASS Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}]
+PASS Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}]
+PASS Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}]
 FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%c3%a9" but got "café"
 FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%c3%a9" but got "café"
-FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: test() result expected true but got false
 FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
-FAIL Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}]
 FAIL Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","port":"80"}] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
-FAIL Pattern: [{"port":"80"}] Inputs: [{"port":"80"}] The operation is not supported.
-FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] The operation is not supported.
+PASS Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"port":"80"}] Inputs: [{"port":"80"}]
+FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] assert_equals: test() result expected false but got true
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}]
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}]
 FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "./foo/bar"
 FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/" but got ""
-FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Initial URLPatternInit input should not contain a base URL string.
 FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/b" but got "b"
-FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
+PASS Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"]
 FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
 FAIL Pattern: [{"pathname":":name.html","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo.html"] assert_equals: compiled pattern property 'pathname' expected "/:name.html" but got ":name.html"
-FAIL Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
-FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] The operation is not supported.
-FAIL Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
-FAIL Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}] The operation is not supported.
-FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] The operation is not supported.
-FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] The operation is not supported.
-FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] The operation is not supported.
+PASS Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}]
+PASS Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}]
+PASS Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}]
+PASS Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}]
+PASS Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}]
+PASS Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}]
+FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] assert_equals: test() result expected true but got false
 PASS Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined
-FAIL Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}] The operation is not supported.
+PASS Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}]
+PASS Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}]
+FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}]
 FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+PASS Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}]
 FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
 FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
-FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}]
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" did not throw
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Not implemented.
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
 FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
@@ -252,13 +250,13 @@ FAIL Pattern: ["(café)://foo"] Inputs: undefined assert_throws_js: URLPattern()
     [native code]
 }" ("TypeError")
 FAIL Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}] Not implemented.
-FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] The operation is not supported.
+FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Type error
 FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Type error
 FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Type error
 FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Type error
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] The operation is not supported.
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"] The operation is not supported.
+FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] assert_equals: test() result expected false but got true
+PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"]
 FAIL Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"] Not implemented.
 FAIL Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"] Not implemented.
 FAIL Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"] Not implemented.
@@ -293,12 +291,12 @@ PASS Pattern: ["/foo",""] Inputs: undefined
 FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
+PASS Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}]
+PASS Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}]
+PASS Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"hostname":"bad hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined
@@ -316,52 +314,52 @@ PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{}] Inputs: ["https://example.com/"] The operation is not supported.
+FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_equals: test() result expected true but got false
 FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
 FAIL Pattern: [] Inputs: [{}] Not implemented.
 FAIL Pattern: [] Inputs: [] Not implemented.
-FAIL Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:foo.."}] Inputs: [{"pathname":"/bar.."}] The operation is not supported.
-FAIL Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
-FAIL Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
+PASS Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}]
+PASS Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}]
+PASS Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}]
+PASS Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}]
+PASS Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}]
+PASS Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}]
+PASS Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}]
+PASS Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}]
+PASS Pattern: [{"pathname":"/:foo.."}] Inputs: [{"pathname":"/bar.."}]
+PASS Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}]
+PASS Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}]
+PASS Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}]
+PASS Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}]
+PASS Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}]
+PASS Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
+PASS Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Not implemented.
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Type error
 PASS Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
-FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] The operation is not supported.
-FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] The operation is not supported.
+FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Initial URLPatternInit input should not contain a base URL string.
 FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Type error
-FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/3"}] The operation is not supported.
+PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}]
+PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}]
+PASS Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}]
+PASS Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/3"}]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
@@ -1,120 +1,120 @@
 
 PASS Loading data...
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}]
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"]
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}]
+PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}]
+PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}]
 PASS Pattern: [{"protocol":"(café)"}] Inputs: undefined
 PASS Pattern: [{"username":"(café)"}] Inputs: undefined
 PASS Pattern: [{"password":"(café)"}] Inputs: undefined
@@ -129,78 +129,76 @@ FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] assert_equals
 FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/:café" but got "/:caf%C3%A9"
 FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] assert_equals: compiled pattern property 'search' expected ":café" but got ":caf%C3%A9"
 FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] assert_equals: compiled pattern property 'hash' expected ":café" but got ":caf%C3%A9"
-FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
-FAIL Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}] The operation is not supported.
-FAIL Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hostname":":℘"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:℘"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"search":":℘"}] Inputs: [{"search":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hash":":℘"}] Inputs: [{"hash":"foo"}] The operation is not supported.
-FAIL Pattern: [{"protocol":":㐀"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
-FAIL Pattern: [{"username":":㐀"}] Inputs: [{"username":"foo"}] The operation is not supported.
-FAIL Pattern: [{"password":":㐀"}] Inputs: [{"password":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}] The operation is not supported.
+PASS Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}]
+PASS Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}]
+PASS Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}]
+PASS Pattern: [{"hostname":":℘"}] Inputs: [{"hostname":"foo"}]
+PASS Pattern: [{"pathname":"/:℘"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"search":":℘"}] Inputs: [{"search":"foo"}]
+PASS Pattern: [{"hash":":℘"}] Inputs: [{"hash":"foo"}]
+PASS Pattern: [{"protocol":":㐀"}] Inputs: [{"protocol":"foo"}]
+PASS Pattern: [{"username":":㐀"}] Inputs: [{"username":"foo"}]
+PASS Pattern: [{"password":":㐀"}] Inputs: [{"password":"foo"}]
+PASS Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}]
+PASS Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}]
+PASS Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}]
+PASS Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}]
+PASS Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}]
+PASS Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}]
 FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%c3%a9" but got "café"
 FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%c3%a9" but got "café"
-FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: test() result expected true but got false
 FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
-FAIL Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}]
 FAIL Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","port":"80"}] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
-FAIL Pattern: [{"port":"80"}] Inputs: [{"port":"80"}] The operation is not supported.
-FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] The operation is not supported.
+PASS Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"port":"80"}] Inputs: [{"port":"80"}]
+FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] assert_equals: test() result expected false but got true
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}]
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}]
 FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "./foo/bar"
 FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/" but got ""
-FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Initial URLPatternInit input should not contain a base URL string.
 FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/b" but got "b"
-FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
+PASS Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"]
 FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
 FAIL Pattern: [{"pathname":":name.html","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo.html"] assert_equals: compiled pattern property 'pathname' expected "/:name.html" but got ":name.html"
-FAIL Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
-FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] The operation is not supported.
-FAIL Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
-FAIL Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}] The operation is not supported.
-FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] The operation is not supported.
-FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] The operation is not supported.
-FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] The operation is not supported.
+PASS Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}]
+PASS Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}]
+PASS Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}]
+PASS Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}]
+PASS Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}]
+PASS Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}]
+FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] assert_equals: test() result expected true but got false
 PASS Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined
-FAIL Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}] The operation is not supported.
+PASS Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}]
+PASS Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}]
+FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}]
 FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+PASS Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}]
 FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
 FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
-FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}]
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" did not throw
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Not implemented.
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
 FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
@@ -252,13 +250,13 @@ FAIL Pattern: ["(café)://foo"] Inputs: undefined assert_throws_js: URLPattern()
     [native code]
 }" ("TypeError")
 FAIL Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}] Not implemented.
-FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] The operation is not supported.
+FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Type error
 FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Type error
 FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Type error
 FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Type error
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] The operation is not supported.
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"] The operation is not supported.
+FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] assert_equals: test() result expected false but got true
+PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"]
 FAIL Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"] Not implemented.
 FAIL Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"] Not implemented.
 FAIL Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"] Not implemented.
@@ -293,12 +291,12 @@ PASS Pattern: ["/foo",""] Inputs: undefined
 FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
+PASS Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}]
+PASS Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}]
+PASS Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"hostname":"bad hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined
@@ -316,52 +314,52 @@ PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{}] Inputs: ["https://example.com/"] The operation is not supported.
+FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_equals: test() result expected true but got false
 FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
 FAIL Pattern: [] Inputs: [{}] Not implemented.
 FAIL Pattern: [] Inputs: [] Not implemented.
-FAIL Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:foo.."}] Inputs: [{"pathname":"/bar.."}] The operation is not supported.
-FAIL Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
-FAIL Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
+PASS Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}]
+PASS Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}]
+PASS Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}]
+PASS Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}]
+PASS Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}]
+PASS Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}]
+PASS Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}]
+PASS Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}]
+PASS Pattern: [{"pathname":"/:foo.."}] Inputs: [{"pathname":"/bar.."}]
+PASS Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}]
+PASS Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}]
+PASS Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}]
+PASS Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}]
+PASS Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}]
+PASS Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
+PASS Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Not implemented.
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Type error
 PASS Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
-FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] The operation is not supported.
-FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] The operation is not supported.
+FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Initial URLPatternInit input should not contain a base URL string.
 FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Type error
-FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/3"}] The operation is not supported.
+PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}]
+PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}]
+PASS Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}]
+PASS Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/3"}]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
@@ -1,120 +1,120 @@
 
 PASS Loading data...
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}]
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"]
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}]
+PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}]
+PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}]
 PASS Pattern: [{"protocol":"(café)"}] Inputs: undefined
 PASS Pattern: [{"username":"(café)"}] Inputs: undefined
 PASS Pattern: [{"password":"(café)"}] Inputs: undefined
@@ -129,78 +129,76 @@ FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] assert_equals
 FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/:café" but got "/:caf%C3%A9"
 FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] assert_equals: compiled pattern property 'search' expected ":café" but got ":caf%C3%A9"
 FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] assert_equals: compiled pattern property 'hash' expected ":café" but got ":caf%C3%A9"
-FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
-FAIL Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}] The operation is not supported.
-FAIL Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hostname":":℘"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:℘"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"search":":℘"}] Inputs: [{"search":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hash":":℘"}] Inputs: [{"hash":"foo"}] The operation is not supported.
-FAIL Pattern: [{"protocol":":㐀"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
-FAIL Pattern: [{"username":":㐀"}] Inputs: [{"username":"foo"}] The operation is not supported.
-FAIL Pattern: [{"password":":㐀"}] Inputs: [{"password":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}] The operation is not supported.
+PASS Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}]
+PASS Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}]
+PASS Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}]
+PASS Pattern: [{"hostname":":℘"}] Inputs: [{"hostname":"foo"}]
+PASS Pattern: [{"pathname":"/:℘"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"search":":℘"}] Inputs: [{"search":"foo"}]
+PASS Pattern: [{"hash":":℘"}] Inputs: [{"hash":"foo"}]
+PASS Pattern: [{"protocol":":㐀"}] Inputs: [{"protocol":"foo"}]
+PASS Pattern: [{"username":":㐀"}] Inputs: [{"username":"foo"}]
+PASS Pattern: [{"password":":㐀"}] Inputs: [{"password":"foo"}]
+PASS Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}]
+PASS Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}]
+PASS Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}]
+PASS Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}]
+PASS Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}]
+PASS Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}]
 FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%c3%a9" but got "café"
 FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%c3%a9" but got "café"
-FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: test() result expected true but got false
 FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
-FAIL Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}]
 FAIL Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","port":"80"}] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
-FAIL Pattern: [{"port":"80"}] Inputs: [{"port":"80"}] The operation is not supported.
-FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] The operation is not supported.
+PASS Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"port":"80"}] Inputs: [{"port":"80"}]
+FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] assert_equals: test() result expected false but got true
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}]
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}]
 FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "./foo/bar"
 FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/" but got ""
-FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Initial URLPatternInit input should not contain a base URL string.
 FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/b" but got "b"
-FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
+PASS Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"]
 FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
 FAIL Pattern: [{"pathname":":name.html","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo.html"] assert_equals: compiled pattern property 'pathname' expected "/:name.html" but got ":name.html"
-FAIL Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
-FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] The operation is not supported.
-FAIL Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
-FAIL Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}] The operation is not supported.
-FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] The operation is not supported.
-FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] The operation is not supported.
-FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] The operation is not supported.
+PASS Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}]
+PASS Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}]
+PASS Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}]
+PASS Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}]
+PASS Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}]
+PASS Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}]
+FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] assert_equals: test() result expected true but got false
 PASS Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined
-FAIL Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}] The operation is not supported.
+PASS Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}]
+PASS Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}]
+FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}]
 FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+PASS Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}]
 FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
 FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
-FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}]
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" did not throw
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Not implemented.
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
 FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
@@ -252,13 +250,13 @@ FAIL Pattern: ["(café)://foo"] Inputs: undefined assert_throws_js: URLPattern()
     [native code]
 }" ("TypeError")
 FAIL Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}] Not implemented.
-FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] The operation is not supported.
+FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Type error
 FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Type error
 FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Type error
 FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Type error
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] The operation is not supported.
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"] The operation is not supported.
+FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] assert_equals: test() result expected false but got true
+PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"]
 FAIL Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"] Not implemented.
 FAIL Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"] Not implemented.
 FAIL Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"] Not implemented.
@@ -293,12 +291,12 @@ PASS Pattern: ["/foo",""] Inputs: undefined
 FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
+PASS Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}]
+PASS Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}]
+PASS Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"hostname":"bad hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined
@@ -316,52 +314,52 @@ PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{}] Inputs: ["https://example.com/"] The operation is not supported.
+FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_equals: test() result expected true but got false
 FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
 FAIL Pattern: [] Inputs: [{}] Not implemented.
 FAIL Pattern: [] Inputs: [] Not implemented.
-FAIL Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:foo.."}] Inputs: [{"pathname":"/bar.."}] The operation is not supported.
-FAIL Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
-FAIL Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
+PASS Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}]
+PASS Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}]
+PASS Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}]
+PASS Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}]
+PASS Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}]
+PASS Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}]
+PASS Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}]
+PASS Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}]
+PASS Pattern: [{"pathname":"/:foo.."}] Inputs: [{"pathname":"/bar.."}]
+PASS Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}]
+PASS Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}]
+PASS Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}]
+PASS Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}]
+PASS Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}]
+PASS Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
+PASS Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Not implemented.
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Type error
 PASS Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
-FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] The operation is not supported.
-FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] The operation is not supported.
+FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Initial URLPatternInit input should not contain a base URL string.
 FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Type error
-FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/3"}] The operation is not supported.
+PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}]
+PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}]
+PASS Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}]
+PASS Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/3"}]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
@@ -1,120 +1,120 @@
 
 PASS Loading data...
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}]
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"]
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}]
+PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}]
+PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}]
 PASS Pattern: [{"protocol":"(café)"}] Inputs: undefined
 PASS Pattern: [{"username":"(café)"}] Inputs: undefined
 PASS Pattern: [{"password":"(café)"}] Inputs: undefined
@@ -129,78 +129,76 @@ FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] assert_equals
 FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/:café" but got "/:caf%C3%A9"
 FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] assert_equals: compiled pattern property 'search' expected ":café" but got ":caf%C3%A9"
 FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] assert_equals: compiled pattern property 'hash' expected ":café" but got ":caf%C3%A9"
-FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
-FAIL Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}] The operation is not supported.
-FAIL Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hostname":":℘"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:℘"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"search":":℘"}] Inputs: [{"search":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hash":":℘"}] Inputs: [{"hash":"foo"}] The operation is not supported.
-FAIL Pattern: [{"protocol":":㐀"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
-FAIL Pattern: [{"username":":㐀"}] Inputs: [{"username":"foo"}] The operation is not supported.
-FAIL Pattern: [{"password":":㐀"}] Inputs: [{"password":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}] The operation is not supported.
+PASS Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}]
+PASS Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}]
+PASS Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}]
+PASS Pattern: [{"hostname":":℘"}] Inputs: [{"hostname":"foo"}]
+PASS Pattern: [{"pathname":"/:℘"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"search":":℘"}] Inputs: [{"search":"foo"}]
+PASS Pattern: [{"hash":":℘"}] Inputs: [{"hash":"foo"}]
+PASS Pattern: [{"protocol":":㐀"}] Inputs: [{"protocol":"foo"}]
+PASS Pattern: [{"username":":㐀"}] Inputs: [{"username":"foo"}]
+PASS Pattern: [{"password":":㐀"}] Inputs: [{"password":"foo"}]
+PASS Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}]
+PASS Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}]
+PASS Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}]
+PASS Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}]
+PASS Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}]
+PASS Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}]
 FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%c3%a9" but got "café"
 FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%c3%a9" but got "café"
-FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: test() result expected true but got false
 FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
-FAIL Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}]
 FAIL Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","port":"80"}] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
-FAIL Pattern: [{"port":"80"}] Inputs: [{"port":"80"}] The operation is not supported.
-FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] The operation is not supported.
+PASS Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"port":"80"}] Inputs: [{"port":"80"}]
+FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] assert_equals: test() result expected false but got true
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}]
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}]
 FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "./foo/bar"
 FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/" but got ""
-FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Initial URLPatternInit input should not contain a base URL string.
 FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/b" but got "b"
-FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
+PASS Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"]
 FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
 FAIL Pattern: [{"pathname":":name.html","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo.html"] assert_equals: compiled pattern property 'pathname' expected "/:name.html" but got ":name.html"
-FAIL Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
-FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] The operation is not supported.
-FAIL Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
-FAIL Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}] The operation is not supported.
-FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] The operation is not supported.
-FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] The operation is not supported.
-FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] The operation is not supported.
+PASS Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}]
+PASS Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}]
+PASS Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}]
+PASS Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}]
+PASS Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}]
+PASS Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}]
+FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] assert_equals: test() result expected true but got false
 PASS Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined
-FAIL Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}] The operation is not supported.
+PASS Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}]
+PASS Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}]
+FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}]
 FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+PASS Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}]
 FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
 FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
-FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}]
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" did not throw
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Not implemented.
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
 FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
@@ -252,13 +250,13 @@ FAIL Pattern: ["(café)://foo"] Inputs: undefined assert_throws_js: URLPattern()
     [native code]
 }" ("TypeError")
 FAIL Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}] Not implemented.
-FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] The operation is not supported.
+FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Type error
 FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Type error
 FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Type error
 FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Type error
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] The operation is not supported.
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"] The operation is not supported.
+FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] assert_equals: test() result expected false but got true
+PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"]
 FAIL Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"] Not implemented.
 FAIL Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"] Not implemented.
 FAIL Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"] Not implemented.
@@ -293,12 +291,12 @@ PASS Pattern: ["/foo",""] Inputs: undefined
 FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
+PASS Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}]
+PASS Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}]
+PASS Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"hostname":"bad hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined
@@ -316,52 +314,52 @@ PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{}] Inputs: ["https://example.com/"] The operation is not supported.
+FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_equals: test() result expected true but got false
 FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
 FAIL Pattern: [] Inputs: [{}] Not implemented.
 FAIL Pattern: [] Inputs: [] Not implemented.
-FAIL Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:foo.."}] Inputs: [{"pathname":"/bar.."}] The operation is not supported.
-FAIL Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
-FAIL Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
+PASS Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}]
+PASS Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}]
+PASS Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}]
+PASS Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}]
+PASS Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}]
+PASS Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}]
+PASS Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}]
+PASS Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}]
+PASS Pattern: [{"pathname":"/:foo.."}] Inputs: [{"pathname":"/bar.."}]
+PASS Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}]
+PASS Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}]
+PASS Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}]
+PASS Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}]
+PASS Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}]
+PASS Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
+PASS Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Not implemented.
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Type error
 PASS Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
-FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] The operation is not supported.
-FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] The operation is not supported.
+FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Initial URLPatternInit input should not contain a base URL string.
 FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Type error
-FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/3"}] The operation is not supported.
+PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}]
+PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}]
+PASS Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}]
+PASS Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/3"}]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
@@ -1,120 +1,120 @@
 
 PASS Loading data...
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}]
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"]
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}]
+PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}]
+PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}]
 PASS Pattern: [{"protocol":"(café)"}] Inputs: undefined
 PASS Pattern: [{"username":"(café)"}] Inputs: undefined
 PASS Pattern: [{"password":"(café)"}] Inputs: undefined
@@ -129,78 +129,76 @@ FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] assert_equals
 FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/:café" but got "/:caf%C3%A9"
 FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] assert_equals: compiled pattern property 'search' expected ":café" but got ":caf%C3%A9"
 FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] assert_equals: compiled pattern property 'hash' expected ":café" but got ":caf%C3%A9"
-FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
-FAIL Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}] The operation is not supported.
-FAIL Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hostname":":℘"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:℘"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"search":":℘"}] Inputs: [{"search":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hash":":℘"}] Inputs: [{"hash":"foo"}] The operation is not supported.
-FAIL Pattern: [{"protocol":":㐀"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
-FAIL Pattern: [{"username":":㐀"}] Inputs: [{"username":"foo"}] The operation is not supported.
-FAIL Pattern: [{"password":":㐀"}] Inputs: [{"password":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}] The operation is not supported.
+PASS Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}]
+PASS Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}]
+PASS Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}]
+PASS Pattern: [{"hostname":":℘"}] Inputs: [{"hostname":"foo"}]
+PASS Pattern: [{"pathname":"/:℘"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"search":":℘"}] Inputs: [{"search":"foo"}]
+PASS Pattern: [{"hash":":℘"}] Inputs: [{"hash":"foo"}]
+PASS Pattern: [{"protocol":":㐀"}] Inputs: [{"protocol":"foo"}]
+PASS Pattern: [{"username":":㐀"}] Inputs: [{"username":"foo"}]
+PASS Pattern: [{"password":":㐀"}] Inputs: [{"password":"foo"}]
+PASS Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}]
+PASS Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}]
+PASS Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}]
+PASS Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}]
+PASS Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}]
+PASS Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}]
 FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%c3%a9" but got "café"
 FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%c3%a9" but got "café"
-FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: test() result expected true but got false
 FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
-FAIL Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}]
 FAIL Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","port":"80"}] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
-FAIL Pattern: [{"port":"80"}] Inputs: [{"port":"80"}] The operation is not supported.
-FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] The operation is not supported.
+PASS Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"port":"80"}] Inputs: [{"port":"80"}]
+FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] assert_equals: test() result expected false but got true
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}]
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}]
 FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "./foo/bar"
 FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/" but got ""
-FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Initial URLPatternInit input should not contain a base URL string.
 FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/b" but got "b"
-FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
+PASS Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"]
 FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
 FAIL Pattern: [{"pathname":":name.html","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo.html"] assert_equals: compiled pattern property 'pathname' expected "/:name.html" but got ":name.html"
-FAIL Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
-FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] The operation is not supported.
-FAIL Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
-FAIL Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}] The operation is not supported.
-FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] The operation is not supported.
-FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] The operation is not supported.
-FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] The operation is not supported.
+PASS Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}]
+PASS Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}]
+PASS Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}]
+PASS Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}]
+PASS Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}]
+PASS Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}]
+FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] assert_equals: test() result expected true but got false
 PASS Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined
-FAIL Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}] The operation is not supported.
+PASS Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}]
+PASS Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}]
+FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}]
 FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+PASS Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}]
 FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
 FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
-FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}]
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" did not throw
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Not implemented.
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
 FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
@@ -252,13 +250,13 @@ FAIL Pattern: ["(café)://foo"] Inputs: undefined assert_throws_js: URLPattern()
     [native code]
 }" ("TypeError")
 FAIL Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}] Not implemented.
-FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] The operation is not supported.
+FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Type error
 FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Type error
 FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Type error
 FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Type error
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] The operation is not supported.
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"] The operation is not supported.
+FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] assert_equals: test() result expected false but got true
+PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"]
 FAIL Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"] Not implemented.
 FAIL Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"] Not implemented.
 FAIL Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"] Not implemented.
@@ -293,12 +291,12 @@ PASS Pattern: ["/foo",""] Inputs: undefined
 FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
+PASS Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}]
+PASS Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}]
+PASS Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"hostname":"bad hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined
@@ -316,52 +314,52 @@ PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{}] Inputs: ["https://example.com/"] The operation is not supported.
+FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_equals: test() result expected true but got false
 FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
 FAIL Pattern: [] Inputs: [{}] Not implemented.
 FAIL Pattern: [] Inputs: [] Not implemented.
-FAIL Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:foo.."}] Inputs: [{"pathname":"/bar.."}] The operation is not supported.
-FAIL Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
-FAIL Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
+PASS Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}]
+PASS Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}]
+PASS Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}]
+PASS Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}]
+PASS Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}]
+PASS Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}]
+PASS Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}]
+PASS Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}]
+PASS Pattern: [{"pathname":"/:foo.."}] Inputs: [{"pathname":"/bar.."}]
+PASS Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}]
+PASS Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}]
+PASS Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}]
+PASS Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}]
+PASS Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}]
+PASS Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
+PASS Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Not implemented.
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Type error
 PASS Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
-FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] The operation is not supported.
-FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] The operation is not supported.
+FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Initial URLPatternInit input should not contain a base URL string.
 FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Type error
-FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/3"}] The operation is not supported.
+PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}]
+PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}]
+PASS Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}]
+PASS Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/3"}]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
@@ -1,120 +1,120 @@
 
 PASS Loading data...
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}]
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"]
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}]
+PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}]
+PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}]
 PASS Pattern: [{"protocol":"(café)"}] Inputs: undefined
 PASS Pattern: [{"username":"(café)"}] Inputs: undefined
 PASS Pattern: [{"password":"(café)"}] Inputs: undefined
@@ -129,78 +129,76 @@ FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] assert_equals
 FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/:café" but got "/:caf%C3%A9"
 FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] assert_equals: compiled pattern property 'search' expected ":café" but got ":caf%C3%A9"
 FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] assert_equals: compiled pattern property 'hash' expected ":café" but got ":caf%C3%A9"
-FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
-FAIL Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}] The operation is not supported.
-FAIL Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hostname":":℘"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:℘"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"search":":℘"}] Inputs: [{"search":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hash":":℘"}] Inputs: [{"hash":"foo"}] The operation is not supported.
-FAIL Pattern: [{"protocol":":㐀"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
-FAIL Pattern: [{"username":":㐀"}] Inputs: [{"username":"foo"}] The operation is not supported.
-FAIL Pattern: [{"password":":㐀"}] Inputs: [{"password":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}] The operation is not supported.
+PASS Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}]
+PASS Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}]
+PASS Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}]
+PASS Pattern: [{"hostname":":℘"}] Inputs: [{"hostname":"foo"}]
+PASS Pattern: [{"pathname":"/:℘"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"search":":℘"}] Inputs: [{"search":"foo"}]
+PASS Pattern: [{"hash":":℘"}] Inputs: [{"hash":"foo"}]
+PASS Pattern: [{"protocol":":㐀"}] Inputs: [{"protocol":"foo"}]
+PASS Pattern: [{"username":":㐀"}] Inputs: [{"username":"foo"}]
+PASS Pattern: [{"password":":㐀"}] Inputs: [{"password":"foo"}]
+PASS Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}]
+PASS Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}]
+PASS Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}]
+PASS Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}]
+PASS Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}]
+PASS Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}]
 FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%c3%a9" but got "café"
 FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%c3%a9" but got "café"
-FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: test() result expected true but got false
 FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
-FAIL Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}]
 FAIL Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","port":"80"}] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
-FAIL Pattern: [{"port":"80"}] Inputs: [{"port":"80"}] The operation is not supported.
-FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] The operation is not supported.
+PASS Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"port":"80"}] Inputs: [{"port":"80"}]
+FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] assert_equals: test() result expected false but got true
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}]
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}]
 FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "./foo/bar"
 FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/" but got ""
-FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Initial URLPatternInit input should not contain a base URL string.
 FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/b" but got "b"
-FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
+PASS Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"]
 FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
 FAIL Pattern: [{"pathname":":name.html","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo.html"] assert_equals: compiled pattern property 'pathname' expected "/:name.html" but got ":name.html"
-FAIL Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
-FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] The operation is not supported.
-FAIL Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
-FAIL Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}] The operation is not supported.
-FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] The operation is not supported.
-FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] The operation is not supported.
-FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] The operation is not supported.
+PASS Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}]
+PASS Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}]
+PASS Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}]
+PASS Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}]
+PASS Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}]
+PASS Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}]
+FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] assert_equals: test() result expected true but got false
 PASS Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined
-FAIL Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}] The operation is not supported.
+PASS Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}]
+PASS Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}]
+FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}]
 FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+PASS Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}]
 FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
 FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
-FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}]
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" did not throw
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Not implemented.
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
 FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
@@ -252,13 +250,13 @@ FAIL Pattern: ["(café)://foo"] Inputs: undefined assert_throws_js: URLPattern()
     [native code]
 }" ("TypeError")
 FAIL Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}] Not implemented.
-FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] The operation is not supported.
+FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Type error
 FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Type error
 FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Type error
 FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Type error
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] The operation is not supported.
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"] The operation is not supported.
+FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] assert_equals: test() result expected false but got true
+PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"]
 FAIL Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"] Not implemented.
 FAIL Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"] Not implemented.
 FAIL Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"] Not implemented.
@@ -293,12 +291,12 @@ PASS Pattern: ["/foo",""] Inputs: undefined
 FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
+PASS Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}]
+PASS Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}]
+PASS Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"hostname":"bad hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined
@@ -316,52 +314,52 @@ PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{}] Inputs: ["https://example.com/"] The operation is not supported.
+FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_equals: test() result expected true but got false
 FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
 FAIL Pattern: [] Inputs: [{}] Not implemented.
 FAIL Pattern: [] Inputs: [] Not implemented.
-FAIL Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:foo.."}] Inputs: [{"pathname":"/bar.."}] The operation is not supported.
-FAIL Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
-FAIL Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
+PASS Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}]
+PASS Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}]
+PASS Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}]
+PASS Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}]
+PASS Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}]
+PASS Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}]
+PASS Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}]
+PASS Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}]
+PASS Pattern: [{"pathname":"/:foo.."}] Inputs: [{"pathname":"/bar.."}]
+PASS Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}]
+PASS Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}]
+PASS Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}]
+PASS Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}]
+PASS Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}]
+PASS Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
+PASS Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Not implemented.
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Type error
 PASS Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
-FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] The operation is not supported.
-FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] The operation is not supported.
+FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Initial URLPatternInit input should not contain a base URL string.
 FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Type error
-FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/3"}] The operation is not supported.
+PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}]
+PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}]
+PASS Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}]
+PASS Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/3"}]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
@@ -1,120 +1,120 @@
 
 PASS Loading data...
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}]
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"]
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}]
+PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}]
+PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}]
+PASS Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}]
 PASS Pattern: [{"protocol":"(café)"}] Inputs: undefined
 PASS Pattern: [{"username":"(café)"}] Inputs: undefined
 PASS Pattern: [{"password":"(café)"}] Inputs: undefined
@@ -129,78 +129,76 @@ FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] assert_equals
 FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/:café" but got "/:caf%C3%A9"
 FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] assert_equals: compiled pattern property 'search' expected ":café" but got ":caf%C3%A9"
 FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] assert_equals: compiled pattern property 'hash' expected ":café" but got ":caf%C3%A9"
-FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
-FAIL Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}] The operation is not supported.
-FAIL Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hostname":":℘"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:℘"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"search":":℘"}] Inputs: [{"search":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hash":":℘"}] Inputs: [{"hash":"foo"}] The operation is not supported.
-FAIL Pattern: [{"protocol":":㐀"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
-FAIL Pattern: [{"username":":㐀"}] Inputs: [{"username":"foo"}] The operation is not supported.
-FAIL Pattern: [{"password":":㐀"}] Inputs: [{"password":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}] The operation is not supported.
+PASS Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}]
+PASS Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}]
+PASS Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}]
+PASS Pattern: [{"hostname":":℘"}] Inputs: [{"hostname":"foo"}]
+PASS Pattern: [{"pathname":"/:℘"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"search":":℘"}] Inputs: [{"search":"foo"}]
+PASS Pattern: [{"hash":":℘"}] Inputs: [{"hash":"foo"}]
+PASS Pattern: [{"protocol":":㐀"}] Inputs: [{"protocol":"foo"}]
+PASS Pattern: [{"username":":㐀"}] Inputs: [{"username":"foo"}]
+PASS Pattern: [{"password":":㐀"}] Inputs: [{"password":"foo"}]
+PASS Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}]
+PASS Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}]
+PASS Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}]
+PASS Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}]
+PASS Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}]
+PASS Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}]
 FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%c3%a9" but got "café"
 FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%c3%a9" but got "café"
-FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: test() result expected true but got false
 FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
-FAIL Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}]
 FAIL Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","port":"80"}] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
-FAIL Pattern: [{"port":"80"}] Inputs: [{"port":"80"}] The operation is not supported.
-FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] The operation is not supported.
+PASS Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"port":"80"}] Inputs: [{"port":"80"}]
+FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] assert_equals: test() result expected false but got true
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}]
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}]
 FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "./foo/bar"
 FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/" but got ""
-FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Initial URLPatternInit input should not contain a base URL string.
 FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/b" but got "b"
-FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
+PASS Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"]
 FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
 FAIL Pattern: [{"pathname":":name.html","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo.html"] assert_equals: compiled pattern property 'pathname' expected "/:name.html" but got ":name.html"
-FAIL Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
-FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] The operation is not supported.
-FAIL Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
-FAIL Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}] The operation is not supported.
-FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] The operation is not supported.
-FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] The operation is not supported.
-FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] The operation is not supported.
+PASS Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}]
+PASS Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}]
+PASS Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}]
+PASS Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}]
+PASS Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}]
+PASS Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}]
+FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] assert_equals: test() result expected true but got false
 PASS Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined
-FAIL Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}] The operation is not supported.
+PASS Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}]
+PASS Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}]
+FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}]
 FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+PASS Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}]
 FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
 FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
-FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}]
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" did not throw
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Not implemented.
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
 FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
@@ -252,13 +250,13 @@ FAIL Pattern: ["(café)://foo"] Inputs: undefined assert_throws_js: URLPattern()
     [native code]
 }" ("TypeError")
 FAIL Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}] Not implemented.
-FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] The operation is not supported.
+FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Type error
 FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Type error
 FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Type error
 FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Type error
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] The operation is not supported.
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"] The operation is not supported.
+FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] assert_equals: test() result expected false but got true
+PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"]
 FAIL Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"] Not implemented.
 FAIL Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"] Not implemented.
 FAIL Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"] Not implemented.
@@ -293,12 +291,12 @@ PASS Pattern: ["/foo",""] Inputs: undefined
 FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
+PASS Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}]
+PASS Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}]
+PASS Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"hostname":"bad hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined
@@ -316,52 +314,52 @@ PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{}] Inputs: ["https://example.com/"] The operation is not supported.
+FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_equals: test() result expected true but got false
 FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
 FAIL Pattern: [] Inputs: [{}] Not implemented.
 FAIL Pattern: [] Inputs: [] Not implemented.
-FAIL Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:foo.."}] Inputs: [{"pathname":"/bar.."}] The operation is not supported.
-FAIL Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
-FAIL Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
+PASS Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
+PASS Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}]
+PASS Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}]
+PASS Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}]
+PASS Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}]
+PASS Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}]
+PASS Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}]
+PASS Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}]
+PASS Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}]
+PASS Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}]
+PASS Pattern: [{"pathname":"/:foo.."}] Inputs: [{"pathname":"/bar.."}]
+PASS Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}]
+PASS Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}]
+PASS Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}]
+PASS Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}]
+PASS Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}]
+PASS Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
+PASS Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Not implemented.
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Type error
 PASS Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
-FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] The operation is not supported.
-FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] The operation is not supported.
+FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Initial URLPatternInit input should not contain a base URL string.
 FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Type error
-FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/3"}] The operation is not supported.
+PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}]
+PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}]
+PASS Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}]
+PASS Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/3"}]
 

--- a/Source/WebCore/Modules/url-pattern/URLPattern.h
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.h
@@ -54,9 +54,9 @@ public:
     static ExceptionOr<Ref<URLPattern>> create(ScriptExecutionContext&, std::optional<URLPatternInput>&&, URLPatternOptions&&);
     ~URLPattern();
 
-    ExceptionOr<bool> test(std::optional<URLPatternInput>&&, String&& baseURL) const;
+    ExceptionOr<bool> test(ScriptExecutionContext&, std::optional<URLPatternInput>&&, String&& baseURL) const;
 
-    ExceptionOr<std::optional<URLPatternResult>> exec(std::optional<URLPatternInput>&&, String&& baseURL) const;
+    ExceptionOr<std::optional<URLPatternResult>> exec(ScriptExecutionContext&, std::optional<URLPatternInput>&&, String&& baseURL) const;
 
     const String& protocol() const { return m_protocolComponent.patternString(); }
     const String& username() const { return m_usernameComponent.patternString(); }
@@ -72,6 +72,7 @@ public:
 private:
     URLPattern();
     ExceptionOr<void> compileAllComponents(ScriptExecutionContext&, URLPatternInit&&, const URLPatternOptions&);
+    ExceptionOr<std::optional<URLPatternResult>> match(ScriptExecutionContext&, std::variant<URL, URLPatternInput>&&, std::optional<String>&& baseURLString) const;
 
     URLPatternUtilities::URLPatternComponent m_protocolComponent;
     URLPatternUtilities::URLPatternComponent m_usernameComponent;

--- a/Source/WebCore/Modules/url-pattern/URLPattern.idl
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.idl
@@ -37,9 +37,9 @@ typedef (USVString or URLPatternInit) URLPatternInput;
     [CallWith=CurrentScriptExecutionContext] constructor(URLPatternInit input, USVString baseURL, optional URLPatternOptions options);
     [CallWith=CurrentScriptExecutionContext] constructor(optional URLPatternInput input, optional URLPatternOptions options);
 
-    boolean test(optional URLPatternInput input, optional USVString baseURL);
-  
-    URLPatternResult? exec(optional URLPatternInput input, optional USVString baseURL);
+    [CallWith=CurrentScriptExecutionContext] boolean test(optional URLPatternInput input, optional USVString baseURL);
+
+    [CallWith=CurrentScriptExecutionContext] URLPatternResult? exec(optional URLPatternInput input, optional USVString baseURL);
 
     readonly attribute USVString protocol;
     readonly attribute USVString username;

--- a/Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp
@@ -27,6 +27,7 @@
 #include "URLPatternCanonical.h"
 
 #include "URLPattern.h"
+#include <wtf/URL.h>
 #include <wtf/URLParser.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringToIntegerConversion.h>
@@ -162,8 +163,13 @@ ExceptionOr<String> canonicalizePort(StringView portValue, const std::optional<S
 
     URL dummyURL(dummyURLCharacters);
 
-    if (protocolValue)
+    if (protocolValue) {
+        auto parsedPort = parseInteger<uint16_t>(portValue);
+        if (!parsedPort || isDefaultPortForProtocol(*parsedPort, *protocolValue))
+            return String { emptyString() };
+
         dummyURL.setProtocol(*protocolValue);
+    }
 
     dummyURL.setPort(parseInteger<uint16_t>(portValue));
 

--- a/Source/WebCore/Modules/url-pattern/URLPatternComponent.h
+++ b/Source/WebCore/Modules/url-pattern/URLPatternComponent.h
@@ -31,11 +31,13 @@
 namespace JSC {
 class RegExp;
 class VM;
+class JSValue;
 }
 
 namespace WebCore {
 
 class ScriptExecutionContext;
+struct URLPatternComponentResult;
 enum class EncodingCallbackType : uint8_t;
 template<typename> class ExceptionOr;
 
@@ -47,6 +49,8 @@ public:
     static ExceptionOr<URLPatternComponent> compile(Ref<JSC::VM>, StringView, EncodingCallbackType, const URLPatternStringOptions&);
     const String& patternString() const { return m_patternString; }
     bool matchSpecialSchemeProtocol(ScriptExecutionContext&) const;
+    JSC::JSValue componentExec(ScriptExecutionContext&, StringView) const;
+    URLPatternComponentResult createComponentMatchResult(ScriptExecutionContext&, String&& input, const JSC::JSValue& execResult) const;
     URLPatternComponent() = default;
 
 private:

--- a/Source/WebCore/Modules/url-pattern/URLPatternResult.h
+++ b/Source/WebCore/Modules/url-pattern/URLPatternResult.h
@@ -30,7 +30,8 @@
 namespace WebCore {
 
 struct URLPatternComponentResult {
-    using GroupsRecord = Vector<KeyValuePair<String, std::variant<std::monostate, String>>>;
+    using NameMatchPair = KeyValuePair<String, std::variant<std::monostate, String>>;
+    using GroupsRecord = Vector<NameMatchPair>;
     String input;
     GroupsRecord groups;
 };


### PR DESCRIPTION
#### 719e478475ea019476249826a0c0707bb3f2e72f
<pre>
Implement URLPattern matching
<a href="https://bugs.webkit.org/show_bug.cgi?id=284077">https://bugs.webkit.org/show_bug.cgi?id=284077</a>
<a href="https://rdar.apple.com/140946287">rdar://140946287</a>

Reviewed by Chris Dumez and Sihui Liu.

URLPattern match function spec: <a href="https://urlpattern.spec.whatwg.org/#url-pattern-match">https://urlpattern.spec.whatwg.org/#url-pattern-match</a>

* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt:
* Source/WebCore/Modules/url-pattern/URLPattern.cpp:
(WebCore::URLPattern::test const):
(WebCore::URLPattern::exec const):
(WebCore::URLPattern::match const):
* Source/WebCore/Modules/url-pattern/URLPattern.h:
* Source/WebCore/Modules/url-pattern/URLPattern.idl:
* Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp:
(WebCore::canonicalizePort):
* Source/WebCore/Modules/url-pattern/URLPatternComponent.cpp:
(WebCore::URLPatternUtilities::URLPatternComponent::componentExec const):
(WebCore::URLPatternUtilities::URLPatternComponent::createComponentMatchResult const):
* Source/WebCore/Modules/url-pattern/URLPatternComponent.h:
* Source/WebCore/Modules/url-pattern/URLPatternResult.h:

Canonical link: <a href="https://commits.webkit.org/287741@main">https://commits.webkit.org/287741@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d899a99cb98106b33dd6af3cc60c3ca853e6794b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80608 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59615 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34542 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85132 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31590 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82719 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68676 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7921 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62962 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20766 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83677 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/53083 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73380 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43267 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50372 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27540 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30049 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71519 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28063 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86565 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7834 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5556 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71255 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8009 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69217 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70495 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14508 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13457 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12501 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7796 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13315 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7635 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11154 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9440 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->