### PR TITLE
Non-unified source build fix of December 2024 (part 2)

### DIFF
--- a/Source/WebCore/css/CSSColorValue.cpp
+++ b/Source/WebCore/css/CSSColorValue.cpp
@@ -25,6 +25,8 @@
 #include "config.h"
 #include "CSSColorValue.h"
 
+#include "CSSPrimitiveValue.h"
+
 namespace WebCore {
 
 Ref<CSSColorValue> CSSColorValue::create(CSS::Color color)

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp
@@ -64,6 +64,7 @@
 #include "CSSValue.h"
 #include "CSSValueList.h"
 #include "CSSValuePool.h"
+#include "CSSVariableData.h"
 #include "StyleImage.h"
 #include <wtf/SortedArrayMap.h>
 

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.cpp
@@ -29,6 +29,7 @@
 #include "InlineIteratorBox.h"
 #include "LayoutIntegrationLineLayout.h"
 #include "RenderStyleInlines.h"
+#include "SVGTextFragment.h"
 #include "TextPainter.h"
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -58,6 +58,7 @@
 #include "RenderLayoutState.h"
 #include "RenderLineBreak.h"
 #include "RenderView.h"
+#include "SVGTextFragment.h"
 #include "Settings.h"
 #include "ShapeOutsideInfo.h"
 #include "TextBreakingPositionCache.h"

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -31,6 +31,7 @@
 #include "StyleBuilderState.h"
 
 #include "CSSCanvasValue.h"
+#include "CSSColorValue.h"
 #include "CSSCrossfadeValue.h"
 #include "CSSCursorImageValue.h"
 #include "CSSFilterImageValue.h"

--- a/Source/WebCore/style/values/color/StyleColorMix.cpp
+++ b/Source/WebCore/style/values/color/StyleColorMix.cpp
@@ -31,6 +31,7 @@
 #include "CSSPrimitiveNumericTypes+Serialization.h"
 #include "ColorSerialization.h"
 #include "StyleColorResolutionState.h"
+#include "StylePrimitiveNumericTypes+Conversions.h"
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {

--- a/Source/WebCore/style/values/color/StyleColorResolutionState.h
+++ b/Source/WebCore/style/values/color/StyleColorResolutionState.h
@@ -25,9 +25,10 @@
 
 #pragma once
 
+#include "CSSToLengthConversionData.h"
+
 namespace WebCore {
 
-class CSSToLengthConversionData;
 class Document;
 class RenderStyle;
 

--- a/Source/WebKit/NetworkProcess/NetworkLoad.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoad.cpp
@@ -37,6 +37,7 @@
 #include "NetworkSession.h"
 #include "WebCoreArgumentCoders.h"
 #include "WebErrors.h"
+#include <WebCore/AuthenticationChallenge.h>
 #include <WebCore/ResourceRequest.h>
 #include <WebCore/SharedBuffer.h>
 #include <wtf/NeverDestroyed.h>

--- a/Source/WebKit/UIProcess/RemotePageVisitedLinkStoreRegistration.h
+++ b/Source/WebKit/UIProcess/RemotePageVisitedLinkStoreRegistration.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "VisitedLinkStore.h"
 #include "WebPageProxy.h"
 #include "WebProcessProxy.h"
 #include <wtf/TZoneMallocInlines.h>


### PR DESCRIPTION
#### d5c9af74ecc9730ed3e211f264e1b207faeffa62
<pre>
Non-unified source build fix of December 2024 (part 2)
<a href="https://bugs.webkit.org/show_bug.cgi?id=283880">https://bugs.webkit.org/show_bug.cgi?id=283880</a>

Unreviewed non-unified build fix for Windows port.

* Source/WebCore/Modules/url-pattern/URLPatternComponent.cpp:
* Source/WebCore/css/CSSColorValue.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp:
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.cpp:
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
* Source/WebCore/style/StyleBuilderState.cpp:
* Source/WebCore/style/values/color/StyleColorMix.cpp:
* Source/WebCore/style/values/color/StyleColorResolutionState.h:
* Source/WebKit/NetworkProcess/NetworkLoad.cpp:
* Source/WebKit/UIProcess/RemotePageVisitedLinkStoreRegistration.h:

Canonical link: <a href="https://commits.webkit.org/287383@main">https://commits.webkit.org/287383@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46d8c272b67167973752aee7f47c91a3c22a27d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79446 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58456 "") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32814 "") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84030 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/30548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81569 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/67573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6726 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/62123 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/30548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82510 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/67573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/32814 "") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42433 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/67573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/32814 "") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28960 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/67573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/32814 "") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85441 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6706 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/70373 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6870 "") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/32814 "") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/69616 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17357 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/32814 "") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12271 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6662 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/6560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10044 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/8360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->