### PR TITLE
[IFC][SVG text] Implement fragment-aware selections

### DIFF
--- a/Source/WebCore/layout/integration/inline/InlineIteratorSVGTextBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorSVGTextBox.h
@@ -41,6 +41,7 @@ public:
     SVGTextBox(PathVariant&&);
 
     FloatRect calculateBoundariesIncludingSVGTransform() const;
+    LayoutRect localSelectionRect(unsigned start, unsigned end) const;
     const Vector<SVGTextFragment>& textFragments() const;
 
     const RenderSVGInlineText& renderer() const { return downcast<RenderSVGInlineText>(TextBox::renderer()); }

--- a/Source/WebCore/rendering/CaretRectComputation.cpp
+++ b/Source/WebCore/rendering/CaretRectComputation.cpp
@@ -31,6 +31,7 @@
 #include "InlineIteratorLineBox.h"
 #include "InlineIteratorTextBox.h"
 #include "InlineIteratorTextBoxInlines.h"
+#include "InlineIteratorSVGTextBox.h"
 #include "LayoutIntegrationLineLayout.h"
 #include "LineSelection.h"
 #include "RenderBlockFlow.h"
@@ -225,18 +226,20 @@ static LayoutRect computeCaretRectForLineBreak(const InlineBoxAndOffset& boxAndO
 
 static LayoutRect computeCaretRectForSVGInlineText(const InlineBoxAndOffset& boxAndOffset, CaretRectMode)
 {
-    auto* box = boxAndOffset.box ? boxAndOffset.box->legacyInlineBox() : nullptr;
+    auto box = boxAndOffset.box;
     auto caretOffset = boxAndOffset.offset;
+    if (!is<InlineIterator::SVGTextBoxIterator>(box))
+        return { };
 
-    auto* textBox = dynamicDowncast<LegacyInlineTextBox>(*box);
+    auto textBox = downcast<InlineIterator::SVGTextBoxIterator>(box);
     if (!textBox)
         return { };
 
-    if (caretOffset < textBox->start() || caretOffset > textBox->start() + textBox->len())
+    if (caretOffset < textBox->start() || caretOffset > textBox->start() + textBox->length())
         return { };
 
     // Use the edge of the selection rect to determine the caret rect.
-    if (caretOffset < textBox->start() + textBox->len()) {
+    if (caretOffset < textBox->start() + textBox->length()) {
         LayoutRect rect = textBox->localSelectionRect(caretOffset, caretOffset + 1);
         LayoutUnit x = textBox->isLeftToRightDirection() ? rect.x() : rect.maxX();
         return LayoutRect(x, rect.y(), caretWidth(), rect.height());

--- a/Source/WebCore/rendering/RenderLineBreak.cpp
+++ b/Source/WebCore/rendering/RenderLineBreak.cpp
@@ -28,6 +28,7 @@
 #include "HTMLWBRElement.h"
 #include "InlineIteratorBoxInlines.h"
 #include "InlineIteratorLineBox.h"
+#include "InlineIteratorSVGTextBox.h"
 #include "InlineRunAndOffset.h"
 #include "LineSelection.h"
 #include "LogicalSelectionOffsetCaches.h"
@@ -176,7 +177,7 @@ void RenderLineBreak::collectSelectionGeometries(Vector<SelectionGeometry>& rect
 
     bool isFixed = false;
     auto absoluteQuad = localToAbsoluteQuad(FloatRect(rect), UseTransforms, &isFixed);
-    bool boxIsHorizontal = !is<SVGInlineTextBox>(run->legacyInlineBox()) ? run->isHorizontal() : !writingMode().isVertical();
+    bool boxIsHorizontal = !is<InlineIterator::SVGTextBoxIterator>(run) ? run->isHorizontal() : !writingMode().isVertical();
 
     rects.append(SelectionGeometry(absoluteQuad, HTMLElement::selectionRenderingBehavior(element()), run->direction(), extentsRect.x(), extentsRect.maxX(), extentsRect.maxY(), 0, run->isLineBreak(), isFirstOnLine, isLastOnLine, false, false, boxIsHorizontal, isFixed, view().pageNumberForBlockProgressionOffset(absoluteQuad.enclosingBoundingBox().x())));
 }

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -268,8 +268,8 @@ String capitalize(const String& string, Vector<UChar> previousCharacter)
 
 static LayoutRect selectionRectForTextBox(const InlineIterator::TextBox& textBox, unsigned rangeStart, unsigned rangeEnd)
 {
-    if (auto* svgInlineTextBox = dynamicDowncast<SVGInlineTextBox>(textBox.legacyInlineBox()))
-        return svgInlineTextBox->localSelectionRect(rangeStart, rangeEnd);
+    if (auto* svgTextBox = dynamicDowncast<InlineIterator::SVGTextBox>(textBox))
+        return svgTextBox->localSelectionRect(rangeStart, rangeEnd);
 
     bool isCaretCase = rangeStart == rangeEnd;
 
@@ -555,7 +555,7 @@ void RenderText::collectSelectionGeometries(Vector<SelectionGeometry>& rects, un
 
         bool isFixed = false;
         auto absoluteQuad = localToAbsoluteQuad(FloatRect(rect), UseTransforms, &isFixed);
-        bool boxIsHorizontal = !is<SVGInlineTextBox>(textBox->legacyInlineBox()) ? textBox->isHorizontal() : !writingMode().isVertical();
+        bool boxIsHorizontal = !is<InlineIterator::SVGTextBoxIterator>(textBox) ? textBox->isHorizontal() : !writingMode().isVertical();
 
         rects.append(SelectionGeometry(absoluteQuad, HTMLElement::selectionRenderingBehavior(textNode()), textBox->direction(), extentsRect.x(), extentsRect.maxX(), extentsRect.maxY(), 0, textBox->isLineBreak(), isFirstOnLine, isLastOnLine, containsStart, containsEnd, boxIsHorizontal, isFixed, view().pageNumberForBlockProgressionOffset(absoluteQuad.enclosingBoundingBox().x())));
     }
@@ -643,7 +643,7 @@ static Vector<LayoutRect> characterRects(const InlineIterator::TextBox& run, uns
     if (clampedStart >= clampedEnd)
         return { };
 
-    if (auto* svgTextBox = dynamicDowncast<SVGInlineTextBox>(run.legacyInlineBox())) {
+    if (auto* svgTextBox = dynamicDowncast<InlineIterator::SVGTextBox>(run)) {
         return Vector<LayoutRect>(clampedEnd - clampedStart, [&, clampedStart = clampedStart](size_t i) {
             size_t index = clampedStart + i;
             return svgTextBox->localSelectionRect(index, index + 1);

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
@@ -40,6 +40,7 @@
 #include "SVGLayerTransformComputation.h"
 #include "SVGRenderingContext.h"
 #include "SVGRootInlineBox.h"
+#include "SVGTextBoxPainter.h"
 #include "StyleFontSizeFunctions.h"
 #include "StyleResolver.h"
 #include "VisiblePosition.h"
@@ -158,6 +159,24 @@ bool RenderSVGInlineText::characterStartsNewTextChunk(int position) const
     return !SVGTextLayoutAttributes::isEmptyValue(it->value.x) || !SVGTextLayoutAttributes::isEmptyValue(it->value.y);
 }
 
+static int offsetForPositionInFragment(const InlineIterator::SVGTextBox& textBox, const SVGTextFragment& fragment, float position)
+{
+    float scalingFactor = textBox.renderer().scalingFactor();
+    ASSERT(scalingFactor);
+
+    TextRun textRun = constructTextRun(textBox.renderer().text(), textBox.direction(), textBox.style(), fragment);
+
+    // Eventually handle lengthAdjust="spacingAndGlyphs".
+    // FIXME: Handle vertical text.
+    AffineTransform fragmentTransform;
+    fragment.buildFragmentTransform(fragmentTransform);
+    if (!fragmentTransform.isIdentity())
+        textRun.setHorizontalGlyphStretch(narrowPrecisionToFloat(fragmentTransform.xScale()));
+
+    const bool includePartialGlyphs = true;
+    return fragment.characterOffset - textBox.start() + textBox.renderer().scaledFont().offsetForPosition(textRun, position * scalingFactor, includePartialGlyphs);
+}
+
 VisiblePosition RenderSVGInlineText::positionForPoint(const LayoutPoint& point, HitTestSource, const RenderFragmentContainer*)
 {
     if (!InlineIterator::firstTextBoxFor(*this) || text().isEmpty())
@@ -175,7 +194,7 @@ VisiblePosition RenderSVGInlineText::positionForPoint(const LayoutPoint& point, 
     float closestDistance = std::numeric_limits<float>::max();
     float closestDistancePosition = 0;
     const SVGTextFragment* closestDistanceFragment = nullptr;
-    const SVGInlineTextBox* closestDistanceBox = nullptr;
+    InlineIterator::SVGTextBoxIterator closestDistanceBox;
 
     AffineTransform fragmentTransform;
     for (auto& box : InlineIterator::svgTextBoxesFor(*this)) {
@@ -194,7 +213,7 @@ VisiblePosition RenderSVGInlineText::positionForPoint(const LayoutPoint& point, 
 
             if (distance < closestDistance) {
                 closestDistance = distance;
-                closestDistanceBox = downcast<SVGInlineTextBox>(box.legacyInlineBox());
+                closestDistanceBox = box;
                 closestDistanceFragment = &fragment;
                 closestDistancePosition = fragmentRect.x();
             }
@@ -204,7 +223,7 @@ VisiblePosition RenderSVGInlineText::positionForPoint(const LayoutPoint& point, 
     if (!closestDistanceFragment)
         return createVisiblePosition(0, Affinity::Downstream);
 
-    int offset = closestDistanceBox->offsetForPositionInFragment(*closestDistanceFragment, absolutePoint.x() - closestDistancePosition);
+    int offset = offsetForPositionInFragment(*closestDistanceBox, *closestDistanceFragment, absolutePoint.x() - closestDistancePosition);
     return createVisiblePosition(offset + closestDistanceBox->start(), offset > 0 ? Affinity::Upstream : Affinity::Downstream);
 }
 

--- a/Source/WebCore/rendering/svg/SVGInlineTextBox.h
+++ b/Source/WebCore/rendering/svg/SVGInlineTextBox.h
@@ -40,8 +40,6 @@ public:
     float virtualLogicalHeight() const override { return m_logicalHeight; }
     void setLogicalHeight(float height) { m_logicalHeight = height; }
 
-    LayoutRect localSelectionRect(unsigned startPosition, unsigned endPosition) const override;
-
     bool mapStartEndPositionsIntoFragmentCoordinates(const SVGTextFragment&, unsigned& startPosition, unsigned& endPosition) const;
 
     FloatRect calculateBoundaries() const;
@@ -52,22 +50,13 @@ public:
     void dirtyOwnLineBoxes() override;
     void dirtyLineBoxes() override;
 
-    bool startsNewTextChunk() const { return m_startsNewTextChunk; }
-    void setStartsNewTextChunk(bool newTextChunk) { m_startsNewTextChunk = newTextChunk; }
-
-    int offsetForPositionInFragment(const SVGTextFragment&, float position) const;
-    FloatRect selectionRectForTextFragment(const SVGTextFragment&, unsigned fragmentStartPosition, unsigned fragmentEndPosition, const RenderStyle&) const;
-
     inline SVGInlineTextBox* nextTextBox() const;
     
 private:
     bool isSVGInlineTextBox() const override { return true; }
 
-    TextRun constructTextRun(const RenderStyle&, const SVGTextFragment&) const;
-
 private:
     float m_logicalHeight { 0 };
-    unsigned m_startsNewTextChunk : 1;
 
     Vector<SVGTextFragment> m_textFragments;
 };

--- a/Source/WebCore/rendering/svg/SVGTextBoxPainter.h
+++ b/Source/WebCore/rendering/svg/SVGTextBoxPainter.h
@@ -53,7 +53,6 @@ private:
     const RenderBoxModelObject& parentRenderer() const;
     OptionSet<RenderSVGResourceMode> paintingResourceMode() const { return m_paintingResourceMode; }
 
-    FloatRect selectionRectForTextFragment(const SVGTextFragment&, unsigned startPosition, unsigned endPosition, const RenderStyle&) const;
     void paintDecoration(OptionSet<TextDecorationLine>, const SVGTextFragment&);
     void paintDecorationWithStyle(OptionSet<TextDecorationLine>, const SVGTextFragment&, const RenderBoxModelObject&);
     void paintTextWithShadows(const RenderStyle&, TextRun&, const SVGTextFragment&, unsigned startPosition, unsigned endPosition);
@@ -65,9 +64,6 @@ private:
     bool acquireLegacyPaintingResource(GraphicsContext*&, float scalingFactor, RenderBoxModelObject&, const RenderStyle&);
     void releaseLegacyPaintingResource(GraphicsContext*&, const Path*);
 
-    bool mapStartEndPositionsIntoFragmentCoordinates(const SVGTextFragment&, unsigned& startPosition, unsigned& endPosition) const;
-
-    TextRun constructTextRun(const RenderStyle&, const SVGTextFragment&) const;
     std::pair<unsigned, unsigned> selectionStartEnd() const;
 
     const TextBoxPath m_textBox;
@@ -90,5 +86,9 @@ class ModernSVGTextBoxPainter : public SVGTextBoxPainter<InlineIterator::BoxMode
 public:
     ModernSVGTextBoxPainter(const LayoutIntegration::InlineContent&, size_t boxIndex, PaintInfo&, const LayoutPoint& paintOffset);
 };
+
+TextRun constructTextRun(StringView, TextDirection, const RenderStyle&, const SVGTextFragment&);
+FloatRect selectionRectForTextFragment(const RenderSVGInlineText&, TextDirection, const SVGTextFragment&, unsigned startPosition, unsigned endPosition, const RenderStyle&);
+bool mapStartEndPositionsIntoFragmentCoordinates(unsigned textBoxStart, const SVGTextFragment&, unsigned& startPosition, unsigned& endPosition);
 
 }


### PR DESCRIPTION
#### 49ce7dd518bace2f6535229b4d55cf03ca9880c7
<pre>
[IFC][SVG text] Implement fragment-aware selections
<a href="https://bugs.webkit.org/show_bug.cgi?id=284102">https://bugs.webkit.org/show_bug.cgi?id=284102</a>
<a href="https://rdar.apple.com/140967464">rdar://140967464</a>

Reviewed by Alan Baradlay.

Use the iterator and generalize SVG selection related functions.

* Source/WebCore/layout/integration/inline/InlineIteratorSVGTextBox.cpp:
(WebCore::InlineIterator::SVGTextBox::localSelectionRect const):
* Source/WebCore/layout/integration/inline/InlineIteratorSVGTextBox.h:
* Source/WebCore/rendering/CaretRectComputation.cpp:
(WebCore::computeCaretRectForSVGInlineText):
* Source/WebCore/rendering/RenderLineBreak.cpp:
(WebCore::RenderLineBreak::collectSelectionGeometries):
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::selectionRectForTextBox):
(WebCore::RenderText::collectSelectionGeometries):
(WebCore::characterRects):
* Source/WebCore/rendering/svg/RenderSVGInlineText.cpp:
(WebCore::offsetForPositionInFragment):
(WebCore::RenderSVGInlineText::positionForPoint):
* Source/WebCore/rendering/svg/SVGInlineTextBox.cpp:
(WebCore::SVGInlineTextBox::SVGInlineTextBox):
(WebCore::SVGInlineTextBox::offsetForPositionInFragment const): Deleted.
(WebCore::SVGInlineTextBox::selectionRectForTextFragment const): Deleted.
(WebCore::SVGInlineTextBox::localSelectionRect const): Deleted.
(WebCore::SVGInlineTextBox::constructTextRun const): Deleted.
* Source/WebCore/rendering/svg/SVGInlineTextBox.h:
* Source/WebCore/rendering/svg/SVGTextBoxPainter.cpp:
(WebCore::selectionRectForTextFragment):
(WebCore::SVGTextBoxPainter&lt;TextBoxPath&gt;::paintSelectionBackground):
(WebCore::mapStartEndPositionsIntoFragmentCoordinates):
(WebCore::SVGTextBoxPainter&lt;TextBoxPath&gt;::paintText):
(WebCore::constructTextRun):
(WebCore::SVGTextBoxPainter&lt;TextBoxPath&gt;::selectionRectForTextFragment const): Deleted.
(WebCore::SVGTextBoxPainter&lt;TextBoxPath&gt;::mapStartEndPositionsIntoFragmentCoordinates const): Deleted.
(WebCore::SVGTextBoxPainter&lt;TextBoxPath&gt;::constructTextRun const): Deleted.

Expose these helper functions.

* Source/WebCore/rendering/svg/SVGTextBoxPainter.h:

Canonical link: <a href="https://commits.webkit.org/287407@main">https://commits.webkit.org/287407@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f22352c0c93c14a1139ffee01f7307b108cf89f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79529 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58538 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32906 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84108 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30622 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81663 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67631 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6817 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62194 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20053 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82600 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52250 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72452 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/42503 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49598 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26615 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29038 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70717 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27073 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85519 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6795 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4733 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70445 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6960 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68314 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69690 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17370 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13713 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12605 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6747 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6643 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10125 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8442 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->