### PR TITLE
[AutoInstall] Remove any manifest item on failure

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py
@@ -428,15 +428,19 @@ class Package(object):
                     'version': str(archive.version),
                 }
 
+                AutoInstall.log('Installed {}!'.format(archive))
+            except Exception:
+                if self.name in AutoInstall.manifest:
+                    del AutoInstall.manifest[self.name]
+
+                AutoInstall.log('Failed to install {}!'.format(archive), level=logging.CRITICAL)
+                raise
+            finally:
                 manifest = os.path.join(AutoInstall.directory, AutoInstall.MANIFEST_JSON)
                 with open(manifest, 'w') as file:
                     json.dump(AutoInstall.manifest, file, indent=4)
                 AutoInstall.userspace_should_own(manifest)
 
-                AutoInstall.log('Installed {}!'.format(archive))
-            except Exception:
-                AutoInstall.log('Failed to install {}!'.format(archive), level=logging.CRITICAL)
-                raise
 
 
 def _default_pypi_index():


### PR DESCRIPTION
#### 881ba2ce3758ee4769818e3a7a9efb9417965c03
<pre>
[AutoInstall] Remove any manifest item on failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=284086">https://bugs.webkit.org/show_bug.cgi?id=284086</a>

Reviewed by Jonathan Bedard.

We had an EWS bot in a state where the manifest said something was
installed but it was not, likely due to installation failing.

When we&apos;re changing what version of a package is installed,
installation failing can lead us to a state where we have neither the
new nor old version installed, but the manifest would claim that the
old version still was.

To fix this, we delete any relevant manifest item on failure, which
will force a reinstall (of either version) in the future.

Untested, because of <a href="https://bugs.webkit.org/show_bug.cgi?id=284070.">https://bugs.webkit.org/show_bug.cgi?id=284070.</a>

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py:
(Package.install):

Canonical link: <a href="https://commits.webkit.org/287426@main">https://commits.webkit.org/287426@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0cf652edcede2af3f8c1d48019310bc5f3d864b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79679 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58455 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32813 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84029 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30547 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81565 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67572 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6725 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62122 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19987 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82679 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52202 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72397 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42432 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/78939 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49552 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26542 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28959 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70672 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26998 "Failed to checkout and rebase branch from PR 37474") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85440 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6704 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4664 "Failed to checkout and rebase branch from PR 37474") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70372 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/79320 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6869 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68242 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69615 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13750 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12533 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12302 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6819 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6716 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10211 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8359 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->