### PR TITLE
REGRESSION(285820@main): [TextureMapper][GTK][WPE] ASSERTION FAILED: textureIndex < m_textures.size() on luna.amazon.com

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
@@ -77,10 +77,13 @@ public:
 
     IntRect layerRect() const { return m_rect; }
 
-    bool needsUpdate() const { return m_textures.isEmpty(); }
+    bool needsUpdate() const { return m_needsUpdate; }
 
     void update(TextureMapperPaintOptions& options, const std::function<void(TextureMapperPaintOptions&)>& paintFunction)
     {
+        if (!m_needsUpdate)
+            return;
+
         auto [prevZNear, prevZFar] =  options.textureMapper.depthRange();
         options.textureMapper.setDepthRange(m_zNear, m_zFar);
 
@@ -95,6 +98,7 @@ public:
                 SetForScope scopedOpacity(options.opacity, 1);
 
                 options.textureMapper.bindSurface(options.surface.get());
+
                 paintFunction(options);
 
                 // If paintFunction applies filters to flattened surface then surface object might have
@@ -107,6 +111,8 @@ public:
 
         options.textureMapper.bindSurface(options.surface.get());
         options.textureMapper.setDepthRange(prevZNear, prevZFar);
+
+        m_needsUpdate = false;
     }
 
     void paintToTextureMapper(TextureMapper& textureMapper, const FloatRect& targetRect, TransformationMatrix& modelViewMatrix, float opacity)
@@ -140,6 +146,7 @@ private:
     double m_zNear;
     double m_zFar;
     Vector<RefPtr<BitmapTexture>> m_textures;
+    bool m_needsUpdate { true };
 };
 
 TextureMapperLayer::TextureMapperLayer() = default;


### PR DESCRIPTION
#### 23bfb2f9346ea6765e3cff46700f81f522f2ae33
<pre>
REGRESSION(285820@main): [TextureMapper][GTK][WPE] ASSERTION FAILED: textureIndex &lt; m_textures.size() on luna.amazon.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=283914">https://bugs.webkit.org/show_bug.cgi?id=283914</a>

Reviewed by Fujii Hironori.

The needsUpdate state for flattened layers was incorrectly reset before the
layer was fully updated. This issue occurred when processing large layers
that required tiling, as the state was based on the number of tile textures
being greater than zero. This fix adjusts the logic to correctly account for
layers that require multiple tiles to render.

* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:

Canonical link: <a href="https://commits.webkit.org/287414@main">https://commits.webkit.org/287414@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52d83f038144ed45790c1467e3d1bad34c3220ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79519 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58528 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32896 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84098 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30612 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81653 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67621 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6807 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62184 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20049 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82590 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52247 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72446 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42494 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49595 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26609 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29028 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70714 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27067 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85509 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6785 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4773 "") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70430 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6950 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68308 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69674 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13710 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12599 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12294 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6737 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12438 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6633 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10115 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8432 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->