### PR TITLE
[WebGPU] Using array length in the fragment but not vertex buffer leads to AB size mismatch

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-284090-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-284090-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-284090.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-284090.html
@@ -1,0 +1,23314 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = console.log;
+
+async function gc() {
+  await 0;
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUComputePassEncoder} computePassEncoder
+ */
+function clearResourceUsages(device, computePassEncoder) {
+  let code = `@compute @workgroup_size(1) fn c() {}`;
+  let module = device.createShaderModule({code});
+  computePassEncoder.setPipeline(device.createComputePipeline(
+    {
+      layout: 'auto',
+      compute: {module},
+    }));
+  computePassEncoder.dispatchWorkgroups(1);
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+const videoUrls = [
+
+];
+
+/**
+ * @param {number} index
+ * @returns {Promise<HTMLVideoElement>}
+ */
+function videoWithData(index) {
+  let video = document.createElement('video');
+  video.src = videoUrls[index % videoUrls.length];
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+/**
+ * @param {string} payload
+ * @returns {string}
+ */
+function toBlobUrl(payload) {
+  let blob = new Blob([payload], {type: 'text/javascript'});
+  return URL.createObjectURL(blob);
+}
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+let adapter0 = await navigator.gpu.requestAdapter({});
+let device0 = await adapter0.requestDevice({requiredLimits: {maxUniformBufferBindingSize: 1814704, maxStorageBufferBindingSize: 146882510}});
+let commandEncoder0 = device0.createCommandEncoder({});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder1 = device0.createCommandEncoder({});
+let computePassEncoder0 = commandEncoder0.beginComputePass({});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer0 = device0.createBuffer({
+  size: 8513,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture0 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 13},
+  format: 'r8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({colorFormats: ['rgba8sint'], depthStencilFormat: 'depth32float', stencilReadOnly: true});
+try {
+buffer0.unmap();
+} catch {}
+let commandEncoder2 = device0.createCommandEncoder({});
+let computePassEncoder1 = commandEncoder1.beginComputePass({});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8sint'],
+  depthStencilFormat: 'depth32float',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let videoFrame0 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte240m', primaries: 'bt470m', transfer: 'log'} });
+let commandEncoder3 = device0.createCommandEncoder({});
+let texture1 = device0.createTexture({
+  size: {width: 30, height: 10, depthOrArrayLayers: 1},
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView0 = texture1.createView({dimension: '2d', aspect: 'all', baseMipLevel: 0});
+let computePassEncoder2 = commandEncoder3.beginComputePass({});
+let sampler0 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', mipmapFilter: 'nearest', lodMaxClamp: 92.83});
+try {
+buffer0.destroy();
+} catch {}
+try {
+computePassEncoder2.insertDebugMarker('\u37c4');
+} catch {}
+let querySet0 = device0.createQuerySet({type: 'occlusion', count: 902});
+let texture2 = device0.createTexture({
+  size: {width: 120, height: 40, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'depth32float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let buffer1 = device0.createBuffer({size: 876, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let computePassEncoder3 = commandEncoder2.beginComputePass({});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer2 = device0.createBuffer({size: 83, usage: GPUBufferUsage.COPY_DST, mappedAtCreation: false});
+let commandEncoder4 = device0.createCommandEncoder();
+let texture3 = device0.createTexture({
+  size: {width: 120, height: 40, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8sint', 'rgba8sint', 'rgba8sint'],
+});
+let computePassEncoder4 = commandEncoder4.beginComputePass({});
+let sampler1 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', minFilter: 'linear', lodMaxClamp: 62.35});
+try {
+renderBundleEncoder0.setVertexBuffer(2, undefined);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 8, new DataView(new ArrayBuffer(32165)), 2542, 4);
+} catch {}
+let promise0 = device0.queue.onSubmittedWorkDone();
+let commandEncoder5 = device0.createCommandEncoder({});
+let computePassEncoder5 = commandEncoder5.beginComputePass();
+let renderBundle0 = renderBundleEncoder0.finish({label: '\u3e3e\u0a41\u8be0\u62a6\u070d'});
+let veryExplicitBindGroupLayout0 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 396,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let sampler2 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 12,
+});
+let buffer3 = device0.createBuffer({size: 6224, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder6 = device0.createCommandEncoder();
+let texture4 = device0.createTexture({
+  size: [60, 20, 4],
+  mipLevelCount: 5,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder6 = commandEncoder6.beginComputePass({});
+let sampler3 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 4,
+});
+try {
+  await promise0;
+} catch {}
+let pipelineLayout0 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0, veryExplicitBindGroupLayout0]});
+let sampler4 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMaxClamp: 93.27,
+});
+try {
+renderBundleEncoder1.setVertexBuffer(3, undefined, 0, 8_115_938);
+} catch {}
+let commandEncoder7 = device0.createCommandEncoder();
+let textureView1 = texture2.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder7 = commandEncoder7.beginComputePass({});
+await gc();
+try {
+globalThis.someLabel = device0.label;
+} catch {}
+let buffer4 = device0.createBuffer({
+  size: 10736,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+globalThis.someLabel = computePassEncoder0.label;
+} catch {}
+let commandEncoder8 = device0.createCommandEncoder({});
+let computePassEncoder8 = commandEncoder8.beginComputePass({});
+let externalTexture0 = device0.importExternalTexture({source: videoFrame0, colorSpace: 'srgb'});
+let renderBundle1 = renderBundleEncoder1.finish({});
+try {
+device0.queue.writeBuffer(buffer2, 12, new DataView(new ArrayBuffer(5225)), 1042, 4);
+} catch {}
+let buffer5 = device0.createBuffer({size: 15160, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let sampler5 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 88.92,
+  compare: 'less',
+  maxAnisotropy: 1,
+});
+await gc();
+let veryExplicitBindGroupLayout1 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 396,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let texture5 = device0.createTexture({
+  size: {width: 240, height: 80, depthOrArrayLayers: 21},
+  mipLevelCount: 2,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler6 = device0.createSampler({
+  label: '\u4459\u296a\u0bda\u1da6\u{1f6ad}',
+  addressModeU: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 81.78,
+  compare: 'not-equal',
+  maxAnisotropy: 6,
+});
+try {
+globalThis.someLabel = commandEncoder7.label;
+} catch {}
+let bindGroup0 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 396, resource: {buffer: buffer5, offset: 3072}}],
+});
+let pipelineLayout1 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0, veryExplicitBindGroupLayout1]});
+let sampler7 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  maxAnisotropy: 1,
+});
+let imageData0 = new ImageData(24, 52);
+let pipelineLayout2 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let texture6 = device0.createTexture({
+  size: [60, 20, 1],
+  mipLevelCount: 2,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let bindGroup1 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 396, resource: {buffer: buffer5, offset: 1792, size: 1784}}],
+});
+let commandEncoder9 = device0.createCommandEncoder({});
+let querySet1 = device0.createQuerySet({type: 'occlusion', count: 1090});
+let texture7 = device0.createTexture({
+  size: [30, 10, 16],
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView2 = texture4.createView({dimension: '2d', aspect: 'depth-only', baseMipLevel: 0, mipLevelCount: 1});
+let computePassEncoder9 = commandEncoder9.beginComputePass({});
+try {
+device0.queue.writeBuffer(buffer4, 1652, new Float32Array(47930), 18062, 1292);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(295).fill(8), /* required buffer size: 295 */
+{offset: 295, bytesPerRow: 118}, {width: 60, height: 20, depthOrArrayLayers: 0});
+} catch {}
+let veryExplicitBindGroupLayout2 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 116,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 258,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let bindGroup2 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 396, resource: {buffer: buffer5, offset: 512}}],
+});
+let commandEncoder10 = device0.createCommandEncoder({});
+let texture8 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 13},
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder10 = commandEncoder10.beginComputePass({});
+let sampler8 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'mirror-repeat', minFilter: 'nearest', lodMaxClamp: 72.45});
+let texture9 = device0.createTexture({
+  size: {width: 120, height: 40, depthOrArrayLayers: 35},
+  mipLevelCount: 2,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView3 = texture2.createView({dimension: '2d-array', aspect: 'depth-only', mipLevelCount: 1});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+computePassEncoder0.setBindGroup(3, bindGroup1, new Uint32Array(2174), 327, 0);
+} catch {}
+let imageData1 = new ImageData(24, 224);
+try {
+buffer4.label = '\u2ae0\ubbcf\u0445\ud1ea\u0324\u8c4f\u{1f76f}\ub101\u{1fb27}\u4360\u0e70';
+} catch {}
+let textureView4 = texture6.createView({dimension: '2d-array', aspect: 'stencil-only', mipLevelCount: 1});
+try {
+buffer2.unmap();
+} catch {}
+let commandEncoder11 = device0.createCommandEncoder({});
+let texture10 = device0.createTexture({
+  size: {width: 240, height: 80, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView5 = texture2.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder2.pushDebugGroup('\u{1f87f}');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 12, new Int16Array(1379), 401, 4);
+} catch {}
+let shaderModule0 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+enable f16;
+
+enable f16;
+
+enable f16;
+
+alias vec3b = vec3<bool>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<workgroup> vw0: vec4f;
+
+var<workgroup> vw1: atomic<i32>;
+
+fn fn1() -> VertexOutput0 {
+  var out: VertexOutput0;
+  let ptr14: ptr<storage, array<array<f16, 3>, 3>, read> = &(*&buffer6)[arrayLength(&(*&buffer6))][u32(unconst_u32(62))][u32(unconst_u32(234))];
+  out = VertexOutput0(vec4f(f32((*&buffer6)[arrayLength(&(*&buffer6))][u32(unconst_u32(38))][2][2][2])));
+  let ptr15: ptr<storage, f16, read> = &(*&buffer6)[arrayLength(&(*&buffer6))][0][u32(unconst_u32(74))][2][u32(unconst_u32(103))];
+  return out;
+  _ = buffer6;
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn fn0(a0: ptr<private, array<T0, 1>>) -> array<vec2i, 1> {
+  var out: array<vec2i, 1>;
+  let ptr0: ptr<storage, array<f16, 3>, read> = &buffer6[u32(unconst_u32(60))][0][u32(unconst_u32(45))][2];
+  let ptr1: ptr<storage, array<array<f16, 3>, 3>, read> = &(*&buffer6)[arrayLength(&(*&buffer6))][u32(unconst_u32(247))][u32(unconst_u32(126))];
+  (*a0)[u32(unconst_u32(8))].f0 -= mat3x3f(f32(buffer6[u32(unconst_u32(175))][0][2][u32(buffer6[arrayLength(&buffer6)][u32(unconst_u32(121))][2][2][2])][u32(unconst_u32(864))]), f32(buffer6[u32(unconst_u32(175))][0][2][u32(buffer6[arrayLength(&buffer6)][u32(unconst_u32(121))][2][2][2])][u32(unconst_u32(864))]), f32(buffer6[u32(unconst_u32(175))][0][2][u32(buffer6[arrayLength(&buffer6)][u32(unconst_u32(121))][2][2][2])][u32(unconst_u32(864))]), f32(buffer6[u32(unconst_u32(175))][0][2][u32(buffer6[arrayLength(&buffer6)][u32(unconst_u32(121))][2][2][2])][u32(unconst_u32(864))]), f32(buffer6[u32(unconst_u32(175))][0][2][u32(buffer6[arrayLength(&buffer6)][u32(unconst_u32(121))][2][2][2])][u32(unconst_u32(864))]), f32(buffer6[u32(unconst_u32(175))][0][2][u32(buffer6[arrayLength(&buffer6)][u32(unconst_u32(121))][2][2][2])][u32(unconst_u32(864))]), f32(buffer6[u32(unconst_u32(175))][0][2][u32(buffer6[arrayLength(&buffer6)][u32(unconst_u32(121))][2][2][2])][u32(unconst_u32(864))]), f32(buffer6[u32(unconst_u32(175))][0][2][u32(buffer6[arrayLength(&buffer6)][u32(unconst_u32(121))][2][2][2])][u32(unconst_u32(864))]), f32(buffer6[u32(unconst_u32(175))][0][2][u32(buffer6[arrayLength(&buffer6)][u32(unconst_u32(121))][2][2][2])][u32(unconst_u32(864))]));
+  let ptr2: ptr<storage, array<array<f16, 3>, 3>, read> = &buffer6[arrayLength(&buffer6)][0][u32(unconst_u32(60))];
+  out[u32(unconst_u32(5))] = vec2i(i32((*&buffer6)[u32(unconst_u32(67))][0][u32(unconst_u32(205))][2][u32(unconst_u32(391))]));
+  let ptr3: ptr<storage, f16, read> = &(*ptr1)[u32(unconst_u32(231))][u32(unconst_u32(2))];
+  out[u32(unconst_u32(168))] ^= vec2i(i32((*&buffer6)[vec3u((*a0)[0].f0[unconst_i32(1)]).x][u32(unconst_u32(303))][2][2][2]));
+  let ptr4: ptr<storage, array<array<f16, 3>, 3>, read> = &buffer6[u32(unconst_u32(265))][u32(unconst_u32(657))][2];
+  (*a0)[u32(unconst_u32(43))].f0 += mat3x3f(f32(buffer6[arrayLength(&buffer6)][u32(unconst_u32(565))][u32(unconst_u32(131))][u32(unconst_u32(120))][2]), f32(buffer6[arrayLength(&buffer6)][u32(unconst_u32(565))][u32(unconst_u32(131))][u32(unconst_u32(120))][2]), f32(buffer6[arrayLength(&buffer6)][u32(unconst_u32(565))][u32(unconst_u32(131))][u32(unconst_u32(120))][2]), f32(buffer6[arrayLength(&buffer6)][u32(unconst_u32(565))][u32(unconst_u32(131))][u32(unconst_u32(120))][2]), f32(buffer6[arrayLength(&buffer6)][u32(unconst_u32(565))][u32(unconst_u32(131))][u32(unconst_u32(120))][2]), f32(buffer6[arrayLength(&buffer6)][u32(unconst_u32(565))][u32(unconst_u32(131))][u32(unconst_u32(120))][2]), f32(buffer6[arrayLength(&buffer6)][u32(unconst_u32(565))][u32(unconst_u32(131))][u32(unconst_u32(120))][2]), f32(buffer6[arrayLength(&buffer6)][u32(unconst_u32(565))][u32(unconst_u32(131))][u32(unconst_u32(120))][2]), f32(buffer6[arrayLength(&buffer6)][u32(unconst_u32(565))][u32(unconst_u32(131))][u32(unconst_u32(120))][2]));
+  let ptr5: ptr<storage, f16, read> = &(*&buffer6)[u32(unconst_u32(151))][u32(unconst_u32(561))][u32(unconst_u32(53))][u32(unconst_u32(1))][2];
+  let ptr6: ptr<storage, array<array<f16, 3>, 3>, read> = &buffer6[u32(unconst_u32(103))][0][u32(unconst_u32(39))];
+  let ptr7: ptr<storage, f16, read> = &buffer6[arrayLength(&buffer6)][0][u32(unconst_u32(100))][u32(unconst_u32(138))][u32(unconst_u32(72))];
+  (*a0)[u32(unconst_u32(115))] = T0(mat3x3f(f32((*ptr2)[u32(unconst_u32(241))][2]), f32((*ptr2)[u32(unconst_u32(241))][2]), f32((*ptr2)[u32(unconst_u32(241))][2]), f32((*ptr2)[u32(unconst_u32(241))][2]), f32((*ptr2)[u32(unconst_u32(241))][2]), f32((*ptr2)[u32(unconst_u32(241))][2]), f32((*ptr2)[u32(unconst_u32(241))][2]), f32((*ptr2)[u32(unconst_u32(241))][2]), f32((*ptr2)[u32(unconst_u32(241))][2])));
+  out[u32(unconst_u32(428))] = vec2i(i32(buffer6[arrayLength(&buffer6)][0][u32(unconst_u32(119))][u32(unconst_u32(68))][2]));
+  let ptr8: ptr<storage, f16, read> = &(*ptr4)[u32(unconst_u32(153))][u32((*&buffer6)[arrayLength(&(*&buffer6))][u32(unconst_u32(256))][2][u32((*&buffer6)[arrayLength(&(*&buffer6))][0][u32(unconst_u32(160))][2][2])][u32(unconst_u32(19))])];
+  let ptr9: ptr<storage, f16, read> = &(*ptr0)[2];
+  out[u32(unconst_u32(82))] ^= vec2i(i32(buffer6[u32(unconst_u32(36))][u32(unconst_u32(132))][u32(unconst_u32(81))][u32(unconst_u32(215))][2]));
+  let ptr10: ptr<storage, array<array<f16, 3>, 3>, read> = &buffer6[arrayLength(&buffer6)][0][u32(unconst_u32(340))];
+  let ptr11: ptr<storage, array<array<f16, 3>, 3>, read> = &buffer6[u32(unconst_u32(48))][u32(unconst_u32(23))][u32(unconst_u32(89))];
+  let ptr12: ptr<storage, f16, read> = &buffer6[u32(unconst_u32(111))][0][u32((*&buffer6)[arrayLength(&(*&buffer6))][u32(unconst_u32(382))][2][2][2])][u32(unconst_u32(231))][u32((*ptr2)[u32(unconst_u32(132))][u32(unconst_u32(103))])];
+  out[u32(unconst_u32(54))] = vec2i(i32((*&buffer6)[arrayLength(&(*&buffer6))][u32(unconst_u32(15))][u32(unconst_u32(9))][u32(unconst_u32(12))][2]));
+  let ptr13: ptr<storage, array<array<f16, 3>, 3>, read> = &buffer6[arrayLength(&buffer6)][0][u32(unconst_u32(108))];
+  return out;
+  _ = buffer6;
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4i,
+  @location(7) @interpolate(flat) f1: vec4u,
+}
+
+struct T0 {
+  @size(64) f0: mat3x3f,
+}
+
+struct VertexOutput0 {
+  @builtin(position) f0: vec4f,
+}
+
+@group(0) @binding(8) var<storage, read> buffer6: array<array<array<array<array<f16, 3>, 3>, 3>, 1>>;
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  var out: VertexOutput0;
+  let ptr16: ptr<storage, f16, read> = &buffer6[arrayLength(&buffer6)][0][2][u32(unconst_u32(15))][2];
+  return out;
+  _ = buffer6;
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool) -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  let ptr17: ptr<storage, array<f16, 3>, read> = &buffer6[u32(unconst_u32(350))][0][2][2];
+  out.f0 ^= vec4i(i32(buffer6[arrayLength(&buffer6)][0][2][u32(unconst_u32(404))][u32((*&buffer6)[arrayLength(&(*&buffer6))][0][u32(unconst_u32(16))][u32(unconst_u32(594))][u32(unconst_u32(225))])]));
+  var vf0 = fn1();
+  let ptr18: ptr<storage, f16, read> = &buffer6[arrayLength(&buffer6)][u32(unconst_u32(167))][2][2][u32(unconst_u32(70))];
+  vf0.f0 = vec4f(f32(buffer6[arrayLength(&buffer6)][0][2][2][2]));
+  let ptr19: ptr<storage, array<array<f16, 3>, 3>, read> = &(*&buffer6)[u32(unconst_u32(67))][0][u32(unconst_u32(127))];
+  var vf1: vec4h = sin(vec4h(unconst_f16(6717.9), unconst_f16(5768.4), unconst_f16(10341.8), unconst_f16(17517.4)));
+  out = FragmentOutput0(vec4i(i32((*&buffer6)[u32(unconst_u32(64))][u32(unconst_u32(14))][2][2][2])), unpack4xU8(u32((*&buffer6)[u32(unconst_u32(64))][u32(unconst_u32(14))][2][2][2])));
+  vf1 = vec4h((*&buffer6)[arrayLength(&(*&buffer6))][0][u32(unconst_u32(130))][u32(unconst_u32(287))][2]);
+  vf0.f0 *= vec4f(f32((*&buffer6)[arrayLength(&(*&buffer6))][u32(unconst_u32(17))][2][2][u32(unconst_u32(135))]));
+  let ptr20: ptr<storage, f16, read> = &(*&buffer6)[arrayLength(&(*&buffer6))][0][u32(unconst_u32(225))][2][2];
+  let ptr21: ptr<storage, array<f16, 3>, read> = &buffer6[arrayLength(&buffer6)][u32(unconst_u32(586))][2][2];
+  let ptr22: ptr<storage, array<f16, 3>, read> = &(*&buffer6)[arrayLength(&(*&buffer6))][u32(unconst_u32(68))][2][u32(unconst_u32(666))];
+  fn1();
+  return out;
+  _ = buffer6;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+  let ptr23: ptr<storage, array<array<array<array<f16, 3>, 3>, 3>, 1>, read> = &(*&buffer6)[arrayLength(&(*&buffer6)) - 1];
+  let ptr24: ptr<storage, f16, read> = &(*&buffer6)[arrayLength(&(*&buffer6))][u32(unconst_u32(318))][u32(unconst_u32(468))][2][2];
+  vw0 -= vec4f(f32((*ptr23)[0][u32(unconst_u32(176))][u32(unconst_u32(322))][2]));
+  _ = buffer6;
+}`,
+});
+let bindGroup3 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 396, resource: {buffer: buffer5, offset: 2304}}],
+});
+let buffer7 = device0.createBuffer({
+  size: 5114,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture11 = device0.createTexture({
+  size: [60, 20, 73],
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView6 = texture10.createView({});
+let sampler9 = device0.createSampler({addressModeV: 'repeat', lodMaxClamp: 88.43, compare: 'greater'});
+try {
+computePassEncoder10.setBindGroup(0, bindGroup1, new Uint32Array(1822), 336, 0);
+} catch {}
+let bindGroup4 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 396, resource: {buffer: buffer7, offset: 0, size: 320}}],
+});
+let computePassEncoder11 = commandEncoder11.beginComputePass({});
+try {
+computePassEncoder10.setBindGroup(0, bindGroup1, new Uint32Array(1382), 132, 0);
+} catch {}
+let bindGroup5 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 396, resource: {buffer: buffer7, offset: 1024, size: 388}}],
+});
+let commandEncoder12 = device0.createCommandEncoder({});
+let computePassEncoder12 = commandEncoder12.beginComputePass({});
+let sampler10 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 81.20,
+});
+try {
+computePassEncoder12.setBindGroup(0, bindGroup1, []);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+let commandEncoder13 = device0.createCommandEncoder({});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+commandEncoder13.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 192 */
+  offset: 192,
+  bytesPerRow: 15360,
+  buffer: buffer4,
+}, {
+  texture: texture3,
+  mipLevel: 1,
+  origin: {x: 2, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 12, new Float32Array(30746), 7920, 4);
+} catch {}
+let veryExplicitBindGroupLayout3 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 53,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup6 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 396, resource: {buffer: buffer5, offset: 1280, size: 4124}}],
+});
+let textureView7 = texture9.createView({aspect: 'depth-only', mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 1});
+let computePassEncoder13 = commandEncoder13.beginComputePass({});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup6, new Uint32Array(43), 2, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 2200, new Float32Array(39480), 5373, 80);
+} catch {}
+let bindGroup7 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout3,
+  entries: [{binding: 53, resource: {buffer: buffer7, offset: 512, size: 20}}],
+});
+let externalTexture1 = device0.importExternalTexture({label: '\u0f07\u{1fa07}', source: videoFrame0});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder14 = device0.createCommandEncoder({});
+let textureView8 = texture10.createView({mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder14 = commandEncoder14.beginComputePass({});
+try {
+computePassEncoder3.setBindGroup(3, bindGroup7, new Uint32Array(1941), 310, 0);
+} catch {}
+try {
+  await buffer1.mapAsync(GPUMapMode.WRITE, 0, 84);
+} catch {}
+let buffer8 = device0.createBuffer({
+  size: 2549,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder3.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+computePassEncoder10.setBindGroup(2, bindGroup7, new Uint32Array(1077), 363, 0);
+} catch {}
+let buffer9 = device0.createBuffer({
+  size: 8215,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder15 = device0.createCommandEncoder({});
+let sampler11 = device0.createSampler({addressModeU: 'repeat', lodMaxClamp: 82.18});
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+commandEncoder15.copyTextureToBuffer({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'depth-only',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3232 */
+  offset: 3232,
+  buffer: buffer0,
+}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline0 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule0}});
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let imageBitmap0 = await createImageBitmap(videoFrame0);
+let shaderModule1 = device0.createShaderModule({
+  code: `
+requires pointer_composite_access;
+
+enable f16;
+
+diagnostic(info, xyz);
+
+requires unrestricted_pointer_parameters;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw5: atomic<i32>;
+
+@group(0) @binding(8) var<storage, read> buffer10: array<array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 27>>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<workgroup> vw3: array<atomic<i32>, 6>;
+
+struct FragmentOutput1 {
+  @builtin(frag_depth) f0: f32,
+  @location(0) @interpolate(flat, centroid) f1: vec4i,
+}
+
+var<workgroup> vw6: mat2x2h;
+
+struct T0 {
+  @size(56) f0: array<u32>,
+}
+
+var<workgroup> vw2: array<array<vec4<bool>, 1>, 1>;
+
+var<workgroup> vw4: FragmentOutput1;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@fragment
+fn fragment1() -> FragmentOutput1 {
+  var out: FragmentOutput1;
+  let ptr25: ptr<storage, array<f16, 1>, read> = &(*&buffer10)[u32(unconst_u32(346))][u32(unconst_u32(220))][u32(unconst_u32(77))][0][u32(unconst_u32(91))];
+  let ptr26: ptr<storage, array<f16, 1>, read> = &buffer10[arrayLength(&buffer10)][u32(unconst_u32(163))][u32(unconst_u32(550))][u32(unconst_u32(222))][u32(unconst_u32(617))];
+  let ptr27: ptr<storage, f16, read> = &buffer10[arrayLength(&buffer10)][u32(unconst_u32(52))][0][0][0][0];
+  out.f0 = f32((*&buffer10)[arrayLength(&(*&buffer10))][26][0][0][0][0]);
+  let ptr28: ptr<storage, array<f16, 1>, read> = &buffer10[arrayLength(&buffer10)][u32(unconst_u32(122))][0][u32(unconst_u32(686))][u32(unconst_u32(52))];
+  out.f0 *= f32((*&buffer10)[arrayLength(&(*&buffer10))][26][u32(unconst_u32(300))][0][0][0]);
+  let ptr29: ptr<storage, array<f16, 1>, read> = &buffer10[u32(unconst_u32(50))][u32(unconst_u32(26))][0][u32(unconst_u32(162))][0];
+  let ptr30: ptr<storage, f16, read> = &buffer10[u32(unconst_u32(283))][26][0][0][u32(unconst_u32(24))][u32(unconst_u32(12))];
+  out.f0 = f32((*&buffer10)[arrayLength(&(*&buffer10))][u32(unconst_u32(81))][0][0][0][0]);
+  out.f0 = f32((*&buffer10)[u32(unconst_u32(258))][26][u32(unconst_u32(52))][0][0][0]);
+  let ptr31: ptr<storage, array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 27>, read> = &buffer10[u32(unconst_u32(25))];
+  discard;
+  let ptr32: ptr<storage, f16, read> = &buffer10[u32((*&buffer10)[arrayLength(&(*&buffer10))][u32(unconst_u32(69))][0][0][u32(unconst_u32(48))][u32(unconst_u32(396))])][u32(unconst_u32(32))][u32(unconst_u32(284))][u32(unconst_u32(166))][u32(unconst_u32(60))][0];
+  let ptr33: ptr<storage, array<array<array<f16, 1>, 1>, 1>, read> = &buffer10[u32(unconst_u32(36))][26][u32(unconst_u32(197))];
+  let ptr34: ptr<storage, f16, read> = &(*&buffer10)[arrayLength(&(*&buffer10))][u32(unconst_u32(49))][0][0][0][0];
+  out.f0 -= f32((*&buffer10)[arrayLength(&(*&buffer10))][u32((*&buffer10)[arrayLength(&(*&buffer10))][u32(unconst_u32(269))][u32(unconst_u32(50))][u32(unconst_u32(349))][0][u32(unconst_u32(86))])][0][0][u32(unconst_u32(200))][u32(buffer10[u32(unconst_u32(551))][u32(unconst_u32(38))][u32(unconst_u32(188))][u32(unconst_u32(31))][u32(unconst_u32(76))][0])]);
+  return out;
+  _ = buffer10;
+}
+
+@compute @workgroup_size(5, 2, 1)
+fn compute1() {
+  let ptr35: ptr<storage, array<f16, 1>, read> = &(*&buffer10)[u32(unconst_u32(196))][u32(unconst_u32(100))][0][u32(unconst_u32(145))][u32(unconst_u32(402))];
+  let vf2: bool = (*&vw2)[0][0][u32(buffer10[arrayLength(&buffer10)][u32(unconst_u32(219))][0][0][0][u32(unconst_u32(680))])];
+  let ptr36: ptr<storage, array<f16, 1>, read> = &(*&buffer10)[u32(unconst_u32(76))][26][0][0][0];
+  vw4.f1 = vec4i(i32(buffer10[arrayLength(&buffer10)][26][u32(unconst_u32(515))][u32(unconst_u32(61))][u32(unconst_u32(12))][0]));
+  let ptr37: ptr<storage, f16, read> = &(*&buffer10)[arrayLength(&(*&buffer10))][u32(unconst_u32(291))][u32(unconst_u32(173))][u32(unconst_u32(108))][0][u32((*&buffer10)[u32(unconst_u32(154))][26][0][u32(unconst_u32(109))][0][0])];
+  let ptr38: ptr<workgroup, array<array<vec4<bool>, 1>, 1>> = &vw2;
+  atomicAnd(&vw5, i32(unconst_i32(270)));
+  let ptr39: ptr<storage, array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 27>, read> = &(*&buffer10)[u32(unconst_u32(261))];
+  let ptr40: ptr<storage, f16, read> = &buffer10[u32(unconst_u32(307))][u32(unconst_u32(47))][0][u32(unconst_u32(194))][0][0];
+  var vf3: i32 = atomicExchange(&(*&vw3)[5], i32(unconst_i32(1)));
+  let ptr41: ptr<storage, array<f16, 1>, read> = &buffer10[u32(unconst_u32(27))][u32(unconst_u32(196))][u32(unconst_u32(301))][0][0];
+  let ptr42: ptr<storage, array<f16, 1>, read> = &buffer10[arrayLength(&buffer10)][u32(unconst_u32(346))][0][0][u32(buffer10[u32(any(vw2[0][u32(unconst_u32(219))]))][u32(unconst_u32(329))][u32((*&buffer10)[arrayLength(&(*&buffer10))][26][u32(unconst_u32(127))][u32(unconst_u32(167))][0][0])][u32(unconst_u32(138))][u32(unconst_u32(678))][0])];
+  atomicAnd(&vw5, i32(unconst_i32(205)));
+  vw2[u32(unconst_u32(93))][u32(unconst_u32(192))] = vec4<bool>(bool(buffer10[arrayLength(&buffer10)][26][0][0][u32(unconst_u32(23))][0]));
+  let ptr43: ptr<storage, array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 27>, read> = &(*&buffer10)[i32(unconst_i32(40))];
+  _ = buffer10;
+}`,
+});
+let autogeneratedBindGroupLayout0 = pipeline0.getBindGroupLayout(0);
+let bindGroup8 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout3,
+  entries: [{binding: 53, resource: {buffer: buffer8, offset: 1024, size: 64}}],
+});
+let texture12 = device0.createTexture({
+  size: {width: 30, height: 10, depthOrArrayLayers: 77},
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView9 = texture0.createView({baseArrayLayer: 1, arrayLayerCount: 3});
+let computePassEncoder15 = commandEncoder15.beginComputePass();
+try {
+computePassEncoder15.setBindGroup(2, bindGroup5, new Uint32Array(948), 125, 0);
+} catch {}
+try {
+computePassEncoder11.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder2.popDebugGroup();
+} catch {}
+let pipeline1 = device0.createRenderPipeline({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule1,
+  targets: [{format: 'rgba8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth32float',
+    depthWriteEnabled: true,
+    depthCompare: 'greater-equal',
+    depthBias: -1938757720,
+    depthBiasClamp: 510.4241458041224,
+  },
+  vertex: {module: shaderModule0, buffers: []},
+});
+let commandEncoder16 = device0.createCommandEncoder({});
+let texture13 = device0.createTexture({
+  size: [240, 80, 1],
+  mipLevelCount: 3,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture14 = device0.createTexture({
+  size: {width: 60, height: 20, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  sampleCount: 1,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView10 = texture0.createView({dimension: '2d', aspect: 'all'});
+try {
+computePassEncoder13.setPipeline(pipeline0);
+} catch {}
+let bindGroup9 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout0,
+  entries: [{binding: 8, resource: {buffer: buffer5, offset: 5376, size: 156}}],
+});
+let buffer11 = device0.createBuffer({
+  size: 6398,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder17 = device0.createCommandEncoder({});
+let sampler12 = device0.createSampler({});
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let videoFrame1 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'fcc', primaries: 'bt2020', transfer: 'iec6196624'} });
+let autogeneratedBindGroupLayout1 = pipeline0.getBindGroupLayout(0);
+let texture15 = device0.createTexture({
+  size: [30, 10, 1],
+  mipLevelCount: 2,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder1.setPipeline(pipeline0);
+} catch {}
+let computePassEncoder16 = commandEncoder17.beginComputePass({});
+let sampler13 = device0.createSampler({
+  label: '\u{1fe80}\uce85\u07a1\ufef1\ud1cd',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 71.36,
+  compare: 'greater',
+});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup8, new Uint32Array(39), 18, 0);
+} catch {}
+try {
+computePassEncoder14.setPipeline(pipeline0);
+} catch {}
+let imageData2 = new ImageData(20, 72);
+try {
+adapter0.label = '\u0605\u0d32\u2a41';
+} catch {}
+let textureView11 = texture7.createView({dimension: '2d', aspect: 'depth-only'});
+try {
+computePassEncoder7.setBindGroup(1, bindGroup4);
+} catch {}
+let buffer12 = device0.createBuffer({
+  size: 20327,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let commandEncoder18 = device0.createCommandEncoder({});
+let texture16 = device0.createTexture({size: [30, 10, 1], format: 'depth32float', usage: GPUTextureUsage.COPY_DST});
+let computePassEncoder17 = commandEncoder18.beginComputePass();
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder16.copyTextureToBuffer({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 8},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 28 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 796 */
+  offset: 796,
+  bytesPerRow: 1024,
+  rowsPerImage: 1574,
+  buffer: buffer4,
+}, {width: 7, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 1, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(22).fill(52), /* required buffer size: 22 */
+{offset: 22, bytesPerRow: 111}, {width: 10, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let imageData3 = new ImageData(80, 32);
+let bindGroup10 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [
+    {binding: 116, resource: {buffer: buffer7, offset: 0, size: 1244}},
+    {binding: 258, resource: textureView10},
+  ],
+});
+let commandEncoder19 = device0.createCommandEncoder({});
+try {
+computePassEncoder8.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder16.copyBufferToBuffer(buffer11, 492, buffer0, 792, 148);
+} catch {}
+try {
+commandEncoder19.copyTextureToTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 2, y: 3, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture15,
+  mipLevel: 1,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let autogeneratedBindGroupLayout2 = pipeline1.getBindGroupLayout(0);
+let buffer13 = device0.createBuffer({size: 34641, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM});
+let textureView12 = texture11.createView({});
+let renderPassEncoder0 = commandEncoder16.beginRenderPass({
+    label: 'a',
+  colorAttachments: [{view: textureView12, depthSlice: 35, loadOp: 'clear', storeOp: 'discard'}],
+  depthStencilAttachment: {view: textureView2, depthClearValue: -7.957212059547041, depthReadOnly: true, stencilClearValue: 22320},
+});
+try {
+computePassEncoder11.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+computePassEncoder14.setBindGroup(2, bindGroup4, new Uint32Array(1433), 66, 0);
+} catch {}
+try {
+computePassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder19.copyBufferToTexture({
+  /* bytesInLastRow: 56 widthInBlocks: 14 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3488 */
+  offset: 3488,
+  buffer: buffer12,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 14, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder19.copyTextureToBuffer({
+  texture: texture4,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'depth-only',
+}, {
+  /* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1992 */
+  offset: 1992,
+  bytesPerRow: 18176,
+  buffer: buffer13,
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let autogeneratedBindGroupLayout3 = pipeline1.getBindGroupLayout(0);
+let renderPassEncoder1 = commandEncoder19.beginRenderPass({
+    label: 'b',
+  colorAttachments: [{
+  view: textureView12,
+  depthSlice: 15,
+  clearValue: { r: -505.9, g: 535.7, b: 413.6, a: 862.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {view: textureView2, depthReadOnly: true, stencilClearValue: 13577},
+  occlusionQuerySet: querySet0,
+});
+let sampler14 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'not-equal',
+});
+try {
+renderPassEncoder0.end();
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer8, 344);
+} catch {}
+try {
+commandEncoder16.copyBufferToBuffer(buffer11, 1068, buffer2, 16, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 644, new BigUint64Array(13976), 5809, 136);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(32).fill(4), /* required buffer size: 32 */
+{offset: 32}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer0 = commandEncoder16.finish();
+let texture17 = device0.createTexture({
+  size: [120, 40, 147],
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let sampler15 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 92.19,
+  compare: 'not-equal',
+});
+try {
+computePassEncoder17.setBindGroup(1, bindGroup8, new Uint32Array(5703), 1_320, 0);
+} catch {}
+try {
+computePassEncoder16.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(6, buffer9);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 508, new DataView(new ArrayBuffer(8854)), 599, 1120);
+} catch {}
+let veryExplicitBindGroupLayout4 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 5,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba8sint', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 18,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 20,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let autogeneratedBindGroupLayout4 = pipeline0.getBindGroupLayout(0);
+let texture18 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 13},
+  mipLevelCount: 1,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView13 = texture3.createView({mipLevelCount: 1, arrayLayerCount: 1});
+try {
+computePassEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup8, new Uint32Array(1306), 7, 0);
+} catch {}
+let commandEncoder20 = device0.createCommandEncoder();
+let texture19 = device0.createTexture({
+  size: [60, 20, 55],
+  mipLevelCount: 2,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView14 = texture15.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+computePassEncoder17.setBindGroup(2, bindGroup8, new Uint32Array(234), 5, 0);
+} catch {}
+try {
+computePassEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 5, z: 0},
+  aspect: 'all',
+}, new Uint8Array(207).fill(97), /* required buffer size: 207 */
+{offset: 207}, {width: 60, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let textureView15 = texture13.createView({mipLevelCount: 1});
+let computePassEncoder18 = commandEncoder20.beginComputePass({});
+try {
+buffer2.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 152, new Float32Array(5469), 1789, 28);
+} catch {}
+try {
+globalThis.someLabel = renderBundle1.label;
+} catch {}
+let autogeneratedBindGroupLayout5 = pipeline0.getBindGroupLayout(0);
+let bindGroup11 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout1,
+  entries: [{binding: 8, resource: {buffer: buffer7, offset: 512, size: 96}}],
+});
+let buffer14 = device0.createBuffer({
+  size: 2105,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder21 = device0.createCommandEncoder({});
+let texture20 = device0.createTexture({
+  size: [30],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler16 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'greater-equal',
+  maxAnisotropy: 10,
+});
+let externalTexture2 = device0.importExternalTexture({source: videoFrame1});
+try {
+computePassEncoder14.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup8, new Uint32Array(1394), 120, 0);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(97);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer9, 'uint32', 200, 1_256);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(4, buffer9, 0, 257);
+} catch {}
+try {
+commandEncoder21.copyBufferToBuffer(buffer14, 1456, buffer13, 752, 288);
+} catch {}
+let bindGroup12 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout5,
+  entries: [{binding: 8, resource: {buffer: buffer14, offset: 0, size: 80}}],
+});
+let buffer15 = device0.createBuffer({
+  size: 64775,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture21 = device0.createTexture({
+  size: {width: 240, height: 80, depthOrArrayLayers: 42},
+  dimension: '2d',
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let sampler17 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.79,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder4.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+computePassEncoder7.setPipeline(pipeline0);
+} catch {}
+let texture22 = device0.createTexture({
+  size: [30, 10, 29],
+  mipLevelCount: 2,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView16 = texture1.createView({dimension: '2d-array', aspect: 'stencil-only', baseMipLevel: 0});
+let computePassEncoder19 = commandEncoder21.beginComputePass({});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8sint'],
+  depthStencilFormat: 'depth32float',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle2 = renderBundleEncoder2.finish({});
+let sampler18 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 9,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder14); computePassEncoder14.dispatchWorkgroupsIndirect(buffer4, 232); };
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(147);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle2, renderBundle2]);
+} catch {}
+let arrayBuffer0 = buffer1.getMappedRange(8, 20);
+let commandEncoder22 = device0.createCommandEncoder({});
+let textureView17 = texture8.createView({dimension: '2d-array', aspect: 'depth-only', baseArrayLayer: 8, arrayLayerCount: 1});
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup5, new Uint32Array(2440), 416, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer9, 'uint32', 2_288, 214);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(4, buffer11, 2_820, 81);
+} catch {}
+try {
+commandEncoder22.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1956 */
+  offset: 1956,
+  buffer: buffer12,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder22.resolveQuerySet(querySet0, 332, 200, buffer5, 3584);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let buffer16 = device0.createBuffer({size: 6308, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture23 = device0.createTexture({
+  size: {width: 60, height: 20, depthOrArrayLayers: 96},
+  format: 'r32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder20 = commandEncoder22.beginComputePass({});
+let sampler19 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', lodMaxClamp: 88.60});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+computePassEncoder5.setBindGroup(2, bindGroup1, new Uint32Array(608), 359, 0);
+} catch {}
+try {
+computePassEncoder6.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle1, renderBundle2, renderBundle1, renderBundle2]);
+} catch {}
+try {
+texture18.destroy();
+} catch {}
+let autogeneratedBindGroupLayout6 = pipeline0.getBindGroupLayout(0);
+let commandEncoder23 = device0.createCommandEncoder({});
+let commandBuffer1 = commandEncoder23.finish({});
+let texture24 = device0.createTexture({
+  size: {width: 120, height: 40, depthOrArrayLayers: 34},
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder15.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: -687.4, g: 428.5, b: -91.33, a: -805.4, });
+} catch {}
+let commandEncoder24 = device0.createCommandEncoder({});
+let textureView18 = texture23.createView({baseMipLevel: 0, baseArrayLayer: 46, arrayLayerCount: 1});
+let textureView19 = texture21.createView({aspect: 'depth-only', baseArrayLayer: 9, arrayLayerCount: 10});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup9, new Uint32Array(4753), 502, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder15); computePassEncoder15.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup4, new Uint32Array(781), 62, 0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(3, buffer11, 0, 1_358);
+} catch {}
+try {
+commandEncoder24.copyBufferToBuffer(buffer12, 1440, buffer4, 3592, 44);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 5, y: 2, z: 2},
+  aspect: 'all',
+}, new Uint8Array(101).fill(237), /* required buffer size: 101 */
+{offset: 101, rowsPerImage: 42}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup13 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout0,
+  entries: [{binding: 8, resource: {buffer: buffer7, offset: 512, size: 776}}],
+});
+let commandEncoder25 = device0.createCommandEncoder({});
+let computePassEncoder21 = commandEncoder24.beginComputePass({});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup8, new Uint32Array(2367), 220, 0);
+} catch {}
+try {
+computePassEncoder16.end();
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup5, new Uint32Array(679), 20, 0);
+} catch {}
+let buffer17 = device0.createBuffer({
+  size: 6364,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder26 = device0.createCommandEncoder({});
+let computePassEncoder22 = commandEncoder17.beginComputePass();
+let sampler20 = device0.createSampler({addressModeU: 'mirror-repeat', minFilter: 'nearest', lodMaxClamp: 91.83});
+try {
+computePassEncoder22.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder9.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup9);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(4, buffer17, 0, 265);
+} catch {}
+try {
+buffer2.label = '\u{1ff4d}\ua4ae\u{1fe7c}\u0865\ua1fd\ue6e6\u65da\ub24d\u{1f8ff}';
+} catch {}
+let buffer18 = device0.createBuffer({size: 4584, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder27 = device0.createCommandEncoder({label: '\u3940\u197b\ucbac\uf18d\ued07\uaf68\udbae\u087e\u0c8b\u106f'});
+let texture25 = device0.createTexture({
+  size: [120, 40, 1],
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder23 = commandEncoder25.beginComputePass({});
+let renderPassEncoder2 = commandEncoder26.beginRenderPass({
+    label: 'c',
+  colorAttachments: [{
+  view: textureView12,
+  depthSlice: 9,
+  clearValue: { r: -944.2, g: 92.63, b: -522.4, a: -534.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView2,
+    depthLoadOp: 'load',
+    depthStoreOp: 'discard',
+    depthReadOnly: false,
+    stencilClearValue: 21370,
+  },
+});
+try {
+computePassEncoder17.setBindGroup(0, bindGroup1, new Uint32Array(1259), 94, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle1, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer8, 'uint16', 8, 2_029);
+} catch {}
+try {
+commandEncoder27.copyBufferToTexture({
+  /* bytesInLastRow: 30 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 340 */
+  offset: 340,
+  bytesPerRow: 19968,
+  buffer: buffer4,
+}, {
+  texture: texture6,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 30, height: 10, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder28 = device0.createCommandEncoder({});
+let texture26 = device0.createTexture({
+  size: [120, 40, 99],
+  mipLevelCount: 1,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder24 = commandEncoder27.beginComputePass({});
+let renderPassEncoder3 = commandEncoder28.beginRenderPass({
+    label: 'd',
+  colorAttachments: [{
+  view: textureView12,
+  depthSlice: 56,
+  clearValue: { r: -593.2, g: 338.0, b: 117.8, a: 414.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {view: textureView2, depthLoadOp: 'load', depthStoreOp: 'discard', depthReadOnly: false},
+});
+try {
+renderPassEncoder2.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer9, 'uint16', 1_074, 461);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder3.insertDebugMarker('\u2b49');
+} catch {}
+try {
+device0.queue.submit([commandBuffer1]);
+} catch {}
+let textureView20 = texture26.createView({dimension: '2d', aspect: 'depth-only', baseArrayLayer: 11});
+try {
+device0.queue.writeBuffer(buffer4, 3376, new Int16Array(5887), 1156, 524);
+} catch {}
+let commandEncoder29 = device0.createCommandEncoder({});
+let computePassEncoder25 = commandEncoder29.beginComputePass();
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let bindGroup14 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 396, resource: {buffer: buffer17, offset: 256}}],
+});
+let commandEncoder30 = device0.createCommandEncoder({});
+let computePassEncoder26 = commandEncoder30.beginComputePass({});
+try {
+computePassEncoder9.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer9, 'uint16', 1_430, 150);
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline2 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule0}});
+let autogeneratedBindGroupLayout7 = pipeline1.getBindGroupLayout(0);
+let buffer19 = device0.createBuffer({
+  size: 11000,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder23.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup9);
+} catch {}
+let commandEncoder31 = device0.createCommandEncoder({});
+let renderPassEncoder4 = commandEncoder31.beginRenderPass({
+    label: 'f',
+  colorAttachments: [{
+  view: textureView12,
+  depthSlice: 56,
+  clearValue: { r: 710.1, g: 454.0, b: 942.3, a: 841.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView2,
+    depthClearValue: 0.45780801017292794,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'store',
+    stencilClearValue: 47208,
+  },
+});
+let sampler21 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', lodMaxClamp: 80.23});
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup1, new Uint32Array(105), 1, 0);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(142);
+} catch {}
+let textureView21 = texture23.createView({mipLevelCount: 1, baseArrayLayer: 38, arrayLayerCount: 13});
+let textureView22 = texture5.createView({dimension: '2d', mipLevelCount: 1});
+try {
+{ clearResourceUsages(device0, computePassEncoder14); computePassEncoder14.dispatchWorkgroupsIndirect(buffer12, 6_688); };
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer9, 'uint32', 360, 1_318);
+} catch {}
+let bindGroup15 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [
+    {binding: 116, resource: {buffer: buffer19, offset: 3072, size: 1356}},
+    {binding: 258, resource: textureView0},
+  ],
+});
+let commandEncoder32 = device0.createCommandEncoder({});
+let textureView23 = texture4.createView({aspect: 'depth-only', format: 'depth32float', mipLevelCount: 1, arrayLayerCount: 1});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder15); computePassEncoder15.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder0.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle0, renderBundle1]);
+} catch {}
+try {
+commandEncoder32.copyBufferToTexture({
+  /* bytesInLastRow: 24 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1500 */
+  offset: 1500,
+  bytesPerRow: 29696,
+  buffer: buffer16,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let imageData4 = new ImageData(4, 20);
+let veryExplicitBindGroupLayout5 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 159,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 256,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {binding: 290, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let computePassEncoder27 = commandEncoder32.beginComputePass({});
+try {
+computePassEncoder17.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup7, new Uint32Array(408), 6, 0);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer8, 'uint16', 218, 216);
+} catch {}
+let bindGroup16 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout2,
+  entries: [{binding: 8, resource: {buffer: buffer7, offset: 1536, size: 780}}],
+});
+let commandEncoder33 = device0.createCommandEncoder();
+let texture27 = device0.createTexture({
+  size: [30, 10, 1],
+  mipLevelCount: 2,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder28 = commandEncoder33.beginComputePass({});
+try {
+computePassEncoder18.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup7, new Uint32Array(367), 34, 0);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer8, 'uint32', 492, 1_899);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer17, 348, new Float32Array(6097), 1159, 428);
+} catch {}
+let texture28 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 13},
+  format: 'rg11b10ufloat',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture29 = device0.createTexture({
+  size: [60],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup13, new Uint32Array(77), 0, 0);
+} catch {}
+try {
+computePassEncoder10.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer8, 'uint16', 422, 629);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(2, buffer9);
+} catch {}
+try {
+buffer17.unmap();
+} catch {}
+await gc();
+let buffer20 = device0.createBuffer({
+  size: 6203,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView24 = texture28.createView({dimension: 'cube-array', baseArrayLayer: 1, arrayLayerCount: 6});
+let sampler22 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 11.62,
+});
+try {
+computePassEncoder10.setBindGroup(0, bindGroup7, new Uint32Array(463), 12, 0);
+} catch {}
+try {
+computePassEncoder27.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+let autogeneratedBindGroupLayout8 = pipeline0.getBindGroupLayout(0);
+let textureView25 = texture16.createView({});
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup15, new Uint32Array(867), 51, 0);
+} catch {}
+let autogeneratedBindGroupLayout9 = pipeline1.getBindGroupLayout(0);
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({colorFormats: ['rgba8sint'], depthStencilFormat: 'depth32float', stencilReadOnly: true});
+let sampler23 = device0.createSampler({
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder23.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+computePassEncoder17.setBindGroup(1, bindGroup16, new Uint32Array(3278), 993, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder15); computePassEncoder15.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder14.end();
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup4, new Uint32Array(2527), 420, 0);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(3, buffer17, 696);
+} catch {}
+let texture30 = device0.createTexture({
+  size: {width: 60, height: 20, depthOrArrayLayers: 73},
+  mipLevelCount: 4,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder29 = commandEncoder14.beginComputePass();
+try {
+computePassEncoder19.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(1, buffer7, 0);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(buffer8, 'uint16', 56, 319);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 21, z: 0},
+  aspect: 'all',
+}, new Uint8Array(47).fill(245), /* required buffer size: 47 */
+{offset: 47}, {width: 40, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let texture31 = device0.createTexture({
+  size: [240, 80, 1],
+  mipLevelCount: 4,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder17.setBindGroup(3, bindGroup10, new Uint32Array(1562), 33, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder15); computePassEncoder15.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder15.end();
+} catch {}
+try {
+computePassEncoder26.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(3, buffer4);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(5, buffer11, 0, 1_527);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+commandEncoder15.copyBufferToTexture({
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 396 */
+  offset: 376,
+  buffer: buffer3,
+}, {
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 6, y: 1, z: 3},
+  aspect: 'all',
+}, {width: 5, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder15.copyTextureToTexture({
+  texture: texture30,
+  mipLevel: 2,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture22,
+  mipLevel: 1,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer2 = commandEncoder15.finish();
+let sampler24 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 91.03});
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup13, new Uint32Array(297), 42, 0);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(buffer9, 'uint16', 2_578, 1_983);
+} catch {}
+let pipelineLayout3 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout5]});
+let buffer21 = device0.createBuffer({
+  size: 14119,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let commandEncoder34 = device0.createCommandEncoder({});
+let texture32 = device0.createTexture({
+  size: [240, 80, 1],
+  mipLevelCount: 4,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder5 = commandEncoder34.beginRenderPass({
+    label: 'g',
+  colorAttachments: [{view: textureView13, loadOp: 'load', storeOp: 'discard'}],
+  depthStencilAttachment: {view: textureView20, depthClearValue: 0.20025147634243212, depthLoadOp: 'clear', depthStoreOp: 'store'},
+});
+try {
+computePassEncoder23.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+computePassEncoder13.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder25.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer8, 'uint32', 612, 1_170);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(buffer8, 'uint16', 96, 557);
+} catch {}
+try {
+adapter0.label = '\u{1f9a3}\ua56a\u0a3b\u3de2\u83d5\u0a22\u{1fad8}\ueedc';
+} catch {}
+let autogeneratedBindGroupLayout10 = pipeline1.getBindGroupLayout(0);
+let bindGroup17 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout1,
+  entries: [{binding: 8, resource: {buffer: buffer7, offset: 1792, size: 448}}],
+});
+let sampler25 = device0.createSampler({addressModeW: 'mirror-repeat', magFilter: 'linear', mipmapFilter: 'linear'});
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer8, 'uint32', 1_080, 824);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(buffer8, 'uint16', 788, 577);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(6, buffer4, 2_996, 189);
+} catch {}
+let buffer22 = device0.createBuffer({
+  size: 35318,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let texture33 = device0.createTexture({
+  size: {width: 60, height: 20, depthOrArrayLayers: 34},
+  mipLevelCount: 4,
+  dimension: '2d',
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture3 = device0.importExternalTexture({source: videoFrame1});
+try {
+computePassEncoder4.setBindGroup(0, bindGroup17, new Uint32Array(259), 121, 0);
+} catch {}
+try {
+computePassEncoder20.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup9);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup12, new Uint32Array(3199), 269, 0);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle2, renderBundle2, renderBundle0, renderBundle2]);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(buffer22, 'uint16', 4_558, 1_511);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let commandEncoder35 = device0.createCommandEncoder({});
+let computePassEncoder30 = commandEncoder35.beginComputePass({});
+let sampler26 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 6.060,
+  lodMaxClamp: 80.58,
+  compare: 'greater-equal',
+});
+try {
+computePassEncoder7.setBindGroup(1, bindGroup15, new Uint32Array(1842), 141, 0);
+} catch {}
+try {
+computePassEncoder18.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder12.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer21, 'uint16', 1_218, 1_200);
+} catch {}
+let promise1 = device0.queue.onSubmittedWorkDone();
+let pipeline3 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {module: shaderModule1, targets: [{format: 'rgba8sint', writeMask: GPUColorWrite.GREEN}]},
+  depthStencil: {
+    format: 'depth32float',
+    depthWriteEnabled: false,
+    stencilFront: {},
+    stencilWriteMask: 1677114679,
+    depthBias: -1874332198,
+  },
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', constants: {}, buffers: []},
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', cullMode: 'front'},
+});
+let autogeneratedBindGroupLayout11 = pipeline2.getBindGroupLayout(0);
+let bindGroup18 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout1,
+  entries: [{binding: 8, resource: {buffer: buffer19, offset: 1024}}],
+});
+let commandEncoder36 = device0.createCommandEncoder();
+let computePassEncoder31 = commandEncoder36.beginComputePass();
+try {
+computePassEncoder12.setBindGroup(2, bindGroup1, new Uint32Array(3743), 185, 0);
+} catch {}
+try {
+computePassEncoder30.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer9, 'uint16', 166, 1_722);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(4, buffer11);
+} catch {}
+let bindGroup19 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout8,
+  entries: [{binding: 8, resource: {buffer: buffer15, offset: 11520, size: 18764}}],
+});
+let buffer23 = device0.createBuffer({
+  size: 3579,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let renderBundle3 = renderBundleEncoder3.finish({});
+let sampler27 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'mirror-repeat'});
+try {
+computePassEncoder2.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+computePassEncoder30.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder31.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup15);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer8, 'uint32', 404, 453);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(6, buffer20, 1_600);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 1, y: 3, z: 0},
+  aspect: 'all',
+}, new Uint8Array(10_280).fill(94), /* required buffer size: 10_280 */
+{offset: 179, bytesPerRow: 39, rowsPerImage: 37}, {width: 0, height: 0, depthOrArrayLayers: 8});
+} catch {}
+await gc();
+let autogeneratedBindGroupLayout12 = pipeline3.getBindGroupLayout(0);
+let bindGroup20 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout12,
+  entries: [{binding: 8, resource: {buffer: buffer8, offset: 0, size: 304}}],
+});
+let texture34 = device0.createTexture({
+  size: [2],
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture35 = device0.createTexture({
+  size: [30, 10, 1],
+  sampleCount: 1,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let sampler28 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'mirror-repeat', magFilter: 'nearest', lodMaxClamp: 51.62});
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline3);
+} catch {}
+let texture36 = device0.createTexture({
+  size: [60, 20, 20],
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder7.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder28.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(111);
+} catch {}
+let textureView26 = texture24.createView({format: 'r32uint', baseArrayLayer: 2, arrayLayerCount: 6});
+let texture37 = device0.createTexture({
+  size: [30],
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView27 = texture35.createView({format: 'rgba8sint'});
+try {
+renderPassEncoder3.setVertexBuffer(7, buffer20, 964, 475);
+} catch {}
+try {
+  await promise1;
+} catch {}
+let textureView28 = texture34.createView({});
+let textureView29 = texture0.createView({mipLevelCount: 1, arrayLayerCount: 7});
+let sampler29 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  lodMaxClamp: 86.14,
+});
+try {
+computePassEncoder28.setBindGroup(3, bindGroup19, new Uint32Array(1501), 1_051, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder4); computePassEncoder4.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup16);
+} catch {}
+let veryExplicitBindGroupLayout6 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 8,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 54, hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup21 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout1,
+  entries: [{binding: 8, resource: {buffer: buffer19, offset: 512}}],
+});
+let commandEncoder37 = device0.createCommandEncoder({});
+let computePassEncoder32 = commandEncoder37.beginComputePass();
+let sampler30 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 95.98,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup4, []);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 1, y: 10, z: 4},
+  aspect: 'all',
+}, new Uint8Array(52_555).fill(90), /* required buffer size: 52_555 */
+{offset: 80, bytesPerRow: 193, rowsPerImage: 15}, {width: 43, height: 2, depthOrArrayLayers: 19});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let veryExplicitBindGroupLayout7 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 53,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+try {
+computePassEncoder25.setBindGroup(1, bindGroup16, new Uint32Array(705), 108, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup9, new Uint32Array(424), 74, 0);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(7, buffer20, 3_708);
+} catch {}
+let bindGroup22 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 396, resource: {buffer: buffer22, offset: 3072, size: 7164}}],
+});
+try {
+computePassEncoder12.setBindGroup(0, bindGroup19, new Uint32Array(993), 338, 0);
+} catch {}
+try {
+computePassEncoder24.setPipeline(pipeline0);
+} catch {}
+let imageData5 = new ImageData(52, 8);
+let texture38 = device0.createTexture({
+  size: {width: 30, height: 10, depthOrArrayLayers: 23},
+  mipLevelCount: 2,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder24.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+computePassEncoder20.setBindGroup(1, bindGroup4, new Uint32Array(205), 1, 0);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(2272);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(5, buffer8, 740, 100);
+} catch {}
+let videoFrame2 = new VideoFrame(imageBitmap0, {timestamp: 0});
+let bindGroup23 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout7,
+  entries: [{binding: 53, resource: {buffer: buffer7, offset: 256, size: 1184}}],
+});
+let textureView30 = texture36.createView({label: '\u03fb\ue2a2\u2542\u3f9e', dimension: '2d'});
+let texture39 = device0.createTexture({
+  size: {width: 60, height: 20, depthOrArrayLayers: 25},
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder4); computePassEncoder4.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup5, new Uint32Array(296), 1, 0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle1, renderBundle1]);
+} catch {}
+try {
+computePassEncoder22.setBindGroup(0, bindGroup17);
+} catch {}
+try {
+computePassEncoder24.setBindGroup(0, bindGroup19, new Uint32Array(754), 75, 0);
+} catch {}
+try {
+computePassEncoder32.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(54);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline3);
+} catch {}
+let autogeneratedBindGroupLayout13 = pipeline0.getBindGroupLayout(0);
+let buffer24 = device0.createBuffer({
+  size: 48228,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let sampler31 = device0.createSampler({addressModeV: 'repeat', lodMaxClamp: 84.14, maxAnisotropy: 1});
+try {
+computePassEncoder24.setBindGroup(2, bindGroup4, []);
+} catch {}
+try {
+computePassEncoder21.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup4, new Uint32Array(1752), 690, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+renderPassEncoder3.insertDebugMarker('\u166a');
+} catch {}
+let autogeneratedBindGroupLayout14 = pipeline2.getBindGroupLayout(0);
+let bindGroup24 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 396, resource: {buffer: buffer5, offset: 1536, size: 3840}}],
+});
+let commandEncoder38 = device0.createCommandEncoder({});
+let renderPassEncoder6 = commandEncoder38.beginRenderPass({
+    label: 'h',
+  colorAttachments: [{
+  view: textureView30,
+  clearValue: { r: -470.5, g: 628.0, b: 271.7, a: -562.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {view: textureView23, depthClearValue: 8.868418674524861, depthReadOnly: true, stencilClearValue: 42380},
+});
+try {
+computePassEncoder24.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+computePassEncoder29.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup19, new Uint32Array(4388), 23, 0);
+} catch {}
+try {
+renderPassEncoder4.end();
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle1]);
+} catch {}
+let buffer25 = device0.createBuffer({size: 10513, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE});
+let commandEncoder39 = device0.createCommandEncoder({});
+let textureView31 = texture38.createView({mipLevelCount: 1, baseArrayLayer: 4, arrayLayerCount: 10});
+let textureView32 = texture8.createView({aspect: 'depth-only', baseArrayLayer: 1, arrayLayerCount: 2});
+let sampler32 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 96.90,
+  compare: 'not-equal',
+});
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup8, new Uint32Array(2910), 263, 0);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer22, 'uint32', 16_720, 349);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(5, buffer24);
+} catch {}
+try {
+commandEncoder31.copyBufferToTexture({
+  /* bytesInLastRow: 24 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 76 */
+  offset: 76,
+  bytesPerRow: 35584,
+  buffer: buffer4,
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 2,
+  origin: {x: 2, y: 0, z: 2},
+  aspect: 'all',
+}, new Uint8Array(130).fill(195), /* required buffer size: 130 */
+{offset: 130, rowsPerImage: 9}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup25 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout7,
+  entries: [{binding: 8, resource: {buffer: buffer5, offset: 0, size: 2024}}],
+});
+let commandBuffer3 = commandEncoder31.finish();
+let texture40 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 13},
+  format: 'depth32float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder33 = commandEncoder39.beginComputePass({});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({colorFormats: ['rgba8sint'], depthStencilFormat: 'depth32float', stencilReadOnly: true});
+let renderBundle4 = renderBundleEncoder4.finish({});
+try {
+renderPassEncoder1.setVertexBuffer(2, buffer8, 280);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 3892, new DataView(new ArrayBuffer(6246)), 522);
+} catch {}
+let buffer26 = device0.createBuffer({
+  size: 6908,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder40 = device0.createCommandEncoder({});
+let texture41 = device0.createTexture({
+  size: {width: 120, height: 40, depthOrArrayLayers: 37},
+  mipLevelCount: 3,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler33 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 90.68,
+  compare: 'greater',
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder10.setBindGroup(0, bindGroup17);
+} catch {}
+try {
+computePassEncoder33.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(7, 3, 11, 0);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline3);
+} catch {}
+try {
+commandEncoder40.copyBufferToTexture({
+  /* bytesInLastRow: 30 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2584 */
+  offset: 2584,
+  bytesPerRow: 1792,
+  rowsPerImage: 11,
+  buffer: buffer18,
+}, {
+  texture: texture6,
+  mipLevel: 1,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 30, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup26 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 396, resource: {buffer: buffer22, offset: 1024, size: 4464}}],
+});
+let textureView33 = texture18.createView({aspect: 'all', arrayLayerCount: 3});
+let texture42 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 13},
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8sint'],
+});
+let computePassEncoder34 = commandEncoder40.beginComputePass({});
+try {
+computePassEncoder29.setBindGroup(1, bindGroup6, []);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder5.setViewport(67.75197692782436, 26.237899403912298, 37.49454790998372, 9.707723618525664, 0.3112863064078085, 0.6639444916707524);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(5, buffer26, 128, 798);
+} catch {}
+let promise2 = device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule0,
+  constants: {},
+  targets: [{format: 'rgba8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth32float',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilReadMask: 288354875,
+    depthBias: -2092405046,
+    depthBiasSlopeScale: 0.0,
+    depthBiasClamp: 431.3224277131393,
+  },
+  vertex: {module: shaderModule0, constants: {}, buffers: []},
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'front'},
+});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let commandEncoder41 = device0.createCommandEncoder({});
+let querySet2 = device0.createQuerySet({type: 'occlusion', count: 994});
+let computePassEncoder35 = commandEncoder41.beginComputePass({});
+let sampler34 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 47.69,
+  maxAnisotropy: 8,
+});
+try {
+computePassEncoder35.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup15);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer24, 'uint32', 30_912, 4_468);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline3);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 46, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(12_953).fill(146), /* required buffer size: 12_953 */
+{offset: 349, bytesPerRow: 37, rowsPerImage: 48}, {width: 6, height: 5, depthOrArrayLayers: 8});
+} catch {}
+try {
+adapter0.label = '\u097b\u{1fa71}\u0b85\u9479\u6ccf';
+} catch {}
+try {
+device0.queue.submit([commandBuffer3]);
+} catch {}
+let autogeneratedBindGroupLayout15 = pipeline1.getBindGroupLayout(0);
+try {
+computePassEncoder34.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup17, new Uint32Array(5517), 2_815, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let autogeneratedBindGroupLayout16 = pipeline3.getBindGroupLayout(0);
+let texture43 = device0.createTexture({
+  size: {width: 240, height: 80, depthOrArrayLayers: 1},
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture44 = device0.createTexture({
+  size: {width: 60, height: 20, depthOrArrayLayers: 11},
+  mipLevelCount: 2,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder17.setBindGroup(3, bindGroup8, new Uint32Array(519), 49, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder22); computePassEncoder22.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer22, 'uint32', 8_472, 5_318);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer15, 0, 18_521);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(3).fill(113), /* required buffer size: 3 */
+{offset: 3, rowsPerImage: 2}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let veryExplicitBindGroupLayout8 = device0.createBindGroupLayout({
+  label: '\u4c3b\u923c\u0293\u96ac\u5c9f\u{1f92e}\u066d\u{1f999}\u0102\u283d\u0120',
+  entries: [
+    {
+      binding: 5,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba8sint', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 18,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 20,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let bindGroup27 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout3,
+  entries: [{binding: 8, resource: {buffer: buffer5, offset: 768}}],
+});
+let textureView34 = texture0.createView({label: '\u0949\u9d07\uacb3\u0801\uafa4\u{1febc}', dimension: 'cube-array', arrayLayerCount: 6});
+let texture45 = device0.createTexture({
+  size: [30, 10, 1],
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder34.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle2, renderBundle3, renderBundle0, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(4, buffer20, 2_160, 607);
+} catch {}
+let bindGroup28 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout12,
+  entries: [{binding: 8, resource: {buffer: buffer14, offset: 0, size: 344}}],
+});
+let buffer27 = device0.createBuffer({size: 3674, usage: GPUBufferUsage.COPY_SRC});
+let textureView35 = texture8.createView({dimension: 'cube-array', baseArrayLayer: 1, arrayLayerCount: 6});
+let sampler35 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 96.45,
+  compare: 'greater',
+  maxAnisotropy: 3,
+});
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup26);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup15, new Uint32Array(3231), 1_116, 0);
+} catch {}
+let commandEncoder42 = device0.createCommandEncoder({});
+try {
+renderPassEncoder3.setViewport(41.02018004529836, 16.479005016997647, 3.212884339934029, 2.8720927760273645, 0.3372997116099913, 0.8498705816479961);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer24, 'uint16', 12_138, 703);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 408, new DataView(new ArrayBuffer(8826)), 128, 48);
+} catch {}
+let pipeline4 = device0.createRenderPipeline({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule0,
+  constants: {},
+  targets: [{
+  format: 'rgba8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth32float',
+    depthWriteEnabled: false,
+    stencilFront: {failOp: 'keep'},
+    stencilReadMask: 2244968803,
+    depthBias: -1968190902,
+    depthBiasSlopeScale: 989.0996092380556,
+  },
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', constants: {}, buffers: []},
+  primitive: {topology: 'line-list', frontFace: 'cw'},
+});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let canvas0 = document.createElement('canvas');
+let commandEncoder43 = device0.createCommandEncoder({});
+let texture46 = device0.createTexture({
+  size: [120, 40, 1],
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder36 = commandEncoder43.beginComputePass({});
+try {
+computePassEncoder13.setBindGroup(0, bindGroup12, new Uint32Array(2634), 99, 0);
+} catch {}
+try {
+computePassEncoder36.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(4, buffer24, 0, 19_329);
+} catch {}
+try {
+commandEncoder42.copyBufferToBuffer(buffer8, 56, buffer13, 4092, 40);
+} catch {}
+try {
+commandEncoder42.copyBufferToTexture({
+  /* bytesInLastRow: 52 widthInBlocks: 13 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1320 */
+  offset: 1320,
+  bytesPerRow: 2816,
+  rowsPerImage: 45,
+  buffer: buffer12,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 8, y: 2, z: 21},
+  aspect: 'all',
+}, {width: 13, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder42.copyTextureToBuffer({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 44, y: 13, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 452 widthInBlocks: 113 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 460 */
+  offset: 460,
+  rowsPerImage: 243,
+  buffer: buffer4,
+}, {width: 113, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter0.label = '\ud432\u2216\u0544\u{1ffb6}\u0500\ucf26\u03df';
+} catch {}
+let commandEncoder44 = device0.createCommandEncoder({});
+let textureView36 = texture34.createView({});
+try {
+{ clearResourceUsages(device0, computePassEncoder4); computePassEncoder4.dispatchWorkgroupsIndirect(buffer11, 656); };
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: -947.4, g: -522.3, b: 249.4, a: -597.2, });
+} catch {}
+try {
+commandEncoder42.copyBufferToBuffer(buffer7, 140, buffer4, 740, 92);
+} catch {}
+try {
+commandEncoder44.copyBufferToTexture({
+  /* bytesInLastRow: 28 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 988 */
+  offset: 988,
+  bytesPerRow: 1280,
+  buffer: buffer20,
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer28 = device0.createBuffer({
+  size: 4808,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder12); computePassEncoder12.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup28, new Uint32Array(780), 53, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(158).fill(223), /* required buffer size: 158 */
+{offset: 158}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder45 = device0.createCommandEncoder();
+let computePassEncoder37 = commandEncoder44.beginComputePass();
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup9, new Uint32Array(1029), 98, 0);
+} catch {}
+try {
+commandEncoder45.copyBufferToTexture({
+  /* bytesInLastRow: 28 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1208 */
+  offset: 1208,
+  bytesPerRow: 12288,
+  buffer: buffer14,
+}, {
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(13).fill(125), /* required buffer size: 13 */
+{offset: 13, bytesPerRow: 13}, {width: 2, height: 10, depthOrArrayLayers: 0});
+} catch {}
+let texture47 = device0.createTexture({
+  size: [30, 10, 36],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder38 = commandEncoder45.beginComputePass();
+let renderPassEncoder7 = commandEncoder42.beginRenderPass({
+    label: 'i',
+  colorAttachments: [{
+  view: textureView30,
+  clearValue: { r: -168.3, g: 228.3, b: 891.7, a: -907.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView23,
+    depthClearValue: 2.4541465938260956,
+    depthLoadOp: 'load',
+    depthStoreOp: 'discard',
+    stencilClearValue: 61792,
+  },
+  maxDrawCount: 38273243,
+});
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer28, 'uint16', 100, 816);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+let commandEncoder46 = device0.createCommandEncoder({});
+let textureView37 = texture47.createView({mipLevelCount: 1});
+let renderPassEncoder8 = commandEncoder46.beginRenderPass({
+    label: 'j',
+  colorAttachments: [{
+  view: textureView13,
+  clearValue: { r: -143.0, g: -308.8, b: -405.3, a: -737.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {view: textureView20, depthClearValue: 0.33271487320896775, depthLoadOp: 'clear', depthStoreOp: 'store'},
+});
+try {
+computePassEncoder23.setBindGroup(0, bindGroup9, new Uint32Array(753), 242, 0);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle2]);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+buffer18.unmap();
+} catch {}
+let gpuCanvasContext0 = canvas0.getContext('webgpu');
+let commandEncoder47 = device0.createCommandEncoder({});
+let sampler36 = device0.createSampler({addressModeV: 'mirror-repeat'});
+try {
+computePassEncoder37.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup12, new Uint32Array(1192), 91, 0);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer4, 0, 1_176);
+} catch {}
+let arrayBuffer1 = buffer1.getMappedRange(32, 0);
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+let commandEncoder48 = device0.createCommandEncoder({label: '\u{1fab7}\u2ff1\u0ec1\u01ce\ua7e2\ue91f\u{1f9bd}\u{1fc61}\u{1ff1b}\ua545'});
+let texture48 = device0.createTexture({
+  size: {width: 60},
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder23.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+computePassEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder38.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle1]);
+} catch {}
+await gc();
+let commandEncoder49 = device0.createCommandEncoder();
+let textureView38 = texture28.createView({dimension: 'cube-array', baseArrayLayer: 4, arrayLayerCount: 6});
+try {
+computePassEncoder12.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+computePassEncoder22.end();
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+commandEncoder48.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1552 */
+  offset: 1552,
+  buffer: buffer23,
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder18.pushDebugGroup('\ud5fb');
+} catch {}
+try {
+computePassEncoder18.popDebugGroup();
+} catch {}
+let commandEncoder50 = device0.createCommandEncoder({});
+try {
+computePassEncoder30.setBindGroup(1, bindGroup28, new Uint32Array(3761), 293, 0);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline3);
+} catch {}
+try {
+commandEncoder17.copyBufferToTexture({
+  /* bytesInLastRow: 36 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 416 */
+  offset: 416,
+  bytesPerRow: 18688,
+  buffer: buffer20,
+}, {
+  texture: texture22,
+  mipLevel: 1,
+  origin: {x: 3, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise3 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise3;
+} catch {}
+document.body.append(canvas0);
+let shaderModule2 = device0.createShaderModule({
+  code: `
+requires packed_4x8_integer_dot_product;
+
+enable f16;
+
+diagnostic(info, xyz);
+
+struct VertexOutput1 {
+  @builtin(position) f1: vec4f,
+  @location(13) @interpolate(flat) f2: vec2f,
+  @location(0) @interpolate(flat, centroid) f3: vec4h,
+}
+
+var<workgroup> vw9: FragmentOutput2;
+
+var<workgroup> vw12: array<VertexOutput1, 1>;
+
+@id(29819) override override2: u32;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@id(32077) override override1: u32 = 33;
+
+struct T0 {
+  @align(16) @size(16) f0: atomic<i32>,
+  @align(16) @size(1056) f1: array<array<atomic<i32>, 2>>,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@id(49292) override override3: u32;
+
+struct S0 {
+  @builtin(local_invocation_index) f0: u32,
+}
+
+fn fn0(a0: ptr<function, mat2x4f>) -> FragmentOutput2 {
+  var out: FragmentOutput2;
+  (*a0) -= (*a0);
+  out = FragmentOutput2(vec4i(acosh(vec3h(unconst_f16(5325.3), unconst_f16(4320.3), unconst_f16(8099.0))).bbbb));
+  let vf4: u32 = override3;
+  vp0 = pow(f16(unconst_f16(5005.2)), f16(unconst_f16(-24102.1)));
+  vp0 = f16(vp1.f2[u32(unconst_u32(260))]);
+  return out;
+  _ = override3;
+}
+
+fn fn1(a0: array<mat2x2h, 1>) -> mat2x3f {
+  var out: mat2x3f;
+  vw9 = FragmentOutput2(vec4i((*&vw13)));
+  vw10.f2 += unpack2x16unorm(override4);
+  vw7 = S0(u32(vw12[0].f3.a));
+  vw10 = VertexOutput1(unpack4x8snorm(reverseBits(u32(unconst_u32(34)))), unpack2x16snorm(reverseBits(u32(unconst_u32(34)))), vec4h(f16(reverseBits(u32(unconst_u32(34))))));
+  vw13 = vec4h(f16((*&vw7).f0));
+  vw10.f3 -= vp1.f3;
+  vp2.f0 *= (*&vw7).f0;
+  vw8 = S0(vec4u((*&vw12)[0].f1)[2]);
+  vw8 = S0(bitcast<vec2u>(vp1.f2).y);
+  vp0 += f16((*&vw12)[0].f2[u32(unconst_u32(48))]);
+  let ptr44: ptr<workgroup, vec4h> = &vw10.f3;
+  return out;
+  _ = override4;
+}
+
+var<workgroup> vw10: VertexOutput1;
+
+var<workgroup> vw7: S0;
+
+var<workgroup> vw13: vec4h;
+
+override override4: u32;
+
+var<private> vp1: VertexOutput1 = VertexOutput1();
+
+var<private> vp0: f16 = f16(6384.1);
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<workgroup> vw11: FragmentOutput2;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct T1 {
+  f0: mat2x3h,
+  @size(1184) f1: array<vec2u>,
+}
+
+override override0: u32;
+
+@group(0) @binding(216) var tex0: texture_cube_array<f32>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn fn2() -> FragmentOutput2 {
+  var out: FragmentOutput2;
+  return out;
+}
+
+var<workgroup> vw8: S0;
+
+struct FragmentOutput2 {
+  @location(0) @interpolate(flat, sample) f0: vec4i,
+}
+
+var<private> vp2: S0 = S0(u32(4));
+
+@vertex
+fn vertex1(@location(5) a0: vec2f, @location(14) a1: f16, @location(4) @interpolate(flat) a2: vec2f) -> VertexOutput1 {
+  var out: VertexOutput1;
+  vp0 *= radians(vec4h(unconst_f16(19133.4), unconst_f16(1432.2), unconst_f16(4639.1), unconst_f16(3278.8)))[3];
+  let vf5: u32 = textureNumLevels(tex0);
+  let vf6: u32 = override2;
+  var vf7: f16 = vp1.f3[u32(unconst_u32(77))];
+  let ptr45: ptr<private, vec4f> = &vp1.f1;
+  let ptr46: ptr<private, vec4f> = &vp1.f1;
+  let vf8: vec2f = a2;
+  out = VertexOutput1(mix(vec4f(unconst_f32(0.00054), unconst_f32(0.04568), unconst_f32(0.08450), unconst_f32(0.01121)), vec4f(unconst_f32(0.3550), unconst_f32(0.3115), unconst_f32(0.1461), unconst_f32(0.6961)), vec4f(unconst_f32(0.3184), unconst_f32(0.2893), unconst_f32(-0.4803), unconst_f32(0.6195))), mix(vec4f(unconst_f32(0.00054), unconst_f32(0.04568), unconst_f32(0.08450), unconst_f32(0.01121)), vec4f(unconst_f32(0.3550), unconst_f32(0.3115), unconst_f32(0.1461), unconst_f32(0.6961)), vec4f(unconst_f32(0.3184), unconst_f32(0.2893), unconst_f32(-0.4803), unconst_f32(0.6195))).ra, vec4h(mix(vec4f(unconst_f32(0.00054), unconst_f32(0.04568), unconst_f32(0.08450), unconst_f32(0.01121)), vec4f(unconst_f32(0.3550), unconst_f32(0.3115), unconst_f32(0.1461), unconst_f32(0.6961)), vec4f(unconst_f32(0.3184), unconst_f32(0.2893), unconst_f32(-0.4803), unconst_f32(0.6195)))));
+  let vf9: vec2h = mix(vec2h(unconst_f16(1104.9), unconst_f16(-5745.7)), vec2h(unconst_f16(5089.8), unconst_f16(1024.6)), f16(unconst_f16(6114.5)));
+  vp1.f3 = bitcast<vec4h>(vp1.f2);
+  let vf10: f32 = (*ptr46)[u32(unconst_u32(108))];
+  return out;
+  _ = override2;
+  _ = tex0;
+}
+
+@fragment
+fn fragment2(@location(13) @interpolate(perspective) a0: vec2f, @location(0) @interpolate(linear) a1: vec4h) -> FragmentOutput2 {
+  var out: FragmentOutput2;
+  var vf11 = fn2();
+  fn2();
+  var vf12: vec4h = tanh(vec4h(unconst_f16(1475.6), unconst_f16(-8336.7), unconst_f16(10790.3), unconst_f16(12753.6)));
+  vp0 = f16(a0[u32(unconst_u32(162))]);
+  let vf13: vec2f = a0;
+  vf12 = vf12;
+  vp2.f0 *= vec4u(vp1.f3)[1];
+  vp2.f0 ^= override2;
+  let ptr47: ptr<private, vec4f> = &vp1.f1;
+  var vf14 = fn2();
+  vf14.f0 = vec4i(tanh(vec4h(unconst_f16(974.5), unconst_f16(97.87), unconst_f16(12857.8), unconst_f16(31858.5))));
+  out = FragmentOutput2(bitcast<vec4i>(vp1.f1));
+  var vf15: f32 = vp1.f2[u32(unconst_u32(281))];
+  vp1 = VertexOutput1(vec4f(a1), bitcast<vec2f>(a1), a1);
+  var vf16: u32 = override3;
+  let vf17: f32 = step(f32(unconst_f32(0.2829)), f32(unconst_f32(-0.2386)));
+  let vf18: vec3h = sinh(vec3h(unconst_f16(1804.3), unconst_f16(12853.5), unconst_f16(-18901.2)));
+  var vf19: vec2f = unpack2x16float(u32(unconst_u32(49)));
+  return out;
+  _ = override3;
+  _ = override2;
+}
+
+@compute @workgroup_size(1, 1, 2)
+fn compute2(a0: S0) {
+  vw11.f0 = vec4i(i32(vw12[0].f2[u32(unconst_u32(25))]));
+  var vf20: f16 = vw13[u32(unconst_u32(144))];
+  var vf21: FragmentOutput2 = workgroupUniformLoad(&vw11);
+  fn1(array<mat2x2h, 1>(mat2x2h()));
+  let ptr48: ptr<private, u32> = &vp2.f0;
+  vw10 = VertexOutput1(vec4f((*&vw12)[0].f3), bitcast<vec2f>((*&vw12)[0].f3), (*&vw12)[0].f3);
+  vw12[u32(vp1.f1[u32(unconst_u32(278))])] = VertexOutput1(vw12[u32(unconst_u32(266))].f2.grrr, vw12[u32(unconst_u32(266))].f2, bitcast<vec4h>(vw12[u32(unconst_u32(266))].f2));
+  vw13 += (*&vw12)[0].f3;
+  fn2();
+  vf21 = FragmentOutput2(vec4i((*&vw9).f0[u32(unconst_u32(302))]));
+  let ptr49: ptr<workgroup, vec4h> = &(*&vw10).f3;
+  vw13 -= vec4h(f16((*&vw7).f0));
+  _ = override4;
+}`,
+});
+let computePassEncoder39 = commandEncoder49.beginComputePass({});
+try {
+computePassEncoder39.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer8, 'uint16', 188, 270);
+} catch {}
+try {
+commandEncoder50.insertDebugMarker('\u0f1c');
+} catch {}
+try {
+commandEncoder17.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 992 */
+  offset: 992,
+  bytesPerRow: 1792,
+  buffer: buffer4,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 8, y: 3, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline5 = await device0.createComputePipelineAsync({layout: pipelineLayout0, compute: {module: shaderModule2, constants: {override4: 0}}});
+let buffer29 = device0.createBuffer({
+  size: 10531,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let computePassEncoder40 = commandEncoder50.beginComputePass({});
+try {
+computePassEncoder10.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder24); computePassEncoder24.dispatchWorkgroupsIndirect(buffer23, 228); };
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder17.resolveQuerySet(querySet1, 54, 28, buffer5, 768);
+} catch {}
+let bindGroup29 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout14,
+  entries: [{binding: 8, resource: {buffer: buffer5, offset: 5632}}],
+});
+let querySet3 = device0.createQuerySet({type: 'occlusion', count: 447});
+let textureView39 = texture1.createView({label: '\u{1f947}\ua1f5\ub825\uaeb4', dimension: '2d-array', baseArrayLayer: 0});
+try {
+computePassEncoder32.setBindGroup(2, bindGroup17, new Uint32Array(2063), 1_795, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup26, new Uint32Array(815), 305, 0);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline3);
+} catch {}
+try {
+commandEncoder48.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2584 */
+  offset: 2584,
+  buffer: buffer3,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup30 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout16,
+  entries: [{binding: 8, resource: {buffer: buffer15, offset: 9472, size: 1512}}],
+});
+let commandEncoder51 = device0.createCommandEncoder({});
+let texture49 = device0.createTexture({
+  size: [30, 10, 36],
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder9 = commandEncoder47.beginRenderPass({
+    label: 'k',
+  colorAttachments: [{
+  view: textureView30,
+  clearValue: { r: 826.5, g: -517.7, b: -183.6, a: 123.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView2,
+    depthClearValue: 0.5749965811186777,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'store',
+    stencilReadOnly: false,
+  },
+  occlusionQuerySet: querySet2,
+});
+let sampler37 = device0.createSampler({addressModeU: 'repeat', minFilter: 'linear', mipmapFilter: 'linear', compare: 'not-equal'});
+try {
+computePassEncoder39.setBindGroup(3, bindGroup24);
+} catch {}
+try {
+computePassEncoder30.setBindGroup(2, bindGroup6, new Uint32Array(155), 37, 0);
+} catch {}
+try {
+computePassEncoder4.end();
+} catch {}
+try {
+computePassEncoder40.setPipeline(pipeline5);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let pipeline6 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule1, constants: {}}});
+let buffer30 = device0.createBuffer({
+  size: 7898,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder52 = device0.createCommandEncoder({});
+try {
+renderPassEncoder2.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer21, 'uint32', 3_412, 2_551);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(6, buffer24, 15_820);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let videoFrame3 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'smpte432', transfer: 'smpteSt4281'} });
+let autogeneratedBindGroupLayout17 = pipeline1.getBindGroupLayout(0);
+let commandEncoder53 = device0.createCommandEncoder({});
+let querySet4 = device0.createQuerySet({type: 'occlusion', count: 633});
+let computePassEncoder41 = commandEncoder4.beginComputePass({});
+try {
+computePassEncoder23.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder23); computePassEncoder23.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder20.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup26, new Uint32Array(1448), 236, 0);
+} catch {}
+try {
+buffer17.unmap();
+} catch {}
+try {
+commandEncoder52.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 132 */
+  offset: 132,
+  bytesPerRow: 13312,
+  buffer: buffer18,
+}, {
+  texture: texture30,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas0);
+let bindGroup31 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [
+    {binding: 18, resource: textureView0},
+    {binding: 5, resource: textureView12},
+    {binding: 20, resource: textureView11},
+  ],
+});
+try {
+renderPassEncoder9.beginOcclusionQuery(198);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer29, 'uint16', 550, 740);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(5, buffer17, 2_396, 185);
+} catch {}
+let imageData6 = new ImageData(72, 20);
+let videoFrame4 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'film', transfer: 'log'} });
+let autogeneratedBindGroupLayout18 = pipeline6.getBindGroupLayout(0);
+let querySet5 = device0.createQuerySet({type: 'occlusion', count: 179});
+let computePassEncoder42 = commandEncoder17.beginComputePass({});
+try {
+computePassEncoder7.setBindGroup(3, bindGroup8, new Uint32Array(1436), 100, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup31);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup6, new Uint32Array(4276), 737, 0);
+} catch {}
+try {
+commandEncoder52.clearBuffer(buffer23, 228, 272);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer24, 852, new DataView(new ArrayBuffer(4881)), 189);
+} catch {}
+let pipeline7 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule0, constants: {}}});
+let texture50 = device0.createTexture({
+  size: {width: 240, height: 80, depthOrArrayLayers: 16},
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView40 = texture11.createView({mipLevelCount: 1});
+let renderPassEncoder10 = commandEncoder48.beginRenderPass({
+    label: 'l',
+  colorAttachments: [{
+  view: textureView13,
+  clearValue: { r: -240.4, g: -380.0, b: -407.5, a: 609.1, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView20,
+    depthClearValue: 8.154279140696751,
+    depthLoadOp: 'load',
+    depthStoreOp: 'discard',
+    stencilClearValue: 12532,
+    stencilReadOnly: true,
+  },
+  maxDrawCount: 219300040,
+});
+try {
+computePassEncoder32.setBindGroup(3, bindGroup12, new Uint32Array(4057), 481, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder12); computePassEncoder12.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder6.setPipeline(pipeline5);
+} catch {}
+try {
+computePassEncoder42.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup12);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline3);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(321).fill(243), /* required buffer size: 321 */
+{offset: 321, rowsPerImage: 68}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame5 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'smpte170m', transfer: 'smpte240m'} });
+let commandEncoder54 = device0.createCommandEncoder({});
+let textureView41 = texture30.createView({dimension: '3d', mipLevelCount: 1});
+let computePassEncoder43 = commandEncoder51.beginComputePass({});
+let renderPassEncoder11 = commandEncoder54.beginRenderPass({
+    label: 'm',
+  colorAttachments: [{view: textureView40, depthSlice: 45, loadOp: 'load', storeOp: 'discard'}],
+  depthStencilAttachment: {view: textureView23, depthReadOnly: true},
+  occlusionQuerySet: querySet4,
+});
+let sampler38 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.91,
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder43.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer28, 'uint32', 640, 1_027);
+} catch {}
+try {
+commandEncoder52.resolveQuerySet(querySet5, 11, 1, buffer21, 1280);
+} catch {}
+let pipeline8 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule0}});
+document.body.prepend(canvas0);
+let bindGroup32 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout2,
+  entries: [{binding: 8, resource: {buffer: buffer5, offset: 768}}],
+});
+let commandEncoder55 = device0.createCommandEncoder({});
+try {
+{ clearResourceUsages(device0, computePassEncoder24); computePassEncoder24.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder41.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup30, new Uint32Array(3658), 601, 0);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle0, renderBundle4]);
+} catch {}
+try {
+commandEncoder53.copyBufferToTexture({
+  /* bytesInLastRow: 30 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2180 */
+  offset: 2180,
+  buffer: buffer27,
+}, {
+  texture: texture6,
+  mipLevel: 1,
+  origin: {x: 0, y: 6, z: 0},
+  aspect: 'stencil-only',
+}, {width: 30, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture51 = device0.createTexture({
+  size: [120, 40, 1],
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture52 = device0.createTexture({size: {width: 240}, dimension: '1d', format: 'rgba8sint', usage: GPUTextureUsage.STORAGE_BINDING});
+let renderPassEncoder12 = commandEncoder53.beginRenderPass({
+    label: 'n',
+  colorAttachments: [{
+  view: textureView30,
+  clearValue: { r: -635.0, g: 816.4, b: -343.7, a: 694.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView23,
+    depthClearValue: -7.087787716645398,
+    depthLoadOp: 'load',
+    depthStoreOp: 'discard',
+    depthReadOnly: false,
+    stencilClearValue: 41657,
+    stencilReadOnly: false,
+  },
+  maxDrawCount: 282531233,
+});
+try {
+device0.queue.writeTexture({
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 4, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(492).fill(75), /* required buffer size: 492 */
+{offset: 476}, {width: 4, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let autogeneratedBindGroupLayout19 = pipeline0.getBindGroupLayout(0);
+let computePassEncoder44 = commandEncoder55.beginComputePass({});
+let renderPassEncoder13 = commandEncoder52.beginRenderPass({
+    label: 'o',
+  colorAttachments: [{
+  view: textureView13,
+  clearValue: { r: -682.5, g: -915.2, b: -500.2, a: -45.08, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {view: textureView20, depthClearValue: 0.7052029111325323, depthLoadOp: 'clear', depthStoreOp: 'store'},
+});
+let sampler39 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.47,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder10.setBindGroup(3, bindGroup30, new Uint32Array(1202), 261, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder13); computePassEncoder13.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder44.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup30, new Uint32Array(4202), 72, 0);
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(buffer14, 176);
+} catch {}
+try {
+renderPassEncoder6.drawIndirect(buffer21, 152);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer24, 'uint32', 9_864, 4_593);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer25, 5588, new Int16Array(12372), 2720, 984);
+} catch {}
+try {
+adapter0.label = '\u782d\u4d53\ucb89\u3046';
+} catch {}
+let textureView42 = texture0.createView({dimension: 'cube-array', aspect: 'all', arrayLayerCount: 6});
+try {
+computePassEncoder23.end();
+} catch {}
+try {
+computePassEncoder30.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(buffer11, 252);
+} catch {}
+try {
+renderPassEncoder6.drawIndirect(buffer4, 6_496);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+commandEncoder25.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1228 */
+  offset: 1228,
+  buffer: buffer11,
+}, {
+  texture: texture30,
+  mipLevel: 3,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer31 = device0.createBuffer({size: 9096, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let commandEncoder56 = device0.createCommandEncoder({});
+let textureView43 = texture47.createView({mipLevelCount: 1});
+let texture53 = device0.createTexture({
+  size: [30, 10, 1],
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView44 = texture46.createView({dimension: '2d-array', aspect: 'depth-only'});
+try {
+{ clearResourceUsages(device0, computePassEncoder10); computePassEncoder10.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder6.draw(31, 163, 1_003_791_427, 104_498_331);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer28, 'uint16', 928, 381);
+} catch {}
+try {
+commandEncoder25.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 124 */
+  offset: 124,
+  bytesPerRow: 8704,
+  rowsPerImage: 623,
+  buffer: buffer30,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 4, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(99).fill(248), /* required buffer size: 99 */
+{offset: 99}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let imageData7 = new ImageData(56, 52);
+let bindGroup33 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [
+    {binding: 18, resource: textureView22},
+    {binding: 20, resource: textureView22},
+    {binding: 5, resource: textureView12},
+  ],
+});
+let buffer32 = device0.createBuffer({
+  size: 24304,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let computePassEncoder45 = commandEncoder56.beginComputePass({});
+try {
+computePassEncoder12.setBindGroup(1, bindGroup6, new Uint32Array(206), 4, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder10); computePassEncoder10.dispatchWorkgroupsIndirect(buffer4, 1_984); };
+} catch {}
+try {
+computePassEncoder45.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup16, new Uint32Array(951), 288, 0);
+} catch {}
+try {
+renderPassEncoder6.drawIndirect(buffer9, 1_724);
+} catch {}
+try {
+commandEncoder25.resolveQuerySet(querySet1, 69, 7, buffer11, 1024);
+} catch {}
+let pipeline9 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule1}});
+let videoFrame6 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'bt470m', transfer: 'gamma28curve'} });
+let commandEncoder57 = device0.createCommandEncoder({});
+let computePassEncoder46 = commandEncoder25.beginComputePass({});
+try {
+computePassEncoder46.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup23, new Uint32Array(162), 110, 0);
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(buffer7, 1_360);
+} catch {}
+try {
+renderPassEncoder6.drawIndirect(buffer11, 624);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder58 = device0.createCommandEncoder({});
+let texture54 = device0.createTexture({
+  size: {width: 240, height: 80, depthOrArrayLayers: 1},
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView45 = texture53.createView({dimension: '2d-array', arrayLayerCount: 1});
+let sampler40 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', minFilter: 'linear', lodMaxClamp: 83.76});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup25, new Uint32Array(3714), 1_065, 0);
+} catch {}
+try {
+renderPassEncoder6.draw(2, 191, 858_031_148, 334_811_822);
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(buffer9, 388);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline4);
+} catch {}
+try {
+buffer25.unmap();
+} catch {}
+try {
+commandEncoder57.copyBufferToBuffer(buffer4, 436, buffer8, 304, 236);
+} catch {}
+try {
+commandEncoder57.copyTextureToTexture({
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 148, y: 10, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup34 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout2,
+  entries: [{binding: 8, resource: {buffer: buffer15, offset: 9984, size: 836}}],
+});
+let commandEncoder59 = device0.createCommandEncoder({});
+let computePassEncoder47 = commandEncoder58.beginComputePass({});
+try {
+renderPassEncoder6.draw(87, 56, 154_839_956, 943_726_552);
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(buffer23, 736);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(3, buffer30, 1_876);
+} catch {}
+let autogeneratedBindGroupLayout20 = pipeline1.getBindGroupLayout(0);
+let computePassEncoder48 = commandEncoder57.beginComputePass();
+try {
+computePassEncoder24.setBindGroup(2, bindGroup22, []);
+} catch {}
+try {
+renderPassEncoder2.setViewport(34.685514391725455, 6.600216606569385, 14.04736873602923, 5.290955403892724, 0.764756234350238, 0.9473969486938585);
+} catch {}
+try {
+renderPassEncoder6.draw(86, 405, 561_630_268, 33_930_352);
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(buffer4, 376);
+} catch {}
+try {
+renderPassEncoder6.drawIndirect(buffer7, 1_188);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(1, buffer11, 0);
+} catch {}
+try {
+commandEncoder59.resolveQuerySet(querySet2, 297, 142, buffer7, 512);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(354).fill(170), /* required buffer size: 354 */
+{offset: 354}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas0);
+let autogeneratedBindGroupLayout21 = pipeline3.getBindGroupLayout(0);
+let textureView46 = texture27.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder49 = commandEncoder59.beginComputePass();
+let externalTexture4 = device0.importExternalTexture({source: videoFrame4});
+try {
+computePassEncoder32.setBindGroup(0, bindGroup33);
+} catch {}
+try {
+computePassEncoder47.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(buffer21, 2_832);
+} catch {}
+let buffer33 = device0.createBuffer({size: 2987, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+try {
+computePassEncoder3.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle4, renderBundle0, renderBundle0, renderBundle2, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(buffer0, 1_756);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let autogeneratedBindGroupLayout22 = pipeline7.getBindGroupLayout(0);
+let bindGroup35 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [
+    {binding: 18, resource: textureView2},
+    {binding: 5, resource: textureView40},
+    {binding: 20, resource: textureView0},
+  ],
+});
+let texture55 = device0.createTexture({size: [30, 10, 22], format: 'rgba8sint', usage: GPUTextureUsage.STORAGE_BINDING});
+let textureView47 = texture32.createView({dimension: '2d-array', mipLevelCount: 1, arrayLayerCount: 1});
+try {
+computePassEncoder25.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+computePassEncoder10.end();
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup13, new Uint32Array(469), 53, 0);
+} catch {}
+try {
+renderPassEncoder6.draw(163, 6, 161_992_051, 718_595_568);
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(buffer32, 5_916);
+} catch {}
+try {
+renderPassEncoder6.drawIndirect(buffer28, 840);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer21, 'uint16', 908, 2_304);
+} catch {}
+try {
+commandEncoder10.copyBufferToTexture({
+  /* bytesInLastRow: 88 widthInBlocks: 22 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 952 */
+  offset: 952,
+  bytesPerRow: 25856,
+  buffer: buffer27,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 22, height: 2, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let bindGroup36 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout3,
+  entries: [{binding: 53, resource: {buffer: buffer14, offset: 768, size: 484}}],
+});
+let texture56 = device0.createTexture({
+  size: [30, 10, 1],
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+computePassEncoder48.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder9.beginOcclusionQuery(77);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(buffer28, 1_344);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(6, buffer17, 0, 378);
+} catch {}
+try {
+commandEncoder10.insertDebugMarker('\u0583');
+} catch {}
+let computePassEncoder50 = commandEncoder10.beginComputePass();
+let externalTexture5 = device0.importExternalTexture({source: videoFrame3});
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderPassEncoder6.drawIndirect(buffer11, 1_864);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer24, 'uint16', 4_536, 3_597);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(0, buffer26, 0, 4_891);
+} catch {}
+try {
+buffer32.unmap();
+} catch {}
+let querySet6 = device0.createQuerySet({type: 'occlusion', count: 553});
+let texture57 = device0.createTexture({
+  size: {width: 60},
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView48 = texture48.createView({});
+let sampler41 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 38.62,
+});
+try {
+computePassEncoder27.setBindGroup(1, bindGroup15, new Uint32Array(1469), 117, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder3); computePassEncoder3.dispatchWorkgroupsIndirect(buffer32, 4_596); };
+} catch {}
+try {
+computePassEncoder46.end();
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup12);
+} catch {}
+try {
+renderPassEncoder6.end();
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: 635.6, g: -166.0, b: 259.9, a: 936.9, });
+} catch {}
+try {
+computePassEncoder40.insertDebugMarker('\u023c');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 2, y: 3, z: 1},
+  aspect: 'all',
+}, new Uint8Array(230).fill(36), /* required buffer size: 230 */
+{offset: 230}, {width: 7, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let autogeneratedBindGroupLayout23 = pipeline7.getBindGroupLayout(0);
+let commandEncoder60 = device0.createCommandEncoder();
+let textureView49 = texture10.createView({dimension: '2d-array'});
+let computePassEncoder51 = commandEncoder60.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder13); computePassEncoder13.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder33.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer28, 'uint32', 640, 67);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(4, buffer20);
+} catch {}
+try {
+commandEncoder25.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 220 */
+  offset: 220,
+  buffer: buffer11,
+}, {
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 12, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let imageData8 = new ImageData(120, 92);
+let buffer34 = device0.createBuffer({
+  size: 10839,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let textureView50 = texture34.createView({});
+let renderPassEncoder14 = commandEncoder38.beginRenderPass({
+    label: '[',
+  colorAttachments: [{
+  view: textureView13,
+  clearValue: { r: -905.8, g: 630.1, b: 901.6, a: -376.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView44,
+    depthClearValue: -8.625265349731299,
+    depthLoadOp: 'load',
+    depthStoreOp: 'discard',
+    depthReadOnly: false,
+  },
+  occlusionQuerySet: querySet4,
+  maxDrawCount: 87148844,
+});
+try {
+computePassEncoder47.setBindGroup(0, bindGroup8, new Uint32Array(1071), 101, 0);
+} catch {}
+try {
+computePassEncoder20.end();
+} catch {}
+try {
+computePassEncoder50.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline1);
+} catch {}
+let arrayBuffer2 = buffer1.getMappedRange(0, 0);
+try {
+commandEncoder22.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4804 */
+  offset: 4804,
+  bytesPerRow: 5888,
+  buffer: buffer31,
+}, {
+  texture: texture3,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder25.clearBuffer(buffer23, 180, 572);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let bindGroup37 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout3,
+  entries: [{binding: 53, resource: {buffer: buffer7, offset: 512, size: 1052}}],
+});
+let commandEncoder61 = device0.createCommandEncoder();
+let commandBuffer4 = commandEncoder22.finish();
+let texture58 = device0.createTexture({
+  size: {width: 30, height: 10, depthOrArrayLayers: 36},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder15 = commandEncoder25.beginRenderPass({
+    label: 'p',
+  colorAttachments: [{
+  view: textureView13,
+  clearValue: { r: -696.7, g: -832.6, b: 496.8, a: -351.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {view: textureView20, depthClearValue: 0.5316383215394045, depthLoadOp: 'clear', depthStoreOp: 'store'},
+  occlusionQuerySet: querySet2,
+  maxDrawCount: 304370538,
+});
+let sampler42 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', lodMaxClamp: 86.99});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup16);
+} catch {}
+try {
+computePassEncoder48.setBindGroup(2, bindGroup23, new Uint32Array(2002), 1_652, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder12); computePassEncoder12.dispatchWorkgroupsIndirect(buffer14, 40); };
+} catch {}
+try {
+computePassEncoder51.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle1, renderBundle1, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer28, 'uint32', 1_896, 334);
+} catch {}
+try {
+buffer20.unmap();
+} catch {}
+try {
+commandEncoder61.copyBufferToTexture({
+  /* bytesInLastRow: 120 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 112 */
+  offset: 112,
+  buffer: buffer16,
+}, {
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 30, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture59 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 13},
+  mipLevelCount: 1,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView51 = texture12.createView({baseArrayLayer: 11, arrayLayerCount: 8});
+try {
+computePassEncoder24.end();
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline3);
+} catch {}
+let bindGroup38 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 396, resource: {buffer: buffer32, offset: 5888, size: 344}}],
+});
+let buffer35 = device0.createBuffer({size: 3102, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture60 = device0.createTexture({
+  size: [120, 40, 147],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder52 = commandEncoder61.beginComputePass({});
+try {
+computePassEncoder42.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+computePassEncoder52.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup34, new Uint32Array(982), 240, 0);
+} catch {}
+try {
+commandEncoder27.copyTextureToBuffer({
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 2, y: 10, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 124 widthInBlocks: 31 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 76 */
+  offset: 76,
+  bytesPerRow: 32000,
+  buffer: buffer29,
+}, {width: 31, height: 21, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let autogeneratedBindGroupLayout24 = pipeline2.getBindGroupLayout(0);
+let commandEncoder62 = device0.createCommandEncoder({});
+let textureView52 = texture58.createView({});
+let texture61 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 13},
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder3); computePassEncoder3.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup22, new Uint32Array(555), 376, 0);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle1, renderBundle1, renderBundle4, renderBundle4, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer29, 'uint16', 1_432, 973);
+} catch {}
+try {
+commandEncoder27.copyBufferToBuffer(buffer12, 424, buffer2, 20, 20);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let textureView53 = texture59.createView({dimension: '2d', baseArrayLayer: 2});
+let renderPassEncoder16 = commandEncoder62.beginRenderPass({
+    label: 'q',
+  colorAttachments: [{
+  view: textureView13,
+  clearValue: { r: -318.5, g: 475.4, b: 912.4, a: 181.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView44,
+    depthClearValue: -6.3924745851588005,
+    depthReadOnly: true,
+    stencilClearValue: 21771,
+    stencilReadOnly: true,
+  },
+  occlusionQuerySet: querySet2,
+});
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup25, new Uint32Array(1253), 37, 0);
+} catch {}
+try {
+renderPassEncoder15.executeBundles([renderBundle0, renderBundle3, renderBundle2, renderBundle3, renderBundle1, renderBundle1, renderBundle0, renderBundle1, renderBundle2, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder27.copyTextureToTexture({
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 6},
+  aspect: 'all',
+},
+{
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap1 = await createImageBitmap(imageBitmap0);
+let buffer36 = device0.createBuffer({
+  size: 4499,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let texture62 = device0.createTexture({
+  size: {width: 240, height: 80, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  dimension: '2d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder53 = commandEncoder27.beginComputePass();
+let sampler43 = device0.createSampler({addressModeU: 'repeat', minFilter: 'linear', mipmapFilter: 'linear', lodMaxClamp: 81.99});
+let externalTexture6 = device0.importExternalTexture({source: videoFrame4});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup38, new Uint32Array(123), 17, 0);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(3, bindGroup11, new Uint32Array(5024), 1_475, 0);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer22, 'uint32', 2_380, 6_721);
+} catch {}
+let pipeline10 = await device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule0}});
+document.body.prepend(canvas0);
+let imageData9 = new ImageData(24, 24);
+try {
+computePassEncoder31.setBindGroup(1, bindGroup6, new Uint32Array(438), 107, 0);
+} catch {}
+try {
+computePassEncoder53.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(6, buffer33, 0, 156);
+} catch {}
+try {
+sampler18.label = '\u9da4\u0941\u0bde\u{1f75b}\u{1f765}\u0d17\u0e3c\u070e';
+} catch {}
+try {
+computePassEncoder21.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(3, buffer7, 0, 3);
+} catch {}
+let img0 = await imageWithData(16, 7, '#10101010', '#20202020');
+let textureView54 = texture36.createView({dimension: '2d'});
+try {
+computePassEncoder49.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup13);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup5, new Uint32Array(3941), 279, 0);
+} catch {}
+document.body.prepend(canvas0);
+let buffer37 = device0.createBuffer({size: 3021, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder63 = device0.createCommandEncoder();
+let textureView55 = texture59.createView({dimension: '2d'});
+let texture63 = device0.createTexture({size: [2, 2, 13], format: 'depth32float', usage: GPUTextureUsage.COPY_DST});
+let computePassEncoder54 = commandEncoder63.beginComputePass({});
+let sampler44 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 98.21,
+  lodMaxClamp: 99.60,
+  compare: 'greater-equal',
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder26.setBindGroup(0, bindGroup17, []);
+} catch {}
+try {
+computePassEncoder54.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(1, buffer20, 1_064, 664);
+} catch {}
+let buffer38 = device0.createBuffer({size: 12308, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let commandEncoder64 = device0.createCommandEncoder({});
+let computePassEncoder55 = commandEncoder64.beginComputePass({});
+let sampler45 = device0.createSampler({addressModeU: 'repeat', minFilter: 'linear', lodMaxClamp: 54.53, maxAnisotropy: 1});
+try {
+computePassEncoder34.setBindGroup(2, bindGroup34);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle0, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(3, buffer11);
+} catch {}
+try {
+renderPassEncoder11.pushDebugGroup('\u0d73');
+} catch {}
+try {
+renderPassEncoder11.popDebugGroup();
+} catch {}
+let externalTexture7 = device0.importExternalTexture({source: videoFrame1});
+try {
+{ clearResourceUsages(device0, computePassEncoder13); computePassEncoder13.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder55.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup28, []);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup37, new Uint32Array(342), 27, 0);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(453, 135, 141, 333_264_709, 2_029_850_466);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer7, 1_276);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(4, buffer20, 1_260, 475);
+} catch {}
+let commandEncoder65 = device0.createCommandEncoder({});
+let computePassEncoder56 = commandEncoder65.beginComputePass({});
+let sampler46 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 95.51,
+  maxAnisotropy: 9,
+});
+try {
+renderPassEncoder8.draw(143, 89, 645_433_777, 1_057_783_849);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(240, 244, 191, 454_492_360, 762_321_167);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer24, 8128, new DataView(new ArrayBuffer(11547)), 1101, 5248);
+} catch {}
+let veryExplicitBindGroupLayout9 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 871,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let autogeneratedBindGroupLayout25 = pipeline6.getBindGroupLayout(0);
+let commandEncoder66 = device0.createCommandEncoder({});
+let computePassEncoder57 = commandEncoder66.beginComputePass();
+let sampler47 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'mirror-repeat', lodMaxClamp: 72.73});
+try {
+computePassEncoder56.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(634, 21, 475, 352_990_794, 743_858_668);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer9, 1_132);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline4);
+} catch {}
+let autogeneratedBindGroupLayout26 = pipeline2.getBindGroupLayout(0);
+try {
+computePassEncoder49.setBindGroup(1, bindGroup35);
+} catch {}
+try {
+computePassEncoder49.setBindGroup(1, bindGroup7, new Uint32Array(3616), 1_185, 0);
+} catch {}
+try {
+renderPassEncoder12.setScissorRect(0, 0, 13, 4);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline11 = device0.createRenderPipeline({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule1,
+  targets: [{format: 'rgba8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth32float',
+    depthWriteEnabled: true,
+    depthCompare: 'always',
+    stencilReadMask: 461226108,
+    depthBiasSlopeScale: 544.0944017778428,
+    depthBiasClamp: -61.440352810426525,
+  },
+  vertex: {
+    module: shaderModule2,
+    constants: {29_819: 0},
+    buffers: [
+      {
+        arrayStride: 296,
+        attributes: [
+          {format: 'snorm16x4', offset: 44, shaderLocation: 5},
+          {format: 'unorm8x4', offset: 8, shaderLocation: 14},
+          {format: 'float32x4', offset: 20, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {cullMode: 'back'},
+});
+let buffer39 = device0.createBuffer({size: 8155, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let commandEncoder67 = device0.createCommandEncoder();
+let computePassEncoder58 = commandEncoder67.beginComputePass({});
+try {
+computePassEncoder55.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderPassEncoder11.beginOcclusionQuery(1);
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(1_104, 447, 35, 407_083_263, 3_775_523);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer26, 1_268);
+} catch {}
+let buffer40 = device0.createBuffer({
+  size: 27421,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let texture64 = device0.createTexture({
+  size: [30],
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder58.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup30, new Uint32Array(1361), 21, 0);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle2, renderBundle1, renderBundle2, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(201, 133, 56, 585_646_054, 163_622_160);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer4, 320);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer22, 'uint16', 3_746, 6_002);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline3);
+} catch {}
+let bindGroup39 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 159, resource: {buffer: buffer14, offset: 0, size: 376}},
+    {binding: 256, resource: {buffer: buffer39, offset: 1024, size: 1079}},
+    {binding: 290, resource: externalTexture5},
+  ],
+});
+let commandEncoder68 = device0.createCommandEncoder({});
+let renderPassEncoder17 = commandEncoder68.beginRenderPass({
+    label: 'r',
+  colorAttachments: [{
+  view: textureView13,
+  clearValue: { r: 958.0, g: -618.3, b: -193.0, a: 170.4, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {view: textureView20, depthReadOnly: true, stencilClearValue: 17575},
+});
+let sampler48 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 65.16, compare: 'not-equal'});
+try {
+computePassEncoder48.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+renderPassEncoder7.setScissorRect(0, 2, 2, 3);
+} catch {}
+try {
+renderPassEncoder17.setViewport(86.66754494238742, 32.09210846791985, 19.56139201632414, 2.6903743004394394, 0.5222605343239272, 0.6316506546400393);
+} catch {}
+try {
+renderPassEncoder8.draw(260, 467, 395_384_097, 110_640_387);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(6, buffer15);
+} catch {}
+try {
+buffer20.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let pipeline12 = device0.createRenderPipeline({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment2',
+  constants: {29_819: 0, 49_292: 0},
+  targets: [{format: 'rgba8sint', writeMask: GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth32float',
+    depthWriteEnabled: false,
+    depthCompare: 'less',
+    stencilBack: {compare: 'always'},
+    stencilReadMask: 138168481,
+    depthBiasClamp: -61.997186408086236,
+  },
+  vertex: {
+    module: shaderModule2,
+    constants: {29_819: 0},
+    buffers: [
+      {
+        arrayStride: 200,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float16x4', offset: 8, shaderLocation: 4},
+          {format: 'unorm16x2', offset: 64, shaderLocation: 14},
+          {format: 'snorm16x4', offset: 48, shaderLocation: 5},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', frontFace: 'cw', cullMode: 'front'},
+});
+let autogeneratedBindGroupLayout27 = pipeline2.getBindGroupLayout(0);
+let bindGroup40 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout19,
+  entries: [{binding: 8, resource: {buffer: buffer39, offset: 256, size: 1628}}],
+});
+let pipelineLayout4 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout10, autogeneratedBindGroupLayout3]});
+try {
+renderPassEncoder8.end();
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer8, 'uint16', 202, 1_111);
+} catch {}
+let commandEncoder69 = device0.createCommandEncoder({});
+let texture65 = device0.createTexture({
+  size: [120, 40, 19],
+  mipLevelCount: 1,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler49 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 95.66,
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup12, new Uint32Array(79), 8, 0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup23);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle1, renderBundle1, renderBundle2, renderBundle2, renderBundle1, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer29, 'uint32', 2_432, 1_648);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(4, buffer4, 1_628, 1_145);
+} catch {}
+document.body.prepend(img0);
+let commandEncoder70 = device0.createCommandEncoder();
+let textureView56 = texture31.createView({aspect: 'depth-only', mipLevelCount: 2, arrayLayerCount: 1});
+let computePassEncoder59 = commandEncoder46.beginComputePass({});
+let sampler50 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 97.73});
+try {
+computePassEncoder33.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(3, buffer17, 0, 1_863);
+} catch {}
+let arrayBuffer3 = buffer1.getMappedRange(40, 0);
+let autogeneratedBindGroupLayout28 = pipeline6.getBindGroupLayout(0);
+let bindGroup41 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout1,
+  entries: [{binding: 8, resource: {buffer: buffer15, offset: 1024, size: 19112}}],
+});
+let commandBuffer5 = commandEncoder70.finish();
+let renderPassEncoder18 = commandEncoder69.beginRenderPass({
+    label: 's',
+  colorAttachments: [{
+  view: textureView54,
+  clearValue: { r: -590.1, g: 460.0, b: -318.6, a: -82.07, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {view: textureView23, depthLoadOp: 'load', depthStoreOp: 'discard', stencilClearValue: 26532},
+  maxDrawCount: 7065944,
+});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({colorFormats: ['rgba8sint'], depthStencilFormat: 'depth32float', depthReadOnly: true});
+let sampler51 = device0.createSampler({minFilter: 'nearest', mipmapFilter: 'linear', lodMaxClamp: 54.44, compare: 'never'});
+try {
+computePassEncoder49.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder1); computePassEncoder1.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder59.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(3, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder5.setIndexBuffer(buffer29, 'uint16', 3_576, 827);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(img0);
+let veryExplicitBindGroupLayout10 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 53,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer41 = device0.createBuffer({
+  size: 17965,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder71 = device0.createCommandEncoder({});
+let sampler52 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 86.58,
+  maxAnisotropy: 8,
+});
+try {
+computePassEncoder27.setBindGroup(1, bindGroup26);
+} catch {}
+try {
+computePassEncoder57.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer40, 'uint32', 2_792, 10_448);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(0, buffer34, 0);
+} catch {}
+try {
+commandEncoder71.copyBufferToTexture({
+  /* bytesInLastRow: 48 widthInBlocks: 12 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2156 */
+  offset: 2156,
+  bytesPerRow: 23808,
+  buffer: buffer4,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 8, y: 8, z: 0},
+  aspect: 'all',
+}, {width: 12, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let texture66 = device0.createTexture({
+  size: [240, 80, 1],
+  mipLevelCount: 3,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let sampler53 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 11.21,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder1.setBindGroup(2, bindGroup23, new Uint32Array(5915), 512, 0);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer22, 'uint32', 11_040, 5_779);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(5, buffer20, 0);
+} catch {}
+let buffer42 = device0.createBuffer({size: 13841, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let commandEncoder72 = device0.createCommandEncoder({});
+let computePassEncoder60 = commandEncoder72.beginComputePass({});
+let renderPassEncoder19 = commandEncoder71.beginRenderPass({
+    label: 't',
+  colorAttachments: [{
+  view: textureView40,
+  depthSlice: 27,
+  clearValue: { r: 350.7, g: -210.7, b: -343.1, a: 517.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView2,
+    depthClearValue: 5.199783592823097,
+    depthLoadOp: 'load',
+    depthStoreOp: 'store',
+    stencilClearValue: 36761,
+  },
+  occlusionQuerySet: querySet3,
+});
+try {
+computePassEncoder21.setBindGroup(0, bindGroup28, []);
+} catch {}
+try {
+computePassEncoder48.setBindGroup(3, bindGroup16, new Uint32Array(722), 88, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder3); computePassEncoder3.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer40.unmap();
+} catch {}
+let pipeline13 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule1,
+  constants: {},
+  targets: [{format: 'rgba8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth32float',
+    depthWriteEnabled: false,
+    stencilReadMask: 520928205,
+    stencilWriteMask: 675280976,
+    depthBias: -1583981054,
+    depthBiasSlopeScale: 753.258858911692,
+    depthBiasClamp: 100.02075115084338,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex1',
+    constants: {29_819: 0},
+    buffers: [
+      {
+        arrayStride: 64,
+        attributes: [
+          {format: 'float32x3', offset: 0, shaderLocation: 4},
+          {format: 'unorm8x4', offset: 4, shaderLocation: 14},
+          {format: 'unorm10-10-10-2', offset: 0, shaderLocation: 5},
+        ],
+      },
+    ],
+  },
+  primitive: {cullMode: 'front'},
+});
+let imageData10 = new ImageData(148, 20);
+let veryExplicitBindGroupLayout11 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 189,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let buffer43 = device0.createBuffer({
+  size: 4635,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder8.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+computePassEncoder35.setBindGroup(3, bindGroup34, new Uint32Array(3077), 388, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder13); computePassEncoder13.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder60.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(6, buffer8, 0);
+} catch {}
+await gc();
+let commandEncoder73 = device0.createCommandEncoder({});
+let texture67 = device0.createTexture({
+  size: [2, 2, 13],
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder61 = commandEncoder73.beginComputePass({});
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup28);
+} catch {}
+try {
+renderPassEncoder1.setViewport(13.773713024290632, 9.484276040337392, 36.68662383360463, 3.1631652780641213, 0.10697111857616193, 0.6774278519829905);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(0, bindGroup38);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(1, bindGroup13, new Uint32Array(1757), 63, 0);
+} catch {}
+try {
+renderBundleEncoder5.setIndexBuffer(buffer36, 'uint16', 2_262, 424);
+} catch {}
+try {
+renderBundleEncoder5.setPipeline(pipeline12);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer21, 1460, new Int16Array(31973), 3760, 396);
+} catch {}
+let autogeneratedBindGroupLayout29 = pipeline0.getBindGroupLayout(0);
+let bindGroup42 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout8,
+  entries: [{binding: 8, resource: {buffer: buffer19, offset: 4864}}],
+});
+let buffer44 = device0.createBuffer({
+  size: 728,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let sampler54 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'mirror-repeat', addressModeW: 'mirror-repeat'});
+try {
+computePassEncoder29.setBindGroup(2, bindGroup13, new Uint32Array(661), 20, 0);
+} catch {}
+try {
+computePassEncoder61.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+renderPassEncoder13.setScissorRect(2, 9, 8, 0);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline13);
+} catch {}
+try {
+computePassEncoder47.setBindGroup(2, bindGroup25);
+} catch {}
+try {
+computePassEncoder44.setBindGroup(3, bindGroup6, new Uint32Array(1097), 317, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder13); computePassEncoder13.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder11.setStencilReference(1923);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer44, 'uint32', 212, 286);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline3);
+} catch {}
+let commandEncoder74 = device0.createCommandEncoder({});
+let textureView57 = texture2.createView({aspect: 'depth-only', mipLevelCount: 1});
+let computePassEncoder62 = commandEncoder74.beginComputePass({});
+let renderBundle5 = renderBundleEncoder5.finish();
+let externalTexture8 = device0.importExternalTexture({source: videoFrame2});
+try {
+computePassEncoder30.setBindGroup(1, bindGroup19, new Uint32Array(964), 22, 0);
+} catch {}
+try {
+computePassEncoder12.end();
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup22);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(6, 0, 4, 0);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(6, buffer11);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(182).fill(27), /* required buffer size: 182 */
+{offset: 182}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture68 = device0.createTexture({
+  size: [240, 80, 294],
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture69 = device0.createTexture({
+  size: {width: 60, height: 20, depthOrArrayLayers: 14},
+  mipLevelCount: 3,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder63 = commandEncoder12.beginComputePass({});
+let sampler55 = device0.createSampler({
+  label: '\u06ac\ufb44\u0032\u064b\u{1fa8a}\uec88',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  lodMaxClamp: 88.68,
+});
+try {
+computePassEncoder6.setBindGroup(1, bindGroup38);
+} catch {}
+try {
+computePassEncoder62.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+buffer28.unmap();
+} catch {}
+let autogeneratedBindGroupLayout30 = pipeline13.getBindGroupLayout(0);
+let bindGroup43 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout6,
+  entries: [{binding: 8, resource: {buffer: buffer30, offset: 1536, size: 424}}],
+});
+let commandEncoder75 = device0.createCommandEncoder();
+try {
+computePassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup30);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle4, renderBundle5]);
+} catch {}
+try {
+commandEncoder75.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 12, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData11 = new ImageData(36, 28);
+let videoFrame7 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'rgb', primaries: 'smpte170m', transfer: 'hlg'} });
+let bindGroup44 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout16,
+  entries: [{binding: 8, resource: {buffer: buffer19, offset: 256}}],
+});
+let textureView58 = texture4.createView({baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 1});
+let sampler56 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder49.setBindGroup(0, bindGroup28, new Uint32Array(2192), 180, 0);
+} catch {}
+try {
+computePassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+renderPassEncoder11.end();
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(3, buffer34, 6_376, 1_104);
+} catch {}
+try {
+computePassEncoder44.pushDebugGroup('\ud4c7');
+} catch {}
+let buffer45 = device0.createBuffer({size: 8690, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder76 = device0.createCommandEncoder({});
+let computePassEncoder64 = commandEncoder76.beginComputePass({});
+try {
+computePassEncoder53.setBindGroup(1, bindGroup39);
+} catch {}
+try {
+computePassEncoder64.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer40, 'uint32', 2_484, 8_637);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+});
+} catch {}
+let bindGroup45 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 396, resource: {buffer: buffer17, offset: 0}}],
+});
+let commandBuffer6 = commandEncoder2.finish();
+let texture70 = gpuCanvasContext0.getCurrentTexture();
+let textureView59 = texture58.createView({});
+try {
+computePassEncoder64.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+computePassEncoder63.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer28, 'uint32', 112, 426);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline13);
+} catch {}
+try {
+computePassEncoder57.pushDebugGroup('\u0d75');
+} catch {}
+let canvas1 = document.createElement('canvas');
+let offscreenCanvas0 = new OffscreenCanvas(46, 50);
+let bindGroup46 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout15,
+  entries: [{binding: 8, resource: {buffer: buffer8, offset: 256, size: 284}}],
+});
+let buffer46 = device0.createBuffer({
+  size: 3389,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView60 = texture32.createView({aspect: 'depth-only', mipLevelCount: 1});
+let sampler57 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'repeat', lodMinClamp: 95.14, lodMaxClamp: 99.10});
+try {
+computePassEncoder64.setBindGroup(3, bindGroup22);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder13); computePassEncoder13.dispatchWorkgroupsIndirect(buffer38, 432); };
+} catch {}
+try {
+computePassEncoder13.end();
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup17, new Uint32Array(26), 4, 0);
+} catch {}
+try {
+commandEncoder75.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2780 */
+  offset: 2780,
+  buffer: buffer28,
+}, {
+  texture: texture15,
+  mipLevel: 1,
+  origin: {x: 6, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 5, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(4_736).fill(171), /* required buffer size: 4_736 */
+{offset: 288, bytesPerRow: 32, rowsPerImage: 17}, {width: 0, height: 4, depthOrArrayLayers: 9});
+} catch {}
+let imageData12 = new ImageData(172, 148);
+let texture71 = device0.createTexture({
+  size: [120, 40, 39],
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder65 = commandEncoder1.beginComputePass({});
+let renderPassEncoder20 = commandEncoder75.beginRenderPass({
+    label: 'u',
+  colorAttachments: [{
+  view: textureView12,
+  depthSlice: 41,
+  clearValue: { r: 597.2, g: 946.5, b: -277.9, a: 44.40, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {view: textureView23, depthLoadOp: 'load', depthStoreOp: 'store', stencilClearValue: 65105},
+});
+let sampler58 = device0.createSampler({addressModeV: 'repeat', minFilter: 'linear', mipmapFilter: 'linear', compare: 'equal'});
+try {
+computePassEncoder59.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+computePassEncoder65.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle3, renderBundle0, renderBundle4, renderBundle1, renderBundle1, renderBundle3, renderBundle2, renderBundle3, renderBundle3, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder17.insertDebugMarker('\u09f5');
+} catch {}
+let pipeline14 = await device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule0}});
+document.body.prepend(img0);
+let buffer47 = device0.createBuffer({size: 2757, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let texture72 = device0.createTexture({
+  size: [120],
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture73 = device0.createTexture({
+  size: {width: 240, height: 80, depthOrArrayLayers: 1},
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32float', 'rgba32float'],
+});
+let textureView61 = texture33.createView({dimension: '2d', aspect: 'depth-only', mipLevelCount: 1, baseArrayLayer: 4, arrayLayerCount: 1});
+let computePassEncoder66 = commandEncoder54.beginComputePass({});
+try {
+computePassEncoder66.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer46, 'uint16', 154, 162);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(3, buffer26, 848, 108);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(93).fill(122), /* required buffer size: 93 */
+{offset: 93, bytesPerRow: 79, rowsPerImage: 1}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup47 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 396, resource: {buffer: buffer5, offset: 6912}}],
+});
+let buffer48 = device0.createBuffer({size: 3339, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let commandBuffer7 = commandEncoder13.finish({label: '\u092d\uf50a\u9e12\u{1f7f6}\u0d23\u072a\u{1fa9a}\u2263'});
+let textureView62 = texture72.createView({format: 'r32uint'});
+let sampler59 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 60.07,
+});
+try {
+computePassEncoder48.setBindGroup(3, bindGroup43, new Uint32Array(463), 10, 0);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline4);
+} catch {}
+try {
+computePassEncoder44.popDebugGroup();
+} catch {}
+let pipelineLayout5 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout2]});
+let buffer49 = device0.createBuffer({size: 19896, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let texture74 = device0.createTexture({
+  size: {width: 30, height: 10, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rg8snorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture75 = device0.createTexture({
+  size: [60, 20, 83],
+  sampleCount: 1,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext1 = offscreenCanvas0.getContext('webgpu');
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+let bindGroup48 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout8,
+  entries: [
+    {binding: 18, resource: textureView2},
+    {binding: 20, resource: textureView61},
+    {binding: 5, resource: textureView12},
+  ],
+});
+let textureView63 = texture29.createView({});
+let texture76 = device0.createTexture({
+  size: [30, 10, 17],
+  mipLevelCount: 1,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({colorFormats: ['rgba8sint'], depthStencilFormat: 'depth32float', depthReadOnly: true});
+try {
+computePassEncoder45.setBindGroup(0, bindGroup9, []);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderBundleEncoder6.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(0, buffer7, 0, 953);
+} catch {}
+let arrayBuffer4 = buffer1.getMappedRange(48, 12);
+let gpuCanvasContext2 = canvas1.getContext('webgpu');
+try {
+externalTexture0.label = '\u006a\u398f\u99be\u10cf\u{1f6a1}';
+} catch {}
+let buffer50 = device0.createBuffer({
+  size: 747,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView64 = texture28.createView({dimension: '2d'});
+try {
+computePassEncoder21.setBindGroup(0, bindGroup23);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder45); computePassEncoder45.dispatchWorkgroups(1, 2); };
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(3, bindGroup1, new Uint32Array(34), 20, 0);
+} catch {}
+let imageData13 = new ImageData(32, 16);
+let bindGroup49 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout29,
+  entries: [{binding: 8, resource: {buffer: buffer25, offset: 0, size: 1428}}],
+});
+let buffer51 = device0.createBuffer({size: 8565, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder77 = device0.createCommandEncoder({});
+let texture77 = device0.createTexture({
+  size: {width: 240},
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder67 = commandEncoder77.beginComputePass({});
+let renderBundle6 = renderBundleEncoder6.finish({});
+try {
+renderPassEncoder17.setBindGroup(1, bindGroup46, new Uint32Array(285), 103, 0);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let imageBitmap2 = await createImageBitmap(imageData7);
+let textureView65 = texture77.createView({});
+try {
+computePassEncoder37.setBindGroup(0, bindGroup26, []);
+} catch {}
+try {
+renderPassEncoder7.setBlendConstant({ r: 792.4, g: 736.1, b: 381.8, a: 770.8, });
+} catch {}
+try {
+device0.queue.submit([commandBuffer5, commandBuffer7]);
+} catch {}
+try {
+adapter0.label = '\u9e37\u265a\u31fc\u{1fb75}\u85ba\uc1ab\u0f88\u{1fe92}\ufa99';
+} catch {}
+let shaderModule3 = device0.createShaderModule({
+  code: `
+requires unrestricted_pointer_parameters;
+
+enable f16;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<workgroup> vw14: f16;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<workgroup> vw23: atomic<i32>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@group(0) @binding(8) var<storage, read> buffer52: array<array<array<array<array<array<f16, 1>, 1>, 1>, 3>, 9>>;
+
+var<workgroup> vw15: mat4x2h;
+
+struct S2 {
+  @builtin(vertex_index) f0: u32,
+  @location(5) f1: vec4h,
+  @location(10) f2: f32,
+  @location(8) @interpolate(flat) f3: vec2i,
+  @location(0) @interpolate(flat) f4: vec2f,
+}
+
+var<workgroup> vw21: mat4x4h;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw20: array<array<array<array<atomic<i32>, 1>, 1>, 1>, 21>;
+
+alias vec3b = vec3<bool>;
+
+fn fn2() -> array<array<S2, 1>, 1> {
+  var out: array<array<S2, 1>, 1>;
+  out[u32(unconst_u32(9))][u32(unconst_u32(367))].f2 = f32(buffer52[u32(unconst_u32(466))][8][u32(unconst_u32(24))][u32(unconst_u32(31))][u32(unconst_u32(497))][u32(unconst_u32(437))]);
+  out[u32(unconst_u32(78))][u32(unconst_u32(113))] = S2(u32((*&buffer52)[u32(unconst_u32(122))][u32(unconst_u32(92))][u32(buffer52[u32(unconst_u32(143))][u32(unconst_u32(371))][u32(unconst_u32(35))][u32(unconst_u32(263))][0][u32(unconst_u32(124))])][0][u32(unconst_u32(16))][0]), vec4h((*&buffer52)[u32(unconst_u32(122))][u32(unconst_u32(92))][u32(buffer52[u32(unconst_u32(143))][u32(unconst_u32(371))][u32(unconst_u32(35))][u32(unconst_u32(263))][0][u32(unconst_u32(124))])][0][u32(unconst_u32(16))][0]), f32((*&buffer52)[u32(unconst_u32(122))][u32(unconst_u32(92))][u32(buffer52[u32(unconst_u32(143))][u32(unconst_u32(371))][u32(unconst_u32(35))][u32(unconst_u32(263))][0][u32(unconst_u32(124))])][0][u32(unconst_u32(16))][0]), vec2i(i32((*&buffer52)[u32(unconst_u32(122))][u32(unconst_u32(92))][u32(buffer52[u32(unconst_u32(143))][u32(unconst_u32(371))][u32(unconst_u32(35))][u32(unconst_u32(263))][0][u32(unconst_u32(124))])][0][u32(unconst_u32(16))][0])), vec2f(f32((*&buffer52)[u32(unconst_u32(122))][u32(unconst_u32(92))][u32(buffer52[u32(unconst_u32(143))][u32(unconst_u32(371))][u32(unconst_u32(35))][u32(unconst_u32(263))][0][u32(unconst_u32(124))])][0][u32(unconst_u32(16))][0])));
+  out[u32(unconst_u32(51))][u32(unconst_u32(16))].f3 &= vec2i(i32(buffer52[arrayLength(&buffer52)][u32(unconst_u32(76))][u32(buffer52[u32((*&buffer52)[u32(unconst_u32(94))][8][u32(unconst_u32(214))][u32(unconst_u32(108))][u32(unconst_u32(9))][0])][u32(unconst_u32(178))][2][u32(unconst_u32(78))][u32(unconst_u32(88))][0])][0][0][0]));
+  return out;
+  _ = buffer52;
+}
+
+var<workgroup> vw22: atomic<i32>;
+
+struct FragmentOutput3 {
+  @location(0) f0: vec4i,
+  @builtin(frag_depth) f1: f32,
+}
+
+struct S1 {
+  @location(13) f0: u32,
+  @location(14) @interpolate(flat) f1: u32,
+  @location(4) @interpolate(flat) f2: vec4i,
+  @location(6) @interpolate(perspective) f3: vec4h,
+  @location(7) @interpolate(linear, centroid) f4: vec4h,
+}
+
+var<workgroup> vw18: FragmentOutput3;
+
+var<workgroup> vw16: vec2h;
+
+struct T0 {
+  @size(56) f0: array<mat3x3h>,
+}
+
+fn fn1() -> array<vec4h, 5> {
+  var out: array<vec4h, 5>;
+  let ptr55: ptr<storage, array<array<array<f16, 1>, 1>, 1>, read> = &(*&buffer52)[u32(unconst_u32(165))][u32(buffer52[arrayLength(&buffer52)][u32(unconst_u32(173))][u32(unconst_u32(179))][0][u32(unconst_u32(28))][0])][u32(unconst_u32(91))];
+  let ptr56: ptr<storage, array<array<array<f16, 1>, 1>, 1>, read> = &(*&buffer52)[arrayLength(&(*&buffer52))][8][u32(unconst_u32(59))];
+  out[u32(unconst_u32(550))] += vec4h(buffer52[u32(unconst_u32(103))][u32(unconst_u32(189))][u32(unconst_u32(20))][0][0][0]);
+  let ptr57: ptr<storage, array<f16, 1>, read> = &buffer52[u32(unconst_u32(161))][8][u32((*&buffer52)[arrayLength(&(*&buffer52))][u32(unconst_u32(15))][u32(unconst_u32(115))][0][u32(unconst_u32(106))][u32(unconst_u32(123))])][0][0];
+  out[u32((*&buffer52)[u32(unconst_u32(248))][u32(unconst_u32(95))][u32(unconst_u32(96))][0][u32(unconst_u32(229))][0])] = vec4h((*ptr56)[0][0][0]);
+  let ptr58: ptr<storage, array<f16, 1>, read> = &(*&buffer52)[arrayLength(&(*&buffer52))][8][2][u32(unconst_u32(192))][0];
+  return out;
+  _ = buffer52;
+}
+
+var<workgroup> vw19: mat2x2f;
+
+var<workgroup> vw17: mat2x4f;
+
+fn fn0(a0: ptr<storage, array<atomic<u32>>, read_write>, a1: ptr<private, vec2<bool>>) -> mat4x2h {
+  var out: mat4x2h;
+  let ptr50: ptr<storage, array<f16, 1>, read> = &(*&buffer52)[u32(unconst_u32(114))][u32(unconst_u32(69))][u32(unconst_u32(29))][0][u32(unconst_u32(81))];
+  let ptr51: ptr<storage, f16, read> = &buffer52[arrayLength(&buffer52)][u32(unconst_u32(240))][u32(unconst_u32(263))][u32(unconst_u32(304))][0][u32(buffer52[arrayLength(&buffer52)][8][u32(unconst_u32(385))][0][0][0])];
+  let ptr52: ptr<storage, array<f16, 1>, read> = &buffer52[u32(unconst_u32(156))][8][2][u32(unconst_u32(105))][u32(unconst_u32(89))];
+  let ptr53: ptr<storage, f16, read> = &buffer52[u32(unconst_u32(113))][u32(unconst_u32(122))][2][0][u32(unconst_u32(264))][u32(unconst_u32(463))];
+  let ptr54: ptr<storage, f16, read> = &(*ptr50)[u32((*&buffer52)[arrayLength(&(*&buffer52))][8][u32(unconst_u32(222))][u32(unconst_u32(272))][0][0])];
+  return out;
+  _ = buffer52;
+}
+
+@vertex
+fn vertex2(@location(12) @interpolate(flat) a0: vec2i, @location(3) a1: vec4u, a2: S1, @location(15) @interpolate(flat) a3: vec4i, @location(2) @interpolate(flat, centroid) a4: vec4u, @location(11) a5: u32, @location(9) @interpolate(flat) a6: f32, a7: S2, @builtin(instance_index) a8: u32) -> @builtin(position) vec4f {
+  var out: vec4f;
+  let ptr59: ptr<storage, array<f16, 1>, read> = &(*&buffer52)[u32(unconst_u32(422))][u32(unconst_u32(162))][2][0][u32(unconst_u32(19))];
+  let ptr60: ptr<storage, array<array<array<f16, 1>, 1>, 1>, read> = &(*&buffer52)[u32(unconst_u32(348))][u32(unconst_u32(9))][2];
+  out = unpack4x8unorm(arrayLength(&buffer52));
+  out = vec4f(f32((*&buffer52)[arrayLength(&(*&buffer52))][u32(unconst_u32(162))][2][u32(unconst_u32(103))][u32(unconst_u32(39))][0]));
+  let ptr61: ptr<storage, array<array<array<f16, 1>, 1>, 1>, read> = &(*&buffer52)[u32(unconst_u32(229))][8][2];
+  out = vec4f(f32((*ptr60)[0][u32(unconst_u32(39))][u32(unconst_u32(109))]));
+  let ptr62: ptr<storage, f16, read> = &(*&buffer52)[arrayLength(&(*&buffer52))][u32(unconst_u32(200))][u32(unconst_u32(85))][u32(unconst_u32(114))][0][0];
+  out = vec4f(f32(buffer52[u32(unconst_u32(95))][u32(unconst_u32(287))][2][u32(unconst_u32(61))][0][0]));
+  let ptr63: ptr<storage, array<array<array<array<f16, 1>, 1>, 1>, 3>, read> = &(*&buffer52)[arrayLength(&(*&buffer52))][u32(unconst_u32(114))];
+  let ptr64: ptr<storage, array<array<array<array<array<f16, 1>, 1>, 1>, 3>, 9>, read> = &(*&buffer52)[i32(unconst_i32(13))];
+  out = vec4f(f32((*ptr61)[0][u32((*ptr63)[2][u32(unconst_u32(437))][0][0])][u32(unconst_u32(621))]));
+  out += vec4f(f32((*&buffer52)[u32(unconst_u32(0))][8][u32(unconst_u32(27))][u32(unconst_u32(697))][0][0]));
+  var vf22 = fn2();
+  vf22[u32((*ptr64)[u32(unconst_u32(219))][u32(unconst_u32(443))][0][0][0])][u32(unconst_u32(90))] = S2(u32((*&buffer52)[u32(unconst_u32(298))][8][2][0][u32(unconst_u32(10))][0]), vec4h((*&buffer52)[u32(unconst_u32(298))][8][2][0][u32(unconst_u32(10))][0]), f32((*&buffer52)[u32(unconst_u32(298))][8][2][0][u32(unconst_u32(10))][0]), vec2i(i32((*&buffer52)[u32(unconst_u32(298))][8][2][0][u32(unconst_u32(10))][0])), vec2f(f32((*&buffer52)[u32(unconst_u32(298))][8][2][0][u32(unconst_u32(10))][0])));
+  return out;
+  _ = buffer52;
+}
+
+@fragment
+fn fragment3() -> FragmentOutput3 {
+  var out: FragmentOutput3;
+  fn1();
+  fn1();
+  out.f1 = f32(buffer52[arrayLength(&buffer52)][8][u32(unconst_u32(86))][u32(unconst_u32(117))][u32(unconst_u32(321))][0]);
+  out.f0 = vec4i(i32((*&buffer52)[arrayLength(&(*&buffer52))][8][2][0][0][0]));
+  let ptr65: ptr<storage, array<f16, 1>, read> = &(*&buffer52)[u32(unconst_u32(84))][u32(unconst_u32(14))][2][u32(unconst_u32(307))][0];
+  out = FragmentOutput3(vec4i(i32(buffer52[arrayLength(&buffer52)][u32(buffer52[u32(unconst_u32(170))][8][u32(unconst_u32(4))][u32(unconst_u32(76))][0][0])][2][u32(unconst_u32(0))][u32(unconst_u32(201))][0])), f32(buffer52[arrayLength(&buffer52)][u32(buffer52[u32(unconst_u32(170))][8][u32(unconst_u32(4))][u32(unconst_u32(76))][0][0])][2][u32(unconst_u32(0))][u32(unconst_u32(201))][0]));
+  let ptr66: ptr<storage, array<array<array<array<array<f16, 1>, 1>, 1>, 3>, 9>, read> = &(*&buffer52)[i32(unconst_i32(-198))];
+  let ptr67: ptr<storage, f16, read> = &(*ptr66)[8][2][0][u32(unconst_u32(336))][0];
+  var vf23 = fn1();
+  out.f1 = f32(buffer52[u32(unconst_u32(431))][u32(unconst_u32(46))][2][0][0][0]);
+  out.f1 += f32((*&buffer52)[u32(unconst_u32(9))][8][2][0][0][0]);
+  return out;
+  _ = buffer52;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute3() {
+  vw14 = buffer52[arrayLength(&buffer52)][8][2][0][u32(unconst_u32(459))][0];
+  let ptr68: ptr<storage, f16, read> = &(*&buffer52)[arrayLength(&(*&buffer52))][8][2][pack4xU8Clamp(unpack4xU8(u32(buffer52[arrayLength(&buffer52)][u32(unconst_u32(67))][u32(unconst_u32(341))][u32(unconst_u32(334))][u32(unconst_u32(20))][u32(unconst_u32(351))])))][u32(unconst_u32(588))][u32(unconst_u32(42))];
+  vw15 -= mat4x2h((*&buffer52)[u32(unconst_u32(60))][8][u32(unconst_u32(294))][u32(unconst_u32(76))][0][0], (*&buffer52)[u32(unconst_u32(60))][8][u32(unconst_u32(294))][u32(unconst_u32(76))][0][0], (*&buffer52)[u32(unconst_u32(60))][8][u32(unconst_u32(294))][u32(unconst_u32(76))][0][0], (*&buffer52)[u32(unconst_u32(60))][8][u32(unconst_u32(294))][u32(unconst_u32(76))][0][0], (*&buffer52)[u32(unconst_u32(60))][8][u32(unconst_u32(294))][u32(unconst_u32(76))][0][0], (*&buffer52)[u32(unconst_u32(60))][8][u32(unconst_u32(294))][u32(unconst_u32(76))][0][0], (*&buffer52)[u32(unconst_u32(60))][8][u32(unconst_u32(294))][u32(unconst_u32(76))][0][0], (*&buffer52)[u32(unconst_u32(60))][8][u32(unconst_u32(294))][u32(unconst_u32(76))][0][0]);
+  let ptr69: ptr<storage, array<array<array<array<f16, 1>, 1>, 1>, 3>, read> = &(*&buffer52)[arrayLength(&(*&buffer52))][8];
+  vw17 = mat2x4f(bitcast<vec4f>(workgroupUniformLoad(&vw18).f0), vec4f(workgroupUniformLoad(&vw18).f0));
+  var vf24: i32 = atomicExchange(&(*&vw20)[u32(unconst_u32(177))][u32(unconst_u32(128))][0][u32(unconst_u32(519))], i32(unconst_i32(-247)));
+  let ptr70: ptr<storage, f16, read> = &buffer52[arrayLength(&buffer52)][8][u32(unconst_u32(79))][0][u32(unconst_u32(307))][0];
+  let ptr71: ptr<workgroup, array<array<atomic<i32>, 1>, 1>> = &vw20[20][0];
+  atomicExchange(&vw20[20][u32((*&buffer52)[u32(unconst_u32(133))][8][u32(unconst_u32(282))][0][0][0])][0][u32(unconst_u32(922))], i32(unconst_i32(-151)));
+  vf24 = i32((*&buffer52)[u32(unconst_u32(8))][8][u32(unconst_u32(313))][0][0][u32(unconst_u32(124))]);
+  _ = buffer52;
+}`,
+});
+try {
+computePassEncoder37.setBindGroup(2, bindGroup22);
+} catch {}
+try {
+computePassEncoder67.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 1, y: 5, z: 0},
+  aspect: 'all',
+}, new Uint8Array(196).fill(134), /* required buffer size: 196 */
+{offset: 196, bytesPerRow: 219}, {width: 36, height: 18, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder78 = device0.createCommandEncoder({label: '\u{1ffe5}\u0117\u{1f96d}\u5251\u7d70\u0476\ufaee'});
+let commandBuffer8 = commandEncoder78.finish({});
+try {
+computePassEncoder41.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+computePassEncoder43.setBindGroup(0, bindGroup40, new Uint32Array(590), 20, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder43); computePassEncoder43.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup34, new Uint32Array(244), 3, 0);
+} catch {}
+try {
+renderPassEncoder17.setScissorRect(9, 2, 7, 12);
+} catch {}
+let pipeline15 = device0.createComputePipeline({layout: pipelineLayout1, compute: {module: shaderModule2, constants: {override4: 0}}});
+offscreenCanvas0.height = 987;
+let autogeneratedBindGroupLayout31 = pipeline11.getBindGroupLayout(0);
+let buffer53 = device0.createBuffer({
+  size: 9626,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE,
+});
+let textureView66 = texture53.createView({dimension: '2d-array'});
+let sampler60 = device0.createSampler({
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'greater',
+  maxAnisotropy: 1,
+});
+let veryExplicitBindGroupLayout12 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 116,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 258,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let buffer54 = device0.createBuffer({size: 6207, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let commandEncoder79 = device0.createCommandEncoder({label: '\u{1f762}\u6f15\u2478\uae92\u0080\u0a9f\u03aa\u02a9\u05bd\u0ae4\u4aba'});
+let textureView67 = texture77.createView({mipLevelCount: 1});
+let renderPassEncoder21 = commandEncoder79.beginRenderPass({
+    label: 'v',
+  colorAttachments: [{
+  view: textureView13,
+  clearValue: { r: -478.6, g: 730.5, b: -477.7, a: 511.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView20,
+    depthClearValue: 0.5642293199910583,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'store',
+    stencilClearValue: 3624,
+  },
+  occlusionQuerySet: querySet1,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder43); computePassEncoder43.dispatchWorkgroupsIndirect(buffer26, 448); };
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(0, bindGroup6, new Uint32Array(511), 3, 0);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(7, buffer33, 0, 231);
+} catch {}
+let texture78 = device0.createTexture({
+  size: {width: 60, height: 20, depthOrArrayLayers: 60},
+  mipLevelCount: 2,
+  format: 'depth32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder19.executeBundles([renderBundle0, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder19.setViewport(37.59057587284601, 5.555021820711938, 4.672554349941216, 8.476696951432482, 0.5033924923222989, 0.5303501794572869);
+} catch {}
+try {
+buffer18.unmap();
+} catch {}
+let autogeneratedBindGroupLayout32 = pipeline9.getBindGroupLayout(0);
+let commandEncoder80 = device0.createCommandEncoder({});
+try {
+computePassEncoder45.end();
+} catch {}
+try {
+computePassEncoder55.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle3]);
+} catch {}
+try {
+commandEncoder80.copyBufferToBuffer(buffer28, 48, buffer34, 96, 28);
+} catch {}
+try {
+device0.queue.submit([commandBuffer6]);
+} catch {}
+let imageBitmap3 = await createImageBitmap(videoFrame7);
+let computePassEncoder68 = commandEncoder80.beginComputePass({});
+try {
+computePassEncoder34.setBindGroup(0, bindGroup35);
+} catch {}
+let commandBuffer9 = commandEncoder56.finish();
+let texture79 = device0.createTexture({
+  size: {width: 240, height: 80, depthOrArrayLayers: 1},
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView68 = texture72.createView({baseArrayLayer: 0});
+try {
+{ clearResourceUsages(device0, computePassEncoder41); computePassEncoder41.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder68.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer9, 'uint16', 284, 1_745);
+} catch {}
+let texture80 = device0.createTexture({
+  size: {width: 2},
+  dimension: '1d',
+  format: 'rgb9e5ufloat',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let sampler61 = device0.createSampler({addressModeV: 'repeat', lodMaxClamp: 91.37});
+try {
+{ clearResourceUsages(device0, computePassEncoder43); computePassEncoder43.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup37, []);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(3, bindGroup10, new Uint32Array(1093), 38, 0);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(1, buffer40, 0, 378);
+} catch {}
+let textureView69 = texture74.createView({format: 'rg8snorm', mipLevelCount: 1});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({colorFormats: ['rgba8sint'], depthStencilFormat: 'depth32float', depthReadOnly: true});
+try {
+renderPassEncoder9.setVertexBuffer(3, buffer38);
+} catch {}
+try {
+buffer27.unmap();
+} catch {}
+try {
+renderBundleEncoder7.insertDebugMarker('\u{1fe0d}');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup50 = device0.createBindGroup({layout: veryExplicitBindGroupLayout11, entries: [{binding: 189, resource: textureView42}]});
+try {
+computePassEncoder48.setBindGroup(2, bindGroup24);
+} catch {}
+try {
+computePassEncoder28.setBindGroup(0, bindGroup28, new Uint32Array(1295), 4, 0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup39, new Uint32Array(5106), 1_026, 0);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+computePassEncoder52.pushDebugGroup('\u1fd8');
+} catch {}
+try {
+renderBundleEncoder7.insertDebugMarker('\u5285');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer50, 164, new Float32Array(13030), 2324, 28);
+} catch {}
+document.body.append(img0);
+let bindGroup51 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout6,
+  entries: [{binding: 8, resource: {buffer: buffer46, offset: 0, size: 388}}],
+});
+let commandEncoder81 = device0.createCommandEncoder({});
+let texture81 = device0.createTexture({
+  size: [240, 80, 32],
+  mipLevelCount: 3,
+  dimension: '2d',
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView70 = texture40.createView({dimension: 'cube', arrayLayerCount: 6});
+let computePassEncoder69 = commandEncoder81.beginComputePass({});
+try {
+computePassEncoder47.setBindGroup(3, bindGroup28);
+} catch {}
+try {
+computePassEncoder42.setBindGroup(0, bindGroup51, new Uint32Array(215), 41, 0);
+} catch {}
+try {
+computePassEncoder49.end();
+} catch {}
+try {
+computePassEncoder69.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(1, buffer43, 244, 198);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer28, 'uint32', 1_444, 3);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(1, buffer40, 0, 2_381);
+} catch {}
+let videoFrame8 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-ncl', primaries: 'smpteRp431', transfer: 'linear'} });
+let buffer55 = device0.createBuffer({size: 10927, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let commandEncoder82 = device0.createCommandEncoder({});
+let computePassEncoder70 = commandEncoder82.beginComputePass({});
+let renderBundle7 = renderBundleEncoder7.finish({});
+try {
+computePassEncoder33.setBindGroup(2, bindGroup45, []);
+} catch {}
+try {
+computePassEncoder11.setBindGroup(1, bindGroup1, new Uint32Array(2378), 780, 0);
+} catch {}
+try {
+computePassEncoder41.end();
+} catch {}
+try {
+computePassEncoder70.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup25);
+} catch {}
+try {
+commandEncoder59.clearBuffer(buffer8, 636, 64);
+} catch {}
+let textureView71 = texture13.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder71 = commandEncoder4.beginComputePass({});
+let externalTexture9 = device0.importExternalTexture({source: videoFrame0});
+try {
+buffer54.unmap();
+} catch {}
+await gc();
+let imageData14 = new ImageData(8, 16);
+let texture82 = device0.createTexture({
+  size: {width: 2},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView72 = texture68.createView({});
+let sampler62 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 60.78,
+  compare: 'less-equal',
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder71.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup46);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(6, 4, 11, 0);
+} catch {}
+try {
+commandEncoder59.copyBufferToTexture({
+  /* bytesInLastRow: 56 widthInBlocks: 14 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2692 */
+  offset: 2692,
+  bytesPerRow: 4864,
+  buffer: buffer49,
+}, {
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+canvas0.width = 1702;
+let bindGroup52 = device0.createBindGroup({
+  label: '\u0118\u2d41\u{1fec9}\uaad4\uf1be\uaf35\u0ba1\uc09c\u{1ffb8}\u07ee',
+  layout: autogeneratedBindGroupLayout15,
+  entries: [{binding: 8, resource: {buffer: buffer22, offset: 10752, size: 740}}],
+});
+let commandEncoder83 = device0.createCommandEncoder({});
+let querySet7 = device0.createQuerySet({type: 'occlusion', count: 23});
+let computePassEncoder72 = commandEncoder59.beginComputePass({});
+let renderPassEncoder22 = commandEncoder83.beginRenderPass({
+    label: 'w',
+  colorAttachments: [{view: textureView12, depthSlice: 41, loadOp: 'clear', storeOp: 'store'}],
+  depthStencilAttachment: {
+    view: textureView23,
+    depthLoadOp: 'load',
+    depthStoreOp: 'store',
+    stencilClearValue: 6248,
+    stencilReadOnly: false,
+  },
+  occlusionQuerySet: querySet3,
+});
+try {
+computePassEncoder52.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+computePassEncoder60.setBindGroup(1, bindGroup52, new Uint32Array(4718), 1_755, 0);
+} catch {}
+try {
+computePassEncoder72.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder57.popDebugGroup();
+} catch {}
+let commandEncoder84 = device0.createCommandEncoder({});
+let textureView73 = texture17.createView({});
+let computePassEncoder73 = commandEncoder84.beginComputePass({});
+try {
+computePassEncoder65.setBindGroup(2, bindGroup38, new Uint32Array(1351), 68, 0);
+} catch {}
+try {
+computePassEncoder52.popDebugGroup();
+} catch {}
+let pipeline16 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule1}});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let autogeneratedBindGroupLayout33 = pipeline13.getBindGroupLayout(0);
+try {
+computePassEncoder21.setBindGroup(0, bindGroup37, new Uint32Array(2281), 485, 0);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(1, bindGroup34, new Uint32Array(405), 191, 0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle5, renderBundle7, renderBundle5, renderBundle2, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer29, 'uint16', 2_088, 1_473);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(4, buffer33, 12);
+} catch {}
+let texture83 = device0.createTexture({
+  size: [30, 10, 1],
+  sampleCount: 4,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler63 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 82.87,
+});
+try {
+device0.queue.submit([commandBuffer9]);
+} catch {}
+let commandEncoder85 = device0.createCommandEncoder({});
+let querySet8 = device0.createQuerySet({type: 'occlusion', count: 369});
+let computePassEncoder74 = commandEncoder85.beginComputePass({});
+try {
+computePassEncoder6.setBindGroup(2, bindGroup41, []);
+} catch {}
+try {
+computePassEncoder74.setPipeline(pipeline15);
+} catch {}
+let pipeline17 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule0}});
+let buffer56 = device0.createBuffer({size: 15463, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT, mappedAtCreation: false});
+let commandEncoder86 = device0.createCommandEncoder({});
+let renderPassEncoder23 = commandEncoder86.beginRenderPass({
+    label: 'x',
+  colorAttachments: [{view: textureView12, depthSlice: 4, loadOp: 'clear', storeOp: 'store'}],
+  depthStencilAttachment: {view: textureView58, depthClearValue: -0.27756306406098474, depthReadOnly: true},
+});
+let sampler64 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 29.95,
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder53.end();
+} catch {}
+try {
+computePassEncoder43.end();
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup8, new Uint32Array(788), 84, 0);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline4);
+} catch {}
+try {
+buffer41.unmap();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder87 = device0.createCommandEncoder({});
+let textureView74 = texture28.createView({dimension: 'cube'});
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup12);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer40, 'uint32', 520, 2_531);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline13);
+} catch {}
+try {
+commandEncoder27.copyTextureToTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 8, y: 2, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+document.body.prepend(canvas0);
+let commandEncoder88 = device0.createCommandEncoder({});
+try {
+computePassEncoder71.setBindGroup(3, bindGroup26, new Uint32Array(1743), 30, 0);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer29, 'uint32', 1_752, 60);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(7, buffer20, 0, 2_363);
+} catch {}
+try {
+device0.queue.submit([commandBuffer8]);
+} catch {}
+let buffer57 = device0.createBuffer({
+  size: 367,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let querySet9 = device0.createQuerySet({type: 'occlusion', count: 1});
+let textureView75 = texture8.createView({dimension: '2d', mipLevelCount: 1, arrayLayerCount: 1});
+try {
+computePassEncoder7.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer28, 'uint16', 1_980, 565);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline4);
+} catch {}
+let texture84 = device0.createTexture({
+  size: {width: 60, height: 20, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  dimension: '2d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture85 = device0.createTexture({size: [120, 40, 1], format: 'depth32float', usage: GPUTextureUsage.COPY_DST});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8sint'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler65 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.12,
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder11.setBindGroup(0, bindGroup19, new Uint32Array(708), 337, 0);
+} catch {}
+try {
+computePassEncoder73.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(0, bindGroup12, new Uint32Array(439), 112, 0);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(0, bindGroup45);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(5, buffer33, 0, 29);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+buffer36.unmap();
+} catch {}
+try {
+commandEncoder27.copyBufferToBuffer(buffer41, 996, buffer21, 1268, 192);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer22, 5772, new BigUint64Array(4259), 1537, 60);
+} catch {}
+let imageData15 = new ImageData(60, 44);
+try {
+renderPassEncoder21.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer36, 'uint32', 64, 586);
+} catch {}
+try {
+commandEncoder51.resolveQuerySet(querySet7, 13, 0, buffer41, 4864);
+} catch {}
+document.body.prepend(canvas0);
+let imageBitmap4 = await createImageBitmap(imageData3);
+let imageData16 = new ImageData(80, 12);
+let buffer58 = device0.createBuffer({size: 5347, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+let texture86 = device0.createTexture({
+  size: {width: 120, height: 40, depthOrArrayLayers: 1},
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder75 = commandEncoder51.beginComputePass({});
+let externalTexture10 = device0.importExternalTexture({source: videoFrame6});
+try {
+computePassEncoder75.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup43);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer29, 'uint32', 2_828, 799);
+} catch {}
+try {
+commandEncoder27.copyBufferToBuffer(buffer4, 2152, buffer17, 308, 452);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(239).fill(188), /* required buffer size: 239 */
+{offset: 239, rowsPerImage: 11}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer59 = device0.createBuffer({size: 13709, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let commandEncoder89 = device0.createCommandEncoder({});
+let texture87 = device0.createTexture({
+  size: {width: 60, height: 20, depthOrArrayLayers: 1},
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let sampler66 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 95.87, compare: 'always'});
+try {
+renderPassEncoder21.setIndexBuffer(buffer21, 'uint16', 662, 450);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(3, buffer44);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder87.insertDebugMarker('\u{1fab6}');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 4},
+  aspect: 'all',
+}, new Uint8Array(49_612).fill(60), /* required buffer size: 49_612 */
+{offset: 72, bytesPerRow: 58, rowsPerImage: 122}, {width: 2, height: 1, depthOrArrayLayers: 8});
+} catch {}
+let promise4 = device0.queue.onSubmittedWorkDone();
+let promise5 = device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule0,
+  constants: {},
+  targets: [{
+  format: 'rgba8sint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth32float',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilBack: {compare: 'always'},
+    stencilWriteMask: 1657591805,
+    depthBias: -1847628493,
+  },
+  vertex: {module: shaderModule0, constants: {}, buffers: []},
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'cw'},
+});
+try {
+  await promise4;
+} catch {}
+let imageData17 = new ImageData(28, 8);
+let commandEncoder90 = device0.createCommandEncoder({});
+let commandBuffer10 = commandEncoder27.finish({});
+let computePassEncoder76 = commandEncoder87.beginComputePass({});
+let renderBundle8 = renderBundleEncoder8.finish({});
+let sampler67 = device0.createSampler({addressModeU: 'repeat'});
+try {
+commandEncoder89.copyTextureToTexture({
+  texture: texture64,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline18 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule3, constants: {}}});
+let pipeline19 = device0.createRenderPipeline({
+  layout: 'auto',
+  multisample: {mask: 0x1e13631b},
+  fragment: {
+  module: shaderModule3,
+  targets: [{
+  format: 'rgba8sint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth32float',
+    depthWriteEnabled: false,
+    stencilReadMask: 1029599521,
+    stencilWriteMask: 613497832,
+    depthBias: -2126780142,
+  },
+  vertex: {
+    module: shaderModule2,
+    constants: {29_819: 0},
+    buffers: [
+      {
+        arrayStride: 28,
+        attributes: [
+          {format: 'snorm16x2', offset: 0, shaderLocation: 14},
+          {format: 'float32x3', offset: 4, shaderLocation: 4},
+          {format: 'unorm8x4', offset: 0, shaderLocation: 5},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'back'},
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder91 = device0.createCommandEncoder({});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup49);
+} catch {}
+try {
+computePassEncoder11.setBindGroup(2, bindGroup33, new Uint32Array(3708), 555, 0);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(2, bindGroup15, new Uint32Array(3628), 1_097, 0);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle0, renderBundle2, renderBundle1, renderBundle4]);
+} catch {}
+let veryExplicitBindGroupLayout13 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 33, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+    {
+      binding: 203,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder92 = device0.createCommandEncoder({});
+try {
+computePassEncoder47.setBindGroup(1, bindGroup39, new Uint32Array(3), 1, 0);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(3, bindGroup33, new Uint32Array(22), 0, 0);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle5]);
+} catch {}
+try {
+commandEncoder89.copyBufferToBuffer(buffer28, 3560, buffer35, 536, 144);
+} catch {}
+try {
+computePassEncoder57.insertDebugMarker('\ua164');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 5},
+  aspect: 'all',
+}, new Uint8Array(2_096).fill(46), /* required buffer size: 2_096 */
+{offset: 464, bytesPerRow: 108, rowsPerImage: 7}, {width: 3, height: 2, depthOrArrayLayers: 3});
+} catch {}
+let texture88 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 13},
+  mipLevelCount: 1,
+  format: 'depth32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView76 = texture43.createView({baseArrayLayer: 0});
+let computePassEncoder77 = commandEncoder91.beginComputePass({});
+let sampler68 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.58,
+  compare: 'greater-equal',
+  maxAnisotropy: 2,
+});
+try {
+computePassEncoder21.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup38);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle4, renderBundle1, renderBundle4, renderBundle1, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline13);
+} catch {}
+try {
+commandEncoder88.copyBufferToTexture({
+  /* bytesInLastRow: 40 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1308 */
+  offset: 1308,
+  bytesPerRow: 17408,
+  rowsPerImage: 1073,
+  buffer: buffer3,
+}, {
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup53 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout11,
+  entries: [{binding: 8, resource: {buffer: buffer39, offset: 0, size: 412}}],
+});
+let textureView77 = texture33.createView({mipLevelCount: 1, baseArrayLayer: 7, arrayLayerCount: 4});
+let computePassEncoder78 = commandEncoder88.beginComputePass();
+try {
+computePassEncoder76.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder15.executeBundles([renderBundle3]);
+} catch {}
+try {
+commandEncoder90.insertDebugMarker('\u0795');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 440, new BigUint64Array(11275), 5624, 80);
+} catch {}
+let texture89 = device0.createTexture({
+  size: [60, 20, 1],
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder79 = commandEncoder90.beginComputePass({});
+try {
+computePassEncoder50.setBindGroup(0, bindGroup46, new Uint32Array(751), 51, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder18); computePassEncoder18.dispatchWorkgroups(2); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder11); computePassEncoder11.dispatchWorkgroupsIndirect(buffer38, 4_940); };
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup23, new Uint32Array(6564), 214, 0);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(6, buffer50, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer57, 12, new Int16Array(22280), 1580, 0);
+} catch {}
+let bindGroup54 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout17,
+  entries: [{binding: 8, resource: {buffer: buffer15, offset: 21504, size: 2812}}],
+});
+let buffer60 = device0.createBuffer({size: 9877, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+let commandEncoder93 = device0.createCommandEncoder({});
+let textureView78 = texture63.createView({dimension: 'cube-array', aspect: 'depth-only', arrayLayerCount: 6});
+let computePassEncoder80 = commandEncoder92.beginComputePass({});
+let sampler69 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 61.51,
+  compare: 'less-equal',
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder77.setBindGroup(2, bindGroup48, new Uint32Array(2762), 80, 0);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle1]);
+} catch {}
+try {
+commandEncoder89.clearBuffer(buffer60, 3156, 904);
+} catch {}
+let bindGroup55 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout32,
+  entries: [{binding: 8, resource: {buffer: buffer19, offset: 0}}],
+});
+let renderPassEncoder24 = commandEncoder93.beginRenderPass({
+    label: 'y',
+  colorAttachments: [{
+  view: textureView13,
+  clearValue: { r: -239.0, g: 111.3, b: -595.5, a: -560.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView20,
+    depthClearValue: 0.9613332329078684,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'discard',
+    depthReadOnly: false,
+    stencilClearValue: 31310,
+  },
+  occlusionQuerySet: querySet6,
+  maxDrawCount: 26433273,
+});
+let externalTexture11 = device0.importExternalTexture({source: videoFrame0});
+try {
+computePassEncoder78.setBindGroup(1, bindGroup36, new Uint32Array(597), 213, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder18); computePassEncoder18.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder77.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup35);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup6, new Uint32Array(703), 302, 0);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle7, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(1, buffer4);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer57, 112, new Float32Array(8900), 3134, 0);
+} catch {}
+let texture90 = device0.createTexture({
+  size: {width: 120},
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView79 = texture26.createView({baseArrayLayer: 16, arrayLayerCount: 1});
+try {
+computePassEncoder34.setBindGroup(0, bindGroup34, new Uint32Array(942), 75, 0);
+} catch {}
+try {
+commandEncoder89.copyBufferToBuffer(buffer53, 852, buffer36, 76, 1176);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(86).fill(221), /* required buffer size: 86 */
+{offset: 86}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer61 = device0.createBuffer({
+  size: 3527,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let querySet10 = device0.createQuerySet({type: 'occlusion', count: 191});
+let texture91 = device0.createTexture({size: [30, 10, 1], format: 'depth32float', usage: GPUTextureUsage.COPY_SRC});
+let sampler70 = device0.createSampler({addressModeU: 'clamp-to-edge', addressModeV: 'mirror-repeat', lodMaxClamp: 94.88});
+try {
+renderPassEncoder12.setIndexBuffer(buffer44, 'uint32', 120, 65);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(7, buffer59, 1_672, 969);
+} catch {}
+let textureView80 = texture25.createView({dimension: '2d-array', aspect: 'depth-only'});
+try {
+computePassEncoder79.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(1, bindGroup45, new Uint32Array(865), 480, 0);
+} catch {}
+try {
+commandEncoder89.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1232 */
+  offset: 1232,
+  bytesPerRow: 19200,
+  buffer: buffer20,
+}, {
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline20 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule3}});
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+document.body.append(canvas0);
+let autogeneratedBindGroupLayout34 = pipeline12.getBindGroupLayout(0);
+let texture92 = device0.createTexture({
+  size: [30, 10, 36],
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder81 = commandEncoder89.beginComputePass();
+try {
+computePassEncoder79.setBindGroup(2, bindGroup38, new Uint32Array(74), 8, 0);
+} catch {}
+try {
+computePassEncoder48.setPipeline(pipeline6);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 39, y: 28, z: 2},
+  aspect: 'all',
+}, new Uint8Array(303).fill(72), /* required buffer size: 303 */
+{offset: 303, bytesPerRow: 298, rowsPerImage: 47}, {width: 62, height: 19, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let autogeneratedBindGroupLayout35 = pipeline14.getBindGroupLayout(0);
+let buffer62 = device0.createBuffer({
+  size: 20528,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder94 = device0.createCommandEncoder({});
+let querySet11 = device0.createQuerySet({type: 'occlusion', count: 719});
+let commandBuffer11 = commandEncoder94.finish();
+try {
+computePassEncoder26.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(7, buffer39);
+} catch {}
+try {
+device0.queue.submit([commandBuffer11]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 12},
+  aspect: 'all',
+}, new Uint8Array(3_290).fill(245), /* required buffer size: 3_290 */
+{offset: 82, bytesPerRow: 40, rowsPerImage: 39}, {width: 1, height: 3, depthOrArrayLayers: 3});
+} catch {}
+let commandEncoder95 = device0.createCommandEncoder();
+let computePassEncoder82 = commandEncoder95.beginComputePass({});
+let sampler71 = device0.createSampler({addressModeU: 'mirror-repeat', lodMaxClamp: 91.39});
+try {
+renderPassEncoder5.setPipeline(pipeline3);
+} catch {}
+let buffer63 = device0.createBuffer({size: 5060, usage: GPUBufferUsage.STORAGE});
+try {
+renderPassEncoder24.setScissorRect(16, 15, 17, 3);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer53, 'uint32', 224, 3_228);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(3, buffer8, 36);
+} catch {}
+let commandEncoder96 = device0.createCommandEncoder({label: '\u4a85\u8b94\u0df1\u{1fa27}\u35b4\u878a\u07e9\u0b07'});
+let textureView81 = texture71.createView({dimension: '2d'});
+try {
+computePassEncoder63.setBindGroup(2, bindGroup54);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup10, new Uint32Array(2731), 28, 0);
+} catch {}
+let offscreenCanvas1 = new OffscreenCanvas(38, 70);
+let autogeneratedBindGroupLayout36 = pipeline2.getBindGroupLayout(0);
+let commandEncoder97 = device0.createCommandEncoder();
+let texture93 = device0.createTexture({
+  size: {width: 30, height: 10, depthOrArrayLayers: 1},
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture94 = device0.createTexture({
+  size: {width: 30, height: 10, depthOrArrayLayers: 49},
+  format: 'depth32float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder83 = commandEncoder96.beginComputePass({});
+try {
+computePassEncoder39.setBindGroup(3, bindGroup12, new Uint32Array(1159), 287, 0);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer36, 'uint16', 670, 832);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline11);
+} catch {}
+try {
+commandEncoder97.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 204 */
+  offset: 192,
+  bytesPerRow: 768,
+  buffer: buffer62,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 6, y: 4, z: 19},
+  aspect: 'all',
+}, {width: 3, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 696, new Float32Array(663), 89, 44);
+} catch {}
+document.body.append(img0);
+let textureView82 = texture93.createView({});
+let computePassEncoder84 = commandEncoder97.beginComputePass({});
+try {
+computePassEncoder39.setBindGroup(2, bindGroup13, new Uint32Array(3508), 464, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder11); computePassEncoder11.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup11, new Uint32Array(711), 6, 0);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(5, buffer50, 0, 17);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer29, 700, new BigUint64Array(1795), 583, 60);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture90,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(2).fill(71), /* required buffer size: 2 */
+{offset: 2}, {width: 21, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas0);
+let commandEncoder98 = device0.createCommandEncoder({});
+try {
+{ clearResourceUsages(device0, computePassEncoder18); computePassEncoder18.dispatchWorkgroupsIndirect(buffer32, 6_552); };
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup50);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer46, 'uint16', 626, 169);
+} catch {}
+let videoFrame9 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'smpte432', transfer: 'bt709'} });
+let bindGroup56 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout13,
+  entries: [{binding: 203, resource: {buffer: buffer63, offset: 1024}}, {binding: 33, resource: sampler32}],
+});
+let buffer64 = device0.createBuffer({
+  size: 9443,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture95 = device0.createTexture({
+  size: [120, 40, 105],
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView83 = texture92.createView({});
+let computePassEncoder85 = commandEncoder98.beginComputePass();
+try {
+computePassEncoder69.setBindGroup(1, bindGroup24);
+} catch {}
+try {
+computePassEncoder18.end();
+} catch {}
+try {
+computePassEncoder80.setPipeline(pipeline10);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+let buffer65 = device0.createBuffer({size: 23281, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let commandEncoder99 = device0.createCommandEncoder();
+let textureView84 = texture0.createView({dimension: '2d'});
+try {
+computePassEncoder57.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+computePassEncoder19.setPipeline(pipeline17);
+} catch {}
+try {
+computePassEncoder84.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(1, buffer30);
+} catch {}
+try {
+commandEncoder20.copyBufferToBuffer(buffer47, 64, buffer53, 272, 1704);
+} catch {}
+let videoFrame10 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'bt2020', transfer: 'smpte170m'} });
+let commandEncoder100 = device0.createCommandEncoder({});
+let querySet12 = device0.createQuerySet({type: 'occlusion', count: 405});
+let renderPassEncoder25 = commandEncoder20.beginRenderPass({
+    label: 'z',
+  colorAttachments: [{view: textureView73, depthSlice: 69, loadOp: 'load', storeOp: 'store'}],
+  depthStencilAttachment: {view: textureView79, depthClearValue: 5.698687022757374, depthReadOnly: true, stencilClearValue: 30570},
+});
+let sampler72 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+});
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let textureView85 = texture28.createView({format: 'rg11b10ufloat', baseArrayLayer: 1, arrayLayerCount: 4});
+try {
+computePassEncoder69.setBindGroup(2, bindGroup30);
+} catch {}
+try {
+computePassEncoder79.setBindGroup(0, bindGroup6, new Uint32Array(2233), 57, 0);
+} catch {}
+try {
+computePassEncoder85.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(6, buffer44);
+} catch {}
+let bindGroup57 = device0.createBindGroup({layout: autogeneratedBindGroupLayout34, entries: [{binding: 216, resource: textureView24}]});
+let textureView86 = texture47.createView({mipLevelCount: 1});
+let textureView87 = texture47.createView({mipLevelCount: 1});
+try {
+commandEncoder100.copyBufferToTexture({
+  /* bytesInLastRow: 40 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3652 */
+  offset: 3652,
+  buffer: buffer55,
+}, {
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas1);
+let texture96 = device0.createTexture({
+  size: {width: 30, height: 10, depthOrArrayLayers: 17},
+  mipLevelCount: 2,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView88 = texture33.createView({
+  aspect: 'depth-only',
+  format: 'depth32float',
+  baseMipLevel: 0,
+  mipLevelCount: 1,
+  baseArrayLayer: 7,
+  arrayLayerCount: 2,
+});
+let sampler73 = device0.createSampler({addressModeU: 'repeat', magFilter: 'nearest', lodMaxClamp: 79.95});
+try {
+computePassEncoder34.setBindGroup(0, bindGroup55, []);
+} catch {}
+try {
+renderPassEncoder25.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer8, 'uint32', 1_896, 29);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(0, buffer33);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let bindGroup58 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout33,
+  entries: [
+    {binding: 8, resource: {buffer: buffer43, offset: 768, size: 1884}},
+    {binding: 216, resource: textureView38},
+  ],
+});
+let buffer66 = device0.createBuffer({size: 3619, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let texture97 = device0.createTexture({
+  label: '\u0ee9\u0efd\u{1fe38}\u0420',
+  size: [2, 2, 13],
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder86 = commandEncoder100.beginComputePass({});
+try {
+computePassEncoder59.setBindGroup(1, bindGroup7, new Uint32Array(6544), 21, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder11); computePassEncoder11.dispatchWorkgroupsIndirect(buffer12, 2_752); };
+} catch {}
+try {
+computePassEncoder82.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup30);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer8, 'uint16', 306, 59);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(1, buffer15, 7_264, 17_479);
+} catch {}
+let videoFrame11 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'smpte170m', transfer: 'bt2020_12bit'} });
+let buffer67 = device0.createBuffer({
+  label: '\u084c\uc8d5\u{1f84e}\u{1fad8}\u01cd\u{1f8fb}\u060a\u6cc3\uf669\u8e32',
+  size: 7499,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder101 = device0.createCommandEncoder({});
+let textureView89 = texture74.createView({mipLevelCount: 1});
+let texture98 = device0.createTexture({
+  size: {width: 30, height: 10, depthOrArrayLayers: 67},
+  mipLevelCount: 1,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder87 = commandEncoder99.beginComputePass();
+let renderPassEncoder26 = commandEncoder101.beginRenderPass({
+    label: '1',
+  colorAttachments: [{view: textureView30, loadOp: 'clear', storeOp: 'store'}],
+  depthStencilAttachment: {view: textureView2, depthClearValue: 4.786577580045957, depthReadOnly: true, stencilClearValue: 10555},
+  maxDrawCount: 203381158,
+});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8sint'],
+  depthStencilFormat: 'depth32float',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder32.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+computePassEncoder83.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup19);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline19);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let autogeneratedBindGroupLayout37 = pipeline0.getBindGroupLayout(0);
+try {
+computePassEncoder78.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle2, renderBundle3, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline13);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(3, bindGroup26, new Uint32Array(3630), 332, 0);
+} catch {}
+try {
+buffer24.unmap();
+} catch {}
+let buffer68 = device0.createBuffer({
+  size: 2078,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let renderBundle9 = renderBundleEncoder9.finish({});
+let sampler74 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 74.41,
+  maxAnisotropy: 16,
+});
+try {
+renderPassEncoder17.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(5, buffer9, 0, 805);
+} catch {}
+let textureView90 = texture93.createView({});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], stencilReadOnly: true});
+let renderBundle10 = renderBundleEncoder10.finish({});
+try {
+computePassEncoder80.setBindGroup(0, bindGroup35);
+} catch {}
+try {
+computePassEncoder0.setBindGroup(2, bindGroup51, new Uint32Array(2272), 10, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder11); computePassEncoder11.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup54, new Uint32Array(786), 11, 0);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer22, 'uint32', 412, 232);
+} catch {}
+let autogeneratedBindGroupLayout38 = pipeline16.getBindGroupLayout(0);
+let buffer69 = device0.createBuffer({
+  size: 784,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView91 = texture34.createView({});
+let sampler75 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'clamp-to-edge', minFilter: 'nearest'});
+try {
+computePassEncoder81.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(0, bindGroup51, []);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer29, 'uint16', 1_572, 888);
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.TEXTURE_BINDING, alphaMode: 'opaque'});
+} catch {}
+let gpuCanvasContext3 = offscreenCanvas1.getContext('webgpu');
+let buffer70 = device0.createBuffer({
+  size: 11800,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let sampler76 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder86.setBindGroup(0, bindGroup40);
+} catch {}
+try {
+computePassEncoder59.setBindGroup(3, bindGroup41, new Uint32Array(709), 118, 0);
+} catch {}
+try {
+computePassEncoder11.end();
+} catch {}
+try {
+commandEncoder11.copyTextureToBuffer({
+  texture: texture91,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'depth-only',
+}, {
+  /* bytesInLastRow: 120 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 272 */
+  offset: 272,
+  bytesPerRow: 35328,
+  buffer: buffer4,
+}, {width: 30, height: 10, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder11.resolveQuerySet(querySet3, 75, 30, buffer44, 0);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(185).fill(148), /* required buffer size: 185 */
+{offset: 185}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup59 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout32,
+  entries: [{binding: 8, resource: {buffer: buffer14, offset: 0, size: 212}}],
+});
+let buffer71 = device0.createBuffer({size: 15557, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let renderPassEncoder27 = commandEncoder11.beginRenderPass({label: '2', colorAttachments: [{view: textureView15, loadOp: 'clear', storeOp: 'store'}]});
+try {
+computePassEncoder39.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(0, bindGroup45, new Uint32Array(228), 65, 0);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline19);
+} catch {}
+let textureView92 = texture28.createView({dimension: 'cube-array', baseArrayLayer: 2, arrayLayerCount: 6});
+try {
+computePassEncoder84.setBindGroup(0, bindGroup17);
+} catch {}
+let textureView93 = texture28.createView({dimension: 'cube', mipLevelCount: 1, baseArrayLayer: 2});
+let sampler77 = device0.createSampler({lodMaxClamp: 81.59, compare: 'not-equal'});
+try {
+computePassEncoder86.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([renderBundle7]);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let autogeneratedBindGroupLayout39 = pipeline11.getBindGroupLayout(0);
+let commandEncoder102 = device0.createCommandEncoder({});
+let texture99 = device0.createTexture({
+  size: [60, 20, 1],
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder88 = commandEncoder102.beginComputePass();
+try {
+computePassEncoder88.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup31, new Uint32Array(804), 340, 0);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([renderBundle5, renderBundle6, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder23.setStencilReference(1879);
+} catch {}
+await gc();
+let veryExplicitBindGroupLayout14 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 396,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let texture100 = device0.createTexture({
+  size: {width: 30, height: 10, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler78 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  lodMaxClamp: 44.94,
+  compare: 'equal',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder76.setBindGroup(0, bindGroup35, []);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup34);
+} catch {}
+try {
+renderPassEncoder21.setBlendConstant({ r: -444.4, g: -949.8, b: -454.0, a: 906.3, });
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(3, buffer64);
+} catch {}
+try {
+renderPassEncoder22.insertDebugMarker('\u0fc0');
+} catch {}
+let img1 = await imageWithData(2, 87, '#10101010', '#20202020');
+let videoFrame12 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte240m', primaries: 'jedecP22Phosphors', transfer: 'logSqrt'} });
+let texture101 = device0.createTexture({
+  size: {width: 60, height: 20, depthOrArrayLayers: 56},
+  mipLevelCount: 2,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({colorFormats: ['rgba8sint'], depthStencilFormat: 'depth32float'});
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup39, new Uint32Array(2700), 432, 0);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(5, buffer29, 0, 2_255);
+} catch {}
+try {
+buffer54.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let autogeneratedBindGroupLayout40 = pipeline0.getBindGroupLayout(0);
+let commandEncoder103 = device0.createCommandEncoder({});
+let querySet13 = device0.createQuerySet({type: 'occlusion', count: 5});
+let textureView94 = texture74.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder89 = commandEncoder103.beginComputePass({});
+let renderBundle11 = renderBundleEncoder11.finish();
+try {
+computePassEncoder61.setBindGroup(0, bindGroup23, []);
+} catch {}
+try {
+computePassEncoder87.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup24);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(3, buffer24, 0, 14_588);
+} catch {}
+try {
+renderPassEncoder1.insertDebugMarker('\uc426');
+} catch {}
+let bindGroup60 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 290, resource: externalTexture10},
+    {binding: 159, resource: {buffer: buffer5, offset: 1024}},
+    {binding: 256, resource: {buffer: buffer15, offset: 13568, size: 8094}},
+  ],
+});
+let textureView95 = texture47.createView({mipLevelCount: 1});
+try {
+computePassEncoder89.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup46);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer9, 'uint16', 2_584, 3_002);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline19);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 49, y: 0, z: 3},
+  aspect: 'all',
+}, new Uint8Array(9_892).fill(220), /* required buffer size: 9_892 */
+{offset: 12, bytesPerRow: 52, rowsPerImage: 26}, {width: 0, height: 9, depthOrArrayLayers: 8});
+} catch {}
+let promise6 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise6;
+} catch {}
+let veryExplicitBindGroupLayout15 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 8,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 54, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder104 = device0.createCommandEncoder({});
+let computePassEncoder90 = commandEncoder104.beginComputePass({});
+let sampler79 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 21.43,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder50.setBindGroup(2, bindGroup11, new Uint32Array(88), 4, 0);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(3, bindGroup51, new Uint32Array(1807), 324, 0);
+} catch {}
+let autogeneratedBindGroupLayout41 = pipeline17.getBindGroupLayout(0);
+let commandEncoder105 = device0.createCommandEncoder({});
+let texture102 = device0.createTexture({
+  size: [120],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder91 = commandEncoder105.beginComputePass();
+try {
+computePassEncoder91.setBindGroup(3, bindGroup6, new Uint32Array(1905), 80, 0);
+} catch {}
+try {
+renderPassEncoder2.setViewport(38.46101498225467, 3.0909525508578373, 3.8687232392674464, 5.602490404892497, 0.15091331820149645, 0.9327056222239721);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let autogeneratedBindGroupLayout42 = pipeline16.getBindGroupLayout(0);
+let buffer72 = device0.createBuffer({size: 4772, usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let commandEncoder106 = device0.createCommandEncoder();
+let textureView96 = texture56.createView({});
+let computePassEncoder92 = commandEncoder106.beginComputePass({});
+try {
+computePassEncoder33.setBindGroup(3, bindGroup58);
+} catch {}
+try {
+computePassEncoder0.setPipeline(pipeline16);
+} catch {}
+try {
+computePassEncoder91.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer44, 'uint16', 232, 5);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(2, buffer62, 0, 3_308);
+} catch {}
+let commandEncoder107 = device0.createCommandEncoder({});
+let computePassEncoder93 = commandEncoder107.beginComputePass({});
+try {
+computePassEncoder19.setBindGroup(3, bindGroup25, new Uint32Array(1559), 91, 0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+renderPassEncoder15.executeBundles([renderBundle11, renderBundle7, renderBundle8, renderBundle11, renderBundle5, renderBundle0, renderBundle6, renderBundle8, renderBundle11]);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(3, buffer44);
+} catch {}
+try {
+buffer60.unmap();
+} catch {}
+let recycledExplicitBindGroupLayout0 = pipeline5.getBindGroupLayout(0);
+let commandEncoder108 = device0.createCommandEncoder({});
+let commandBuffer12 = commandEncoder108.finish();
+try {
+computePassEncoder9.setBindGroup(2, bindGroup15);
+} catch {}
+try {
+computePassEncoder92.setPipeline(pipeline5);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+await gc();
+let commandEncoder109 = device0.createCommandEncoder();
+let computePassEncoder94 = commandEncoder109.beginComputePass({});
+try {
+computePassEncoder47.setBindGroup(0, bindGroup23, new Uint32Array(2350), 54, 0);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(5, buffer69);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer34, 836, new Int16Array(13760), 3452, 152);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 15, y: 4, z: 0},
+  aspect: 'all',
+}, new Uint8Array(45).fill(240), /* required buffer size: 45 */
+{offset: 45, bytesPerRow: 145}, {width: 5, height: 16, depthOrArrayLayers: 0});
+} catch {}
+let texture103 = device0.createTexture({
+  size: {width: 240, height: 80, depthOrArrayLayers: 11},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder60.setBindGroup(0, bindGroup19);
+} catch {}
+try {
+computePassEncoder90.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline4);
+} catch {}
+let bindGroup61 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout10,
+  entries: [{binding: 8, resource: {buffer: buffer53, offset: 1536, size: 56}}],
+});
+let textureView97 = texture102.createView({});
+let sampler80 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 65.52,
+  lodMaxClamp: 72.02,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder55.setBindGroup(0, bindGroup41);
+} catch {}
+try {
+computePassEncoder25.setBindGroup(0, bindGroup13, new Uint32Array(1492), 697, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder60); computePassEncoder60.dispatchWorkgroupsIndirect(buffer4, 660); };
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle1, renderBundle9, renderBundle1, renderBundle6, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder9.insertDebugMarker('\u08c5');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(457).fill(60), /* required buffer size: 457 */
+{offset: 337, bytesPerRow: 1, rowsPerImage: 23}, {width: 0, height: 6, depthOrArrayLayers: 6});
+} catch {}
+let imageData18 = new ImageData(40, 44);
+let textureView98 = texture75.createView({aspect: 'depth-only', baseArrayLayer: 6, arrayLayerCount: 7});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup53, []);
+} catch {}
+try {
+computePassEncoder68.setBindGroup(1, bindGroup8, new Uint32Array(1676), 187, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder25); computePassEncoder25.dispatchWorkgroupsIndirect(buffer15, 5_436); };
+} catch {}
+try {
+computePassEncoder93.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(3, bindGroup5, new Uint32Array(1393), 22, 0);
+} catch {}
+try {
+renderPassEncoder27.executeBundles([renderBundle10]);
+} catch {}
+try {
+renderPassEncoder3.setViewport(3.5901499914368484, 10.56768838557312, 26.895848434603153, 3.019387330132418, 0.911973758253343, 0.9751321683094214);
+} catch {}
+let pipeline21 = device0.createComputePipeline({
+  layout: pipelineLayout1,
+  compute: {module: shaderModule2, entryPoint: 'compute2', constants: {override4: 0}},
+});
+let commandEncoder110 = device0.createCommandEncoder({});
+let texture104 = device0.createTexture({
+  size: [30],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder95 = commandEncoder110.beginComputePass({});
+let sampler81 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'repeat', mipmapFilter: 'nearest', lodMaxClamp: 99.67});
+try {
+computePassEncoder89.setBindGroup(3, bindGroup1, new Uint32Array(3862), 276, 0);
+} catch {}
+try {
+computePassEncoder94.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(0, bindGroup13, new Uint32Array(469), 159, 0);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline3);
+} catch {}
+try {
+buffer33.unmap();
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let texture105 = device0.createTexture({
+  size: {width: 60, height: 20, depthOrArrayLayers: 13},
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let texture106 = gpuCanvasContext2.getCurrentTexture();
+let sampler82 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 94.13,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder25.end();
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer40, 'uint32', 1_876, 619);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(1, buffer20, 548, 313);
+} catch {}
+let computePassEncoder96 = commandEncoder29.beginComputePass({});
+let sampler83 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 99.66,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder12.setIndexBuffer(buffer64, 'uint16', 86, 3_405);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(7, buffer46, 0);
+} catch {}
+let promise7 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: img0,
+  origin: { x: 0, y: 1 },
+  flipY: false,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 35, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 5, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup62 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout13,
+  entries: [
+    {binding: 203, resource: {buffer: buffer15, offset: 5632, size: 17884}},
+    {binding: 33, resource: sampler69},
+  ],
+});
+let textureView99 = texture61.createView({dimension: 'cube', aspect: 'all'});
+let sampler84 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMinClamp: 86.67,
+  lodMaxClamp: 98.81,
+});
+try {
+computePassEncoder95.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(0, bindGroup62, new Uint32Array(382), 96, 0);
+} catch {}
+try {
+renderPassEncoder17.setStencilReference(299);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer46, 'uint16', 290, 79);
+} catch {}
+try {
+device0.queue.submit([commandBuffer12]);
+} catch {}
+try {
+computePassEncoder96.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder10.setViewport(52.75641112165022, 10.494968568541374, 23.950440295757144, 5.693733226632708, 0.0678243882431141, 0.2524412054243823);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline11);
+} catch {}
+let imageData19 = new ImageData(12, 100);
+let bindGroup63 = device0.createBindGroup({layout: autogeneratedBindGroupLayout34, entries: [{binding: 216, resource: textureView24}]});
+let buffer73 = device0.createBuffer({size: 7137, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+try {
+computePassEncoder87.setBindGroup(2, bindGroup37);
+} catch {}
+try {
+computePassEncoder88.setBindGroup(1, bindGroup37, new Uint32Array(745), 379, 0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup23, new Uint32Array(725), 77, 0);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(4, buffer8, 0, 774);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture66,
+  mipLevel: 1,
+  origin: {x: 13, y: 12, z: 0},
+  aspect: 'all',
+}, new Uint8Array(52).fill(248), /* required buffer size: 52 */
+{offset: 52, bytesPerRow: 185}, {width: 36, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout6 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout25]});
+let commandEncoder111 = device0.createCommandEncoder();
+let texture107 = device0.createTexture({
+  size: [120, 40, 147],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let sampler85 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat'});
+try {
+computePassEncoder77.setBindGroup(2, bindGroup63, new Uint32Array(1064), 510, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder60); computePassEncoder60.dispatchWorkgroupsIndirect(buffer19, 1_496); };
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(7, buffer33, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData12,
+  origin: { x: 8, y: 9 },
+  flipY: true,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 39, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 31, height: 5, depthOrArrayLayers: 0});
+} catch {}
+try {
+globalThis.someLabel = device0.queue.label;
+} catch {}
+let commandEncoder112 = device0.createCommandEncoder({});
+let computePassEncoder97 = commandEncoder112.beginComputePass({});
+try {
+computePassEncoder50.setBindGroup(1, bindGroup31, new Uint32Array(3901), 105, 0);
+} catch {}
+try {
+computePassEncoder27.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer62, 'uint16', 3_424, 1_149);
+} catch {}
+let autogeneratedBindGroupLayout43 = pipeline16.getBindGroupLayout(0);
+let computePassEncoder98 = commandEncoder111.beginComputePass({});
+let sampler86 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 97.43});
+try {
+computePassEncoder9.setBindGroup(2, bindGroup34, new Uint32Array(357), 17, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder55); computePassEncoder55.dispatchWorkgroupsIndirect(buffer44, 200); };
+} catch {}
+try {
+computePassEncoder98.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder16.setViewport(98.0573104874695, 9.300178119174053, 20.821443153091373, 3.6158600139569015, 0.6521293556637312, 0.6995921792039166);
+} catch {}
+let bindGroup64 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout5,
+  entries: [{binding: 8, resource: {buffer: buffer12, offset: 0, size: 4952}}],
+});
+try {
+computePassEncoder97.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup15);
+} catch {}
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8sint'],
+  depthStencilFormat: 'depth32float',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder2.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(1, buffer4, 6_868);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(0, bindGroup13, new Uint32Array(218), 69, 0);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer62, 'uint16', 818, 2_322);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(0, buffer43, 0);
+} catch {}
+let autogeneratedBindGroupLayout44 = pipeline12.getBindGroupLayout(0);
+let commandEncoder113 = device0.createCommandEncoder({});
+let texture108 = device0.createTexture({
+  size: [240, 80, 1],
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder99 = commandEncoder113.beginComputePass({});
+let renderBundle12 = renderBundleEncoder12.finish({label: '\u{1f946}\u4094\u{1f637}\u{1fc2f}\u9b55\u{1fbe8}\u0aed'});
+try {
+{ clearResourceUsages(device0, computePassEncoder55); computePassEncoder55.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(0, bindGroup51, new Uint32Array(935), 93, 0);
+} catch {}
+try {
+renderPassEncoder7.setViewport(28.55691233134902, 3.1780958155599315, 25.219956479923265, 5.6689207034485944, 0.5701937638872513, 0.7268503891161959);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline4);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let bindGroup65 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout5,
+  entries: [{binding: 8, resource: {buffer: buffer70, offset: 1280}}],
+});
+let commandEncoder114 = device0.createCommandEncoder();
+let commandBuffer13 = commandEncoder114.finish();
+let texture109 = device0.createTexture({size: [120, 40, 147], dimension: '3d', format: 'rgb10a2uint', usage: GPUTextureUsage.TEXTURE_BINDING});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup40, new Uint32Array(2466), 65, 0);
+} catch {}
+try {
+buffer31.unmap();
+} catch {}
+let bindGroup66 = device0.createBindGroup({
+  label: '\u4e27\u{1febe}\u{1ff99}',
+  layout: veryExplicitBindGroupLayout6,
+  entries: [{binding: 8, resource: {buffer: buffer22, offset: 15104, size: 1280}}],
+});
+let commandEncoder115 = device0.createCommandEncoder({});
+let texture110 = device0.createTexture({
+  size: {width: 120, height: 40, depthOrArrayLayers: 147},
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let renderPassEncoder28 = commandEncoder115.beginRenderPass({
+    label: '3',
+  colorAttachments: [{view: textureView71, loadOp: 'clear', storeOp: 'discard'}],
+  maxDrawCount: 75620451,
+});
+try {
+computePassEncoder31.setBindGroup(0, bindGroup51);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(0, bindGroup30);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer53, 'uint32', 1_028, 1_687);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline4);
+} catch {}
+try {
+  await promise7;
+} catch {}
+let bindGroup67 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout14,
+  entries: [{binding: 8, resource: {buffer: buffer41, offset: 8960, size: 720}}],
+});
+let commandEncoder116 = device0.createCommandEncoder({});
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup36);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer36, 'uint16', 64, 193);
+} catch {}
+try {
+commandEncoder116.copyBufferToBuffer(buffer12, 2364, buffer34, 2460, 6620);
+} catch {}
+try {
+commandEncoder116.resolveQuerySet(querySet9, 0, 0, buffer7, 512);
+} catch {}
+try {
+computePassEncoder50.insertDebugMarker('\udf4d');
+} catch {}
+let buffer74 = device0.createBuffer({
+  size: 9496,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let renderPassEncoder29 = commandEncoder116.beginRenderPass({
+    label: '4',
+  colorAttachments: [{
+  view: textureView13,
+  clearValue: { r: 685.3, g: -748.0, b: 463.4, a: 399.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {view: textureView44, depthReadOnly: true, stencilClearValue: 23030, stencilReadOnly: false},
+});
+let externalTexture12 = device0.importExternalTexture({source: videoFrame5});
+try {
+computePassEncoder55.end();
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer69, 'uint32', 104, 66);
+} catch {}
+try {
+commandEncoder64.copyBufferToTexture({
+  /* bytesInLastRow: 24 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1028 */
+  offset: 1028,
+  bytesPerRow: 1792,
+  buffer: buffer56,
+}, {
+  texture: texture102,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, new Uint8Array(175).fill(70), /* required buffer size: 175 */
+{offset: 175, rowsPerImage: 22}, {width: 30, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline22 = await promise2;
+document.body.prepend(img1);
+let buffer75 = device0.createBuffer({size: 6095, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder117 = device0.createCommandEncoder({});
+let textureView100 = texture98.createView({dimension: '2d', format: 'rgba8sint', baseArrayLayer: 12});
+let computePassEncoder100 = commandEncoder64.beginComputePass({});
+try {
+computePassEncoder35.setBindGroup(2, bindGroup64);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder5); computePassEncoder5.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder100.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(0, bindGroup67);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup54, new Uint32Array(381), 19, 0);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle12]);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer29, 'uint32', 832, 3_249);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(7, buffer26, 0, 814);
+} catch {}
+try {
+commandEncoder117.copyBufferToBuffer(buffer56, 5816, buffer29, 5532, 3832);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer36, 288, new Float32Array(12440), 194, 36);
+} catch {}
+let bindGroup68 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout0,
+  entries: [{binding: 8, resource: {buffer: buffer49, offset: 768}}],
+});
+let textureView101 = texture107.createView({mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder101 = commandEncoder117.beginComputePass({});
+try {
+renderPassEncoder17.setBlendConstant({ r: -737.0, g: 228.5, b: 268.4, a: 646.6, });
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline4);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder118 = device0.createCommandEncoder({});
+try {
+computePassEncoder91.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline22);
+} catch {}
+let pipeline23 = await promise5;
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let renderPassEncoder30 = commandEncoder118.beginRenderPass({
+    label: '5',
+  colorAttachments: [{
+  view: textureView73,
+  depthSlice: 79,
+  clearValue: { r: -50.22, g: 334.1, b: -662.7, a: 24.16, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {view: textureView20, depthReadOnly: true, stencilClearValue: 37870, stencilReadOnly: false},
+  maxDrawCount: 267366526,
+});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderPassEncoder24.beginOcclusionQuery(12);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer44, 'uint16', 102, 78);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline12);
+} catch {}
+let promise8 = device0.queue.onSubmittedWorkDone();
+let autogeneratedBindGroupLayout45 = pipeline3.getBindGroupLayout(0);
+let pipelineLayout7 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout23]});
+let sampler87 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 86.53});
+try {
+computePassEncoder101.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(0, bindGroup46, new Uint32Array(1121), 182, 0);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(1, buffer59, 0, 2_331);
+} catch {}
+let autogeneratedBindGroupLayout46 = pipeline14.getBindGroupLayout(0);
+let buffer76 = device0.createBuffer({
+  size: 10648,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let sampler88 = device0.createSampler({
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.45,
+  compare: 'always',
+  maxAnisotropy: 20,
+});
+try {
+renderPassEncoder27.setBindGroup(1, bindGroup46, new Uint32Array(2158), 255, 0);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle11]);
+} catch {}
+let buffer77 = device0.createBuffer({
+  size: 32964,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture111 = device0.createTexture({
+  size: [60, 20, 1],
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder22.setBindGroup(3, bindGroup43);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer69, 'uint32', 88, 418);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(7, buffer24, 0, 16_692);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture98,
+  mipLevel: 0,
+  origin: {x: 4, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(6_468).fill(76), /* required buffer size: 6_468 */
+{offset: 73, bytesPerRow: 77, rowsPerImage: 41}, {width: 1, height: 2, depthOrArrayLayers: 3});
+} catch {}
+try {
+  await promise8;
+} catch {}
+let texture112 = device0.createTexture({
+  size: {width: 60},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgb10a2uint'],
+});
+try {
+computePassEncoder60.setBindGroup(3, bindGroup48, new Uint32Array(184), 53, 0);
+} catch {}
+try {
+renderPassEncoder22.setBlendConstant({ r: 447.8, g: -996.6, b: 18.24, a: -642.3, });
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer24, 'uint32', 1_136, 2_872);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame11,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 16, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup69 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout20,
+  entries: [{binding: 8, resource: {buffer: buffer23, offset: 1280, size: 204}}],
+});
+let buffer78 = device0.createBuffer({
+  size: 2716,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+try {
+computePassEncoder54.setBindGroup(0, bindGroup7, new Uint32Array(3826), 2_251, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder5); computePassEncoder5.dispatchWorkgroupsIndirect(buffer56, 3_392); };
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup67, new Uint32Array(833), 89, 0);
+} catch {}
+try {
+renderPassEncoder24.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.setViewport(36.689217974202656, 13.876907807118936, 4.437919558770667, 2.1137180289943385, 0.5968029325283659, 0.7639930697340673);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer36, 'uint16', 68, 1_478);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(0, buffer62, 0);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer13]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline24 = device0.createRenderPipeline({
+    label: 'aaa',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule0,
+  targets: [{format: 'rgba8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth32float',
+    depthWriteEnabled: true,
+    depthCompare: 'always',
+    stencilReadMask: 21175866,
+    stencilWriteMask: 133367085,
+    depthBiasSlopeScale: 622.6705603081632,
+  },
+  vertex: {module: shaderModule0, constants: {}, buffers: []},
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'back'},
+});
+let autogeneratedBindGroupLayout47 = pipeline22.getBindGroupLayout(0);
+let querySet14 = device0.createQuerySet({type: 'occlusion', count: 247});
+try {
+computePassEncoder32.setBindGroup(0, bindGroup34);
+} catch {}
+try {
+computePassEncoder77.setBindGroup(3, bindGroup39, new Uint32Array(2684), 51, 0);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(2, bindGroup43);
+} catch {}
+try {
+renderPassEncoder27.setViewport(2.755819882650181, 50.697284780969305, 67.0886292121161, 4.005073330723198, 0.021308173007800524, 0.3987961708658724);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+renderPassEncoder14.insertDebugMarker('\uc7ee');
+} catch {}
+let autogeneratedBindGroupLayout48 = pipeline23.getBindGroupLayout(0);
+try {
+computePassEncoder95.setBindGroup(1, bindGroup61, new Uint32Array(189), 29, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder5); computePassEncoder5.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder60); computePassEncoder60.dispatchWorkgroupsIndirect(buffer14, 484); };
+} catch {}
+try {
+computePassEncoder78.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(1, buffer73, 1_980, 1_029);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer79 = device0.createBuffer({size: 373, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let commandEncoder119 = device0.createCommandEncoder();
+let computePassEncoder102 = commandEncoder119.beginComputePass();
+try {
+computePassEncoder26.setBindGroup(2, bindGroup55, new Uint32Array(2556), 1_059, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder5); computePassEncoder5.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder102.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([renderBundle1, renderBundle12]);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+computePassEncoder86.insertDebugMarker('\u05bc');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 45, y: 9, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture113 = device0.createTexture({
+  size: {width: 30, height: 10, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView102 = texture59.createView({dimension: 'cube', baseArrayLayer: 2});
+let sampler89 = device0.createSampler({addressModeV: 'mirror-repeat', magFilter: 'linear', minFilter: 'linear', lodMaxClamp: 98.07});
+try {
+computePassEncoder99.setPipeline(pipeline7);
+} catch {}
+try {
+  await buffer65.mapAsync(GPUMapMode.WRITE, 0, 1320);
+} catch {}
+let bindGroup70 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout21,
+  entries: [{binding: 8, resource: {buffer: buffer19, offset: 256}}],
+});
+let buffer80 = device0.createBuffer({size: 9329, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX});
+let textureView103 = texture59.createView({dimension: 'cube', baseArrayLayer: 1, arrayLayerCount: 6});
+let textureView104 = texture108.createView({dimension: '2d-array', aspect: 'depth-only'});
+let sampler90 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat'});
+try {
+computePassEncoder32.setPipeline(pipeline8);
+} catch {}
+try {
+gpuCanvasContext2.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.COPY_DST, alphaMode: 'opaque'});
+} catch {}
+let buffer81 = device0.createBuffer({size: 24278, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let querySet15 = device0.createQuerySet({type: 'occlusion', count: 304});
+let texture114 = gpuCanvasContext3.getCurrentTexture();
+try {
+{ clearResourceUsages(device0, computePassEncoder5); computePassEncoder5.dispatchWorkgroups(2); };
+} catch {}
+try {
+computePassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(1, bindGroup51, new Uint32Array(504), 5, 0);
+} catch {}
+try {
+commandEncoder5.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 916 */
+  offset: 916,
+  rowsPerImage: 939,
+  buffer: buffer51,
+}, {
+  texture: texture113,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let texture115 = device0.createTexture({size: [2, 2, 13], format: 'rgba16uint', usage: GPUTextureUsage.TEXTURE_BINDING, viewFormats: []});
+let computePassEncoder103 = commandEncoder5.beginComputePass({});
+let sampler91 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'greater-equal',
+});
+let externalTexture13 = device0.importExternalTexture({source: videoFrame11});
+try {
+computePassEncoder103.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(0, bindGroup25, new Uint32Array(2699), 358, 0);
+} catch {}
+try {
+texture94.destroy();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 11, y: 16 },
+  flipY: false,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 298, y: 19, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas1);
+let buffer82 = device0.createBuffer({
+  size: 2694,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture116 = device0.createTexture({size: [30, 10, 1], format: 'depth32float', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC});
+try {
+renderPassEncoder3.executeBundles([renderBundle6, renderBundle4, renderBundle2, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline19);
+} catch {}
+try {
+buffer80.unmap();
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData17,
+  origin: { x: 4, y: 0 },
+  flipY: false,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 175, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let recycledExplicitBindGroupLayout1 = pipeline21.getBindGroupLayout(0);
+let buffer83 = device0.createBuffer({size: 8687, usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let commandEncoder120 = device0.createCommandEncoder({});
+let texture117 = device0.createTexture({
+  size: [120, 40, 1],
+  dimension: '2d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView105 = texture58.createView({});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup51);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+commandEncoder120.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 892 */
+  offset: 892,
+  bytesPerRow: 8960,
+  buffer: buffer3,
+}, {
+  texture: texture48,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame13 = new VideoFrame(imageBitmap1, {timestamp: 0});
+let buffer84 = device0.createBuffer({
+  size: 6122,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+try {
+computePassEncoder90.setBindGroup(2, bindGroup61, new Uint32Array(2024), 22, 0);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(2, bindGroup35, new Uint32Array(1454), 128, 0);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline23);
+} catch {}
+let pipeline25 = device0.createComputePipeline({layout: pipelineLayout0, compute: {module: shaderModule2, constants: {override4: 0}}});
+try {
+globalThis.someLabel = autogeneratedBindGroupLayout34.label;
+} catch {}
+let commandEncoder121 = device0.createCommandEncoder({});
+let textureView106 = texture61.createView({mipLevelCount: 1, baseArrayLayer: 3, arrayLayerCount: 2});
+let computePassEncoder104 = commandEncoder120.beginComputePass({});
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup51, []);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup41, new Uint32Array(1497), 668, 0);
+} catch {}
+let pipeline26 = device0.createRenderPipeline({
+  layout: 'auto',
+  fragment: {module: shaderModule1, targets: [{format: 'rgba8sint'}]},
+  depthStencil: {
+    format: 'depth32float',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {},
+    stencilReadMask: 752315593,
+    stencilWriteMask: 241962736,
+    depthBias: 0,
+    depthBiasSlopeScale: 427.1794136799574,
+    depthBiasClamp: 462.8842022566364,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex2',
+    buffers: [
+      {
+        arrayStride: 80,
+        attributes: [
+          {format: 'float32', offset: 20, shaderLocation: 0},
+          {format: 'float32', offset: 0, shaderLocation: 10},
+          {format: 'uint32', offset: 8, shaderLocation: 13},
+          {format: 'float16x2', offset: 8, shaderLocation: 7},
+          {format: 'sint32x4', offset: 4, shaderLocation: 12},
+          {format: 'uint8x2', offset: 44, shaderLocation: 14},
+          {format: 'sint32x3', offset: 8, shaderLocation: 8},
+          {format: 'uint32x4', offset: 40, shaderLocation: 3},
+          {format: 'sint8x2', offset: 22, shaderLocation: 15},
+          {format: 'uint16x4', offset: 0, shaderLocation: 2},
+          {format: 'float32x4', offset: 0, shaderLocation: 9},
+          {format: 'snorm8x2', offset: 0, shaderLocation: 6},
+          {format: 'float32x2', offset: 4, shaderLocation: 5},
+          {format: 'sint32x3', offset: 4, shaderLocation: 4},
+        ],
+      },
+      {arrayStride: 752, attributes: [{format: 'uint32x4', offset: 20, shaderLocation: 11}]},
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'front'},
+});
+let videoFrame14 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'film', transfer: 'linear'} });
+let bindGroup71 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout48,
+  entries: [{binding: 8, resource: {buffer: buffer61, offset: 256, size: 184}}],
+});
+let texture118 = device0.createTexture({
+  size: {width: 60},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder31 = commandEncoder121.beginRenderPass({
+  colorAttachments: [{
+  view: textureView71,
+  clearValue: { r: 664.4, g: 376.7, b: 27.61, a: -958.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8sint'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 1,
+  stencilReadOnly: false,
+});
+try {
+computePassEncoder84.setBindGroup(3, bindGroup69, new Uint32Array(986), 6, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup30);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(1, buffer70, 0, 1_283);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(1, bindGroup67);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer37, 316, new Float32Array(1036), 52, 12);
+} catch {}
+let canvas2 = document.createElement('canvas');
+try {
+globalThis.someLabel = computePassEncoder11.label;
+} catch {}
+let commandEncoder122 = device0.createCommandEncoder({});
+let computePassEncoder105 = commandEncoder122.beginComputePass({});
+let renderBundle13 = renderBundleEncoder13.finish({});
+try {
+computePassEncoder71.setBindGroup(0, bindGroup49, new Uint32Array(2586), 40, 0);
+} catch {}
+try {
+computePassEncoder60.end();
+} catch {}
+try {
+computePassEncoder104.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(2, bindGroup63);
+} catch {}
+try {
+commandEncoder72.copyBufferToBuffer(buffer47, 468, buffer75, 536, 364);
+} catch {}
+let bindGroup72 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout13,
+  entries: [{binding: 33, resource: sampler5}, {binding: 203, resource: {buffer: buffer62, offset: 3840}}],
+});
+let arrayBuffer5 = buffer65.getMappedRange(0, 112);
+try {
+commandEncoder72.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 684 */
+  offset: 684,
+  buffer: buffer47,
+}, {
+  texture: texture15,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData0,
+  origin: { x: 19, y: 4 },
+  flipY: true,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 24, y: 9, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 8, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img1);
+let bindGroup73 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout17,
+  entries: [{binding: 8, resource: {buffer: buffer49, offset: 1024}}],
+});
+let buffer85 = device0.createBuffer({
+  size: 2744,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture119 = device0.createTexture({
+  size: {width: 240, height: 80, depthOrArrayLayers: 26},
+  format: 'depth24plus',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder32 = commandEncoder72.beginRenderPass({
+  colorAttachments: [{
+  view: textureView12,
+  depthSlice: 51,
+  clearValue: { r: -724.1, g: -466.1, b: 572.8, a: -353.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView58,
+    depthClearValue: 8.298106651158037,
+    depthLoadOp: 'load',
+    depthStoreOp: 'discard',
+    depthReadOnly: false,
+  },
+  occlusionQuerySet: querySet1,
+  maxDrawCount: 163992768,
+});
+try {
+computePassEncoder105.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(2, bindGroup16);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(1, bindGroup36, new Uint32Array(1124), 20, 0);
+} catch {}
+try {
+renderPassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(2, buffer46, 0, 93);
+} catch {}
+let textureView107 = texture71.createView({dimension: '2d-array', arrayLayerCount: 5});
+let sampler92 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  lodMaxClamp: 91.76,
+});
+try {
+computePassEncoder35.setBindGroup(1, bindGroup5, new Uint32Array(1415), 220, 0);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer9, 'uint16', 760, 777);
+} catch {}
+try {
+commandEncoder28.copyTextureToBuffer({
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1768 */
+  offset: 1768,
+  buffer: buffer74,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder28.resolveQuerySet(querySet11, 5, 150, buffer26, 1024);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let autogeneratedBindGroupLayout49 = pipeline14.getBindGroupLayout(0);
+let texture120 = device0.createTexture({
+  size: {width: 30, height: 10, depthOrArrayLayers: 36},
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture121 = device0.createTexture({
+  size: [2, 2, 13],
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView108 = texture73.createView({label: '\u{1f7a0}\uff4e\u4cb3\u04ef', dimension: '2d-array', baseArrayLayer: 0});
+let computePassEncoder106 = commandEncoder28.beginComputePass();
+try {
+renderPassEncoder26.setIndexBuffer(buffer83, 'uint16', 2_126, 108);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline26);
+} catch {}
+try {
+gpuCanvasContext1.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.COPY_SRC});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas0,
+  origin: { x: 310, y: 5 },
+  flipY: true,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 13, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 33, height: 21, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext4 = canvas2.getContext('webgpu');
+let bindGroup74 = device0.createBindGroup({layout: autogeneratedBindGroupLayout44, entries: [{binding: 216, resource: textureView92}]});
+let commandEncoder123 = device0.createCommandEncoder({});
+let texture122 = device0.createTexture({
+  size: {width: 30, height: 10, depthOrArrayLayers: 36},
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture123 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 13},
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView109 = texture123.createView({dimension: 'cube-array', aspect: 'depth-only', baseArrayLayer: 1, arrayLayerCount: 6});
+let renderPassEncoder33 = commandEncoder123.beginRenderPass({
+  label: '\uf963\u0043\u{1fe1c}\u{1fe3e}\ua77c\u{1fe28}\u{1fce4}',
+  colorAttachments: [{
+  view: textureView71,
+  clearValue: { r: -148.1, g: -603.8, b: 629.7, a: 852.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder106.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(3, bindGroup64, new Uint32Array(6230), 4_398, 0);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle9, renderBundle11, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer29, 'uint16', 1_582, 761);
+} catch {}
+let buffer86 = device0.createBuffer({
+  size: 30476,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView110 = texture122.createView({format: 'rgba8uint', baseArrayLayer: 0});
+try {
+buffer27.unmap();
+} catch {}
+let buffer87 = device0.createBuffer({
+  size: 2581,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder124 = device0.createCommandEncoder({});
+let texture124 = device0.createTexture({
+  size: [2, 2, 13],
+  mipLevelCount: 1,
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder107 = commandEncoder124.beginComputePass();
+try {
+computePassEncoder90.setBindGroup(0, bindGroup17, new Uint32Array(3712), 1_195, 0);
+} catch {}
+try {
+computePassEncoder107.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: -77.14, g: 503.0, b: -879.2, a: 250.8, });
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline19);
+} catch {}
+try {
+  await shaderModule0.getCompilationInfo();
+} catch {}
+try {
+computePassEncoder37.pushDebugGroup('\u{1fe0d}');
+} catch {}
+let pipelineLayout8 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout2]});
+let textureView111 = texture124.createView({dimension: '2d', format: 'rgba8snorm', baseArrayLayer: 1});
+let sampler93 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', magFilter: 'nearest'});
+try {
+computePassEncoder102.setBindGroup(1, bindGroup52);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer77, 'uint16', 19_378, 4_751);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(6, buffer64, 0, 3_671);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer61, 1500, new Int16Array(18777), 1209, 220);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 4, y: 21, z: 0},
+  aspect: 'all',
+}, new Uint8Array(1).fill(113), /* required buffer size: 1 */
+{offset: 1, bytesPerRow: 26}, {width: 5, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let buffer88 = device0.createBuffer({
+  size: 10048,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let textureView112 = texture32.createView({aspect: 'depth-only', mipLevelCount: 1, baseArrayLayer: 0});
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], stencilReadOnly: true});
+let sampler94 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 93.00,
+  compare: 'equal',
+});
+let externalTexture14 = device0.importExternalTexture({source: videoFrame4, colorSpace: 'srgb'});
+try {
+computePassEncoder86.setBindGroup(0, bindGroup31, new Uint32Array(71), 6, 0);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(3, bindGroup31);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer86, 'uint16', 2_284, 6_195);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(3, undefined, 1_808_599_694);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(1, buffer64);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+try {
+renderPassEncoder5.insertDebugMarker('\u0b23');
+} catch {}
+let promise9 = device0.queue.onSubmittedWorkDone();
+try {
+{ clearResourceUsages(device0, computePassEncoder8); computePassEncoder8.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(3, bindGroup37, new Uint32Array(779), 71, 0);
+} catch {}
+try {
+renderPassEncoder20.setScissorRect(7, 1, 5, 1);
+} catch {}
+try {
+renderPassEncoder30.setViewport(109.33540341327891, 36.058348201187854, 5.887908041008904, 0.1264247568168852, 0.6673026899388872, 0.9375298901480178);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(4, buffer34, 0);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer87, 'uint16', 70, 184);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(2, buffer8, 0, 406);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer36, 2140, new DataView(new ArrayBuffer(9538)), 4989, 560);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append(canvas1);
+await gc();
+let imageData20 = new ImageData(16, 104);
+let veryExplicitBindGroupLayout16 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 5,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba8sint', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 18,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 20,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let bindGroup75 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 396, resource: {buffer: buffer14, offset: 0, size: 1084}}],
+});
+let textureView113 = texture124.createView({dimension: '2d', format: 'rgba8snorm', baseArrayLayer: 1});
+let textureView114 = texture48.createView({dimension: '1d'});
+let renderBundle14 = renderBundleEncoder14.finish({});
+let sampler95 = device0.createSampler({addressModeU: 'mirror-repeat', minFilter: 'nearest'});
+try {
+computePassEncoder31.setBindGroup(1, bindGroup20);
+} catch {}
+try {
+computePassEncoder51.setBindGroup(0, bindGroup41, new Uint32Array(321), 36, 0);
+} catch {}
+try {
+buffer56.unmap();
+} catch {}
+let autogeneratedBindGroupLayout50 = pipeline3.getBindGroupLayout(0);
+let buffer89 = device0.createBuffer({
+  size: 1254,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false,
+});
+let textureView115 = texture71.createView({mipLevelCount: 1, arrayLayerCount: 6});
+try {
+computePassEncoder9.setBindGroup(2, bindGroup45);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle0, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer29, 'uint16', 3_258, 2_251);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(3, buffer64, 260, 36);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer26.unmap();
+} catch {}
+let img2 = await imageWithData(32, 9, '#10101010', '#20202020');
+let videoFrame15 = new VideoFrame(imageBitmap2, {timestamp: 0});
+let autogeneratedBindGroupLayout51 = pipeline12.getBindGroupLayout(0);
+let externalTexture15 = device0.importExternalTexture({source: videoFrame6, colorSpace: 'display-p3'});
+try {
+computePassEncoder19.setBindGroup(3, bindGroup34, new Uint32Array(1520), 40, 0);
+} catch {}
+try {
+renderPassEncoder15.beginOcclusionQuery(151);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer87, 'uint32', 584, 1_530);
+} catch {}
+try {
+buffer38.unmap();
+} catch {}
+let promise10 = device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule3,
+  constants: {},
+  targets: [{
+  format: 'rgba8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}],
+},
+  depthStencil: {
+    format: 'depth32float',
+    depthWriteEnabled: false,
+    stencilBack: {},
+    stencilReadMask: 450636390,
+    stencilWriteMask: 238473436,
+    depthBias: -1773429811,
+    depthBiasSlopeScale: 902.9015600285811,
+  },
+  vertex: {
+    module: shaderModule2,
+    constants: {29_819: 0},
+    buffers: [
+      {
+        arrayStride: 624,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 24, shaderLocation: 5},
+          {format: 'float32x3', offset: 204, shaderLocation: 14},
+          {format: 'unorm10-10-10-2', offset: 56, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'cw'},
+});
+let imageData21 = new ImageData(20, 16);
+try {
+adapter0.label = '\u061e\u7cfd';
+} catch {}
+let bindGroup76 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout9,
+  entries: [{binding: 8, resource: {buffer: buffer69, offset: 0}}],
+});
+let buffer90 = device0.createBuffer({size: 1443, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.VERTEX});
+try {
+computePassEncoder27.setBindGroup(3, bindGroup74, new Uint32Array(3245), 184, 0);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let videoFrame16 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'unspecified', transfer: 'bt2020_12bit'} });
+let autogeneratedBindGroupLayout52 = pipeline23.getBindGroupLayout(0);
+let bindGroup77 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout7,
+  entries: [{binding: 53, resource: {buffer: buffer5, offset: 1024}}],
+});
+let textureView116 = texture62.createView({});
+let sampler96 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'greater',
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder83.setBindGroup(2, bindGroup76);
+} catch {}
+try {
+computePassEncoder8.end();
+} catch {}
+try {
+  await buffer51.mapAsync(GPUMapMode.WRITE, 1200, 8);
+} catch {}
+let imageData22 = new ImageData(80, 44);
+let commandEncoder125 = device0.createCommandEncoder({});
+let renderPassEncoder34 = commandEncoder8.beginRenderPass({
+  colorAttachments: [{
+  view: textureView73,
+  depthSlice: 9,
+  clearValue: { r: -141.3, g: -497.6, b: -68.81, a: 174.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView44,
+    depthClearValue: 0.9819984718965795,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'store',
+    stencilClearValue: 37630,
+  },
+});
+let sampler97 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'mirror-repeat', magFilter: 'nearest', lodMaxClamp: 97.73});
+try {
+computePassEncoder35.setBindGroup(0, bindGroup53, new Uint32Array(4270), 1_778, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder35); computePassEncoder35.dispatchWorkgroupsIndirect(buffer7, 204); };
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer78, 'uint16', 1_282, 68);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline13);
+} catch {}
+try {
+  await promise9;
+} catch {}
+await gc();
+let commandEncoder126 = device0.createCommandEncoder({});
+let textureView117 = texture9.createView({aspect: 'all', mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 7});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle15 = renderBundleEncoder15.finish({});
+let sampler98 = device0.createSampler({addressModeV: 'repeat', minFilter: 'nearest', lodMaxClamp: 75.03});
+try {
+computePassEncoder76.setBindGroup(0, bindGroup24);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder35); computePassEncoder35.dispatchWorkgroupsIndirect(buffer15, 732); };
+} catch {}
+try {
+renderPassEncoder15.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.setScissorRect(9, 0, 8, 2);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer21, 'uint16', 7_652, 24);
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline22);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer23, 1316, new Float32Array(28203), 36, 316);
+} catch {}
+await gc();
+let computePassEncoder108 = commandEncoder125.beginComputePass({});
+let renderPassEncoder35 = commandEncoder126.beginRenderPass({
+  colorAttachments: [{
+  view: textureView71,
+  clearValue: { r: -219.1, g: -75.21, b: -173.5, a: -206.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder100.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder34.setBlendConstant({ r: 929.4, g: 425.6, b: 7.645, a: -252.1, });
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer40, 'uint16', 1_066, 4_607);
+} catch {}
+let commandEncoder127 = device0.createCommandEncoder({});
+let textureView118 = texture89.createView({dimension: '2d-array', aspect: 'depth-only'});
+let computePassEncoder109 = commandEncoder127.beginComputePass({});
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup15);
+} catch {}
+try {
+computePassEncoder81.insertDebugMarker('\u06e9');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer85, 500, new DataView(new ArrayBuffer(8404)), 2585, 280);
+} catch {}
+let commandEncoder128 = device0.createCommandEncoder();
+let texture125 = device0.createTexture({
+  size: {width: 240, height: 80, depthOrArrayLayers: 2},
+  mipLevelCount: 3,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder110 = commandEncoder128.beginComputePass({});
+try {
+computePassEncoder63.setBindGroup(3, bindGroup45, new Uint32Array(1131), 66, 0);
+} catch {}
+try {
+renderPassEncoder32.beginOcclusionQuery(14);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(7, buffer29, 0, 932);
+} catch {}
+let bindGroup78 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout20,
+  entries: [{binding: 8, resource: {buffer: buffer85, offset: 0}}],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder35); computePassEncoder35.dispatchWorkgroupsIndirect(buffer86, 3_228); };
+} catch {}
+try {
+computePassEncoder109.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup30);
+} catch {}
+try {
+renderPassEncoder14.setBlendConstant({ r: 322.7, g: 493.4, b: 793.5, a: 869.9, });
+} catch {}
+try {
+  await shaderModule1.getCompilationInfo();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer85, 224, new Float32Array(35598), 5293, 0);
+} catch {}
+let pipeline27 = device0.createRenderPipeline({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth32float',
+    depthWriteEnabled: false,
+    stencilFront: {},
+    stencilReadMask: 485820707,
+    stencilWriteMask: 182783011,
+    depthBias: -2050829032,
+    depthBiasSlopeScale: 758.4282818954757,
+  },
+  vertex: {module: shaderModule0, constants: {}, buffers: []},
+  primitive: {frontFace: 'cw'},
+});
+let commandEncoder129 = device0.createCommandEncoder({});
+let textureView119 = texture120.createView({baseMipLevel: 0});
+let computePassEncoder111 = commandEncoder129.beginComputePass({});
+let sampler99 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.98,
+  maxAnisotropy: 2,
+});
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup12, new Uint32Array(832), 246, 0);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer80, 'uint32', 324, 4_773);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(7, buffer83, 704, 166);
+} catch {}
+let bindGroup79 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout33,
+  entries: [{binding: 216, resource: textureView38}, {binding: 8, resource: {buffer: buffer28, offset: 512}}],
+});
+let commandEncoder130 = device0.createCommandEncoder();
+let textureView120 = texture105.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 2});
+let renderPassEncoder36 = commandEncoder130.beginRenderPass({
+  colorAttachments: [{
+  view: textureView13,
+  clearValue: { r: 398.9, g: -872.0, b: -820.0, a: 354.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {view: textureView44, depthReadOnly: true},
+});
+try {
+computePassEncoder95.setBindGroup(1, bindGroup43, new Uint32Array(2153), 392, 0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle1, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer40, 'uint32', 5_168, 322);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(7, buffer83, 0);
+} catch {}
+let bindGroup80 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout11,
+  entries: [{binding: 8, resource: {buffer: buffer79, offset: 0, size: 100}}],
+});
+let buffer91 = device0.createBuffer({size: 390, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder131 = device0.createCommandEncoder({});
+let texture126 = device0.createTexture({
+  size: [240],
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let renderPassEncoder37 = commandEncoder131.beginRenderPass({
+  colorAttachments: [{
+  view: textureView73,
+  depthSlice: 21,
+  clearValue: { r: 845.1, g: 596.9, b: 406.0, a: 736.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {view: textureView20, depthClearValue: -4.811770165568667, depthLoadOp: 'load', depthStoreOp: 'store'},
+  maxDrawCount: 540614247,
+});
+try {
+computePassEncoder50.setBindGroup(2, bindGroup25);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder35); computePassEncoder35.dispatchWorkgroupsIndirect(buffer61, 92); };
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(2, bindGroup80, new Uint32Array(1647), 11, 0);
+} catch {}
+try {
+renderPassEncoder31.setBlendConstant({ r: -721.7, g: 152.2, b: -938.5, a: -744.1, });
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer62, 'uint32', 312, 7_059);
+} catch {}
+try {
+buffer62.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer64, 1176, new Int16Array(18073), 283, 1000);
+} catch {}
+document.body.prepend(img0);
+let bindGroup81 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout45,
+  entries: [{binding: 8, resource: {buffer: buffer50, offset: 0, size: 216}}],
+});
+let commandEncoder132 = device0.createCommandEncoder({});
+let computePassEncoder112 = commandEncoder132.beginComputePass();
+let sampler100 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 59.91,
+});
+try {
+computePassEncoder111.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer62, 'uint16', 1_618, 786);
+} catch {}
+let pipeline28 = device0.createComputePipeline({layout: pipelineLayout8, compute: {module: shaderModule2, constants: {override4: 0}}});
+let veryExplicitBindGroupLayout17 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 32, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+  ],
+});
+let commandEncoder133 = device0.createCommandEncoder({});
+let externalTexture16 = device0.importExternalTexture({label: '\ub43b\u{1fc1d}\u01ec\u7959\u9ef2\u016a\ubc5e\uf3c4\uf415\ufc4d\u1027', source: videoFrame11});
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup12, new Uint32Array(1919), 124, 0);
+} catch {}
+try {
+renderPassEncoder29.setViewport(94.79956566718174, 5.761032748892756, 20.99371760734585, 0.17201462834034092, 0.6527615485044552, 0.8651034772662964);
+} catch {}
+try {
+buffer78.unmap();
+} catch {}
+let bindGroup82 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout6,
+  entries: [{binding: 8, resource: {buffer: buffer83, offset: 768, size: 3972}}],
+});
+let buffer92 = device0.createBuffer({size: 478, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX});
+let commandEncoder134 = device0.createCommandEncoder({});
+let renderPassEncoder38 = commandEncoder134.beginRenderPass({
+  colorAttachments: [{
+  view: textureView120,
+  clearValue: { r: 805.5, g: 337.7, b: -719.7, a: 245.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 40760579,
+});
+try {
+computePassEncoder73.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+computePassEncoder26.setBindGroup(0, bindGroup61, new Uint32Array(493), 38, 0);
+} catch {}
+try {
+computePassEncoder48.setPipeline(pipeline28);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer46, 'uint16', 494, 301);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline27);
+} catch {}
+try {
+commandEncoder133.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2364 */
+  offset: 2364,
+  bytesPerRow: 4864,
+  buffer: buffer31,
+}, {
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder135 = device0.createCommandEncoder({});
+try {
+renderPassEncoder23.setBindGroup(0, bindGroup41, new Uint32Array(263), 131, 0);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(754);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle0, renderBundle4, renderBundle2, renderBundle9, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer36, 'uint16', 256, 950);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb'],
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer26, 532, new Float32Array(37436), 3473, 172);
+} catch {}
+let veryExplicitBindGroupLayout18 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 39,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {binding: 261, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 303,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let computePassEncoder113 = commandEncoder133.beginComputePass({});
+try {
+computePassEncoder34.setBindGroup(3, bindGroup81);
+} catch {}
+try {
+computePassEncoder64.setBindGroup(0, bindGroup48, new Uint32Array(1808), 105, 0);
+} catch {}
+try {
+computePassEncoder112.setPipeline(pipeline28);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(1, bindGroup64, new Uint32Array(1953), 772, 0);
+} catch {}
+let buffer93 = device0.createBuffer({size: 7172, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let texture127 = device0.createTexture({
+  size: [240, 80, 1],
+  sampleCount: 4,
+  format: 'depth32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView121 = texture78.createView({dimension: '2d', aspect: 'depth-only', baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 2});
+let computePassEncoder114 = commandEncoder135.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder35); computePassEncoder35.dispatchWorkgroupsIndirect(buffer77, 1_980); };
+} catch {}
+try {
+computePassEncoder35.end();
+} catch {}
+try {
+renderPassEncoder36.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer80, 'uint32', 48, 567);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline23);
+} catch {}
+try {
+buffer63.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 8, new DataView(new ArrayBuffer(13556)), 3533, 0);
+} catch {}
+let bindGroup83 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout10,
+  entries: [{binding: 53, resource: {buffer: buffer62, offset: 2560, size: 3304}}],
+});
+let computePassEncoder115 = commandEncoder41.beginComputePass({});
+try {
+computePassEncoder114.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(1, bindGroup52);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(2, bindGroup59, new Uint32Array(578), 86, 0);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle1, renderBundle7, renderBundle8, renderBundle8, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer21, 'uint16', 1_934, 2_121);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline22);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 116, y: 7, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet16 = device0.createQuerySet({type: 'occlusion', count: 499});
+let texture128 = device0.createTexture({
+  size: {width: 30, height: 10, depthOrArrayLayers: 36},
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder108.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(2, bindGroup45, new Uint32Array(2166), 115, 0);
+} catch {}
+try {
+renderPassEncoder14.beginOcclusionQuery(27);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer87, 'uint16', 304, 692);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(4, buffer7, 0, 625);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData13,
+  origin: { x: 2, y: 6 },
+  flipY: false,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 216, y: 9, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup84 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout1,
+  entries: [{binding: 8, resource: {buffer: buffer19, offset: 2304}}],
+});
+let buffer94 = device0.createBuffer({
+  size: 485,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder136 = device0.createCommandEncoder();
+let computePassEncoder116 = commandEncoder136.beginComputePass({});
+try {
+computePassEncoder113.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(2, bindGroup53, new Uint32Array(1408), 19, 0);
+} catch {}
+try {
+renderPassEncoder32.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer28, 'uint32', 476, 529);
+} catch {}
+try {
+computePassEncoder112.setBindGroup(0, bindGroup46);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder10.end();
+} catch {}
+try {
+renderPassEncoder25.setViewport(12.800250057323396, 25.336897165971777, 11.830119332132114, 1.0910023311180013, 0.7702941672349232, 0.8261737823616597);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture100,
+  mipLevel: 0,
+  origin: {x: 7, y: 4, z: 0},
+  aspect: 'all',
+}, new Uint8Array(93).fill(89), /* required buffer size: 93 */
+{offset: 93, bytesPerRow: 77}, {width: 11, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup85 = device0.createBindGroup({layout: autogeneratedBindGroupLayout44, entries: [{binding: 216, resource: textureView92}]});
+let buffer95 = device0.createBuffer({size: 7803, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture129 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 13},
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView122 = texture28.createView({dimension: 'cube', aspect: 'all', format: 'rg11b10ufloat'});
+let computePassEncoder117 = commandEncoder48.beginComputePass({});
+try {
+computePassEncoder78.setBindGroup(0, bindGroup58, new Uint32Array(569), 59, 0);
+} catch {}
+try {
+computePassEncoder117.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder37.setIndexBuffer(buffer53, 'uint16', 6_360, 1_580);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(5, buffer80, 2_976);
+} catch {}
+let promise11 = device0.queue.onSubmittedWorkDone();
+let autogeneratedBindGroupLayout53 = pipeline16.getBindGroupLayout(0);
+let buffer96 = device0.createBuffer({size: 20323, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView123 = texture109.createView({});
+let texture130 = device0.createTexture({
+  size: {width: 30, height: 10, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler101 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 89.22,
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder17.setBindGroup(1, bindGroup66, new Uint32Array(993), 61, 0);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(3, bindGroup51, new Uint32Array(4895), 240, 0);
+} catch {}
+try {
+renderPassEncoder26.setViewport(36.09642985191905, 0.35208353790811664, 7.493617476337307, 7.928608227671376, 0.9276106782549967, 0.9410328947278568);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(2, buffer79, 0, 135);
+} catch {}
+let arrayBuffer6 = buffer65.getMappedRange(368, 112);
+let buffer97 = device0.createBuffer({
+  size: 2754,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder137 = device0.createCommandEncoder({});
+let computePassEncoder118 = commandEncoder137.beginComputePass({});
+try {
+computePassEncoder28.setBindGroup(2, bindGroup33);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(1, bindGroup11, new Uint32Array(776), 79, 0);
+} catch {}
+try {
+renderPassEncoder14.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(3, buffer78, 756, 901);
+} catch {}
+let promise12 = device0.queue.onSubmittedWorkDone();
+document.body.append(canvas2);
+try {
+textureView43.label = '\u{1f70c}\ue522\u242a\u025a';
+} catch {}
+let textureView124 = texture0.createView({dimension: '2d-array', baseArrayLayer: 2, arrayLayerCount: 2});
+try {
+computePassEncoder110.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer62, 'uint32', 6_216, 2_842);
+} catch {}
+let arrayBuffer7 = buffer65.getMappedRange(488, 700);
+let commandEncoder138 = device0.createCommandEncoder({});
+let textureView125 = texture90.createView({});
+let computePassEncoder119 = commandEncoder138.beginComputePass();
+let sampler102 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  lodMaxClamp: 80.26,
+});
+try {
+renderPassEncoder27.setBindGroup(0, bindGroup20, new Uint32Array(527), 45, 0);
+} catch {}
+try {
+renderPassEncoder20.setBlendConstant({ r: -123.3, g: -389.3, b: 880.9, a: -448.3, });
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(2, buffer9, 1_476);
+} catch {}
+await gc();
+let imageData23 = new ImageData(44, 48);
+let autogeneratedBindGroupLayout54 = pipeline20.getBindGroupLayout(0);
+let texture131 = device0.createTexture({size: {width: 2}, dimension: '1d', format: 'rgb10a2uint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let textureView126 = texture25.createView({aspect: 'depth-only'});
+try {
+computePassEncoder84.setBindGroup(2, bindGroup15);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(1, bindGroup71);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(2, bindGroup25, new Uint32Array(52), 18, 0);
+} catch {}
+try {
+renderPassEncoder14.beginOcclusionQuery(6);
+} catch {}
+try {
+renderPassEncoder14.endOcclusionQuery();
+} catch {}
+try {
+computePassEncoder62.setBindGroup(2, bindGroup41);
+} catch {}
+try {
+computePassEncoder54.setBindGroup(2, bindGroup71, new Uint32Array(301), 0, 0);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle7, renderBundle5, renderBundle12, renderBundle2, renderBundle6, renderBundle1, renderBundle1, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(0, buffer7, 0, 489);
+} catch {}
+try {
+  await promise12;
+} catch {}
+let videoFrame17 = new VideoFrame(videoFrame11, {timestamp: 0});
+let veryExplicitBindGroupLayout19 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 32, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+  ],
+});
+let texture132 = device0.createTexture({
+  size: [60, 20, 1],
+  sampleCount: 1,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder115.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer40, 'uint32', 5_312, 2_956);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline26);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer91, 96, new Int16Array(4617), 31, 92);
+} catch {}
+try {
+  await promise11;
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(55, 44);
+let buffer98 = device0.createBuffer({
+  size: 3245,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder139 = device0.createCommandEncoder({});
+try {
+computePassEncoder109.setBindGroup(0, bindGroup5, new Uint32Array(2422), 255, 0);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(3, bindGroup78);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup15, new Uint32Array(3871), 27, 0);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle8, renderBundle1, renderBundle8, renderBundle2]);
+} catch {}
+try {
+computePassEncoder37.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer96, 6996, new Int16Array(14230), 2803, 1064);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer99 = device0.createBuffer({size: 3625, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let commandEncoder140 = device0.createCommandEncoder({});
+try {
+renderPassEncoder32.setBindGroup(3, bindGroup30);
+} catch {}
+try {
+renderPassEncoder37.executeBundles([renderBundle1, renderBundle5, renderBundle9, renderBundle12, renderBundle1, renderBundle0]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData9,
+  origin: { x: 0, y: 6 },
+  flipY: true,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 37, y: 70, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 12, depthOrArrayLayers: 0});
+} catch {}
+let autogeneratedBindGroupLayout55 = pipeline3.getBindGroupLayout(0);
+let texture133 = gpuCanvasContext1.getCurrentTexture();
+let renderPassEncoder39 = commandEncoder140.beginRenderPass({
+  colorAttachments: [{
+  view: textureView71,
+  clearValue: { r: 227.8, g: -417.8, b: 709.4, a: 205.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder108.setBindGroup(3, bindGroup38);
+} catch {}
+try {
+computePassEncoder40.setBindGroup(1, bindGroup69, new Uint32Array(269), 88, 0);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(0, bindGroup28, new Uint32Array(40), 3, 0);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(150);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder20.drawIndexedIndirect(buffer73, 148);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer64, 'uint32', 3_080, 2_387);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline22);
+} catch {}
+let promise13 = device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule0, constants: {}}});
+document.body.append(img1);
+let videoFrame18 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'bt709', transfer: 'iec61966-2-1'} });
+let commandEncoder141 = device0.createCommandEncoder();
+let querySet17 = device0.createQuerySet({type: 'occlusion', count: 294});
+let computePassEncoder120 = commandEncoder139.beginComputePass({});
+try {
+computePassEncoder119.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(0, bindGroup23);
+} catch {}
+try {
+renderPassEncoder14.beginOcclusionQuery(632);
+} catch {}
+try {
+renderPassEncoder20.draw(126, 89, 1_064_289_164, 1_402_047_601);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(5, buffer87, 0);
+} catch {}
+try {
+commandEncoder141.resolveQuerySet(querySet6, 146, 74, buffer46, 0);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+let textureView127 = texture10.createView({dimension: '2d-array', baseArrayLayer: 0});
+let computePassEncoder121 = commandEncoder141.beginComputePass();
+try {
+computePassEncoder99.setBindGroup(2, bindGroup24);
+} catch {}
+try {
+renderPassEncoder20.drawIndexedIndirect(buffer4, 296);
+} catch {}
+try {
+renderPassEncoder20.drawIndirect(buffer38, 400);
+} catch {}
+let recycledExplicitBindGroupLayout2 = pipeline5.getBindGroupLayout(0);
+let buffer100 = device0.createBuffer({size: 21154, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+try {
+renderPassEncoder31.setBindGroup(2, bindGroup40, new Uint32Array(163), 5, 0);
+} catch {}
+try {
+renderPassEncoder20.end();
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(4, buffer8);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer96, 8244, new Float32Array(2492), 301, 236);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(145).fill(231), /* required buffer size: 145 */
+{offset: 145}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup86 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout12,
+  entries: [
+    {binding: 116, resource: {buffer: buffer17, offset: 0, size: 464}},
+    {binding: 258, resource: textureView84},
+  ],
+});
+let commandEncoder142 = device0.createCommandEncoder({});
+let computePassEncoder122 = commandEncoder75.beginComputePass({});
+let sampler103 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 72.93,
+  compare: 'never',
+  maxAnisotropy: 12,
+});
+try {
+renderPassEncoder14.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(3, buffer55, 2_800);
+} catch {}
+try {
+externalTexture14.label = '\uec88\u{1fe7f}\u0354\u{1faa4}\u1845\ub7f2\ufe20\ue4d0\u08d7\u093c\ua299';
+} catch {}
+let buffer101 = device0.createBuffer({
+  size: 8063,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView128 = texture62.createView({dimension: '2d-array'});
+try {
+computePassEncoder50.setBindGroup(1, bindGroup45, new Uint32Array(2585), 260, 0);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(2, undefined, 0, 454_237_800);
+} catch {}
+try {
+buffer84.unmap();
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+await gc();
+let veryExplicitBindGroupLayout20 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 8,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 54, hasDynamicOffset: false },
+    },
+  ],
+});
+let autogeneratedBindGroupLayout56 = pipeline27.getBindGroupLayout(0);
+let textureView129 = texture74.createView({
+  label: '\u5f1d\u608e\u0768\u5372\u85fe\u{1f87b}\u2920\ub2f9\u0ad7',
+  dimension: '2d-array',
+  mipLevelCount: 1,
+});
+let computePassEncoder123 = commandEncoder142.beginComputePass();
+try {
+computePassEncoder50.setBindGroup(3, bindGroup55);
+} catch {}
+try {
+renderPassEncoder37.setScissorRect(2, 5, 5, 7);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer69, 'uint32', 280, 4);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(3, buffer50, 24);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(353).fill(70), /* required buffer size: 353 */
+{offset: 163, bytesPerRow: 38, rowsPerImage: 5}, {width: 0, height: 0, depthOrArrayLayers: 2});
+} catch {}
+let gpuCanvasContext5 = offscreenCanvas2.getContext('webgpu');
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let bindGroup87 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout0,
+  entries: [{binding: 8, resource: {buffer: buffer43, offset: 0, size: 492}}],
+});
+let commandEncoder143 = device0.createCommandEncoder({});
+try {
+commandEncoder143.resolveQuerySet(querySet5, 3, 75, buffer88, 1792);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame18,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 24, y: 22, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline29 = device0.createRenderPipeline({
+  layout: 'auto',
+  multisample: {},
+  fragment: {
+  module: shaderModule1,
+  targets: [{format: 'rgba8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth32float',
+    depthWriteEnabled: false,
+    depthCompare: 'never',
+    stencilReadMask: 993149734,
+    stencilWriteMask: 2045311569,
+    depthBias: -2134437771,
+    depthBiasSlopeScale: 190.57814241354845,
+    depthBiasClamp: 599.1309168820513,
+  },
+  vertex: {
+    module: shaderModule2,
+    constants: {29_819: 0},
+    buffers: [
+      {
+        arrayStride: 604,
+        attributes: [
+          {format: 'float32x4', offset: 88, shaderLocation: 5},
+          {format: 'snorm8x2', offset: 116, shaderLocation: 14},
+          {format: 'float32x2', offset: 72, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw'},
+});
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let computePassEncoder124 = commandEncoder143.beginComputePass({});
+try {
+computePassEncoder71.setBindGroup(2, bindGroup45);
+} catch {}
+try {
+computePassEncoder121.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(5, buffer79, 0, 53);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let commandEncoder144 = device0.createCommandEncoder({});
+let renderPassEncoder40 = commandEncoder144.beginRenderPass({
+  colorAttachments: [{
+  view: textureView73,
+  depthSlice: 139,
+  clearValue: { r: -134.4, g: 865.2, b: 886.2, a: 545.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView20,
+    depthClearValue: 0.03582174841397456,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'discard',
+    stencilClearValue: 17369,
+  },
+  maxDrawCount: 17822099,
+});
+try {
+computePassEncoder124.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup51);
+} catch {}
+let arrayBuffer8 = buffer51.getMappedRange(1200, 0);
+let autogeneratedBindGroupLayout57 = pipeline17.getBindGroupLayout(0);
+let querySet18 = device0.createQuerySet({type: 'occlusion', count: 651});
+try {
+computePassEncoder30.setBindGroup(3, bindGroup75, new Uint32Array(1843), 1_049, 0);
+} catch {}
+try {
+renderPassEncoder19.beginOcclusionQuery(121);
+} catch {}
+try {
+renderPassEncoder19.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer82, 'uint32', 196, 840);
+} catch {}
+let pipeline30 = device0.createComputePipeline({layout: pipelineLayout3, compute: {module: shaderModule2, constants: {override4: 0}}});
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+let offscreenCanvas3 = new OffscreenCanvas(199, 33);
+let imageData24 = new ImageData(120, 48);
+let videoFrame19 = new VideoFrame(videoFrame6, {timestamp: 0});
+try {
+offscreenCanvas3.getContext('bitmaprenderer');
+} catch {}
+try {
+globalThis.someLabel = externalTexture15.label;
+} catch {}
+let autogeneratedBindGroupLayout58 = pipeline24.getBindGroupLayout(0);
+let bindGroup88 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout21,
+  entries: [{binding: 8, resource: {buffer: buffer22, offset: 13824, size: 8304}}],
+});
+let buffer102 = device0.createBuffer({size: 22970, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let texture134 = device0.createTexture({
+  size: {width: 120, height: 40, depthOrArrayLayers: 92},
+  mipLevelCount: 2,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder118.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer46, 'uint32', 896, 26);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline29);
+} catch {}
+let texture135 = device0.createTexture({
+  size: {width: 240, height: 80, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder5.executeBundles([renderBundle11, renderBundle11]);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer21, 'uint16', 214, 4_360);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(5, buffer98, 0, 133);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+let shaderModule4 = device0.createShaderModule({
+  code: `
+requires unrestricted_pointer_parameters;
+
+enable f16;
+
+struct S3 {
+  @location(13) f0: f32,
+  @location(8) f1: i32,
+  @builtin(instance_index) f2: u32,
+  @builtin(vertex_index) f3: u32,
+  @location(10) @interpolate(flat) f4: u32,
+}
+
+@group(0) @binding(8) var<storage, read> buffer103: array<array<array<array<array<array<f16, 1>, 3>, 1>, 1>, 9>>;
+
+struct T1 {
+  @size(56) f0: array<u32>,
+}
+
+fn fn1() -> array<vec2u, 1> {
+  var out: array<vec2u, 1>;
+  let ptr87: ptr<storage, f16, read> = &(*&buffer103)[arrayLength(&(*&buffer103))][8][0][u32(unconst_u32(117))][2][0];
+  let ptr88: ptr<storage, array<array<array<array<f16, 1>, 3>, 1>, 1>, read> = &buffer103[u32(unconst_u32(146))][8];
+  let ptr89: ptr<storage, f16, read> = &(*&buffer103)[arrayLength(&(*&buffer103))][u32(unconst_u32(176))][0][0][2][0];
+  out[u32(unconst_u32(385))] <<= vec2u(u32(buffer103[arrayLength(&buffer103)][u32(unconst_u32(49))][u32((*&buffer103)[arrayLength(&(*&buffer103))][8][0][0][2][0])][0][2][0]));
+  out[u32(unconst_u32(145))] ^= vec2u(u32(buffer103[arrayLength(&buffer103)][8][u32(unconst_u32(93))][0][arrayLength(&(*&buffer103))][0]));
+  let ptr90: ptr<storage, array<f16, 1>, read> = &(*&buffer103)[arrayLength(&(*&buffer103))][u32(unconst_u32(75))][u32(unconst_u32(1))][0][u32(unconst_u32(286))];
+  return out;
+  _ = buffer103;
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+alias vec3b = vec3<bool>;
+
+fn fn2() -> S3 {
+  var out: S3;
+  out.f2 *= u32((*&buffer103)[u32(buffer103[u32(unconst_u32(40))][8][u32(unconst_u32(165))][0][2][0])][u32(unconst_u32(200))][u32(unconst_u32(24))][0][2][0]);
+  let ptr91: ptr<storage, array<array<f16, 1>, 3>, read> = &(*&buffer103)[arrayLength(&(*&buffer103))][8][u32(unconst_u32(10))][u32(unconst_u32(506))];
+  let ptr92: ptr<storage, f16, read> = &buffer103[u32(unconst_u32(13))][u32(unconst_u32(338))][0][u32(unconst_u32(74))][u32(unconst_u32(349))][0];
+  let ptr93: ptr<storage, array<array<f16, 1>, 3>, read> = &buffer103[u32(unconst_u32(237))][8][0][0];
+  let ptr94: ptr<storage, array<array<array<f16, 1>, 3>, 1>, read> = &(*&buffer103)[arrayLength(&(*&buffer103))][u32(unconst_u32(331))][0];
+  return out;
+  _ = buffer103;
+}
+
+struct T2 {
+  @size(56) f0: u32,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct T3 {
+  @size(56) f0: array<u32>,
+}
+
+struct T0 {
+  @size(56) f0: array<u32>,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct VertexOutput2 {
+  @builtin(position) f4: vec4f,
+  @location(11) @interpolate(flat, centroid) f5: u32,
+  @location(14) @interpolate(flat, centroid) f6: vec2i,
+}
+
+fn fn0() {
+  let ptr72: ptr<storage, array<f16, 1>, read> = &buffer103[u32(unconst_u32(229))][u32(unconst_u32(546))][u32(unconst_u32(340))][0][2];
+  let ptr73: ptr<storage, array<f16, 1>, read> = &buffer103[u32(unconst_u32(1000))][u32(unconst_u32(236))][0][u32(unconst_u32(136))][u32((*&buffer103)[arrayLength(&(*&buffer103))][u32(unconst_u32(257))][0][0][2][0])];
+  let ptr74: ptr<storage, array<array<array<f16, 1>, 3>, 1>, read> = &(*&buffer103)[arrayLength(&(*&buffer103))][8][0];
+  let ptr75: ptr<storage, f16, read> = &buffer103[u32(unconst_u32(10))][u32(unconst_u32(1000))][0][0][2][u32(unconst_u32(500))];
+  let ptr76: ptr<storage, array<f16, 1>, read> = &(*&buffer103)[arrayLength(&(*&buffer103))][8][u32(unconst_u32(320))][u32(unconst_u32(149))][u32(buffer103[u32(unconst_u32(228))][8][0][0][2][u32(unconst_u32(53))])];
+  let ptr77: ptr<storage, array<f16, 1>, read> = &(*&buffer103)[u32((*&buffer103)[arrayLength(&(*&buffer103))][8][0][u32(unconst_u32(186))][2][0])][u32(unconst_u32(35))][u32(unconst_u32(111))][u32(unconst_u32(19))][u32(unconst_u32(108))];
+  let ptr78: ptr<storage, f16, read> = &(*&buffer103)[u32(unconst_u32(315))][u32(unconst_u32(27))][u32(unconst_u32(202))][0][2][u32(unconst_u32(95))];
+  let ptr79: ptr<storage, f16, read> = &(*&buffer103)[u32(unconst_u32(24))][u32((*&buffer103)[u32(unconst_u32(124))][u32(unconst_u32(66))][0][0][2][0])][0][0][u32(unconst_u32(5))][u32(unconst_u32(214))];
+  let ptr80: ptr<storage, array<f16, 1>, read> = &buffer103[u32(unconst_u32(82))][u32(unconst_u32(28))][u32(unconst_u32(258))][u32(unconst_u32(3))][2];
+  let ptr81: ptr<storage, f16, read> = &buffer103[arrayLength(&buffer103)][u32(unconst_u32(223))][u32(unconst_u32(92))][0][u32(unconst_u32(303))][u32(unconst_u32(55))];
+  let ptr82: ptr<storage, f16, read> = &(*ptr74)[0][2][u32(unconst_u32(16))];
+  let ptr83: ptr<storage, array<array<array<array<f16, 1>, 3>, 1>, 1>, read> = &buffer103[arrayLength(&buffer103)][u32(unconst_u32(35))];
+  let ptr84: ptr<storage, f16, read> = &(*ptr72)[0];
+  let ptr85: ptr<storage, f16, read> = &(*&buffer103)[arrayLength(&(*&buffer103))][u32(unconst_u32(194))][0][u32(unconst_u32(117))][2][0];
+  let ptr86: ptr<storage, f16, read> = &buffer103[u32(unconst_u32(56))][u32(unconst_u32(80))][0][u32(unconst_u32(244))][2][u32(unconst_u32(4))];
+  _ = buffer103;
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct FragmentOutput4 {
+  @location(7) @interpolate(flat) f0: vec4u,
+  @location(0) @interpolate(flat, sample) f1: vec4u,
+}
+
+@vertex @must_use
+fn vertex3(@location(14) a0: vec4h, @location(7) @interpolate(linear, center) a1: vec4f, @location(5) a2: f32, a3: S3, @location(4) @interpolate(flat, centroid) a4: u32) -> VertexOutput2 {
+  var out: VertexOutput2;
+  var vf25 = fn2();
+  let ptr95: ptr<storage, array<f16, 1>, read> = &buffer103[u32(unconst_u32(20))][u32(unconst_u32(67))][u32(unconst_u32(79))][0][u32(buffer103[u32((*&buffer103)[u32(unconst_u32(194))][8][u32(unconst_u32(174))][0][2][u32(unconst_u32(284))])][8][0][u32(unconst_u32(445))][u32(unconst_u32(101))][u32(unconst_u32(23))])];
+  out = VertexOutput2(vec4f(f32((*&buffer103)[u32(unconst_u32(89))][8][u32(unconst_u32(354))][u32(unconst_u32(13))][2][0])), u32((*&buffer103)[u32(unconst_u32(89))][8][u32(unconst_u32(354))][u32(unconst_u32(13))][2][0]), vec2i(i32((*&buffer103)[u32(unconst_u32(89))][8][u32(unconst_u32(354))][u32(unconst_u32(13))][2][0])));
+  out.f6 &= vec2i(i32((*&buffer103)[u32(unconst_u32(137))][8][u32(unconst_u32(69))][u32(unconst_u32(294))][2][0]));
+  return out;
+  _ = buffer103;
+}
+
+@fragment
+fn fragment4(@location(13) @interpolate(linear, sample) a0: vec2f, @location(0) a1: vec4h) -> FragmentOutput4 {
+  var out: FragmentOutput4;
+  let ptr96: ptr<storage, array<array<f16, 1>, 3>, read> = &buffer103[arrayLength(&buffer103)][8][u32(unconst_u32(87))][0];
+  fn0();
+  var vf26: vec3h = mix(vec3h(buffer103[u32(unconst_u32(214))][u32(unconst_u32(174))][0][0][2][0]), vec3h((*&buffer103)[u32(unconst_u32(80))][8][0][0][2][u32(unconst_u32(347))]), f16(unconst_f16(1400.5)));
+  out.f1 = unpack4xU8(u32(buffer103[u32(unconst_u32(60))][8][u32(unconst_u32(52))][0][2][0]));
+  fn0();
+  out.f1 = unpack4xU8(u32(buffer103[arrayLength(&buffer103)][u32(unconst_u32(41))][0][0][2][u32((*&buffer103)[arrayLength(&(*&buffer103))][8][0][0][2][0])]));
+  let ptr97: ptr<storage, f16, read> = &(*&buffer103)[arrayLength(&(*&buffer103))][8][u32(unconst_u32(167))][0][u32((*&buffer103)[u32(unconst_u32(85))][u32(unconst_u32(152))][0][0][2][u32(unconst_u32(13))])][u32(unconst_u32(70))];
+  out.f0 += unpack4xU8(u32(buffer103[u32(unconst_u32(176))][8][u32(unconst_u32(168))][0][2][0]));
+  out.f0 = vec4u(u32(buffer103[u32(unconst_u32(206))][8][0][0][u32(unconst_u32(26))][u32(unconst_u32(28))]));
+  vf26 -= vec3h(buffer103[u32(unconst_u32(107))][8][u32(buffer103[u32(unconst_u32(4))][u32(unconst_u32(87))][0][u32(unconst_u32(398))][u32(unconst_u32(65))][0])][0][2][u32(unconst_u32(109))]);
+  let ptr98: ptr<storage, f16, read> = &(*ptr97);
+  let ptr99: ptr<storage, array<f16, 1>, read> = &(*&buffer103)[arrayLength(&(*&buffer103))][8][u32(buffer103[u32(unconst_u32(27))][8][0][0][2][0])][u32(unconst_u32(232))][2];
+  fn0();
+  out.f1 &= unpack4xU8(u32((*&buffer103)[u32((*&buffer103)[u32(unconst_u32(322))][u32(unconst_u32(69))][u32(unconst_u32(61))][0][2][u32(buffer103[u32(buffer103[u32((*&buffer103)[u32(unconst_u32(20))][u32(unconst_u32(31))][u32(unconst_u32(17))][u32(unconst_u32(179))][u32(unconst_u32(126))][0])][u32(unconst_u32(147))][u32((*ptr96)[2][0])][u32(unconst_u32(401))][2][0])][u32(unconst_u32(238))][u32(unconst_u32(245))][u32(unconst_u32(459))][u32(unconst_u32(31))][0])])][8][0][0][u32(unconst_u32(445))][0]));
+  out = FragmentOutput4(vec4u(u32(buffer103[u32(unconst_u32(295))][u32(buffer103[arrayLength(&buffer103)][u32(unconst_u32(23))][u32(unconst_u32(70))][u32(unconst_u32(644))][2][0])][u32(unconst_u32(199))][u32(unconst_u32(229))][2][0])), vec4u(u32(buffer103[u32(unconst_u32(295))][u32(buffer103[arrayLength(&buffer103)][u32(unconst_u32(23))][u32(unconst_u32(70))][u32(unconst_u32(644))][2][0])][u32(unconst_u32(199))][u32(unconst_u32(229))][2][0])));
+  fn0();
+  out.f0 *= vec4u(u32(buffer103[arrayLength(&buffer103)][u32(unconst_u32(141))][u32(unconst_u32(10))][0][2][u32(unconst_u32(290))]));
+  out.f1 &= unpack4xU8(u32(buffer103[arrayLength(&buffer103)][8][0][0][2][0]));
+  let ptr100: ptr<storage, f16, read> = &buffer103[u32(unconst_u32(200))][8][u32(unconst_u32(208))][u32((*&buffer103)[arrayLength(&(*&buffer103))][8][u32(unconst_u32(57))][u32(unconst_u32(263))][2][0])][2][0];
+  let ptr101: ptr<storage, f16, read> = &(*&buffer103)[arrayLength(&(*&buffer103))][8][u32(unconst_u32(95))][u32(unconst_u32(440))][2][0];
+  vf26 = vec3h((*&buffer103)[arrayLength(&(*&buffer103))][u32(unconst_u32(86))][u32(unconst_u32(32))][u32(unconst_u32(36))][u32(unconst_u32(17))][u32(unconst_u32(200))]);
+  let ptr102: ptr<storage, f16, read> = &buffer103[arrayLength(&buffer103)][8][0][u32(unconst_u32(91))][u32((*&buffer103)[arrayLength(&(*&buffer103))][u32(unconst_u32(28))][u32(unconst_u32(154))][0][2][0])][0];
+  let ptr103: ptr<storage, array<f16, 1>, read> = &buffer103[u32(unconst_u32(784))][8][0][0][2];
+  fn0();
+  return out;
+  _ = buffer103;
+}
+
+@compute @workgroup_size(2, 1, 2)
+fn compute4(@builtin(local_invocation_id) a0: vec3u) {
+  fn1();
+  fn1();
+  var vf27 = fn2();
+  fn2();
+  vf27.f0 = f32((*&buffer103)[arrayLength(&(*&buffer103))][8][u32(unconst_u32(33))][u32(unconst_u32(386))][2][0]);
+  fn2();
+  fn1();
+  var vf28 = fn1();
+  vf28[u32(unconst_u32(33))] = vec2u(u32((*&buffer103)[arrayLength(&(*&buffer103))][u32(unconst_u32(364))][u32(unconst_u32(305))][u32(unconst_u32(860))][u32(unconst_u32(292))][0]));
+  var vf29 = fn1();
+  fn1();
+  fn2();
+  vf28[u32(unconst_u32(212))] -= vec2u(u32(buffer103[u32(unconst_u32(71))][8][u32(unconst_u32(175))][0][u32(unconst_u32(655))][0]));
+  vf29[0] |= vec2u(u32((*&buffer103)[arrayLength(&(*&buffer103))][8][0][u32(unconst_u32(186))][2][u32(unconst_u32(120))]));
+  fn1();
+  let vf30: vec3h = faceForward(vec3h(unconst_f16(-808.6), unconst_f16(3017.9), unconst_f16(22135.4)), vec3h(unconst_f16(6195.2), unconst_f16(13149.8), unconst_f16(12987.9)), vec3h(unconst_f16(-45512.5), unconst_f16(1039.0), unconst_f16(16144.6)));
+  vf28[vec3u(inverseSqrt(vec3f(unconst_f32(0.2119), unconst_f32(0.5364), unconst_f32(0.03011))))[1]] -= vec2u(u32(buffer103[u32(unconst_u32(11))][8][u32(unconst_u32(44))][u32((*&buffer103)[arrayLength(&(*&buffer103))][8][u32(unconst_u32(124))][0][2][0])][u32(unconst_u32(46))][0]));
+  _ = buffer103;
+}
+
+@compute @workgroup_size(8, 1, 1)
+fn compute5() {
+  let ptr104: ptr<storage, array<array<f16, 1>, 3>, read> = &(*&buffer103)[arrayLength(&(*&buffer103))][8][u32(unconst_u32(81))][0];
+  var vf31 = fn1();
+  _ = buffer103;
+}`,
+});
+let querySet19 = device0.createQuerySet({type: 'occlusion', count: 145});
+let texture136 = device0.createTexture({
+  size: [30, 10, 10],
+  sampleCount: 1,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder21.setBindGroup(1, bindGroup10, []);
+} catch {}
+try {
+computePassEncoder122.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(2, bindGroup64, new Uint32Array(693), 234, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer14, 72, new Int16Array(8537), 1309, 180);
+} catch {}
+let bindGroup89 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout1,
+  entries: [{binding: 8, resource: {buffer: buffer46, offset: 512, size: 280}}],
+});
+try {
+computePassEncoder116.setPipeline(pipeline28);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(2, bindGroup74);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle2, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer62, 'uint16', 9_858, 3_549);
+} catch {}
+let pipeline31 = await promise13;
+let autogeneratedBindGroupLayout59 = pipeline24.getBindGroupLayout(0);
+let textureView130 = texture65.createView({dimension: '2d', baseMipLevel: 0, baseArrayLayer: 1});
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8sint'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle16 = renderBundleEncoder16.finish({});
+try {
+computePassEncoder78.setBindGroup(2, bindGroup6, new Uint32Array(47), 7, 0);
+} catch {}
+try {
+computePassEncoder123.setPipeline(pipeline28);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(1, bindGroup58);
+} catch {}
+try {
+renderPassEncoder38.executeBundles([renderBundle15]);
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer94, 'uint32', 168, 2);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture117,
+  mipLevel: 0,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(6).fill(30), /* required buffer size: 6 */
+{offset: 6, bytesPerRow: 48, rowsPerImage: 18}, {width: 1, height: 12, depthOrArrayLayers: 0});
+} catch {}
+let buffer104 = device0.createBuffer({
+  size: 7446,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder145 = device0.createCommandEncoder({});
+let querySet20 = device0.createQuerySet({type: 'occlusion', count: 2292});
+let texture137 = gpuCanvasContext0.getCurrentTexture();
+let textureView131 = texture137.createView({dimension: '2d-array'});
+let renderPassEncoder41 = commandEncoder145.beginRenderPass({
+  colorAttachments: [{view: textureView41, depthSlice: 33, loadOp: 'clear', storeOp: 'discard'}],
+  depthStencilAttachment: {view: textureView23, depthClearValue: -4.706338721921995, depthLoadOp: 'load', depthStoreOp: 'store'},
+});
+try {
+computePassEncoder38.setBindGroup(1, bindGroup87, []);
+} catch {}
+try {
+computePassEncoder120.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(2, buffer34, 0, 3_387);
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55); };
+} catch {}
+document.body.prepend(canvas1);
+let texture138 = device0.createTexture({size: [240, 80, 1], format: 'depth32float', usage: GPUTextureUsage.COPY_DST, viewFormats: []});
+let sampler104 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 53.97, compare: 'less-equal'});
+try {
+computePassEncoder63.setBindGroup(2, bindGroup30);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline29);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(2, buffer40, 716, 5_719);
+} catch {}
+try {
+buffer81.unmap();
+} catch {}
+let buffer105 = device0.createBuffer({
+  size: 5182,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX,
+  mappedAtCreation: false,
+});
+let texture139 = device0.createTexture({
+  size: {width: 30, height: 10, depthOrArrayLayers: 36},
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView132 = texture27.createView({aspect: 'depth-only', baseMipLevel: 0, mipLevelCount: 1});
+let sampler105 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+});
+try {
+computePassEncoder106.setBindGroup(1, bindGroup85, new Uint32Array(4059), 820, 0);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer24, 'uint32', 4_740, 6_033);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let bindGroup90 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout56,
+  entries: [{binding: 8, resource: {buffer: buffer54, offset: 768, size: 840}}],
+});
+let textureView133 = texture52.createView({arrayLayerCount: 1});
+let sampler106 = device0.createSampler({addressModeW: 'repeat', lodMaxClamp: 97.53});
+try {
+renderPassEncoder12.pushDebugGroup('\u0753');
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let pipeline32 = await promise10;
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let buffer106 = device0.createBuffer({size: 29, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder146 = device0.createCommandEncoder();
+let sampler107 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  lodMinClamp: 40.95,
+  lodMaxClamp: 41.83,
+});
+try {
+computePassEncoder72.setBindGroup(3, bindGroup74);
+} catch {}
+try {
+renderPassEncoder15.executeBundles([renderBundle3, renderBundle7, renderBundle13, renderBundle8]);
+} catch {}
+let promise14 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame15,
+  origin: { x: 1, y: 2 },
+  flipY: false,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 108, y: 9, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 10, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let autogeneratedBindGroupLayout60 = pipeline4.getBindGroupLayout(0);
+let textureView134 = texture0.createView({dimension: '2d', baseArrayLayer: 5});
+let computePassEncoder125 = commandEncoder146.beginComputePass({});
+let externalTexture17 = device0.importExternalTexture({source: videoFrame11});
+try {
+computePassEncoder28.setBindGroup(1, bindGroup5, new Uint32Array(588), 8, 0);
+} catch {}
+try {
+buffer102.unmap();
+} catch {}
+let promise15 = device0.queue.onSubmittedWorkDone();
+let recycledExplicitBindGroupLayout3 = pipeline5.getBindGroupLayout(0);
+let commandEncoder147 = device0.createCommandEncoder();
+let computePassEncoder126 = commandEncoder147.beginComputePass({});
+try {
+computePassEncoder126.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup30, new Uint32Array(1241), 63, 0);
+} catch {}
+try {
+renderPassEncoder5.draw(101, 23, 1_635_267_246, 641_110_838);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer14, 92);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer8, 'uint16', 316, 1_384);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline19);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let autogeneratedBindGroupLayout61 = pipeline26.getBindGroupLayout(0);
+let texture140 = device0.createTexture({size: [60, 20, 31], format: 'rgba8sint', usage: GPUTextureUsage.COPY_DST});
+try {
+renderPassEncoder34.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder5.draw(25, 7, 1_988_339_113, 3_976_282);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer23, 752);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(1, buffer76, 0, 4_306);
+} catch {}
+try {
+renderPassEncoder12.popDebugGroup();
+} catch {}
+document.body.prepend(canvas1);
+let commandEncoder148 = device0.createCommandEncoder();
+let textureView135 = texture52.createView({label: '\uf994\u0d5e\u95dd\u00cd\uce8b\u0271', arrayLayerCount: 1});
+let textureView136 = texture113.createView({dimension: '2d-array', baseMipLevel: 0, mipLevelCount: 1});
+try {
+computePassEncoder37.setBindGroup(0, bindGroup19);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(3, bindGroup17, []);
+} catch {}
+try {
+renderPassEncoder5.draw(92, 91, 400_029_846, 377_989_611);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer0, 668);
+} catch {}
+try {
+renderPassEncoder14.pushDebugGroup('\u0e5e');
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let commandEncoder149 = device0.createCommandEncoder();
+let sampler108 = device0.createSampler({lodMaxClamp: 76.75});
+try {
+{ clearResourceUsages(device0, computePassEncoder37); computePassEncoder37.dispatchWorkgroupsIndirect(buffer15, 884); };
+} catch {}
+try {
+computePassEncoder125.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder7.end();
+} catch {}
+try {
+renderPassEncoder33.executeBundles([renderBundle10]);
+} catch {}
+try {
+renderPassEncoder5.draw(65, 93, 2_055_086_372, 852_244_541);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer102, 492);
+} catch {}
+try {
+commandEncoder42.clearBuffer(buffer2, 32, 16);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer76, 2336, new Int16Array(17418), 4961, 540);
+} catch {}
+await gc();
+try {
+externalTexture3.label = '\u2079\u{1f7e0}';
+} catch {}
+let texture141 = device0.createTexture({
+  size: [120, 40, 1],
+  dimension: '2d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture142 = device0.createTexture({
+  size: {width: 240},
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder127 = commandEncoder42.beginComputePass({});
+try {
+renderPassEncoder39.setBindGroup(0, bindGroup35, new Uint32Array(232), 71, 0);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer88, 'uint16', 374, 2_388);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline13);
+} catch {}
+try {
+commandEncoder149.copyBufferToTexture({
+  /* bytesInLastRow: 72 widthInBlocks: 18 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2704 */
+  offset: 2704,
+  bytesPerRow: 15616,
+  buffer: buffer59,
+}, {
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 8, y: 7, z: 0},
+  aspect: 'all',
+}, {width: 18, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let textureView137 = texture141.createView({dimension: '2d-array'});
+let texture143 = device0.createTexture({
+  size: {width: 240},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView138 = texture124.createView({dimension: 'cube-array', mipLevelCount: 1, baseArrayLayer: 0, arrayLayerCount: 6});
+let computePassEncoder128 = commandEncoder148.beginComputePass({});
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], depthReadOnly: true});
+let renderBundle17 = renderBundleEncoder17.finish({});
+try {
+{ clearResourceUsages(device0, computePassEncoder37); computePassEncoder37.dispatchWorkgroups(1, 2); };
+} catch {}
+try {
+computePassEncoder128.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder5.draw(140, 122, 219_924_833, 337_158_021);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer53, 'uint16', 420, 6_163);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(4, buffer24, 0);
+} catch {}
+let arrayBuffer9 = buffer1.getMappedRange(64, 8);
+let pipeline33 = device0.createRenderPipeline({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule3,
+  targets: [{
+  format: 'rgba8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth32float',
+    depthWriteEnabled: true,
+    depthCompare: 'always',
+    stencilBack: {depthFailOp: 'keep'},
+    stencilWriteMask: 425950104,
+  },
+  vertex: {
+    module: shaderModule2,
+    constants: {29_819: 0},
+    buffers: [
+      {
+        arrayStride: 568,
+        attributes: [
+          {format: 'float32', offset: 12, shaderLocation: 4},
+          {format: 'float16x2', offset: 60, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 40,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x4', offset: 16, shaderLocation: 14}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'back'},
+});
+let buffer107 = device0.createBuffer({
+  size: 809,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture144 = device0.createTexture({
+  size: {width: 30, height: 10, depthOrArrayLayers: 25},
+  sampleCount: 1,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder42 = commandEncoder149.beginRenderPass({
+  colorAttachments: [{
+  view: textureView13,
+  clearValue: { r: -990.2, g: -630.3, b: 487.8, a: 156.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {view: textureView130, depthReadOnly: true},
+  occlusionQuerySet: querySet1,
+  maxDrawCount: 78407087,
+});
+try {
+renderPassEncoder17.setBindGroup(3, bindGroup8, []);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(1, bindGroup57, new Uint32Array(3512), 93, 0);
+} catch {}
+try {
+renderPassEncoder16.setBlendConstant({ r: -560.0, g: 250.1, b: -67.11, a: -967.5, });
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer53, 'uint16', 188, 521);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline33);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(0, buffer38, 1_044, 139);
+} catch {}
+try {
+buffer101.unmap();
+} catch {}
+let bindGroup91 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout6,
+  entries: [{binding: 8, resource: {buffer: buffer17, offset: 0}}],
+});
+let texture145 = device0.createTexture({
+  size: {width: 240},
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder91.setBindGroup(2, bindGroup49, new Uint32Array(2282), 161, 0);
+} catch {}
+try {
+computePassEncoder127.setPipeline(pipeline30);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(1, bindGroup8, new Uint32Array(884), 60, 0);
+} catch {}
+try {
+renderPassEncoder38.executeBundles([renderBundle17, renderBundle14]);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer82, 140);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(4, buffer102, 3_584, 9_757);
+} catch {}
+try {
+  await buffer75.mapAsync(GPUMapMode.READ, 168, 1896);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1702, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData4,
+  origin: { x: 1, y: 5 },
+  flipY: true,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 33, y: 33, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let recycledAutogeneratedBindGroupLayout0 = pipeline30.getBindGroupLayout(0);
+let bindGroup92 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout41,
+  entries: [{binding: 8, resource: {buffer: buffer32, offset: 4608, size: 936}}],
+});
+let textureView139 = texture24.createView({dimension: '2d', baseArrayLayer: 3});
+let texture146 = device0.createTexture({
+  size: {width: 120, height: 40, depthOrArrayLayers: 1},
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView140 = texture141.createView({dimension: '2d-array'});
+let sampler109 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+});
+try {
+computePassEncoder78.setBindGroup(2, bindGroup15);
+} catch {}
+try {
+computePassEncoder30.setBindGroup(3, bindGroup53, new Uint32Array(1650), 83, 0);
+} catch {}
+try {
+computePassEncoder93.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(2, bindGroup22, new Uint32Array(1377), 346, 0);
+} catch {}
+try {
+buffer86.unmap();
+} catch {}
+await gc();
+let bindGroup93 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout59,
+  entries: [{binding: 8, resource: {buffer: buffer86, offset: 256, size: 6028}}],
+});
+let commandEncoder150 = device0.createCommandEncoder();
+let texture147 = device0.createTexture({
+  size: {width: 1, height: 1, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView141 = texture81.createView({
+  label: '\u7ecd\u{1f9a0}\u0893\u6e58\u3c45\u5a32\u0bfa\u{1fd90}',
+  mipLevelCount: 2,
+  baseArrayLayer: 6,
+  arrayLayerCount: 2,
+});
+let computePassEncoder129 = commandEncoder150.beginComputePass({});
+try {
+computePassEncoder129.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder5.draw(266, 295, 593_676_204, 497_426_462);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer40, 2_856);
+} catch {}
+try {
+renderPassEncoder37.setIndexBuffer(buffer21, 'uint16', 2_126, 2_676);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData3,
+  origin: { x: 4, y: 8 },
+  flipY: true,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 3, y: 23, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData25 = new ImageData(4, 84);
+let bindGroup94 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout46,
+  entries: [{binding: 8, resource: {buffer: buffer39, offset: 1792, size: 360}}],
+});
+let commandEncoder151 = device0.createCommandEncoder({});
+let textureView142 = texture147.createView({});
+let textureView143 = texture111.createView({dimension: '2d-array'});
+let computePassEncoder130 = commandEncoder151.beginComputePass({});
+try {
+renderPassEncoder22.setBindGroup(1, bindGroup69);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+let autogeneratedBindGroupLayout62 = pipeline31.getBindGroupLayout(0);
+let pipelineLayout9 = device0.createPipelineLayout({
+  label: '\u056b\u{1fcd3}\u0521\u{1fe50}\udd36\u8764\ud9ac\u{1ffd8}\u6f09\u0b22',
+  bindGroupLayouts: [veryExplicitBindGroupLayout3],
+});
+let commandEncoder152 = device0.createCommandEncoder();
+let texture148 = device0.createTexture({
+  size: [30, 10, 1],
+  format: 'rg32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView144 = texture54.createView({dimension: '2d-array', aspect: 'depth-only'});
+let computePassEncoder131 = commandEncoder152.beginComputePass({});
+try {
+renderPassEncoder17.setBindGroup(3, bindGroup34);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer32, 3_824);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1702, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 276, y: 4, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame20 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'fcc', primaries: 'bt470m', transfer: 'unspecified'} });
+let bindGroup95 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout28,
+  entries: [{binding: 8, resource: {buffer: buffer61, offset: 512, size: 84}}],
+});
+let textureView145 = texture129.createView({dimension: 'cube-array', arrayLayerCount: 6});
+let texture149 = device0.createTexture({
+  size: {width: 240},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView146 = texture24.createView({format: 'r32uint', baseArrayLayer: 2, arrayLayerCount: 5});
+try {
+computePassEncoder131.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer36, 'uint32', 388, 248);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline19);
+} catch {}
+let imageData26 = new ImageData(4, 112);
+let recycledExplicitBindGroupLayout4 = pipeline25.getBindGroupLayout(0);
+let bindGroup96 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout36,
+  entries: [{binding: 8, resource: {buffer: buffer83, offset: 1792, size: 260}}],
+});
+let sampler110 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', lodMaxClamp: 91.07});
+try {
+computePassEncoder37.end();
+} catch {}
+try {
+computePassEncoder62.setPipeline(pipeline14);
+} catch {}
+try {
+computePassEncoder130.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(3, bindGroup50);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(0, bindGroup31, new Uint32Array(9858), 463, 0);
+} catch {}
+try {
+renderPassEncoder24.setScissorRect(25, 0, 20, 17);
+} catch {}
+try {
+renderPassEncoder5.draw(204, 394, 1_305_067_447, 470_166_578);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer41, 968);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline12);
+} catch {}
+let pipeline34 = device0.createRenderPipeline({
+  layout: 'auto',
+  fragment: {module: shaderModule1, entryPoint: 'fragment1', targets: [{format: 'rgba8sint', writeMask: 0}]},
+  depthStencil: {
+    format: 'depth32float',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilBack: {depthFailOp: 'keep'},
+    stencilReadMask: 710325391,
+    depthBias: -1827395533,
+  },
+  vertex: {
+    module: shaderModule3,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 16,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 4, shaderLocation: 5},
+          {format: 'uint8x2', offset: 0, shaderLocation: 14},
+          {format: 'float32x3', offset: 0, shaderLocation: 0},
+          {format: 'sint16x4', offset: 0, shaderLocation: 4},
+          {format: 'snorm16x4', offset: 0, shaderLocation: 9},
+          {format: 'uint16x2', offset: 0, shaderLocation: 3},
+          {format: 'sint8x2', offset: 0, shaderLocation: 12},
+          {format: 'sint16x4', offset: 0, shaderLocation: 15},
+          {format: 'unorm8x4', offset: 4, shaderLocation: 6},
+          {format: 'uint16x2', offset: 0, shaderLocation: 13},
+          {format: 'float32x4', offset: 0, shaderLocation: 10},
+          {format: 'unorm10-10-10-2', offset: 0, shaderLocation: 7},
+          {format: 'uint32x3', offset: 0, shaderLocation: 2},
+          {format: 'sint32x3', offset: 0, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 80,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x4', offset: 12, shaderLocation: 11}],
+      },
+    ],
+  },
+});
+let commandBuffer14 = commandEncoder44.finish({});
+let texture150 = device0.createTexture({
+  size: {width: 240, height: 80, depthOrArrayLayers: 54},
+  dimension: '2d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture151 = device0.createTexture({
+  size: {width: 240, height: 80, depthOrArrayLayers: 294},
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler111 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 84.60,
+  lodMaxClamp: 94.69,
+});
+try {
+renderPassEncoder19.beginOcclusionQuery(15);
+} catch {}
+try {
+renderPassEncoder19.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer21, 'uint16', 1_268, 5_706);
+} catch {}
+try {
+renderPassEncoder14.popDebugGroup();
+} catch {}
+let autogeneratedBindGroupLayout63 = pipeline3.getBindGroupLayout(0);
+let bindGroup97 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout0,
+  entries: [{binding: 396, resource: {buffer: buffer8, offset: 256, size: 360}}],
+});
+let sampler112 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'repeat', magFilter: 'linear', lodMaxClamp: 88.20});
+try {
+renderPassEncoder36.setBindGroup(2, bindGroup25);
+} catch {}
+try {
+renderPassEncoder17.setStencilReference(14);
+} catch {}
+try {
+renderPassEncoder5.draw(229, 160, 17_932_566, 49_890_030);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer107, 60);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer72, 'uint16', 504, 142);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(5, buffer78, 108, 466);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let autogeneratedBindGroupLayout64 = pipeline26.getBindGroupLayout(0);
+let commandEncoder153 = device0.createCommandEncoder({});
+let computePassEncoder132 = commandEncoder153.beginComputePass({});
+try {
+computePassEncoder80.setBindGroup(1, bindGroup23, new Uint32Array(119), 6, 0);
+} catch {}
+try {
+computePassEncoder132.setPipeline(pipeline31);
+} catch {}
+try {
+renderPassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder15.executeBundles([renderBundle5]);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(2, buffer64);
+} catch {}
+let promise16 = device0.queue.onSubmittedWorkDone();
+let veryExplicitBindGroupLayout21 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 8,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 54, hasDynamicOffset: false },
+    },
+  ],
+});
+let autogeneratedBindGroupLayout65 = pipeline8.getBindGroupLayout(0);
+let bindGroup98 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout52,
+  entries: [{binding: 8, resource: {buffer: buffer19, offset: 2304, size: 272}}],
+});
+let commandBuffer15 = commandEncoder34.finish();
+let texture152 = device0.createTexture({
+  size: {width: 60, height: 20, depthOrArrayLayers: 73},
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler113 = device0.createSampler({addressModeU: 'mirror-repeat', minFilter: 'linear', mipmapFilter: 'linear', compare: 'greater-equal'});
+try {
+computePassEncoder106.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(7, buffer102, 0, 3_756);
+} catch {}
+try {
+renderPassEncoder23.insertDebugMarker('\u05dc');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer35, 156, new Int16Array(3771), 1141, 76);
+} catch {}
+try {
+  await promise14;
+} catch {}
+let imageData27 = new ImageData(4, 36);
+let buffer108 = device0.createBuffer({
+  size: 4573,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE,
+});
+try {
+computePassEncoder7.setBindGroup(2, bindGroup9, new Uint32Array(706), 494, 0);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup71);
+} catch {}
+try {
+renderPassEncoder42.beginOcclusionQuery(626);
+} catch {}
+try {
+renderPassEncoder42.endOcclusionQuery();
+} catch {}
+let commandEncoder154 = device0.createCommandEncoder({});
+let renderPassEncoder43 = commandEncoder154.beginRenderPass({
+  label: '\u06d0\u{1fb77}\u0696\u0b57',
+  colorAttachments: [{view: textureView71, loadOp: 'clear', storeOp: 'store'}],
+});
+let externalTexture18 = device0.importExternalTexture({source: videoFrame18});
+try {
+computePassEncoder114.setBindGroup(2, bindGroup82);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(2, bindGroup63);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup41, new Uint32Array(2526), 1_071, 0);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline32);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer26, 880, new DataView(new ArrayBuffer(62061)), 2486, 580);
+} catch {}
+let videoFrame21 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'bt2020', transfer: 'iec6196624'} });
+let commandEncoder155 = device0.createCommandEncoder({});
+let computePassEncoder133 = commandEncoder155.beginComputePass({});
+try {
+computePassEncoder80.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+computePassEncoder133.setPipeline(pipeline30);
+} catch {}
+try {
+renderPassEncoder21.beginOcclusionQuery(269);
+} catch {}
+await gc();
+let bindGroup99 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout9,
+  entries: [{binding: 8, resource: {buffer: buffer43, offset: 512, size: 400}}],
+});
+let renderBundleEncoder18 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8sint'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder27.executeBundles([renderBundle14]);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer80, 'uint16', 42, 569);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(6, buffer69, 32);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(1, bindGroup39, new Uint32Array(682), 98, 0);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline27);
+} catch {}
+let arrayBuffer10 = buffer65.getMappedRange(480, 0);
+try {
+buffer104.unmap();
+} catch {}
+let bindGroup100 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout49,
+  entries: [{binding: 8, resource: {buffer: buffer61, offset: 256, size: 212}}],
+});
+let buffer109 = device0.createBuffer({
+  size: 82,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let texture153 = device0.createTexture({
+  size: {width: 30, height: 10, depthOrArrayLayers: 59},
+  mipLevelCount: 1,
+  sampleCount: 1,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle18 = renderBundleEncoder18.finish({});
+let externalTexture19 = device0.importExternalTexture({source: videoFrame0});
+try {
+computePassEncoder125.setBindGroup(2, bindGroup94);
+} catch {}
+try {
+computePassEncoder120.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder19.beginOcclusionQuery(64);
+} catch {}
+try {
+computePassEncoder111.insertDebugMarker('\u07cd');
+} catch {}
+try {
+device0.queue.submit([commandBuffer14]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer45, 696, new Int16Array(1446), 163, 36);
+} catch {}
+try {
+  await promise16;
+} catch {}
+let bindGroup101 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout23,
+  entries: [{binding: 8, resource: {buffer: buffer19, offset: 1792}}],
+});
+let buffer110 = device0.createBuffer({size: 40709, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM});
+let texture154 = device0.createTexture({
+  size: [2, 2, 13],
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder43.setIndexBuffer(buffer83, 'uint32', 28, 375);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(223).fill(146), /* required buffer size: 223 */
+{offset: 223, bytesPerRow: 135}, {width: 60, height: 20, depthOrArrayLayers: 0});
+} catch {}
+let buffer111 = device0.createBuffer({size: 14870, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture155 = device0.createTexture({
+  size: [30, 10, 1],
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder19.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder41.setPipeline(pipeline24);
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let buffer112 = device0.createBuffer({
+  size: 3205,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder156 = device0.createCommandEncoder({});
+let textureView147 = texture82.createView({baseMipLevel: 0});
+try {
+renderPassEncoder24.setIndexBuffer(buffer77, 'uint32', 148, 2_515);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline24);
+} catch {}
+try {
+buffer108.unmap();
+} catch {}
+let imageBitmap5 = await createImageBitmap(videoFrame9);
+let bindGroup102 = device0.createBindGroup({
+  layout: recycledAutogeneratedBindGroupLayout0,
+  entries: [{binding: 8, resource: {buffer: buffer86, offset: 5120}}],
+});
+let commandEncoder157 = device0.createCommandEncoder({});
+let texture156 = device0.createTexture({
+  size: {width: 120, height: 40, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], stencilReadOnly: true});
+try {
+renderPassEncoder22.setBindGroup(3, bindGroup43);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline29);
+} catch {}
+try {
+renderPassEncoder28.insertDebugMarker('\u0eb4');
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let renderPassEncoder44 = commandEncoder157.beginRenderPass({
+  colorAttachments: [{
+  view: textureView71,
+  clearValue: { r: -131.8, g: 508.4, b: 680.9, a: -83.95, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 260005638,
+});
+let sampler114 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 96.48,
+});
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup63);
+} catch {}
+try {
+renderPassEncoder19.beginOcclusionQuery(60);
+} catch {}
+let pipeline35 = await device0.createComputePipelineAsync({layout: pipelineLayout3, compute: {module: shaderModule2, constants: {override4: 0}}});
+let imageData28 = new ImageData(76, 96);
+let commandEncoder158 = device0.createCommandEncoder({});
+let sampler115 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'mirror-repeat', magFilter: 'nearest'});
+try {
+computePassEncoder111.setBindGroup(3, bindGroup35, new Uint32Array(2139), 94, 0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup71, []);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(3, buffer19, 4_960, 473);
+} catch {}
+try {
+commandEncoder156.insertDebugMarker('\u611b');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer30, 256, new Float32Array(1458), 212, 8);
+} catch {}
+await gc();
+let imageData29 = new ImageData(40, 80);
+let autogeneratedBindGroupLayout66 = pipeline20.getBindGroupLayout(0);
+let computePassEncoder134 = commandEncoder158.beginComputePass({});
+let sampler116 = device0.createSampler({addressModeV: 'repeat', magFilter: 'linear', lodMaxClamp: 99.85});
+try {
+renderPassEncoder44.executeBundles([renderBundle17]);
+} catch {}
+try {
+renderPassEncoder16.setStencilReference(306);
+} catch {}
+try {
+renderPassEncoder43.setIndexBuffer(buffer72, 'uint32', 1_760, 126);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(6, buffer9);
+} catch {}
+await gc();
+let autogeneratedBindGroupLayout67 = pipeline20.getBindGroupLayout(0);
+let texture157 = device0.createTexture({
+  size: {width: 120, height: 40, depthOrArrayLayers: 147},
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderPassEncoder45 = commandEncoder156.beginRenderPass({
+  colorAttachments: [{
+  view: textureView71,
+  clearValue: { r: -179.5, g: -332.6, b: -268.8, a: -173.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 511108445,
+});
+let renderBundle19 = renderBundleEncoder19.finish({});
+try {
+computePassEncoder134.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup20);
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture156,
+  mipLevel: 0,
+  origin: {x: 2, y: 9, z: 0},
+  aspect: 'all',
+}, new Uint8Array(245).fill(58), /* required buffer size: 245 */
+{offset: 245}, {width: 24, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise17 = device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule2,
+  constants: {29_819: 0, 49_292: 0},
+  targets: [{
+  format: 'rgba8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth32float',
+    depthWriteEnabled: false,
+    depthCompare: 'less',
+    stencilReadMask: 178016935,
+    stencilWriteMask: 710340969,
+    depthBias: -1479387667,
+    depthBiasSlopeScale: 655.959541229983,
+    depthBiasClamp: 710.8896571970527,
+  },
+  vertex: {
+    module: shaderModule2,
+    constants: {29_819: 0},
+    buffers: [
+      {
+        arrayStride: 108,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 0, shaderLocation: 14},
+          {format: 'unorm10-10-10-2', offset: 0, shaderLocation: 5},
+          {format: 'snorm16x2', offset: 12, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'back'},
+});
+let veryExplicitBindGroupLayout22 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 238,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let commandEncoder159 = device0.createCommandEncoder({});
+let computePassEncoder135 = commandEncoder159.beginComputePass({});
+let sampler117 = device0.createSampler({addressModeW: 'repeat', magFilter: 'nearest'});
+try {
+computePassEncoder80.setBindGroup(3, bindGroup96, []);
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(1, bindGroup85);
+} catch {}
+try {
+renderPassEncoder36.executeBundles([renderBundle12]);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(2, buffer70, 0, 943);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer40, 1668, new BigUint64Array(2428), 600, 908);
+} catch {}
+let textureView148 = texture64.createView({});
+try {
+computePassEncoder39.setBindGroup(0, bindGroup5, new Uint32Array(920), 181, 0);
+} catch {}
+try {
+computePassEncoder135.setPipeline(pipeline28);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(0, bindGroup40);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(0, bindGroup90, new Uint32Array(1299), 200, 0);
+} catch {}
+try {
+buffer88.unmap();
+} catch {}
+let autogeneratedBindGroupLayout68 = pipeline17.getBindGroupLayout(0);
+let buffer113 = device0.createBuffer({
+  size: 55732,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+});
+let textureView149 = texture150.createView({dimension: '2d', aspect: 'all', baseArrayLayer: 7, arrayLayerCount: 1});
+let texture158 = device0.createTexture({
+  size: {width: 240, height: 80, depthOrArrayLayers: 1},
+  format: 'depth32float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView150 = texture121.createView({dimension: '2d', aspect: 'depth-only', baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 2});
+try {
+renderPassEncoder41.setBindGroup(0, bindGroup93, new Uint32Array(948), 3, 0);
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let bindGroup103 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout7,
+  entries: [{binding: 8, resource: {buffer: buffer86, offset: 16128}}],
+});
+let buffer114 = device0.createBuffer({size: 1623, usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let sampler118 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+});
+try {
+computePassEncoder40.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder41.draw(123, 65, 682_957_993, 410_023_912);
+} catch {}
+try {
+renderPassEncoder41.drawIndirect(buffer48, 104);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(3, buffer69);
+} catch {}
+let promise18 = device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule4, entryPoint: 'compute5'}});
+let commandEncoder160 = device0.createCommandEncoder({});
+let computePassEncoder136 = commandEncoder160.beginComputePass({});
+let externalTexture20 = device0.importExternalTexture({source: videoFrame15, colorSpace: 'display-p3'});
+try {
+renderPassEncoder19.executeBundles([renderBundle7, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder41.draw(47, 124, 305_063_567, 685_771_575);
+} catch {}
+try {
+buffer40.unmap();
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let imageData30 = new ImageData(52, 16);
+let recycledAutogeneratedBindGroupLayout1 = pipeline35.getBindGroupLayout(0);
+let pipelineLayout10 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout21]});
+let querySet21 = device0.createQuerySet({type: 'occlusion', count: 121});
+let texture159 = device0.createTexture({
+  size: [30, 10, 122],
+  sampleCount: 1,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder136.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(1, bindGroup92);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(0, bindGroup34, new Uint32Array(1372), 341, 0);
+} catch {}
+try {
+renderPassEncoder19.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder41.drawIndirect(buffer77, 1_664);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(7, buffer64, 4_188, 569);
+} catch {}
+let querySet22 = device0.createQuerySet({type: 'occlusion', count: 1395});
+let texture160 = device0.createTexture({
+  size: [2, 2, 13],
+  format: 'depth32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView151 = texture86.createView({dimension: '2d-array', baseArrayLayer: 0});
+let renderBundleEncoder20 = device0.createRenderBundleEncoder({colorFormats: ['rgba8sint'], depthStencilFormat: 'depth32float', depthReadOnly: true});
+let renderBundle20 = renderBundleEncoder20.finish({});
+try {
+renderPassEncoder45.setBindGroup(0, bindGroup13, new Uint32Array(221), 43, 0);
+} catch {}
+try {
+renderPassEncoder44.executeBundles([renderBundle15]);
+} catch {}
+try {
+renderPassEncoder41.drawIndirect(buffer87, 820);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(3, buffer29, 192, 1_148);
+} catch {}
+let videoFrame22 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'unspecified', transfer: 'logSqrt'} });
+let texture161 = device0.createTexture({
+  size: [2, 2, 3],
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let externalTexture21 = device0.importExternalTexture({source: videoFrame21});
+try {
+computePassEncoder79.setBindGroup(1, bindGroup67);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(0, bindGroup78);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle13]);
+} catch {}
+try {
+renderPassEncoder41.drawIndirect(buffer7, 2_336);
+} catch {}
+try {
+renderPassEncoder42.setPipeline(pipeline19);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1702, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData11,
+  origin: { x: 14, y: 7 },
+  flipY: true,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 22, y: 5, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let buffer115 = device0.createBuffer({
+  size: 4866,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder131.setBindGroup(0, bindGroup55);
+} catch {}
+try {
+computePassEncoder135.setBindGroup(3, bindGroup20, new Uint32Array(466), 17, 0);
+} catch {}
+try {
+renderPassEncoder41.draw(186, 42, 1_018_997_133, 592_490_016);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(3, buffer77, 0, 996);
+} catch {}
+try {
+buffer45.unmap();
+} catch {}
+let commandEncoder161 = device0.createCommandEncoder({});
+let texture162 = device0.createTexture({
+  size: {width: 60},
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder46 = commandEncoder161.beginRenderPass({
+  colorAttachments: [{
+  view: textureView15,
+  clearValue: { r: -317.5, g: 663.5, b: -938.9, a: -112.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder131); computePassEncoder131.dispatchWorkgroupsIndirect(buffer12, 4_728); };
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(2, bindGroup36, new Uint32Array(1502), 64, 0);
+} catch {}
+try {
+renderPassEncoder21.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline26);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(0, buffer62, 0, 2_586);
+} catch {}
+offscreenCanvas1.width = 1220;
+let imageData31 = new ImageData(20, 12);
+let videoFrame23 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'bt470m', transfer: 'log'} });
+try {
+globalThis.someLabel = textureView55.label;
+} catch {}
+let textureView152 = texture104.createView({format: 'rgb10a2uint', arrayLayerCount: 1});
+try {
+computePassEncoder103.setBindGroup(2, bindGroup31, new Uint32Array(714), 22, 0);
+} catch {}
+try {
+renderPassEncoder44.setIndexBuffer(buffer9, 'uint16', 520, 3_837);
+} catch {}
+let autogeneratedBindGroupLayout69 = pipeline18.getBindGroupLayout(0);
+try {
+computePassEncoder96.setBindGroup(2, bindGroup88, new Uint32Array(238), 127, 0);
+} catch {}
+try {
+renderPassEncoder41.draw(54, 6, 94_915_290, 210_813_311);
+} catch {}
+try {
+renderPassEncoder41.drawIndirect(buffer7, 1_992);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1702, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: img0,
+  origin: { x: 1, y: 0 },
+  flipY: true,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 179, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView153 = texture82.createView({dimension: '1d'});
+try {
+computePassEncoder85.setBindGroup(0, bindGroup78, new Uint32Array(1), 0, 0);
+} catch {}
+try {
+computePassEncoder131.end();
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup48, new Uint32Array(166), 60, 0);
+} catch {}
+try {
+renderPassEncoder41.drawIndirect(buffer89, 24);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline23);
+} catch {}
+let pipeline36 = device0.createComputePipeline({layout: pipelineLayout10, compute: {module: shaderModule1}});
+let bindGroup104 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout60,
+  entries: [{binding: 8, resource: {buffer: buffer79, offset: 0, size: 60}}],
+});
+let computePassEncoder137 = commandEncoder152.beginComputePass({});
+let sampler119 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', minFilter: 'linear', lodMaxClamp: 74.44});
+let externalTexture22 = device0.importExternalTexture({source: videoFrame6, colorSpace: 'srgb'});
+try {
+renderPassEncoder41.draw(7, 173, 872_513_712, 811_078_048);
+} catch {}
+try {
+renderPassEncoder41.drawIndirect(buffer85, 416);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(0, buffer64, 1_896, 3_218);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1702, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame18,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 106, y: 44, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let autogeneratedBindGroupLayout70 = pipeline1.getBindGroupLayout(0);
+let texture163 = device0.createTexture({
+  size: [2, 2, 13],
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture164 = device0.createTexture({
+  size: {width: 120, height: 40, depthOrArrayLayers: 78},
+  mipLevelCount: 2,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder21 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], depthReadOnly: true, stencilReadOnly: true});
+let sampler120 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 66.73,
+  maxAnisotropy: 14,
+});
+try {
+renderPassEncoder33.setBindGroup(0, bindGroup23);
+} catch {}
+try {
+renderPassEncoder41.drawIndirect(buffer61, 80);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(6, buffer64, 3_468, 877);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(3, bindGroup78, new Uint32Array(1027), 572, 0);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer98, 'uint32', 12, 558);
+} catch {}
+let pipeline37 = device0.createComputePipeline({layout: pipelineLayout10, compute: {module: shaderModule0}});
+try {
+  await promise15;
+} catch {}
+let bindGroup105 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout20,
+  entries: [{binding: 8, resource: {buffer: buffer46, offset: 0, size: 436}}],
+});
+let texture165 = device0.createTexture({
+  size: {width: 30},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler121 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 88.93});
+try {
+computePassEncoder137.setBindGroup(1, bindGroup82);
+} catch {}
+try {
+computePassEncoder137.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup104);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(1, bindGroup59, new Uint32Array(1449), 60, 0);
+} catch {}
+try {
+renderPassEncoder41.end();
+} catch {}
+let arrayBuffer11 = buffer1.getMappedRange(72, 0);
+let commandBuffer16 = commandEncoder145.finish({});
+let textureView154 = texture61.createView({dimension: 'cube'});
+let textureView155 = texture65.createView({dimension: '2d', aspect: 'depth-only', baseArrayLayer: 15});
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup49);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle20, renderBundle8, renderBundle4, renderBundle7, renderBundle16]);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+let promise19 = device0.queue.onSubmittedWorkDone();
+let autogeneratedBindGroupLayout71 = pipeline0.getBindGroupLayout(0);
+let bindGroup106 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout32,
+  entries: [{binding: 8, resource: {buffer: buffer77, offset: 9728}}],
+});
+let buffer116 = device0.createBuffer({
+  size: 2748,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView156 = texture165.createView({});
+let textureView157 = texture132.createView({});
+let renderBundle21 = renderBundleEncoder21.finish();
+try {
+computePassEncoder102.setBindGroup(2, bindGroup43);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(3, bindGroup20, []);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup34, new Uint32Array(542), 80, 0);
+} catch {}
+document.body.prepend(img0);
+let commandEncoder162 = device0.createCommandEncoder({});
+let computePassEncoder138 = commandEncoder162.beginComputePass({});
+try {
+computePassEncoder90.setBindGroup(3, bindGroup15);
+} catch {}
+try {
+computePassEncoder138.setPipeline(pipeline25);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(img0);
+let autogeneratedBindGroupLayout72 = pipeline10.getBindGroupLayout(0);
+let buffer117 = device0.createBuffer({size: 995, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let querySet23 = device0.createQuerySet({type: 'occlusion', count: 266});
+let texture166 = device0.createTexture({
+  size: {width: 240, height: 80, depthOrArrayLayers: 294},
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView158 = texture87.createView({dimension: '2d', aspect: 'depth-only'});
+let sampler122 = device0.createSampler({addressModeV: 'repeat', lodMaxClamp: 94.26, compare: 'not-equal'});
+let externalTexture23 = device0.importExternalTexture({source: videoFrame9});
+try {
+computePassEncoder58.setBindGroup(2, bindGroup82, new Uint32Array(1669), 628, 0);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(3, bindGroup104);
+} catch {}
+try {
+renderPassEncoder46.executeBundles([renderBundle15, renderBundle14, renderBundle14, renderBundle14, renderBundle10, renderBundle15]);
+} catch {}
+try {
+renderPassEncoder44.setStencilReference(48);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline33);
+} catch {}
+try {
+renderPassEncoder35.insertDebugMarker('\u2a01');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer29, 988, new Float32Array(747), 13, 104);
+} catch {}
+let commandEncoder163 = device0.createCommandEncoder({});
+let texture167 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 13},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView159 = texture40.createView({dimension: '2d'});
+let computePassEncoder139 = commandEncoder163.beginComputePass({});
+try {
+computePassEncoder9.setBindGroup(2, bindGroup75);
+} catch {}
+try {
+computePassEncoder139.setPipeline(pipeline35);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(2, bindGroup58);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline3);
+} catch {}
+try {
+buffer104.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer24, 5352, new Int16Array(5193), 329);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData29,
+  origin: { x: 1, y: 4 },
+  flipY: true,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 175, y: 10, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 12, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let bindGroup107 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout19,
+  entries: [{binding: 32, resource: {buffer: buffer115, offset: 0, size: 860}}],
+});
+let buffer118 = device0.createBuffer({
+  size: 38651,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let querySet24 = device0.createQuerySet({type: 'occlusion', count: 538});
+let sampler123 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 80.30,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder65.setBindGroup(3, bindGroup80, new Uint32Array(366), 32, 0);
+} catch {}
+try {
+renderPassEncoder37.setIndexBuffer(buffer107, 'uint16', 20, 38);
+} catch {}
+let recycledExplicitBindGroupLayout5 = pipeline25.getBindGroupLayout(1);
+let buffer119 = device0.createBuffer({
+  size: 8608,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture168 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 13},
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView160 = texture126.createView({});
+try {
+computePassEncoder111.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(0, bindGroup98);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(2, bindGroup48, new Uint32Array(1384), 798, 0);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer115, 'uint16', 1_326, 1_774);
+} catch {}
+let pipeline38 = await device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule4, entryPoint: 'compute4', constants: {}}});
+let buffer120 = device0.createBuffer({size: 2281, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let texture169 = device0.createTexture({
+  size: [30],
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba8sint'],
+});
+let textureView161 = texture26.createView({dimension: '2d', aspect: 'depth-only', baseArrayLayer: 11, arrayLayerCount: 1});
+try {
+computePassEncoder138.setBindGroup(1, bindGroup69, new Uint32Array(1977), 103, 0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer16]);
+} catch {}
+let textureView162 = texture112.createView({});
+try {
+renderPassEncoder13.executeBundles([renderBundle8, renderBundle7]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: img2,
+  origin: { x: 1, y: 1 },
+  flipY: false,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 27, y: 21, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let pipeline39 = device0.createRenderPipeline({
+  layout: pipelineLayout10,
+  fragment: {
+  module: shaderModule3,
+  targets: [{format: 'rgba8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth32float',
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    stencilReadMask: 286352031,
+    stencilWriteMask: 220467825,
+    depthBias: -1945576027,
+    depthBiasSlopeScale: 235.25284947047908,
+    depthBiasClamp: 174.28991846810004,
+  },
+  vertex: {module: shaderModule0, constants: {}, buffers: []},
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', frontFace: 'cw'},
+});
+await gc();
+let buffer121 = device0.createBuffer({size: 9539, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX});
+let textureView163 = texture151.createView({});
+try {
+renderPassEncoder27.executeBundles([renderBundle15, renderBundle21, renderBundle10]);
+} catch {}
+try {
+renderPassEncoder37.setViewport(37.32129535023813, 3.4736149926413518, 49.873288383429916, 15.705526923735702, 0.04380060373099992, 0.3777101237683578);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline19);
+} catch {}
+let img3 = await imageWithData(28, 29, '#10101010', '#20202020');
+let autogeneratedBindGroupLayout73 = pipeline18.getBindGroupLayout(0);
+let buffer122 = device0.createBuffer({size: 8140, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM});
+let commandEncoder164 = device0.createCommandEncoder({label: '\u4c41\u8df8\u45fb'});
+try {
+computePassEncoder63.setBindGroup(2, bindGroup100, new Uint32Array(4324), 1_362, 0);
+} catch {}
+try {
+renderPassEncoder16.setStencilReference(4096);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer98, 'uint16', 490, 377);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+commandEncoder164.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 612 */
+  offset: 612,
+  buffer: buffer121,
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData14,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 25, y: 11, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let texture170 = device0.createTexture({
+  size: {width: 240, height: 80, depthOrArrayLayers: 1},
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView164 = texture64.createView({});
+let renderPassEncoder47 = commandEncoder164.beginRenderPass({
+  colorAttachments: [{
+  view: textureView15,
+  clearValue: { r: -881.4, g: 163.9, b: 418.7, a: -687.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 447581061,
+});
+let sampler124 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 51.55,
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder82.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder38.executeBundles([renderBundle19]);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(5, buffer62, 112);
+} catch {}
+try {
+buffer94.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 384, new Int16Array(413), 16, 140);
+} catch {}
+let veryExplicitBindGroupLayout23 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 213,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 346,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup108 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout3,
+  entries: [{binding: 8, resource: {buffer: buffer50, offset: 0, size: 248}}],
+});
+let commandEncoder165 = device0.createCommandEncoder();
+let textureView165 = texture74.createView({mipLevelCount: 1});
+let computePassEncoder140 = commandEncoder165.beginComputePass({});
+try {
+computePassEncoder90.setBindGroup(0, bindGroup76);
+} catch {}
+try {
+computePassEncoder140.setPipeline(pipeline37);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder17.setViewport(94.4739255398464, 14.397441332520021, 1.5592759820390318, 20.842745047958864, 0.21238956095003125, 0.6165040542012713);
+} catch {}
+try {
+  await promise19;
+} catch {}
+let commandEncoder166 = device0.createCommandEncoder({});
+let texture171 = device0.createTexture({
+  size: {width: 30, height: 10, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'depth32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView166 = texture122.createView({baseArrayLayer: 0});
+try {
+computePassEncoder2.setBindGroup(0, bindGroup19, new Uint32Array(3471), 1_495, 0);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup57, new Uint32Array(916), 131, 0);
+} catch {}
+try {
+commandEncoder166.copyBufferToTexture({
+  /* bytesInLastRow: 84 widthInBlocks: 21 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1044 */
+  offset: 1044,
+  bytesPerRow: 25088,
+  buffer: buffer84,
+}, {
+  texture: texture90,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 21, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise20 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1702, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData0,
+  origin: { x: 1, y: 10 },
+  flipY: false,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 263, y: 12, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let recycledAutogeneratedBindGroupLayout2 = pipeline35.getBindGroupLayout(0);
+let bindGroup109 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout47,
+  entries: [{binding: 8, resource: {buffer: buffer30, offset: 1792, size: 564}}],
+});
+let textureView167 = texture148.createView({dimension: '2d-array', aspect: 'all', arrayLayerCount: 1});
+let computePassEncoder141 = commandEncoder166.beginComputePass({});
+let sampler125 = device0.createSampler({addressModeV: 'repeat', compare: 'less'});
+try {
+computePassEncoder93.setBindGroup(2, bindGroup37);
+} catch {}
+try {
+computePassEncoder141.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup92, new Uint32Array(1023), 151, 0);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([renderBundle18]);
+} catch {}
+try {
+renderPassEncoder15.setStencilReference(841);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+  await promise20;
+} catch {}
+let texture172 = device0.createTexture({size: [240, 80, 1], format: 'depth32float', usage: GPUTextureUsage.RENDER_ATTACHMENT, viewFormats: []});
+let sampler126 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 87.21,
+  lodMaxClamp: 97.28,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder2); computePassEncoder2.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder24.beginOcclusionQuery(340);
+} catch {}
+let autogeneratedBindGroupLayout74 = pipeline4.getBindGroupLayout(0);
+let texture173 = device0.createTexture({
+  size: [120, 40, 20],
+  mipLevelCount: 1,
+  format: 'depth32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler127 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'clamp-to-edge', lodMaxClamp: 78.01, compare: 'never'});
+try {
+renderPassEncoder24.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline27);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(3, buffer43);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+document.body.append(canvas2);
+let bindGroup110 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout28,
+  entries: [{binding: 8, resource: {buffer: buffer70, offset: 0}}],
+});
+let commandEncoder167 = device0.createCommandEncoder({});
+let computePassEncoder142 = commandEncoder167.beginComputePass();
+try {
+computePassEncoder83.setBindGroup(1, bindGroup10, new Uint32Array(615), 14, 0);
+} catch {}
+try {
+computePassEncoder9.setPipeline(pipeline10);
+} catch {}
+try {
+computePassEncoder142.setPipeline(pipeline37);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer29, 'uint16', 1_198, 334);
+} catch {}
+let commandEncoder168 = device0.createCommandEncoder();
+let computePassEncoder143 = commandEncoder168.beginComputePass({});
+try {
+renderPassEncoder32.setBindGroup(2, bindGroup105, []);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer28, 'uint32', 1_124, 1_150);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(1, buffer83, 0, 1_557);
+} catch {}
+try {
+buffer104.unmap();
+} catch {}
+document.body.prepend(img2);
+let videoFrame24 = videoFrame4.clone();
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let recycledExplicitBindGroupLayout6 = pipeline28.getBindGroupLayout(0);
+let buffer123 = device0.createBuffer({
+  size: 3928,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder169 = device0.createCommandEncoder();
+let texture174 = device0.createTexture({
+  size: {width: 240, height: 80, depthOrArrayLayers: 1},
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture175 = gpuCanvasContext4.getCurrentTexture();
+let textureView168 = texture6.createView({dimension: '2d-array', aspect: 'stencil-only', mipLevelCount: 1});
+let computePassEncoder144 = commandEncoder169.beginComputePass({});
+try {
+computePassEncoder30.setBindGroup(1, bindGroup8, new Uint32Array(2039), 107, 0);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(0, bindGroup83, new Uint32Array(1462), 373, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer124 = device0.createBuffer({size: 17335, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+try {
+computePassEncoder97.setBindGroup(0, bindGroup99);
+} catch {}
+try {
+computePassEncoder38.setBindGroup(1, bindGroup37, new Uint32Array(1148), 74, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder2); computePassEncoder2.dispatchWorkgroupsIndirect(buffer68, 40); };
+} catch {}
+try {
+computePassEncoder143.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer112, 'uint32', 356, 157);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(1, buffer90, 0);
+} catch {}
+let bindGroup111 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout18,
+  entries: [
+    {binding: 303, resource: textureView147},
+    {binding: 261, resource: externalTexture1},
+    {binding: 39, resource: textureView60},
+  ],
+});
+try {
+computePassEncoder144.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup58);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(1, bindGroup22, new Uint32Array(936), 374, 0);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer62, 'uint16', 1_502, 1_148);
+} catch {}
+try {
+buffer9.unmap();
+} catch {}
+let autogeneratedBindGroupLayout75 = pipeline27.getBindGroupLayout(0);
+let bindGroup112 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout41,
+  entries: [{binding: 8, resource: {buffer: buffer8, offset: 0, size: 1708}}],
+});
+let commandEncoder170 = device0.createCommandEncoder();
+let renderBundleEncoder22 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], stencilReadOnly: true});
+try {
+renderPassEncoder31.setBindGroup(3, bindGroup22, new Uint32Array(2443), 81, 0);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer8, 'uint32', 64, 949);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(7, buffer17, 0);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+buffer53.unmap();
+} catch {}
+try {
+commandEncoder170.copyBufferToTexture({
+  /* bytesInLastRow: 44 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2436 */
+  offset: 2436,
+  bytesPerRow: 4096,
+  buffer: buffer74,
+}, {
+  texture: texture118,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder170.copyTextureToTexture({
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 30, height: 10, depthOrArrayLayers: 0});
+} catch {}
+let texture176 = device0.createTexture({
+  size: [240, 80, 294],
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture177 = device0.createTexture({
+  label: '\uf419\uce04\ueccf\u11d2\u398b\u8012\u{1fa94}\u0773\u0f15\u{1fe5f}\u{1fae3}',
+  size: {width: 60, height: 20, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  sampleCount: 1,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView169 = texture39.createView({dimension: '2d', baseArrayLayer: 8});
+let computePassEncoder145 = commandEncoder170.beginComputePass({});
+try {
+computePassEncoder47.setBindGroup(0, bindGroup85);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder2); computePassEncoder2.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup75);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(2, buffer102, 3_972);
+} catch {}
+let pipeline40 = device0.createComputePipeline({layout: pipelineLayout10, compute: {module: shaderModule4, entryPoint: 'compute5', constants: {}}});
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let imageData32 = new ImageData(108, 20);
+let veryExplicitBindGroupLayout24 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 189,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let textureView170 = texture176.createView({dimension: '3d', aspect: 'all', arrayLayerCount: 1});
+let texture178 = device0.createTexture({
+  size: [60, 20, 15],
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle22 = renderBundleEncoder22.finish({});
+try {
+renderPassEncoder18.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder45.setIndexBuffer(buffer9, 'uint16', 980, 506);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer87.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 32, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(33).fill(52), /* required buffer size: 33 */
+{offset: 33, bytesPerRow: 9, rowsPerImage: 22}, {width: 1, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup113 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout64,
+  entries: [{binding: 8, resource: {buffer: buffer7, offset: 4096, size: 180}}],
+});
+let textureView171 = texture176.createView({});
+let sampler128 = device0.createSampler({addressModeV: 'mirror-repeat', mipmapFilter: 'nearest', compare: 'equal', maxAnisotropy: 1});
+try {
+computePassEncoder145.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(0, bindGroup105, new Uint32Array(441), 90, 0);
+} catch {}
+let pipeline41 = device0.createComputePipeline({layout: pipelineLayout10, compute: {module: shaderModule1, constants: {}}});
+try {
+renderPassEncoder30.setViewport(39.16547340469037, 28.647565591013485, 27.34931982734788, 1.2782747314514176, 0.08411214380551635, 0.8515478640599239);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(0, buffer8, 0, 502);
+} catch {}
+let buffer125 = device0.createBuffer({
+  size: 11901,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder171 = device0.createCommandEncoder({});
+let texture179 = device0.createTexture({
+  size: {width: 240, height: 80, depthOrArrayLayers: 294},
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView172 = texture132.createView({dimension: '2d-array'});
+try {
+renderPassEncoder2.end();
+} catch {}
+try {
+commandEncoder26.copyBufferToBuffer(buffer23, 168, buffer68, 372, 36);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData27,
+  origin: { x: 0, y: 6 },
+  flipY: false,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 86, y: 24, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 13, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder172 = device0.createCommandEncoder({});
+let texture180 = device0.createTexture({
+  size: [30],
+  dimension: '1d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder146 = commandEncoder171.beginComputePass();
+let sampler129 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 81.48,
+  maxAnisotropy: 10,
+});
+let externalTexture24 = device0.importExternalTexture({source: videoFrame24});
+try {
+computePassEncoder9.setBindGroup(1, bindGroup20);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([renderBundle18, renderBundle5, renderBundle13, renderBundle7, renderBundle7, renderBundle8, renderBundle20]);
+} catch {}
+try {
+renderPassEncoder37.setBlendConstant({ r: 946.3, g: -449.8, b: 879.6, a: 891.7, });
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline34);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(0, buffer30, 1_892, 755);
+} catch {}
+document.body.prepend(canvas0);
+let buffer126 = device0.createBuffer({size: 5810, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let commandEncoder173 = device0.createCommandEncoder({});
+let textureView173 = texture180.createView({arrayLayerCount: 1});
+let renderPassEncoder48 = commandEncoder173.beginRenderPass({
+  colorAttachments: [{
+  view: textureView15,
+  clearValue: { r: -907.3, g: -210.1, b: -144.8, a: 212.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder146.setPipeline(pipeline25);
+} catch {}
+try {
+commandEncoder26.copyBufferToTexture({
+  /* bytesInLastRow: 76 widthInBlocks: 19 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1116 */
+  offset: 1116,
+  bytesPerRow: 25344,
+  rowsPerImage: 1247,
+  buffer: buffer118,
+}, {
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 5, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 19, height: 14, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer91, 108, new Int16Array(5834), 293, 28);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData15,
+  origin: { x: 9, y: 6 },
+  flipY: false,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 90, y: 16, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 25, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let pipeline42 = await promise18;
+document.body.prepend(canvas1);
+let commandEncoder174 = device0.createCommandEncoder({});
+let textureView174 = texture179.createView({});
+try {
+computePassEncoder80.setBindGroup(0, bindGroup11, new Uint32Array(1195), 37, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder2); computePassEncoder2.dispatchWorkgroupsIndirect(buffer42, 1_712); };
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup9, new Uint32Array(2784), 122, 0);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer72, 'uint16', 3_128, 69);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(3, buffer29);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1702, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData29,
+  origin: { x: 1, y: 1 },
+  flipY: true,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 280, y: 64, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 7, height: 8, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let texture181 = device0.createTexture({
+  size: {width: 30, height: 10, depthOrArrayLayers: 36},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView175 = texture99.createView({dimension: '2d-array'});
+let computePassEncoder147 = commandEncoder174.beginComputePass({label: '\u02ca\udff5\u6c76'});
+let renderPassEncoder49 = commandEncoder26.beginRenderPass({
+  colorAttachments: [{
+  view: textureView13,
+  clearValue: { r: 980.2, g: 945.6, b: 404.6, a: -802.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView20,
+    depthClearValue: 0.4518504834394399,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'discard',
+    depthReadOnly: false,
+    stencilClearValue: 61337,
+  },
+  occlusionQuerySet: querySet6,
+  maxDrawCount: 115152478,
+});
+try {
+computePassEncoder123.setBindGroup(1, bindGroup112);
+} catch {}
+try {
+computePassEncoder147.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(3, bindGroup12, new Uint32Array(320), 33, 0);
+} catch {}
+try {
+renderPassEncoder49.setIndexBuffer(buffer69, 'uint32', 24, 319);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline27);
+} catch {}
+try {
+commandEncoder172.clearBuffer(buffer116);
+} catch {}
+document.body.append(canvas1);
+let autogeneratedBindGroupLayout76 = pipeline13.getBindGroupLayout(0);
+let bindGroup114 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout3,
+  entries: [{binding: 8, resource: {buffer: buffer43, offset: 512, size: 348}}],
+});
+let commandEncoder175 = device0.createCommandEncoder({});
+let textureView176 = texture148.createView({dimension: '2d-array'});
+let textureView177 = texture8.createView({format: 'depth32float', baseArrayLayer: 1, arrayLayerCount: 2});
+let computePassEncoder148 = commandEncoder172.beginComputePass({});
+let renderPassEncoder50 = commandEncoder175.beginRenderPass({
+  colorAttachments: [{
+  view: textureView15,
+  clearValue: { r: 388.2, g: 369.9, b: 271.7, a: 150.3, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let sampler130 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.46,
+  compare: 'not-equal',
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder144.setBindGroup(3, bindGroup67);
+} catch {}
+try {
+computePassEncoder40.setBindGroup(3, bindGroup33, new Uint32Array(374), 75, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder2); computePassEncoder2.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder148.setPipeline(pipeline20);
+} catch {}
+let offscreenCanvas4 = new OffscreenCanvas(352, 218);
+let videoFrame25 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'jedecP22Phosphors', transfer: 'bt2020_10bit'} });
+let buffer127 = device0.createBuffer({size: 2646, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM});
+try {
+gpuCanvasContext0.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.TEXTURE_BINDING, alphaMode: 'opaque'});
+} catch {}
+let pipelineLayout11 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout57, autogeneratedBindGroupLayout17]});
+let texture182 = device0.createTexture({
+  size: {width: 30, height: 10, depthOrArrayLayers: 25},
+  mipLevelCount: 2,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder18.setVertexBuffer(4, buffer83);
+} catch {}
+let promise21 = device0.queue.onSubmittedWorkDone();
+let imageData33 = new ImageData(24, 56);
+let buffer128 = device0.createBuffer({size: 6570, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+try {
+computePassEncoder113.setBindGroup(0, bindGroup67);
+} catch {}
+try {
+renderPassEncoder34.executeBundles([renderBundle7]);
+} catch {}
+document.body.append(img2);
+let commandEncoder176 = device0.createCommandEncoder();
+let textureView178 = texture135.createView({mipLevelCount: 1});
+let computePassEncoder149 = commandEncoder176.beginComputePass({});
+let sampler131 = device0.createSampler({label: '\u122a\u5378\u21ad\u9ccf\u051f\u00a8\ud1f2\u36df\u0eb9', addressModeV: 'repeat'});
+try {
+computePassEncoder144.pushDebugGroup('\u0993');
+} catch {}
+try {
+renderPassEncoder32.insertDebugMarker('\u2ae9');
+} catch {}
+let pipeline43 = device0.createRenderPipeline({
+  layout: pipelineLayout10,
+  fragment: {module: shaderModule1, constants: {}, targets: [{format: 'rgba8sint', writeMask: 0}]},
+  depthStencil: {
+    format: 'depth32float',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilReadMask: 188841631,
+    stencilWriteMask: 427737036,
+    depthBiasSlopeScale: 682.6888620517204,
+    depthBiasClamp: 699.977410448268,
+  },
+  vertex: {module: shaderModule0, buffers: []},
+});
+let commandEncoder177 = device0.createCommandEncoder({});
+try {
+computePassEncoder136.setBindGroup(1, bindGroup114);
+} catch {}
+try {
+computePassEncoder149.setPipeline(pipeline40);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer114, 0);
+} catch {}
+let arrayBuffer12 = buffer65.getMappedRange(112, 108);
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let recycledExplicitBindGroupLayout7 = pipeline41.getBindGroupLayout(0);
+let computePassEncoder150 = commandEncoder177.beginComputePass({});
+let sampler132 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 95.08,
+  compare: 'always',
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder67.setBindGroup(1, bindGroup78);
+} catch {}
+try {
+computePassEncoder108.setPipeline(pipeline16);
+} catch {}
+try {
+computePassEncoder150.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(3, bindGroup90);
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline32);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let bindGroup115 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout18,
+  entries: [{binding: 8, resource: {buffer: buffer84, offset: 256, size: 856}}],
+});
+try {
+computePassEncoder137.setBindGroup(1, bindGroup98);
+} catch {}
+try {
+computePassEncoder133.setBindGroup(0, bindGroup35, new Uint32Array(1975), 123, 0);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle6, renderBundle16]);
+} catch {}
+let recycledExplicitBindGroupLayout8 = pipeline5.getBindGroupLayout(1);
+let commandEncoder178 = device0.createCommandEncoder({});
+let texture183 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 13},
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+renderPassEncoder34.setVertexBuffer(5, buffer33, 444, 48);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData9,
+  origin: { x: 8, y: 6 },
+  flipY: true,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 71, y: 41, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas5 = new OffscreenCanvas(198, 76);
+let computePassEncoder151 = commandEncoder178.beginComputePass();
+try {
+computePassEncoder151.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer36, 'uint16', 472, 139);
+} catch {}
+let recycledExplicitBindGroupLayout9 = pipeline39.getBindGroupLayout(0);
+let commandEncoder179 = device0.createCommandEncoder();
+let renderPassEncoder51 = commandEncoder179.beginRenderPass({
+  colorAttachments: [{
+  view: textureView15,
+  clearValue: { r: -379.1, g: -676.7, b: -658.9, a: 302.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder93.setBindGroup(1, bindGroup10, new Uint32Array(231), 14, 0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup41, new Uint32Array(3266), 154, 0);
+} catch {}
+try {
+  await promise21;
+} catch {}
+let veryExplicitBindGroupLayout25 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 68,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 100,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8uint', access: 'read-only', viewDimension: '1d' },
+    },
+  ],
+});
+let commandEncoder180 = device0.createCommandEncoder();
+let texture184 = device0.createTexture({size: {width: 2}, dimension: '1d', format: 'rgb10a2uint', usage: GPUTextureUsage.TEXTURE_BINDING});
+try {
+computePassEncoder99.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder2); computePassEncoder2.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(1, buffer62, 272, 1_360);
+} catch {}
+try {
+commandEncoder3.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2640 */
+  offset: 2640,
+  bytesPerRow: 20480,
+  buffer: buffer33,
+}, {
+  texture: texture102,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup116 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout14,
+  entries: [{binding: 8, resource: {buffer: buffer108, offset: 0, size: 800}}],
+});
+let commandEncoder181 = device0.createCommandEncoder({});
+let textureView179 = texture179.createView({});
+let renderPassEncoder52 = commandEncoder180.beginRenderPass({
+  colorAttachments: [{
+  view: textureView81,
+  clearValue: { r: 811.8, g: 924.8, b: 916.6, a: 287.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView44,
+    depthClearValue: 0.8600335979097944,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'store',
+    depthReadOnly: false,
+    stencilClearValue: 5074,
+  },
+  occlusionQuerySet: querySet7,
+});
+try {
+computePassEncoder129.setBindGroup(1, bindGroup78, new Uint32Array(1851), 1_439, 0);
+} catch {}
+try {
+commandEncoder3.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 968 */
+  offset: 968,
+  bytesPerRow: 44800,
+  buffer: buffer89,
+}, {
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture136,
+  mipLevel: 0,
+  origin: {x: 3, y: 1, z: 2},
+  aspect: 'all',
+}, new Uint8Array(122).fill(22), /* required buffer size: 122 */
+{offset: 59, bytesPerRow: 43}, {width: 5, height: 2, depthOrArrayLayers: 1});
+} catch {}
+let recycledExplicitBindGroupLayout10 = pipeline43.getBindGroupLayout(0);
+let computePassEncoder152 = commandEncoder181.beginComputePass({});
+let renderPassEncoder53 = commandEncoder3.beginRenderPass({
+  colorAttachments: [{view: textureView73, depthSlice: 20, loadOp: 'clear', storeOp: 'discard'}],
+  depthStencilAttachment: {view: textureView44, depthLoadOp: 'load', depthStoreOp: 'store', depthReadOnly: false},
+});
+try {
+computePassEncoder152.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(0, bindGroup95);
+} catch {}
+try {
+renderPassEncoder42.executeBundles([renderBundle1, renderBundle12]);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(1, undefined, 0, 243_208_212);
+} catch {}
+try {
+computePassEncoder144.popDebugGroup();
+} catch {}
+let bindGroup117 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout19,
+  entries: [{binding: 32, resource: {buffer: buffer123, offset: 0}}],
+});
+try {
+computePassEncoder121.setBindGroup(1, bindGroup76);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline27);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(4, buffer17);
+} catch {}
+let videoFrame26 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'fcc', primaries: 'bt470m', transfer: 'hlg'} });
+try {
+bindGroup38.label = '\u6813\u6046\u0d6b\u{1ffe4}\u6918\uffc0\u{1fa27}\ua955\u39a4\u{1f68c}';
+} catch {}
+let commandEncoder182 = device0.createCommandEncoder({});
+let querySet25 = device0.createQuerySet({type: 'occlusion', count: 0});
+let texture185 = device0.createTexture({
+  size: [2, 2, 66],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder153 = commandEncoder182.beginComputePass({});
+try {
+computePassEncoder153.setPipeline(pipeline0);
+} catch {}
+try {
+  await buffer111.mapAsync(GPUMapMode.WRITE, 184, 4764);
+} catch {}
+try {
+computePassEncoder42.insertDebugMarker('\u00e4');
+} catch {}
+let veryExplicitBindGroupLayout26 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 0,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 35,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8uint', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 58,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 96,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 116,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 205,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '2d' },
+    },
+    {
+      binding: 285,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 309,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 334,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '2d' },
+    },
+    {binding: 376, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform', hasDynamicOffset: false }},
+  ],
+});
+let autogeneratedBindGroupLayout77 = pipeline32.getBindGroupLayout(0);
+let textureView180 = texture136.createView({dimension: '2d-array', aspect: 'all', baseMipLevel: 0, baseArrayLayer: 3, arrayLayerCount: 1});
+document.body.append(canvas1);
+let bindGroup118 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout54,
+  entries: [{binding: 8, resource: {buffer: buffer97, offset: 256, size: 668}}],
+});
+let commandEncoder183 = device0.createCommandEncoder({});
+let computePassEncoder154 = commandEncoder183.beginComputePass();
+try {
+computePassEncoder125.setBindGroup(2, bindGroup115);
+} catch {}
+try {
+computePassEncoder127.setBindGroup(1, bindGroup33, new Uint32Array(937), 140, 0);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer89, 'uint16', 84, 183);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(1, buffer34, 12, 1_286);
+} catch {}
+let commandEncoder184 = device0.createCommandEncoder();
+try {
+computePassEncoder154.setPipeline(pipeline5);
+} catch {}
+try {
+commandEncoder184.copyTextureToBuffer({
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 22, y: 2, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1780 */
+  offset: 1780,
+  bytesPerRow: 9216,
+  buffer: buffer116,
+}, {width: 1, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer40, 20364, new Int16Array(10770), 5889, 8);
+} catch {}
+let pipeline44 = await promise17;
+let autogeneratedBindGroupLayout78 = pipeline42.getBindGroupLayout(0);
+let bindGroup119 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout4,
+  entries: [{binding: 396, resource: {buffer: buffer115, offset: 1024, size: 864}}],
+});
+let buffer129 = device0.createBuffer({
+  size: 15508,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture186 = device0.createTexture({
+  size: [2, 2, 11],
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder155 = commandEncoder184.beginComputePass({});
+let externalTexture25 = device0.importExternalTexture({source: videoFrame11});
+try {
+renderPassEncoder23.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderPassEncoder25.setScissorRect(24, 4, 1, 16);
+} catch {}
+try {
+computePassEncoder95.insertDebugMarker('\uf67d');
+} catch {}
+let autogeneratedBindGroupLayout79 = pipeline13.getBindGroupLayout(0);
+let commandEncoder185 = device0.createCommandEncoder({});
+let textureView181 = texture180.createView({dimension: '1d'});
+let texture187 = device0.createTexture({
+  size: [60, 20, 44],
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder156 = commandEncoder185.beginComputePass({});
+try {
+renderPassEncoder31.setIndexBuffer(buffer78, 'uint32', 1_072, 34);
+} catch {}
+let imageBitmap6 = await createImageBitmap(videoFrame3);
+let recycledExplicitBindGroupLayout11 = pipeline28.getBindGroupLayout(0);
+let sampler133 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 65.72,
+});
+try {
+computePassEncoder127.setBindGroup(0, bindGroup40, new Uint32Array(1116), 39, 0);
+} catch {}
+try {
+renderPassEncoder49.setPipeline(pipeline24);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder127); computePassEncoder127.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder21.setPipeline(pipeline9);
+} catch {}
+document.body.append(img1);
+let buffer130 = device0.createBuffer({size: 2418, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let sampler134 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMinClamp: 19.48,
+});
+try {
+computePassEncoder156.setPipeline(pipeline30);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer123, 'uint16', 844, 138);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline11);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture164,
+  mipLevel: 0,
+  origin: {x: 5, y: 9, z: 6},
+  aspect: 'all',
+}, new Uint8Array(58_637).fill(11), /* required buffer size: 58_637 */
+{offset: 269, bytesPerRow: 96, rowsPerImage: 152}, {width: 11, height: 0, depthOrArrayLayers: 5});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1702, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData32,
+  origin: { x: 27, y: 7 },
+  flipY: false,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 323, y: 99, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 12, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame27 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte170m', primaries: 'smpte432', transfer: 'unspecified'} });
+let veryExplicitBindGroupLayout27 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 13,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '3d' },
+    },
+    {binding: 20, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+    {
+      binding: 40,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 43,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 46,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 61,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 70,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 79,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 89,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 97,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 112,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 158,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 175,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 181, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+    {
+      binding: 258,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 317,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 427,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+try {
+computePassEncoder71.setBindGroup(1, bindGroup113, new Uint32Array(142), 2, 0);
+} catch {}
+try {
+computePassEncoder155.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer86, 'uint16', 1_304, 790);
+} catch {}
+try {
+renderPassEncoder52.setPipeline(pipeline43);
+} catch {}
+try {
+buffer35.unmap();
+} catch {}
+let texture188 = device0.createTexture({
+  size: {width: 2},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup90);
+} catch {}
+try {
+renderPassEncoder49.executeBundles([renderBundle7, renderBundle16, renderBundle0, renderBundle11, renderBundle11]);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(5, buffer78, 96, 231);
+} catch {}
+let bindGroup120 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout17,
+  entries: [{binding: 8, resource: {buffer: buffer43, offset: 512, size: 228}}],
+});
+let textureView182 = texture181.createView({format: 'rgba8sint'});
+let sampler135 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  compare: 'less-equal',
+});
+try {
+computePassEncoder106.setPipeline(pipeline16);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1702, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap4,
+  origin: { x: 7, y: 2 },
+  flipY: true,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 260, y: 21, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 16, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder186 = device0.createCommandEncoder({});
+let computePassEncoder157 = commandEncoder186.beginComputePass({});
+let sampler136 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', magFilter: 'linear', mipmapFilter: 'linear'});
+try {
+computePassEncoder157.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(3, bindGroup31);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline44);
+} catch {}
+let autogeneratedBindGroupLayout80 = pipeline2.getBindGroupLayout(0);
+let bindGroup121 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout8,
+  entries: [{binding: 396, resource: {buffer: buffer28, offset: 0}}],
+});
+let renderBundleEncoder23 = device0.createRenderBundleEncoder({colorFormats: ['rg32sint'], stencilReadOnly: true});
+try {
+computePassEncoder90.setBindGroup(3, bindGroup48, new Uint32Array(865), 6, 0);
+} catch {}
+try {
+computePassEncoder30.setPipeline(pipeline36);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer112, 'uint32', 600, 10);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(2, bindGroup24);
+} catch {}
+let buffer131 = device0.createBuffer({size: 3303, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder187 = device0.createCommandEncoder({});
+let renderPassEncoder54 = commandEncoder187.beginRenderPass({
+  colorAttachments: [{
+  view: textureView40,
+  depthSlice: 20,
+  clearValue: { r: 390.1, g: -547.4, b: 380.7, a: -620.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView169,
+    depthClearValue: 0.9317817342425659,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'discard',
+    stencilReadOnly: true,
+  },
+});
+let sampler137 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 72.96,
+  maxAnisotropy: 6,
+});
+try {
+renderPassEncoder42.setBindGroup(0, bindGroup41, new Uint32Array(1224), 13, 0);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(0, bindGroup107);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(0, bindGroup36, new Uint32Array(705), 41, 0);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(4, buffer86, 0, 9_239);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+let veryExplicitBindGroupLayout28 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 68,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 100,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8uint', access: 'read-only', viewDimension: '1d' },
+    },
+  ],
+});
+let bindGroup122 = device0.createBindGroup({
+  label: '\ub32a\u4395\uaf11\ude42\u8e60\u0abc\u8de4\uf985',
+  layout: autogeneratedBindGroupLayout29,
+  entries: [{binding: 8, resource: {buffer: buffer84, offset: 1280, size: 316}}],
+});
+let commandEncoder188 = device0.createCommandEncoder();
+let texture189 = device0.createTexture({
+  size: {width: 60, height: 20, depthOrArrayLayers: 35},
+  mipLevelCount: 2,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView183 = texture34.createView({arrayLayerCount: 1});
+let renderPassEncoder55 = commandEncoder188.beginRenderPass({
+  colorAttachments: [{
+  view: textureView41,
+  depthSlice: 12,
+  clearValue: { r: -613.2, g: 833.5, b: 328.5, a: 442.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView121,
+    depthClearValue: 0.7589916562470291,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'discard',
+    stencilClearValue: 42535,
+  },
+});
+let renderBundle23 = renderBundleEncoder23.finish({});
+let sampler138 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.73,
+  compare: 'not-equal',
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder127); computePassEncoder127.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline19);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture157,
+  mipLevel: 0,
+  origin: {x: 13, y: 15, z: 63},
+  aspect: 'all',
+}, new Uint8Array(4_159).fill(237), /* required buffer size: 4_159 */
+{offset: 55, bytesPerRow: 228, rowsPerImage: 3}, {width: 49, height: 0, depthOrArrayLayers: 7});
+} catch {}
+let gpuCanvasContext6 = offscreenCanvas4.getContext('webgpu');
+let buffer132 = device0.createBuffer({
+  size: 8919,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder189 = device0.createCommandEncoder();
+try {
+renderPassEncoder39.setBindGroup(3, bindGroup35, new Uint32Array(850), 55, 0);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline26);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture190 = device0.createTexture({size: {width: 30}, dimension: '1d', format: 'rgb10a2uint', usage: GPUTextureUsage.COPY_SRC});
+let computePassEncoder158 = commandEncoder189.beginComputePass({});
+try {
+computePassEncoder158.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder50.executeBundles([renderBundle14]);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline39);
+} catch {}
+try {
+buffer44.unmap();
+} catch {}
+let bindGroup123 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout19,
+  entries: [{binding: 8, resource: {buffer: buffer118, offset: 19456, size: 7752}}],
+});
+let textureView184 = texture41.createView({dimension: '2d', aspect: 'depth-only', mipLevelCount: 2, baseArrayLayer: 16});
+try {
+renderPassEncoder44.executeBundles([renderBundle10, renderBundle14, renderBundle19, renderBundle14, renderBundle14]);
+} catch {}
+try {
+computePassEncoder127.insertDebugMarker('\u9328');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap5,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 16, y: 10, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas0);
+let buffer133 = device0.createBuffer({size: 12491, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let commandEncoder190 = device0.createCommandEncoder({});
+let textureView185 = texture82.createView({format: 'rg32uint', mipLevelCount: 1});
+try {
+computePassEncoder65.setBindGroup(3, bindGroup67, []);
+} catch {}
+try {
+computePassEncoder67.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder42.executeBundles([renderBundle7, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(1, buffer73, 88);
+} catch {}
+try {
+commandEncoder190.resolveQuerySet(querySet1, 187, 22, buffer70, 1536);
+} catch {}
+let pipeline45 = await device0.createComputePipelineAsync({layout: pipelineLayout10, compute: {module: shaderModule1}});
+let textureView186 = texture27.createView({aspect: 'depth-only', mipLevelCount: 1, baseArrayLayer: 0, arrayLayerCount: 1});
+try {
+computePassEncoder95.setBindGroup(0, bindGroup58, new Uint32Array(619), 224, 0);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(2, bindGroup62);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup25, new Uint32Array(2218), 314, 0);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline32);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(0, buffer118, 0);
+} catch {}
+try {
+commandEncoder190.copyBufferToTexture({
+  /* bytesInLastRow: 24 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2336 */
+  offset: 2336,
+  buffer: buffer85,
+}, {
+  texture: texture143,
+  mipLevel: 0,
+  origin: {x: 38, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder190.insertDebugMarker('\u{1fd7d}');
+} catch {}
+let commandEncoder191 = device0.createCommandEncoder({});
+let texture191 = device0.createTexture({
+  size: [240, 80, 14],
+  mipLevelCount: 2,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView187 = texture86.createView({dimension: '2d-array', aspect: 'depth-only'});
+let computePassEncoder159 = commandEncoder191.beginComputePass({});
+try {
+computePassEncoder126.setBindGroup(3, bindGroup112, new Uint32Array(1807), 642, 0);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(1, bindGroup105);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(1, bindGroup74, new Uint32Array(1237), 0, 0);
+} catch {}
+try {
+renderPassEncoder15.beginOcclusionQuery(27);
+} catch {}
+try {
+renderPassEncoder9.setScissorRect(4, 0, 5, 2);
+} catch {}
+try {
+renderPassEncoder49.setPipeline(pipeline32);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(0, buffer120, 668, 309);
+} catch {}
+try {
+computePassEncoder48.pushDebugGroup('\udbba');
+} catch {}
+let pipeline46 = await device0.createComputePipelineAsync({layout: pipelineLayout10, compute: {module: shaderModule0, constants: {}}});
+try {
+globalThis.someLabel = externalTexture18.label;
+} catch {}
+let commandEncoder192 = device0.createCommandEncoder({});
+let texture192 = gpuCanvasContext4.getCurrentTexture();
+let renderBundleEncoder24 = device0.createRenderBundleEncoder({colorFormats: ['rg32sint'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle24 = renderBundleEncoder24.finish({});
+let externalTexture26 = device0.importExternalTexture({source: videoFrame19});
+try {
+computePassEncoder76.setBindGroup(1, bindGroup91, []);
+} catch {}
+try {
+computePassEncoder127.end();
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(6, buffer40, 11_416, 2_221);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+try {
+adapter0.label = '\u044f\u9d7e\u834a\u194b\u{1fa87}';
+} catch {}
+let pipelineLayout12 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout65]});
+let commandEncoder193 = device0.createCommandEncoder({});
+let computePassEncoder160 = commandEncoder190.beginComputePass();
+let renderPassEncoder56 = commandEncoder193.beginRenderPass({
+  colorAttachments: [{
+  view: textureView120,
+  clearValue: { r: -43.12, g: 596.2, b: 516.4, a: 894.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet19,
+  maxDrawCount: 316559435,
+});
+let externalTexture27 = device0.importExternalTexture({source: videoFrame2, colorSpace: 'display-p3'});
+try {
+computePassEncoder79.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(2, bindGroup85);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let bindGroup124 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout10,
+  entries: [{binding: 53, resource: {buffer: buffer5, offset: 512}}],
+});
+let commandEncoder194 = device0.createCommandEncoder({});
+let textureView188 = texture165.createView({});
+let texture193 = device0.createTexture({
+  size: {width: 60},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let computePassEncoder161 = commandEncoder42.beginComputePass({});
+let renderBundleEncoder25 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], sampleCount: 1});
+try {
+computePassEncoder133.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder15.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(2, buffer98);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder192.resolveQuerySet(querySet19, 7, 57, buffer99, 256);
+} catch {}
+let bindGroup125 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 396, resource: {buffer: buffer107, offset: 256, size: 48}}],
+});
+let computePassEncoder162 = commandEncoder194.beginComputePass();
+let renderBundle25 = renderBundleEncoder25.finish({});
+let sampler139 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 88.67,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder82.setBindGroup(1, bindGroup55);
+} catch {}
+try {
+computePassEncoder74.setPipeline(pipeline5);
+} catch {}
+try {
+computePassEncoder159.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(4, buffer33);
+} catch {}
+try {
+commandEncoder192.copyBufferToBuffer(buffer113, 10296, buffer105, 500, 72);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+});
+} catch {}
+let imageBitmap7 = await createImageBitmap(videoFrame1);
+let videoFrame28 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'unspecified', transfer: 'bt2020_10bit'} });
+let buffer134 = device0.createBuffer({
+  size: 7456,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder195 = device0.createCommandEncoder({});
+let externalTexture28 = device0.importExternalTexture({source: videoFrame22, colorSpace: 'display-p3'});
+try {
+computePassEncoder44.setBindGroup(3, bindGroup24);
+} catch {}
+let buffer135 = device0.createBuffer({size: 20111, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+try {
+computePassEncoder160.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder56.setBindGroup(3, bindGroup19);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer101, 'uint32', 6_804, 353);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(7, buffer97, 436);
+} catch {}
+try {
+commandEncoder195.insertDebugMarker('\u2312');
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer50, 36, new BigUint64Array(4025), 1034, 12);
+} catch {}
+let promise22 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1702, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas2,
+  origin: { x: 11, y: 11 },
+  flipY: false,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 190, y: 34, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise22;
+} catch {}
+document.body.append(canvas0);
+let veryExplicitBindGroupLayout29 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 72,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 198,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer136 = device0.createBuffer({size: 8792, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture194 = device0.createTexture({
+  size: {width: 30, height: 10, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'depth32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder137.setBindGroup(1, bindGroup82);
+} catch {}
+try {
+computePassEncoder162.setPipeline(pipeline45);
+} catch {}
+try {
+renderPassEncoder15.pushDebugGroup('\u3af7');
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let autogeneratedBindGroupLayout81 = pipeline3.getBindGroupLayout(0);
+let commandEncoder196 = device0.createCommandEncoder();
+let texture195 = device0.createTexture({
+  size: [120, 40, 147],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture196 = device0.createTexture({
+  size: {width: 60, height: 20, depthOrArrayLayers: 16},
+  mipLevelCount: 2,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView189 = texture131.createView({});
+let sampler140 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 67.80,
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder161.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup108, new Uint32Array(2170), 362, 0);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer22, 'uint32', 5_388, 14_077);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(7, buffer69);
+} catch {}
+try {
+commandEncoder195.insertDebugMarker('\ubfcb');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame29 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'smpte432', transfer: 'bt2020_10bit'} });
+let bindGroup126 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout15,
+  entries: [{binding: 8, resource: {buffer: buffer129, offset: 0}}],
+});
+let commandEncoder197 = device0.createCommandEncoder({});
+let texture197 = device0.createTexture({
+  label: '\u{1fbb8}\u0681',
+  size: {width: 240},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView190 = texture99.createView({dimension: '2d-array'});
+let computePassEncoder163 = commandEncoder196.beginComputePass();
+let renderPassEncoder57 = commandEncoder197.beginRenderPass({
+  colorAttachments: [{
+  view: textureView15,
+  clearValue: { r: -765.4, g: -192.2, b: -590.1, a: -176.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let renderBundleEncoder26 = device0.createRenderBundleEncoder({colorFormats: ['rgba8sint'], depthStencilFormat: 'depth32float', stencilReadOnly: true});
+try {
+renderPassEncoder55.executeBundles([renderBundle6, renderBundle18]);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(6, buffer26, 2_812, 1_547);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(0, bindGroup10, []);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(buffer46, 'uint16', 166, 558);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline32);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext7 = offscreenCanvas5.getContext('webgpu');
+let bindGroup127 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout47,
+  entries: [{binding: 8, resource: {buffer: buffer82, offset: 768, size: 592}}],
+});
+let commandEncoder198 = device0.createCommandEncoder({});
+let renderPassEncoder58 = commandEncoder198.beginRenderPass({
+  colorAttachments: [{
+  view: textureView12,
+  depthSlice: 34,
+  clearValue: { r: -608.0, g: -795.4, b: -766.6, a: 639.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {view: textureView61, depthReadOnly: true, stencilReadOnly: false},
+});
+let externalTexture29 = device0.importExternalTexture({source: videoFrame25});
+try {
+computePassEncoder163.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder38.setViewport(21.022865637131584, 4.57122140807158, 0.5022060770878405, 1.1294527532597167, 0.836565883192145, 0.9204101010929906);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer87, 'uint16', 56, 22);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(2, bindGroup75);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(buffer64, 'uint32', 0, 630);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline34);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture197,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(19).fill(31), /* required buffer size: 19 */
+{offset: 19, rowsPerImage: 43}, {width: 50, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise23 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1702, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: img2,
+  origin: { x: 4, y: 3 },
+  flipY: true,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 192, y: 20, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup128 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout14,
+  entries: [{binding: 8, resource: {buffer: buffer119, offset: 3584}}],
+});
+let commandEncoder199 = device0.createCommandEncoder();
+let texture198 = device0.createTexture({
+  size: {width: 60, height: 20, depthOrArrayLayers: 73},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture199 = gpuCanvasContext3.getCurrentTexture();
+let computePassEncoder164 = commandEncoder199.beginComputePass();
+let renderPassEncoder59 = commandEncoder192.beginRenderPass({
+  colorAttachments: [{view: textureView120, loadOp: 'load', storeOp: 'discard'}],
+  maxDrawCount: 119672471,
+});
+let renderBundleEncoder27 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], stencilReadOnly: true});
+try {
+computePassEncoder160.setBindGroup(1, bindGroup49, new Uint32Array(1456), 475, 0);
+} catch {}
+try {
+computePassEncoder164.setPipeline(pipeline28);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(3, bindGroup35, new Uint32Array(3559), 557, 0);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(4, buffer121, 4, 2_506);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer112, 'uint16', 12, 167);
+} catch {}
+try {
+  await promise23;
+} catch {}
+let imageData34 = new ImageData(12, 48);
+let computePassEncoder165 = commandEncoder195.beginComputePass({});
+try {
+computePassEncoder134.setBindGroup(1, bindGroup86);
+} catch {}
+try {
+renderPassEncoder44.setVertexBuffer(2, buffer38, 56, 2_458);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(buffer109, 'uint16', 14, 12);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(0, buffer78, 0, 128);
+} catch {}
+try {
+adapter0.label = '\udfd3\u0d6a\u0252\u04cc\u89c0\u04c6\u00f7\u0e77';
+} catch {}
+let buffer137 = device0.createBuffer({
+  label: '\u937b\u9e6b\u{1fc5d}\u{1ffa4}',
+  size: 23589,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView191 = texture129.createView({dimension: 'cube-array', baseArrayLayer: 2, arrayLayerCount: 6});
+let texture200 = device0.createTexture({
+  label: '\u5112\u9e02\u3284\u0627\u{1feb9}\u0ae0\u0468\u0132\u5ae0',
+  size: {width: 240, height: 80, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView192 = texture168.createView({dimension: 'cube', baseArrayLayer: 0});
+try {
+computePassEncoder33.setBindGroup(3, bindGroup39, []);
+} catch {}
+try {
+computePassEncoder165.setPipeline(pipeline42);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(1, bindGroup121, new Uint32Array(2817), 98, 0);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(5, undefined, 0, 714_000_563);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(0, bindGroup89, new Uint32Array(2112), 3, 0);
+} catch {}
+let textureView193 = texture9.createView({dimension: '2d-array', aspect: 'depth-only', mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 13});
+try {
+renderPassEncoder16.setBlendConstant({ r: 628.2, g: -827.1, b: -848.7, a: 427.5, });
+} catch {}
+try {
+renderPassEncoder56.setIndexBuffer(buffer114, 'uint32', 0, 13);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(7, buffer120);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer109, 8, new BigUint64Array(4505), 540, 0);
+} catch {}
+let offscreenCanvas6 = new OffscreenCanvas(222, 74);
+let buffer138 = device0.createBuffer({size: 1131, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder200 = device0.createCommandEncoder({});
+let querySet26 = device0.createQuerySet({type: 'occlusion', count: 11});
+let computePassEncoder166 = commandEncoder200.beginComputePass({});
+let sampler141 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 77.17,
+  lodMaxClamp: 86.97,
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder166.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder45.setBindGroup(1, bindGroup74);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(7, buffer82);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(1, bindGroup46);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline43);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(108).fill(253), /* required buffer size: 108 */
+{offset: 108, bytesPerRow: 268}, {width: 57, height: 39, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder201 = device0.createCommandEncoder({});
+let computePassEncoder167 = commandEncoder201.beginComputePass({});
+try {
+computePassEncoder136.setBindGroup(3, bindGroup25);
+} catch {}
+try {
+renderPassEncoder50.setVertexBuffer(2, buffer97, 700, 85);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(4, buffer19, 0, 1_317);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer105, 408, new Float32Array(1006), 9, 56);
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+let bindGroup129 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout58,
+  entries: [{binding: 8, resource: {buffer: buffer125, offset: 0, size: 400}}],
+});
+let pipelineLayout13 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout21]});
+let texture201 = device0.createTexture({
+  size: {width: 60, height: 20, depthOrArrayLayers: 18},
+  mipLevelCount: 2,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder65.setBindGroup(3, bindGroup62, new Uint32Array(2419), 367, 0);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer101, 'uint16', 2_392, 908);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(3, bindGroup48, []);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(buffer62, 'uint32', 1_216, 1_569);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline13);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(4, buffer39, 0, 2_376);
+} catch {}
+let videoFrame30 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'unspecified', primaries: 'bt709', transfer: 'gamma28curve'} });
+let shaderModule5 = device0.createShaderModule({
+  code: `
+requires readonly_and_readwrite_storage_textures;
+
+enable f16;
+
+struct FragmentOutput5 {
+  @location(0) @interpolate(flat, sample) f0: vec4i,
+  @builtin(sample_mask) f1: u32,
+  @builtin(frag_depth) f2: f32,
+}
+
+@group(0) @binding(203) var<storage, read> buffer139: vec2f;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct T0 {
+  @size(8) f0: array<i32>,
+}
+
+var<workgroup> vw25: array<f32, 41>;
+
+struct VertexOutput3 {
+  @builtin(position) f7: vec4f,
+}
+
+fn fn0(a0: ptr<storage, array<vec2u, 1>, read>) -> array<mat3x3h, 1> {
+  var out: array<mat3x3h, 1>;
+  out[u32(unconst_u32(79))] = mat3x3h(f16((*a0)[u32(unconst_u32(222))][u32(unconst_u32(164))]), f16((*a0)[u32(unconst_u32(222))][u32(unconst_u32(164))]), f16((*a0)[u32(unconst_u32(222))][u32(unconst_u32(164))]), f16((*a0)[u32(unconst_u32(222))][u32(unconst_u32(164))]), f16((*a0)[u32(unconst_u32(222))][u32(unconst_u32(164))]), f16((*a0)[u32(unconst_u32(222))][u32(unconst_u32(164))]), f16((*a0)[u32(unconst_u32(222))][u32(unconst_u32(164))]), f16((*a0)[u32(unconst_u32(222))][u32(unconst_u32(164))]), f16((*a0)[u32(unconst_u32(222))][u32(unconst_u32(164))]));
+  out[0] = mat3x3h(f16(textureNumLayers(tex1)), f16(textureNumLayers(tex1)), f16(textureNumLayers(tex1)), f16(textureNumLayers(tex1)), f16(textureNumLayers(tex1)), f16(textureNumLayers(tex1)), f16(textureNumLayers(tex1)), f16(textureNumLayers(tex1)), f16(textureNumLayers(tex1)));
+  out[u32(unconst_u32(45))] = mat3x3h(vec3h(unpack4x8unorm(u32(unconst_u32(127))).xyy), vec3h(unpack4x8unorm(u32(unconst_u32(127))).yzx), vec3h(unpack4x8unorm(u32(unconst_u32(127))).wyx));
+  var vf32: u32 = textureNumLayers(tex1);
+  vf32 = pack4x8unorm(unpack4x8unorm(u32(unconst_u32(131))));
+  vf32 -= textureDimensions(tex1).x;
+  let vf33: i32 = dot4I8Packed(u32(unconst_u32(104)), u32(unconst_u32(55)));
+  var vf34: u32 = textureNumLevels(tex1);
+  vf34 = (*a0)[0].y;
+  let ptr105: ptr<storage, vec2u, read> = &(*a0)[0];
+  let vf35: vec4f = unpack4x8unorm(u32(unconst_u32(99)));
+  let vf36: vec2u = textureDimensions(tex1, i32(unconst_i32(64)));
+  let vf37: i32 = insertBits(i32(unconst_i32(88)), i32(unconst_i32(447)), u32(unconst_u32(4)), u32(unconst_u32(191)));
+  out[u32(unconst_u32(91))] = mat3x3h(f16(vf37), f16(vf37), f16(vf37), f16(vf37), f16(vf37), f16(vf37), f16(vf37), f16(vf37), f16(vf37));
+  let vf38: u32 = pack4xU8(vec4u(unconst_u32(192), unconst_u32(219), unconst_u32(80), unconst_u32(184)));
+  var vf39: i32 = vf33;
+  vf32 <<= (*a0)[0][0];
+  out[u32(unconst_u32(271))] = mat3x3h(f16(vf39), f16(vf39), f16(vf39), f16(vf39), f16(vf39), f16(vf39), f16(vf39), f16(vf39), f16(vf39));
+  vf39 = i32(unpack4x8unorm(u32(unconst_u32(338))).w);
+  let ptr106: ptr<function, i32> = &vf39;
+  let ptr107: ptr<storage, vec2u, read> = &(*a0)[0];
+  let vf40: vec4f = vf35;
+  let ptr108: ptr<storage, vec2u, read> = &(*a0)[0];
+  var vf41: vec2h = clamp(vec2h(unconst_f16(7845.5), unconst_f16(1965.8)), vec2h(unconst_f16(-18307.8), unconst_f16(3099.0)), vec2h(unconst_f16(9669.1), unconst_f16(3374.2)));
+  return out;
+  _ = tex1;
+}
+
+var<workgroup> vw26: array<mat4x4f, 3>;
+
+fn fn1(a0: array<array<S5, 10>, 1>, a1: ptr<workgroup, S4>) -> mat3x2f {
+  var out: mat3x2f;
+  let vf42: S5 = a0[u32(unconst_u32(232))][9];
+  let vf43: vec3h = fma(vec3h(unconst_f16(27334.1), unconst_f16(1915.1), unconst_f16(12473.4)), vec3h(unconst_f16(-2522.3), unconst_f16(6706.1), unconst_f16(2332.1)), vec3h(unconst_f16(8981.8), unconst_f16(-7441.5), unconst_f16(1632.5)));
+  return out;
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct S5 {
+  @builtin(workgroup_id) @size(16) f0: vec3u,
+}
+
+fn fn2() -> mat2x2f {
+  var out: mat2x2f;
+  out = mat2x2f(inverseSqrt(vec3f(unconst_f32(0.5419), unconst_f32(0.3214), unconst_f32(0.06507))).yz, inverseSqrt(vec3f(unconst_f32(0.5419), unconst_f32(0.3214), unconst_f32(0.06507))).zy);
+  out = mat2x2f(degrees(vec4f(unconst_f32(0.1591), unconst_f32(0.2931), unconst_f32(0.09321), unconst_f32(0.1529))).gg, degrees(vec4f(unconst_f32(0.1591), unconst_f32(0.2931), unconst_f32(0.09321), unconst_f32(0.1529))).yy);
+  out += mat2x2f(vec2f(round(vec3h(unconst_f16(17247.9), unconst_f16(4457.1), unconst_f16(13062.5))).bb), vec2f(round(vec3h(unconst_f16(17247.9), unconst_f16(4457.1), unconst_f16(13062.5))).zy));
+  var vf44: vec3f = floor(vec3f(unconst_f32(0.00587), unconst_f32(0.00536), unconst_f32(0.04498)));
+  out = mat2x2f(unpack4x8snorm(u32(unconst_u32(297))).ag, unpack4x8snorm(u32(unconst_u32(297))).xw);
+  var vf45: vec3h = round(vec3h(unconst_f16(1097.0), unconst_f16(1448.4), unconst_f16(3088.8)));
+  var vf46: u32 = textureNumLevels(tex1);
+  vf44 = vec3f(f32(length(f16(unconst_f16(6755.7)))));
+  vf44 = vec3f(bitcast<f32>(vf46));
+  let vf47: vec4i = reverseBits(vec4i(unconst_i32(76), unconst_i32(75), unconst_i32(-88), unconst_i32(155)));
+  return out;
+  _ = tex1;
+}
+
+var<workgroup> vw24: atomic<i32>;
+
+struct S4 {
+  @location(11) @interpolate(perspective) f0: f32,
+  @location(14) f1: vec2f,
+  @location(7) f2: vec2h,
+  @location(2) f3: vec4h,
+}
+
+@group(1) @binding(216) var tex1: texture_cube_array<f32>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@vertex
+fn vertex4(@location(0) @interpolate(flat, centroid) a0: vec4f, a1: S4, @location(13) @interpolate(linear, centroid) a2: f16) -> VertexOutput3 {
+  var out: VertexOutput3;
+  var vf48 = fn2();
+  out.f7 += vec4f(f32(pow(f16(unconst_f16(3203.6)), f16(unconst_f16(34018.9)))));
+  var vf49 = fn2();
+  vf49 += mat2x2f(f32(a1.f2[u32(unconst_u32(26))]), f32(a1.f2[u32(unconst_u32(26))]), f32(a1.f2[u32(unconst_u32(26))]), f32(a1.f2[u32(unconst_u32(26))]));
+  vf48 = mat2x2f(vec2f(a1.f2), vec2f(a1.f2));
+  let vf50: u32 = pack2x16unorm(vec2f(unconst_f32(0.06854), unconst_f32(-0.2016)));
+  vf49 = mat2x2f(vec2f(a1.f2), vec2f(a1.f2));
+  var vf51: f16 = pow(f16(unconst_f16(4209.0)), f16(unconst_f16(2047.8)));
+  var vf52: u32 = textureNumLevels(tex1);
+  let vf53: vec4f = tanh(vec4f(unconst_f32(-0.09074), unconst_f32(-0.1225), unconst_f32(0.01103), unconst_f32(0.2854)));
+  let vf54: vec2u = textureDimensions(tex1, i32(unconst_i32(170)));
+  fn2();
+  var vf55 = fn2();
+  out.f7 = vec4f(vf53[u32(unconst_u32(251))]);
+  vf49 = mat2x2f(a0.rr, a0.aa);
+  return out;
+  _ = tex1;
+}
+
+@fragment
+fn fragment5() -> FragmentOutput5 {
+  var out: FragmentOutput5;
+  var vf56: vec4h = acosh(vec4h(unconst_f16(7456.9), unconst_f16(16119.3), unconst_f16(343.5), unconst_f16(1137.0)));
+  var vf57: vec3f = ceil(vec3f(unconst_f32(0.02999), unconst_f32(0.1359), unconst_f32(0.1997)));
+  vf56 = vec4h(clamp(vec3f(unconst_f32(-0.1938), unconst_f32(0.05100), unconst_f32(0.3201)), vec3f(unconst_f32(0.3146), unconst_f32(0.03836), unconst_f32(0.3839)), vec3f(unconst_f32(0.5429), unconst_f32(-0.06343), unconst_f32(0.08911))).ggrb);
+  var vf58: vec3f = exp2(vec3f(unconst_f32(-0.03142), unconst_f32(-0.4067), unconst_f32(0.3754)));
+  out.f0 &= countOneBits(vec4i(unconst_i32(304), unconst_i32(22), unconst_i32(219), unconst_i32(124)));
+  out.f2 = unpack2x16unorm(u32(unconst_u32(80))).r;
+  var vf59: vec2f = unpack2x16unorm(bitcast<vec3u>(insertBits(vec3i(unconst_i32(229), unconst_i32(383), unconst_i32(-19)), vec3i(unconst_i32(41), unconst_i32(-142), unconst_i32(245)), u32(unconst_u32(99)), u32(unconst_u32(138))))[0]);
+  out.f0 -= vec4i(i32(vf56[u32(unconst_u32(234))]));
+  let ptr109: ptr<function, vec3f> = &vf58;
+  return out;
+}
+
+@compute @workgroup_size(2, 1, 2)
+fn compute6(@builtin(num_workgroups) a0: vec3u, a1: S5) {
+  var vf60: f32 = ldexp(f32(unconst_f32(0.5491)), i32(unconst_i32(94)));
+  vw26[2] += mat4x4f(unpack2x16unorm(u32(unconst_u32(187))).yyxx, unpack2x16unorm(u32(unconst_u32(187))).rggr, unpack2x16unorm(u32(unconst_u32(187))).rrgr, unpack2x16unorm(u32(unconst_u32(187))).xyxx);
+  vw26[u32(unconst_u32(6))] = mat4x4f(vec4f(a1.f0.rrbr), bitcast<vec4f>(a1.f0.bbbb), bitcast<vec4f>(a1.f0.xxzy), bitcast<vec4f>(a1.f0.xzzy));
+  atomicAnd(&vw24, i32(unconst_i32(584)));
+  let vf61: vec3f = cos(vec3f(unconst_f32(0.3356), unconst_f32(0.02115), unconst_f32(0.09524)));
+  let ptr110: ptr<storage, vec2f, read> = &buffer139;
+  _ = buffer139;
+}`,
+});
+let bindGroup130 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout20,
+  entries: [{binding: 8, resource: {buffer: buffer82, offset: 0, size: 344}}],
+});
+let textureView194 = texture194.createView({dimension: '2d-array', aspect: 'depth-only'});
+let renderBundle26 = renderBundleEncoder26.finish({});
+try {
+renderPassEncoder45.setBindGroup(0, bindGroup39, []);
+} catch {}
+try {
+renderPassEncoder15.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(1, buffer15, 23_616, 507);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+globalThis.someLabel = externalTexture1.label;
+} catch {}
+let texture202 = device0.createTexture({
+  size: [30, 10, 36],
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler142 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', maxAnisotropy: 1});
+try {
+computePassEncoder153.setBindGroup(0, bindGroup43);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+renderPassEncoder53.setIndexBuffer(buffer46, 'uint32', 1_160, 1_014);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(0, bindGroup112);
+} catch {}
+let pipelineLayout14 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout9, veryExplicitBindGroupLayout16]});
+let textureView195 = texture76.createView({dimension: '2d', aspect: 'depth-only', baseArrayLayer: 2});
+try {
+computePassEncoder167.setPipeline(pipeline46);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup104);
+} catch {}
+try {
+renderPassEncoder42.setIndexBuffer(buffer98, 'uint16', 1_400, 52);
+} catch {}
+try {
+renderPassEncoder53.setVertexBuffer(3, buffer119, 0);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(1, bindGroup89);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let commandEncoder202 = device0.createCommandEncoder({});
+let texture203 = device0.createTexture({
+  size: [60, 20, 23],
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView196 = texture20.createView({});
+let computePassEncoder168 = commandEncoder202.beginComputePass({});
+let renderBundle27 = renderBundleEncoder27.finish({});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 323, y: 8 },
+  flipY: true,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 14, y: 90, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 29, height: 7, depthOrArrayLayers: 0});
+} catch {}
+let pipeline47 = device0.createRenderPipeline({
+  layout: pipelineLayout10,
+  fragment: {module: shaderModule0, constants: {}, targets: [{format: 'rgba8sint'}]},
+  depthStencil: {
+    format: 'depth32float',
+    depthWriteEnabled: true,
+    depthCompare: 'always',
+    stencilFront: {failOp: 'keep'},
+    depthBias: -371920211,
+    depthBiasClamp: 364.17352260456823,
+  },
+  vertex: {
+    module: shaderModule4,
+    buffers: [
+      {
+        arrayStride: 340,
+        attributes: [
+          {format: 'sint32', offset: 108, shaderLocation: 8},
+          {format: 'unorm8x4', offset: 32, shaderLocation: 5},
+          {format: 'float16x4', offset: 4, shaderLocation: 13},
+          {format: 'snorm16x2', offset: 36, shaderLocation: 14},
+          {format: 'uint8x2', offset: 2, shaderLocation: 4},
+          {format: 'uint8x4', offset: 0, shaderLocation: 10},
+          {format: 'unorm8x4', offset: 44, shaderLocation: 7},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'front'},
+});
+let gpuCanvasContext8 = offscreenCanvas6.getContext('webgpu');
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let textureView197 = texture20.createView({});
+let textureView198 = texture80.createView({aspect: 'all'});
+try {
+computePassEncoder168.setPipeline(pipeline40);
+} catch {}
+let texture204 = device0.createTexture({
+  size: [30],
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder121.setBindGroup(0, bindGroup108, new Uint32Array(6528), 2_685, 0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup89, new Uint32Array(392), 71, 0);
+} catch {}
+try {
+renderPassEncoder24.beginOcclusionQuery(185);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder37.setScissorRect(12, 4, 16, 10);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer130, 'uint32', 180, 629);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(0, undefined, 143_031_294, 476_982_073);
+} catch {}
+let autogeneratedBindGroupLayout82 = pipeline34.getBindGroupLayout(0);
+let commandEncoder203 = device0.createCommandEncoder();
+let texture205 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 9},
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg32sint'],
+});
+let computePassEncoder169 = commandEncoder203.beginComputePass({});
+try {
+computePassEncoder169.setPipeline(pipeline46);
+} catch {}
+try {
+renderPassEncoder40.setPipeline(pipeline22);
+} catch {}
+let pipeline48 = device0.createComputePipeline({layout: pipelineLayout10, compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}}});
+document.body.append(canvas0);
+let sampler143 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'clamp-to-edge', addressModeW: 'repeat', lodMaxClamp: 62.95});
+try {
+computePassEncoder32.setBindGroup(1, bindGroup88);
+} catch {}
+try {
+computePassEncoder136.setBindGroup(0, bindGroup92, new Uint32Array(1448), 113, 0);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(1, bindGroup33, new Uint32Array(924), 315, 0);
+} catch {}
+try {
+renderPassEncoder36.setScissorRect(27, 6, 0, 15);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let buffer140 = device0.createBuffer({
+  size: 3547,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let commandEncoder204 = device0.createCommandEncoder();
+let computePassEncoder170 = commandEncoder204.beginComputePass({});
+try {
+computePassEncoder76.setBindGroup(2, bindGroup129, new Uint32Array(1955), 485, 0);
+} catch {}
+try {
+computePassEncoder170.setPipeline(pipeline38);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(4, buffer90, 204);
+} catch {}
+try {
+renderPassEncoder15.popDebugGroup();
+} catch {}
+let commandEncoder205 = device0.createCommandEncoder({});
+let texture206 = device0.createTexture({
+  size: [120, 40, 147],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder171 = commandEncoder205.beginComputePass({});
+try {
+computePassEncoder9.setBindGroup(2, bindGroup98);
+} catch {}
+try {
+computePassEncoder171.setPipeline(pipeline46);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup12, new Uint32Array(2451), 1_052, 0);
+} catch {}
+try {
+renderPassEncoder50.setIndexBuffer(buffer87, 'uint32', 252, 567);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let autogeneratedBindGroupLayout83 = pipeline13.getBindGroupLayout(0);
+let texture207 = device0.createTexture({
+  size: [60, 20, 1],
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView199 = texture21.createView({dimension: '2d', aspect: 'all', baseArrayLayer: 20});
+try {
+computePassEncoder70.setBindGroup(3, bindGroup30, new Uint32Array(1201), 212, 0);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(0, bindGroup88, new Uint32Array(64), 29, 0);
+} catch {}
+try {
+renderPassEncoder57.setIndexBuffer(buffer88, 'uint16', 1_238, 2_057);
+} catch {}
+try {
+renderPassEncoder55.setPipeline(pipeline13);
+} catch {}
+let autogeneratedBindGroupLayout84 = pipeline1.getBindGroupLayout(0);
+try {
+computePassEncoder62.setBindGroup(2, bindGroup129, []);
+} catch {}
+try {
+renderPassEncoder55.setBindGroup(1, bindGroup86);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer125, 'uint32', 20, 2_295);
+} catch {}
+try {
+buffer126.unmap();
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData12,
+  origin: { x: 26, y: 18 },
+  flipY: false,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 30, y: 13, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 12, depthOrArrayLayers: 0});
+} catch {}
+let buffer141 = device0.createBuffer({size: 12940, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture208 = device0.createTexture({
+  size: {width: 60, height: 20, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler144 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 79.81,
+});
+try {
+computePassEncoder159.setBindGroup(0, bindGroup61);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(3, bindGroup49);
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer85, 'uint32', 340, 1_040);
+} catch {}
+try {
+renderPassEncoder29.insertDebugMarker('\u81c2');
+} catch {}
+let imageData35 = new ImageData(8, 220);
+let pipelineLayout15 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout29]});
+let texture209 = device0.createTexture({
+  size: {width: 30, height: 10, depthOrArrayLayers: 36},
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder78.setBindGroup(0, bindGroup98);
+} catch {}
+try {
+computePassEncoder26.setBindGroup(2, bindGroup76, new Uint32Array(2604), 34, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder153); computePassEncoder153.dispatchWorkgroups(2, 1); };
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(1, bindGroup43);
+} catch {}
+try {
+renderPassEncoder24.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder53.executeBundles([renderBundle11, renderBundle8, renderBundle20, renderBundle3, renderBundle8, renderBundle26, renderBundle11, renderBundle7, renderBundle0, renderBundle8]);
+} catch {}
+try {
+computePassEncoder78.pushDebugGroup('\u{1fc6f}');
+} catch {}
+let pipeline49 = device0.createComputePipeline({layout: pipelineLayout10, compute: {module: shaderModule3}});
+let bindGroup131 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout74,
+  entries: [{binding: 8, resource: {buffer: buffer84, offset: 0, size: 900}}],
+});
+try {
+computePassEncoder76.setBindGroup(0, bindGroup11, new Uint32Array(859), 230, 0);
+} catch {}
+try {
+renderPassEncoder49.setScissorRect(41, 23, 22, 0);
+} catch {}
+try {
+renderPassEncoder42.setVertexBuffer(0, buffer119, 0, 156);
+} catch {}
+try {
+computePassEncoder32.pushDebugGroup('\uf97e');
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let imageData36 = new ImageData(12, 8);
+let buffer142 = device0.createBuffer({size: 19318, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM});
+try {
+computePassEncoder166.setBindGroup(1, bindGroup123, new Uint32Array(750), 4, 0);
+} catch {}
+document.body.prepend(canvas0);
+let autogeneratedBindGroupLayout85 = pipeline13.getBindGroupLayout(0);
+let commandEncoder206 = device0.createCommandEncoder();
+try {
+renderPassEncoder49.setBindGroup(2, bindGroup25, new Uint32Array(4612), 971, 0);
+} catch {}
+try {
+renderPassEncoder49.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(0, buffer102, 1_272, 3_560);
+} catch {}
+try {
+buffer48.unmap();
+} catch {}
+try {
+commandEncoder206.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5280 */
+  offset: 5280,
+  buffer: buffer110,
+}, {
+  texture: texture183,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline50 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  multisample: {mask: 0xd6915e5},
+  fragment: {module: shaderModule0, targets: [{format: 'rgba8sint', writeMask: GPUColorWrite.RED}]},
+  depthStencil: {
+    format: 'depth32float',
+    depthWriteEnabled: true,
+    depthCompare: 'less-equal',
+    stencilReadMask: 506772065,
+    stencilWriteMask: 504831740,
+    depthBiasSlopeScale: 669.9603252141269,
+  },
+  vertex: {
+    module: shaderModule2,
+    constants: {29_819: 0},
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'vertex',
+        attributes: [{format: 'snorm8x2', offset: 62, shaderLocation: 14}],
+      },
+      {
+        arrayStride: 224,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32', offset: 64, shaderLocation: 4},
+          {format: 'float16x4', offset: 168, shaderLocation: 5},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', frontFace: 'cw', cullMode: 'back'},
+});
+let buffer143 = device0.createBuffer({size: 20857, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let commandEncoder207 = device0.createCommandEncoder({});
+let textureView200 = texture137.createView({dimension: '2d-array'});
+let externalTexture30 = device0.importExternalTexture({source: videoFrame22});
+try {
+computePassEncoder97.setBindGroup(2, bindGroup92);
+} catch {}
+try {
+computePassEncoder128.setBindGroup(1, bindGroup123, new Uint32Array(2062), 963, 0);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let pipeline51 = device0.createRenderPipeline({
+  layout: pipelineLayout10,
+  fragment: {
+  module: shaderModule1,
+  targets: [{format: 'rgba8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth32float',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {},
+    stencilReadMask: 103727255,
+    stencilWriteMask: 3298489874,
+    depthBiasClamp: 974.2160391405555,
+  },
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16'},
+});
+let autogeneratedBindGroupLayout86 = pipeline0.getBindGroupLayout(0);
+let texture210 = device0.createTexture({
+  size: {width: 30, height: 10, depthOrArrayLayers: 36},
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let computePassEncoder172 = commandEncoder207.beginComputePass();
+try {
+computePassEncoder92.setBindGroup(2, bindGroup105, new Uint32Array(664), 81, 0);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline27);
+} catch {}
+try {
+renderPassEncoder58.setVertexBuffer(6, buffer78);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1702, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame20,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 268, y: 24, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline52 = device0.createComputePipeline({layout: pipelineLayout10, compute: {module: shaderModule1, entryPoint: 'compute1'}});
+let buffer144 = device0.createBuffer({size: 12581, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM});
+let commandEncoder208 = device0.createCommandEncoder({});
+let textureView201 = texture89.createView({dimension: '2d'});
+let computePassEncoder173 = commandEncoder206.beginComputePass();
+try {
+computePassEncoder114.setBindGroup(3, bindGroup58, []);
+} catch {}
+try {
+computePassEncoder61.setBindGroup(3, bindGroup126, new Uint32Array(4389), 559, 0);
+} catch {}
+try {
+computePassEncoder134.setPipeline(pipeline52);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(0, bindGroup116);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(2, buffer112, 176);
+} catch {}
+try {
+commandEncoder208.copyTextureToTexture({
+  texture: texture205,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture186,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 3},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder208.resolveQuerySet(querySet16, 75, 55, buffer118, 4096);
+} catch {}
+let promise24 = device0.queue.onSubmittedWorkDone();
+let texture211 = device0.createTexture({
+  label: '\u6990\u0507\u09d9\u02ca\u{1ff91}\u{1fed4}',
+  size: [240, 80, 17],
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderPassEncoder60 = commandEncoder208.beginRenderPass({
+  colorAttachments: [{
+  view: textureView15,
+  clearValue: { r: -302.9, g: 458.9, b: 176.5, a: -428.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder140.setBindGroup(0, bindGroup120);
+} catch {}
+try {
+computePassEncoder143.setBindGroup(3, bindGroup126, new Uint32Array(2629), 124, 0);
+} catch {}
+try {
+computePassEncoder173.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(0, bindGroup55, new Uint32Array(1084), 34, 0);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline4);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let buffer145 = device0.createBuffer({
+  size: 5312,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture212 = device0.createTexture({
+  size: [240, 80, 294],
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView202 = texture99.createView({baseArrayLayer: 0});
+try {
+computePassEncoder121.setBindGroup(1, bindGroup105, new Uint32Array(2267), 734, 0);
+} catch {}
+try {
+renderPassEncoder58.setVertexBuffer(3, buffer123);
+} catch {}
+let commandEncoder209 = device0.createCommandEncoder({});
+let computePassEncoder174 = commandEncoder209.beginComputePass();
+let sampler145 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 79.14,
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder119.setBindGroup(1, bindGroup116);
+} catch {}
+try {
+computePassEncoder153.end();
+} catch {}
+try {
+computePassEncoder174.setPipeline(pipeline41);
+} catch {}
+try {
+renderPassEncoder24.beginOcclusionQuery(313);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(7, buffer9, 2_136, 273);
+} catch {}
+try {
+buffer127.unmap();
+} catch {}
+let textureView203 = texture45.createView({});
+try {
+renderPassEncoder46.setBindGroup(0, bindGroup43, new Uint32Array(3078), 500, 0);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline23);
+} catch {}
+try {
+commandEncoder182.copyBufferToBuffer(buffer59, 1292, buffer82, 484, 160);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+document.body.append(canvas0);
+await gc();
+let imageBitmap8 = await createImageBitmap(imageData4);
+let videoFrame31 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'smpte240m', transfer: 'iec61966-2-1'} });
+let autogeneratedBindGroupLayout87 = pipeline11.getBindGroupLayout(0);
+let texture213 = device0.createTexture({size: [120, 40, 1], sampleCount: 1, format: 'rgba8sint', usage: GPUTextureUsage.STORAGE_BINDING});
+let textureView204 = texture23.createView({baseArrayLayer: 63, arrayLayerCount: 2});
+let computePassEncoder175 = commandEncoder182.beginComputePass();
+try {
+renderPassEncoder58.setVertexBuffer(0, buffer78, 116, 704);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer61, 804, new Float32Array(7589), 196, 116);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1702, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas6,
+  origin: { x: 31, y: 40 },
+  flipY: true,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 203, y: 18, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder210 = device0.createCommandEncoder({});
+let computePassEncoder176 = commandEncoder210.beginComputePass({});
+try {
+computePassEncoder72.setBindGroup(1, bindGroup83);
+} catch {}
+try {
+computePassEncoder144.setBindGroup(2, bindGroup17, new Uint32Array(20), 1, 0);
+} catch {}
+try {
+computePassEncoder176.setPipeline(pipeline37);
+} catch {}
+try {
+renderPassEncoder24.endOcclusionQuery();
+} catch {}
+try {
+texture172.destroy();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise24;
+} catch {}
+let bindGroup132 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout67,
+  entries: [{binding: 8, resource: {buffer: buffer97, offset: 256, size: 1348}}],
+});
+let texture214 = device0.createTexture({
+  size: {width: 120, height: 40, depthOrArrayLayers: 39},
+  dimension: '2d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder32.setIndexBuffer(buffer40, 'uint16', 1_476, 10_086);
+} catch {}
+offscreenCanvas6.height = 201;
+let bindGroup133 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout28,
+  entries: [{binding: 8, resource: {buffer: buffer53, offset: 1792, size: 60}}],
+});
+let commandEncoder211 = device0.createCommandEncoder({});
+let renderPassEncoder61 = commandEncoder211.beginRenderPass({
+  colorAttachments: [{
+  view: textureView71,
+  clearValue: { r: -231.2, g: 529.6, b: -968.9, a: 369.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 132773444,
+});
+try {
+computePassEncoder175.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder52.setViewport(48.653964723235184, 18.198302961824062, 58.11609631027509, 8.568049671428042, 0.41042642948179375, 0.5085771216177767);
+} catch {}
+try {
+renderPassEncoder37.setIndexBuffer(buffer36, 'uint32', 2_628, 344);
+} catch {}
+offscreenCanvas5.height = 111;
+let imageData37 = new ImageData(88, 24);
+let texture215 = device0.createTexture({
+  size: [240, 80, 294],
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let sampler146 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'repeat', mipmapFilter: 'linear', lodMaxClamp: 38.73});
+try {
+computePassEncoder172.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(6, buffer92, 248, 14);
+} catch {}
+try {
+  await buffer143.mapAsync(GPUMapMode.WRITE, 20856, 0);
+} catch {}
+try {
+renderPassEncoder28.insertDebugMarker('\u8a14');
+} catch {}
+let autogeneratedBindGroupLayout88 = pipeline18.getBindGroupLayout(0);
+try {
+renderPassEncoder25.setBindGroup(2, bindGroup132, new Uint32Array(2511), 529, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture140,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(10_037).fill(245), /* required buffer size: 10_037 */
+{offset: 105, bytesPerRow: 62, rowsPerImage: 31}, {width: 3, height: 6, depthOrArrayLayers: 6});
+} catch {}
+let commandEncoder212 = device0.createCommandEncoder({});
+let texture216 = device0.createTexture({
+  size: [60, 20, 17],
+  mipLevelCount: 2,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder177 = commandEncoder212.beginComputePass({});
+try {
+computePassEncoder177.setPipeline(pipeline40);
+} catch {}
+try {
+renderPassEncoder56.setBindGroup(1, bindGroup50);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer112, 'uint16', 310, 146);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer36, 748, new DataView(new ArrayBuffer(11104)), 1731, 492);
+} catch {}
+let bindGroup134 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout39,
+  entries: [{binding: 8, resource: {buffer: buffer77, offset: 12288}}, {binding: 216, resource: textureView24}],
+});
+let sampler147 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 78.15,
+  maxAnisotropy: 17,
+});
+try {
+buffer56.unmap();
+} catch {}
+let textureView205 = texture73.createView({dimension: '2d-array'});
+try {
+renderPassEncoder9.setIndexBuffer(buffer28, 'uint16', 900, 1_777);
+} catch {}
+try {
+renderPassEncoder44.setVertexBuffer(5, undefined, 70_301_043);
+} catch {}
+try {
+buffer138.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData12,
+  origin: { x: 14, y: 20 },
+  flipY: false,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 61, y: 10, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 119, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture217 = device0.createTexture({
+  size: [120, 40, 111],
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView206 = texture176.createView({format: 'r32uint'});
+let renderBundleEncoder28 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], depthReadOnly: true});
+let sampler148 = device0.createSampler({addressModeV: 'mirror-repeat', magFilter: 'linear', lodMaxClamp: 68.10});
+try {
+computePassEncoder149.setBindGroup(3, bindGroup34);
+} catch {}
+try {
+computePassEncoder167.setBindGroup(0, bindGroup41, new Uint32Array(611), 78, 0);
+} catch {}
+try {
+renderPassEncoder34.executeBundles([renderBundle0]);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let bindGroup135 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout2,
+  entries: [{binding: 396, resource: {buffer: buffer32, offset: 5376}}],
+});
+let commandEncoder213 = device0.createCommandEncoder({});
+let computePassEncoder178 = commandEncoder213.beginComputePass({});
+let sampler149 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 91.60});
+try {
+computePassEncoder178.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder9.beginOcclusionQuery(90);
+} catch {}
+try {
+renderPassEncoder59.executeBundles([renderBundle15]);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline32);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(3, buffer70, 0, 2_422);
+} catch {}
+try {
+gpuCanvasContext5.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+} catch {}
+let recycledExplicitBindGroupLayout12 = pipeline15.getBindGroupLayout(1);
+let buffer146 = device0.createBuffer({size: 6148, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+let textureView207 = texture151.createView({});
+let sampler150 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 76.50,
+  maxAnisotropy: 4,
+});
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup38);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup107, new Uint32Array(805), 136, 0);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(6, buffer11, 0, 1_420);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 8},
+  aspect: 'all',
+}, new Uint8Array(965).fill(40), /* required buffer size: 965 */
+{offset: 23, bytesPerRow: 27, rowsPerImage: 17}, {width: 6, height: 1, depthOrArrayLayers: 3});
+} catch {}
+let commandEncoder214 = device0.createCommandEncoder({});
+let textureView208 = texture16.createView({aspect: 'depth-only', baseArrayLayer: 0});
+let sampler151 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 75.63,
+  compare: 'greater',
+});
+try {
+computePassEncoder160.setBindGroup(1, bindGroup86, new Uint32Array(1676), 19, 0);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(2, bindGroup122);
+} catch {}
+let buffer147 = device0.createBuffer({
+  size: 3714,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder215 = device0.createCommandEncoder({});
+let computePassEncoder179 = commandEncoder214.beginComputePass({});
+try {
+computePassEncoder160.setBindGroup(0, bindGroup88);
+} catch {}
+try {
+computePassEncoder112.setBindGroup(3, bindGroup93, new Uint32Array(145), 6, 0);
+} catch {}
+try {
+computePassEncoder179.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer88, 'uint16', 8_310, 139);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline24);
+} catch {}
+try {
+renderPassEncoder59.setVertexBuffer(2, buffer147);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+renderBundleEncoder28.setIndexBuffer(buffer46, 'uint16', 42, 719);
+} catch {}
+try {
+commandEncoder215.copyBufferToBuffer(buffer132, 2640, buffer105, 2684, 368);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer116, 116, new Int16Array(3752), 30, 264);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1702, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData17,
+  origin: { x: 2, y: 0 },
+  flipY: true,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 169, y: 7, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let sampler152 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  lodMaxClamp: 95.78,
+});
+try {
+computePassEncoder117.setBindGroup(2, bindGroup5, new Uint32Array(326), 3, 0);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(7, buffer50);
+} catch {}
+try {
+commandEncoder215.resolveQuerySet(querySet17, 19, 4, buffer82, 0);
+} catch {}
+let commandEncoder216 = device0.createCommandEncoder({});
+let renderBundle28 = renderBundleEncoder28.finish({});
+let sampler153 = device0.createSampler({});
+try {
+computePassEncoder91.setBindGroup(1, bindGroup28);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(2, bindGroup83, new Uint32Array(731), 34, 0);
+} catch {}
+try {
+renderPassEncoder59.setBlendConstant({ r: -456.5, g: -259.7, b: 404.8, a: -475.7, });
+} catch {}
+try {
+renderPassEncoder60.setVertexBuffer(1, buffer4, 92);
+} catch {}
+let canvas3 = document.createElement('canvas');
+let commandEncoder217 = device0.createCommandEncoder();
+let texture218 = device0.createTexture({size: {width: 2}, dimension: '1d', format: 'rgba8sint', usage: GPUTextureUsage.COPY_DST});
+let computePassEncoder180 = commandEncoder215.beginComputePass({});
+try {
+computePassEncoder173.setBindGroup(1, bindGroup52);
+} catch {}
+try {
+computePassEncoder62.setBindGroup(2, bindGroup6, new Uint32Array(759), 199, 0);
+} catch {}
+try {
+renderPassEncoder27.setViewport(27.361270955595643, 30.352101416743686, 191.85388495959475, 32.35837836912588, 0.9293116841448896, 0.9888556332623629);
+} catch {}
+try {
+computePassEncoder58.setBindGroup(0, bindGroup71);
+} catch {}
+try {
+computePassEncoder164.setBindGroup(3, bindGroup9, new Uint32Array(361), 66, 0);
+} catch {}
+try {
+computePassEncoder180.setPipeline(pipeline31);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(3, bindGroup83);
+} catch {}
+try {
+renderPassEncoder47.setIndexBuffer(buffer125, 'uint32', 832, 337);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(5, buffer98, 0, 95);
+} catch {}
+let imageData38 = new ImageData(68, 8);
+let buffer148 = device0.createBuffer({size: 12340, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let querySet27 = device0.createQuerySet({type: 'occlusion', count: 85});
+let texture219 = device0.createTexture({
+  size: [120, 40, 1],
+  dimension: '2d',
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder94.setBindGroup(3, bindGroup23);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder217.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 252 */
+  offset: 252,
+  bytesPerRow: 256,
+  buffer: buffer58,
+}, {
+  texture: texture100,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1702, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame25,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 53, y: 64, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let autogeneratedBindGroupLayout89 = pipeline31.getBindGroupLayout(0);
+let commandEncoder218 = device0.createCommandEncoder({});
+let texture220 = device0.createTexture({
+  size: [240, 80, 294],
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderPassEncoder55.setBlendConstant({ r: -862.2, g: -144.4, b: 560.6, a: -191.2, });
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline23);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas2,
+  origin: { x: 176, y: 0 },
+  flipY: false,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 53, y: 32, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 111, height: 21, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext9 = canvas3.getContext('webgpu');
+let videoFrame32 = new VideoFrame(offscreenCanvas4, {timestamp: 0});
+let commandEncoder219 = device0.createCommandEncoder({});
+let texture221 = device0.createTexture({
+  size: {width: 120, height: 40, depthOrArrayLayers: 1},
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView209 = texture141.createView({dimension: '2d-array', baseMipLevel: 0});
+let computePassEncoder181 = commandEncoder219.beginComputePass({label: '\u984c\u5981\u030c\u0107\ufdfc\u41bc\u{1f9ff}\u1743\u0043\u0bcb'});
+let sampler154 = device0.createSampler({
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 65.05,
+  lodMaxClamp: 74.60,
+  compare: 'never',
+  maxAnisotropy: 3,
+});
+try {
+renderPassEncoder12.executeBundles([renderBundle1]);
+} catch {}
+try {
+commandEncoder218.copyBufferToTexture({
+  /* bytesInLastRow: 24 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1032 */
+  offset: 1032,
+  rowsPerImage: 17,
+  buffer: buffer58,
+}, {
+  texture: texture104,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder78.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(66).fill(103), /* required buffer size: 66 */
+{offset: 66}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder220 = device0.createCommandEncoder({});
+let texture222 = gpuCanvasContext4.getCurrentTexture();
+let computePassEncoder182 = commandEncoder217.beginComputePass({});
+try {
+computePassEncoder182.setPipeline(pipeline45);
+} catch {}
+try {
+renderPassEncoder48.setViewport(3.378161586462225, 5.535889073989733, 164.22955506998298, 38.12528119737974, 0.8989135278707341, 0.9675756884815044);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder221 = device0.createCommandEncoder({});
+let texture223 = device0.createTexture({size: [240], dimension: '1d', format: 'rg16sint', usage: GPUTextureUsage.COPY_SRC});
+let computePassEncoder183 = commandEncoder218.beginComputePass();
+try {
+renderPassEncoder12.setBindGroup(1, bindGroup87, new Uint32Array(629), 67, 0);
+} catch {}
+try {
+renderPassEncoder22.setScissorRect(0, 0, 16, 4);
+} catch {}
+try {
+renderPassEncoder32.setStencilReference(254);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer21, 'uint16', 4_578, 880);
+} catch {}
+try {
+buffer33.unmap();
+} catch {}
+document.body.prepend(img2);
+let videoFrame33 = new VideoFrame(videoFrame23, {timestamp: 0});
+try {
+computePassEncoder85.setBindGroup(0, bindGroup123);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder85); computePassEncoder85.dispatchWorkgroups(3); };
+} catch {}
+try {
+renderPassEncoder46.end();
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer145, 'uint32', 1_444, 63);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData22,
+  origin: { x: 8, y: 1 },
+  flipY: false,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 3, y: 51, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 24, height: 3, depthOrArrayLayers: 0});
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let buffer149 = device0.createBuffer({size: 15617, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let textureView210 = texture206.createView({mipLevelCount: 1});
+let computePassEncoder184 = commandEncoder161.beginComputePass({label: '\u4981\u{1ff4b}\u5966\u4d9c'});
+let renderPassEncoder62 = commandEncoder220.beginRenderPass({
+  label: '\u9e9f\u{1fde5}\u3bb0',
+  colorAttachments: [{
+  view: textureView120,
+  clearValue: { r: 463.2, g: 68.87, b: -108.2, a: -787.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 99815464,
+});
+try {
+computePassEncoder79.setBindGroup(2, bindGroup95, new Uint32Array(122), 38, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder85); computePassEncoder85.dispatchWorkgroups(2); };
+} catch {}
+try {
+computePassEncoder184.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder47.setBindGroup(2, bindGroup55);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer44, 'uint32', 308, 207);
+} catch {}
+try {
+computePassEncoder32.popDebugGroup();
+} catch {}
+let buffer150 = device0.createBuffer({size: 10394, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let computePassEncoder185 = commandEncoder216.beginComputePass();
+try {
+computePassEncoder40.setBindGroup(1, bindGroup133);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder85); computePassEncoder85.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder183.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder54.executeBundles([renderBundle26]);
+} catch {}
+try {
+renderPassEncoder47.setVertexBuffer(7, buffer147, 0);
+} catch {}
+try {
+commandEncoder221.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 20 */
+  offset: 8,
+  bytesPerRow: 18176,
+  buffer: buffer11,
+}, {
+  texture: texture134,
+  mipLevel: 0,
+  origin: {x: 25, y: 1, z: 4},
+  aspect: 'all',
+}, {width: 3, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder221.clearBuffer(buffer116);
+} catch {}
+try {
+computePassEncoder48.popDebugGroup();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1702, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas2,
+  origin: { x: 2, y: 11 },
+  flipY: false,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 599, y: 12, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder222 = device0.createCommandEncoder({});
+let texture224 = device0.createTexture({
+  size: {width: 30, height: 10, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderPassEncoder63 = commandEncoder221.beginRenderPass({
+  colorAttachments: [{
+  view: textureView81,
+  clearValue: { r: 932.7, g: 654.7, b: 244.2, a: -302.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {view: textureView20, depthLoadOp: 'load', depthStoreOp: 'store'},
+});
+try {
+computePassEncoder78.setBindGroup(1, bindGroup5, new Uint32Array(1587), 222, 0);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer113, 'uint32', 15_012, 371);
+} catch {}
+document.body.prepend(canvas1);
+let recycledAutogeneratedBindGroupLayout3 = pipeline35.getBindGroupLayout(0);
+let commandEncoder223 = device0.createCommandEncoder();
+let textureView211 = texture165.createView({});
+let computePassEncoder186 = commandEncoder223.beginComputePass();
+let sampler155 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 89.29,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder185.setPipeline(pipeline42);
+} catch {}
+try {
+commandEncoder222.copyTextureToTexture({
+  texture: texture134,
+  mipLevel: 1,
+  origin: {x: 22, y: 5, z: 8},
+  aspect: 'all',
+},
+{
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 23, y: 5, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 6, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1702, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 45, y: 25, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder224 = device0.createCommandEncoder({});
+try {
+computePassEncoder51.setBindGroup(2, bindGroup120, new Uint32Array(7386), 1_009, 0);
+} catch {}
+try {
+renderPassEncoder58.executeBundles([renderBundle9, renderBundle16]);
+} catch {}
+let commandEncoder225 = device0.createCommandEncoder({});
+let textureView212 = texture64.createView({format: 'rgba8sint', mipLevelCount: 1});
+let renderPassEncoder64 = commandEncoder222.beginRenderPass({
+  colorAttachments: [{
+  view: textureView81,
+  clearValue: { r: 329.1, g: 32.37, b: -963.3, a: -457.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView151,
+    depthClearValue: 0.18430521564793967,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'store',
+    depthReadOnly: false,
+  },
+});
+let sampler156 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'linear',
+  lodMinClamp: 4.464,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder183.setBindGroup(0, bindGroup23, new Uint32Array(4605), 104, 0);
+} catch {}
+try {
+renderPassEncoder9.setScissorRect(5, 2, 8, 2);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+commandEncoder224.copyTextureToBuffer({
+  texture: texture98,
+  mipLevel: 0,
+  origin: {x: 16, y: 4, z: 16},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1440 */
+  offset: 1440,
+  buffer: buffer37,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder119.insertDebugMarker('\u01ff');
+} catch {}
+let bindGroup136 = device0.createBindGroup({
+  layout: recycledAutogeneratedBindGroupLayout2,
+  entries: [{binding: 8, resource: {buffer: buffer133, offset: 4352, size: 856}}],
+});
+let buffer151 = device0.createBuffer({size: 13855, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let computePassEncoder187 = commandEncoder224.beginComputePass({});
+let sampler157 = device0.createSampler({
+  label: '\u{1fe27}\u6cc9\uba16\u6b16',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMaxClamp: 74.76,
+});
+try {
+computePassEncoder97.setBindGroup(2, bindGroup90);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(0, bindGroup125);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(1, bindGroup26, new Uint32Array(3466), 1_576, 0);
+} catch {}
+try {
+renderPassEncoder1.insertDebugMarker('\u0cff');
+} catch {}
+let autogeneratedBindGroupLayout90 = pipeline29.getBindGroupLayout(0);
+let bindGroup137 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout7,
+  entries: [{binding: 8, resource: {buffer: buffer17, offset: 256}}],
+});
+let commandEncoder226 = device0.createCommandEncoder();
+let texture225 = device0.createTexture({
+  size: {width: 30, height: 10, depthOrArrayLayers: 6},
+  mipLevelCount: 2,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder65 = commandEncoder225.beginRenderPass({
+  colorAttachments: [{
+  view: textureView54,
+  clearValue: { r: 813.0, g: -506.7, b: 731.4, a: -377.5, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView58,
+    depthLoadOp: 'load',
+    depthStoreOp: 'store',
+    depthReadOnly: false,
+    stencilReadOnly: true,
+  },
+  occlusionQuerySet: querySet26,
+  maxDrawCount: 340642567,
+});
+try {
+  await buffer45.mapAsync(GPUMapMode.READ, 0, 1240);
+} catch {}
+try {
+commandEncoder226.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3432 */
+  offset: 3432,
+  buffer: buffer62,
+}, {
+  texture: texture183,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture183,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(209).fill(203), /* required buffer size: 209 */
+{offset: 209}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+adapter0.label = '\u3e09\u68f6';
+} catch {}
+let commandEncoder227 = device0.createCommandEncoder({});
+let textureView213 = texture67.createView({dimension: 'cube', aspect: 'all', mipLevelCount: 1, baseArrayLayer: 0, arrayLayerCount: 6});
+try {
+computePassEncoder120.setBindGroup(2, bindGroup129);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder85); computePassEncoder85.dispatchWorkgroupsIndirect(buffer15, 7_436); };
+} catch {}
+try {
+computePassEncoder187.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder60.setIndexBuffer(buffer78, 'uint16', 220, 928);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(5, buffer73, 1_056);
+} catch {}
+try {
+commandEncoder227.copyBufferToBuffer(buffer132, 2688, buffer112, 120, 572);
+} catch {}
+try {
+commandEncoder227.copyTextureToBuffer({
+  texture: texture112,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4272 */
+  offset: 4272,
+  bytesPerRow: 29184,
+  buffer: buffer0,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let sampler158 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', lodMaxClamp: 68.91});
+try {
+renderPassEncoder49.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer146, 'uint32', 1_900, 385);
+} catch {}
+try {
+commandEncoder226.copyBufferToBuffer(buffer145, 332, buffer64, 1900, 316);
+} catch {}
+try {
+commandEncoder227.insertDebugMarker('\u0622');
+} catch {}
+let pipeline53 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule4, entryPoint: 'compute4'}});
+let commandEncoder228 = device0.createCommandEncoder({});
+let texture226 = device0.createTexture({
+  size: [240, 80, 294],
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView214 = texture50.createView({baseArrayLayer: 2, arrayLayerCount: 1});
+let computePassEncoder188 = commandEncoder228.beginComputePass({});
+try {
+computePassEncoder56.setBindGroup(0, bindGroup88, new Uint32Array(8577), 4_610, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture204,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(190).fill(51), /* required buffer size: 190 */
+{offset: 190, bytesPerRow: 12}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture227 = device0.createTexture({size: [120, 40, 1], format: 'rg32sint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let textureView215 = texture69.createView({dimension: '2d', aspect: 'depth-only', mipLevelCount: 1, baseArrayLayer: 1});
+let computePassEncoder189 = commandEncoder226.beginComputePass({});
+try {
+computePassEncoder186.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(3, bindGroup81);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer62, 'uint16', 3_354, 7_798);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData39 = new ImageData(20, 36);
+try {
+globalThis.someLabel = externalTexture7.label;
+} catch {}
+let bindGroup138 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout58,
+  entries: [{binding: 8, resource: {buffer: buffer41, offset: 1536, size: 2192}}],
+});
+let commandEncoder229 = device0.createCommandEncoder();
+let textureView216 = texture124.createView({dimension: '2d-array', aspect: 'all', arrayLayerCount: 4});
+try {
+computePassEncoder188.setPipeline(pipeline40);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup30);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(2, bindGroup58, new Uint32Array(539), 257, 0);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer28, 'uint16', 508, 2_645);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(7, buffer82, 0, 365);
+} catch {}
+let promise25 = device0.queue.onSubmittedWorkDone();
+let commandEncoder230 = device0.createCommandEncoder({});
+let texture228 = device0.createTexture({
+  label: '\u85bb\u{1fbc5}\u02cc\u477b\u5dde\u5752\ua401',
+  size: {width: 2, height: 2, depthOrArrayLayers: 13},
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler159 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 86.00,
+  maxAnisotropy: 2,
+});
+try {
+renderPassEncoder17.setIndexBuffer(buffer82, 'uint16', 98, 410);
+} catch {}
+let promise26 = device0.queue.onSubmittedWorkDone();
+document.body.append(img3);
+let querySet28 = device0.createQuerySet({type: 'occlusion', count: 159});
+let computePassEncoder190 = commandEncoder227.beginComputePass({});
+try {
+computePassEncoder9.setBindGroup(2, bindGroup112, new Uint32Array(1076), 41, 0);
+} catch {}
+try {
+computePassEncoder190.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(2, bindGroup113);
+} catch {}
+try {
+renderPassEncoder30.executeBundles([]);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+commandEncoder229.resolveQuerySet(querySet19, 46, 15, buffer48, 0);
+} catch {}
+document.body.prepend(canvas2);
+let computePassEncoder191 = commandEncoder230.beginComputePass({});
+try {
+renderPassEncoder22.setViewport(44.930310466230836, 6.923339642883796, 11.244319517975956, 0.7826121409801033, 0.22047430715691718, 0.24935676140960733);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(1, buffer9, 0, 1_340);
+} catch {}
+try {
+  await promise25;
+} catch {}
+let recycledExplicitBindGroupLayout13 = pipeline40.getBindGroupLayout(0);
+let bindGroup139 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout7,
+  entries: [{binding: 53, resource: {buffer: buffer39, offset: 2560, size: 104}}],
+});
+let texture229 = device0.createTexture({
+  size: {width: 30, height: 10, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder116.setBindGroup(1, bindGroup89);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder85); computePassEncoder85.dispatchWorkgroups(2, 2, 1); };
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(48);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer128, 'uint32', 344, 483);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(6, buffer125, 256, 1_301);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder229.resolveQuerySet(querySet0, 138, 44, buffer118, 31488);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let querySet29 = device0.createQuerySet({type: 'occlusion', count: 345});
+let textureView217 = texture129.createView({
+  label: '\u0a8c\u3ded\u9d80\u0ef7\u0f7e\ud1e5',
+  dimension: 'cube-array',
+  baseArrayLayer: 1,
+  arrayLayerCount: 6,
+});
+let computePassEncoder192 = commandEncoder229.beginComputePass({});
+let externalTexture31 = device0.importExternalTexture({source: videoFrame28, colorSpace: 'srgb'});
+try {
+computePassEncoder181.setPipeline(pipeline28);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer36, 'uint32', 144, 61);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer84, 516, new Float32Array(1419), 133, 136);
+} catch {}
+let autogeneratedBindGroupLayout91 = pipeline19.getBindGroupLayout(0);
+let bindGroup140 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout18,
+  entries: [{binding: 8, resource: {buffer: buffer123, offset: 512, size: 308}}],
+});
+let texture230 = device0.createTexture({
+  size: [2, 2, 13],
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView218 = texture212.createView({});
+try {
+computePassEncoder33.setBindGroup(2, bindGroup52);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(3, bindGroup125);
+} catch {}
+try {
+renderPassEncoder42.beginOcclusionQuery(247);
+} catch {}
+try {
+buffer115.unmap();
+} catch {}
+let promise27 = device0.queue.onSubmittedWorkDone();
+let pipeline54 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout10,
+  fragment: {
+  module: shaderModule5,
+  targets: [{format: 'rgba8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth32float',
+    depthWriteEnabled: false,
+    stencilFront: {compare: 'always', depthFailOp: 'keep'},
+    stencilBack: {},
+    stencilReadMask: 27698065,
+    stencilWriteMask: 1709583292,
+    depthBiasSlopeScale: 204.22366671074286,
+  },
+  vertex: {
+    module: shaderModule3,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 12,
+        attributes: [
+          {format: 'uint8x2', offset: 0, shaderLocation: 2},
+          {format: 'uint8x4', offset: 0, shaderLocation: 3},
+          {format: 'sint16x2', offset: 0, shaderLocation: 12},
+          {format: 'unorm8x4', offset: 0, shaderLocation: 9},
+          {format: 'sint32', offset: 0, shaderLocation: 4},
+          {format: 'snorm8x2', offset: 0, shaderLocation: 6},
+          {format: 'sint32x2', offset: 0, shaderLocation: 8},
+          {format: 'unorm8x4', offset: 0, shaderLocation: 10},
+          {format: 'unorm16x4', offset: 0, shaderLocation: 5},
+          {format: 'unorm16x4', offset: 0, shaderLocation: 0},
+          {format: 'sint32', offset: 0, shaderLocation: 15},
+          {format: 'uint8x2', offset: 2, shaderLocation: 11},
+          {format: 'uint16x4', offset: 0, shaderLocation: 14},
+          {format: 'unorm16x4', offset: 0, shaderLocation: 7},
+          {format: 'uint16x2', offset: 0, shaderLocation: 13},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw'},
+});
+let bindGroup141 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout2,
+  entries: [{binding: 8, resource: {buffer: buffer140, offset: 1280, size: 116}}],
+});
+let texture231 = device0.createTexture({
+  size: [240, 80, 294],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder101.setBindGroup(0, bindGroup20, new Uint32Array(634), 41, 0);
+} catch {}
+try {
+computePassEncoder85.end();
+} catch {}
+try {
+renderPassEncoder42.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer22, 'uint16', 12_284, 5_246);
+} catch {}
+try {
+commandEncoder98.copyBufferToTexture({
+  /* bytesInLastRow: 192 widthInBlocks: 48 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1160 */
+  offset: 1160,
+  bytesPerRow: 256,
+  buffer: buffer33,
+}, {
+  texture: texture174,
+  mipLevel: 0,
+  origin: {x: 14, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 48, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder98.resolveQuerySet(querySet29, 18, 119, buffer100, 5888);
+} catch {}
+let recycledExplicitBindGroupLayout14 = pipeline46.getBindGroupLayout(0);
+let renderPassEncoder66 = commandEncoder98.beginRenderPass({
+  colorAttachments: [{
+  view: textureView218,
+  depthSlice: 217,
+  clearValue: { r: 37.89, g: 198.0, b: -254.1, a: 264.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 253367466,
+});
+try {
+computePassEncoder107.setBindGroup(3, bindGroup141);
+} catch {}
+try {
+computePassEncoder191.setPipeline(pipeline7);
+} catch {}
+try {
+  await shaderModule1.getCompilationInfo();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture113,
+  mipLevel: 0,
+  origin: {x: 3, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(158).fill(70), /* required buffer size: 158 */
+{offset: 158}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline55 = device0.createComputePipeline({
+  label: '\u4574\u{1fee2}\ucd55',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule1, entryPoint: 'compute1', constants: {}},
+});
+let veryExplicitBindGroupLayout30 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 105,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 343,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '3d' },
+    },
+  ],
+});
+let recycledExplicitBindGroupLayout15 = pipeline25.getBindGroupLayout(1);
+let bindGroup142 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout8,
+  entries: [{binding: 8, resource: {buffer: buffer129, offset: 0}}],
+});
+let commandEncoder231 = device0.createCommandEncoder({});
+let texture232 = device0.createTexture({
+  size: {width: 30},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+computePassEncoder58.end();
+} catch {}
+try {
+renderPassEncoder42.endOcclusionQuery();
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+let arrayBuffer13 = buffer45.getMappedRange(0, 148);
+let commandEncoder232 = device0.createCommandEncoder({});
+let querySet30 = device0.createQuerySet({type: 'occlusion', count: 717});
+let renderPassEncoder67 = commandEncoder67.beginRenderPass({colorAttachments: [{view: textureView15, loadOp: 'load', storeOp: 'store'}]});
+try {
+computePassEncoder103.setBindGroup(3, bindGroup81, new Uint32Array(1854), 194, 0);
+} catch {}
+let buffer152 = device0.createBuffer({size: 9374, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let textureView219 = texture45.createView({baseMipLevel: 0});
+let texture233 = device0.createTexture({
+  size: {width: 60, height: 20, depthOrArrayLayers: 1},
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView220 = texture39.createView({dimension: '2d', baseArrayLayer: 3});
+let renderPassEncoder68 = commandEncoder231.beginRenderPass({
+  colorAttachments: [{
+  view: textureView120,
+  clearValue: { r: -575.9, g: 0.5620, b: -574.5, a: 814.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder186.setBindGroup(2, bindGroup136, new Uint32Array(498), 3, 0);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer78, 'uint16', 298, 458);
+} catch {}
+try {
+renderPassEncoder51.setVertexBuffer(0, buffer97, 1_112);
+} catch {}
+try {
+commandEncoder232.copyBufferToBuffer(buffer85, 60, buffer4, 2512, 452);
+} catch {}
+let veryExplicitBindGroupLayout31 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 43,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8sint', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 57,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 132,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 774,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let texture234 = device0.createTexture({
+  size: {width: 120, height: 40, depthOrArrayLayers: 12},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView221 = texture224.createView({mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder193 = commandEncoder232.beginComputePass({});
+try {
+computePassEncoder119.setPipeline(pipeline30);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup123, new Uint32Array(1204), 27, 0);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer53, 'uint16', 2_446, 314);
+} catch {}
+try {
+renderPassEncoder53.setVertexBuffer(2, buffer112);
+} catch {}
+try {
+buffer64.unmap();
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer17, 3672, new DataView(new ArrayBuffer(6638)), 1586, 220);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder233 = device0.createCommandEncoder({});
+let computePassEncoder194 = commandEncoder233.beginComputePass({label: '\u01b2\u01fc\u{1fb78}\u8db7\u0f6d\ue9d2\u0104\u0641\ub359'});
+let externalTexture32 = device0.importExternalTexture({source: videoFrame11});
+try {
+computePassEncoder130.setBindGroup(1, bindGroup113);
+} catch {}
+try {
+computePassEncoder193.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(3, bindGroup86, new Uint32Array(7234), 6_043, 0);
+} catch {}
+let arrayBuffer14 = buffer65.getMappedRange(1200, 32);
+let texture235 = device0.createTexture({
+  size: [120, 40, 16],
+  mipLevelCount: 2,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture236 = gpuCanvasContext5.getCurrentTexture();
+try {
+computePassEncoder113.setBindGroup(1, bindGroup86);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer44, 'uint32', 112, 19);
+} catch {}
+try {
+renderPassEncoder68.setVertexBuffer(2, buffer129);
+} catch {}
+try {
+renderPassEncoder58.insertDebugMarker('\u0cf3');
+} catch {}
+try {
+  await promise26;
+} catch {}
+try {
+adapter0.label = '\u0325\u{1f6d4}\u8734';
+} catch {}
+try {
+externalTexture27.label = '\ufbd7\u7505\u090c\u0dd1\u2c1e\u{1f926}\u0e4d\u0777\u13af\u0463\u02f5';
+} catch {}
+let bindGroup143 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout20,
+  entries: [{binding: 8, resource: {buffer: buffer89, offset: 0, size: 188}}],
+});
+let commandEncoder234 = device0.createCommandEncoder({});
+let commandBuffer17 = commandEncoder234.finish();
+let textureView222 = texture132.createView({});
+let sampler160 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder192.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder52.executeBundles([renderBundle12, renderBundle9]);
+} catch {}
+try {
+device0.queue.submit([commandBuffer17]);
+} catch {}
+let commandEncoder235 = device0.createCommandEncoder({});
+let textureView223 = texture0.createView({dimension: 'cube-array', arrayLayerCount: 6});
+let computePassEncoder195 = commandEncoder235.beginComputePass();
+let sampler161 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 75.71,
+});
+try {
+computePassEncoder189.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder22.beginOcclusionQuery(52);
+} catch {}
+try {
+renderPassEncoder22.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder52.executeBundles([renderBundle7, renderBundle16]);
+} catch {}
+let recycledExplicitBindGroupLayout16 = pipeline5.getBindGroupLayout(0);
+let buffer153 = device0.createBuffer({
+  size: 1612,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let sampler162 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'mirror-repeat'});
+try {
+computePassEncoder121.setBindGroup(2, bindGroup22, new Uint32Array(265), 10, 0);
+} catch {}
+try {
+renderPassEncoder63.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder35.setBlendConstant({ r: -147.2, g: 409.7, b: -481.4, a: 658.6, });
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(7, buffer34, 0, 760);
+} catch {}
+let querySet31 = device0.createQuerySet({type: 'occlusion', count: 354});
+try {
+computePassEncoder164.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+computePassEncoder91.setBindGroup(0, bindGroup107, new Uint32Array(658), 76, 0);
+} catch {}
+try {
+computePassEncoder195.setPipeline(pipeline36);
+} catch {}
+try {
+  await promise27;
+} catch {}
+let bindGroup144 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout15,
+  entries: [{binding: 8, resource: {buffer: buffer93, offset: 768}}],
+});
+let commandEncoder236 = device0.createCommandEncoder({});
+let texture237 = device0.createTexture({
+  size: [240],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder196 = commandEncoder236.beginComputePass({});
+let externalTexture33 = device0.importExternalTexture({source: videoFrame31});
+let pipeline56 = await device0.createComputePipelineAsync({layout: pipelineLayout7, compute: {module: shaderModule2, constants: {override4: 0}}});
+let canvas4 = document.createElement('canvas');
+let videoFrame34 = new VideoFrame(videoFrame12, {timestamp: 0});
+let commandEncoder237 = device0.createCommandEncoder({});
+let textureView224 = texture74.createView({dimension: '2d-array', aspect: 'all', mipLevelCount: 1});
+let renderPassEncoder69 = commandEncoder237.beginRenderPass({
+  colorAttachments: [{
+  view: textureView81,
+  clearValue: { r: -500.8, g: -207.3, b: -711.0, a: 430.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView155,
+    depthClearValue: 1.583889143093831,
+    depthLoadOp: 'load',
+    depthStoreOp: 'store',
+    stencilClearValue: 59128,
+  },
+});
+try {
+computePassEncoder194.setPipeline(pipeline15);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer14, 32, new Int16Array(39510), 5044, 300);
+} catch {}
+let bindGroup145 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout29,
+  entries: [
+    {binding: 198, resource: {buffer: buffer23, offset: 256, size: 1028}},
+    {binding: 72, resource: textureView137},
+  ],
+});
+let textureView225 = texture67.createView({dimension: 'cube', aspect: 'all', arrayLayerCount: 6});
+let textureView226 = texture76.createView({baseArrayLayer: 2, arrayLayerCount: 6});
+try {
+computePassEncoder42.setBindGroup(0, bindGroup130);
+} catch {}
+try {
+computePassEncoder196.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer24, 'uint16', 3_502, 15_158);
+} catch {}
+try {
+adapter0.label = '\u9efb\uc717\u11b0\ud166\u35c9\u{1fd56}\u{1fa6c}\u9701';
+} catch {}
+let renderBundleEncoder29 = device0.createRenderBundleEncoder({colorFormats: ['rgba8sint'], depthStencilFormat: 'depth32float', stencilReadOnly: true});
+let sampler163 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 75.72,
+  compare: 'always',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder161.setBindGroup(2, bindGroup25, []);
+} catch {}
+try {
+renderPassEncoder19.beginOcclusionQuery(4);
+} catch {}
+let buffer154 = device0.createBuffer({size: 8848, usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE});
+let commandEncoder238 = device0.createCommandEncoder({});
+let textureView227 = texture147.createView({});
+let computePassEncoder197 = commandEncoder238.beginComputePass({});
+try {
+computePassEncoder197.setPipeline(pipeline0);
+} catch {}
+let gpuCanvasContext10 = canvas4.getContext('webgpu');
+let buffer155 = device0.createBuffer({size: 6794, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let sampler164 = device0.createSampler({
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 73.95,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder96.setBindGroup(0, bindGroup138, new Uint32Array(1782), 50, 0);
+} catch {}
+try {
+computePassEncoder59.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder65.setBindGroup(3, bindGroup130);
+} catch {}
+try {
+renderPassEncoder24.beginOcclusionQuery(69);
+} catch {}
+try {
+renderPassEncoder19.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder29.setIndexBuffer(buffer147, 'uint16', 136, 416);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer21, 1480, new Int16Array(17144), 4999, 716);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData14,
+  origin: { x: 0, y: 2 },
+  flipY: false,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 13, y: 4, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+sampler101.label = '\u7df1\u0658\uf74c\ucb0a\u8609\u04cd\uf408\ub0bc';
+} catch {}
+let texture238 = device0.createTexture({
+  size: {width: 60, height: 20, depthOrArrayLayers: 1},
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+renderPassEncoder44.setBindGroup(1, bindGroup114, new Uint32Array(122), 2, 0);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(1, bindGroup117);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(3, bindGroup41, new Uint32Array(345), 180, 0);
+} catch {}
+try {
+renderBundleEncoder29.setPipeline(pipeline13);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(3, buffer59);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: img0,
+  origin: { x: 2, y: 1 },
+  flipY: false,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 49, y: 12, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 7, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame35 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'smpte432', transfer: 'bt1361ExtendedColourGamut'} });
+let recycledAutogeneratedBindGroupLayout4 = pipeline30.getBindGroupLayout(0);
+let buffer156 = device0.createBuffer({size: 27363, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let externalTexture34 = device0.importExternalTexture({source: videoFrame5});
+try {
+computePassEncoder67.setBindGroup(2, bindGroup54);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(2, bindGroup94);
+} catch {}
+try {
+renderPassEncoder49.beginOcclusionQuery(216);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(1, bindGroup111, []);
+} catch {}
+try {
+computePassEncoder78.insertDebugMarker('\u{1fca1}');
+} catch {}
+let videoFrame36 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'fcc', primaries: 'smpte240m', transfer: 'linear'} });
+let bindGroup146 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout15,
+  entries: [{binding: 8, resource: {buffer: buffer108, offset: 512, size: 584}}],
+});
+try {
+renderPassEncoder57.setScissorRect(46, 9, 18, 0);
+} catch {}
+try {
+renderPassEncoder45.setVertexBuffer(0, buffer26, 612, 2_277);
+} catch {}
+try {
+renderBundleEncoder29.setIndexBuffer(buffer89, 'uint32', 60, 177);
+} catch {}
+try {
+buffer48.unmap();
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let img4 = await imageWithData(38, 62, '#10101010', '#20202020');
+let bindGroup147 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout39,
+  entries: [
+    {binding: 216, resource: textureView24},
+    {binding: 8, resource: {buffer: buffer61, offset: 256, size: 800}},
+  ],
+});
+let pipelineLayout16 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout51]});
+let textureView228 = texture103.createView({baseArrayLayer: 0, arrayLayerCount: 1});
+try {
+computePassEncoder135.setBindGroup(1, bindGroup115, new Uint32Array(528), 13, 0);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(2, bindGroup99);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(3, bindGroup10, new Uint32Array(612), 60, 0);
+} catch {}
+try {
+renderBundleEncoder29.setPipeline(pipeline11);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer116, 552, new Int16Array(715), 18, 36);
+} catch {}
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55); };
+} catch {}
+let querySet32 = device0.createQuerySet({type: 'occlusion', count: 1299});
+try {
+computePassEncoder163.setBindGroup(0, bindGroup85, new Uint32Array(165), 13, 0);
+} catch {}
+try {
+renderPassEncoder69.setIndexBuffer(buffer46, 'uint16', 456, 173);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(4, buffer43);
+} catch {}
+try {
+renderPassEncoder68.setBindGroup(1, bindGroup109);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(1, bindGroup78, new Uint32Array(619), 45, 0);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(1, buffer64, 0, 2_661);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(0, bindGroup88);
+} catch {}
+try {
+renderBundleEncoder29.setPipeline(pipeline22);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(3, bindGroup71, new Uint32Array(458), 0, 0);
+} catch {}
+try {
+renderBundleEncoder29.setIndexBuffer(buffer46, 'uint32', 1_072, 642);
+} catch {}
+try {
+renderBundleEncoder29.setPipeline(pipeline19);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(5, buffer8, 136, 664);
+} catch {}
+let sampler165 = device0.createSampler({addressModeV: 'mirror-repeat'});
+try {
+computePassEncoder61.setBindGroup(1, bindGroup108);
+} catch {}
+try {
+renderPassEncoder49.endOcclusionQuery();
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+try {
+renderPassEncoder24.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder29.setIndexBuffer(buffer94, 'uint32', 208, 15);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(6, buffer82, 60, 307);
+} catch {}
+let pipeline57 = device0.createRenderPipeline({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment5',
+  constants: {},
+  targets: [{format: 'rgba8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}],
+},
+  depthStencil: {
+    format: 'depth32float',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilReadMask: 915801827,
+    stencilWriteMask: 207860342,
+    depthBias: -1967931460,
+    depthBiasClamp: 0.0,
+  },
+  vertex: {
+    module: shaderModule5,
+    buffers: [
+      {
+        arrayStride: 144,
+        attributes: [
+          {format: 'float32x4', offset: 4, shaderLocation: 7},
+          {format: 'unorm16x2', offset: 40, shaderLocation: 0},
+          {format: 'unorm16x4', offset: 20, shaderLocation: 2},
+          {format: 'float16x2', offset: 24, shaderLocation: 11},
+          {format: 'unorm8x4', offset: 4, shaderLocation: 13},
+          {format: 'unorm16x4', offset: 8, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front'},
+});
+document.body.append(img2);
+let recycledExplicitBindGroupLayout17 = pipeline46.getBindGroupLayout(0);
+try {
+computePassEncoder104.setBindGroup(0, bindGroup25);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(0, bindGroup80);
+} catch {}
+try {
+renderPassEncoder40.setPipeline(pipeline39);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(1, bindGroup66);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture234,
+  mipLevel: 0,
+  origin: {x: 37, y: 14, z: 0},
+  aspect: 'all',
+}, new Uint8Array(259).fill(226), /* required buffer size: 259 */
+{offset: 175, bytesPerRow: 56, rowsPerImage: 80}, {width: 7, height: 2, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let renderBundle29 = renderBundleEncoder29.finish({});
+try {
+renderPassEncoder38.setBindGroup(3, bindGroup127, new Uint32Array(252), 34, 0);
+} catch {}
+try {
+renderPassEncoder55.setIndexBuffer(buffer28, 'uint16', 154, 576);
+} catch {}
+try {
+renderPassEncoder67.setVertexBuffer(6, buffer78, 0);
+} catch {}
+try {
+buffer64.unmap();
+} catch {}
+try {
+globalThis.someLabel = externalTexture32.label;
+} catch {}
+let commandEncoder239 = device0.createCommandEncoder({});
+let texture239 = device0.createTexture({
+  size: [30, 10, 36],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder198 = commandEncoder239.beginComputePass({});
+try {
+renderPassEncoder59.setBindGroup(2, bindGroup123, new Uint32Array(1875), 472, 0);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer99, 'uint32', 492, 701);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline47);
+} catch {}
+let texture240 = device0.createTexture({
+  size: {width: 30, height: 10, depthOrArrayLayers: 158},
+  mipLevelCount: 2,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+try {
+computePassEncoder77.setBindGroup(1, bindGroup113);
+} catch {}
+try {
+computePassEncoder100.setBindGroup(1, bindGroup28, new Uint32Array(1340), 368, 0);
+} catch {}
+try {
+computePassEncoder198.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer156, 'uint16', 650, 3_179);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(3, buffer151, 0);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture176,
+  mipLevel: 0,
+  origin: {x: 45, y: 28, z: 92},
+  aspect: 'all',
+}, new Uint8Array(87_910).fill(20), /* required buffer size: 87_910 */
+{offset: 52, bytesPerRow: 185, rowsPerImage: 6}, {width: 42, height: 1, depthOrArrayLayers: 80});
+} catch {}
+let pipelineLayout17 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout72]});
+let commandEncoder240 = device0.createCommandEncoder({});
+let texture241 = device0.createTexture({size: [60, 20, 1], format: 'rg8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let textureView229 = texture225.createView({aspect: 'depth-only', mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 1});
+let renderPassEncoder70 = commandEncoder240.beginRenderPass({
+  colorAttachments: [{view: textureView218, depthSlice: 89, loadOp: 'clear', storeOp: 'discard'}],
+  maxDrawCount: 59033494,
+});
+let externalTexture35 = device0.importExternalTexture({source: videoFrame32});
+try {
+renderPassEncoder52.setIndexBuffer(buffer85, 'uint32', 1_032, 124);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 13, y: 11, z: 121},
+  aspect: 'all',
+}, new Uint8Array(264_665).fill(80), /* required buffer size: 264_665 */
+{offset: 183, bytesPerRow: 282, rowsPerImage: 50}, {width: 31, height: 38, depthOrArrayLayers: 19});
+} catch {}
+let pipeline58 = await device0.createComputePipelineAsync({
+  label: '\u0489\u56e1\u73e1\u9b8e',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule4, entryPoint: 'compute5', constants: {}},
+});
+let commandEncoder241 = device0.createCommandEncoder({});
+let querySet33 = device0.createQuerySet({type: 'occlusion', count: 1160});
+let computePassEncoder199 = commandEncoder241.beginComputePass({});
+let sampler166 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 87.34});
+try {
+renderPassEncoder63.setViewport(41.662498089320465, 2.4357921972925256, 54.02276230818051, 17.76571019875878, 0.4035118060563496, 0.6322843261110258);
+} catch {}
+try {
+renderPassEncoder63.setPipeline(pipeline22);
+} catch {}
+let shaderModule6 = device0.createShaderModule({
+  code: `
+enable f16;
+
+diagnostic(info, xyz);
+
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+enable f16;
+
+@id(51249) override override22 = -662;
+
+override override24: f32;
+
+override override16: i32 = 3;
+
+@id(6430) override override5: f16 = 333.7;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@id(58061) override override20: u32;
+
+@id(13133) override override21: i32;
+
+@id(7538) override override15: u32;
+
+@group(0) @binding(8) var<storage, read> buffer157: array<array<array<array<f16, 9>, 1>, 3>>;
+
+override override12: f32;
+
+override override18: f16;
+
+struct T0 {
+  @size(56) f0: array<u32>,
+}
+
+@id(46193) override override9: f32;
+
+override override13: f16 = -45456.8;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct FragmentOutput6 {
+  @location(0) @interpolate(flat) f0: vec4i,
+  @location(3) f1: vec2i,
+  @location(7) @interpolate(flat) f2: i32,
+}
+
+alias vec3b = vec3<bool>;
+
+override override8 = -0.2608;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+override override7 = true;
+
+override override14: f16;
+
+fn fn0() -> mat3x3h {
+  var out: mat3x3h;
+  var vf62: vec4h = asin(vec4h(unconst_f16(190.7), unconst_f16(33354.5), unconst_f16(7114.7), unconst_f16(5229.0)));
+  let ptr111: ptr<storage, array<array<f16, 9>, 1>, read> = &(*&buffer157)[arrayLength(&(*&buffer157))][2];
+  let ptr112: ptr<storage, array<array<array<f16, 9>, 1>, 3>, read> = &(*&buffer157)[arrayLength(&(*&buffer157)) - 1];
+  let ptr113: ptr<storage, array<f16, 9>, read> = &(*ptr111)[u32(unconst_u32(124))];
+  vf62 -= vec4h((*&buffer157)[u32(unconst_u32(464))][u32(unconst_u32(0))][0][u32(unconst_u32(64))]);
+  let vf63: f32 = override12;
+  let ptr114: ptr<storage, array<array<f16, 9>, 1>, read> = &(*ptr112)[u32(unconst_u32(443))];
+  out = mat3x3h((*&buffer157)[u32(unconst_u32(161))][2][0][8], (*&buffer157)[u32(unconst_u32(161))][2][0][8], (*&buffer157)[u32(unconst_u32(161))][2][0][8], (*&buffer157)[u32(unconst_u32(161))][2][0][8], (*&buffer157)[u32(unconst_u32(161))][2][0][8], (*&buffer157)[u32(unconst_u32(161))][2][0][8], (*&buffer157)[u32(unconst_u32(161))][2][0][8], (*&buffer157)[u32(unconst_u32(161))][2][0][8], (*&buffer157)[u32(unconst_u32(161))][2][0][8]);
+  vf62 *= sin(vec3h(unconst_f16(10476.6), unconst_f16(10.15), unconst_f16(1243.0))).rbrb;
+  return out;
+  _ = override12;
+  _ = buffer157;
+}
+
+override override23: i32 = 168;
+
+override override17: i32;
+
+@id(56410) override override10: f16 = 8724.9;
+
+override override6: f16 = 1533.0;
+
+var<workgroup> vw27: mat2x4h;
+
+override override19: u32;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+override override11: u32 = 215;
+
+@fragment
+fn fragment6() -> FragmentOutput6 {
+  var out: FragmentOutput6;
+  fn0();
+  out.f2 = i32((*&buffer157)[u32(unconst_u32(130))][u32(unconst_u32(70))][u32(unconst_u32(26))][8]);
+  var vf64 = fn0();
+  let ptr115: ptr<storage, array<f16, 9>, read> = &(*&buffer157)[vec3u(vf64[unconst_i32(1)])[1]][u32(unconst_u32(94))][u32(unconst_u32(218))];
+  let ptr116: ptr<storage, f16, read> = &(*ptr115)[u32(unconst_u32(55))];
+  let ptr117: ptr<storage, array<array<array<f16, 9>, 1>, 3>, read> = &buffer157[u32(unconst_u32(82))];
+  var vf65 = fn0();
+  fn0();
+  let ptr118: ptr<storage, f16, read> = &buffer157[arrayLength(&buffer157)][2][0][u32(unconst_u32(46))];
+  let ptr119: ptr<storage, array<array<f16, 9>, 1>, read> = &buffer157[arrayLength(&buffer157)][u32(unconst_u32(211))];
+  fn0();
+  var vf66 = fn0();
+  let ptr120: ptr<storage, array<f16, 9>, read> = &(*&buffer157)[arrayLength(&(*&buffer157))][2][u32(unconst_u32(150))];
+  return out;
+  _ = override12;
+  _ = buffer157;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute7() {
+  let vf67: f32 = override9;
+  vw27 = mat2x4h(buffer157[u32(unconst_u32(179))][2][u32(unconst_u32(59))][u32(unconst_u32(95))], buffer157[u32(unconst_u32(179))][2][u32(unconst_u32(59))][u32(unconst_u32(95))], buffer157[u32(unconst_u32(179))][2][u32(unconst_u32(59))][u32(unconst_u32(95))], buffer157[u32(unconst_u32(179))][2][u32(unconst_u32(59))][u32(unconst_u32(95))], buffer157[u32(unconst_u32(179))][2][u32(unconst_u32(59))][u32(unconst_u32(95))], buffer157[u32(unconst_u32(179))][2][u32(unconst_u32(59))][u32(unconst_u32(95))], buffer157[u32(unconst_u32(179))][2][u32(unconst_u32(59))][u32(unconst_u32(95))], buffer157[u32(unconst_u32(179))][2][u32(unconst_u32(59))][u32(unconst_u32(95))]);
+  vw27 = mat2x4h((*&buffer157)[arrayLength(&(*&buffer157))][u32(unconst_u32(65))][0][8], (*&buffer157)[arrayLength(&(*&buffer157))][u32(unconst_u32(65))][0][8], (*&buffer157)[arrayLength(&(*&buffer157))][u32(unconst_u32(65))][0][8], (*&buffer157)[arrayLength(&(*&buffer157))][u32(unconst_u32(65))][0][8], (*&buffer157)[arrayLength(&(*&buffer157))][u32(unconst_u32(65))][0][8], (*&buffer157)[arrayLength(&(*&buffer157))][u32(unconst_u32(65))][0][8], (*&buffer157)[arrayLength(&(*&buffer157))][u32(unconst_u32(65))][0][8], (*&buffer157)[arrayLength(&(*&buffer157))][u32(unconst_u32(65))][0][8]);
+  vw27 = mat2x4h((*&buffer157)[arrayLength(&(*&buffer157))][u32(unconst_u32(197))][u32(unconst_u32(414))][u32(unconst_u32(270))], (*&buffer157)[arrayLength(&(*&buffer157))][u32(unconst_u32(197))][u32(unconst_u32(414))][u32(unconst_u32(270))], (*&buffer157)[arrayLength(&(*&buffer157))][u32(unconst_u32(197))][u32(unconst_u32(414))][u32(unconst_u32(270))], (*&buffer157)[arrayLength(&(*&buffer157))][u32(unconst_u32(197))][u32(unconst_u32(414))][u32(unconst_u32(270))], (*&buffer157)[arrayLength(&(*&buffer157))][u32(unconst_u32(197))][u32(unconst_u32(414))][u32(unconst_u32(270))], (*&buffer157)[arrayLength(&(*&buffer157))][u32(unconst_u32(197))][u32(unconst_u32(414))][u32(unconst_u32(270))], (*&buffer157)[arrayLength(&(*&buffer157))][u32(unconst_u32(197))][u32(unconst_u32(414))][u32(unconst_u32(270))], (*&buffer157)[arrayLength(&(*&buffer157))][u32(unconst_u32(197))][u32(unconst_u32(414))][u32(unconst_u32(270))]);
+  var vf68 = fn0();
+  let ptr121: ptr<storage, array<array<array<f16, 9>, 1>, 3>, read> = &buffer157[u32(unconst_u32(419))];
+  let ptr122: ptr<storage, f16, read> = &(*&buffer157)[arrayLength(&(*&buffer157))][2][u32((*&buffer157)[arrayLength(&(*&buffer157))][2][u32(unconst_u32(185))][8])][8];
+  var vf69 = fn0();
+  _ = override12;
+  _ = override9;
+  _ = buffer157;
+}`,
+});
+let texture242 = gpuCanvasContext0.getCurrentTexture();
+let sampler167 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'mirror-repeat', minFilter: 'nearest', lodMaxClamp: 84.29});
+try {
+computePassEncoder199.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder51.setVertexBuffer(5, buffer120, 0, 667);
+} catch {}
+let arrayBuffer15 = buffer1.getMappedRange(80, 0);
+document.body.prepend(canvas2);
+let recycledExplicitBindGroupLayout18 = pipeline39.getBindGroupLayout(0);
+let commandEncoder242 = device0.createCommandEncoder({});
+let textureView230 = texture124.createView({dimension: 'cube-array', arrayLayerCount: 6});
+let texture243 = device0.createTexture({
+  size: [60, 20, 29],
+  mipLevelCount: 3,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView231 = texture49.createView({format: 'rgba8sint', baseMipLevel: 0});
+let computePassEncoder200 = commandEncoder242.beginComputePass({});
+try {
+computePassEncoder113.setBindGroup(0, bindGroup58, new Uint32Array(449), 17, 0);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(3, bindGroup13, new Uint32Array(2163), 135, 0);
+} catch {}
+try {
+renderPassEncoder69.setScissorRect(0, 18, 25, 9);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(6, buffer115, 0, 561);
+} catch {}
+let texture244 = device0.createTexture({
+  size: [30, 10, 1],
+  mipLevelCount: 1,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView232 = texture110.createView({aspect: 'all', arrayLayerCount: 1});
+let sampler168 = device0.createSampler({
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'equal',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder128.setBindGroup(0, bindGroup82, new Uint32Array(2519), 110, 0);
+} catch {}
+try {
+computePassEncoder200.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder16.setBlendConstant({ r: 66.69, g: 605.0, b: 144.4, a: 702.9, });
+} catch {}
+try {
+buffer90.unmap();
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroup148 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout17,
+  entries: [{binding: 8, resource: {buffer: buffer41, offset: 1792, size: 2428}}],
+});
+let commandEncoder243 = device0.createCommandEncoder({});
+let textureView233 = texture178.createView({arrayLayerCount: 2});
+let renderPassEncoder71 = commandEncoder243.beginRenderPass({
+  colorAttachments: [{
+  view: textureView71,
+  clearValue: { r: 780.3, g: -540.4, b: -45.45, a: -864.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet11,
+});
+try {
+renderPassEncoder54.setIndexBuffer(buffer87, 'uint32', 240, 1_022);
+} catch {}
+document.body.append(img1);
+let commandEncoder244 = device0.createCommandEncoder({});
+let texture245 = device0.createTexture({
+  size: {width: 240, height: 80, depthOrArrayLayers: 16},
+  mipLevelCount: 4,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler169 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 88.73,
+});
+try {
+renderPassEncoder57.setIndexBuffer(buffer112, 'uint16', 650, 82);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(6, buffer78, 0);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+let arrayBuffer16 = buffer45.getMappedRange(152, 200);
+try {
+commandEncoder244.copyTextureToTexture({
+  texture: texture121,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'depth-only',
+},
+{
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline59 = device0.createComputePipeline({layout: pipelineLayout5, compute: {module: shaderModule2, constants: {override4: 0}}});
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let commandEncoder245 = device0.createCommandEncoder();
+let textureView234 = texture87.createView({aspect: 'depth-only'});
+let computePassEncoder201 = commandEncoder245.beginComputePass();
+try {
+computePassEncoder201.setPipeline(pipeline40);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(3, bindGroup38);
+} catch {}
+try {
+renderPassEncoder55.setBindGroup(3, bindGroup113, new Uint32Array(3417), 1_245, 0);
+} catch {}
+try {
+renderPassEncoder59.setIndexBuffer(buffer24, 'uint32', 8_736, 4_437);
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline26);
+} catch {}
+try {
+renderPassEncoder68.setVertexBuffer(5, buffer120, 20, 361);
+} catch {}
+try {
+buffer38.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer113, 1120, new BigUint64Array(7890), 2883);
+} catch {}
+let bindGroup149 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout8,
+  entries: [
+    {binding: 5, resource: textureView182},
+    {binding: 20, resource: textureView22},
+    {binding: 18, resource: textureView201},
+  ],
+});
+let commandEncoder246 = device0.createCommandEncoder();
+let textureView235 = texture1.createView({});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup118);
+} catch {}
+try {
+renderPassEncoder49.setIndexBuffer(buffer98, 'uint16', 730, 872);
+} catch {}
+try {
+commandEncoder244.copyTextureToTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture113,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas3);
+let shaderModule7 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+alias vec3b = vec3<bool>;
+
+struct FragmentOutput7 {
+  @location(0) @interpolate(flat, centroid) f0: vec4i,
+}
+
+struct T0 {
+  @size(88) f0: mat3x4h,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<private> vp4 = modf(f16(13192.9));
+
+fn fn0() {
+  let ptr123: ptr<private, vec3f> = &vp3.fract;
+  var vf70: f16 = dot(vec2h(unconst_f16(2771.4), unconst_f16(5363.6)), vec2h(unconst_f16(2853.2), unconst_f16(9328.5)));
+  vp3.fract = unpack2x16unorm(u32(unconst_u32(265))).yyy;
+  var vf71: vec3f = tan(vec3f(unconst_f32(0.07964), unconst_f32(0.1061), unconst_f32(0.01459)));
+  vp3.fract = vec3f(vf71[u32(unconst_u32(397))]);
+  let vf72: vec3h = fma(vec3h(unconst_f16(-12377.1), unconst_f16(-2722.4), unconst_f16(25407.3)), vec3h(unconst_f16(6609.1), unconst_f16(1443.1), unconst_f16(2098.8)), vec3h(unconst_f16(1597.0), unconst_f16(1756.9), unconst_f16(3396.0)));
+  let vf73: f32 = (*ptr123)[u32(unconst_u32(412))];
+  let ptr124: ptr<private, f16> = &vp4.whole;
+  let ptr125 = &vp3;
+  let vf74: vec3h = vf72;
+  vp3 = modf(vec3f(f32(pack4x8unorm(vec4f(unconst_f32(0.2733), unconst_f32(0.1803), unconst_f32(0.03683), unconst_f32(0.08377))))));
+  vp4 = modf(vec3h(vp3.whole)[2]);
+  var vf75: vec4f = unpack4x8unorm(countLeadingZeros(vec4u(unconst_u32(357), unconst_u32(16), unconst_u32(409), unconst_u32(472)))[0]);
+  let ptr126: ptr<private, vec3f> = &(*ptr125).fract;
+  let vf76: vec3h = fma(vec3h(unconst_f16(1484.8), unconst_f16(546.3), unconst_f16(-6845.8)), vec3h(unconst_f16(265.5), unconst_f16(757.3), unconst_f16(15853.5)), vec3h(unconst_f16(42081.3), unconst_f16(2658.6), unconst_f16(17192.4)));
+  vp5 = modf(unpack2x16unorm(pack4x8unorm(vec4f(unconst_f32(0.2641), unconst_f32(0.1806), unconst_f32(-0.02485), unconst_f32(0.08763)))));
+  vp4.whole = vec3h((*ptr126)).x;
+  var vf77: u32 = pack4x8unorm(vec4f(unconst_f32(0.02717), unconst_f32(0.08944), unconst_f32(0.1166), unconst_f32(0.4499)));
+  vp4.whole *= vec3h(vp3.whole).y;
+  var vf78: f32 = (*ptr123)[u32(unconst_u32(11))];
+  vp3 = modf(vec3f(vf72));
+  let ptr127: ptr<private, vec3f> = &(*ptr123);
+  vf78 = f32((*ptr124));
+  let vf79: u32 = dot(vec4u(unconst_u32(39), unconst_u32(123), unconst_u32(22), unconst_u32(159)), vec4u(unconst_u32(29), unconst_u32(155), unconst_u32(5), unconst_u32(479)));
+  let ptr128: ptr<private, vec3f> = &(*ptr125).fract;
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw29: atomic<i32>;
+
+var<private> vp3 = modf(vec3f(0.3836, 0.2336, 0.1212));
+
+fn fn2(a0: array<array<FragmentOutput7, 1>, 11>) {
+  var vf80: array<FragmentOutput7, 1> = a0[u32(unconst_u32(24))];
+  vp3 = modf(bitcast<vec3f>(vf80[u32(unconst_u32(39))].f0.gab));
+  fn1();
+  atomicSub(&vw29, i32(unconst_i32(56)));
+  atomicAdd(&vw29, i32(unconst_i32(92)));
+  var vf81 = fn1();
+  atomicMax(&vw29, i32(unconst_i32(345)));
+  var vf82 = fn1();
+  fn1();
+  fn1();
+  vw28[u32(unconst_u32(307))] = S6(vec4u(sinh(vec4h(unconst_f16(2083.5), unconst_f16(18111.1), unconst_f16(16918.0), unconst_f16(9951.8))))[3]);
+  atomicMax(&buffer158[u32(unconst_u32(68))], u32(unconst_u32(245)));
+  vw28[u32(unconst_u32(44))] = (*&vw28)[53];
+  atomicMin(&vw29, i32(unconst_i32(43)));
+  vf81[u32(unconst_u32(78))] += mat2x2f(bitcast<f32>(atomicLoad(&buffer158[u32(unconst_u32(49))])), f32(atomicLoad(&buffer158[u32(unconst_u32(49))])), f32(atomicLoad(&buffer158[u32(unconst_u32(49))])), bitcast<f32>(atomicLoad(&buffer158[u32(unconst_u32(49))])));
+  vp3.fract = vec3f(f32(vw28[53].f0));
+  fn0();
+  let ptr129: ptr<function, vec4i> = &vf80[0].f0;
+  vp5.whole *= bitcast<vec2f>(a0[10][0].f0.yy);
+  var vf83: FragmentOutput7 = a0[u32(unconst_u32(30))][0];
+  var vf84: vec4i = a0[10][0].f0;
+  fn1();
+  _ = buffer158;
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct S6 {
+  @builtin(sample_index) f0: u32,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@group(0) @binding(32) var<storage, read_write> buffer158: array<atomic<u32>, 21>;
+
+var<private> vp5 = modf(vec2f(-0.06465, 0.2954));
+
+struct VertexOutput4 {
+  @invariant @builtin(position) f8: vec4f,
+}
+
+var<workgroup> vw28: array<S6, 54>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn fn1() -> array<mat2x2f, 1> {
+  var out: array<mat2x2f, 1>;
+  fn0();
+  fn0();
+  return out;
+}
+
+@vertex
+fn vertex5(@location(4) @interpolate(linear) a0: f32, @location(10) @interpolate(flat, sample) a1: vec2f, @location(7) @interpolate(flat) a2: vec2u, @location(14) @interpolate(flat, center) a3: vec2h) -> VertexOutput4 {
+  var out: VertexOutput4;
+  var vf85: f16 = a3[u32(unconst_u32(21))];
+  vp5 = modf(vec2f(f32(a3[u32(unconst_u32(38))])));
+  fn0();
+  vp4 = modf(f16(a1[1]));
+  var vf86: vec3f = tan(vec3f(unconst_f32(0.07086), unconst_f32(0.05359), unconst_f32(0.3532)));
+  return out;
+}
+
+@fragment
+fn fragment7(a0: S6) -> FragmentOutput7 {
+  var out: FragmentOutput7;
+  var vf87 = fn1();
+  let ptr130 = &vp4;
+  let vf88: f16 = atanh(f16(unconst_f16(20.39)));
+  vp3.whole *= vec3f(sqrt(vec3h(unconst_f16(7371.0), unconst_f16(1329.8), unconst_f16(3163.4))));
+  vp4 = modf(vp4.fract);
+  vp4.fract *= trunc(vec2h(unconst_f16(12208.0), unconst_f16(6791.5))).x;
+  vp5.whole *= vec2f(vf87[u32(unconst_u32(175))][u32(unconst_u32(14))][u32(unconst_u32(73))]);
+  fn0();
+  fn0();
+  let vf89: vec2i = sign(vec2i(unconst_i32(277), unconst_i32(33)));
+  fn0();
+  return out;
+}
+
+@compute @workgroup_size(2, 2, 2)
+fn compute8() {
+  fn2(array<array<FragmentOutput7, 1>, 11>(array<FragmentOutput7, 1>(FragmentOutput7(vec4i(i32(vp4.fract)))), array<FragmentOutput7, 1>(FragmentOutput7(vec4i(i32(vp4.fract)))), array<FragmentOutput7, 1>(FragmentOutput7(vec4i(i32(vp4.fract)))), array<FragmentOutput7, 1>(FragmentOutput7(vec4i(i32(vp4.fract)))), array<FragmentOutput7, 1>(FragmentOutput7(vec4i(i32(vp4.fract)))), array<FragmentOutput7, 1>(FragmentOutput7(vec4i(i32(vp4.fract)))), array<FragmentOutput7, 1>(FragmentOutput7(vec4i(i32(vp4.fract)))), array<FragmentOutput7, 1>(FragmentOutput7(vec4i(i32(vp4.fract)))), array<FragmentOutput7, 1>(FragmentOutput7(vec4i(i32(vp4.fract)))), array<FragmentOutput7, 1>(FragmentOutput7(vec4i(i32(vp4.fract)))), array<FragmentOutput7, 1>(FragmentOutput7(vec4i(i32(vp4.fract))))));
+  vp4.whole *= f16(atomicLoad(&(*&buffer158)[u32(unconst_u32(54))]));
+  fn1();
+  fn0();
+  let ptr131: ptr<workgroup, S6> = &(*&vw28)[53];
+  let vf90: u32 = pack2x16float(vec2f(unconst_f32(0.2934), unconst_f32(0.1256)));
+  let ptr132: ptr<workgroup, S6> = &vw28[u32(unconst_u32(48))];
+  fn2(array<array<FragmentOutput7, 1>, 11>(array<FragmentOutput7, 1>(FragmentOutput7(unpack4xI8((*&vw28)[u32(unconst_u32(419))].f0))), array<FragmentOutput7, 1>(FragmentOutput7(unpack4xI8((*&vw28)[u32(unconst_u32(419))].f0))), array<FragmentOutput7, 1>(FragmentOutput7(unpack4xI8((*&vw28)[u32(unconst_u32(419))].f0))), array<FragmentOutput7, 1>(FragmentOutput7(unpack4xI8((*&vw28)[u32(unconst_u32(419))].f0))), array<FragmentOutput7, 1>(FragmentOutput7(unpack4xI8((*&vw28)[u32(unconst_u32(419))].f0))), array<FragmentOutput7, 1>(FragmentOutput7(vec4i(bitcast<i32>((*&vw28)[u32(unconst_u32(419))].f0)))), array<FragmentOutput7, 1>(FragmentOutput7(vec4i(i32((*&vw28)[u32(unconst_u32(419))].f0)))), array<FragmentOutput7, 1>(FragmentOutput7(unpack4xI8((*&vw28)[u32(unconst_u32(419))].f0))), array<FragmentOutput7, 1>(FragmentOutput7(unpack4xI8((*&vw28)[u32(unconst_u32(419))].f0))), array<FragmentOutput7, 1>(FragmentOutput7(unpack4xI8((*&vw28)[u32(unconst_u32(419))].f0))), array<FragmentOutput7, 1>(FragmentOutput7(unpack4xI8((*&vw28)[u32(unconst_u32(419))].f0)))));
+  let ptr133: ptr<workgroup, u32> = &(*&vw28)[53].f0;
+  fn1();
+  let vf91: u32 = vf90;
+  vw28[u32(unconst_u32(53))] = S6((*ptr132).f0);
+  vp4.fract = f16((*ptr131).f0);
+  var vf92 = fn1();
+  vp5.fract = vec2f(faceForward(bitcast<vec2h>(vw28[u32(unconst_u32(82))].f0), vec2h(unconst_f16(1820.6), unconst_f16(-16148.1)), vec2h(unconst_f16(4733.6), unconst_f16(2666.0))));
+  let vf93: u32 = atomicLoad(&(*&buffer158)[20]);
+  vf92[u32(unconst_u32(35))] += mat2x2f(step(f32(unconst_f32(0.3809)), f32(unconst_f32(0.3053))), step(f32(unconst_f32(0.3809)), f32(unconst_f32(0.3053))), step(f32(unconst_f32(0.3809)), f32(unconst_f32(0.3053))), step(f32(unconst_f32(0.3809)), f32(unconst_f32(0.3053))));
+  vp3 = modf(vp3.fract);
+  _ = buffer158;
+}`,
+});
+let buffer159 = device0.createBuffer({
+  size: 5449,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder247 = device0.createCommandEncoder({});
+let renderPassEncoder72 = commandEncoder247.beginRenderPass({
+  colorAttachments: [{view: textureView218, depthSlice: 101, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet15,
+  maxDrawCount: 20965493,
+});
+let sampler170 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 62.66,
+  lodMaxClamp: 77.35,
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder140.setBindGroup(0, bindGroup37, []);
+} catch {}
+try {
+commandEncoder246.copyBufferToBuffer(buffer129, 3524, buffer88, 5640, 688);
+} catch {}
+let commandEncoder248 = device0.createCommandEncoder({});
+let texture246 = device0.createTexture({
+  size: [30, 10, 4],
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView236 = texture4.createView({aspect: 'depth-only', format: 'depth32float', mipLevelCount: 1, arrayLayerCount: 1});
+let renderPassEncoder73 = commandEncoder244.beginRenderPass({
+  colorAttachments: [{view: textureView221, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet4,
+});
+try {
+renderPassEncoder34.setBindGroup(3, bindGroup59);
+} catch {}
+try {
+renderPassEncoder69.setIndexBuffer(buffer88, 'uint32', 772, 2_430);
+} catch {}
+try {
+renderPassEncoder51.setVertexBuffer(5, buffer87, 552, 212);
+} catch {}
+let textureView237 = texture194.createView({aspect: 'depth-only', arrayLayerCount: 1});
+let computePassEncoder202 = commandEncoder248.beginComputePass({});
+try {
+computePassEncoder64.setPipeline(pipeline46);
+} catch {}
+try {
+renderPassEncoder44.executeBundles([renderBundle17]);
+} catch {}
+try {
+renderPassEncoder51.setIndexBuffer(buffer130, 'uint16', 422, 185);
+} catch {}
+let arrayBuffer17 = buffer75.getMappedRange(168, 72);
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture247 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 13},
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder203 = commandEncoder246.beginComputePass({});
+try {
+renderPassEncoder50.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer80, 'uint32', 2_624, 1_413);
+} catch {}
+let pipeline60 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule7, constants: {}}});
+let offscreenCanvas7 = new OffscreenCanvas(70, 77);
+let bindGroup150 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout74,
+  entries: [{binding: 8, resource: {buffer: buffer28, offset: 768}}],
+});
+let commandEncoder249 = device0.createCommandEncoder({});
+try {
+computePassEncoder202.setPipeline(pipeline48);
+} catch {}
+try {
+renderPassEncoder40.setScissorRect(30, 19, 8, 1);
+} catch {}
+let arrayBuffer18 = buffer111.getMappedRange(184, 2104);
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer145, 776, new Float32Array(3710), 484, 104);
+} catch {}
+try {
+if (!arrayBuffer15.detached) { new Uint8Array(arrayBuffer15).fill(0x55); };
+} catch {}
+let texture248 = device0.createTexture({
+  size: {width: 120, height: 40, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView238 = texture135.createView({aspect: 'all', format: 'rgba8sint', mipLevelCount: 1, baseArrayLayer: 0});
+let renderBundleEncoder30 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], stencilReadOnly: true});
+try {
+computePassEncoder122.setBindGroup(0, bindGroup82, new Uint32Array(1414), 277, 0);
+} catch {}
+try {
+computePassEncoder203.setPipeline(pipeline9);
+} catch {}
+try {
+buffer153.unmap();
+} catch {}
+let gpuCanvasContext11 = offscreenCanvas7.getContext('webgpu');
+let textureView239 = texture102.createView({});
+let computePassEncoder204 = commandEncoder249.beginComputePass({});
+try {
+computePassEncoder139.setBindGroup(1, bindGroup115);
+} catch {}
+try {
+computePassEncoder122.setBindGroup(2, bindGroup115, new Uint32Array(368), 67, 0);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(1, buffer39, 0, 28);
+} catch {}
+let commandEncoder250 = device0.createCommandEncoder({});
+let texture249 = device0.createTexture({
+  size: [2, 2, 13],
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder205 = commandEncoder250.beginComputePass({});
+try {
+renderPassEncoder38.setBindGroup(2, bindGroup12, new Uint32Array(470), 138, 0);
+} catch {}
+try {
+renderBundleEncoder30.setIndexBuffer(buffer28, 'uint32', 1_672, 1_104);
+} catch {}
+let img5 = await imageWithData(71, 16, '#10101010', '#20202020');
+let imageBitmap9 = await createImageBitmap(videoFrame16);
+let commandEncoder251 = device0.createCommandEncoder();
+let textureView240 = texture249.createView({dimension: '2d-array', aspect: 'all', baseArrayLayer: 1, arrayLayerCount: 1});
+let computePassEncoder206 = commandEncoder251.beginComputePass({});
+let renderBundle30 = renderBundleEncoder30.finish({});
+let sampler171 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 88.91});
+try {
+computePassEncoder68.setBindGroup(0, bindGroup67, new Uint32Array(331), 8, 0);
+} catch {}
+try {
+computePassEncoder206.setPipeline(pipeline42);
+} catch {}
+try {
+renderPassEncoder56.beginOcclusionQuery(3);
+} catch {}
+try {
+renderPassEncoder56.endOcclusionQuery();
+} catch {}
+let img6 = await imageWithData(11, 7, '#10101010', '#20202020');
+try {
+externalTexture23.label = '\u0749\u{1fbab}\u2b0a\u27d1\u08db\u7b58\u0eac\u{1fa9c}\u{1fe9c}';
+} catch {}
+let recycledExplicitBindGroupLayout19 = pipeline5.getBindGroupLayout(0);
+let bindGroup151 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout0,
+  entries: [{binding: 396, resource: {buffer: buffer15, offset: 19200, size: 8480}}],
+});
+let buffer160 = device0.createBuffer({size: 4045, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.VERTEX});
+try {
+{ clearResourceUsages(device0, computePassEncoder68); computePassEncoder68.dispatchWorkgroups(2); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder68); computePassEncoder68.dispatchWorkgroupsIndirect(buffer140, 1_092); };
+} catch {}
+try {
+computePassEncoder204.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup126, new Uint32Array(148), 41, 0);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer53, 'uint16', 7_874, 90);
+} catch {}
+try {
+renderPassEncoder48.setVertexBuffer(0, buffer70);
+} catch {}
+try {
+computePassEncoder145.pushDebugGroup('\u0701');
+} catch {}
+let veryExplicitBindGroupLayout32 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 6,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder252 = device0.createCommandEncoder({});
+try {
+renderPassEncoder51.setBindGroup(2, bindGroup92);
+} catch {}
+try {
+renderPassEncoder71.setBindGroup(0, bindGroup118, new Uint32Array(28), 2, 0);
+} catch {}
+try {
+commandEncoder252.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 400 */
+  offset: 400,
+  rowsPerImage: 2411,
+  buffer: buffer27,
+}, {
+  texture: texture249,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1702, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData14,
+  origin: { x: 1, y: 0 },
+  flipY: true,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 19, y: 20, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+externalTexture32.label = '\u3a5c\u01e3\u0800';
+} catch {}
+let commandEncoder253 = device0.createCommandEncoder({});
+let renderPassEncoder74 = commandEncoder252.beginRenderPass({
+  colorAttachments: [{
+  view: textureView221,
+  clearValue: { r: -511.1, g: 952.8, b: 551.3, a: -186.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let sampler172 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 60.84,
+  lodMaxClamp: 98.97,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder68); computePassEncoder68.dispatchWorkgroups(1); };
+} catch {}
+try {
+commandEncoder253.copyBufferToBuffer(buffer89, 104, buffer112, 156, 112);
+} catch {}
+let textureView241 = texture220.createView({});
+let computePassEncoder207 = commandEncoder253.beginComputePass({});
+try {
+computePassEncoder174.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+computePassEncoder205.setPipeline(pipeline6);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let recycledExplicitBindGroupLayout20 = pipeline21.getBindGroupLayout(1);
+let buffer161 = device0.createBuffer({
+  size: 18977,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView242 = texture117.createView({dimension: '2d-array'});
+try {
+renderPassEncoder70.setBindGroup(1, bindGroup53);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(3, bindGroup53, new Uint32Array(114), 75, 0);
+} catch {}
+try {
+renderPassEncoder44.setScissorRect(28, 36, 11, 2);
+} catch {}
+let bindGroup152 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout88,
+  entries: [{binding: 8, resource: {buffer: buffer145, offset: 2560}}],
+});
+let texture250 = device0.createTexture({
+  size: {width: 60},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView243 = texture61.createView({dimension: 'cube-array', mipLevelCount: 1, arrayLayerCount: 6});
+let sampler173 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'repeat', lodMinClamp: 79.91, lodMaxClamp: 96.54});
+try {
+{ clearResourceUsages(device0, computePassEncoder68); computePassEncoder68.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder47.setIndexBuffer(buffer94, 'uint32', 220, 16);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+document.body.append(img1);
+let veryExplicitBindGroupLayout33 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 43,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8uint', access: 'read-only', viewDimension: '3d' },
+    },
+    {binding: 216, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let textureView244 = texture53.createView({aspect: 'all'});
+try {
+computePassEncoder126.setBindGroup(1, bindGroup45, new Uint32Array(481), 31, 0);
+} catch {}
+try {
+renderPassEncoder53.setVertexBuffer(3, buffer145, 0, 553);
+} catch {}
+let canvas5 = document.createElement('canvas');
+let bindGroup153 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout62,
+  entries: [{binding: 8, resource: {buffer: buffer137, offset: 3072, size: 144}}],
+});
+let commandEncoder254 = device0.createCommandEncoder({});
+let texture251 = device0.createTexture({
+  size: {width: 120, height: 40, depthOrArrayLayers: 147},
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder208 = commandEncoder254.beginComputePass({});
+try {
+computePassEncoder75.setBindGroup(2, bindGroup64, new Uint32Array(1174), 316, 0);
+} catch {}
+try {
+computePassEncoder68.end();
+} catch {}
+try {
+renderPassEncoder68.setBindGroup(0, bindGroup143);
+} catch {}
+try {
+commandEncoder80.copyBufferToTexture({
+  /* bytesInLastRow: 144 widthInBlocks: 36 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3360 */
+  offset: 3360,
+  bytesPerRow: 33280,
+  buffer: buffer156,
+}, {
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 7, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 36, height: 9, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder55.insertDebugMarker('\u88f1');
+} catch {}
+let commandBuffer18 = commandEncoder80.finish();
+try {
+computePassEncoder160.setBindGroup(1, bindGroup151, new Uint32Array(556), 23, 0);
+} catch {}
+try {
+computePassEncoder207.setPipeline(pipeline21);
+} catch {}
+try {
+computePassEncoder145.popDebugGroup();
+} catch {}
+try {
+computePassEncoder116.insertDebugMarker('\u07bd');
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer18]);
+} catch {}
+let pipeline61 = device0.createComputePipeline({layout: pipelineLayout4, compute: {module: shaderModule2, constants: {override4: 0}}});
+let buffer162 = device0.createBuffer({
+  size: 3795,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView245 = texture228.createView({dimension: 'cube-array', arrayLayerCount: 6});
+let textureView246 = texture248.createView({mipLevelCount: 1});
+try {
+computePassEncoder186.setBindGroup(0, bindGroup20, new Uint32Array(3548), 237, 0);
+} catch {}
+try {
+computePassEncoder208.setPipeline(pipeline53);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(2, bindGroup153, new Uint32Array(337), 93, 0);
+} catch {}
+try {
+renderPassEncoder26.setViewport(3.1540063997037926, 18.275376882850395, 29.594964740249768, 1.7233750903226968, 0.514629271494298, 0.779055612738637);
+} catch {}
+let texture252 = device0.createTexture({
+  size: {width: 240, height: 80, depthOrArrayLayers: 1},
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+computePassEncoder126.setBindGroup(3, bindGroup119);
+} catch {}
+try {
+computePassEncoder90.setBindGroup(2, bindGroup43, new Uint32Array(3770), 371, 0);
+} catch {}
+try {
+renderPassEncoder66.setBindGroup(1, bindGroup100);
+} catch {}
+try {
+buffer152.unmap();
+} catch {}
+let commandEncoder255 = device0.createCommandEncoder();
+let texture253 = device0.createTexture({
+  size: [240, 80, 61],
+  sampleCount: 1,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder75 = commandEncoder255.beginRenderPass({
+  colorAttachments: [{
+  view: textureView221,
+  clearValue: { r: -341.2, g: 298.3, b: 338.4, a: 241.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let sampler174 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 12,
+});
+try {
+device0.queue.writeBuffer(buffer110, 4976, new BigUint64Array(17217), 3207, 276);
+} catch {}
+let bindGroup154 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout45,
+  entries: [{binding: 8, resource: {buffer: buffer19, offset: 1280}}],
+});
+let querySet34 = device0.createQuerySet({type: 'occlusion', count: 1261});
+let externalTexture36 = device0.importExternalTexture({source: videoFrame3});
+try {
+renderPassEncoder58.setIndexBuffer(buffer162, 'uint32', 884, 81);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline26);
+} catch {}
+await gc();
+try {
+canvas5.getContext('webgl');
+} catch {}
+let autogeneratedBindGroupLayout92 = pipeline3.getBindGroupLayout(0);
+let bindGroup155 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout65,
+  entries: [{binding: 8, resource: {buffer: buffer162, offset: 0, size: 532}}],
+});
+let textureView247 = texture248.createView({mipLevelCount: 1});
+let renderBundleEncoder31 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8sint'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler175 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  lodMinClamp: 70.55,
+  lodMaxClamp: 87.59,
+});
+try {
+computePassEncoder38.setBindGroup(3, bindGroup131);
+} catch {}
+try {
+computePassEncoder191.setBindGroup(2, bindGroup46, new Uint32Array(2522), 338, 0);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.append(canvas4);
+let veryExplicitBindGroupLayout34 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 104,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 643,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let texture254 = device0.createTexture({
+  size: {width: 30},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+try {
+computePassEncoder89.setBindGroup(0, bindGroup131);
+} catch {}
+try {
+renderPassEncoder53.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder43.setBlendConstant({ r: 937.4, g: -936.7, b: -428.4, a: -942.3, });
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(1, bindGroup140);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(6, buffer153);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer84, 1388, new DataView(new ArrayBuffer(9344)), 3926, 1500);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let veryExplicitBindGroupLayout35 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 6,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let recycledExplicitBindGroupLayout21 = pipeline46.getBindGroupLayout(0);
+let commandEncoder256 = device0.createCommandEncoder({});
+try {
+computePassEncoder186.setBindGroup(0, bindGroup93);
+} catch {}
+try {
+computePassEncoder21.setBindGroup(0, bindGroup148, new Uint32Array(2378), 418, 0);
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(3, bindGroup55);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle18, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer46, 0, 684);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(1, bindGroup129, new Uint32Array(4511), 742, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer24, 1040, new BigUint64Array(7070), 811, 1688);
+} catch {}
+document.body.append(img4);
+let texture255 = device0.createTexture({
+  size: [2],
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder209 = commandEncoder256.beginComputePass();
+try {
+renderPassEncoder27.setIndexBuffer(buffer94, 'uint16', 10, 257);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(buffer146, 'uint32', 940, 20);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(0, buffer160, 1_148);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let bindGroup156 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout33,
+  entries: [{binding: 43, resource: textureView110}, {binding: 216, resource: externalTexture24}],
+});
+let commandEncoder257 = device0.createCommandEncoder({});
+let querySet35 = device0.createQuerySet({type: 'occlusion', count: 501});
+let renderBundle31 = renderBundleEncoder31.finish({});
+try {
+renderPassEncoder23.setBindGroup(3, bindGroup89, new Uint32Array(1121), 234, 0);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle31, renderBundle16, renderBundle20, renderBundle9, renderBundle2, renderBundle20, renderBundle5, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder56.setVertexBuffer(6, buffer34, 2_752, 1_214);
+} catch {}
+try {
+  await buffer141.mapAsync(GPUMapMode.READ);
+} catch {}
+document.body.append(canvas0);
+let recycledAutogeneratedBindGroupLayout5 = pipeline30.getBindGroupLayout(0);
+let buffer163 = device0.createBuffer({
+  size: 2309,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let texture256 = gpuCanvasContext2.getCurrentTexture();
+let textureView248 = texture221.createView({dimension: '2d-array', format: 'rgba8sint', baseMipLevel: 0});
+let computePassEncoder210 = commandEncoder257.beginComputePass();
+try {
+computePassEncoder209.setPipeline(pipeline35);
+} catch {}
+let autogeneratedBindGroupLayout93 = pipeline14.getBindGroupLayout(0);
+let bindGroup157 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout80,
+  entries: [{binding: 8, resource: {buffer: buffer125, offset: 0, size: 3120}}],
+});
+try {
+computePassEncoder116.setBindGroup(1, bindGroup93);
+} catch {}
+try {
+computePassEncoder210.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup98, new Uint32Array(1610), 315, 0);
+} catch {}
+try {
+renderPassEncoder60.setIndexBuffer(buffer94, 'uint16', 76, 58);
+} catch {}
+document.body.prepend(img6);
+let recycledExplicitBindGroupLayout22 = pipeline59.getBindGroupLayout(0);
+try {
+renderPassEncoder63.setPipeline(pipeline51);
+} catch {}
+try {
+renderPassEncoder71.insertDebugMarker('\u{1ff86}');
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1702, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData39,
+  origin: { x: 0, y: 6 },
+  flipY: false,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 20, y: 65, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let buffer164 = device0.createBuffer({
+  size: 5539,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder100.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(2, bindGroup94);
+} catch {}
+try {
+renderPassEncoder53.setBindGroup(0, bindGroup50, new Uint32Array(1966), 36, 0);
+} catch {}
+let arrayBuffer19 = buffer65.getMappedRange(1232, 16);
+document.body.append(img5);
+let commandEncoder258 = device0.createCommandEncoder({label: '\u4871\u{1fb5c}\u2152\uc395\u199c'});
+let computePassEncoder211 = commandEncoder258.beginComputePass({});
+try {
+computePassEncoder187.setBindGroup(2, bindGroup121);
+} catch {}
+try {
+computePassEncoder211.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(6, buffer123, 440);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer84, 732, new BigUint64Array(170), 11, 4);
+} catch {}
+let pipeline62 = device0.createComputePipeline({
+  layout: pipelineLayout10,
+  compute: {module: shaderModule6, entryPoint: 'compute7', constants: {46_193: 0, override12: 0}},
+});
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+let buffer165 = device0.createBuffer({
+  size: 16568,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder259 = device0.createCommandEncoder();
+let computePassEncoder212 = commandEncoder259.beginComputePass({});
+try {
+renderPassEncoder60.executeBundles([renderBundle17, renderBundle21, renderBundle22]);
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55); };
+} catch {}
+let recycledExplicitBindGroupLayout23 = pipeline52.getBindGroupLayout(0);
+let bindGroup158 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout45,
+  entries: [{binding: 8, resource: {buffer: buffer129, offset: 3072}}],
+});
+let buffer166 = device0.createBuffer({
+  size: 1444,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture257 = gpuCanvasContext3.getCurrentTexture();
+let textureView249 = texture4.createView({dimension: '2d', aspect: 'depth-only', mipLevelCount: 1});
+try {
+computePassEncoder212.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(7, buffer15, 13_980);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+document.body.prepend(canvas3);
+let bindGroup159 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout75,
+  entries: [{binding: 8, resource: {buffer: buffer23, offset: 768, size: 848}}],
+});
+let commandEncoder260 = device0.createCommandEncoder({});
+let textureView250 = texture227.createView({});
+let computePassEncoder213 = commandEncoder260.beginComputePass({});
+try {
+computePassEncoder213.setPipeline(pipeline62);
+} catch {}
+let videoFrame37 = new VideoFrame(videoFrame16, {timestamp: 0});
+let texture258 = device0.createTexture({
+  size: {width: 240, height: 80, depthOrArrayLayers: 294},
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder49.beginOcclusionQuery(139);
+} catch {}
+try {
+renderPassEncoder49.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder43.setIndexBuffer(buffer28, 'uint16', 506, 138);
+} catch {}
+try {
+computePassEncoder64.insertDebugMarker('\u{1fabf}');
+} catch {}
+try {
+renderPassEncoder30.insertDebugMarker('\uabb1');
+} catch {}
+let pipeline63 = await device0.createRenderPipelineAsync({
+  label: '\ud9db\u2588\u0f89\u4713\u0e8d\u0d3e\u0c1d\uc046\u030a\u{1f65f}',
+  layout: pipelineLayout10,
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment6',
+  constants: {override12: 0},
+  targets: [{format: 'rgba16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}],
+},
+  vertex: {module: shaderModule0, buffers: []},
+  primitive: {topology: 'line-list', cullMode: 'front'},
+});
+let autogeneratedBindGroupLayout94 = pipeline0.getBindGroupLayout(0);
+let commandEncoder261 = device0.createCommandEncoder({});
+let texture259 = device0.createTexture({size: [240, 80, 62], format: 'rgb10a2uint', usage: GPUTextureUsage.COPY_DST});
+let computePassEncoder214 = commandEncoder261.beginComputePass({});
+let renderBundleEncoder32 = device0.createRenderBundleEncoder({colorFormats: ['rgba16sint'], depthReadOnly: true, stencilReadOnly: true});
+let sampler176 = device0.createSampler({addressModeU: 'repeat'});
+try {
+computePassEncoder214.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup138, []);
+} catch {}
+try {
+renderPassEncoder68.setIndexBuffer(buffer123, 'uint16', 70, 1_203);
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(3, bindGroup123, []);
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(1, bindGroup127, new Uint32Array(532), 26, 0);
+} catch {}
+try {
+renderBundleEncoder32.setPipeline(pipeline63);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer135, 15324, new Float32Array(1671), 202, 224);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture143,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(146).fill(164), /* required buffer size: 146 */
+{offset: 146, bytesPerRow: 91}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData40 = new ImageData(4, 72);
+try {
+adapter0.label = '\u0012\u26e1\u{1faa6}\u006b\u{1f6d1}';
+} catch {}
+let textureView251 = texture22.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 5});
+try {
+computePassEncoder149.setBindGroup(2, bindGroup30);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup88, new Uint32Array(1510), 80, 0);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer164, 'uint32', 1_304, 464);
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(2, bindGroup52);
+} catch {}
+let sampler177 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 39.94,
+  compare: 'not-equal',
+  maxAnisotropy: 14,
+});
+try {
+renderPassEncoder32.setBindGroup(1, bindGroup159, []);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(3, bindGroup131, new Uint32Array(2628), 1_319, 0);
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(1, bindGroup149, new Uint32Array(5113), 357, 0);
+} catch {}
+try {
+buffer134.unmap();
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let commandEncoder262 = device0.createCommandEncoder({});
+let texture260 = device0.createTexture({
+  size: [120, 40, 179],
+  mipLevelCount: 2,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder76 = commandEncoder262.beginRenderPass({
+  colorAttachments: [{
+  view: textureView218,
+  depthSlice: 201,
+  clearValue: { r: 962.5, g: 164.2, b: -55.56, a: -685.5, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder51.setVertexBuffer(6, buffer69, 172, 9);
+} catch {}
+try {
+renderBundleEncoder32.setIndexBuffer(buffer112, 'uint16', 360, 867);
+} catch {}
+try {
+computePassEncoder191.insertDebugMarker('\u1f41');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(81).fill(36), /* required buffer size: 81 */
+{offset: 81, bytesPerRow: 31}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let texture261 = device0.createTexture({
+  size: [240, 80, 28],
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler178 = device0.createSampler({compare: 'not-equal', maxAnisotropy: 1});
+try {
+computePassEncoder199.setBindGroup(1, bindGroup86, new Uint32Array(580), 20, 0);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(0, bindGroup133);
+} catch {}
+try {
+renderPassEncoder42.setIndexBuffer(buffer137, 'uint32', 3_104, 4_741);
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(1, bindGroup112, new Uint32Array(2370), 8, 0);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let renderBundleEncoder33 = device0.createRenderBundleEncoder({colorFormats: ['rg32sint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderBundleEncoder32.setIndexBuffer(buffer94, 'uint16', 2, 131);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let buffer167 = device0.createBuffer({
+  size: 6094,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let renderBundle32 = renderBundleEncoder32.finish({});
+let sampler179 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  lodMaxClamp: 92.66,
+  compare: 'less',
+});
+let externalTexture37 = device0.importExternalTexture({source: videoFrame3, colorSpace: 'display-p3'});
+try {
+renderPassEncoder50.setBindGroup(1, bindGroup57);
+} catch {}
+try {
+renderPassEncoder66.setBindGroup(3, bindGroup54, new Uint32Array(5981), 86, 0);
+} catch {}
+try {
+renderPassEncoder60.setIndexBuffer(buffer89, 'uint16', 284, 86);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(3, buffer46, 0, 805);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(1, buffer82, 1_004);
+} catch {}
+let buffer168 = device0.createBuffer({
+  size: 2295,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder97.setBindGroup(0, bindGroup146);
+} catch {}
+try {
+computePassEncoder144.setBindGroup(0, bindGroup5, new Uint32Array(255), 2, 0);
+} catch {}
+try {
+renderPassEncoder64.setIndexBuffer(buffer168, 'uint32', 28, 384);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(6, buffer112);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer30, 828, new BigUint64Array(9208), 2962, 48);
+} catch {}
+let recycledExplicitBindGroupLayout24 = pipeline15.getBindGroupLayout(0);
+let texture262 = device0.createTexture({
+  size: {width: 60, height: 20, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder68.setIndexBuffer(buffer82, 'uint16', 194, 220);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer107, 'uint16', 122, 51);
+} catch {}
+let arrayBuffer20 = buffer111.getMappedRange(2512, 72);
+let pipelineLayout18 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout21]});
+let externalTexture38 = device0.importExternalTexture({source: videoFrame18});
+try {
+computePassEncoder143.setBindGroup(1, bindGroup20);
+} catch {}
+try {
+renderPassEncoder58.executeBundles([renderBundle5, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder27.setViewport(175.57896649810348, 50.827040524040505, 41.69992417942854, 4.610636438455123, 0.4087010392003627, 0.9707786587397965);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(3, buffer26, 24, 1_449);
+} catch {}
+try {
+computePassEncoder160.insertDebugMarker('\u0cd5');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture156,
+  mipLevel: 1,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(237).fill(155), /* required buffer size: 237 */
+{offset: 237, bytesPerRow: 22}, {width: 4, height: 6, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+let commandEncoder263 = device0.createCommandEncoder({});
+let textureView252 = texture27.createView({dimension: '2d-array', aspect: 'depth-only', mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder215 = commandEncoder263.beginComputePass({});
+try {
+computePassEncoder124.setBindGroup(3, bindGroup138);
+} catch {}
+try {
+renderPassEncoder62.setStencilReference(1026);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1702, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData2,
+  origin: { x: 1, y: 0 },
+  flipY: false,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 52, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let autogeneratedBindGroupLayout95 = pipeline14.getBindGroupLayout(0);
+let textureView253 = texture215.createView({format: 'rg32sint'});
+try {
+computePassEncoder215.setPipeline(pipeline53);
+} catch {}
+try {
+renderPassEncoder60.setBlendConstant({ r: 897.3, g: -34.76, b: -572.0, a: 584.2, });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer160, 524, new DataView(new ArrayBuffer(19795)), 5250, 196);
+} catch {}
+try {
+adapter0.label = '\u0796\uc497\u5d69\ucd93\u2dc8';
+} catch {}
+let commandEncoder264 = device0.createCommandEncoder();
+try {
+renderBundleEncoder33.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(0, bindGroup82, new Uint32Array(1760), 556, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture204,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(6).fill(10), /* required buffer size: 6 */
+{offset: 6, bytesPerRow: 106}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer169 = device0.createBuffer({size: 20363, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let computePassEncoder216 = commandEncoder264.beginComputePass({});
+try {
+computePassEncoder199.setBindGroup(1, bindGroup108, []);
+} catch {}
+try {
+computePassEncoder216.setPipeline(pipeline31);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(2, bindGroup133);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(0, bindGroup112, new Uint32Array(1179), 115, 0);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(2, bindGroup43, new Uint32Array(630), 21, 0);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(0, buffer8, 0, 488);
+} catch {}
+try {
+renderPassEncoder57.pushDebugGroup('\u006c');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append(canvas3);
+let commandEncoder265 = device0.createCommandEncoder();
+let computePassEncoder217 = commandEncoder265.beginComputePass();
+let renderBundle33 = renderBundleEncoder33.finish({});
+try {
+renderPassEncoder68.setBindGroup(0, bindGroup142, new Uint32Array(509), 225, 0);
+} catch {}
+try {
+renderPassEncoder45.setIndexBuffer(buffer166, 'uint32', 0, 101);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55); };
+} catch {}
+document.body.prepend(img6);
+let recycledExplicitBindGroupLayout25 = pipeline41.getBindGroupLayout(0);
+let buffer170 = device0.createBuffer({
+  size: 3052,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+try {
+computePassEncoder105.setBindGroup(3, bindGroup15, new Uint32Array(3550), 1_227, 0);
+} catch {}
+try {
+computePassEncoder217.setPipeline(pipeline53);
+} catch {}
+try {
+renderPassEncoder52.setStencilReference(12);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder109.setBindGroup(1, bindGroup74);
+} catch {}
+try {
+computePassEncoder105.setBindGroup(0, bindGroup142, new Uint32Array(5422), 1_131, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder105); computePassEncoder105.dispatchWorkgroupsIndirect(buffer38, 2_236); };
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(1, bindGroup99, new Uint32Array(3703), 345, 0);
+} catch {}
+let buffer171 = device0.createBuffer({
+  size: 3763,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE,
+});
+let textureView254 = texture26.createView({baseArrayLayer: 3, arrayLayerCount: 1});
+try {
+computePassEncoder87.setBindGroup(1, bindGroup85);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 192, y: 10, z: 0},
+  aspect: 'all',
+}, new Uint8Array(165).fill(110), /* required buffer size: 165 */
+{offset: 165, bytesPerRow: 134}, {width: 33, height: 10, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder266 = device0.createCommandEncoder({});
+let computePassEncoder218 = commandEncoder266.beginComputePass();
+try {
+computePassEncoder82.setBindGroup(2, bindGroup80, new Uint32Array(988), 288, 0);
+} catch {}
+try {
+computePassEncoder218.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder53.executeBundles([renderBundle2, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer119, 'uint32', 1_288, 756);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline24);
+} catch {}
+try {
+computePassEncoder26.pushDebugGroup('\u{1f8e3}');
+} catch {}
+let img7 = await imageWithData(31, 51, '#10101010', '#20202020');
+let texture263 = device0.createTexture({
+  size: [240, 80, 294],
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder34 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint']});
+try {
+renderPassEncoder70.setIndexBuffer(buffer168, 'uint32', 252, 141);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(3, bindGroup49, new Uint32Array(2888), 1_196, 0);
+} catch {}
+try {
+renderBundleEncoder34.setIndexBuffer(buffer29, 'uint16', 98, 6_027);
+} catch {}
+let buffer172 = device0.createBuffer({
+  size: 8018,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let textureView255 = texture124.createView({dimension: '2d', baseMipLevel: 0});
+let renderBundle34 = renderBundleEncoder34.finish();
+try {
+{ clearResourceUsages(device0, computePassEncoder105); computePassEncoder105.dispatchWorkgroupsIndirect(buffer125, 2_588); };
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(2, bindGroup57, new Uint32Array(479), 50, 0);
+} catch {}
+try {
+renderPassEncoder42.setPipeline(pipeline3);
+} catch {}
+let buffer173 = device0.createBuffer({
+  size: 11144,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder267 = device0.createCommandEncoder({});
+let texture264 = device0.createTexture({
+  label: '\u3ab0\ubc33\u2c46\u6538\u0aff',
+  size: {width: 30, height: 10, depthOrArrayLayers: 26},
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder219 = commandEncoder267.beginComputePass({});
+try {
+computePassEncoder219.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(3, bindGroup30, new Uint32Array(4456), 2_539, 0);
+} catch {}
+try {
+renderPassEncoder48.setIndexBuffer(buffer113, 'uint32', 4_464, 6_166);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline44);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(1, buffer129, 0);
+} catch {}
+let recycledExplicitBindGroupLayout26 = pipeline63.getBindGroupLayout(0);
+let renderBundleEncoder35 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], sampleCount: 1, stencilReadOnly: false});
+let sampler180 = device0.createSampler({addressModeU: 'clamp-to-edge', addressModeV: 'mirror-repeat', lodMinClamp: 32.56, lodMaxClamp: 95.80});
+try {
+computePassEncoder73.setBindGroup(3, bindGroup97, new Uint32Array(70), 12, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder105); computePassEncoder105.dispatchWorkgroupsIndirect(buffer166, 28); };
+} catch {}
+try {
+renderPassEncoder64.setBindGroup(2, bindGroup69, new Uint32Array(1135), 13, 0);
+} catch {}
+try {
+buffer75.unmap();
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let buffer174 = device0.createBuffer({size: 1903, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let textureView256 = texture215.createView({aspect: 'all', baseArrayLayer: 0});
+let renderBundle35 = renderBundleEncoder35.finish({});
+try {
+computePassEncoder170.setBindGroup(1, bindGroup92);
+} catch {}
+try {
+computePassEncoder51.setBindGroup(2, bindGroup64, new Uint32Array(802), 55, 0);
+} catch {}
+let commandEncoder268 = device0.createCommandEncoder({});
+let texture265 = device0.createTexture({
+  size: {width: 120, height: 40, depthOrArrayLayers: 1},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler181 = device0.createSampler({addressModeU: 'mirror-repeat', mipmapFilter: 'nearest', lodMaxClamp: 75.45});
+try {
+renderPassEncoder74.setVertexBuffer(5, buffer15);
+} catch {}
+document.body.prepend(img4);
+let buffer175 = device0.createBuffer({
+  size: 19178,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let textureView257 = texture232.createView({});
+let renderPassEncoder77 = commandEncoder268.beginRenderPass({
+  colorAttachments: [{
+  view: textureView12,
+  depthSlice: 17,
+  clearValue: { r: -351.7, g: -631.0, b: -927.3, a: -214.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {view: textureView169, depthReadOnly: true, stencilReadOnly: true},
+});
+let renderBundleEncoder36 = device0.createRenderBundleEncoder({colorFormats: ['rgba8sint'], depthStencilFormat: 'depth32float', stencilReadOnly: true});
+try {
+computePassEncoder6.setBindGroup(2, bindGroup85, new Uint32Array(1112), 40, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder105); computePassEncoder105.dispatchWorkgroupsIndirect(buffer50, 108); };
+} catch {}
+try {
+computePassEncoder105.end();
+} catch {}
+try {
+renderPassEncoder74.setIndexBuffer(buffer113, 'uint16', 7_738, 5_878);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline44);
+} catch {}
+try {
+renderPassEncoder52.setVertexBuffer(1, undefined, 0, 626_681_415);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(1, bindGroup119, new Uint32Array(6660), 401, 0);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let autogeneratedBindGroupLayout96 = pipeline19.getBindGroupLayout(0);
+let bindGroup160 = device0.createBindGroup({
+  label: '\ue442\u9571\u078b\u{1f71a}\ue440\u4bd3\u06d6\u69d3\u68a1\u37d5',
+  layout: autogeneratedBindGroupLayout92,
+  entries: [{binding: 8, resource: {buffer: buffer154, offset: 1024}}],
+});
+let pipelineLayout19 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout32]});
+try {
+computePassEncoder176.setBindGroup(0, bindGroup115, new Uint32Array(492), 57, 0);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(0, bindGroup125);
+} catch {}
+try {
+renderPassEncoder73.setIndexBuffer(buffer40, 'uint32', 4_756, 10_549);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer171, 'uint16', 492, 128);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1702, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas2,
+  origin: { x: 11, y: 17 },
+  flipY: false,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 488, y: 35, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 4, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let imageData41 = new ImageData(168, 44);
+let bindGroup161 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout21,
+  entries: [{binding: 8, resource: {buffer: buffer66, offset: 256, size: 552}}],
+});
+let computePassEncoder220 = commandEncoder122.beginComputePass({});
+let renderBundle36 = renderBundleEncoder36.finish({});
+let externalTexture39 = device0.importExternalTexture({source: videoFrame24});
+try {
+computePassEncoder100.setBindGroup(0, bindGroup140);
+} catch {}
+try {
+computePassEncoder220.setPipeline(pipeline25);
+} catch {}
+let promise28 = shaderModule5.getCompilationInfo();
+let bindGroup162 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout31,
+  entries: [
+    {binding: 216, resource: textureView92},
+    {binding: 8, resource: {buffer: buffer98, offset: 768, size: 700}},
+  ],
+});
+let textureView258 = texture260.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 22});
+try {
+renderPassEncoder9.beginOcclusionQuery(130);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+let bindGroup163 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout50,
+  entries: [{binding: 8, resource: {buffer: buffer83, offset: 1280, size: 148}}],
+});
+let texture266 = device0.createTexture({
+  size: [2, 2, 13],
+  mipLevelCount: 1,
+  sampleCount: 1,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+try {
+renderPassEncoder39.setIndexBuffer(buffer114, 'uint32', 100, 59);
+} catch {}
+try {
+renderPassEncoder57.popDebugGroup();
+} catch {}
+await gc();
+let bindGroup164 = device0.createBindGroup({
+  label: '\u{1fb05}\u080f\uc865',
+  layout: autogeneratedBindGroupLayout72,
+  entries: [{binding: 8, resource: {buffer: buffer107, offset: 0, size: 100}}],
+});
+let textureView259 = texture136.createView({arrayLayerCount: 1});
+try {
+renderPassEncoder62.setBindGroup(2, bindGroup95);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer60, 388, new Float32Array(6353), 48, 192);
+} catch {}
+let pipeline64 = device0.createRenderPipeline({
+  layout: 'auto',
+  fragment: {module: shaderModule7, targets: [{format: 'rg32sint'}]},
+  vertex: {
+    module: shaderModule5,
+    buffers: [
+      {
+        arrayStride: 880,
+        attributes: [
+          {format: 'snorm16x2', offset: 44, shaderLocation: 14},
+          {format: 'snorm16x2', offset: 244, shaderLocation: 11},
+          {format: 'snorm8x2', offset: 20, shaderLocation: 2},
+          {format: 'float32x3', offset: 8, shaderLocation: 13},
+          {format: 'snorm8x2', offset: 430, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 212,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x2', offset: 142, shaderLocation: 0}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'cw', unclippedDepth: false},
+});
+try {
+  await promise28;
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1702, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 605, y: 7, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline65 = await device0.createComputePipelineAsync({layout: pipelineLayout18, compute: {module: shaderModule4, entryPoint: 'compute4'}});
+let texture267 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 13},
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder183.setBindGroup(1, bindGroup62);
+} catch {}
+try {
+computePassEncoder83.setBindGroup(2, bindGroup91, new Uint32Array(3235), 171, 0);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([renderBundle28]);
+} catch {}
+try {
+renderPassEncoder75.setVertexBuffer(0, buffer80, 0, 65);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let buffer176 = device0.createBuffer({
+  size: 7462,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder269 = device0.createCommandEncoder({});
+let sampler182 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', lodMaxClamp: 85.80});
+try {
+computePassEncoder136.setBindGroup(1, bindGroup52);
+} catch {}
+try {
+computePassEncoder187.setBindGroup(2, bindGroup97, new Uint32Array(785), 1, 0);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(0, bindGroup46);
+} catch {}
+try {
+renderPassEncoder57.setIndexBuffer(buffer98, 'uint16', 618, 218);
+} catch {}
+try {
+renderPassEncoder42.setPipeline(pipeline27);
+} catch {}
+try {
+commandEncoder269.copyBufferToTexture({
+  /* bytesInLastRow: 64 widthInBlocks: 16 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 168 */
+  offset: 168,
+  bytesPerRow: 9472,
+  buffer: buffer87,
+}, {
+  texture: texture104,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 16, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder269.resolveQuerySet(querySet11, 351, 74, buffer74, 256);
+} catch {}
+try {
+computePassEncoder26.popDebugGroup();
+} catch {}
+let autogeneratedBindGroupLayout97 = pipeline22.getBindGroupLayout(0);
+let buffer177 = device0.createBuffer({size: 1319, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+let commandEncoder270 = device0.createCommandEncoder({});
+let texture268 = device0.createTexture({
+  size: [60, 20, 1],
+  mipLevelCount: 2,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView260 = texture79.createView({aspect: 'all'});
+let computePassEncoder221 = commandEncoder269.beginComputePass({});
+try {
+computePassEncoder221.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(2, bindGroup122, new Uint32Array(3552), 919, 0);
+} catch {}
+try {
+renderPassEncoder31.end();
+} catch {}
+try {
+renderPassEncoder39.setScissorRect(35, 2, 62, 21);
+} catch {}
+try {
+commandEncoder270.clearBuffer(buffer13, 628, 6216);
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let imageData42 = new ImageData(68, 80);
+let querySet36 = device0.createQuerySet({type: 'occlusion', count: 778});
+let commandBuffer19 = commandEncoder121.finish();
+let texture269 = device0.createTexture({
+  size: [2, 2, 163],
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder222 = commandEncoder270.beginComputePass({});
+try {
+computePassEncoder70.setBindGroup(2, bindGroup57, []);
+} catch {}
+try {
+computePassEncoder164.setBindGroup(3, bindGroup130, new Uint32Array(1341), 542, 0);
+} catch {}
+try {
+computePassEncoder222.setPipeline(pipeline59);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(3, bindGroup109);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(1, buffer78, 2_112, 177);
+} catch {}
+try {
+buffer27.unmap();
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let veryExplicitBindGroupLayout36 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 5,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba8sint', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 18,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 20,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let bindGroup165 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout64,
+  entries: [{binding: 8, resource: {buffer: buffer8, offset: 1024, size: 720}}],
+});
+let buffer178 = device0.createBuffer({
+  size: 1378,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture270 = device0.createTexture({
+  size: [60, 20, 8],
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder28.setIndexBuffer(buffer171, 'uint16', 20, 1_324);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(7, buffer77, 0);
+} catch {}
+let pipeline66 = device0.createComputePipeline({
+  layout: pipelineLayout18,
+  compute: {module: shaderModule6, entryPoint: 'compute7', constants: {46_193: 0, override12: 0}},
+});
+document.body.prepend(img5);
+let videoFrame38 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'smpteRp431', transfer: 'smpte240m'} });
+let shaderModule8 = device0.createShaderModule({
+  code: `
+requires readonly_and_readwrite_storage_textures;
+
+enable f16;
+
+diagnostic(info, xyz);
+
+var<workgroup> vw36: atomic<u32>;
+
+var<workgroup> vw31: array<array<array<FragmentOutput9, 1>, 1>, 2>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<workgroup> vw35: vec2<bool>;
+
+struct T0 {
+  @size(8) f0: array<u32>,
+}
+
+fn fn0() -> array<vec2i, 17> {
+  var out: array<vec2i, 17>;
+  var vf94: f16 = (*&vw30)[1].f9[u32(unconst_u32(130))];
+  let ptr134: ptr<workgroup, vec2u> = &(*&vw33).f11;
+  let ptr135: ptr<workgroup, vec4i> = &vw31[1][0][u32(unconst_u32(0))].f0;
+  return out;
+}
+
+var<workgroup> vw33: VertexOutput5;
+
+var<workgroup> vw34: FragmentOutput8;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn fn1() -> array<vec4i, 1> {
+  var out: array<vec4i, 1>;
+  let vf95: u32 = pack4xI8Clamp(vec4i(unconst_i32(146), unconst_i32(148), unconst_i32(143), unconst_i32(168)));
+  out[u32(unconst_u32(235))] = vec4i(i32(exp2(f32(unconst_f32(0.05419)))));
+  vp6 &= vec2u(vf95);
+  out[u32(unconst_u32(121))] -= unpack4xI8(vp6[u32(unconst_u32(670))]);
+  let vf96: u32 = pack4xI8Clamp(vec4i(i32(dot(vec4h(unconst_f16(17595.5), unconst_f16(1073.7), unconst_f16(16602.2), unconst_f16(4352.6)), vec4h(unconst_f16(35406.2), unconst_f16(24742.2), unconst_f16(3544.2), unconst_f16(1384.8))))));
+  vp6 ^= vec2u(insertBits(vec3i(unconst_i32(116), unconst_i32(469), unconst_i32(127)), vec3i(unconst_i32(97), unconst_i32(82), unconst_i32(260)), u32(unconst_u32(33)), u32(unconst_u32(8))).zx);
+  let vf97: vec2f = unpack2x16unorm(u32(unconst_u32(27)));
+  let vf98: vec2f = unpack2x16unorm(u32(unconst_u32(231)));
+  var vf99: vec4h = refract(vec4h(unconst_f16(22489.4), unconst_f16(6376.4), unconst_f16(12910.1), unconst_f16(2763.6)), vec4h(unconst_f16(2267.6), unconst_f16(563.7), unconst_f16(4403.4), unconst_f16(16347.9)), f16(unconst_f16(14466.0)));
+  var vf100: vec3f = sinh(vec3f(unconst_f32(0.4962), unconst_f32(0.03385), unconst_f32(0.2184)));
+  var vf101: u32 = pack4xI8Clamp(vec4i(unconst_i32(26), unconst_i32(33), unconst_i32(87), unconst_i32(180)));
+  return out;
+}
+
+struct VertexOutput5 {
+  @location(13) @interpolate(perspective, center) f9: vec4h,
+  @location(15) f10: i32,
+  @location(12) @interpolate(flat, centroid) f11: vec2u,
+  @builtin(position) f12: vec4f,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<private> vp6: vec2u = vec2u(21, 0);
+
+struct FragmentOutput8 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: vec4i,
+}
+
+var<workgroup> vw32: f32;
+
+var<workgroup> vw30: array<VertexOutput5, 2>;
+
+struct FragmentOutput9 {
+  @location(0) @interpolate(flat) f0: vec4i,
+}
+
+@vertex
+fn vertex6(@location(14) a0: vec2i, @location(0) a1: vec2i) -> VertexOutput5 {
+  var out: VertexOutput5;
+  out.f12 -= vec4f(f32(all(bool(unconst_bool(false)))));
+  var vf102: u32 = pack2x16snorm(vec2f(unconst_f32(0.00177), unconst_f32(0.07436)));
+  vf102 <<= bitcast<u32>(max(i32(unconst_i32(53)), i32(unconst_i32(7))));
+  out.f12 -= bitcast<vec4f>(firstTrailingBit(vec3i(a1[u32(unconst_u32(60))])).yyxx);
+  out.f9 = vec4h(f16(all(bool(unconst_bool(true)))));
+  vp6 ^= vec2u(u32(asinh(f32(unconst_f32(0.1087)))));
+  return out;
+}
+
+@fragment
+fn fragment8() -> FragmentOutput8 {
+  var out: FragmentOutput8;
+  out = FragmentOutput8(pack4x8unorm(unpack4x8unorm(u32(unconst_u32(32)))), bitcast<vec4i>(unpack4x8unorm(u32(unconst_u32(32)))));
+  out.f1 = unpack4xI8(pack2x16unorm(vec2f(unconst_f32(0.08222), unconst_f32(0.02175))));
+  out.f1 |= bitcast<vec4i>(vp6.yxyx);
+  return out;
+}
+
+@fragment
+fn fragment9() -> FragmentOutput9 {
+  var out: FragmentOutput9;
+  var vf103: vec2f = unpack2x16snorm(u32(unconst_u32(92)));
+  vp6 += bitcast<vec2u>(unpack2x16snorm(u32(unconst_u32(47))));
+  out.f0 |= vec4i(bitcast<i32>(vp6[vp6.x]));
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute9() {
+  fn0();
+  vw33 = vw30[u32(unconst_u32(184))];
+  vw31[u32(unconst_u32(45))][u32(unconst_u32(62))][u32(unconst_u32(333))] = vw31[u32(vw30[1].f10)][0][u32(unconst_u32(72))];
+  let ptr136: ptr<workgroup, array<FragmentOutput9, 1>> = &(*&vw31)[u32(unconst_u32(1))][0];
+  fn0();
+  atomicCompareExchangeWeak(&vw36, unconst_u32(93), unconst_u32(48));
+  fn1();
+  let ptr137: ptr<workgroup, vec4f> = &vw33.f12;
+  let vf104: i32 = (*ptr136)[0].f0[u32(unconst_u32(33))];
+  var vf105 = fn1();
+  vw34.f1 = bitcast<vec4i>(vw30[u32(unconst_u32(1))].f11.gggg);
+  fn0();
+  vw32 = bitcast<f32>((*&vw34).f0);
+  var vf106 = fn0();
+  fn0();
+  var vf107 = fn1();
+  vf105[u32(unconst_u32(345))] = vw31[u32(unconst_u32(118))][0][bitcast<vec4u>(vw31[pack4xI8Clamp(vf107[0])][0][0].f0).y].f0;
+  vf106[16] = vec2i((*&vw30)[1].f11);
+  vw32 += vec4f((*&vw31)[u32(unconst_u32(209))][u32(unconst_u32(156))][u32(unconst_u32(69))].f0)[3];
+  vf105[u32(unconst_u32(111))] = vec4i((*&vw33).f9);
+  let ptr138: ptr<workgroup, i32> = &(*&vw33).f10;
+  var vf108 = fn1();
+  fn0();
+}`,
+});
+let texture271 = device0.createTexture({
+  size: [30, 10, 30],
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+renderPassEncoder65.setBindGroup(2, bindGroup58, new Uint32Array(3039), 1_076, 0);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer29, 'uint32', 280, 911);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline32);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(0, buffer137);
+} catch {}
+let arrayBuffer21 = buffer111.getMappedRange(2288, 60);
+let buffer180 = device0.createBuffer({size: 10077, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture272 = device0.createTexture({
+  size: [1, 1, 1],
+  sampleCount: 4,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView261 = texture69.createView({aspect: 'depth-only', mipLevelCount: 1, arrayLayerCount: 2});
+try {
+computePassEncoder161.setBindGroup(1, bindGroup125);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(0, bindGroup89);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData41,
+  origin: { x: 30, y: 2 },
+  flipY: true,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 73, y: 6, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 36, height: 29, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder271 = device0.createCommandEncoder({});
+let textureView262 = texture272.createView({label: '\u607c\u02c0\u7d20'});
+try {
+computePassEncoder158.setBindGroup(0, bindGroup163, new Uint32Array(846), 94, 0);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle12, renderBundle6, renderBundle20, renderBundle4, renderBundle9, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder45.setIndexBuffer(buffer94, 'uint16', 0, 162);
+} catch {}
+try {
+renderPassEncoder73.setPipeline(pipeline63);
+} catch {}
+let bindGroup166 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout63,
+  entries: [{binding: 8, resource: {buffer: buffer41, offset: 3840, size: 3832}}],
+});
+let pipelineLayout20 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout38]});
+let buffer181 = device0.createBuffer({
+  size: 19570,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let texture273 = device0.createTexture({
+  size: {width: 30, height: 10, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView263 = texture131.createView({});
+let computePassEncoder223 = commandEncoder271.beginComputePass({});
+try {
+computePassEncoder6.setBindGroup(2, bindGroup147, new Uint32Array(4100), 219, 0);
+} catch {}
+try {
+computePassEncoder223.setPipeline(pipeline42);
+} catch {}
+try {
+renderPassEncoder54.setBlendConstant({ r: 217.3, g: 528.8, b: -247.9, a: -110.2, });
+} catch {}
+document.body.prepend(img5);
+let bindGroup167 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout94,
+  entries: [{binding: 8, resource: {buffer: buffer17, offset: 256}}],
+});
+let buffer182 = device0.createBuffer({
+  size: 2718,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder272 = device0.createCommandEncoder({});
+let computePassEncoder224 = commandEncoder272.beginComputePass({});
+let sampler183 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 79.66,
+  lodMaxClamp: 92.58,
+});
+try {
+computePassEncoder150.setBindGroup(3, bindGroup19);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(1, buffer29, 1_712, 2_892);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture162,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(203).fill(93), /* required buffer size: 203 */
+{offset: 203, bytesPerRow: 84}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55); };
+} catch {}
+document.body.append(img3);
+let bindGroup168 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout63,
+  entries: [{binding: 8, resource: {buffer: buffer163, offset: 0, size: 480}}],
+});
+let commandEncoder273 = device0.createCommandEncoder();
+let textureView264 = texture254.createView({baseMipLevel: 0, baseArrayLayer: 0});
+let renderPassEncoder78 = commandEncoder273.beginRenderPass({
+  colorAttachments: [{
+  view: textureView218,
+  depthSlice: 138,
+  clearValue: { r: -468.6, g: 166.4, b: -835.3, a: -6.976, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder166.setBindGroup(3, bindGroup163);
+} catch {}
+try {
+computePassEncoder224.setPipeline(pipeline45);
+} catch {}
+try {
+renderPassEncoder38.setStencilReference(927);
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer101, 'uint32', 884, 836);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+document.body.prepend(img4);
+let querySet37 = device0.createQuerySet({type: 'occlusion', count: 43});
+let sampler184 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder104.setBindGroup(2, bindGroup80);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(3, bindGroup83);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(2, bindGroup97, new Uint32Array(2320), 732, 0);
+} catch {}
+try {
+renderPassEncoder15.insertDebugMarker('\u966b');
+} catch {}
+let autogeneratedBindGroupLayout98 = pipeline13.getBindGroupLayout(0);
+let texture274 = device0.createTexture({
+  size: {width: 240, height: 80, depthOrArrayLayers: 43},
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let sampler185 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 22.52,
+  compare: 'greater-equal',
+});
+try {
+computePassEncoder140.setBindGroup(0, bindGroup91);
+} catch {}
+try {
+computePassEncoder27.end();
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline33);
+} catch {}
+let bindGroup169 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout10,
+  entries: [{binding: 8, resource: {buffer: buffer140, offset: 768, size: 912}}],
+});
+let textureView265 = texture243.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 6});
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer19]);
+} catch {}
+let autogeneratedBindGroupLayout99 = pipeline10.getBindGroupLayout(0);
+let bindGroup170 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout30,
+  entries: [{binding: 105, resource: textureView6}, {binding: 343, resource: textureView170}],
+});
+let textureView266 = texture45.createView({dimension: '2d-array'});
+let texture275 = device0.createTexture({
+  size: {width: 120, height: 40, depthOrArrayLayers: 1},
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView267 = texture224.createView({label: '\u{1fd63}\u0e46\u64f0\u00a0\uf663\u064c\u158e\u0419\u{1f8bd}\u{1fa58}', mipLevelCount: 1});
+let computePassEncoder225 = commandEncoder32.beginComputePass({});
+try {
+computePassEncoder36.setBindGroup(0, bindGroup142, new Uint32Array(2789), 35, 0);
+} catch {}
+try {
+computePassEncoder225.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder48.setScissorRect(10, 52, 157, 4);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer166, 'uint16', 28, 658);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let bindGroup171 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout10,
+  entries: [{binding: 8, resource: {buffer: buffer22, offset: 5120, size: 3244}}],
+});
+try {
+computePassEncoder28.setBindGroup(1, bindGroup114);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder36); computePassEncoder36.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder75.setVertexBuffer(3, buffer26);
+} catch {}
+let arrayBuffer22 = buffer65.getMappedRange(1248, 40);
+let shaderModule9 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+struct T0 {
+  f0: atomic<u32>,
+  @size(52) f1: atomic<u32>,
+}
+
+struct VertexOutput6 {
+  @invariant @builtin(position) f13: vec4f,
+}
+
+var<workgroup> vw38: atomic<i32>;
+
+@id(1422) override override25: bool;
+
+struct FragmentOutput11 {
+  @location(0) f0: vec4i,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@group(0) @binding(8) var<storage, read> buffer183: array<array<array<array<f16, 1>, 3>, 1>, 9>;
+
+override override28: u32;
+
+var<workgroup> vw37: array<atomic<u32>, 1>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@id(10930) override override30: f16 = 10539.9;
+
+@id(60915) override override27: u32;
+
+var<workgroup> vw39: vec2f;
+
+@id(21664) override override26 = true;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+override override29: f16;
+
+struct FragmentOutput10 {
+  @location(0) f0: vec4i,
+}
+
+var<workgroup> vw40: FragmentOutput11;
+
+var<private> vp7: vec2u = vec2u(424, 47);
+
+override override31: f32;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+alias vec3b = vec3<bool>;
+
+@vertex @must_use
+fn vertex7() -> VertexOutput6 {
+  var out: VertexOutput6;
+  out.f13 = vec4f(f32((*&buffer183)[8][0][2][0]));
+  let ptr139: ptr<storage, f16, read> = &buffer183[u32(unconst_u32(21))][0][u32(unconst_u32(168))][0];
+  let ptr140: ptr<storage, array<f16, 1>, read> = &(*&buffer183)[8][0][u32(buffer183[u32(buffer183[8][u32(unconst_u32(433))][u32(unconst_u32(90))][0])][0][2][0])];
+  let ptr141: ptr<storage, f16, read> = &buffer183[8][0][u32(unconst_u32(101))][0];
+  out = VertexOutput6(vec4f(f32((*&buffer183)[8][0][2][0])));
+  vp7 = vec2u(u32(buffer183[8][0][2][0]));
+  var vf109: u32 = firstTrailingBit(u32(unconst_u32(67)));
+  out.f13 += vec4f(f32(buffer183[u32((*&buffer183)[8][0][u32(unconst_u32(72))][0])][0][2][u32(unconst_u32(134))]));
+  let ptr142: ptr<storage, f16, read> = &(*&buffer183)[u32(unconst_u32(48))][0][u32(unconst_u32(85))][u32(unconst_u32(266))];
+  let ptr143: ptr<storage, array<f16, 1>, read> = &(*&buffer183)[8][0][u32(unconst_u32(49))];
+  out.f13 = vec4f(f32(buffer183[8][0][2][0]));
+  vp7 |= vec2u(u32((*&buffer183)[u32(unconst_u32(71))][u32(unconst_u32(55))][2][0]));
+  out.f13 = vec4f(extractBits(vec2i(unconst_i32(214), unconst_i32(18)), u32(unconst_u32(101)), u32(unconst_u32(83))).grrr);
+  let ptr144: ptr<storage, f16, read> = &buffer183[u32(unconst_u32(62))][u32(buffer183[8][u32(unconst_u32(686))][2][0])][2][0];
+  let ptr145: ptr<storage, f16, read> = &(*&buffer183)[8][0][2][u32(unconst_u32(199))];
+  let ptr146: ptr<storage, f16, read> = &(*&buffer183)[u32(unconst_u32(112))][u32(unconst_u32(196))][2][u32(unconst_u32(23))];
+  var vf110: vec4f = reflect(vec4f(unconst_f32(0.6183), unconst_f32(0.00657), unconst_f32(0.4377), unconst_f32(0.00951)), vec4f(unconst_f32(0.02018), unconst_f32(0.2574), unconst_f32(0.1338), unconst_f32(0.07367)));
+  out.f13 += vec4f(f32(buffer183[8][0][2][0]));
+  let ptr147: ptr<storage, array<array<f16, 1>, 3>, read> = &(*&buffer183)[8][0];
+  let vf111: bool = any(bool(unconst_bool(true)));
+  out.f13 = vec4f(f32((*ptr147)[2][u32(unconst_u32(134))]));
+  vf110 = vec4f(f32(buffer183[8][u32(unconst_u32(650))][u32(unconst_u32(105))][0]));
+  out.f13 = vec4f(f32(buffer183[8][u32(unconst_u32(377))][2][0]));
+  let ptr148: ptr<storage, array<f16, 1>, read> = &buffer183[8][u32(unconst_u32(572))][2];
+  return out;
+  _ = buffer183;
+}
+
+@fragment
+fn fragment10() -> FragmentOutput10 {
+  var out: FragmentOutput10;
+  let ptr149: ptr<storage, array<array<array<array<f16, 1>, 3>, 1>, 9>, read> = &buffer183;
+  discard;
+  let ptr150: ptr<storage, array<f16, 1>, read> = &(*&buffer183)[u32((*ptr149)[8][u32(unconst_u32(52))][u32(unconst_u32(593))][0])][0][u32(unconst_u32(87))];
+  let ptr151: ptr<storage, f16, read> = &(*ptr149)[8][u32(unconst_u32(160))][u32(unconst_u32(78))][u32(unconst_u32(315))];
+  let ptr152: ptr<storage, array<f16, 1>, read> = &buffer183[8][0][2];
+  out.f0 -= bitcast<vec4i>(reflect(vec3f(unconst_f32(0.00256), unconst_f32(0.03072), unconst_f32(0.08572)), vec3f(unconst_f32(0.03313), unconst_f32(0.3255), unconst_f32(0.1037))).yxyz);
+  out.f0 += vec4i(floor(vec4f(unconst_f32(0.1955), unconst_f32(0.9360), unconst_f32(0.08490), unconst_f32(0.3724))));
+  let ptr153: ptr<storage, f16, read> = &(*ptr149)[u32(unconst_u32(208))][u32(unconst_u32(189))][2][u32(unconst_u32(42))];
+  let ptr154: ptr<storage, f16, read> = &(*ptr149)[u32(unconst_u32(8))][u32(unconst_u32(67))][u32(unconst_u32(141))][0];
+  vp7 += vec2u(u32((*&buffer183)[8][0][2][0]));
+  vp7 = vec2u(u32((*&buffer183)[u32(unconst_u32(151))][u32(unconst_u32(74))][2][0]));
+  let vf112: vec2h = log2(vec2h(unpack4xI8(u32(unconst_u32(65))).yx));
+  out.f0 = vec4i(countTrailingZeros(i32(unconst_i32(228))));
+  let ptr155: ptr<storage, f16, read> = &(*&buffer183)[u32(unconst_u32(111))][0][u32(unconst_u32(263))][0];
+  vp7 &= vec2u(u32((*ptr149)[8][0][u32(unconst_u32(220))][0]));
+  let ptr156: ptr<storage, f16, read> = &(*&buffer183)[u32(unconst_u32(212))][u32(unconst_u32(115))][u32(unconst_u32(372))][0];
+  let ptr157: ptr<storage, array<f16, 1>, read> = &(*&buffer183)[8][0][u32(unconst_u32(17))];
+  return out;
+  _ = buffer183;
+}
+
+@fragment
+fn fragment11() -> FragmentOutput11 {
+  var out: FragmentOutput11;
+  vp7 = vec2u(u32(buffer183[8][0][u32(buffer183[8][0][2][0])][0]));
+  out = FragmentOutput11(vec4i(i32(override30)));
+  let ptr158: ptr<storage, array<array<f16, 1>, 3>, read> = &(*&buffer183)[u32(unconst_u32(46))][u32(unconst_u32(1))];
+  var vf113: vec4i = unpack4xI8(u32(unconst_u32(29)));
+  let ptr159: ptr<storage, f16, read> = &(*&buffer183)[8][u32(unconst_u32(13))][u32(unconst_u32(18))][u32(unconst_u32(98))];
+  out.f0 = vec4i(i32(buffer183[u32(unconst_u32(216))][u32(unconst_u32(250))][2][u32(unconst_u32(11))]));
+  vp7 -= vec2u(u32(buffer183[pack2x16snorm(vec2f(f32(override30)))][0][2][0]));
+  out = FragmentOutput11(vec4i(i32(buffer183[u32(unconst_u32(458))][u32(unconst_u32(22))][u32(unconst_u32(104))][u32(unconst_u32(243))])));
+  vp7 = vec2u(u32((*&buffer183)[8][0][u32(unconst_u32(456))][0]));
+  let ptr160: ptr<storage, array<array<f16, 1>, 3>, read> = &(*&buffer183)[u32(unconst_u32(13))][0];
+  let ptr161: ptr<storage, array<array<array<f16, 1>, 3>, 1>, read> = &buffer183[u32(unconst_u32(229))];
+  let ptr162: ptr<storage, array<f16, 1>, read> = &(*&buffer183)[8][u32(unconst_u32(202))][u32(unconst_u32(141))];
+  vf113 += vec4i(i32(buffer183[u32(unconst_u32(328))][u32(buffer183[u32((*ptr161)[0][u32(unconst_u32(169))][u32(unconst_u32(129))])][u32(unconst_u32(0))][2][0])][2][u32(unconst_u32(34))]));
+  out.f0 += vec4i(i32(buffer183[u32(unconst_u32(86))][0][2][0]));
+  return out;
+  _ = override30;
+  _ = buffer183;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute10() {
+  let ptr163: ptr<storage, array<array<array<f16, 1>, 3>, 1>, read> = &buffer183[8];
+  let ptr164: ptr<storage, f16, read> = &(*&buffer183)[8][0][u32(unconst_u32(40))][0];
+  atomicAdd(&vw38, i32(unconst_i32(220)));
+  let ptr165: ptr<storage, f16, read> = &(*&buffer183)[u32(unconst_u32(33))][0][2][0];
+  vp7 = vec2u(u32((*ptr163)[0][2][0]));
+  let ptr166: ptr<workgroup, atomic<u32>> = &vw37[u32(unconst_u32(16))];
+  let ptr167: ptr<storage, array<array<f16, 1>, 3>, read> = &(*&buffer183)[u32(unconst_u32(354))][0];
+  vw39 += vec2f(f32((*&buffer183)[u32(unconst_u32(175))][u32(unconst_u32(116))][2][u32(unconst_u32(509))]));
+  atomicAnd(&vw37[u32(unconst_u32(244))], u32(unconst_u32(104)));
+  let ptr168: ptr<storage, f16, read> = &buffer183[8][0][2][u32(unconst_u32(169))];
+  vw39 = vec2f(f32((*&buffer183)[8][0][2][0]));
+  var vf114: u32 = atomicExchange(&vw37[u32(unconst_u32(109))], u32(unconst_u32(236)));
+  let vf115: u32 = atomicLoad(&vw37[u32((*&buffer183)[u32(unconst_u32(73))][0][u32(unconst_u32(806))][0])]);
+  let ptr169: ptr<storage, f16, read> = &buffer183[8][0][u32(unconst_u32(245))][u32(unconst_u32(264))];
+  vw39 += vec2f(f32((*&buffer183)[8][0][2][0]));
+  vw40.f0 = vec4i(i32((*&buffer183)[u32(unconst_u32(3))][u32(unconst_u32(371))][2][0]));
+  let ptr170: ptr<storage, array<f16, 1>, read> = &(*ptr163)[u32(unconst_u32(79))][u32(unconst_u32(3))];
+  let ptr171: ptr<storage, array<f16, 1>, read> = &(*ptr167)[u32(buffer183[8][0][2][u32(unconst_u32(306))])];
+  let vf116: u32 = atomicExchange(&(*&vw37)[0], u32(unconst_u32(42)));
+  _ = buffer183;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute11() {
+  var vf117: f16 = override30;
+  let ptr172: ptr<storage, array<array<f16, 1>, 3>, read> = &buffer183[u32(unconst_u32(797))][0];
+  let ptr173: ptr<storage, f16, read> = &(*&buffer183)[u32((*&buffer183)[u32(unconst_u32(201))][u32(unconst_u32(254))][bitcast<vec2u>(vw39).r][0])][0][2][0];
+  let vf118: u32 = override27;
+  let ptr174: ptr<storage, f16, read> = &buffer183[u32(unconst_u32(60))][0][u32(unconst_u32(477))][u32((*&buffer183)[8][u32(unconst_u32(142))][u32(unconst_u32(6))][u32(unconst_u32(124))])];
+  _ = override27;
+  _ = override30;
+  _ = buffer183;
+}`,
+});
+let commandEncoder274 = device0.createCommandEncoder({});
+let renderPassEncoder79 = commandEncoder274.beginRenderPass({
+  colorAttachments: [{view: textureView218, depthSlice: 31, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet2,
+  maxDrawCount: 169896479,
+});
+let sampler186 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 76.57,
+  maxAnisotropy: 3,
+});
+try {
+renderPassEncoder14.executeBundles([renderBundle18, renderBundle8, renderBundle2, renderBundle11]);
+} catch {}
+try {
+buffer122.unmap();
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let bindGroup172 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout97,
+  entries: [{binding: 8, resource: {buffer: buffer153, offset: 256, size: 376}}],
+});
+let texture276 = device0.createTexture({
+  size: [60, 20, 73],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView268 = texture20.createView({baseMipLevel: 0});
+try {
+computePassEncoder133.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderPassEncoder73.setBindGroup(2, bindGroup38, new Uint32Array(3843), 284, 0);
+} catch {}
+let bindGroup173 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout13,
+  entries: [
+    {binding: 203, resource: {buffer: buffer43, offset: 1280, size: 644}},
+    {binding: 33, resource: sampler32},
+  ],
+});
+let texture277 = device0.createTexture({
+  size: {width: 60, height: 20, depthOrArrayLayers: 73},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView269 = texture72.createView({});
+try {
+{ clearResourceUsages(device0, computePassEncoder36); computePassEncoder36.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(1, bindGroup66, new Uint32Array(564), 18, 0);
+} catch {}
+canvas2.height = 2276;
+let commandEncoder275 = device0.createCommandEncoder({});
+let querySet38 = device0.createQuerySet({type: 'occlusion', count: 764});
+let computePassEncoder226 = commandEncoder275.beginComputePass({});
+let sampler187 = device0.createSampler({addressModeU: 'clamp-to-edge', addressModeW: 'mirror-repeat', mipmapFilter: 'linear'});
+try {
+computePassEncoder182.setBindGroup(2, bindGroup20);
+} catch {}
+try {
+computePassEncoder71.setBindGroup(1, bindGroup28, new Uint32Array(5026), 5, 0);
+} catch {}
+try {
+renderPassEncoder62.end();
+} catch {}
+try {
+renderPassEncoder59.setIndexBuffer(buffer107, 'uint16', 168, 170);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(352).fill(28), /* required buffer size: 352 */
+{offset: 352, bytesPerRow: 41, rowsPerImage: 21}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData43 = new ImageData(4, 32);
+let bindGroup174 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout28,
+  entries: [
+    {binding: 68, resource: {buffer: buffer94, offset: 0, size: 200}},
+    {binding: 100, resource: textureView211},
+  ],
+});
+let buffer184 = device0.createBuffer({
+  size: 2497,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let texture278 = device0.createTexture({
+  size: [240, 80, 30],
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8sint'],
+});
+let textureView270 = texture248.createView({mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder227 = commandEncoder220.beginComputePass({});
+try {
+computePassEncoder19.setBindGroup(3, bindGroup22);
+} catch {}
+try {
+computePassEncoder226.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder75.setBindGroup(0, bindGroup153, new Uint32Array(440), 48, 0);
+} catch {}
+try {
+renderPassEncoder58.setVertexBuffer(1, buffer113, 3_668, 36_958);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 5, y: 3, z: 0},
+  aspect: 'all',
+}, new Uint8Array(24).fill(62), /* required buffer size: 24 */
+{offset: 24}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder93.setBindGroup(0, bindGroup107);
+} catch {}
+try {
+computePassEncoder227.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder72.beginOcclusionQuery(38);
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer62, 'uint16', 1_212, 7_714);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer36, 368, new Float32Array(41206), 595, 392);
+} catch {}
+let bindGroup175 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout7,
+  entries: [{binding: 53, resource: {buffer: buffer39, offset: 3840, size: 2088}}],
+});
+let buffer185 = device0.createBuffer({size: 1434, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let texture279 = device0.createTexture({size: [120, 40, 1], format: 'rgb10a2uint', usage: GPUTextureUsage.TEXTURE_BINDING, viewFormats: []});
+try {
+{ clearResourceUsages(device0, computePassEncoder36); computePassEncoder36.dispatchWorkgroupsIndirect(buffer23, 256); };
+} catch {}
+try {
+renderPassEncoder77.setBindGroup(1, bindGroup17);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(3, bindGroup147, new Uint32Array(1455), 576, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer108, 1204, new Float32Array(15411), 1946, 16);
+} catch {}
+let textureView271 = texture42.createView({dimension: '2d'});
+let sampler188 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 87.43,
+});
+try {
+renderPassEncoder72.endOcclusionQuery();
+} catch {}
+try {
+buffer54.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 4},
+  aspect: 'all',
+}, new Uint8Array(161).fill(28), /* required buffer size: 161 */
+{offset: 161, bytesPerRow: 117}, {width: 7, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let sampler189 = device0.createSampler({
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 86.41,
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder36.end();
+} catch {}
+try {
+computePassEncoder118.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer62, 'uint16', 3_634, 457);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder45.setVertexBuffer(4, buffer97, 0, 565);
+} catch {}
+try {
+commandEncoder43.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1008 */
+  offset: 1008,
+  bytesPerRow: 5376,
+  buffer: buffer11,
+}, {
+  texture: texture156,
+  mipLevel: 1,
+  origin: {x: 4, y: 5, z: 0},
+  aspect: 'all',
+}, {width: 4, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture145,
+  mipLevel: 0,
+  origin: {x: 32, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(64).fill(118), /* required buffer size: 64 */
+{offset: 64}, {width: 57, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup176 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout63,
+  entries: [{binding: 8, resource: {buffer: buffer108, offset: 1792, size: 232}}],
+});
+let buffer186 = device0.createBuffer({
+  size: 3786,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture280 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 13},
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView272 = texture153.createView({baseArrayLayer: 25, arrayLayerCount: 23});
+let computePassEncoder228 = commandEncoder43.beginComputePass({});
+try {
+computePassEncoder183.setBindGroup(0, bindGroup127);
+} catch {}
+try {
+renderPassEncoder38.executeBundles([renderBundle25]);
+} catch {}
+try {
+renderPassEncoder75.setIndexBuffer(buffer99, 'uint16', 558, 99);
+} catch {}
+let imageData44 = new ImageData(20, 32);
+let buffer187 = device0.createBuffer({
+  size: 21778,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let texture281 = device0.createTexture({
+  size: [30, 10, 1],
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture282 = device0.createTexture({
+  size: {width: 60},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView273 = texture146.createView({baseArrayLayer: 0});
+let sampler190 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.39,
+});
+try {
+renderPassEncoder63.setBindGroup(1, bindGroup81);
+} catch {}
+let pipeline67 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule5}});
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let texture283 = device0.createTexture({
+  size: [30, 10, 36],
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder71.setVertexBuffer(1, undefined, 0, 261_027_335);
+} catch {}
+let offscreenCanvas8 = new OffscreenCanvas(204, 72);
+let recycledExplicitBindGroupLayout27 = pipeline48.getBindGroupLayout(0);
+let textureView274 = texture86.createView({dimension: '2d-array', aspect: 'depth-only', arrayLayerCount: 1});
+let externalTexture40 = device0.importExternalTexture({source: videoFrame35});
+try {
+renderPassEncoder38.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(2, bindGroup59, new Uint32Array(294), 37, 0);
+} catch {}
+try {
+renderPassEncoder40.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder71.setVertexBuffer(2, buffer17, 0, 921);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer159, 1084, new BigUint64Array(12195), 777, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture165,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(214).fill(112), /* required buffer size: 214 */
+{offset: 214, bytesPerRow: 117, rowsPerImage: 25}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup177 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout2,
+  entries: [{binding: 8, resource: {buffer: buffer140, offset: 1024, size: 288}}],
+});
+let textureView275 = texture252.createView({dimension: '2d-array', arrayLayerCount: 1});
+try {
+computePassEncoder224.setBindGroup(3, bindGroup166);
+} catch {}
+try {
+computePassEncoder228.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup123, new Uint32Array(230), 15, 0);
+} catch {}
+try {
+renderPassEncoder50.setIndexBuffer(buffer145, 'uint16', 2_170, 184);
+} catch {}
+let gpuCanvasContext12 = offscreenCanvas8.getContext('webgpu');
+let buffer188 = device0.createBuffer({size: 255, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let querySet39 = device0.createQuerySet({type: 'occlusion', count: 1226});
+let textureView276 = texture89.createView({baseArrayLayer: 0});
+try {
+computePassEncoder144.setBindGroup(2, bindGroup169, new Uint32Array(1705), 127, 0);
+} catch {}
+let autogeneratedBindGroupLayout100 = pipeline32.getBindGroupLayout(0);
+let querySet40 = device0.createQuerySet({type: 'occlusion', count: 814});
+let textureView277 = texture118.createView({});
+try {
+computePassEncoder146.setBindGroup(1, bindGroup129, []);
+} catch {}
+try {
+renderPassEncoder9.beginOcclusionQuery(30);
+} catch {}
+try {
+renderPassEncoder65.setScissorRect(1, 2, 39, 2);
+} catch {}
+let bindGroup178 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout79,
+  entries: [
+    {binding: 8, resource: {buffer: buffer41, offset: 2560, size: 1684}},
+    {binding: 216, resource: textureView92},
+  ],
+});
+let renderBundleEncoder37 = device0.createRenderBundleEncoder({colorFormats: ['rgba16sint'], depthReadOnly: true});
+try {
+computePassEncoder196.setBindGroup(0, bindGroup142);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(2, bindGroup112, []);
+} catch {}
+try {
+renderPassEncoder74.setBindGroup(1, bindGroup15, new Uint32Array(1744), 126, 0);
+} catch {}
+try {
+renderPassEncoder57.executeBundles([renderBundle34, renderBundle34, renderBundle17, renderBundle34, renderBundle34, renderBundle25, renderBundle27, renderBundle14]);
+} catch {}
+try {
+renderPassEncoder54.setVertexBuffer(0, buffer17, 976, 332);
+} catch {}
+try {
+renderBundleEncoder37.setIndexBuffer(buffer77, 'uint32', 4_552, 18_323);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(2, buffer15, 6_964);
+} catch {}
+let promise29 = device0.queue.onSubmittedWorkDone();
+let imageData45 = new ImageData(80, 16);
+try {
+computePassEncoder155.setBindGroup(1, bindGroup119);
+} catch {}
+try {
+renderPassEncoder65.setVertexBuffer(1, buffer102);
+} catch {}
+try {
+renderBundleEncoder37.setIndexBuffer(buffer181, 'uint16', 4_022, 231);
+} catch {}
+let pipeline68 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule5}});
+let textureView278 = texture45.createView({dimension: '2d-array', mipLevelCount: 1});
+let texture284 = device0.createTexture({
+  size: {width: 60},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle37 = renderBundleEncoder37.finish({});
+try {
+renderPassEncoder70.setVertexBuffer(5, buffer97, 0);
+} catch {}
+document.body.prepend(canvas4);
+let autogeneratedBindGroupLayout101 = pipeline68.getBindGroupLayout(0);
+let bindGroup179 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout11,
+  entries: [{binding: 8, resource: {buffer: buffer94, offset: 0, size: 116}}],
+});
+let pipelineLayout21 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout20]});
+try {
+renderPassEncoder76.setBindGroup(1, bindGroup153, new Uint32Array(1866), 648, 0);
+} catch {}
+let bindGroup180 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout82,
+  entries: [{binding: 8, resource: {buffer: buffer97, offset: 512, size: 552}}],
+});
+let pipelineLayout22 = device0.createPipelineLayout({bindGroupLayouts: [recycledExplicitBindGroupLayout1]});
+let buffer189 = device0.createBuffer({
+  size: 11670,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder25.setIndexBuffer(buffer44, 'uint16', 156, 124);
+} catch {}
+try {
+renderPassEncoder54.setPipeline(pipeline51);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView279 = texture107.createView({baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 0});
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(26).fill(139), /* required buffer size: 26 */
+{offset: 26, rowsPerImage: 19}, {width: 18, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img2);
+let imageData46 = new ImageData(52, 84);
+try {
+computePassEncoder130.setBindGroup(2, bindGroup156);
+} catch {}
+try {
+computePassEncoder65.setBindGroup(0, bindGroup74, new Uint32Array(1317), 38, 0);
+} catch {}
+try {
+buffer29.unmap();
+} catch {}
+document.body.prepend(canvas5);
+let autogeneratedBindGroupLayout102 = pipeline60.getBindGroupLayout(0);
+let buffer190 = device0.createBuffer({size: 4476, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+try {
+renderPassEncoder24.executeBundles([renderBundle16, renderBundle7, renderBundle1, renderBundle6]);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData33,
+  origin: { x: 0, y: 1 },
+  flipY: false,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 9, y: 5, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 6, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout23 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+try {
+computePassEncoder156.setBindGroup(2, bindGroup59);
+} catch {}
+try {
+computePassEncoder110.setBindGroup(1, bindGroup88, new Uint32Array(3591), 57, 0);
+} catch {}
+try {
+renderPassEncoder74.setIndexBuffer(buffer166, 'uint16', 102, 217);
+} catch {}
+try {
+renderPassEncoder49.setPipeline(pipeline19);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer36, 8, new Float32Array(7636), 609, 144);
+} catch {}
+let pipeline69 = await device0.createComputePipelineAsync({layout: pipelineLayout18, compute: {module: shaderModule4, entryPoint: 'compute4'}});
+try {
+adapter0.label = '\u{1fb80}\ua937\u54df\u071c\u{1fd3f}\u069a\u0952';
+} catch {}
+let texture285 = device0.createTexture({
+  size: [240, 80, 294],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture286 = device0.createTexture({
+  size: [120],
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder136.setBindGroup(2, bindGroup28);
+} catch {}
+try {
+computePassEncoder158.setBindGroup(3, bindGroup52, new Uint32Array(917), 80, 0);
+} catch {}
+try {
+renderPassEncoder57.setBindGroup(0, bindGroup26, new Uint32Array(2159), 291, 0);
+} catch {}
+try {
+renderPassEncoder66.setPipeline(pipeline64);
+} catch {}
+try {
+buffer176.unmap();
+} catch {}
+let sampler191 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 69.94,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder76.setBindGroup(0, bindGroup131);
+} catch {}
+try {
+renderPassEncoder27.setViewport(11.351753209091653, 8.971783183109965, 82.26362182155314, 11.655462740265994, 0.16274497770716811, 0.6636302487036915);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(0, buffer64, 0);
+} catch {}
+try {
+buffer107.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer22, 2164, new Int16Array(22467), 3632, 1268);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture244,
+  mipLevel: 0,
+  origin: {x: 4, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(7).fill(193), /* required buffer size: 7 */
+{offset: 7}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let promise30 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1702, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData32,
+  origin: { x: 1, y: 1 },
+  flipY: false,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 33, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 103, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let autogeneratedBindGroupLayout103 = pipeline26.getBindGroupLayout(0);
+let textureView280 = texture1.createView({dimension: '2d-array', aspect: 'depth-only'});
+try {
+computePassEncoder93.setBindGroup(1, bindGroup69, new Uint32Array(2666), 631, 0);
+} catch {}
+try {
+renderPassEncoder42.setIndexBuffer(buffer85, 'uint16', 222, 77);
+} catch {}
+let bindGroup181 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout11,
+  entries: [
+    {binding: 116, resource: {buffer: buffer61, offset: 512, size: 344}},
+    {binding: 258, resource: textureView134},
+  ],
+});
+let sampler192 = device0.createSampler({addressModeU: 'mirror-repeat', mipmapFilter: 'nearest', lodMaxClamp: 62.72});
+try {
+computePassEncoder47.setBindGroup(2, bindGroup148, []);
+} catch {}
+try {
+computePassEncoder136.setBindGroup(2, bindGroup146, new Uint32Array(910), 236, 0);
+} catch {}
+try {
+renderPassEncoder58.setBindGroup(2, bindGroup91);
+} catch {}
+try {
+renderPassEncoder42.executeBundles([renderBundle20, renderBundle16, renderBundle8, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder42.setIndexBuffer(buffer125, 'uint16', 784, 3_084);
+} catch {}
+try {
+adapter0.label = '\u{1ff4f}\ub076\u{1fdb4}\ud316\ub9e2';
+} catch {}
+let texture287 = device0.createTexture({
+  size: [2, 2, 13],
+  sampleCount: 1,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView281 = texture135.createView({format: 'rgba8sint', mipLevelCount: 1});
+try {
+computePassEncoder113.setBindGroup(2, bindGroup171);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(2, bindGroup123);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(2, buffer79, 16, 151);
+} catch {}
+try {
+computePassEncoder146.setBindGroup(2, bindGroup71, new Uint32Array(1264), 306, 0);
+} catch {}
+try {
+buffer84.unmap();
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer166, 'uint32', 228, 325);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture169,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(95).fill(228), /* required buffer size: 95 */
+{offset: 95, bytesPerRow: 0}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer191 = device0.createBuffer({
+  size: 7738,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder66.setBindGroup(0, bindGroup113);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline23);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture258,
+  mipLevel: 0,
+  origin: {x: 13, y: 28, z: 95},
+  aspect: 'all',
+}, new Uint8Array(691_644).fill(180), /* required buffer size: 691_644 */
+{offset: 57, bytesPerRow: 537, rowsPerImage: 33}, {width: 117, height: 1, depthOrArrayLayers: 40});
+} catch {}
+let veryExplicitBindGroupLayout37 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 33,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 100, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 256,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba32float', access: 'write-only', viewDimension: '2d' },
+    },
+    {
+      binding: 291,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rg32sint', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 352,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup182 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout87,
+  entries: [
+    {binding: 8, resource: {buffer: buffer178, offset: 0, size: 296}},
+    {binding: 216, resource: textureView24},
+  ],
+});
+let textureView282 = texture189.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 6});
+let externalTexture41 = device0.importExternalTexture({source: videoFrame15});
+try {
+computePassEncoder109.setBindGroup(0, bindGroup54, []);
+} catch {}
+let texture288 = device0.createTexture({
+  size: [2],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder67.setBindGroup(1, bindGroup179, new Uint32Array(2313), 44, 0);
+} catch {}
+try {
+renderPassEncoder9.beginOcclusionQuery(430);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder38.setStencilReference(33);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture164,
+  mipLevel: 1,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(8_181).fill(193), /* required buffer size: 8_181 */
+{offset: 61, bytesPerRow: 116, rowsPerImage: 70}, {width: 6, height: 0, depthOrArrayLayers: 2});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1702, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap9,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 461, y: 19, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let recycledExplicitBindGroupLayout28 = pipeline25.getBindGroupLayout(0);
+try {
+renderPassEncoder58.setBindGroup(1, bindGroup85, new Uint32Array(2358), 412, 0);
+} catch {}
+try {
+renderPassEncoder55.setVertexBuffer(0, buffer33, 76);
+} catch {}
+let arrayBuffer23 = buffer65.getMappedRange(1288, 0);
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap8,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 29, y: 19, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder87.setBindGroup(0, bindGroup59);
+} catch {}
+try {
+  await promise29;
+} catch {}
+let texture289 = device0.createTexture({
+  size: [120, 40, 147],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView283 = texture37.createView({});
+try {
+computePassEncoder175.setBindGroup(3, bindGroup31);
+} catch {}
+try {
+renderPassEncoder70.setScissorRect(42, 6, 21, 16);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1702, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData11,
+  origin: { x: 0, y: 5 },
+  flipY: true,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 111, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas9 = new OffscreenCanvas(66, 46);
+let veryExplicitBindGroupLayout38 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 105,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 343,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '3d' },
+    },
+  ],
+});
+let texture290 = device0.createTexture({
+  size: {width: 240, height: 80, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler193 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 93.03,
+  maxAnisotropy: 19,
+});
+let gpuCanvasContext13 = offscreenCanvas9.getContext('webgpu');
+let textureView284 = texture132.createView({aspect: 'all'});
+let externalTexture42 = device0.importExternalTexture({source: videoFrame11});
+try {
+computePassEncoder70.setPipeline(pipeline56);
+} catch {}
+try {
+renderPassEncoder42.executeBundles([renderBundle5, renderBundle20, renderBundle12]);
+} catch {}
+try {
+renderPassEncoder50.setVertexBuffer(7, buffer17, 1_264, 1_181);
+} catch {}
+let arrayBuffer24 = buffer45.getMappedRange(456, 160);
+try {
+device0.queue.writeBuffer(buffer132, 1304, new Float32Array(7478), 156, 324);
+} catch {}
+try {
+  await promise30;
+} catch {}
+let recycledExplicitBindGroupLayout29 = pipeline62.getBindGroupLayout(0);
+let renderBundleEncoder38 = device0.createRenderBundleEncoder({colorFormats: ['rg32sint'], stencilReadOnly: true});
+try {
+device0.queue.writeTexture({
+  texture: texture117,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'all',
+}, new Uint8Array(94).fill(55), /* required buffer size: 94 */
+{offset: 94, bytesPerRow: 131}, {width: 24, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer192 = device0.createBuffer({
+  size: 10337,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder154.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+computePassEncoder116.setBindGroup(1, bindGroup45, new Uint32Array(5780), 4_855, 0);
+} catch {}
+try {
+renderPassEncoder78.setBindGroup(1, bindGroup85);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer147, 'uint32', 1_088, 959);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(3, buffer33);
+} catch {}
+try {
+renderBundleEncoder38.setBindGroup(1, bindGroup40, new Uint32Array(1364), 120, 0);
+} catch {}
+let arrayBuffer25 = buffer111.getMappedRange(2352, 24);
+let pipeline70 = await device0.createComputePipelineAsync({
+  layout: pipelineLayout21,
+  compute: {module: shaderModule9, entryPoint: 'compute11', constants: {60_915: 0}},
+});
+let autogeneratedBindGroupLayout104 = pipeline26.getBindGroupLayout(0);
+let texture291 = device0.createTexture({size: [120, 40, 51], mipLevelCount: 2, format: 'rgb10a2uint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let renderBundle38 = renderBundleEncoder38.finish({});
+let sampler194 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 92.52});
+try {
+buffer151.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture134,
+  mipLevel: 0,
+  origin: {x: 5, y: 5, z: 39},
+  aspect: 'all',
+}, new Uint8Array(23_953).fill(80), /* required buffer size: 23_953 */
+{offset: 173, bytesPerRow: 26, rowsPerImage: 101}, {width: 4, height: 6, depthOrArrayLayers: 10});
+} catch {}
+let buffer193 = device0.createBuffer({size: 13898, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+let textureView285 = texture150.createView({dimension: '2d', baseArrayLayer: 1});
+try {
+computePassEncoder109.setBindGroup(0, bindGroup81);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(0, bindGroup139);
+} catch {}
+try {
+renderPassEncoder67.setBindGroup(0, bindGroup99, new Uint32Array(5471), 1_047, 0);
+} catch {}
+try {
+renderPassEncoder28.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder39.setScissorRect(43, 22, 11, 29);
+} catch {}
+try {
+renderPassEncoder65.setVertexBuffer(7, buffer151, 188, 577);
+} catch {}
+await gc();
+let veryExplicitBindGroupLayout39 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 32, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+  ],
+});
+let textureView286 = texture287.createView({dimension: '2d'});
+let textureView287 = texture177.createView({dimension: '2d-array', aspect: 'depth-only'});
+try {
+computePassEncoder86.setBindGroup(0, bindGroup41);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(2, bindGroup95);
+} catch {}
+try {
+buffer141.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1702, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame17,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 273, y: 10, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas0);
+let buffer194 = device0.createBuffer({
+  size: 20481,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+});
+let textureView288 = texture3.createView({dimension: '2d', mipLevelCount: 1});
+try {
+renderPassEncoder39.setIndexBuffer(buffer107, 'uint16', 238, 11);
+} catch {}
+try {
+renderPassEncoder66.setVertexBuffer(2, buffer59);
+} catch {}
+let bindGroup183 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout84,
+  entries: [{binding: 8, resource: {buffer: buffer39, offset: 0, size: 2152}}],
+});
+let buffer195 = device0.createBuffer({
+  size: 7535,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let textureView289 = texture11.createView({arrayLayerCount: 1});
+try {
+computePassEncoder187.setBindGroup(0, bindGroup108, new Uint32Array(3), 0, 0);
+} catch {}
+try {
+renderPassEncoder79.setIndexBuffer(buffer109, 'uint16', 22, 54);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture221,
+  mipLevel: 0,
+  origin: {x: 12, y: 4, z: 0},
+  aspect: 'all',
+}, new Uint8Array(25).fill(232), /* required buffer size: 25 */
+{offset: 25, rowsPerImage: 6}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let recycledExplicitBindGroupLayout30 = pipeline52.getBindGroupLayout(0);
+let texture292 = device0.createTexture({
+  size: {width: 60, height: 20, depthOrArrayLayers: 73},
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder140.setBindGroup(2, bindGroup177, new Uint32Array(93), 3, 0);
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let texture293 = device0.createTexture({
+  size: {width: 30, height: 10, depthOrArrayLayers: 1},
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderPassEncoder59.setBindGroup(1, bindGroup20, new Uint32Array(250), 32, 0);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer109, 'uint32', 0, 12);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba16float'],
+});
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline3);
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55); };
+} catch {}
+let textureView290 = texture223.createView({baseArrayLayer: 0});
+let sampler195 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', addressModeW: 'repeat', magFilter: 'nearest'});
+try {
+renderPassEncoder21.setBindGroup(1, bindGroup11, new Uint32Array(1674), 800, 0);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer171, 'uint32', 444, 377);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(3, buffer181, 0, 6_000);
+} catch {}
+try {
+computePassEncoder47.pushDebugGroup('\uf636');
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(1, bindGroup123);
+} catch {}
+try {
+buffer83.unmap();
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer85, 1260, new Int16Array(4747), 258, 276);
+} catch {}
+let bindGroup184 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout13,
+  entries: [{binding: 8, resource: {buffer: buffer115, offset: 768, size: 2436}}],
+});
+let bindGroup185 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout5,
+  entries: [{binding: 396, resource: {buffer: buffer84, offset: 512, size: 268}}],
+});
+let texture294 = device0.createTexture({
+  size: {width: 240, height: 80, depthOrArrayLayers: 294},
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder39 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], depthReadOnly: false, stencilReadOnly: false});
+let sampler196 = device0.createSampler({addressModeW: 'repeat', minFilter: 'linear', mipmapFilter: 'linear', lodMaxClamp: 86.20});
+try {
+renderPassEncoder75.setIndexBuffer(buffer36, 'uint16', 394, 678);
+} catch {}
+try {
+renderPassEncoder54.setVertexBuffer(4, buffer59);
+} catch {}
+try {
+renderBundleEncoder39.setIndexBuffer(buffer153, 'uint32', 272, 273);
+} catch {}
+try {
+buffer63.unmap();
+} catch {}
+try {
+computePassEncoder47.popDebugGroup();
+} catch {}
+let querySet41 = device0.createQuerySet({type: 'occlusion', count: 319});
+let sampler197 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 93.73,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder192.setBindGroup(3, bindGroup118);
+} catch {}
+try {
+computePassEncoder21.setBindGroup(3, bindGroup111, new Uint32Array(481), 67, 0);
+} catch {}
+try {
+renderPassEncoder64.setBindGroup(2, bindGroup52);
+} catch {}
+try {
+renderPassEncoder21.setScissorRect(59, 23, 2, 0);
+} catch {}
+try {
+renderPassEncoder53.setIndexBuffer(buffer105, 'uint32', 1_172, 704);
+} catch {}
+try {
+computePassEncoder106.setBindGroup(3, bindGroup92, new Uint32Array(161), 31, 0);
+} catch {}
+try {
+renderBundleEncoder39.setBindGroup(3, bindGroup145, new Uint32Array(434), 12, 0);
+} catch {}
+try {
+renderPassEncoder28.insertDebugMarker('\u0b1d');
+} catch {}
+let videoFrame39 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'film', transfer: 'logSqrt'} });
+let buffer196 = device0.createBuffer({size: 2481, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture295 = device0.createTexture({size: {width: 60}, dimension: '1d', format: 'rgba8sint', usage: GPUTextureUsage.COPY_DST});
+let textureView291 = texture98.createView({mipLevelCount: 1, baseArrayLayer: 66});
+let renderBundle39 = renderBundleEncoder39.finish({});
+let sampler198 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'repeat', minFilter: 'linear'});
+try {
+computePassEncoder214.setBindGroup(0, bindGroup66, new Uint32Array(990), 204, 0);
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(7, buffer159);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture296 = device0.createTexture({
+  size: {width: 1, height: 1, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder30.setPipeline(pipeline44);
+} catch {}
+try {
+buffer87.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame22,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 18, y: 20, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let recycledExplicitBindGroupLayout31 = pipeline25.getBindGroupLayout(0);
+let bindGroup186 = device0.createBindGroup({
+  label: '\ua742\u1010\ubaaf\u{1f906}\uacb2',
+  layout: autogeneratedBindGroupLayout91,
+  entries: [
+    {binding: 8, resource: {buffer: buffer61, offset: 256, size: 1424}},
+    {binding: 216, resource: textureView24},
+  ],
+});
+let textureView292 = texture268.createView({dimension: '2d-array', mipLevelCount: 1, arrayLayerCount: 1});
+try {
+computePassEncoder97.setBindGroup(0, bindGroup61, new Uint32Array(138), 27, 0);
+} catch {}
+try {
+renderPassEncoder51.setIndexBuffer(buffer80, 'uint16', 1_792, 1_563);
+} catch {}
+let querySet42 = device0.createQuerySet({type: 'occlusion', count: 3639});
+let sampler199 = device0.createSampler({addressModeU: 'mirror-repeat', minFilter: 'linear', mipmapFilter: 'linear', lodMaxClamp: 89.35});
+try {
+computePassEncoder121.setBindGroup(1, bindGroup28);
+} catch {}
+try {
+renderPassEncoder76.setBindGroup(2, bindGroup184, new Uint32Array(4991), 291, 0);
+} catch {}
+let imageData47 = new ImageData(28, 16);
+let bindGroup187 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout57,
+  entries: [{binding: 8, resource: {buffer: buffer85, offset: 1024}}],
+});
+let texture297 = device0.createTexture({
+  size: {width: 1, height: 1, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder38.setBindGroup(0, bindGroup46, new Uint32Array(1094), 275, 0);
+} catch {}
+try {
+renderPassEncoder42.setIndexBuffer(buffer173, 'uint16', 1_476, 5_932);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let recycledExplicitBindGroupLayout32 = pipeline37.getBindGroupLayout(0);
+let bindGroup188 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout11,
+  entries: [{binding: 258, resource: textureView201}, {binding: 116, resource: {buffer: buffer85, offset: 256}}],
+});
+let buffer197 = device0.createBuffer({
+  size: 4388,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let sampler200 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 90.15,
+  lodMaxClamp: 94.84,
+});
+try {
+renderPassEncoder32.beginOcclusionQuery(31);
+} catch {}
+try {
+renderPassEncoder58.setVertexBuffer(7, buffer120, 48, 132);
+} catch {}
+let imageData48 = new ImageData(20, 48);
+let bindGroup189 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout75,
+  entries: [{binding: 8, resource: {buffer: buffer189, offset: 8448, size: 736}}],
+});
+let sampler201 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'repeat'});
+try {
+renderPassEncoder32.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: -705.0, g: -662.0, b: -277.9, a: 772.4, });
+} catch {}
+try {
+renderPassEncoder52.setVertexBuffer(7, buffer132, 4_148);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+computePassEncoder44.setBindGroup(1, bindGroup38, new Uint32Array(615), 27, 0);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(3, bindGroup185);
+} catch {}
+let veryExplicitBindGroupLayout40 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 13, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 217,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 252,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+try {
+computePassEncoder83.setBindGroup(2, bindGroup109, new Uint32Array(1610), 0, 0);
+} catch {}
+try {
+renderPassEncoder73.setBindGroup(3, bindGroup165, new Uint32Array(2565), 322, 0);
+} catch {}
+try {
+computePassEncoder189.pushDebugGroup('\uebb6');
+} catch {}
+try {
+computePassEncoder189.popDebugGroup();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline43);
+} catch {}
+let pipeline71 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment10',
+  constants: {},
+  targets: [{format: 'rgba8sint', writeMask: GPUColorWrite.ALPHA}],
+},
+  depthStencil: {
+    format: 'depth32float',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilReadMask: 448305405,
+    stencilWriteMask: 504776883,
+    depthBias: -868774828,
+    depthBiasSlopeScale: 161.02611878274132,
+    depthBiasClamp: -74.25540117566453,
+  },
+  vertex: {
+    module: shaderModule5,
+    buffers: [
+      {
+        arrayStride: 1136,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x3', offset: 572, shaderLocation: 0},
+          {format: 'float32x4', offset: 124, shaderLocation: 13},
+          {format: 'unorm10-10-10-2', offset: 400, shaderLocation: 7},
+          {format: 'snorm8x2', offset: 194, shaderLocation: 14},
+          {format: 'snorm16x4', offset: 892, shaderLocation: 2},
+          {format: 'snorm16x2', offset: 80, shaderLocation: 11},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', frontFace: 'cw', cullMode: 'front'},
+});
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let buffer198 = device0.createBuffer({size: 8624, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT});
+let sampler202 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 49.20,
+  maxAnisotropy: 18,
+});
+try {
+renderPassEncoder56.setIndexBuffer(buffer123, 'uint16', 1_420, 148);
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let autogeneratedBindGroupLayout105 = pipeline18.getBindGroupLayout(0);
+let bindGroup190 = device0.createBindGroup({
+  layout: recycledAutogeneratedBindGroupLayout3,
+  entries: [{binding: 8, resource: {buffer: buffer79, offset: 0, size: 144}}],
+});
+let querySet43 = device0.createQuerySet({type: 'occlusion', count: 12});
+let texture298 = device0.createTexture({
+  label: '\u04ef\ud522\u{1f8c0}\u7a15\u64d0',
+  size: [2, 2, 1],
+  sampleCount: 4,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture299 = device0.createTexture({size: [120], dimension: '1d', format: 'rgb10a2uint', usage: GPUTextureUsage.COPY_SRC, viewFormats: []});
+let textureView293 = texture2.createView({dimension: '2d-array', baseMipLevel: 0, mipLevelCount: 1, arrayLayerCount: 1});
+try {
+renderPassEncoder75.setPipeline(pipeline63);
+} catch {}
+let textureView294 = texture125.createView({dimension: '2d', aspect: 'all', mipLevelCount: 1});
+let sampler203 = device0.createSampler({addressModeV: 'repeat', minFilter: 'nearest', lodMaxClamp: 91.69});
+try {
+computePassEncoder71.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder67.setViewport(140.0879461742269, 13.198894049755117, 62.861610253899876, 48.08089529457232, 0.40632234253649324, 0.4949070493290795);
+} catch {}
+try {
+renderPassEncoder70.setIndexBuffer(buffer153, 'uint32', 100, 127);
+} catch {}
+try {
+gpuCanvasContext13.unconfigure();
+} catch {}
+let recycledAutogeneratedBindGroupLayout6 = pipeline30.getBindGroupLayout(0);
+let bindGroup191 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout25,
+  entries: [{binding: 8, resource: {buffer: buffer49, offset: 2560}}],
+});
+let buffer199 = device0.createBuffer({size: 19517, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM, mappedAtCreation: false});
+let texture300 = device0.createTexture({size: [120, 40, 1], format: 'rgba16sint', usage: GPUTextureUsage.TEXTURE_BINDING});
+try {
+computePassEncoder155.setBindGroup(1, bindGroup108);
+} catch {}
+try {
+computePassEncoder128.end();
+} catch {}
+try {
+renderPassEncoder65.setBindGroup(3, bindGroup83, []);
+} catch {}
+try {
+renderPassEncoder40.setStencilReference(2598);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline23);
+} catch {}
+try {
+  await shaderModule6.getCompilationInfo();
+} catch {}
+try {
+commandEncoder148.copyBufferToBuffer(buffer71, 1624, buffer122, 1788, 160);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+if (!arrayBuffer25.detached) { new Uint8Array(arrayBuffer25).fill(0x55); };
+} catch {}
+let bindGroup192 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout14,
+  entries: [{binding: 396, resource: {buffer: buffer165, offset: 5120}}],
+});
+let commandBuffer20 = commandEncoder148.finish();
+try {
+computePassEncoder108.setBindGroup(3, bindGroup92);
+} catch {}
+let bindGroup193 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 396, resource: {buffer: buffer165, offset: 1792}}],
+});
+try {
+computePassEncoder66.setBindGroup(3, bindGroup54);
+} catch {}
+try {
+renderPassEncoder64.setIndexBuffer(buffer86, 'uint16', 7_782, 938);
+} catch {}
+let commandEncoder276 = device0.createCommandEncoder();
+let computePassEncoder229 = commandEncoder276.beginComputePass({});
+try {
+computePassEncoder167.setBindGroup(3, bindGroup113, new Uint32Array(2006), 309, 0);
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(2, bindGroup179);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle12, renderBundle11, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer36, 'uint16', 36, 4_463);
+} catch {}
+let sampler204 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 61.80,
+  compare: 'less-equal',
+});
+try {
+computePassEncoder152.setBindGroup(2, bindGroup112);
+} catch {}
+try {
+computePassEncoder101.setBindGroup(1, bindGroup157, new Uint32Array(2298), 836, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(148).fill(118), /* required buffer size: 148 */
+{offset: 148}, {width: 27, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder96.setBindGroup(3, bindGroup17);
+} catch {}
+try {
+computePassEncoder229.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder59.setBindGroup(2, bindGroup122, new Uint32Array(655), 112, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture250,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(22).fill(153), /* required buffer size: 22 */
+{offset: 22, bytesPerRow: 136}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+globalThis.someLabel = texture69.label;
+} catch {}
+let textureView295 = texture240.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 5});
+let sampler205 = device0.createSampler({
+  label: '\u{1f6ce}\u374c\u05a7\u35b4\u{1fc2e}\u6db1\u{1fe7e}\u3495',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 98.72,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder17.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder17.setBlendConstant({ r: 434.4, g: 386.6, b: 831.5, a: -405.4, });
+} catch {}
+try {
+buffer42.unmap();
+} catch {}
+let textureView296 = texture248.createView({baseMipLevel: 0, mipLevelCount: 1});
+let sampler206 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+});
+try {
+computePassEncoder114.setBindGroup(3, bindGroup39);
+} catch {}
+try {
+renderPassEncoder74.setBindGroup(3, bindGroup74);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline27);
+} catch {}
+let buffer200 = device0.createBuffer({size: 19199, usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+try {
+computePassEncoder200.setBindGroup(0, bindGroup180, new Uint32Array(11), 2, 0);
+} catch {}
+try {
+renderPassEncoder61.setBindGroup(2, bindGroup94, new Uint32Array(3852), 182, 0);
+} catch {}
+try {
+renderPassEncoder54.executeBundles([renderBundle16]);
+} catch {}
+let img8 = await imageWithData(22, 8, '#10101010', '#20202020');
+try {
+computePassEncoder61.label = '\u070a\u61b8\u7be1\u009b\u07ef\u05ae\u24b6';
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline19);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture117,
+  mipLevel: 0,
+  origin: {x: 2, y: 4, z: 0},
+  aspect: 'all',
+}, new Uint8Array(29).fill(121), /* required buffer size: 29 */
+{offset: 29, bytesPerRow: 120, rowsPerImage: 54}, {width: 29, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup194 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout3,
+  entries: [{binding: 8, resource: {buffer: buffer66, offset: 0, size: 240}}],
+});
+let buffer201 = device0.createBuffer({size: 5330, usage: GPUBufferUsage.INDEX});
+let textureView297 = texture141.createView({dimension: '2d-array'});
+let sampler207 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', addressModeW: 'repeat', minFilter: 'linear'});
+try {
+renderPassEncoder68.executeBundles([renderBundle10, renderBundle10]);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let textureView298 = texture48.createView({});
+try {
+computePassEncoder126.setBindGroup(2, bindGroup51, new Uint32Array(768), 192, 0);
+} catch {}
+let bindGroup195 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout83,
+  entries: [{binding: 216, resource: textureView230}, {binding: 8, resource: {buffer: buffer69, offset: 0}}],
+});
+let texture301 = device0.createTexture({
+  size: {width: 2},
+  dimension: '1d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder95.setBindGroup(2, bindGroup136);
+} catch {}
+try {
+computePassEncoder206.setBindGroup(2, bindGroup39, new Uint32Array(254), 71, 0);
+} catch {}
+try {
+renderPassEncoder55.setViewport(28.03461752856692, 4.375276031720025, 13.525690115659282, 12.481387151857056, 0.8420359862725488, 0.93392518324153);
+} catch {}
+try {
+renderPassEncoder58.setVertexBuffer(7, buffer147, 0, 339);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData28,
+  origin: { x: 3, y: 5 },
+  flipY: false,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 165, y: 77, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 11, height: 12, depthOrArrayLayers: 0});
+} catch {}
+let buffer202 = device0.createBuffer({
+  size: 4221,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture302 = device0.createTexture({
+  size: [60],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder13.executeBundles([renderBundle4]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer90, 404, new Int16Array(30081), 575, 12);
+} catch {}
+try {
+globalThis.someLabel = externalTexture42.label;
+} catch {}
+let bindGroup196 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout80,
+  entries: [{binding: 8, resource: {buffer: buffer63, offset: 0}}],
+});
+let sampler208 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 66.75,
+  compare: 'greater',
+  maxAnisotropy: 3,
+});
+let buffer203 = device0.createBuffer({size: 10728, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let texture303 = device0.createTexture({
+  size: {width: 60, height: 20, depthOrArrayLayers: 73},
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView299 = texture80.createView({});
+let sampler209 = device0.createSampler({addressModeW: 'mirror-repeat', minFilter: 'linear', lodMaxClamp: 96.54});
+let externalTexture43 = device0.importExternalTexture({source: videoFrame36});
+try {
+computePassEncoder144.setBindGroup(1, bindGroup37);
+} catch {}
+try {
+computePassEncoder142.setBindGroup(0, bindGroup120, new Uint32Array(1128), 160, 0);
+} catch {}
+try {
+buffer177.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer20]);
+} catch {}
+let promise31 = device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule5}});
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let buffer204 = device0.createBuffer({size: 19253, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let texture304 = device0.createTexture({
+  size: {width: 60},
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderPassEncoder57.setBindGroup(1, bindGroup163, new Uint32Array(302), 36, 0);
+} catch {}
+try {
+renderPassEncoder72.setIndexBuffer(buffer192, 'uint32', 2_676, 78);
+} catch {}
+try {
+renderPassEncoder54.setPipeline(pipeline3);
+} catch {}
+let pipeline72 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule7, entryPoint: 'compute8', constants: {}}});
+try {
+adapter0.label = '\ub1a6\u57d8\ubf7e\uf5f0\u{1ff20}';
+} catch {}
+let textureView300 = texture20.createView({dimension: '1d'});
+try {
+computePassEncoder162.setBindGroup(1, bindGroup156);
+} catch {}
+try {
+computePassEncoder213.setBindGroup(2, bindGroup40, new Uint32Array(936), 97, 0);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer105, 'uint16', 768, 636);
+} catch {}
+try {
+renderPassEncoder52.setPipeline(pipeline39);
+} catch {}
+let arrayBuffer26 = buffer45.getMappedRange(352, 48);
+try {
+gpuCanvasContext11.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let pipeline73 = await device0.createComputePipelineAsync({layout: pipelineLayout21, compute: {module: shaderModule0, constants: {}}});
+let shaderModule10 = device0.createShaderModule({
+  code: `
+requires pointer_composite_access;
+
+enable f16;
+
+diagnostic(info, xyz);
+
+requires pointer_composite_access;
+
+fn fn0() -> vec4u {
+  var out: vec4u;
+  let ptr175: ptr<storage, array<array<f16, 1>, 1>, read> = &(*&buffer205)[26][0][0];
+  let ptr176: ptr<storage, f16, read> = &buffer205[26][0][u32(unconst_u32(209))][u32(unconst_u32(444))][0];
+  let ptr177: ptr<storage, f16, read> = &(*&buffer205)[26][0][u32(unconst_u32(11))][u32(unconst_u32(145))][0];
+  let ptr178: ptr<storage, f16, read> = &buffer205[u32(unconst_u32(10))][u32(unconst_u32(76))][0][u32(unconst_u32(268))][0];
+  let ptr179: ptr<storage, array<array<array<f16, 1>, 1>, 1>, read> = &buffer205[26][u32(unconst_u32(113))];
+  let ptr180: ptr<storage, f16, read> = &(*&buffer205)[26][0][u32(unconst_u32(100))][0][u32(unconst_u32(426))];
+  out |= unpack4xU8(u32((*&buffer205)[u32(unconst_u32(250))][u32(unconst_u32(62))][u32(unconst_u32(2))][u32(unconst_u32(265))][0]));
+  let ptr181: ptr<storage, f16, read> = &buffer205[26][0][u32(unconst_u32(253))][u32(unconst_u32(22))][0];
+  let ptr182: ptr<storage, f16, read> = &(*ptr179)[u32(unconst_u32(7))][0][u32(unconst_u32(341))];
+  return out;
+  _ = buffer205;
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct FragmentOutput12 {
+  @builtin(sample_mask) f0: u32,
+  @location(5) f1: vec4u,
+  @location(0) @interpolate(flat) f2: vec4u,
+}
+
+@group(0) @binding(8) var<storage, read> buffer205: array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 27>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct T0 {
+  f0: array<atomic<u32>>,
+}
+
+@fragment
+fn fragment12() -> FragmentOutput12 {
+  var out: FragmentOutput12;
+  out.f1 &= unpack4xU8(u32((*&buffer205)[26][0][u32(unconst_u32(360))][u32(unconst_u32(86))][u32(unconst_u32(76))]));
+  let ptr183: ptr<storage, array<array<f16, 1>, 1>, read> = &buffer205[u32(unconst_u32(49))][u32(unconst_u32(70))][u32(unconst_u32(197))];
+  out.f2 = unpack4xU8(u32(buffer205[u32(unconst_u32(91))][0][u32(unconst_u32(147))][u32(unconst_u32(178))][0]));
+  let ptr184: ptr<storage, array<array<array<f16, 1>, 1>, 1>, read> = &(*&buffer205)[u32(unconst_u32(53))][0];
+  out.f1 = vec4u(u32(buffer205[u32(unconst_u32(307))][u32(unconst_u32(59))][u32(unconst_u32(83))][u32(unconst_u32(34))][0]));
+  let ptr185: ptr<storage, f16, read> = &buffer205[26][u32(unconst_u32(179))][0][0][u32(unconst_u32(97))];
+  out.f2 &= vec4u(u32((*&buffer205)[26][u32(unconst_u32(161))][0][0][0]));
+  let ptr186: ptr<storage, array<f16, 1>, read> = &buffer205[26][0][0][0];
+  out.f2 -= vec4u(u32((*&buffer205)[26][u32(unconst_u32(72))][0][0][0]));
+  var vf119: vec4f = faceForward(vec4f(unconst_f32(0.4875), unconst_f32(0.02107), unconst_f32(0.1270), unconst_f32(0.4729)), vec4f(f32((*&buffer205)[26][u32(unconst_u32(306))][0][0][u32(unconst_u32(269))])), vec4f(unconst_f32(0.07854), unconst_f32(0.1603), unconst_f32(0.2225), unconst_f32(0.1082)));
+  let ptr187: ptr<storage, array<f16, 1>, read> = &buffer205[26][u32(unconst_u32(92))][u32(unconst_u32(100))][0];
+  let ptr188: ptr<storage, f16, read> = &(*&buffer205)[u32(unconst_u32(30))][0][u32(unconst_u32(14))][u32(unconst_u32(259))][0];
+  let ptr189: ptr<storage, array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 27>, read> = &buffer205;
+  let ptr190: ptr<storage, f16, read> = &(*ptr189)[u32(unconst_u32(3))][0][u32((*&buffer205)[u32(unconst_u32(582))][0][0][u32(unconst_u32(311))][0])][u32(unconst_u32(793))][u32(unconst_u32(513))];
+  out.f0 = u32((*&buffer205)[26][0][0][0][0]);
+  let ptr191: ptr<storage, array<array<f16, 1>, 1>, read> = &(*ptr189)[u32(unconst_u32(16))][0][u32(unconst_u32(314))];
+  let ptr192: ptr<storage, array<f16, 1>, read> = &buffer205[u32(unconst_u32(28))][0][u32(unconst_u32(146))][u32(unconst_u32(290))];
+  out.f2 >>= unpack4xU8(u32((*ptr191)[0][u32(unconst_u32(175))]));
+  out.f2 = unpack4xU8(u32((*ptr189)[26][0][u32(unconst_u32(63))][u32(buffer205[u32(unconst_u32(66))][0][u32(unconst_u32(267))][0][0])][u32(unconst_u32(554))]));
+  let ptr193: ptr<storage, array<array<f16, 1>, 1>, read> = &(*ptr184)[u32(unconst_u32(46))];
+  out.f0 <<= u32((*ptr187)[0]);
+  let ptr194: ptr<storage, array<f16, 1>, read> = &buffer205[26][0][0][0];
+  let ptr195: ptr<storage, f16, read> = &buffer205[u32((*&buffer205)[u32(unconst_u32(501))][u32(unconst_u32(188))][0][0][u32(unconst_u32(160))])][0][u32((*&buffer205)[u32(unconst_u32(115))][u32(unconst_u32(72))][0][0][0])][0][u32(unconst_u32(9))];
+  out.f0 <<= u32((*ptr191)[u32(unconst_u32(371))][0]);
+  return out;
+  _ = buffer205;
+}`,
+});
+let querySet44 = device0.createQuerySet({type: 'occlusion', count: 607});
+try {
+renderPassEncoder53.setBlendConstant({ r: 578.9, g: 965.5, b: -119.4, a: -950.1, });
+} catch {}
+let sampler210 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'repeat', lodMaxClamp: 62.77});
+let pipeline74 = device0.createRenderPipeline({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule0,
+  constants: {},
+  targets: [{format: 'rgba8sint', writeMask: GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth32float',
+    depthWriteEnabled: true,
+    depthCompare: 'always',
+    stencilBack: {failOp: 'keep', passOp: 'keep'},
+    stencilWriteMask: 665730465,
+    depthBiasClamp: 157.25358971935026,
+  },
+  vertex: {
+    module: shaderModule8,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 284,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x4', offset: 16, shaderLocation: 0},
+          {format: 'sint16x4', offset: 12, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+});
+try {
+externalTexture18.label = '\ucd7b\u7251\u3f2e\u0aa2\u401e\u96b8\u{1f79f}';
+} catch {}
+let textureView301 = texture297.createView({});
+let textureView302 = texture105.createView({mipLevelCount: 1, baseArrayLayer: 4, arrayLayerCount: 1});
+try {
+renderPassEncoder22.setBindGroup(0, bindGroup132);
+} catch {}
+try {
+renderPassEncoder69.setIndexBuffer(buffer115, 'uint32', 472, 438);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture266,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(4_078).fill(28), /* required buffer size: 4_078 */
+{offset: 18, bytesPerRow: 116, rowsPerImage: 35}, {width: 0, height: 0, depthOrArrayLayers: 2});
+} catch {}
+let videoFrame40 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'fcc', primaries: 'unspecified', transfer: 'smpte240m'} });
+let texture305 = device0.createTexture({
+  size: [120, 40, 19],
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder14.executeBundles([renderBundle11]);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let promise32 = device0.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+let recycledExplicitBindGroupLayout33 = pipeline58.getBindGroupLayout(0);
+try {
+renderPassEncoder33.setBindGroup(3, bindGroup78);
+} catch {}
+try {
+renderPassEncoder75.setIndexBuffer(buffer105, 'uint16', 1_556, 687);
+} catch {}
+try {
+renderPassEncoder65.setPipeline(pipeline29);
+} catch {}
+let buffer206 = device0.createBuffer({
+  size: 1574,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let sampler211 = device0.createSampler({addressModeU: 'mirror-repeat', minFilter: 'linear', mipmapFilter: 'linear'});
+try {
+renderPassEncoder23.setIndexBuffer(buffer82, 'uint32', 76, 31);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline57);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(4, buffer163, 0, 917);
+} catch {}
+let autogeneratedBindGroupLayout106 = pipeline64.getBindGroupLayout(0);
+let texture306 = device0.createTexture({
+  label: '\u{1fcfd}\u0e28\u5b9c',
+  size: {width: 240, height: 80, depthOrArrayLayers: 104},
+  sampleCount: 1,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView303 = texture276.createView({mipLevelCount: 1});
+let sampler212 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 87.65,
+  compare: 'equal',
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder217.setBindGroup(1, bindGroup89);
+} catch {}
+try {
+renderPassEncoder56.setBindGroup(0, bindGroup105);
+} catch {}
+try {
+renderPassEncoder56.setBlendConstant({ r: -175.3, g: -774.0, b: 632.9, a: 817.7, });
+} catch {}
+try {
+renderPassEncoder78.setIndexBuffer(buffer112, 'uint32', 448, 201);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline44);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(5, buffer98, 0, 463);
+} catch {}
+let arrayBuffer27 = buffer65.getMappedRange(1296, 12);
+document.body.append(img4);
+let texture307 = device0.createTexture({
+  size: {width: 120, height: 40, depthOrArrayLayers: 16},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder40 = device0.createRenderBundleEncoder({colorFormats: ['rgba8sint'], depthStencilFormat: 'depth32float', depthReadOnly: true});
+try {
+computePassEncoder157.setBindGroup(0, bindGroup143);
+} catch {}
+try {
+computePassEncoder76.setBindGroup(1, bindGroup115, new Uint32Array(941), 312, 0);
+} catch {}
+try {
+renderPassEncoder59.setBindGroup(2, bindGroup75);
+} catch {}
+try {
+renderPassEncoder23.setScissorRect(0, 2, 14, 1);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(3, bindGroup109);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(3, bindGroup99, new Uint32Array(600), 51, 0);
+} catch {}
+try {
+renderBundleEncoder40.setPipeline(pipeline32);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1702, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame12,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 249, y: 12, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer207 = device0.createBuffer({
+  size: 3022,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let renderBundleEncoder41 = device0.createRenderBundleEncoder({colorFormats: ['rgba8sint'], depthStencilFormat: 'depth32float', depthReadOnly: true});
+let externalTexture44 = device0.importExternalTexture({source: videoFrame11});
+try {
+renderPassEncoder65.setBindGroup(2, bindGroup172, new Uint32Array(1061), 300, 0);
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer185, 'uint16', 166, 65);
+} catch {}
+try {
+renderPassEncoder57.setVertexBuffer(0, buffer7, 900, 548);
+} catch {}
+let arrayBuffer28 = buffer45.getMappedRange(400, 0);
+try {
+  await promise32;
+} catch {}
+let sampler213 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 92.10,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder177.setBindGroup(1, bindGroup190, new Uint32Array(2712), 144, 0);
+} catch {}
+try {
+renderBundleEncoder40.setIndexBuffer(buffer72, 'uint32', 292, 168);
+} catch {}
+let arrayBuffer29 = buffer111.getMappedRange(3952, 160);
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame26,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 32, y: 11, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let sampler214 = device0.createSampler({addressModeV: 'clamp-to-edge', magFilter: 'nearest', mipmapFilter: 'nearest'});
+try {
+renderPassEncoder9.setVertexBuffer(5, buffer17);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(1, bindGroup39);
+} catch {}
+let buffer208 = device0.createBuffer({size: 5334, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC, mappedAtCreation: false});
+try {
+computePassEncoder19.setBindGroup(3, bindGroup39, new Uint32Array(2375), 54, 0);
+} catch {}
+try {
+renderPassEncoder77.setBindGroup(0, bindGroup75, new Uint32Array(2908), 383, 0);
+} catch {}
+try {
+renderPassEncoder49.setIndexBuffer(buffer78, 'uint32', 316, 242);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline74);
+} catch {}
+try {
+renderBundleEncoder41.setBindGroup(2, bindGroup178, new Uint32Array(123), 29, 0);
+} catch {}
+try {
+renderBundleEncoder41.setVertexBuffer(3, buffer92, 0, 109);
+} catch {}
+let veryExplicitBindGroupLayout41 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 8,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 54, hasDynamicOffset: false },
+    },
+  ],
+});
+let textureView304 = texture129.createView({dimension: 'cube', arrayLayerCount: 6});
+try {
+computePassEncoder183.setBindGroup(0, bindGroup71);
+} catch {}
+try {
+computePassEncoder108.setBindGroup(0, bindGroup123, new Uint32Array(955), 54, 0);
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(3, bindGroup115);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer46, 'uint32', 608, 237);
+} catch {}
+try {
+renderPassEncoder66.setVertexBuffer(1, buffer123);
+} catch {}
+try {
+renderBundleEncoder41.setBindGroup(0, bindGroup196);
+} catch {}
+try {
+renderBundleEncoder41.setIndexBuffer(buffer85, 'uint32', 464, 672);
+} catch {}
+try {
+renderBundleEncoder41.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder41.setVertexBuffer(0, buffer33, 0);
+} catch {}
+try {
+buffer66.unmap();
+} catch {}
+try {
+computePassEncoder32.pushDebugGroup('\u0970');
+} catch {}
+try {
+computePassEncoder219.setBindGroup(0, bindGroup115);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(2, bindGroup123);
+} catch {}
+try {
+renderPassEncoder55.setPipeline(pipeline4);
+} catch {}
+let autogeneratedBindGroupLayout107 = pipeline0.getBindGroupLayout(0);
+try {
+computePassEncoder32.setBindGroup(1, bindGroup110);
+} catch {}
+try {
+renderPassEncoder74.setPipeline(pipeline63);
+} catch {}
+try {
+renderPassEncoder58.setVertexBuffer(4, buffer147);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(0, bindGroup30);
+} catch {}
+try {
+renderBundleEncoder40.setPipeline(pipeline54);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer153, 188, new Float32Array(16875), 869, 116);
+} catch {}
+document.body.prepend(canvas5);
+let autogeneratedBindGroupLayout108 = pipeline10.getBindGroupLayout(0);
+try {
+computePassEncoder34.setBindGroup(3, bindGroup133);
+} catch {}
+try {
+computePassEncoder183.setBindGroup(3, bindGroup125, new Uint32Array(869), 135, 0);
+} catch {}
+try {
+renderPassEncoder71.setBindGroup(2, bindGroup179);
+} catch {}
+try {
+renderPassEncoder73.setBindGroup(1, bindGroup99, new Uint32Array(119), 19, 0);
+} catch {}
+try {
+renderBundleEncoder40.setIndexBuffer(buffer9, 'uint32', 3_636, 329);
+} catch {}
+try {
+renderBundleEncoder41.setVertexBuffer(0, buffer182, 668, 741);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let buffer209 = device0.createBuffer({
+  size: 515,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup39);
+} catch {}
+try {
+computePassEncoder117.setBindGroup(3, bindGroup196, new Uint32Array(2294), 0, 0);
+} catch {}
+try {
+renderPassEncoder59.setBindGroup(3, bindGroup120);
+} catch {}
+try {
+renderPassEncoder60.setIndexBuffer(buffer94, 'uint16', 20, 27);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(0, bindGroup43);
+} catch {}
+try {
+renderBundleEncoder40.setPipeline(pipeline54);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(3, buffer204, 0, 6_509);
+} catch {}
+try {
+adapter0.label = '\u0f37\uacfd\u0439\uca18\u{1fe44}\ufa0b\u7374\u912a\u7aaa\u{1fbf1}\u{1ff07}';
+} catch {}
+let bindGroup197 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout86,
+  entries: [{binding: 8, resource: {buffer: buffer207, offset: 256, size: 128}}],
+});
+let texture308 = device0.createTexture({
+  size: [30, 10, 79],
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder84.setBindGroup(0, bindGroup184);
+} catch {}
+try {
+renderPassEncoder22.beginOcclusionQuery(62);
+} catch {}
+try {
+renderPassEncoder22.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle20, renderBundle7, renderBundle18, renderBundle4, renderBundle8, renderBundle18, renderBundle7, renderBundle2, renderBundle12]);
+} catch {}
+try {
+renderPassEncoder28.setScissorRect(72, 5, 47, 60);
+} catch {}
+try {
+renderPassEncoder49.setIndexBuffer(buffer86, 'uint16', 4_380, 517);
+} catch {}
+try {
+renderBundleEncoder41.setPipeline(pipeline19);
+} catch {}
+try {
+buffer140.unmap();
+} catch {}
+let textureView305 = texture308.createView({dimension: '2d', baseArrayLayer: 34});
+let texture309 = device0.createTexture({size: [120, 40, 28], format: 'rgb10a2uint', usage: GPUTextureUsage.COPY_DST});
+let textureView306 = texture52.createView({dimension: '1d'});
+let renderBundle40 = renderBundleEncoder41.finish({});
+try {
+renderPassEncoder25.setBindGroup(2, bindGroup45);
+} catch {}
+try {
+computePassEncoder84.insertDebugMarker('\u049a');
+} catch {}
+let promise33 = device0.queue.onSubmittedWorkDone();
+let imageData49 = new ImageData(28, 4);
+try {
+computePassEncoder100.end();
+} catch {}
+try {
+renderPassEncoder55.setBindGroup(3, bindGroup107);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer109, 'uint16', 54, 7);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(0, bindGroup24, new Uint32Array(89), 16, 0);
+} catch {}
+try {
+commandEncoder64.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4348 */
+  offset: 4348,
+  bytesPerRow: 13824,
+  rowsPerImage: 672,
+  buffer: buffer133,
+}, {
+  texture: texture162,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline75 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout21,
+  fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment9',
+  targets: [{format: 'rgba16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule3,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 120,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint32x2', offset: 4, shaderLocation: 8},
+          {format: 'float32x3', offset: 0, shaderLocation: 0},
+          {format: 'uint8x4', offset: 44, shaderLocation: 13},
+          {format: 'uint16x2', offset: 32, shaderLocation: 14},
+          {format: 'uint32x2', offset: 0, shaderLocation: 2},
+          {format: 'uint32x4', offset: 8, shaderLocation: 3},
+          {format: 'sint32', offset: 28, shaderLocation: 15},
+          {format: 'float32', offset: 4, shaderLocation: 7},
+          {format: 'unorm16x2', offset: 0, shaderLocation: 9},
+          {format: 'sint16x4', offset: 32, shaderLocation: 12},
+          {format: 'snorm16x2', offset: 4, shaderLocation: 5},
+          {format: 'sint32', offset: 12, shaderLocation: 4},
+          {format: 'snorm8x2', offset: 6, shaderLocation: 10},
+          {format: 'uint8x4', offset: 40, shaderLocation: 11},
+        ],
+      },
+      {arrayStride: 20, attributes: [{format: 'float32', offset: 0, shaderLocation: 6}]},
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front'},
+});
+try {
+if (!arrayBuffer28.detached) { new Uint8Array(arrayBuffer28).fill(0x55); };
+} catch {}
+try {
+  await promise33;
+} catch {}
+let bindGroup198 = device0.createBindGroup({
+  label: '\u01ef\u5d9f\u0568\u6e06\u{1f65e}\u8def\u8388',
+  layout: autogeneratedBindGroupLayout59,
+  entries: [{binding: 8, resource: {buffer: buffer57, offset: 0, size: 152}}],
+});
+let renderPassEncoder80 = commandEncoder64.beginRenderPass({colorAttachments: [{view: textureView267, loadOp: 'clear', storeOp: 'store'}]});
+let sampler215 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+});
+try {
+renderPassEncoder69.setVertexBuffer(5, buffer79, 52, 25);
+} catch {}
+try {
+renderBundleEncoder40.setPipeline(pipeline44);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1702, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData40,
+  origin: { x: 0, y: 5 },
+  flipY: false,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 122, y: 4, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer210 = device0.createBuffer({size: 27510, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE});
+let texture310 = device0.createTexture({
+  size: {width: 120, height: 40, depthOrArrayLayers: 15},
+  format: 'r16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let sampler216 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'mirror-repeat'});
+try {
+renderPassEncoder53.setBindGroup(1, bindGroup35, new Uint32Array(1289), 2, 0);
+} catch {}
+try {
+renderBundleEncoder40.setIndexBuffer(buffer109, 'uint16', 26, 2);
+} catch {}
+try {
+renderBundleEncoder40.setPipeline(pipeline13);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1702, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData2,
+  origin: { x: 1, y: 24 },
+  flipY: false,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 240, y: 51, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline76 = device0.createRenderPipeline({
+  layout: pipelineLayout10,
+  fragment: {
+  module: shaderModule10,
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule7,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 612,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x4', offset: 104, shaderLocation: 10},
+          {format: 'unorm8x4', offset: 64, shaderLocation: 4},
+          {format: 'uint8x4', offset: 56, shaderLocation: 7},
+          {format: 'snorm8x4', offset: 48, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+  primitive: {cullMode: 'front'},
+});
+await gc();
+let texture311 = device0.createTexture({
+  size: {width: 60, height: 20, depthOrArrayLayers: 73},
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg32sint'],
+});
+let textureView307 = texture142.createView({baseMipLevel: 0});
+let sampler217 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 96.40,
+});
+try {
+computePassEncoder119.setBindGroup(0, bindGroup91);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder119); computePassEncoder119.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+computePassEncoder119.end();
+} catch {}
+try {
+renderBundleEncoder40.setIndexBuffer(buffer171, 'uint16', 310, 132);
+} catch {}
+try {
+renderBundleEncoder40.setPipeline(pipeline26);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(3, buffer121, 7_088, 57);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+commandEncoder138.copyBufferToBuffer(buffer133, 936, buffer104, 236, 552);
+} catch {}
+try {
+commandEncoder138.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 384 */
+  offset: 384,
+  bytesPerRow: 1792,
+  buffer: buffer42,
+}, {
+  texture: texture3,
+  mipLevel: 1,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 6, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder138.resolveQuerySet(querySet28, 10, 0, buffer204, 4608);
+} catch {}
+let promise34 = device0.queue.onSubmittedWorkDone();
+let commandBuffer21 = commandEncoder138.finish();
+let texture312 = device0.createTexture({
+  size: [60],
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder90.setBindGroup(3, bindGroup62, new Uint32Array(4046), 329, 0);
+} catch {}
+try {
+renderPassEncoder76.setBindGroup(0, bindGroup67, new Uint32Array(2357), 270, 0);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(2, bindGroup97);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture145,
+  mipLevel: 0,
+  origin: {x: 107, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(165).fill(16), /* required buffer size: 165 */
+{offset: 165, bytesPerRow: 102}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame9,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 40, y: 71, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder277 = device0.createCommandEncoder({});
+let texture313 = device0.createTexture({
+  size: [60, 20, 19],
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView308 = texture195.createView({mipLevelCount: 1});
+let computePassEncoder230 = commandEncoder277.beginComputePass({label: '\u0d66\uea44\uab2e\u8f8e\u0aac\u03c5\u0d52\u22a5\u{1f989}'});
+try {
+computePassEncoder220.setBindGroup(1, bindGroup159, new Uint32Array(401), 52, 0);
+} catch {}
+try {
+  await buffer75.mapAsync(GPUMapMode.READ, 0, 308);
+} catch {}
+let pipeline77 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule9, entryPoint: 'compute10'}});
+let autogeneratedBindGroupLayout109 = pipeline33.getBindGroupLayout(0);
+try {
+computePassEncoder220.setBindGroup(1, bindGroup1, new Uint32Array(4570), 1_386, 0);
+} catch {}
+try {
+computePassEncoder230.setPipeline(pipeline45);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(4, buffer132, 0, 952);
+} catch {}
+try {
+renderBundleEncoder40.setPipeline(pipeline3);
+} catch {}
+let recycledExplicitBindGroupLayout34 = pipeline37.getBindGroupLayout(0);
+try {
+computePassEncoder152.setBindGroup(3, bindGroup39);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer21, 'uint16', 286, 2_402);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(3, buffer112, 756, 665);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(1, bindGroup37, new Uint32Array(1459), 148, 0);
+} catch {}
+try {
+renderPassEncoder9.insertDebugMarker('\u0936');
+} catch {}
+try {
+gpuCanvasContext11.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+} catch {}
+await gc();
+try {
+adapter0.label = '\u{1fbec}\u9728\uaa90';
+} catch {}
+let bindGroup199 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout26,
+  entries: [{binding: 8, resource: {buffer: buffer98, offset: 512, size: 456}}],
+});
+let texture314 = device0.createTexture({
+  size: [60, 20, 1],
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder48.setBindGroup(2, bindGroup125, new Uint32Array(1699), 719, 0);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup90, new Uint32Array(507), 252, 0);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(2, buffer207);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let offscreenCanvas10 = new OffscreenCanvas(61, 209);
+let texture315 = device0.createTexture({size: [30, 10, 22], format: 'rgba16sint', usage: GPUTextureUsage.TEXTURE_BINDING});
+try {
+computePassEncoder117.setBindGroup(0, bindGroup55, new Uint32Array(1461), 21, 0);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(6, buffer153, 348);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(4, buffer181);
+} catch {}
+let renderBundle41 = renderBundleEncoder40.finish({});
+try {
+renderPassEncoder32.setBindGroup(3, bindGroup46);
+} catch {}
+try {
+renderPassEncoder16.setStencilReference(109);
+} catch {}
+let gpuCanvasContext14 = offscreenCanvas10.getContext('webgpu');
+let textureView309 = texture195.createView({format: 'r32sint', mipLevelCount: 1});
+let textureView310 = texture103.createView({dimension: '2d', baseArrayLayer: 1});
+let renderBundleEncoder42 = device0.createRenderBundleEncoder({colorFormats: ['rgba16sint'], stencilReadOnly: true});
+let renderBundle42 = renderBundleEncoder42.finish();
+let sampler218 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 38.21,
+  lodMaxClamp: 65.22,
+  maxAnisotropy: 7,
+});
+document.body.prepend(canvas1);
+let bindGroup200 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout26,
+  entries: [{binding: 8, resource: {buffer: buffer163, offset: 256, size: 640}}],
+});
+try {
+computePassEncoder112.setBindGroup(2, bindGroup194);
+} catch {}
+try {
+device0.queue.submit([commandBuffer21]);
+} catch {}
+let promise35 = device0.queue.onSubmittedWorkDone();
+try {
+renderPassEncoder29.setBindGroup(0, bindGroup48, new Uint32Array(2580), 829, 0);
+} catch {}
+try {
+renderPassEncoder72.setVertexBuffer(1, buffer129, 0, 789);
+} catch {}
+let arrayBuffer30 = buffer75.getMappedRange(0, 28);
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let texture316 = device0.createTexture({
+  size: [2, 2, 13],
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder42.setBindGroup(1, bindGroup117);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(3, bindGroup194, new Uint32Array(365), 3, 0);
+} catch {}
+try {
+computePassEncoder32.popDebugGroup();
+} catch {}
+let veryExplicitBindGroupLayout42 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 124,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d-array' },
+    },
+  ],
+});
+let textureView311 = texture266.createView({dimension: '2d', arrayLayerCount: 1});
+try {
+renderPassEncoder37.setPipeline(pipeline26);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let buffer211 = device0.createBuffer({size: 24780, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+try {
+computePassEncoder54.setBindGroup(0, bindGroup130, new Uint32Array(2226), 1_514, 0);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(1, bindGroup8, new Uint32Array(1316), 24, 0);
+} catch {}
+try {
+computePassEncoder219.insertDebugMarker('\u0577');
+} catch {}
+try {
+  await promise34;
+} catch {}
+let texture317 = device0.createTexture({
+  size: {width: 120, height: 40, depthOrArrayLayers: 147},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView312 = texture317.createView({baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 0});
+let sampler219 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'mirror-repeat', lodMinClamp: 87.88, lodMaxClamp: 95.32});
+try {
+renderPassEncoder45.setBindGroup(2, bindGroup93, new Uint32Array(4197), 322, 0);
+} catch {}
+try {
+renderPassEncoder76.insertDebugMarker('\u0354');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 57, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(173).fill(129), /* required buffer size: 173 */
+{offset: 173}, {width: 17, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture318 = device0.createTexture({
+  size: {width: 120, height: 40, depthOrArrayLayers: 29},
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder173.setBindGroup(3, bindGroup78);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(1, buffer197, 500, 1_663);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1702, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData6,
+  origin: { x: 19, y: 6 },
+  flipY: false,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 12, y: 24, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 4, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup201 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [
+    {binding: 258, resource: textureView84},
+    {binding: 116, resource: {buffer: buffer178, offset: 0, size: 368}},
+  ],
+});
+let buffer212 = device0.createBuffer({size: 10245, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM});
+let sampler220 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 74.64,
+});
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup175);
+} catch {}
+try {
+renderPassEncoder42.setPipeline(pipeline27);
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let buffer213 = device0.createBuffer({
+  size: 31805,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let externalTexture45 = device0.importExternalTexture({source: videoFrame33, colorSpace: 'display-p3'});
+try {
+renderPassEncoder1.setPipeline(pipeline3);
+} catch {}
+let autogeneratedBindGroupLayout110 = pipeline0.getBindGroupLayout(0);
+try {
+computePassEncoder222.setBindGroup(3, bindGroup13);
+} catch {}
+try {
+computePassEncoder158.setBindGroup(1, bindGroup71, new Uint32Array(840), 20, 0);
+} catch {}
+try {
+renderPassEncoder79.setBindGroup(0, bindGroup85);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(3, bindGroup49, new Uint32Array(741), 104, 0);
+} catch {}
+try {
+renderPassEncoder71.setViewport(191.4923825879517, 75.41452260315782, 29.49545320154882, 1.3340599134133233, 0.26035078142393975, 0.3213653394982892);
+} catch {}
+try {
+renderPassEncoder42.setIndexBuffer(buffer40, 'uint32', 2_508, 997);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline27);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer187, 132, new Int16Array(7248), 61, 692);
+} catch {}
+try {
+  await promise35;
+} catch {}
+let autogeneratedBindGroupLayout111 = pipeline6.getBindGroupLayout(0);
+let pipelineLayout24 = device0.createPipelineLayout({bindGroupLayouts: [recycledExplicitBindGroupLayout8, veryExplicitBindGroupLayout42]});
+let querySet45 = device0.createQuerySet({type: 'occlusion', count: 513});
+let texture319 = device0.createTexture({
+  size: {width: 30, height: 10, depthOrArrayLayers: 116},
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+renderPassEncoder58.setBindGroup(3, bindGroup110, new Uint32Array(4152), 1_058, 0);
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer21, 'uint32', 5_668, 673);
+} catch {}
+try {
+renderPassEncoder77.setPipeline(pipeline54);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(4, buffer172, 0);
+} catch {}
+try {
+buffer82.unmap();
+} catch {}
+let texture320 = device0.createTexture({
+  size: {width: 240},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture321 = gpuCanvasContext4.getCurrentTexture();
+try {
+renderPassEncoder39.setBindGroup(0, bindGroup121);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer36, 'uint16', 670, 392);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline24);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData48,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 2, y: 30, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let pipeline78 = device0.createRenderPipeline({
+  layout: pipelineLayout10,
+  multisample: {},
+  fragment: {module: shaderModule1, constants: {}, targets: [{format: 'rgba8sint', writeMask: 0}]},
+  depthStencil: {
+    format: 'depth32float',
+    depthWriteEnabled: false,
+    depthCompare: 'not-equal',
+    stencilBack: {failOp: 'keep'},
+    stencilReadMask: 176315360,
+    stencilWriteMask: 289449842,
+    depthBias: -1904353400,
+    depthBiasSlopeScale: 0.0,
+    depthBiasClamp: 492.55528816237074,
+  },
+  vertex: {
+    module: shaderModule8,
+    buffers: [
+      {
+        arrayStride: 440,
+        attributes: [
+          {format: 'sint32x4', offset: 24, shaderLocation: 14},
+          {format: 'sint16x4', offset: 4, shaderLocation: 0},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'none'},
+});
+let buffer214 = device0.createBuffer({size: 1081, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture322 = device0.createTexture({
+  size: [30, 10, 36],
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder199.setBindGroup(3, bindGroup155, new Uint32Array(64), 1, 0);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(0, bindGroup11, new Uint32Array(2015), 178, 0);
+} catch {}
+try {
+renderPassEncoder56.insertDebugMarker('\u{1f7bc}');
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+try {
+globalThis.someLabel = externalTexture31.label;
+} catch {}
+let autogeneratedBindGroupLayout112 = pipeline9.getBindGroupLayout(0);
+let bindGroup202 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout74,
+  entries: [{binding: 8, resource: {buffer: buffer62, offset: 3072}}],
+});
+let textureView313 = texture322.createView({});
+let texture323 = device0.createTexture({
+  size: [120, 40, 147],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView314 = texture110.createView({label: '\u0618\ub66e\u0d93', aspect: 'all'});
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup20, new Uint32Array(1286), 84, 0);
+} catch {}
+try {
+renderPassEncoder79.setIndexBuffer(buffer40, 'uint16', 2_486, 3_854);
+} catch {}
+try {
+renderPassEncoder54.setPipeline(pipeline43);
+} catch {}
+let promise36 = device0.queue.onSubmittedWorkDone();
+await gc();
+let buffer215 = device0.createBuffer({
+  size: 2955,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let texture324 = device0.createTexture({
+  size: {width: 240, height: 80, depthOrArrayLayers: 1},
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderPassEncoder23.setBindGroup(1, bindGroup54, new Uint32Array(1308), 318, 0);
+} catch {}
+try {
+renderPassEncoder58.setVertexBuffer(2, buffer189);
+} catch {}
+let bindGroup203 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout72,
+  entries: [{binding: 8, resource: {buffer: buffer154, offset: 2816}}],
+});
+let textureView315 = texture233.createView({dimension: '2d-array', aspect: 'depth-only'});
+try {
+computePassEncoder67.setBindGroup(2, bindGroup35);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup166);
+} catch {}
+try {
+renderPassEncoder73.setBindGroup(3, bindGroup33, new Uint32Array(3128), 310, 0);
+} catch {}
+try {
+renderPassEncoder65.setIndexBuffer(buffer82, 'uint32', 0, 1_358);
+} catch {}
+try {
+renderPassEncoder80.setVertexBuffer(4, buffer19, 600, 367);
+} catch {}
+try {
+buffer31.unmap();
+} catch {}
+try {
+  await promise36;
+} catch {}
+document.body.append(canvas5);
+try {
+computePassEncoder183.setBindGroup(0, bindGroup109);
+} catch {}
+try {
+computePassEncoder142.setBindGroup(0, bindGroup19, new Uint32Array(1362), 73, 0);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(3, bindGroup198);
+} catch {}
+try {
+renderPassEncoder75.executeBundles([renderBundle37]);
+} catch {}
+try {
+renderPassEncoder80.setIndexBuffer(buffer125, 'uint32', 1_544, 389);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline54);
+} catch {}
+let arrayBuffer31 = buffer75.getMappedRange(208, 0);
+try {
+device0.queue.writeBuffer(buffer163, 160, new Int16Array(12081), 1171, 20);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1702, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: img0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 692, y: 9, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup204 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout0,
+  entries: [{binding: 396, resource: {buffer: buffer8, offset: 256, size: 32}}],
+});
+let buffer216 = device0.createBuffer({
+  size: 439,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder16.executeBundles([renderBundle16, renderBundle1, renderBundle16]);
+} catch {}
+try {
+renderPassEncoder63.setPipeline(pipeline51);
+} catch {}
+let bindGroup205 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout15,
+  entries: [{binding: 396, resource: {buffer: buffer140, offset: 512, size: 32}}],
+});
+let buffer217 = device0.createBuffer({size: 5338, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView316 = texture79.createView({});
+try {
+computePassEncoder166.setBindGroup(1, bindGroup107);
+} catch {}
+try {
+computePassEncoder61.setBindGroup(1, bindGroup57, new Uint32Array(4409), 680, 0);
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(0, bindGroup41);
+} catch {}
+let pipeline79 = device0.createRenderPipeline({
+  label: '\u6d2c\u04ad\u{1fd4a}\u089c\ua528\u56d9\u{1fe67}\u021e\u0d66\ud9f2',
+  layout: 'auto',
+  multisample: {mask: 0x326206a2},
+  fragment: {
+  module: shaderModule5,
+  targets: [{format: 'rgba8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth32float',
+    depthWriteEnabled: true,
+    depthCompare: 'always',
+    stencilReadMask: 364251703,
+    stencilWriteMask: 1514785743,
+    depthBias: 0,
+    depthBiasClamp: 88.09519889749438,
+  },
+  vertex: {
+    module: shaderModule5,
+    buffers: [
+      {
+        arrayStride: 40,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 0, shaderLocation: 13},
+          {format: 'unorm8x4', offset: 4, shaderLocation: 0},
+          {format: 'unorm16x4', offset: 0, shaderLocation: 7},
+          {format: 'float32x3', offset: 0, shaderLocation: 14},
+          {format: 'float32x2', offset: 4, shaderLocation: 2},
+          {format: 'float16x2', offset: 4, shaderLocation: 11},
+        ],
+      },
+    ],
+  },
+  primitive: {cullMode: 'front', unclippedDepth: false},
+});
+let recycledAutogeneratedBindGroupLayout7 = pipeline30.getBindGroupLayout(0);
+try {
+renderPassEncoder79.setIndexBuffer(buffer44, 'uint32', 64, 91);
+} catch {}
+try {
+renderPassEncoder74.insertDebugMarker('\u3000');
+} catch {}
+let texture325 = device0.createTexture({
+  size: [30, 10, 1],
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder229.setBindGroup(2, bindGroup176);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(1, bindGroup43, new Uint32Array(211), 65, 0);
+} catch {}
+try {
+renderPassEncoder56.beginOcclusionQuery(43);
+} catch {}
+try {
+renderPassEncoder70.executeBundles([renderBundle24]);
+} catch {}
+try {
+renderPassEncoder74.setPipeline(pipeline75);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData3,
+  origin: { x: 11, y: 2 },
+  flipY: true,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 96, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 8, height: 3, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img2);
+let texture326 = device0.createTexture({
+  size: [120, 40, 1],
+  mipLevelCount: 2,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderBundleEncoder43 = device0.createRenderBundleEncoder({colorFormats: ['rgba16sint'], stencilReadOnly: true});
+try {
+renderPassEncoder56.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder75.setPipeline(pipeline75);
+} catch {}
+try {
+renderBundleEncoder43.setBindGroup(0, bindGroup67, []);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline80 = device0.createComputePipeline({layout: pipelineLayout21, compute: {module: shaderModule1}});
+let shaderModule11 = device0.createShaderModule({
+  code: `
+requires unrestricted_pointer_parameters;
+
+enable f16;
+
+var<workgroup> vw50: atomic<u32>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<workgroup> vw43: atomic<u32>;
+
+struct T1 {
+  @align(8) @size(248) f0: array<u32>,
+}
+
+@group(0) @binding(216) var tex3: texture_cube_array<f32>;
+
+var<workgroup> vw42: atomic<i32>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<workgroup> vw51: mat4x4h;
+
+var<workgroup> vw48: atomic<i32>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<workgroup> vw44: array<atomic<i32>, 1>;
+
+var<workgroup> vw45: atomic<u32>;
+
+struct S7 {
+  @location(13) @interpolate(flat) f0: u32,
+}
+
+struct T0 {
+  f0: array<u32, 1>,
+}
+
+var<workgroup> vw41: array<FragmentOutput13, 1>;
+
+struct VertexOutput7 {
+  @builtin(position) f14: vec4f,
+  @location(2) @interpolate(linear, centroid) f15: vec2f,
+  @location(7) f16: vec4h,
+}
+
+struct FragmentOutput13 {
+  @builtin(frag_depth) f0: f32,
+  @location(0) @interpolate(flat) f1: vec4i,
+}
+
+var<workgroup> vw49: FragmentOutput13;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct T2 {
+  @align(32) @size(544) f0: array<u32>,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw47: FragmentOutput13;
+
+var<workgroup> vw46: S7;
+
+@vertex
+fn vertex8(@location(5) a0: u32, @location(14) @interpolate(flat) a1: u32, @location(6) @interpolate(perspective) a2: vec4f, @location(0) @interpolate(perspective, centroid) a3: vec4f, a4: S7, @location(11) @interpolate(flat) a5: i32, @location(2) a6: vec4i, @location(3) @interpolate(perspective, center) a7: vec4f, @location(4) a8: vec2h, @builtin(vertex_index) a9: u32, @location(1) @interpolate(flat) a10: vec2i) -> VertexOutput7 {
+  var out: VertexOutput7;
+  var vf120: i32 = a10[u32(unconst_u32(226))];
+  var vf121: vec4i = unpack4xI8(u32(unconst_u32(104)));
+  vf121 -= vec4i(i32(mix(f16(unconst_f16(10398.8)), vec2h(textureDimensions(tex3)).r, f16(unconst_f16(6126.0)))));
+  vf120 ^= i32(a2[u32(unconst_u32(87))]);
+  out.f14 = a3;
+  vf120 *= a6.z;
+  out.f14 *= unpack4x8snorm(pack4xU8Clamp(vec4u(unconst_u32(91), unconst_u32(17), unconst_u32(408), unconst_u32(264))));
+  out.f16 = vec4h(a6);
+  out.f15 = vec2f(bitcast<f32>(a1));
+  var vf122: f16 = log2(log2(f16(unconst_f16(39209.4))));
+  out.f14 = vec4f(mix(vec4f(unpack4xU8(u32(unconst_u32(7))))[0], f32(vf120), f32(unconst_f32(0.01225))));
+  let vf123: vec3f = cross(vec3f(unconst_f32(0.2976), unconst_f32(-0.04829), unconst_f32(0.1135)), vec3f(unconst_f32(0.09422), unconst_f32(-0.2030), unconst_f32(0.1676)));
+  vf121 = vec4i(i32(vf122));
+  var vf124: u32 = a1;
+  let vf125: vec3f = trunc(vec3f(unconst_f32(0.4202), unconst_f32(0.1167), unconst_f32(-0.01040)));
+  let vf126: f16 = a8[u32(unconst_u32(59))];
+  let ptr196: ptr<function, f16> = &vf122;
+  out.f16 *= vec4h(f16(a6[u32(unconst_u32(206))]));
+  var vf127: u32 = textureNumLevels(tex3);
+  let vf128: u32 = textureNumLayers(tex3);
+  let vf129: vec4f = a7;
+  var vf130: f32 = mix(f32(unconst_f32(0.03335)), f32(unconst_f32(0.05372)), f32(unconst_f32(0.4873)));
+  return out;
+  _ = tex3;
+}
+
+@fragment
+fn fragment13() -> FragmentOutput13 {
+  var out: FragmentOutput13;
+  var vf131: u32 = pack2x16unorm(vec2f(unconst_f32(0.2783), unconst_f32(-0.06227)));
+  let vf132: f16 = log(f16(unconst_f16(21730.4)));
+  var vf133: i32 = countOneBits(i32(round(vec4f(unconst_f32(0.01123), unconst_f32(0.00924), unconst_f32(0.1754), unconst_f32(0.5308))).g));
+  var vf134: f16 = length(vec4h(unconst_f16(14021.5), unconst_f16(4402.3), unconst_f16(8750.8), unconst_f16(-23860.5)));
+  var vf135: vec4f = round(vec4f(unconst_f32(0.00975), unconst_f32(0.01168), unconst_f32(0.2171), unconst_f32(-0.05165)));
+  var vf136: vec4f = round(vec4f(unconst_f32(0.00226), unconst_f32(0.04516), unconst_f32(0.2610), unconst_f32(0.05799)));
+  out.f0 -= bitcast<f32>(pack4xU8Clamp(vec4u(unconst_u32(102), unconst_u32(47), unconst_u32(252), unconst_u32(60))));
+  let ptr197: ptr<function, vec4f> = &vf135;
+  let vf137: f16 = log(f16(unconst_f16(5986.2)));
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute12(@builtin(num_workgroups) a0: vec3u) {
+  var vf138: f32 = sqrt(f32(unconst_f32(0.02505)));
+  let vf139: u32 = atomicLoad(&vw43);
+}`,
+});
+let autogeneratedBindGroupLayout113 = pipeline16.getBindGroupLayout(0);
+let bindGroup206 = device0.createBindGroup({layout: veryExplicitBindGroupLayout9, entries: [{binding: 871, resource: textureView37}]});
+let buffer218 = device0.createBuffer({
+  size: 3659,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let texture327 = device0.createTexture({
+  size: [120, 40, 14],
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder24.setBindGroup(0, bindGroup87, new Uint32Array(1602), 311, 0);
+} catch {}
+try {
+renderBundleEncoder43.setPipeline(pipeline75);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let buffer219 = device0.createBuffer({
+  size: 2261,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder184.setBindGroup(3, bindGroup149, new Uint32Array(5154), 476, 0);
+} catch {}
+try {
+renderBundleEncoder43.setBindGroup(3, bindGroup22, new Uint32Array(43), 4, 0);
+} catch {}
+try {
+renderBundleEncoder43.setVertexBuffer(1, buffer44, 0, 11);
+} catch {}
+try {
+renderBundleEncoder43.insertDebugMarker('\u989e');
+} catch {}
+let texture328 = device0.createTexture({
+  size: [30, 10, 1],
+  mipLevelCount: 2,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView317 = texture248.createView({format: 'rgba16sint', mipLevelCount: 1});
+let renderBundle43 = renderBundleEncoder43.finish({});
+try {
+computePassEncoder226.setBindGroup(2, bindGroup180, new Uint32Array(615), 43, 0);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(2, bindGroup30, new Uint32Array(98), 17, 0);
+} catch {}
+try {
+renderPassEncoder60.end();
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle8, renderBundle18, renderBundle31]);
+} catch {}
+try {
+renderPassEncoder37.setScissorRect(111, 7, 1, 1);
+} catch {}
+try {
+commandEncoder208.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2168 */
+  offset: 2168,
+  bytesPerRow: 3328,
+  buffer: buffer124,
+}, {
+  texture: texture247,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+videoFrame0.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame22.close();
+videoFrame24.close();
+videoFrame25.close();
+videoFrame28.close();
+videoFrame29.close();
+videoFrame30.close();
+videoFrame31.close();
+videoFrame33.close();
+videoFrame34.close();
+videoFrame35.close();
+videoFrame36.close();
+videoFrame37.close();
+videoFrame38.close();
+videoFrame39.close();
+videoFrame40.close();
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -876,6 +876,7 @@ NSString* Device::addPipelineLayouts(Vector<Vector<WGPUBindGroupLayoutEntry>>& p
                 std::span(entries[existingBindingIndex].metalBinding)[stage] = entry.binding;
                 if (!BindGroupLayout::equalBindingEntries(toBindingLayout(entries[existingBindingIndex]), makeBindingLayout(newEntry, entry.bindingMember)))
                     return @"Binding mismatch in auto-generated layouts";
+                entryMap.set(entry.name, entry.webBinding);
                 continue;
             }
             uint64_t bufferSizeForBinding = 0;


### PR DESCRIPTION
#### 4abdcb41023887bb6b06b4b5f90452e1361e8351
<pre>
[WebGPU] Using array length in the fragment but not vertex buffer leads to AB size mismatch
<a href="https://bugs.webkit.org/show_bug.cgi?id=284090">https://bugs.webkit.org/show_bug.cgi?id=284090</a>
<a href="https://rdar.apple.com/140803154">rdar://140803154</a>

Reviewed by Tadeu Zagallo.

A bind group shared between vertex and fragment stages will will be treated
as a single element in the entries container, but the vertex shader may not
use the bind group&apos;s length while the fragment shader does.

This leads to the AB in the vertex shader being 8 bytes (for the single buffer case)
while the fragment shader was 16 bytes.

Correct the out of bounds read by ensuring we consider reused entries.

* LayoutTests/fast/webgpu/nocrash/fuzz-284090-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-284090.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::Device::addPipelineLayouts):

Canonical link: <a href="https://commits.webkit.org/287493@main">https://commits.webkit.org/287493@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/998bb0e049839ee29290b8b79a98bc79cc9206d1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79458 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58469 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32828 "") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84041 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30558 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67581 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6746 "") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62133 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19996 "Passed tests") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82524 "Failed to checkout and rebase branch from PR 37479") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52209 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/32828 "") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42443 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49559 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/32828 "") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28971 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70678 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/32828 "") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85452 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6723 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/6746 "") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70382 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6889 "") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/32828 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69625 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17427 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/32828 "") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6678 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6575 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10058 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8374 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->