### PR TITLE
[Static Analyzer CI] Reported results do not reflect changes to expectations in PRs

### DIFF
--- a/Tools/CISupport/ews-build/factories.py
+++ b/Tools/CISupport/ews-build/factories.py
@@ -112,6 +112,7 @@ class SaferCPPStaticAnalyzerFactory(factory.BuildFactory):
         self.addStep(CheckOutPullRequest())
         self.addStep(KillOldProcesses())
         self.addStep(ValidateChange(addURLs=False))
+        self.addStep(FindModifiedSaferCPPExpectations())
         self.addStep(ScanBuild())
 
 

--- a/Tools/CISupport/ews-build/factories_unittest.py
+++ b/Tools/CISupport/ews-build/factories_unittest.py
@@ -311,6 +311,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'checkout-pull-request',
             'kill-old-processes',
             'validate-change',
+            'find-modified-safer-cpp-expectations',
             'scan-build'
         ],
         'macOS-Release-WK2-Stress-Tests-EWS': [


### PR DESCRIPTION
#### b3d26961a782dcdcc7fa912ffa4de9c4943e944f
<pre>
[Static Analyzer CI] Reported results do not reflect changes to expectations in PRs
<a href="https://rdar.apple.com/140374383">rdar://140374383</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=284085">https://bugs.webkit.org/show_bug.cgi?id=284085</a>

Reviewed by Aakash Jain.

When expectations are changed in the PR, EWS results should abide by those expectations.
If not, we see inaccurate comments on PRs and miss potential regressions.

This change introduces logic that checks for modified expectations and will filter the
given results to conform to the expectations.
    1. If a file is removed from expectations, it will be treated as an unexpected failure.
       - If it passes, we suppress the pass as expected.
       - If it fails, we surface the failure, even if it was pre-existing.
    2. If a file is added to expectations, it will be treated as an expected failure.
       - If it passes, we surface the unexpected pass.
       - If it fails, we suppress the failure as expected.

* Tools/CISupport/ews-build/factories.py: Add FindModifiedSaferCPPExpectations to the factory.
(SaferCPPStaticAnalyzerFactory.__init__):
* Tools/CISupport/ews-build/factories_unittest.py:
(TestExpectedBuildSteps):

* Tools/CISupport/ews-build/steps.py:
(FindModifiedSaferCPPExpectations):
    - New step that parses the diff of the PR to find which Safer CPP expectations
      were modified by the PR.
    - Tests are saved as &apos;user_removed_tests&apos; and &apos;user_added_tests&apos; build properties.
(FindModifiedSaferCPPExpectations.__init__):
(FindModifiedSaferCPPExpectations.run):
(FindModifiedSaferCPPExpectations.getResultSummary):

(FindUnexpectedStaticAnalyzerResults):
(FindUnexpectedStaticAnalyzerResults.run):
    - On this first run, we compare against the expectations in the PR. If the unexpected results
      match with the user modified tests, we can return results and skip a second build/results_db.
    - Otherwise, we check results_db but we ignore filtering tests if they are modified by the user.
(FindUnexpectedStaticAnalyzerResults.decode_results_data):
    - Load the log text in this function.
(FindUnexpectedStaticAnalyzerResults.get_unexpected_tests):
    - Simple function to convert a dictionary of results into a list of test strings.
(FindUnexpectedStaticAnalyzerResults.filter_results_using_results_db):
(FindUnexpectedStaticAnalyzerResults.check_results_db):
    - This is where we check for user modified tests. The logic is as follows:
      If a test is a pre-existing failure or pass after checking resultsdb, we
          1. Keep it as unexpected failure if a user removed the test
          2. Keep it as unexpected pass if a user added the test
          3. Remove it from unexpected if a user did not modify the test (normal behaviour)

(FindUnexpectedStaticAnalyzerResultsWithoutChange):
    - On the second run, we compare the build with PR changes to a build on ToT.
      If there are user modified tests, we filter the unexpected results and regenerate the results
      index if needed.
(FindUnexpectedStaticAnalyzerResultsWithoutChange.run):
(FindUnexpectedStaticAnalyzerResultsWithoutChange.filter_results_by_user_modification):
    - The filtering logic lives here!
    - For tests that the user added to expectations:
           1. If unexpected pass in the 1st run, add to unexpected passes here.
           2. If unexpected fail in the 2nd run, remove from unexpected failures here.
    - For tests that the user removed from expectations:
           1. If unexpected fail in the 1st run, add to unexpected failures here.
           2. If unexpected pass in the 2nd run, remove from unexpected passes here.
    - This filter ensures that the test results reflect the user modified expectations and not
      just which results were new to this PR.

* Tools/CISupport/ews-build/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/290621@main">https://commits.webkit.org/290621@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93d5711284386d60f28db21a090d850b6306c8ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90485 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/10017 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45421 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/95496 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/41267 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92537 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/10410 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18336 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/95496 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/41267 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93486 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/10410 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/82068 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/95496 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/10410 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/36420 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/40397 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/10410 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/37507 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/97325 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/17677 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12982 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/97325 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/90070 "Passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/17935 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/77891 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/97325 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/20918 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/10999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14262 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/17687 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/17426 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/20881 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/19210 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->