### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/html

### DIFF
--- a/Source/WebCore/dom/make_names.pl
+++ b/Source/WebCore/dom/make_names.pl
@@ -817,6 +817,7 @@ sub printNamesHeaderFile
 
     printLicenseHeader($F);
     printHeaderHead($F, "DOM", $parameters{namespace}, <<END, "class $parameters{namespace}QualifiedName : public QualifiedName { };\n\n");
+#include <span>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/AtomString.h>
 #include "QualifiedName.h"
@@ -840,12 +841,12 @@ END
     print F "\n";
 
     if (keys %allElements) {
-        print F "const unsigned $parameters{namespace}TagsCount = ", scalar(keys %allElements), ";\n";
-        print F "const WebCore::$parameters{namespace}QualifiedName* const* get$parameters{namespace}Tags();\n";
+        print F "constexpr unsigned $parameters{namespace}TagsCount = ", scalar(keys %allElements), ";\n";
+        print F "std::span<const WebCore::$parameters{namespace}QualifiedName* const, $parameters{namespace}TagsCount> get$parameters{namespace}Tags();\n";
     }
 
     if (keys %allAttrs) {
-        print F "const unsigned $parameters{namespace}AttrsCount = ", scalar(keys %allAttrs), ";\n";
+        print F "constexpr unsigned $parameters{namespace}AttrsCount = ", scalar(keys %allAttrs), ";\n";
     }
 
     printInit($F, 1);
@@ -1477,6 +1478,7 @@ sub printNamesCppFile
     printCppHead($F, "DOM", $parameters{namespace}, <<END, "WebCore");
 #include "Namespace.h"
 #include "NodeName.h"
+#include <array>
 END
 
     my $lowercaseNamespacePrefix = lc($parameters{namespacePrefix});
@@ -1499,8 +1501,8 @@ END
             print F "WEBCORE_EXPORT LazyNeverDestroyed<const $parameters{namespace}QualifiedName> $allElements{$elementKey}{identifier}Tag;\n";
         }
 
-        print F "\n\nconst WebCore::$parameters{namespace}QualifiedName* const* get$parameters{namespace}Tags()\n";
-        print F "{\n    static const WebCore::$parameters{namespace}QualifiedName* const $parameters{namespace}Tags[] = {\n";
+        print F "\n\nstd::span<const WebCore::$parameters{namespace}QualifiedName* const, $parameters{namespace}TagsCount> get$parameters{namespace}Tags()\n";
+        print F "{\n    static const std::array<const WebCore::$parameters{namespace}QualifiedName*, $parameters{namespace}TagsCount> $parameters{namespace}Tags {\n";
         for my $elementKey (sort keys %allElements) {
             print F "        &$allElements{$elementKey}{identifier}Tag.get(),\n";
         }

--- a/Source/WebCore/html/FTPDirectoryDocument.cpp
+++ b/Source/WebCore/html/FTPDirectoryDocument.cpp
@@ -38,15 +38,15 @@
 #include "Settings.h"
 #include "SharedBuffer.h"
 #include "Text.h"
+#include <wtf/CheckedArithmetic.h>
 #include <wtf/GregorianDateTime.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/Vector.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringToIntegerConversion.h>
 #include <wtf/unicode/CharacterNames.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 
@@ -67,14 +67,12 @@ private:
     void append(RefPtr<StringImpl>&&) override;
     void finish() override;
 
-    void checkBuffer(int len = 10)
+    void checkBuffer(size_t length = 10)
     {
-        if ((m_dest - m_buffer) > m_size - len) {
+        if (m_destIndex > m_size - length) {
             // Enlarge buffer
-            int newSize = std::max(m_size * 2, m_size + len);
-            int oldOffset = m_dest - m_buffer;
-            m_buffer = static_cast<UChar*>(fastRealloc(m_buffer, newSize * sizeof(UChar)));
-            m_dest = m_buffer + oldOffset;
+            CheckedSize newSize = std::max(CheckedSize(m_size) * 2lu, CheckedSize(m_size) + length);
+            m_buffer.grow(newSize);
             m_size = newSize;
         }
     }
@@ -95,9 +93,9 @@ private:
 
     bool m_skipLF { false };
     
-    int m_size { 254 };
-    UChar* m_buffer;
-    UChar* m_dest;
+    size_t m_size { 254 };
+    Vector<UChar> m_buffer;
+    size_t m_destIndex { 0 };
     StringBuilder m_carryOver;
     
     ListState m_listState;
@@ -105,8 +103,7 @@ private:
 
 FTPDirectoryDocumentParser::FTPDirectoryDocumentParser(HTMLDocument& document)
     : HTMLDocumentParser(document)
-    , m_buffer(static_cast<UChar*>(fastMalloc(sizeof(UChar) * m_size)))
-    , m_dest(m_buffer)
+    , m_buffer(m_size)
 {
 }
 
@@ -180,7 +177,7 @@ static String processFilesizeString(const String& size, bool isDirectory)
 
 static bool wasLastDayOfMonth(int year, int month, int day)
 {
-    static const int lastDays[] = { 31, 0, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
+    static constexpr std::array lastDays { 31, 0, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
     if (month < 0 || month > 11)
         return false;
 
@@ -355,23 +352,23 @@ void FTPDirectoryDocumentParser::append(RefPtr<StringImpl>&& inputSource)
 
     bool foundNewLine = false;
 
-    m_dest = m_buffer;
+    m_destIndex = 0;
     SegmentedString string { String { WTFMove(inputSource) } };
     while (!string.isEmpty()) {
         UChar c = string.currentCharacter();
 
         if (c == '\r') {
-            *m_dest++ = '\n';
+            m_buffer[m_destIndex++] = '\n';
             foundNewLine = true;
             // possibly skip an LF in the case of an CRLF sequence
             m_skipLF = true;
         } else if (c == '\n') {
             if (!m_skipLF)
-                *m_dest++ = c;
+                m_buffer[m_destIndex++] = c;
             else
                 m_skipLF = false;
         } else {
-            *m_dest++ = c;
+            m_buffer[m_destIndex++] = c;
             m_skipLF = false;
         }
 
@@ -382,28 +379,28 @@ void FTPDirectoryDocumentParser::append(RefPtr<StringImpl>&& inputSource)
     }
 
     if (!foundNewLine) {
-        m_dest = m_buffer;
+        m_destIndex = 0;
         return;
     }
 
-    UChar* start = m_buffer;
-    UChar* cursor = start;
+    size_t start = 0;
+    size_t cursor = 0;
 
-    while (cursor < m_dest) {
-        if (*cursor == '\n') {
-            m_carryOver.append(StringView(std::span(start, cursor - start)));
+    while (cursor < m_destIndex) {
+        if (m_buffer[cursor] == '\n') {
+            m_carryOver.append(StringView(m_buffer.subspan(start, cursor - start)));
             LOG(FTP, "%s", m_carryOver.toString().ascii().data());
             parseAndAppendOneLine(m_carryOver.toString());
             m_carryOver.clear();
 
             start = ++cursor;
         } else 
-            cursor++;
+            ++cursor;
     }
 
     // Copy the partial line we have left to the carryover buffer
     if (cursor - start > 1)
-        m_carryOver.append(StringView(std::span(start, cursor - start - 1)));
+        m_carryOver.append(StringView(m_buffer.subspan(start, cursor - start - 1)));
 }
 
 void FTPDirectoryDocumentParser::finish()
@@ -415,7 +412,7 @@ void FTPDirectoryDocumentParser::finish()
     }
 
     m_tableElement = nullptr;
-    fastFree(m_buffer);
+    m_buffer = { };
 
     HTMLDocumentParser::finish();
 }
@@ -434,7 +431,5 @@ Ref<DocumentParser> FTPDirectoryDocument::createParser()
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(FTPDIR)

--- a/Source/WebCore/html/HTMLFontElement.cpp
+++ b/Source/WebCore/html/HTMLFontElement.cpp
@@ -36,8 +36,6 @@
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringToIntegerConversion.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(HTMLFontElement);
@@ -62,20 +60,16 @@ static bool parseFontSize(std::span<const CharacterType> characters, int& size)
 
     // Step 1
     // Step 2
-    const CharacterType* position = characters.data();
-    const CharacterType* end = characters.data() + characters.size();
-
     // Step 3
-    while (position < end) {
-        if (!isASCIIWhitespace(*position))
+    while (!characters.empty()) {
+        if (!isASCIIWhitespace(characters.front()))
             break;
-        ++position;
+        characters = characters.subspan(1);
     }
 
     // Step 4
-    if (position == end)
+    if (characters.empty())
         return false;
-    ASSERT_WITH_SECURITY_IMPLICATION(position < end);
 
     // Step 5
     enum {
@@ -84,14 +78,14 @@ static bool parseFontSize(std::span<const CharacterType> characters, int& size)
         Absolute
     } mode;
 
-    switch (*position) {
+    switch (characters.front()) {
     case '+':
         mode = RelativePlus;
-        ++position;
+        characters = characters.subspan(1);
         break;
     case '-':
         mode = RelativeMinus;
-        ++position;
+        characters = characters.subspan(1);
         break;
     default:
         mode = Absolute;
@@ -101,10 +95,11 @@ static bool parseFontSize(std::span<const CharacterType> characters, int& size)
     // Step 6
     StringBuilder digits;
     digits.reserveCapacity(16);
-    while (position < end) {
-        if (!isASCIIDigit(*position))
+    while (!characters.empty()) {
+        if (!isASCIIDigit(characters.front()))
             break;
-        digits.append(*position++);
+        digits.append(characters.front());
+        characters = characters.subspan(1);
     }
 
     // Step 7
@@ -216,5 +211,3 @@ void HTMLFontElement::collectPresentationalHintsForAttribute(const QualifiedName
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -211,8 +211,6 @@
 #include "MediaSessionCoordinator.h"
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF {
 template <>
 struct LogArgument<URL> {
@@ -257,7 +255,7 @@ using namespace HTMLNames;
 
 String convertEnumerationToString(HTMLMediaElement::ReadyState enumerationValue)
 {
-    static const NeverDestroyed<String> values[] = {
+    static const std::array<NeverDestroyed<String>, 5> values {
         MAKE_STATIC_STRING_IMPL("HAVE_NOTHING"),
         MAKE_STATIC_STRING_IMPL("HAVE_METADATA"),
         MAKE_STATIC_STRING_IMPL("HAVE_CURRENT_DATA"),
@@ -275,7 +273,7 @@ String convertEnumerationToString(HTMLMediaElement::ReadyState enumerationValue)
 
 String convertEnumerationToString(HTMLMediaElement::NetworkState enumerationValue)
 {
-    static const NeverDestroyed<String> values[] = {
+    static const std::array<NeverDestroyed<String>, 4> values {
         MAKE_STATIC_STRING_IMPL("NETWORK_EMPTY"),
         MAKE_STATIC_STRING_IMPL("NETWORK_IDLE"),
         MAKE_STATIC_STRING_IMPL("NETWORK_LOADING"),
@@ -291,7 +289,7 @@ String convertEnumerationToString(HTMLMediaElement::NetworkState enumerationValu
 
 String convertEnumerationToString(HTMLMediaElement::AutoplayEventPlaybackState enumerationValue)
 {
-    static const NeverDestroyed<String> values[] = {
+    static const std::array<NeverDestroyed<String>, 4> values {
         MAKE_STATIC_STRING_IMPL("None"),
         MAKE_STATIC_STRING_IMPL("PreventedAutoplay"),
         MAKE_STATIC_STRING_IMPL("StartedWithUserGesture"),
@@ -307,7 +305,7 @@ String convertEnumerationToString(HTMLMediaElement::AutoplayEventPlaybackState e
 
 String convertEnumerationToString(HTMLMediaElement::TextTrackVisibilityCheckType enumerationValue)
 {
-    static const NeverDestroyed<String> values[] = {
+    static const std::array<NeverDestroyed<String>, 2> values {
         MAKE_STATIC_STRING_IMPL("CheckTextTrackVisibility"),
         MAKE_STATIC_STRING_IMPL("AssumeTextTrackVisibilityChanged"),
     };
@@ -319,7 +317,7 @@ String convertEnumerationToString(HTMLMediaElement::TextTrackVisibilityCheckType
 
 String convertEnumerationToString(HTMLMediaElement::SpeechSynthesisState enumerationValue)
 {
-    static const NeverDestroyed<String> values[] = {
+    static const std::array<NeverDestroyed<String>, 4> values {
         MAKE_STATIC_STRING_IMPL("None"),
         MAKE_STATIC_STRING_IMPL("Speaking"),
         MAKE_STATIC_STRING_IMPL("CompletingExtendedDescription"),
@@ -336,7 +334,7 @@ String convertEnumerationToString(HTMLMediaElement::SpeechSynthesisState enumera
 String convertEnumerationToString(HTMLMediaElement::ControlsState enumerationValue)
 {
     // None, Initializing, Ready, PartiallyDeinitialized
-    static const NeverDestroyed<String> values[] = {
+    static const std::array<NeverDestroyed<String>, 4> values {
         MAKE_STATIC_STRING_IMPL("None"),
         MAKE_STATIC_STRING_IMPL("Initializing"),
         MAKE_STATIC_STRING_IMPL("Ready"),
@@ -10026,7 +10024,5 @@ void HTMLMediaElement::invalidateBufferingStopwatch()
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(VIDEO)

--- a/Source/WebCore/html/HTMLObjectElement.cpp
+++ b/Source/WebCore/html/HTMLObjectElement.cpp
@@ -55,8 +55,6 @@
 #include <wtf/RuntimeApplicationChecks.h>
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(HTMLObjectElement);
@@ -312,10 +310,10 @@ static inline bool preventsParentObjectFromExposure(const Element& child)
 {
     static NeverDestroyed mostKnownTags = [] {
         MemoryCompactLookupOnlyRobinHoodHashSet<QualifiedName> set;
-        auto* tags = HTMLNames::getHTMLTags();
-        set.reserveInitialCapacity(HTMLNames::HTMLTagsCount);
-        for (size_t i = 0; i < HTMLNames::HTMLTagsCount; i++) {
-            auto& tag = *tags[i];
+        auto tags = HTMLNames::getHTMLTags();
+        set.reserveInitialCapacity(tags.size());
+        for (auto* tagPtr : tags) {
+            auto& tag = *tagPtr;
             // Only the param element was explicitly mentioned in the HTML specification rule
             // we were trying to implement, but these are other known HTML elements that we
             // have decided, over the years, to treat as children that do not prevent object
@@ -326,8 +324,9 @@ static inline bool preventsParentObjectFromExposure(const Element& child)
                 || tag == figureTag
                 || tag == paramTag
                 || tag == summaryTag
-                || tag == trackTag)
+                || tag == trackTag) {
                 continue;
+            }
             set.add(tag);
         }
         return set;
@@ -407,5 +406,3 @@ bool HTMLObjectElement::canContainRangeEndPoint() const
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -79,8 +79,6 @@
 #include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaElementSession);
@@ -1402,7 +1400,7 @@ void MediaElementSession::updateMediaUsageIfChanged()
 
 String convertEnumerationToString(const MediaPlaybackDenialReason enumerationValue)
 {
-    static const NeverDestroyed<String> values[] = {
+    static const std::array<NeverDestroyed<String>, 4> values {
         MAKE_STATIC_STRING_IMPL("UserGestureRequired"),
         MAKE_STATIC_STRING_IMPL("FullscreenRequired"),
         MAKE_STATIC_STRING_IMPL("PageConsentRequired"),
@@ -1507,7 +1505,5 @@ String MediaElementSession::description() const
 #endif
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(VIDEO)


### PR DESCRIPTION
#### 8b47c9cc90208f1859c2da053ad0d6c4c94953b6
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/html
<a href="https://bugs.webkit.org/show_bug.cgi?id=284092">https://bugs.webkit.org/show_bug.cgi?id=284092</a>

Reviewed by Darin Adler.

* Source/WebCore/dom/make_names.pl:
(printNamesHeaderFile):
(printNamesCppFile):
* Source/WebCore/html/FTPDirectoryDocument.cpp:
(WebCore::FTPDirectoryDocumentParser::FTPDirectoryDocumentParser):
(WebCore::wasLastDayOfMonth):
(WebCore::FTPDirectoryDocumentParser::append):
(WebCore::FTPDirectoryDocumentParser::finish):
* Source/WebCore/html/HTMLFontElement.cpp:
(WebCore::parseFontSize):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::convertEnumerationToString):
* Source/WebCore/html/HTMLObjectElement.cpp:
(WebCore::preventsParentObjectFromExposure):
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::convertEnumerationToString):

Canonical link: <a href="https://commits.webkit.org/287447@main">https://commits.webkit.org/287447@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abf2dfc933ccb00bf15aa7f61147fe0bd6341d58

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79681 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58676 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33071 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84218 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30714 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81789 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67762 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6968 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62278 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20130 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82748 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52338 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72566 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42586 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49682 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26717 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29145 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70820 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27179 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85635 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6923 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4832 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70539 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7093 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68411 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69783 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13793 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12702 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12309 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6876 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6761 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10263 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8565 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->