### PR TITLE
REGRESSION(284617@main): Media query does not recognize the p3 color-gamut display

### DIFF
--- a/Source/WebCore/css/query/MediaQueryFeatures.cpp
+++ b/Source/WebCore/css/query/MediaQueryFeatures.cpp
@@ -266,12 +266,8 @@ const FeatureSchema& colorGamut()
         [](auto& context) {
             // FIXME: At some point we should start detecting displays that support more colors.
             MatchingIdentifiers identifiers { CSSValueSRGB };
-#if HAVE(IOSURFACE_RGB10)
-            if (screenContentsFormat(context.document->protectedFrame()->mainFrame().protectedVirtualView().get()) == ContentsFormat::RGBA10)
+            if (screenSupportsExtendedColor(context.document->protectedFrame()->mainFrame().protectedVirtualView().get()))
                 identifiers.append(CSSValueP3);
-#else
-            UNUSED_PARAM(context);
-#endif
             return identifiers;
         }
     };

--- a/Source/WebCore/platform/PlatformScreen.h
+++ b/Source/WebCore/platform/PlatformScreen.h
@@ -82,6 +82,7 @@ FloatRect screenRect(Widget*);
 FloatRect screenAvailableRect(Widget*);
 
 WEBCORE_EXPORT ContentsFormat screenContentsFormat(Widget* = nullptr, PlatformCALayerClient* = nullptr);
+WEBCORE_EXPORT bool screenSupportsExtendedColor(Widget* = nullptr);
 
 enum class DynamicRangeMode : uint8_t {
     None,

--- a/Source/WebCore/platform/ScreenProperties.h
+++ b/Source/WebCore/platform/ScreenProperties.h
@@ -40,7 +40,7 @@ struct ScreenData {
     DestinationColorSpace colorSpace { DestinationColorSpace::SRGB() };
     int screenDepth { 0 };
     int screenDepthPerComponent { 0 };
-    ContentsFormat screenContentsFormat { ContentsFormat::RGBA8 };
+    bool screenSupportsExtendedColor { false };
     bool screenHasInvertedColors { false };
     bool screenSupportsHighDynamicRange { false };
 #if PLATFORM(MAC)

--- a/Source/WebCore/platform/ios/PlatformScreenIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformScreenIOS.mm
@@ -78,20 +78,24 @@ ContentsFormat screenContentsFormat(Widget* widget, PlatformCALayerClient* clien
 #if HAVE(HDR_SUPPORT)
     if (client && client->hdrForImagesEnabled() && screenSupportsHighDynamicRange(widget))
         return ContentsFormat::RGBA16F;
-#else
-    UNUSED_PARAM(widget);
-    UNUSED_PARAM(client);
 #endif
 
-    if (auto data = screenData(primaryScreenDisplayID()))
-        return data->screenContentsFormat;
-
 #if HAVE(IOSURFACE_RGB10)
-    if (MGGetBoolAnswer(kMGQHasExtendedColorDisplay))
+    if (screenSupportsExtendedColor(widget))
         return ContentsFormat::RGBA10;
 #endif
 
+    UNUSED_PARAM(widget);
+    UNUSED_PARAM(client);
     return ContentsFormat::RGBA8;
+}
+
+bool screenSupportsExtendedColor(Widget*)
+{
+    if (auto data = screenData(primaryScreenDisplayID()))
+        return data->screenSupportsExtendedColor;
+
+    return MGGetBoolAnswer(kMGQHasExtendedColorDisplay);
 }
 
 bool screenSupportsHighDynamicRange(Widget*)
@@ -232,7 +236,7 @@ ScreenProperties collectScreenProperties()
         screenData.colorSpace = { screenColorSpace(nullptr) };
         screenData.screenDepth = WebCore::screenDepth(nullptr);
         screenData.screenDepthPerComponent = WebCore::screenDepthPerComponent(nullptr);
-        screenData.screenContentsFormat = screenContentsFormat(nullptr);
+        screenData.screenSupportsExtendedColor = WebCore::screenSupportsExtendedColor(nullptr);
         screenData.screenHasInvertedColors = WebCore::screenHasInvertedColors();
         screenData.screenSupportsHighDynamicRange = WebCore::screenSupportsHighDynamicRange(nullptr);
         screenData.scaleFactor = WebCore::screenPPIFactor();

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2441,7 +2441,7 @@ header: <WebCore/ScreenProperties.h>
     WebCore::DestinationColorSpace colorSpace;
     int screenDepth;
     int screenDepthPerComponent;
-    WebCore::ContentsFormat screenContentsFormat;
+    bool screenSupportsExtendedColor;
     bool screenHasInvertedColors;
     bool screenSupportsHighDynamicRange;
 #if PLATFORM(MAC)


### PR DESCRIPTION
#### f09cec069734290b173a7002a6aa99be3dc14aa0
<pre>
REGRESSION(284617@main): Media query does not recognize the p3 color-gamut display
<a href="https://bugs.webkit.org/show_bug.cgi?id=284135">https://bugs.webkit.org/show_bug.cgi?id=284135</a>
<a href="https://rdar.apple.com/138933101">rdar://138933101</a>

Reviewed by Simon Fraser.

284617@main changed `colorGamut()` such that it checks for the display-p3 color
gamut only when HAVE(IOSURFACE_RGB10) which is enabled on iOS only.

screenProperties should not use screenContentsFormat to set its fields. In fact
the opposite should happen.

The fix is to revert some of the changes in 284617@main.

1. A bool flag screenSupportsExtendedColor will replace screenContentsFormat
   in ScreenData.

2. The function screenSupportsExtendedColor() will be readded. It will be used
   by screenContentsFormat().

3. colorGamut() will replace the call to screenContentsFormat() by calling
   screenSupportsExtendedColor().

* Source/WebCore/css/query/MediaQueryFeatures.cpp:
(WebCore::MQ::Features::colorGamut):
* Source/WebCore/platform/PlatformScreen.h:
* Source/WebCore/platform/ScreenProperties.h:
* Source/WebCore/platform/ios/PlatformScreenIOS.mm:
(WebCore::screenContentsFormat):
(WebCore::screenSupportsExtendedColor):
(WebCore::collectScreenProperties):
* Source/WebCore/platform/mac/PlatformScreenMac.mm:
(WebCore::collectScreenProperties):
(WebCore::screenContentsFormat):
(WebCore::screenSupportsExtendedColor):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/287482@main">https://commits.webkit.org/287482@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8139f337dec35e0967c357417f8fb7807a912b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79676 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58672 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33067 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84214 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30710 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81785 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67758 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6962 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62274 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20127 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82742 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52334 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72562 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42582 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49677 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26713 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29141 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70816 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27176 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85631 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6919 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4828 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70528 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7089 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68407 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69774 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17421 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13788 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12698 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6872 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12505 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6757 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10261 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8560 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->