### PR TITLE
[check-webkit-style] Prevent log without channel

### DIFF
--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -2908,9 +2908,29 @@ def check_lock_guard(clean_lines, line_number, file_state, error):
     error(line_number, 'runtime/lock_guard', 4, "Use 'Locker locker { lock }' instead of 'std::lock_guard<>'.")
 
 
+def check_log(clean_lines, line_number, file_state, error):
+    """Looks for use of always log which should never happen'.
+
+    Args:
+      clean_lines: A CleansedLines instance containing the file.
+      line_number: The number of the line to check.
+      file_state: A _FileState instance which maintains information about
+                  the state of things in the file.
+      error: The function to call with any errors found.
+    """
+
+    line = clean_lines.elided[line_number]  # Get rid of comments and strings.
+
+    using_always_log = search(r'\b(WTF_ALWAYS_LOG|ALWAYS_LOG_WITH_STREAM|WTFLogAlways)\s*\(', line)
+    if not using_always_log:
+        return
+
+    error(line_number, 'runtime/log', 4, "Use a channel to log with 'LOG...(MyChannel,...)'.")
+
+
 def check_ctype_functions(clean_lines, line_number, file_state, error):
     """Looks for use of the standard functions in ctype.h and suggest they be replaced
-       by use of equivilent ones in <wtf/ASCIICType.h>?.
+       by use of equivalent ones in <wtf/ASCIICType.h>?.
 
     Args:
       clean_lines: A CleansedLines instance containing the file.
@@ -3521,6 +3541,7 @@ def check_style(clean_lines, line_number, file_extension, class_state, file_stat
     check_wtf_make_unique(clean_lines, line_number, file_state, error)
     check_wtf_never_destroyed(clean_lines, line_number, file_state, error)
     check_lock_guard(clean_lines, line_number, file_state, error)
+    check_log(clean_lines, line_number, file_state, error)
     check_ctype_functions(clean_lines, line_number, file_state, error)
     check_switch_indentation(clean_lines, line_number, error)
     check_braces(clean_lines, line_number, file_state, error)
@@ -4771,6 +4792,7 @@ class CppChecker(object):
         'runtime/ismainthread',
         'runtime/leaky_pattern',
         'runtime/lock_guard',
+        'runtime/log',
         'runtime/max_min_macros',
         'runtime/memset',
         'runtime/once_flag',

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -6187,6 +6187,34 @@ class WebKitStyleTest(CppStyleTestBase):
             "  [runtime/lock_guard] [4]",
             'foo.mm')
 
+    def test_log(self):
+        error_string = "Use a channel to log with 'LOG...(MyChannel,...)'.  [runtime/log] [4]"
+
+        self.assert_lint(
+            'LOG_WITH_STREAM(Channel, stream << 2);',
+            '',
+            'foo.cpp')
+
+        self.assert_lint(
+            'CUSTOM_MACRO_WTF_ALWAYS_LOG(2);',
+            '',
+            'foo.cpp')
+
+        self.assert_lint(
+            '// WTF_ALWAYS_LOG(2);',
+            '',
+            'foo.cpp')
+
+        self.assert_lint(
+            'WTFLogAlways("foo");',
+            error_string,
+            'foo.cpp')
+
+        self.assert_lint(
+            'WTF_ALWAYS_LOG(34);',
+            error_string,
+            'foo.cpp')
+
     def test_once_flag(self):
         self.assert_lint(
             'static std::once_flag onceKey;',


### PR DESCRIPTION
#### 5ac8f6af64f942db419c1654710ba81e0335be34
<pre>
[check-webkit-style] Prevent log without channel
<a href="https://bugs.webkit.org/show_bug.cgi?id=284079">https://bugs.webkit.org/show_bug.cgi?id=284079</a>

Reviewed by Simon Fraser.

Fixing the existing ones need some decision
about the appropriate log channel for each of them,
thus this patch doesn&apos;t fix them.

check-webkit-style Source -f &quot;-,+runtime/log&quot;

* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_log):
(check_ctype_functions):
(check_style):
(CppChecker):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(WebKitStyleTest.test_log):

Canonical link: <a href="https://commits.webkit.org/287412@main">https://commits.webkit.org/287412@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2f131707fa5740be6109ae94e4672619c6f2ff4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79527 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58536 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32904 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84106 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30620 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81661 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67629 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6815 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62191 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20052 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82598 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52248 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72448 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42501 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/79016 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49596 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26611 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29036 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70715 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27069 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85517 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6793 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4731 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70440 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6958 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68310 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69685 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/17390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13715 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12601 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6745 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6641 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10123 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8440 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->