### PR TITLE
Remove Quirk shouldStarBePermissionsPolicyDefaultValue for jsfiddle.net

### DIFF
--- a/Source/WebCore/html/PermissionsPolicy.cpp
+++ b/Source/WebCore/html/PermissionsPolicy.cpp
@@ -310,14 +310,10 @@ static bool computeFeatureEnabled(PermissionsPolicy::Feature feature, const Docu
     return enabled;
 }
 
-static Allowlist parseAllowlist(StringView value, const SecurityOriginData& containerOrigin, const SecurityOriginData& targetOrigin, bool useStarAsDefaultAllowlistValue)
+static Allowlist parseAllowlist(StringView value, const SecurityOriginData& containerOrigin, const SecurityOriginData& targetOrigin)
 {
-    if (value.isEmpty()) {
-        if (useStarAsDefaultAllowlistValue)
-            return Allowlist::AllowAllOrigins { };
-
+    if (value.isEmpty())
         return Allowlist { targetOrigin };
-    }
 
     HashSet<SecurityOriginData> allowedOrigins;
     while (!value.isEmpty()) {
@@ -349,7 +345,7 @@ static Allowlist parseAllowlist(StringView value, const SecurityOriginData& cont
 }
 
 // https://w3c.github.io/webappsec-permissions-policy/#algo-parse-policy-directive
-static PermissionsPolicy::PolicyDirective parsePolicyDirective(StringView value, const SecurityOriginData& containerOrigin, const SecurityOriginData& targetOrigin, bool useStarAsDefaultAllowlistValue)
+static PermissionsPolicy::PolicyDirective parsePolicyDirective(StringView value, const SecurityOriginData& containerOrigin, const SecurityOriginData& targetOrigin)
 {
     PermissionsPolicy::PolicyDirective result;
     for (auto item : value.split(';')) {
@@ -357,7 +353,7 @@ static PermissionsPolicy::PolicyDirective parsePolicyDirective(StringView value,
         if (feature == PermissionsPolicy::Feature::Invalid)
             continue;
 
-        result.add(feature, parseAllowlist(remainingItem, containerOrigin, targetOrigin, useStarAsDefaultAllowlistValue));
+        result.add(feature, parseAllowlist(remainingItem, containerOrigin, targetOrigin));
     }
 
     return result;
@@ -367,7 +363,7 @@ static PermissionsPolicy::PolicyDirective parsePolicyDirective(StringView value,
 PermissionsPolicy::PolicyDirective PermissionsPolicy::processPermissionsPolicyAttribute(const HTMLIFrameElement& iframe)
 {
     auto allowAttributeValue = iframe.attributeWithoutSynchronization(allowAttr);
-    auto policyDirective = parsePolicyDirective(allowAttributeValue, iframe.document().securityOrigin().data(), declaredOrigin(iframe)->data(), iframe.document().quirks().shouldStarBePermissionsPolicyDefaultValue());
+    auto policyDirective = parsePolicyDirective(allowAttributeValue, iframe.document().securityOrigin().data(), declaredOrigin(iframe)->data());
 
     if (iframe.hasAttribute(allowfullscreenAttr) || iframe.hasAttribute(webkitallowfullscreenAttr))
         policyDirective.add(Feature::Fullscreen, Allowlist::AllowAllOrigins { });

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1691,19 +1691,6 @@ bool Quirks::needsResettingTransitionCancelsRunningTransitionQuirk() const
 #endif
 }
 
-bool Quirks::shouldStarBePermissionsPolicyDefaultValue() const
-{
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.shouldStarBePermissionsPolicyDefaultValueQuirk) {
-        auto domain = m_document->securityOrigin().domain();
-        m_quirksData.shouldStarBePermissionsPolicyDefaultValueQuirk = domain == "jsfiddle.net"_s;
-    }
-
-    return *m_quirksData.shouldStarBePermissionsPolicyDefaultValueQuirk;
-}
-
 // Microsoft office online generates data URLs with incorrect padding on Safari only (rdar://114573089).
 bool Quirks::shouldDisableDataURLPaddingValidation() const
 {

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -201,7 +201,6 @@ public:
 
     bool needsResettingTransitionCancelsRunningTransitionQuirk() const;
 
-    bool shouldStarBePermissionsPolicyDefaultValue() const;
     bool shouldDisableDataURLPaddingValidation() const;
 
     bool needsDisableDOMPasteAccessQuirk() const;

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -66,7 +66,6 @@ struct WEBCORE_EXPORT QuirksData {
     std::optional<bool> shouldIgnorePlaysInlineRequirementQuirk;
     std::optional<bool> shouldLayOutAtMinimumWindowWidthWhenIgnoringScalingConstraintsQuirk;
     std::optional<bool> shouldPreventOrientationMediaQueryFromEvaluatingToLandscapeQuirk;
-    std::optional<bool> shouldStarBePermissionsPolicyDefaultValueQuirk;
     std::optional<bool> shouldUseLegacySelectPopoverDismissalBehaviorInDataActivationQuirk;
 
 #if PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 5f235ae331ec87577ec2decf92522d80d671b74b
<pre>
Remove Quirk shouldStarBePermissionsPolicyDefaultValue for jsfiddle.net
<a href="https://bugs.webkit.org/show_bug.cgi?id=284106">https://bugs.webkit.org/show_bug.cgi?id=284106</a>
<a href="https://rdar.apple.com/140975683">rdar://140975683</a>

Reviewed by Sihui Liu.

This removes shouldStarBePermissionsPolicyDefaultValue as it is not needed
after being tested.

* Source/WebCore/html/PermissionsPolicy.cpp:
(WebCore::parseAllowlist):
(WebCore::parsePolicyDirective):
(WebCore::PermissionsPolicy::processPermissionsPolicyAttribute):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldStarBePermissionsPolicyDefaultValue const): Deleted.
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:

Canonical link: <a href="https://commits.webkit.org/287433@main">https://commits.webkit.org/287433@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f3dec7f014bb7899afed3b5a10783ca96bb2f67

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79666 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58662 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33057 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84205 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30702 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81775 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67750 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6951 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62268 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20122 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82732 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52324 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72545 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42576 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49667 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26697 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29133 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70807 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27156 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85621 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6911 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4820 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70519 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7080 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68391 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69765 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17395 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13778 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12684 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6863 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6748 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10243 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8547 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->