### PR TITLE
[AutoInstall] retry logic doesn't actually throw on eventual failure

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py
@@ -112,7 +112,7 @@ class Package(object):
                             file.write(data)
                     return
                 except (IOError, URLError) as e:
-                    if count > (AutoInstall.times_to_retry or 0):
+                    if count == (AutoInstall.times_to_retry or 0):
                         raise
                     else:
                         AutoInstall.log(str(e))
@@ -121,6 +121,8 @@ class Package(object):
                     if response:
                         response.close()
                     count += 1
+            # This is unreachable because the raise in the above loop should always return or raise.
+            raise RuntimeError("unreachable")
 
         def unpack(self, target):
             if not os.path.isfile(self.path):

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/autoinstall_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/autoinstall_unittest.py
@@ -1,0 +1,44 @@
+# Copyright (C) 2024 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+from unittest.mock import patch
+from urllib.error import URLError
+
+from webkitcorepy import autoinstall
+from webkitcorepy.autoinstall import AutoInstall, Package
+from webkitcorepy.version import Version
+
+
+class ArchiveTest(unittest.TestCase):
+    @patch.object(AutoInstall, "_verify_index", autospec=True, return_value=None)
+    @patch.object(
+        autoinstall, "urlopen", autospec=True, side_effect=URLError("no network")
+    )
+    @patch.object(AutoInstall, "times_to_retry", new=3)
+    def test_retry(self, mock_urlopen, mock_verify_index):
+        archive = Package.Archive(
+            "dummy", "http://example.example/dummy-1.0-py3-none-any.whl", Version(1, 0)
+        )
+        with self.assertRaises(URLError):
+            archive.download()
+        self.assertEqual(mock_urlopen.call_count, 4)


### PR DESCRIPTION
#### e5e3a6a6bf1460a1b3216398925a353420cc6176
<pre>
[AutoInstall] retry logic doesn&apos;t actually throw on eventual failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=284133">https://bugs.webkit.org/show_bug.cgi?id=284133</a>

Reviewed by Jonathan Bedard.

Our retry logic has actually been broken since it first landed, never
actually raising upon failure. This both fixes the conditional and
adds a test for this behaviour, including how many retries we make.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py:
(Package.Archive.download):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/autoinstall_unittest.py: Added.
(ArchiveTest):
(ArchiveTest.test_retry):

Canonical link: <a href="https://commits.webkit.org/287456@main">https://commits.webkit.org/287456@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bfd9bf9ad1f14dc6d6b08db36a5cf80ce211915

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79632 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58632 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33026 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84176 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30680 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81742 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67728 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6919 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62249 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20102 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82698 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52308 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72521 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42557 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/79088 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49650 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26672 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29104 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70793 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27131 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85589 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6885 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4798 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70497 "Found 2 new test failures: webanimations/accelerated-animation-tiled-while-running.html webanimations/accelerated-transform-animation-to-scale-zero-with-implicit-from-keyframe.html (failure)") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/79274 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7055 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68367 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69742 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13760 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12661 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12319 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6834 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6726 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10219 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8523 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->