### PR TITLE
AX: Set non-style-related attributes when serving attributed strings from the accessibility thread

### DIFF
--- a/LayoutTests/accessibility/ax-thread-text-apis/attributed-string-includes-insertion-deletion-expected.txt
+++ b/LayoutTests/accessibility/ax-thread-text-apis/attributed-string-includes-insertion-deletion-expected.txt
@@ -1,0 +1,11 @@
+This verifies that using the insertion and deletion roles adds the attribute to the attributed string.
+PASS: item1.attributedStringForTextMarkerRangeContainsAttribute('AXIsSuggestedInsertion', markerRange) === true
+PASS: item2.attributedStringForTextMarkerRangeContainsAttribute('AXIsSuggestedDeletion', markerRange) === true
+PASS: item3.attributedStringForTextMarkerRangeContainsAttribute('AXIsSuggestion', markerRange) === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+inserted text
+deleted text
+hellohi

--- a/LayoutTests/accessibility/ax-thread-text-apis/attributed-string-includes-insertion-deletion.html
+++ b/LayoutTests/accessibility/ax-thread-text-apis/attributed-string-includes-insertion-deletion.html
@@ -1,0 +1,56 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ runSingly=true AccessibilityThreadTextApisEnabled=true ] -->
+<!-- This is a modern-style rewrite of existing test mac/attributed-string-includes-insertion-deletion.html. After accessibilityThreadTextApisEnabled is enabled by default, we should replace mac/attributed-string-includes-insertion-deletion.html with this file. -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body id="body" role="group">
+
+<div id="item1"><span role="insertion">inserted text</span></div>
+<div id="item2"><span role="deletion">deleted text</span></div>
+<div id="item3"><span role="suggestion"><span role="insertion">hello</span><span role="deletion">hi</span></span></div>
+
+<script>
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    let output = "This verifies that using the insertion and deletion roles adds the attribute to the attributed string.\n";
+
+    var item1 = accessibilityController.accessibleElementById("item1");
+    var markerRange = item1.textMarkerRangeForElement(item1);
+    output += expect("item1.attributedStringForTextMarkerRangeContainsAttribute('AXIsSuggestedInsertion', markerRange)", "true");
+
+    var item2 = accessibilityController.accessibleElementById("item2");
+    markerRange = item2.textMarkerRangeForElement(item2);
+    output += expect("item2.attributedStringForTextMarkerRangeContainsAttribute('AXIsSuggestedDeletion', markerRange)", "true");
+
+    var item3 = accessibilityController.accessibleElementById("item3");
+    markerRange = item3.textMarkerRangeForElement(item3);
+    output += expect("item3.attributedStringForTextMarkerRangeContainsAttribute('AXIsSuggestion', markerRange)", "true");
+    setTimeout(async function() {
+        document.getElementById("item1").children[0].removeAttribute("role");
+        document.getElementById("item2").children[0].removeAttribute("role");
+        document.getElementById("item3").children[0].removeAttribute("role");
+
+        await waitFor(() => {
+            markerRange = item1.textMarkerRangeForElement(item1);
+            return !item1.attributedStringForTextMarkerRangeContainsAttribute("AXIsSuggestedInsertion", markerRange);
+        });
+
+        await waitFor(() => {
+            markerRange = item2.textMarkerRangeForElement(item2);
+            return !item2.attributedStringForTextMarkerRangeContainsAttribute("AXIsSuggestedDeletion", markerRange);
+        });
+
+        await waitFor(() => {
+            markerRange = item3.textMarkerRangeForElement(item3);
+            return !item3.attributedStringForTextMarkerRangeContainsAttribute("AXIsSuggestion", markerRange);
+        });
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/attributed-string-text-styling.html
+++ b/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/attributed-string-text-styling.html
@@ -16,22 +16,58 @@
     if (window.accessibilityController) {
         var textPlain = accessibilityController.accessibleElementById("text-plain");
         var textPlainRange = textPlain.textMarkerRangeForElement(textPlain);
-        var textPlainAttributes = "AXFont - {\n    AXFontFamily = Times;\n    AXFontName = \"Times-Roman\";\n    AXFontSize = 16;\n}, The";
+        var textPlainAttributes = `Attributes in range {0, 3}:
+AXFont: {
+    AXFontFamily = Times;
+    AXFontName = "Times-Roman";
+    AXFontSize = 16;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+The`;
         shouldBe("textPlain.attributedStringForTextMarkerRange(textPlainRange)", "textPlainAttributes");
 
         var textBold = accessibilityController.accessibleElementById("text-bold");
         var textBoldRange = textBold.textMarkerRangeForElement(textBold);
-        var textBoldAttributes = "AXFont - {\n    AXFontBold = 1;\n    AXFontFamily = Times;\n    AXFontName = \"Times-Bold\";\n    AXFontSize = 16;\n}, Fox";
+        var textBoldAttributes = `Attributes in range {0, 3}:
+AXFont: {
+    AXFontBold = 1;
+    AXFontFamily = Times;
+    AXFontName = "Times-Bold";
+    AXFontSize = 16;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+Fox`;
         shouldBe("textBold.attributedStringForTextMarkerRange(textBoldRange)", "textBoldAttributes");
 
         var textItalic = accessibilityController.accessibleElementById("text-italic");
         var textItalicRange = textItalic.textMarkerRangeForElement(textItalic);
-        var textItalicAttributes = "AXFont - {\n    AXFontFamily = Times;\n    AXFontItalic = 1;\n    AXFontName = \"Times-Italic\";\n    AXFontSize = 16;\n}, Jumped";
+        var textItalicAttributes = `Attributes in range {0, 6}:
+AXFont: {
+    AXFontFamily = Times;
+    AXFontItalic = 1;
+    AXFontName = "Times-Italic";
+    AXFontSize = 16;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+Jumped`;
         shouldBe("textItalic.attributedStringForTextMarkerRange(textItalicRange)", "textItalicAttributes");
 
         var textBoldItalic = accessibilityController.accessibleElementById("text-bold-italic");
         var textBoldItalicRange = textBoldItalic.textMarkerRangeForElement(textBoldItalic);
-        var textBoldItalicAttributes = "AXFont - {\n    AXFontBold = 1;\n    AXFontFamily = Times;\n    AXFontItalic = 1;\n    AXFontName = \"Times-BoldItalic\";\n    AXFontSize = 16;\n}, Over";
+        var textBoldItalicAttributes = `Attributes in range {0, 4}:
+AXFont: {
+    AXFontBold = 1;
+    AXFontFamily = Times;
+    AXFontItalic = 1;
+    AXFontName = "Times-BoldItalic";
+    AXFontSize = 16;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+Over`;
         shouldBe("textBoldItalic.attributedStringForTextMarkerRange(textBoldItalicRange)", "textBoldItalicAttributes");
     }
 </script>

--- a/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/blockquote-level-expected.txt
+++ b/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/blockquote-level-expected.txt
@@ -1,0 +1,8 @@
+This test ensures we represent AXBlockQuoteLevel in attributed strings.
+
+PASS: fooText.attributedStringForTextMarkerRangeContainsAttribute('AXBlockQuoteLevel', markerRange) === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Foo

--- a/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/blockquote-level.html
+++ b/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/blockquote-level.html
@@ -1,0 +1,25 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ runSingly=true AccessibilityThreadTextApisEnabled=true ] -->
+<!-- This is new test added with the accessibilityThreadTextApisEnabled effort. After accessibilityThreadTextApisEnabled is enabled by default, we should move it into LayoutTests/accessibility/mac. -->
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<blockquote id="quote">Foo</blockquote>
+
+<script>
+var output = "This test ensures we represent AXBlockQuoteLevel in attributed strings.\n\n";
+
+if (window.accessibilityController) {
+    var fooText = accessibilityController.accessibleElementById("quote").childAtIndex(0);
+    var markerRange = fooText.textMarkerRangeForElement(fooText);
+    output += expect("fooText.attributedStringForTextMarkerRangeContainsAttribute('AXBlockQuoteLevel', markerRange)", "true");
+
+    debug(output);
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/expanded-text-expected.txt
+++ b/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/expanded-text-expected.txt
@@ -1,0 +1,9 @@
+This test ensures we represent expanded text in attributed strings.
+
+PASS: abbrText.attributedStringForTextMarkerRangeContainsAttribute('AXExpandedTextValue', markerRange) === true
+PASS: acronymText.attributedStringForTextMarkerRangeContainsAttribute('AXExpandedTextValue', markerRange) === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Foo Bar

--- a/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/expanded-text.html
+++ b/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/expanded-text.html
@@ -1,0 +1,30 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ runSingly=true AccessibilityThreadTextApisEnabled=true ] -->
+<!-- This is new test added with the accessibilityThreadTextApisEnabled effort. After accessibilityThreadTextApisEnabled is enabled by default, we should move it into LayoutTests/accessibility/mac. -->
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<abbr role="group" id="abbr" title="a">Foo</abbr>
+<acronym role="group" id="acronym" title="b">Bar</acronym>
+
+<script>
+var output = "This test ensures we represent expanded text in attributed strings.\n\n";
+
+if (window.accessibilityController) {
+    var abbrText = accessibilityController.accessibleElementById("abbr").childAtIndex(0);
+    var markerRange = abbrText.textMarkerRangeForElement(abbrText);
+    output += expect("abbrText.attributedStringForTextMarkerRangeContainsAttribute('AXExpandedTextValue', markerRange)", "true");
+
+    var acronymText = accessibilityController.accessibleElementById("acronym").childAtIndex(0);
+    var markerRange = acronymText.textMarkerRangeForElement(acronymText);
+    output += expect("acronymText.attributedStringForTextMarkerRangeContainsAttribute('AXExpandedTextValue', markerRange)", "true");
+
+    debug(output);
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/heading-level-expected.txt
+++ b/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/heading-level-expected.txt
@@ -1,0 +1,12 @@
+This test ensures we represent AXHeadingLevel in attributed strings.
+
+PASS: fooText.attributedStringForTextMarkerRangeContainsAttribute('AXHeadingLevel', markerRange) === true
+PASS: barText.attributedStringForTextMarkerRangeContainsAttribute('AXHeadingLevel', markerRange) === true
+PASS: AXHeadingLevel is not present after dynamic role attribute change.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Foo
+
+Bar

--- a/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/heading-level.html
+++ b/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/heading-level.html
@@ -1,0 +1,42 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ runSingly=true AccessibilityThreadTextApisEnabled=true ] -->
+<!-- This is new test added with the accessibilityThreadTextApisEnabled effort. After accessibilityThreadTextApisEnabled is enabled by default, we should move it into LayoutTests/accessibility/mac. -->
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<h1 id="h1">Foo</h1>
+<div id="aria-heading" role="heading" aria-level="1">Bar</div>
+
+<script>
+var output = "This test ensures we represent AXHeadingLevel in attributed strings.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var fooText = accessibilityController.accessibleElementById("h1").childAtIndex(0);
+    var markerRange = fooText.textMarkerRangeForElement(fooText);
+    output += expect("fooText.attributedStringForTextMarkerRangeContainsAttribute('AXHeadingLevel', markerRange)", "true");
+
+    var barText = accessibilityController.accessibleElementById("aria-heading").childAtIndex(0);
+    markerRange = barText.textMarkerRangeForElement(barText);
+    output += expect("barText.attributedStringForTextMarkerRangeContainsAttribute('AXHeadingLevel', markerRange)", "true");
+
+    document.getElementById("aria-heading").removeAttribute("role");
+    setTimeout(async function() {
+        await waitFor(() => {
+            markerRange = barText.textMarkerRangeForElement(barText);
+            return !barText.attributedStringForTextMarkerRangeContainsAttribute('AXHeadingLevel', markerRange);
+        });
+        output += "PASS: AXHeadingLevel is not present after dynamic role attribute change.\n";
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/lazy-spellchecking-expected.txt
+++ b/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/lazy-spellchecking-expected.txt
@@ -1,0 +1,17 @@
+This test ensures that the proper attributes are present when "lazy" spellchecking happens.
+
+Attributed string with range: wrods is misspelled aab lotsi nowadays. euep.{
+    AXBackgroundColor = " [ (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1)] ( 0 0 0 0 )";
+    AXDidSpellCheck = 0;
+    AXFont =     {
+        AXFontFamily = Times;
+        AXFontName = "Times-Roman";
+        AXFontSize = 16;
+    };
+    AXForegroundColor = " [ (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1)] ( 0 0 0 1 )";
+}
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+wrods is misspelled aab lotsi nowadays. euep.

--- a/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/lazy-spellchecking.html
+++ b/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/lazy-spellchecking.html
@@ -1,0 +1,25 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ runSingly=true AccessibilityThreadTextApisEnabled=true ] -->
+<!-- This is a copy of existing test mac/lazy-spellchecking.html. After accessibilityThreadTextApisEnabled is enabled by default, this file should be removed. -->
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div contenteditable=true id="contenteditable" role="textbox">
+wrods is misspelled aab lotsi nowadays. euep.
+</div>
+
+<script>
+var output = "This test ensures that the proper attributes are present when \"lazy\" spellchecking happens.\n\n";
+
+if (window.accessibilityController) {
+    accessibilityController.setForceDeferredSpellChecking(true);
+    var contenteditable = accessibilityController.accessibleElementById("contenteditable");
+    output += `Attributed string with range: ${contenteditable.attributedStringForRange(0, 45)}\n`;
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/link-text-expected.txt
+++ b/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/link-text-expected.txt
@@ -1,0 +1,8 @@
+This test ensures we represent NSAccessibilityLinkTextAttribute in attributed strings.
+
+PASS: linkText.attributedStringForTextMarkerRangeContainsAttribute('AXLink', markerRange) === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Foo

--- a/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/link-text.html
+++ b/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/link-text.html
@@ -1,0 +1,25 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ runSingly=true AccessibilityThreadTextApisEnabled=true ] -->
+<!-- This is new test added with the accessibilityThreadTextApisEnabled effort. After accessibilityThreadTextApisEnabled is enabled by default, we should move it into LayoutTests/accessibility/mac. -->
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<a id="link" href="#foo">Foo</a>
+
+<script>
+var output = "This test ensures we represent NSAccessibilityLinkTextAttribute in attributed strings.\n\n";
+
+if (window.accessibilityController) {
+    var linkText = accessibilityController.accessibleElementById("link").childAtIndex(0);
+    var markerRange = linkText.textMarkerRangeForElement(linkText);
+    output += expect("linkText.attributedStringForTextMarkerRangeContainsAttribute('AXLink', markerRange)", "true");
+
+    debug(output);
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/accessibility/ax-thread-text-apis/character-offset-from-upstream-position.html
+++ b/LayoutTests/accessibility/ax-thread-text-apis/character-offset-from-upstream-position.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML><!-- webkit-test-runner [ runSingly=true AccessibilityThreadTextApisEnabled=true ] -->
-<!-- Copy existing test, remove after accessibilityThreadTextApisEnabled is enabled by default. -->
+<!-- Copy of existing test, remove after accessibilityThreadTextApisEnabled is enabled by default. -->
 <html>
 <head>
 <script src="../../resources/js-test.js"></script>

--- a/LayoutTests/accessibility/ax-thread-text-apis/mark-role-expected.txt
+++ b/LayoutTests/accessibility/ax-thread-text-apis/mark-role-expected.txt
@@ -1,0 +1,12 @@
+This test makes sure that the mark role exposes the right attributes in the attributed string.
+PASS: highlight1.attributedStringForTextMarkerRangeContainsAttribute('AXHighlight', markerRange) === true
+PASS: highlight2.attributedStringForTextMarkerRangeContainsAttribute('AXHighlight', markerRange) === true
+PASS: AXHighlight is no longer present when role='mark' is removed.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+This is some
+highlighted
+text.
+This is some highlighted text.

--- a/LayoutTests/accessibility/ax-thread-text-apis/mark-role.html
+++ b/LayoutTests/accessibility/ax-thread-text-apis/mark-role.html
@@ -1,0 +1,40 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ runSingly=true AccessibilityThreadTextApisEnabled=true ] -->
+<!-- This is a modern-style rewrite of existing test mac/mark-role.html. After accessibilityThreadTextApisEnabled is enabled by default, we should replace mac/mark-role.html with this file. -->
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+</head>
+<body>
+
+<div>This is some <div id="highlight1" role="mark">highlighted</div> text.</div>
+<div>This is some <mark id="highlight2">highlighted</mark> text.</div>
+
+<script>
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    let output = "This test makes sure that the mark role exposes the right attributes in the attributed string.\n";
+
+    var highlight1 = accessibilityController.accessibleElementById("highlight1").childAtIndex(0);
+    var markerRange = highlight1.textMarkerRangeForElement(highlight1);
+    output += expect("highlight1.attributedStringForTextMarkerRangeContainsAttribute('AXHighlight', markerRange)", "true");
+
+    var highlight2 = accessibilityController.accessibleElementById("highlight2").childAtIndex(0);
+    var markerRange = highlight2.textMarkerRangeForElement(highlight2);
+    output += expect("highlight2.attributedStringForTextMarkerRangeContainsAttribute('AXHighlight', markerRange)", "true");
+
+    document.getElementById("highlight1").setAttribute("role", "group");
+    setTimeout(async function() {
+        await waitFor(() => {
+            markerRange = highlight1.textMarkerRangeForElement(highlight1);
+            return !highlight1.attributedStringForTextMarkerRangeContainsAttribute("AXHighlight", markerRange);
+        });
+        output += "PASS: AXHighlight is no longer present when role='mark' is removed.\n";
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -61,6 +61,7 @@ typedef const struct __AXTextMarker* AXTextMarkerRef;
 typedef const struct __AXTextMarkerRange* AXTextMarkerRangeRef;
 typedef const struct __CTFont* CTFontRef;
 OBJC_CLASS NSAttributedString;
+OBJC_CLASS NSMutableAttributedString;
 #elif USE(ATSPI)
 
 namespace WebCore {
@@ -1120,11 +1121,13 @@ public:
 #if PLATFORM(COCOA)
     enum class SpellCheck : bool { No, Yes };
     virtual RetainPtr<NSAttributedString> attributedStringForTextMarkerRange(AXTextMarkerRange&&, SpellCheck) const = 0;
-    // Creates an attributed string for the given text (which should be the full or partial text belonging to `this`, depending on the
-    // calling context) based on the style of `this`.
-    RetainPtr<NSAttributedString> createAttributedString(String&& text) const;
     virtual AttributedStringStyle stylesForAttributedString() const = 0;
 #endif
+
+#if PLATFORM(MAC)
+    RetainPtr<NSMutableAttributedString> createAttributedString(StringView text, SpellCheck) const;
+#endif
+
     virtual const String placeholderValue() const = 0;
 
     // Abbreviations
@@ -1424,13 +1427,14 @@ public:
     virtual bool hasClickHandler() const = 0;
     virtual AXCoreObject* clickableSelfOrAncestor(ClickHandlerFilter = ClickHandlerFilter::ExcludeBody) const = 0;
     virtual AXCoreObject* focusableAncestor() = 0;
-    virtual AXCoreObject* editableAncestor() = 0;
+    virtual AXCoreObject* editableAncestor() const = 0;
     virtual AXCoreObject* highestEditableAncestor() = 0;
     virtual AXCoreObject* exposedTableAncestor(bool includeSelf = false) const = 0;
 
     virtual AccessibilityChildrenVector documentLinks() = 0;
 
     virtual bool hasBodyTag() const = 0;
+    virtual bool hasMarkTag() const = 0;
     virtual String innerHTML() const = 0;
     virtual String outerHTML() const = 0;
 
@@ -1469,6 +1473,13 @@ inline Vector<AXID> axIDs(const AXCoreObject::AccessibilityChildrenVector& objec
         return object->objectID();
     });
 }
+
+#if PLATFORM(MAC)
+void attributedStringSetExpandedText(NSMutableAttributedString *, const AXCoreObject&, const NSRange&);
+void attributedStringSetBlockquoteLevel(NSMutableAttributedString *, const AXCoreObject&, const NSRange&);
+void attributedStringSetNeedsSpellCheck(NSMutableAttributedString *, const AXCoreObject&);
+void attributedStringSetElement(NSMutableAttributedString *, NSString *attribute, const AXCoreObject&, const NSRange&);
+#endif // PLATFORM(MAC)
 
 #if PLATFORM(COCOA)
 inline bool AXCoreObject::shouldComputeDescriptionAttributeValue() const
@@ -1605,7 +1616,7 @@ T* clickableSelfOrAncestor(const T& startObject, const F& shouldStop)
 }
 
 template<typename T>
-T* editableAncestor(T& startObject)
+T* editableAncestor(const T& startObject)
 {
     return findAncestor<T>(startObject, false, [] (const auto& ancestor) {
         return ancestor.isTextControl();

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -784,6 +784,9 @@ TextStream& operator<<(WTF::TextStream& stream, AXPropertyName property)
     case AXPropertyName::HasLinethrough:
         stream << "HasLinethrough";
         break;
+    case AXPropertyName::HasMarkTag:
+        stream << "HasMarkTag";
+        break;
     case AXPropertyName::HasPlainText:
         stream << "HasPlainText";
         break;

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -459,7 +459,7 @@ static AXIsolatedObject* findObjectWithRuns(AXIsolatedObject& start, AXDirection
                 return nullptr;
 
             if (searchObject->hasTextRuns())
-                return dynamicDowncast<AXIsolatedObject>(searchObject);
+                return dynamicDowncast<AXIsolatedObject>(searchObject).get();
 
             appendChildren(searchObject, isForward, nullptr, searchStack);
         }

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -575,6 +575,7 @@ public:
     int getIntegralAttribute(const QualifiedName&) const;
     bool hasTagName(const QualifiedName&) const;
     bool hasBodyTag() const final { return hasTagName(HTMLNames::bodyTag); }
+    bool hasMarkTag() const final { return hasTagName(HTMLNames::markTag); }
     AtomString tagName() const;
     bool hasDisplayContents() const;
 
@@ -769,7 +770,7 @@ public:
     bool hasClickHandler() const override { return false; }
     AccessibilityObject* clickableSelfOrAncestor(ClickHandlerFilter filter = ClickHandlerFilter::ExcludeBody) const final { return Accessibility::clickableSelfOrAncestor(*this, filter); };
     AccessibilityObject* focusableAncestor() final { return Accessibility::focusableAncestor(*this); }
-    AccessibilityObject* editableAncestor() final { return Accessibility::editableAncestor(*this); };
+    AccessibilityObject* editableAncestor() const final { return Accessibility::editableAncestor(*this); };
     AccessibilityObject* highestEditableAncestor() final { return Accessibility::highestEditableAncestor(*this); }
     AccessibilityObject* exposedTableAncestor(bool includeSelf = false) const final { return Accessibility::exposedTableAncestor(*this, includeSelf); }
 

--- a/Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm
@@ -82,7 +82,10 @@ RetainPtr<NSAttributedString> AXTextMarkerRange::toAttributedString() const
     if (start.isolatedObject() == end.isolatedObject()) {
         size_t minOffset = std::min(start.offset(), end.offset());
         size_t maxOffset = std::max(start.offset(), end.offset());
-        return start.isolatedObject()->createAttributedString(start.runs()->substring(minOffset, maxOffset - minOffset)).autorelease();
+        // FIXME: createAttributedString takes a StringView, but we create a full-fledged String. Could we create a
+        // new substringView method that returns a StringView?
+        // FIXME: Should we be passing SpellCheck::Yes? Maybe we need to take `SpellCheck` as a function parameter?
+        return start.isolatedObject()->createAttributedString(start.runs()->substring(minOffset, maxOffset - minOffset), AXCoreObject::SpellCheck::No).autorelease();
     }
     // FIXME: Handle ranges that span multiple objects.
     return nil;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -104,8 +104,14 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
     auto& object = axObject.get();
 
     // These properties are cached for all objects, ignored and unignored.
-    setProperty(AXPropertyName::HasBodyTag, object.hasBodyTag());
     setProperty(AXPropertyName::HasClickHandler, object.hasClickHandler());
+    auto tag = object.tagName();
+    if (tag == bodyTag)
+        setProperty(AXPropertyName::HasBodyTag, true);
+#if ENABLE(AX_THREAD_TEXT_APIS)
+    else if (tag == markTag)
+        setProperty(AXPropertyName::HasMarkTag, true);
+#endif // ENABLE(AX_THREAD_TEXT_APIS)
 
 #if ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
     if (object.includeIgnoredInCoreTree()) {

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -64,8 +64,10 @@ public:
     bool isDetached() const final;
     bool isTable() const final { return boolAttributeValue(AXPropertyName::IsTable); }
     bool isExposable() const final { return boolAttributeValue(AXPropertyName::IsExposable); }
-    bool hasBodyTag() const final { return boolAttributeValue(AXPropertyName::HasBodyTag); }
     bool hasClickHandler() const final { return boolAttributeValue(AXPropertyName::HasClickHandler); }
+
+    bool hasBodyTag() const final { return boolAttributeValue(AXPropertyName::HasBodyTag); }
+    bool hasMarkTag() const final { return boolAttributeValue(AXPropertyName::HasMarkTag); }
 
     const AccessibilityChildrenVector& children(bool updateChildrenIfNeeded = true) final;
 #if ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
@@ -76,7 +78,7 @@ public:
     AXIsolatedObject* parentObjectUnignored() const final { return tree()->objectForID(parent()).get(); }
 #endif // ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
     AXIsolatedObject* clickableSelfOrAncestor(ClickHandlerFilter filter = ClickHandlerFilter::ExcludeBody) const final { return Accessibility::clickableSelfOrAncestor(*this, filter); };
-    AXIsolatedObject* editableAncestor() final { return Accessibility::editableAncestor(*this); };
+    AXIsolatedObject* editableAncestor() const final { return Accessibility::editableAncestor(*this); };
     bool canSetFocusAttribute() const final { return boolAttributeValue(AXPropertyName::CanSetFocusAttribute); }
 
 #if ENABLE(AX_THREAD_TEXT_APIS)

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -138,6 +138,7 @@ enum class AXPropertyName : uint16_t {
     HasHighlighting,
     HasItalicFont,
     HasLinethrough,
+    HasMarkTag,
     HasPlainText,
     HasRemoteFrameChild,
     IsSubscript,

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.h
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.h
@@ -56,7 +56,6 @@ void attributedStringSetColor(NSMutableAttributedString *attrString, NSString *a
 void attributedStringSetNumber(NSMutableAttributedString *, NSString *, NSNumber *, const NSRange&);
 void attributedStringSetFont(NSMutableAttributedString *, CTFontRef, const NSRange&);
 void attributedStringSetSpelling(NSMutableAttributedString *, Node&, StringView, const NSRange&);
-void attributedStringSetNeedsSpellCheck(NSMutableAttributedString *, Node&);
 RetainPtr<NSAttributedString> attributedStringCreate(Node&, StringView, const SimpleRange&, AXCoreObject::SpellCheck);
 }
 


### PR DESCRIPTION
#### aff19f98fb652ba02cd995f7ee6b568864f5750f
<pre>
AX: Set non-style-related attributes when serving attributed strings from the accessibility thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=284117">https://bugs.webkit.org/show_bug.cgi?id=284117</a>
<a href="https://rdar.apple.com/140996511">rdar://140996511</a>

Reviewed by Chris Fleizach.

With this commit, we set many new attributes for attributed strings created lazily off the main-thread:
  - AXHighlight
  - AXIsSuggestedInsertion
  - AXIsSuggestedDeletion
  - AXIsSuggestion
  - AXLink
  - AXExpandedTextValue
  - AXHeadingLevel
  - AXBlockQuoteLevel
  - AXDidSpellCheck

After this commit, the two remaining attributes are related to eagerly resolving misspelling (rather than setting AXDidSpellCheck: 0),
and setting text autocompletion attributes (attributedStringSetCompositionAttributes), both of which currently require DOM nodes
or other main-thread state. We&apos;ll figure out what to do with these in a future patch.

Many new tests are added to verify we behave correctly.

* LayoutTests/accessibility/ax-thread-text-apis/attributed-string-includes-insertion-deletion-expected.txt: Added.
* LayoutTests/accessibility/ax-thread-text-apis/attributed-string-includes-insertion-deletion.html: Added.
* LayoutTests/accessibility/ax-thread-text-apis/attributed-string/attributed-string-text-styling.html:
* LayoutTests/accessibility/ax-thread-text-apis/attributed-string/blockquote-level-expected.txt: Added.
* LayoutTests/accessibility/ax-thread-text-apis/attributed-string/blockquote-level.html: Added.
* LayoutTests/accessibility/ax-thread-text-apis/attributed-string/expanded-text-expected.txt: Added.
* LayoutTests/accessibility/ax-thread-text-apis/attributed-string/expanded-text.html: Added.
* LayoutTests/accessibility/ax-thread-text-apis/attributed-string/heading-level-expected.txt: Added.
* LayoutTests/accessibility/ax-thread-text-apis/attributed-string/heading-level.html: Added.
* LayoutTests/accessibility/ax-thread-text-apis/attributed-string/lazy-spellchecking-expected.txt: Added.
* LayoutTests/accessibility/ax-thread-text-apis/attributed-string/lazy-spellchecking.html: Added.
* LayoutTests/accessibility/ax-thread-text-apis/attributed-string/link-text-expected.txt: Added.
* LayoutTests/accessibility/ax-thread-text-apis/attributed-string/link-text.html: Added.
* LayoutTests/accessibility/ax-thread-text-apis/character-offset-from-upstream-position.html:
* LayoutTests/accessibility/ax-thread-text-apis/mark-role-expected.txt: Added.
* LayoutTests/accessibility/ax-thread-text-apis/mark-role.html: Added.
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::Accessibility::editableAncestor):
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AXTextMarker.cpp:
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm:
(WebCore::attributedStringSetColor):
(WebCore::attributedStringSetExpandedText):
(WebCore::attributedStringSetBlockquoteLevel):
(WebCore::attributedStringSetNeedsSpellCheck):
(WebCore::attributedStringSetElement):
(WebCore::attributedStringSetStyle):
(WebCore::AXCoreObject::createAttributedString const):
* Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm:
(WebCore::AXTextMarkerRange::toAttributedString const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::initializeProperties):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
* Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm:
(WebCore::attributedStringCreate):
(WebCore::attributedStringSetStyle): Deleted.
(WebCore::attributedStringSetHeadingLevel): Deleted.
(WebCore::attributedStringSetBlockquoteLevel): Deleted.
(WebCore::attributedStringSetExpandedText): Deleted.
(WebCore::attributedStringSetElement): Deleted.
(WebCore::attributedStringSetNeedsSpellCheck): Deleted.
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.h:

Canonical link: <a href="https://commits.webkit.org/287471@main">https://commits.webkit.org/287471@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bef15c19ef46e920b562541237e867d360a83287

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79782 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58783 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33181 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84307 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30789 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81891 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67857 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7074 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62360 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20201 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82850 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52416 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72657 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42664 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49758 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26805 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29232 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70887 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27276 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85733 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7017 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4914 "Found 1 new test failure: media/media-vp8-hiddenframes.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70617 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7190 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68496 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69856 "Found 5 new API test failures: /TestWebKit:WebKit2UserMessageRoundTripTest.WKURL, /TestWebKit:WebKit.LoadAlternateHTMLStringWithEmptyBaseURL, /TestWebKit:WebKit2.ProvisionalURLAfterWillSendRequestCallback, /TestWebKit:WebKit.FocusedFrameAfterCrash, /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginShouldNotBeDispatchedForAlreadyFocusedField (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17412 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13867 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12782 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6974 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6838 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10346 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8645 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->