### PR TITLE
Make CanvasRenderingContext2D.font include font-weight

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.font.weight-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.font.weight-expected.txt
@@ -1,5 +1,5 @@
 2d.text.font.weight
 Actual output:
 
-FAIL Canvas test: 2d.text.font.weight assert_equals: ctx.font === 'italic 300 12px serif' (got italic 12px serif[string], expected italic 300 12px serif[string]) expected "italic 300 12px serif" but got "italic 12px serif"
+PASS Canvas test: 2d.text.font.weight
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.font.weight-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.font.weight-expected.txt
@@ -1,5 +1,5 @@
 2d.text.font.weight
 
 
-FAIL OffscreenCanvas test: 2d.text.font.weight assert_equals: ctx.font === 'italic 300 12px serif' (got italic 12px serif[string], expected italic 300 12px serif[string]) expected "italic 300 12px serif" but got "italic 12px serif"
+PASS OffscreenCanvas test: 2d.text.font.weight
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.font.weight.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.font.weight.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL 2d assert_equals: ctx.font === 'italic 300 12px serif' (got italic 12px serif[string], expected italic 300 12px serif[string]) expected "italic 300 12px serif" but got "italic 12px serif"
+PASS 2d
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -345,7 +345,13 @@ String CanvasRenderingContext2DBase::State::fontString() const
 
     auto italic = font.italic() ? "italic "_s : ""_s;
     auto smallCaps = font.variantCaps() == FontVariantCaps::Small ? "small-caps "_s : ""_s;
-    serializedFont.append(italic, smallCaps, font.computedSize(), "px"_s);
+    serializedFont.append(italic, smallCaps);
+    auto weight = static_cast<int>(font.weight());
+    if (weight == boldWeightValue())
+        serializedFont.append("bold "_s);
+    else if (weight != normalWeightValue())
+        serializedFont.append(weight, " "_s);
+    serializedFont.append(font.computedSize(), "px"_s);
 
     for (unsigned i = 0; i < font.familyCount(); ++i) {
         StringView family = font.familyAt(i);


### PR DESCRIPTION
#### 2a35d1fbd751c614bf627542f41b333b0fdb4b76
<pre>
Make CanvasRenderingContext2D.font include font-weight
<a href="https://bugs.webkit.org/show_bug.cgi?id=284115">https://bugs.webkit.org/show_bug.cgi?id=284115</a>

Reviewed by Said Abou-Hallawa.

Serialize font-weight in the CanvasRenderingContext2D.font method output but
suppress the default value of 400.

* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.font.weight-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.font.weight-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.font.weight.worker-expected.txt:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::State::fontString const):

Canonical link: <a href="https://commits.webkit.org/287514@main">https://commits.webkit.org/287514@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c98d8035f1034a66778f7de7b5492dfa67a1124a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79937 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58934 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33334 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84451 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30911 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82045 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67998 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7229 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62473 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20300 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83004 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52532 "Found 1 new test failure: media/audioSession/getUserMedia.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72799 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42783 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49874 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26949 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29373 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70994 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27428 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85883 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7153 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5020 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70745 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7330 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68639 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69990 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17435 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13986 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12921 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7117 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12652 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6964 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10476 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8768 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->