### PR TITLE
Update Declarative Web Push to some recent standards changes

### DIFF
--- a/LayoutTests/platform/mac-wk2/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/dom/navigator-detached-no-crash-expected.txt
@@ -29,6 +29,7 @@ navigator.platform is OK
 navigator.plugins is OK
 navigator.product is OK
 navigator.productSub is OK
+navigator.pushManager is OK
 navigator.requestMediaKeySystemAccess() is OK
 navigator.sendBeacon() threw err TypeError: Not enough arguments
 navigator.serviceWorker is OK
@@ -72,6 +73,7 @@ navigator.platform is OK
 navigator.plugins is OK
 navigator.product is OK
 navigator.productSub is OK
+navigator.pushManager is OK
 navigator.requestMediaKeySystemAccess() is OK
 navigator.sendBeacon() threw err TypeError: Not enough arguments
 navigator.serviceWorker is OK

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2435,7 +2435,7 @@ DeclarativeShadowRootsSerializerAPIsEnabled:
 
 DeclarativeWebPush:
   type: bool
-  status: unstable
+  status: testable
   category: dom
   defaultsOverridable: true
   condition: ENABLE(DECLARATIVE_WEB_PUSH)

--- a/Source/WebCore/Modules/notifications/NotificationJSONParser.h
+++ b/Source/WebCore/Modules/notifications/NotificationJSONParser.h
@@ -38,6 +38,7 @@ namespace WebCore {
 
 class NotificationJSONParser {
 public:
+    WEBCORE_EXPORT static bool hasDeclarativeMessageHeader(const String& message);
     WEBCORE_EXPORT static ExceptionOr<NotificationPayload> parseNotificationPayload(const JSON::Object&);
     WEBCORE_EXPORT static ExceptionOr<NotificationOptionsPayload> parseNotificationOptions(const JSON::Object&);
 };

--- a/Source/WebCore/Modules/notifications/NotificationPayload.cpp
+++ b/Source/WebCore/Modules/notifications/NotificationPayload.cpp
@@ -35,6 +35,11 @@
 
 namespace WebCore {
 
+bool NotificationPayload::hasDeclarativeMessageHeader(const String& json)
+{
+    return NotificationJSONParser::hasDeclarativeMessageHeader(json);
+}
+
 ExceptionOr<NotificationPayload> NotificationPayload::parseJSON(const String& json)
 {
     auto value = JSON::Value::parseJSON(json);
@@ -53,6 +58,24 @@ NotificationPayload NotificationPayload::fromNotificationData(const Notification
     NotificationOptionsPayload options { data.direction, data.language, data.body, data.tag, data.iconURL, { }, data.silent };
 
     return { data.defaultActionURL, data.title, std::nullopt, WTFMove(options), false };
+}
+
+NotificationData NotificationPayload::toNotificationData() const
+{
+    NotificationData data;
+    data.defaultActionURL = defaultActionURL;
+    data.title = title;
+
+    if (options) {
+        data.direction = options->dir;
+        data.language = options->lang;
+        data.body = options->body;
+        data.tag = options->tag;
+        data.iconURL = options->icon;
+        data.silent = options->silent;
+    }
+
+    return data;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/notifications/NotificationPayload.h
+++ b/Source/WebCore/Modules/notifications/NotificationPayload.h
@@ -56,8 +56,11 @@ struct NotificationPayload {
     }
 
 #if ENABLE(DECLARATIVE_WEB_PUSH)
+    WEBCORE_EXPORT static bool hasDeclarativeMessageHeader(const String& message);
     WEBCORE_EXPORT static ExceptionOr<NotificationPayload> parseJSON(const String&);
     NotificationPayload static fromNotificationData(const NotificationData&);
+
+    WEBCORE_EXPORT NotificationData toNotificationData() const;
 
 #if PLATFORM(COCOA)
     WEBCORE_EXPORT static std::optional<NotificationPayload> fromDictionary(NSDictionary *);

--- a/Source/WebKit/webpushd/WebPushDaemon.h
+++ b/Source/WebKit/webpushd/WebPushDaemon.h
@@ -106,6 +106,7 @@ public:
 
 #if HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
     void showNotification(PushClientConnection&, const WebCore::NotificationData&, RefPtr<WebCore::NotificationResources>, CompletionHandler<void()>&&);
+    void showNotification(const WebCore::PushSubscriptionSetIdentifier&, const WebCore::NotificationData&, RefPtr<WebCore::NotificationResources>, std::optional<unsigned long long> appBadge, CompletionHandler<void()>&&);
     void getNotifications(PushClientConnection&, const URL& registrationURL, const String& tag, CompletionHandler<void(Expected<Vector<WebCore::NotificationData>, WebCore::ExceptionData>&&)>&&);
     void cancelNotification(PushClientConnection&, WebCore::SecurityOriginData&&, const WTF::UUID& notificationID);
 

--- a/Tools/DumpRenderTree/mac/DumpRenderTree.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTree.mm
@@ -873,11 +873,13 @@ static void setWebPreferencesForTestOptions(WebPreferences *preferences, const W
         if (enableAllExperimentalFeatures) {
             for (WebFeature *feature in [WebPreferences _experimentalFeatures]) {
                 // FIXME: ShowModalDialogEnabled and NeedsSiteSpecificQuirks are `developer` settings which should not be enabled by default, but are currently lumped in with the other user-visible features. rdar://103648153
-                // FIXME: BeaconAPIEnabled and LocalFileContentSniffingEnabled These are `stable` settings but should be turned off in WebKitLegacy.
+                // FIXME: BeaconAPIEnabled, LocalFileContentSniffingEnabled, and DeclarativeWebPush.
+                //        These are `stable` settings but should be turned off in WebKitLegacy.
                 if (![feature.key isEqualToString:@"ShowModalDialogEnabled"]
                     && ![feature.key isEqualToString:@"NeedsSiteSpecificQuirks"]
                     && ![feature.key isEqualToString:@"BeaconAPIEnabled"]
-                    && ![feature.key isEqualToString:@"LocalFileContentSniffingEnabled"]) {
+                    && ![feature.key isEqualToString:@"LocalFileContentSniffingEnabled"]
+                    && ![feature.key isEqualToString:@"DeclarativeWebPush"]) {
                     [preferences _setEnabled:YES forFeature:feature];
                 }
             }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -1902,321 +1902,442 @@ TEST_F(WebPushDTest, NotificationClickExtendsITPCleanupTimerBy30Days)
 
 #if ENABLE(DECLARATIVE_WEB_PUSH)
 
-static constexpr ASCIILiteral json0 = ""_s;
-static constexpr ASCIILiteral json1 = "not really a string"_s;
-static constexpr ASCIILiteral json2 = "\"a string\""_s;
-static constexpr ASCIILiteral json3 = "4"_s;
-static constexpr ASCIILiteral json4 = "{ }"_s;
 static constexpr ASCIILiteral json5 = R"JSONRESOURCE(
 {
-    "default_action_url": "foo"
+    "web_push": 8030,
+    "notification": {
+        "navigate": "foo"
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json6 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/"
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/"
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json7 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": ""
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": ""
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json8 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": 4
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": 4
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json9 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Hello world!",
-    "app_badge": ""
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Hello world!",
+        "app_badge": ""
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json10 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Hello world!",
-    "app_badge": -1
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Hello world!",
+        "app_badge": -1
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json11 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Hello world!",
-    "app_badge": { }
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Hello world!",
+        "app_badge": { }
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json12 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Hello world!",
-    "app_badge": 10
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Hello world!",
+        "app_badge": 10
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json13 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Hello world!",
-    "options": 0
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Hello world!",
+        "options": 0
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json14 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Hello world!",
-    "options": { }
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Hello world!",
+        "options": { }
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json15 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Hello world!",
-    "dir": 0
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Hello world!",
+        "dir": 0
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json16 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Hello world!",
-    "dir": "auto"
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Hello world!",
+        "dir": "auto"
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json17 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Hello world!",
-    "dir": "ltr"
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Hello world!",
+        "dir": "ltr"
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json18 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Hello world!",
-    "dir": "rtl"
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Hello world!",
+        "dir": "rtl"
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json19 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Hello world!",
-    "dir": "nonsense"
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Hello world!",
+        "dir": "nonsense"
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json20 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Hello world!",
-    "lang": { }
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Hello world!",
+        "lang": { }
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json21 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Hello world!",
-    "lang": "language"
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Hello world!",
+        "lang": "language"
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json22 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Hello world!",
-    "body": { }
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Hello world!",
+        "body": { }
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json23 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Hello world!",
-    "body": "world"
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Hello world!",
+        "body": "world"
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json24 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Hello world!",
-    "tag": { }
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Hello world!",
+        "tag": { }
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json25 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Hello world!",
-    "tag": "world"
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Hello world!",
+        "tag": "world"
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json26 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Hello world!",
-    "icon": 0
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Hello world!",
+        "icon": 0
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json27 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Hello world!",
-    "icon": "world"
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Hello world!",
+        "icon": "world"
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json28 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Hello world!",
-    "icon": "https://example.com/icon.png"
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Hello world!",
+        "icon": "https://example.com/icon.png"
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json29 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Hello world!",
-    "silent": 0
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Hello world!",
+        "silent": 0
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json30 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Hello world!",
-    "silent": true
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Hello world!",
+        "silent": true
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json31 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Hello world!",
-    "silent": false
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Hello world!",
+        "silent": false
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json32 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Hello world!",
-    "app_badge": "20"
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Hello world!",
+        "app_badge": "20"
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json33 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Hello world!",
-    "app_badge": "18446744073709551615"
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Hello world!",
+        "app_badge": "8031"
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json34 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Hello world!",
-    "app_badge": "18446744073709551616"
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Hello world!",
+        "app_badge": "18446744073709551616"
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json35 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Hello world!",
-    "mutable": 39
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Hello world!",
+        "mutable": 39
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json36 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Hello world!",
-    "mutable": { }
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Hello world!",
+        "mutable": { }
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json37 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Hello world!",
-    "mutable": "true"
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Hello world!",
+        "mutable": "true"
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json38 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Hello world!",
-    "mutable": true
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Hello world!",
+        "mutable": true
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json39 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Hello world!",
-    "mutable": true,
-    "app_badge": "12"
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Hello world!",
+        "mutable": true,
+        "app_badge": "12"
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json40 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Hello world!",
-    "mutable": true,
-    "tag": "title Gotcha!",
-    "app_badge": "12"
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Hello world!",
+        "mutable": true,
+        "tag": "title Gotcha!",
+        "app_badge": "12"
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json41 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Hello world!",
-    "mutable": true,
-    "tag": "badge 1024",
-    "app_badge": "12"
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Hello world!",
+        "mutable": true,
+        "tag": "badge 1024",
+        "app_badge": "12"
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json42 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Hello world!",
-    "mutable": true,
-    "tag": "titleandbadge ThisRules 4096",
-    "app_badge": "12"
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Hello world!",
+        "mutable": true,
+        "tag": "titleandbadge ThisRules 4096",
+        "app_badge": "12"
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json43 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Test the data object",
-    "mutable": true,
-    "tag": "datatotitle",
-    "data": "Raw string",
-    "app_badge": "12"
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Test the data object",
+        "mutable": true,
+        "tag": "datatotitle",
+        "data": "Raw string",
+        "app_badge": "12"
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json44 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Test the data object",
-    "mutable": true,
-    "tag": "datatotitle",
-    "data": { "key": "value" },
-    "app_badge": "12"
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Test the data object",
+        "mutable": true,
+        "tag": "datatotitle",
+        "data": { "key": "value" },
+        "app_badge": "12"
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json45 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Test a default action URL override",
-    "mutable": true,
-    "tag": "defaultactionurl https://webkit.org/",
-    "app_badge": "12"
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Test a default action URL override",
+        "mutable": true,
+        "tag": "defaultactionurl https://webkit.org/",
+        "app_badge": "12"
+    }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json46 = R"JSONRESOURCE(
 {
-    "default_action_url": "https://example.com/",
-    "title": "Test a missing default action URL override",
-    "mutable": true,
-    "tag": "emptydefaultactionurl",
-    "app_badge": "12"
+    "web_push": 8030,
+    "notification": {
+        "navigate": "https://example.com/",
+        "title": "Test a missing default action URL override",
+        "mutable": true,
+        "tag": "emptydefaultactionurl",
+        "app_badge": "12"
+    }
 }
 )JSONRESOURCE"_s;
 
 static constexpr ASCIILiteral errors[] = {
     "does not contain valid JSON"_s,
     "top level JSON value is not an object"_s,
-    "'default_action_url' member is specified but does not represent a valid URL"_s,
+    "'navigate' member is specified but does not represent a valid URL"_s,
     "'title' member is missing or is an empty string"_s,
     "'title' member is specified but is not a string"_s,
     "'app_badge' member is specified as a string that did not parse to to an unsigned long long"_s,
@@ -2236,11 +2357,6 @@ static constexpr ASCIILiteral errors[] = {
 };
 
 static std::pair<ASCIILiteral, ASCIILiteral> jsonAndErrors[] = {
-    { json0, errors[0] },
-    { json1, errors[0] },
-    { json2, errors[1] },
-    { json3, errors[1] },
-    { json4, errors[2] },
     { json5, errors[2] },
     { json6, errors[3] },
     { json7, errors[3] },
@@ -2356,8 +2472,6 @@ TEST(WebPushD, DeclarativeWebPushHandling)
 {
     setUpTestWebPushD();
 
-    auto utilityConnection = createAndConfigureConnectionToService("org.webkit.webpushtestdaemon.service");
-
     auto dataStoreConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
     dataStoreConfiguration.get().webPushMachServiceName = @"org.webkit.webpushtestdaemon.service";
     dataStoreConfiguration.get().isDeclarativeWebPushEnabled = YES;
@@ -2367,10 +2481,12 @@ TEST(WebPushD, DeclarativeWebPushHandling)
     auto delegate = adoptNS([[PushNotificationDelegate alloc] init]);
     dataStore.get()._delegate = delegate.get();
 
+    auto utilityConnection = createAndConfigureConnectionToService("org.webkit.webpushtestdaemon.service");
     auto sender = WebPushXPCConnectionMessageSender { utilityConnection.get() };
     static bool done = false;
 
     WebKit::WebPushD::PushMessageForTesting message;
+    message.pushPartitionString = "TestWebKitAPI"_s;
     message.targetAppCodeSigningIdentifier = "com.apple.WebKit.TestWebKitAPI"_s;
     message.registrationURL = URL("https://example.com"_s);
     message.disposition = WebKit::WebPushD::PushMessageDisposition::Notification;
@@ -2381,29 +2497,35 @@ TEST(WebPushD, DeclarativeWebPushHandling)
     });
     TestWebKitAPI::Util::run(&done);
 
+    // Verify that even after having sent a push message to the daemon, there are no pending messages, as it was already handled.
     done = false;
     [dataStore _getPendingPushMessages:^(NSArray<NSDictionary *> *messages) {
-        EXPECT_EQ(messages.count, 1u);
-
-        [dataStore _processPushMessage:messages.firstObject completionHandler:^(bool handled) {
-            EXPECT_TRUE(handled);
-            EXPECT_TRUE([delegate.get().mostRecentNotification.get().userInfo[@"WebNotificationDefaultActionURLKey"] isEqualToString:@"https://example.com/"]);
-            EXPECT_EQ(delegate.get().mostRecentAppBadge, 18446744073709551615ULL);
-            done = true;
-        }];
-    }];
-    TestWebKitAPI::Util::run(&done);
-
-
-    // Verify that processing the most recent notification results in its action URL being sent to the data store delegate
-    done = false;
-    [dataStore _processPersistentNotificationClick:delegate.get().mostRecentNotification.get().userInfo completionHandler:^(bool handled) {
-        EXPECT_TRUE(handled);
-        EXPECT_TRUE([delegate.get().mostRecentActionURL.get().absoluteString isEqualToString:@"https://example.com/"]);
-
+        EXPECT_EQ(messages.count, 0u);
         done = true;
     }];
     TestWebKitAPI::Util::run(&done);
+
+#if HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
+    RetainPtr configuration = adoptNS([[_WKWebPushDaemonConnectionConfiguration alloc] init]);
+    configuration.get().machServiceName = @"org.webkit.webpushtestdaemon.service";
+    configuration.get().bundleIdentifierOverrideForTesting = @"com.apple.WebKit.TestWebKitAPI";
+    configuration.get().hostApplicationAuditToken = getSelfAuditToken();
+    configuration.get().partition = @"TestWebKitAPI";
+    RetainPtr connection = adoptNS([[_WKWebPushDaemonConnection alloc] initWithConfiguration:configuration.get()]);
+
+    done = false;
+
+    [connection getNotifications:(NSURL *)message.registrationURL tag:@"" completionHandler:^(NSArray<_WKNotificationData *> *notifications, NSError *error) {
+        EXPECT_NULL(error);
+        EXPECT_NOT_NULL(notifications);
+        EXPECT_EQ(notifications.count, 1u);
+        EXPECT_TRUE([notifications[0].title isEqualToString:@"Hello world!"]);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+#endif // HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
+
+    // FIXME: Figure out how to activate the notification programtically to verify the appropriate delegate callbacks are made
 }
 
 #if HAVE(FULL_FEATURED_USER_NOTIFICATIONS)


### PR DESCRIPTION
#### 986e05d99d9e6bde8dd22bb035a815564994ce2b
<pre>
Update Declarative Web Push to some recent standards changes
<a href="https://rdar.apple.com/114886376">rdar://114886376</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=284094">https://bugs.webkit.org/show_bug.cgi?id=284094</a>

Reviewed by Ben Nham.

This patch:
- Detects as a declarative push message via the new special JSON key/value
- Shows the notification automatically when possible
- Enables it (retaining the switch to disable)

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/notifications/NotificationJSONParser.cpp:
(WebCore::hasDeclarativeMessageJSONValues):
(WebCore::NotificationJSONParser::hasDeclarativeMessageHeader):
(WebCore::NotificationJSONParser::parseNotificationPayload):
(WebCore::NotificationJSONParser::parseNotificationOptions):
(WebCore::dirKey): Deleted.
(WebCore::langKey): Deleted.
(WebCore::bodyKey): Deleted.
(WebCore::tagKey): Deleted.
(WebCore::iconKey): Deleted.
(WebCore::dataKey): Deleted.
(WebCore::silentKey): Deleted.
(WebCore::defaultActionURLKey): Deleted.
(WebCore::titleKey): Deleted.
(WebCore::appBadgeKey): Deleted.
(WebCore::mutableKey): Deleted.
* Source/WebCore/Modules/notifications/NotificationJSONParser.h:
* Source/WebCore/Modules/notifications/NotificationPayload.cpp:
(WebCore::NotificationPayload::hasDeclarativeMessageHeader):
(WebCore::NotificationPayload::toNotificationData const):
* Source/WebCore/Modules/notifications/NotificationPayload.h:
* Source/WebKit/webpushd/WebPushDaemon.h:
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::platformDefaultActionBundleIdentifier):
(WebPushD::WebPushDaemon::injectPushMessageForTesting):
(WebPushD::supportsBuiltinNotifications):
(WebPushD::WebPushDaemon::handleIncomingPushImpl):
(WebPushD::WebPushDaemon::showNotification):

* Tools/DumpRenderTree/mac/DumpRenderTree.mm:
(setWebPreferencesForTestOptions):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:
(TestWebKitAPI::(WebPushD, DeclarativeWebPushHandling)):
* LayoutTests/platform/mac-wk2/fast/dom/navigator-detached-no-crash-expected.txt:

Canonical link: <a href="https://commits.webkit.org/287485@main">https://commits.webkit.org/287485@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53d21229d9274f93b6eecc01fe315e8e52b4812c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79833 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58834 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33232 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84358 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30832 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81942 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67908 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7124 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62399 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20241 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82901 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52459 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72705 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42710 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49799 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26854 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29283 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/72842 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70926 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27327 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85784 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/78930 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7064 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70663 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7238 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68545 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69905 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17422 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13912 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12827 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/101301 "Built successfully") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7023 "Failed to checkout and rebase branch from PR 37481") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/24699 "Found 96 jsc stress test failures: stress/json-stringify-inspector-check.js.no-llint, stress/sampling-profiler-anonymous-function.js.bytecode-cache, stress/sampling-profiler-anonymous-function.js.default, stress/sampling-profiler-anonymous-function.js.dfg-eager, stress/sampling-profiler-anonymous-function.js.dfg-eager-no-cjit-validate ..., JSC test binary failure: testapi") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6881 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10393 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8687 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->