### PR TITLE
[iPad] Trackpad scrolling in nested scroll views sometimes only works during the momentum phase

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -916,6 +916,8 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 - (BOOL)_shouldIgnoreTouchEvent:(UIEvent *)event;
 - (void)_touchEventsRecognized;
 
+- (BOOL)_hasEnclosingScrollView:(UIView *)firstView matchingCriteria:(Function<BOOL(UIScrollView *)>&&)matchFunction;
+
 - (ScopeExit<Function<void()>>)makeTextSelectionViewsNonInteractiveForScope;
 
 @property (nonatomic, readonly) BOOL shouldUseAsyncInteractions;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -3308,7 +3308,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     return pointIsInSelectionRect;
 }
 
-- (BOOL)_hasEnclosingScrollView:(UIScrollView *)firstView matchingCriteria:(Function<BOOL(UIScrollView *)>&&)matchFunction
+- (BOOL)_hasEnclosingScrollView:(UIView *)firstView matchingCriteria:(Function<BOOL(UIScrollView *)>&&)matchFunction
 {
     UIView *view = firstView ?: self.webView.scrollView;
     for (; view; view = view.superview) {

--- a/Tools/TestWebKitAPI/Tests/ios/WKScrollViewTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/WKScrollViewTests.mm
@@ -337,7 +337,7 @@ TEST(WKScrollViewTests, AsynchronousWheelEventHandling)
     EXPECT_FALSE(scrollingPrevented);
 }
 
-TEST(WKScrollViewTests, OverscrollBehaviorShouldNotPreventScrolling)
+TEST(WKScrollViewTests, OverscrollBehaviorAndOverflowHiddenOnRootShouldNotPreventScrolling)
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
@@ -345,7 +345,7 @@ TEST(WKScrollViewTests, OverscrollBehaviorShouldNotPreventScrolling)
         "<meta name='viewport' content='width=device-width, initial-scale=1'>"
         "<head>"
         "    <style>"
-        "    body, html { width: 100%; height: 100%; margin: 0; overscroll-behavior: contain; }"
+        "    body, html { width: 100%; height: 100%; margin: 0; overscroll-behavior: contain; overflow: hidden; }"
         "    .scroller { width: 100%; height: 100%; overflow: scroll; }"
         "    .tall { width: 1px; height: 5000px; }"
         "    </style>"


### PR DESCRIPTION
#### 9935bf6fc5f092db434ce5350cce03cc07267021
<pre>
[iPad] Trackpad scrolling in nested scroll views sometimes only works during the momentum phase
<a href="https://bugs.webkit.org/show_bug.cgi?id=284081">https://bugs.webkit.org/show_bug.cgi?id=284081</a>
<a href="https://rdar.apple.com/140922601">rdar://140922601</a>

Reviewed by Richard Robinson.

Currently, the logic in `-scrollView:handleScrollUpdate:completion:` attempts to call the completion
handler with `handled := YES` in the case where handling a scroll update wouldn&apos;t result in
scrolling anyways. To achieve this, we currently ask the given `scrollView` whether it&apos;s scrollable,
and save the result in a local variable `isHandledByDefault`.

However, in the case of nested `WKChildScrollView`s, this can lead to unpredicable results if the
inner scroll view is scrollable and the outer `WKScrollView` is non-scrollable; this is because
UIKit may deliver the async scroll event to either `UIScrollView` in this case (depending on the
hash table iteration order of an internal `NSSet&lt;UIGestureRecognizer *&gt; *`). If the scroll update is
delivered to the inner child scroll view, the wheel deltas successfully trigger scrolling because
the child scroll view has `-isScrollEnabled := YES`. However, if the scroll update is delivered to
the unscrollable `WKScrollView` instead, scrolling fails because `isHandledByDefault := NO`.

To fix this, we instead set `isHandledByDefault` to `YES` if and only if there are no scrollable
child scroll views underneath the scroll update location. This makes the logic robust regardless of
which subscrollable container receives the update in UIKit.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView scrollView:handleScrollUpdate:completion:]):

Drive-by fix: avoid calling the completion handler 2 times in the case where the web view has been
destroyed and the event is non-cancelable.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:

Expose an internal helper method, for use in `WKWebViewIOS` above.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _hasEnclosingScrollView:matchingCriteria:]):
* Tools/TestWebKitAPI/Tests/ios/WKScrollViewTests.mm:
(TEST(WKScrollViewTests, OverscrollBehaviorAndOverflowHiddenOnRootShouldNotPreventScrolling)):
(TEST(WKScrollViewTests, OverscrollBehaviorShouldNotPreventScrolling)): Deleted.

Augment an existing API test to exercise this change.

Canonical link: <a href="https://commits.webkit.org/287410@main">https://commits.webkit.org/287410@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a24e46795ba91549782bc8a25b52bc4be74c146b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79455 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58465 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32830 "") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84038 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30555 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81580 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67579 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6744 "") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62129 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19993 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82520 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52206 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/32830 "") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42439 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49556 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/32830 "") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28968 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70676 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/32830 "") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85449 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6720 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/6744 "") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70380 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-transforms/animation/scale-and-rotate-both-specified-on-animation-keyframes.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6885 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/32830 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69623 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17376 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13660 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/32830 "") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6674 "") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12382 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6573 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10054 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8371 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->