### PR TITLE
[JSC] Update Intl.DurationFormat not to include grouping for 2-digit / numeric styles

### DIFF
--- a/JSTests/stress/intl-durationformat-rounding-errors.js
+++ b/JSTests/stress/intl-durationformat-rounding-errors.js
@@ -24,7 +24,7 @@ function sameValue(actual, expected) {
   };
 
   const df = new Intl.DurationFormat('en', { style: "digital" });
-  sameValue(df.format(duration), "0:00:10,000,000.000000001");
+  sameValue(df.format(duration), "0:00:10000000.000000001");
 }
 
 {
@@ -37,5 +37,5 @@ function sameValue(actual, expected) {
   };
 
   const df = new Intl.DurationFormat('en', { style: 'digital' });
-  sameValue(df.format(duration), '0:00:9,007,199,254,740,991.975424');
+  sameValue(df.format(duration), '0:00:9007199254740991.975424');
 }

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1150,12 +1150,6 @@ test/intl402/DateTimeFormat/timezone-legacy-non-iana.js:
 test/intl402/DateTimeFormat/timezone-not-canonicalized.js:
   default: 'Test262Error: Expected SameValue(«"Asia/Calcutta"», «"Asia/Kolkata"») to be true'
   strict mode: 'Test262Error: Expected SameValue(«"Asia/Calcutta"», «"Asia/Kolkata"») to be true'
-test/intl402/DurationFormat/prototype/format/precision-exact-mathematical-values.js:
-  default: 'Test262Error: Duration is {"seconds":10000000,"nanoseconds":1} Expected SameValue(«"0:00:10,000,000.000000001"», «"0:00:10000000.000000001"») to be true'
-  strict mode: 'Test262Error: Duration is {"seconds":10000000,"nanoseconds":1} Expected SameValue(«"0:00:10,000,000.000000001"», «"0:00:10000000.000000001"») to be true'
-test/intl402/DurationFormat/prototype/format/style-digital-large-hms-values.js:
-  default: 'Test262Error: failed to suppress grouping separator using digital style Expected SameValue(«"1,234:1,234,567:12,345,678"», «"1234:1234567:12345678"») to be true'
-  strict mode: 'Test262Error: failed to suppress grouping separator using digital style Expected SameValue(«"1,234:1,234,567:12,345,678"», «"1234:1234567:12345678"») to be true'
 test/intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-timezone.js:
   default: 'Test262Error: Expected SameValue(«"und-u-tz-utcw05"», «"und-u-tz-papty"») to be true'
   strict mode: 'Test262Error: Expected SameValue(«"und-u-tz-utcw05"», «"und-u-tz-papty"») to be true'

--- a/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
@@ -463,6 +463,10 @@ static Vector<Element> collectElements(JSGlobalObject* globalObject, const IntlD
         else
             skeletonBuilder.append('0');
 
+        // 9. Perform ! CreateDataPropertyOrThrow(nfOpts, "useGrouping", false).
+        if (style == IntlDurationFormat::UnitStyle::TwoDigit || style ==  IntlDurationFormat::UnitStyle::Numeric)
+            skeletonBuilder.append(" group-off"_s);
+
         // 3.l. If value is not 0 or display is not "auto", then
         value = purifyNaN(value);
         if (value || unitData.display() != IntlDurationFormat::Display::Auto || style == IntlDurationFormat::UnitStyle::TwoDigit || style ==  IntlDurationFormat::UnitStyle::Numeric) {


### PR DESCRIPTION
#### f172ce8e237cc9636c36f55a3536d70addc9532c
<pre>
[JSC] Update Intl.DurationFormat not to include grouping for 2-digit / numeric styles
<a href="https://bugs.webkit.org/show_bug.cgi?id=284087">https://bugs.webkit.org/show_bug.cgi?id=284087</a>
<a href="https://rdar.apple.com/problem/140962232">rdar://problem/140962232</a>

Reviewed by Yijia Huang.

Update the Intl.DurationFormat implementation to include the latest
proposal update[1]. When 2-digit / numeric styles are specified, we
should not use grouping.

[1]: <a href="https://github.com/tc39/proposal-intl-duration-format/commit/68b00f3f272ea5a1bbcd37588da66d07f2d3507d">https://github.com/tc39/proposal-intl-duration-format/commit/68b00f3f272ea5a1bbcd37588da66d07f2d3507d</a>

* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/IntlDurationFormat.cpp:
(JSC::collectElements):

Canonical link: <a href="https://commits.webkit.org/287393@main">https://commits.webkit.org/287393@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bae1996f123cccddeb9030530a884082a5c97ba1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79486 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58495 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32863 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84065 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30579 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67588 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6773 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/62152 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20016 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82557 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52211 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72413 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42462 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/49561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26576 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28995 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/72550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/70680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27033 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85476 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/78651 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6752 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4692 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/70402 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6917 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68276 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69645 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13674 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12568 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/100993 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12280 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6704 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/24639 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/struct-new_default-small-members.js.wasm-no-cjit (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6600 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10082 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8399 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->