### PR TITLE
MediaStreamTrackProcessor::Source should not enqueue once it is closed

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-stop.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-stop.worker-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Stopping a track just after writing
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-stop.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-stop.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-stop.worker.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-stop.worker.js
@@ -1,0 +1,23 @@
+importScripts("/resources/testharness.js");
+
+function makeVideoFrame(timestamp) {
+  const canvas = new OffscreenCanvas(100, 100);
+  const ctx = canvas.getContext('2d');
+  return new VideoFrame(canvas, {timestamp});
+}
+
+promise_test(async t => {
+  const generator = new VideoTrackGenerator();
+  const processor = new MediaStreamTrackProcessor({track: generator.track});
+
+  const reader = processor.readable.getReader();
+  const writer = generator.writable.getWriter();
+
+  await new Promise(resolve => setTimeout(resolve, 0));
+  writer.write(makeVideoFrame(0));
+  generator.track.stop();
+
+  await reader.read().finally(() => { });
+}, "Stopping a track just after writing");
+
+done();

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.h
@@ -67,7 +67,8 @@ public:
         Source(Ref<MediaStreamTrack>&&, MediaStreamTrackProcessor&);
         ~Source();
 
-        bool isWaiting() const;
+        bool isWaiting() const { return m_isWaiting; }
+        bool isCancelled() const { return m_isCancelled; }
         void close();
         void enqueue(WebCodecsVideoFrame&, ScriptExecutionContext&);
 


### PR DESCRIPTION
#### 7526d352bd58750c78a800479573067cc7046e0e
<pre>
MediaStreamTrackProcessor::Source should not enqueue once it is closed
<a href="https://rdar.apple.com/140966032">rdar://140966032</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=284099">https://bugs.webkit.org/show_bug.cgi?id=284099</a>

Reviewed by Jean-Yves Avenard.

Stopping a track will close the readable stream of its MediaStreamTrackProcessor.
When the track is VideoTrackGenerator and gets stopped, it will close synchronously the readable stream of the MediaStreamTrackProcessor observing the VideoTrackGenerator track.
But for video frames, we post a task to the worker thread (even though we are already in the worker thread).
We can thus enqueue video frames after stopping the readable stream.

To prevent this, we set m_isCancelled to true in MediaStreamTrackProcessor::Source::close.
As a small refactoring, we also move the m_isCancelled to MediaStreamTrackProcessor::tryEnqueueingVideoFrame to return earlier.
We add an ASSERT(m_isCancelled) in MediaStreamTrackProcessor::Source::enqueue.

* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-stop.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-stop.worker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-stop.worker.js: Added.
(makeVideoFrame):
(promise_test.async t):
* Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp:
(WebCore::MediaStreamTrackProcessor::tryEnqueueingVideoFrame):
(WebCore::MediaStreamTrackProcessor::Source::close):
(WebCore::MediaStreamTrackProcessor::Source::enqueue):
(WebCore::MediaStreamTrackProcessor::Source::isWaiting const): Deleted.
* Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.h:

Canonical link: <a href="https://commits.webkit.org/287409@main">https://commits.webkit.org/287409@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75d44fe11b087bf1bab6750ee01096ebe8cf1ce2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79513 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58522 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32890 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84092 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30606 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81647 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67615 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6801 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62176 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20042 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82584 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52236 "Build is in progress. Recent messages:OS: Sonoma (14.6), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; 13 new passes 6 flakes 2 failures; Uploaded test results; 13 new passes 8 flakes 2 failures; Compiled WebKit (warnings); layout-tests; Running analyze-layout-tests-results") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72440 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42486 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49584 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26603 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29022 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70703 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27061 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85503 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6779 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4719 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70425 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6944 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68302 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69669 "Found 3 new API test failures: /TestWebKit:WebKit.HitTestResultNodeHandle, /TestWebKit:WebKit2.ProvisionalURLAfterWillSendRequestCallback, /TestWebKit:WebKit.GeolocationBasic (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17373 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13700 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12593 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6731 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6627 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10109 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8426 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->