### PR TITLE
Add WKWebsiteDataStore SPI to restore Local Storage data

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -3116,4 +3116,15 @@ void NetworkProcess::fetchLocalStorage(PAL::SessionID sessionID, CompletionHandl
     session->protectedStorageManager()->fetchLocalStorage(WTFMove(completionHandler));
 }
 
+void NetworkProcess::restoreLocalStorage(PAL::SessionID sessionID, HashMap<WebCore::ClientOrigin, HashMap<String, String>>&& localStorageMap, CompletionHandler<void(bool)>&& completionHandler)
+{
+    CheckedPtr session = networkSession(sessionID);
+    if (!session) {
+        completionHandler(false);
+        return;
+    }
+
+    session->protectedStorageManager()->restoreLocalStorage(WTFMove(localStorageMap), WTFMove(completionHandler));
+}
+
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -453,6 +453,7 @@ public:
     bool enableModernDownloadProgress() const { return m_enableModernDownloadProgress; }
 
     void fetchLocalStorage(PAL::SessionID, CompletionHandler<void(HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&)>&&);
+    void restoreLocalStorage(PAL::SessionID, HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&, CompletionHandler<void(bool)>&&);
 
 private:
     void platformInitializeNetworkProcess(const NetworkProcessCreationParameters&);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -261,4 +261,5 @@ messages -> NetworkProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
     GetAppBadgeForTesting(PAL::SessionID sessionID) -> (std::optional<uint64_t> badge)
 
     FetchLocalStorage(PAL::SessionID sessionID) -> (HashMap<WebCore::ClientOrigin, HashMap<String, String>> localStorageMap)
+    RestoreLocalStorage(PAL::SessionID sessionID, HashMap<WebCore::ClientOrigin, HashMap<String, String>> localStorageMap) -> (bool succeeded)
 }

--- a/Source/WebKit/NetworkProcess/storage/LocalStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/LocalStorageManager.h
@@ -66,12 +66,14 @@ public:
     void disconnectFromStorageArea(IPC::Connection::UniqueID, StorageAreaIdentifier);
 
     HashMap<String, String> fetchStorageMap() const;
+    bool populateStorageArea(WebCore::ClientOrigin, HashMap<String, String>&&, Ref<WorkQueue>&&);
 
 private:
     void connectionClosedForLocalStorageArea(IPC::Connection::UniqueID);
     void connectionClosedForTransientStorageArea(IPC::Connection::UniqueID);
 
-    RefPtr<StorageAreaBase> protectedLocalStorageArea() const;
+    StorageAreaBase& ensureLocalStorageArea(const WebCore::ClientOrigin&, Ref<WorkQueue>&&);
+    MemoryStorageArea& ensureTransientLocalStorageArea(const WebCore::ClientOrigin&);
 
     String m_path;
     CheckedRef<StorageAreaRegistry> m_registry;

--- a/Source/WebKit/NetworkProcess/storage/MemoryStorageArea.cpp
+++ b/Source/WebKit/NetworkProcess/storage/MemoryStorageArea.cpp
@@ -59,7 +59,7 @@ HashMap<String, String> MemoryStorageArea::allItems()
     return m_map.items();
 }
 
-Expected<void, StorageError> MemoryStorageArea::setItem(IPC::Connection::UniqueID connection, StorageAreaImplIdentifier storageAreaImplID, String&& key, String&& value, const String& urlString)
+Expected<void, StorageError> MemoryStorageArea::setItem(std::optional<IPC::Connection::UniqueID> connection, std::optional<StorageAreaImplIdentifier> storageAreaImplID, String&& key, String&& value, const String& urlString)
 {
     String oldValue;
     bool hasQuotaError = false;
@@ -67,7 +67,8 @@ Expected<void, StorageError> MemoryStorageArea::setItem(IPC::Connection::UniqueI
     if (hasQuotaError)
         return makeUnexpected(StorageError::QuotaExceeded);
 
-    dispatchEvents(connection, storageAreaImplID, key, oldValue, value, urlString);
+    if (connection && storageAreaImplID)
+        dispatchEvents(*connection, *storageAreaImplID, key, oldValue, value, urlString);
 
     return { };
 }

--- a/Source/WebKit/NetworkProcess/storage/MemoryStorageArea.h
+++ b/Source/WebKit/NetworkProcess/storage/MemoryStorageArea.h
@@ -47,6 +47,7 @@ public:
 
     // StorageAreaBase
     HashMap<String, String> allItems() final;
+    Expected<void, StorageError> setItem(std::optional<IPC::Connection::UniqueID>, std::optional<StorageAreaImplIdentifier>, String&& key, String&& value, const String& urlString) final;
     
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
@@ -56,7 +57,6 @@ private:
 
     // StorageAreaBase
     StorageAreaBase::StorageType storageType() const final { return m_storageType; }
-    Expected<void, StorageError> setItem(IPC::Connection::UniqueID, StorageAreaImplIdentifier, String&& key, String&& value, const String& urlString) final;
     Expected<void, StorageError> removeItem(IPC::Connection::UniqueID, StorageAreaImplIdentifier, const String& key, const String& urlString) final;
     Expected<void, StorageError> clear(IPC::Connection::UniqueID, StorageAreaImplIdentifier, const String& urlString) final;
 

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -125,6 +125,7 @@ public:
     void handleLowMemoryWarning();
     void syncLocalStorage(CompletionHandler<void()>&&);
     void fetchLocalStorage(CompletionHandler<void(HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&)>&&);
+    void restoreLocalStorage(HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&, CompletionHandler<void(bool)>&&);
     void registerTemporaryBlobFilePaths(IPC::Connection&, const Vector<String>&);
     void requestSpace(const WebCore::ClientOrigin&, uint64_t size, CompletionHandler<void(bool)>&&);
     void resetQuotaForTesting(CompletionHandler<void()>&&);

--- a/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp
+++ b/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp
@@ -341,7 +341,7 @@ HashMap<String, String> SQLiteStorageArea::allItems()
     return items;
 }
 
-Expected<void, StorageError> SQLiteStorageArea::setItem(IPC::Connection::UniqueID connection, StorageAreaImplIdentifier storageAreaImplID, String&& key, String&& value, const String& urlString)
+Expected<void, StorageError> SQLiteStorageArea::setItem(std::optional<IPC::Connection::UniqueID> connection, std::optional<StorageAreaImplIdentifier> storageAreaImplID, String&& key, String&& value, const String& urlString)
 {
     ASSERT(!isMainRunLoop());
 
@@ -379,7 +379,8 @@ Expected<void, StorageError> SQLiteStorageArea::setItem(IPC::Connection::UniqueI
         return makeUnexpected(StorageError::Database);
     }
 
-    dispatchEvents(connection, storageAreaImplID, key, oldValue, value, urlString);
+    if (connection && storageAreaImplID)
+        dispatchEvents(*connection, *storageAreaImplID, key, oldValue, value, urlString);
     updateCacheIfNeeded(key, value);
 
     return { };

--- a/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.h
+++ b/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.h
@@ -59,7 +59,7 @@ private:
     StorageType storageType() const final { return StorageAreaBase::StorageType::Local; };
     bool isEmpty() final;
     HashMap<String, String> allItems() final;
-    Expected<void, StorageError> setItem(IPC::Connection::UniqueID, StorageAreaImplIdentifier, String&& key, String&& value, const String& urlString) final;
+    Expected<void, StorageError> setItem(std::optional<IPC::Connection::UniqueID>, std::optional<StorageAreaImplIdentifier>, String&& key, String&& value, const String& urlString) final;
     Expected<void, StorageError> removeItem(IPC::Connection::UniqueID, StorageAreaImplIdentifier, const String& key, const String& urlString) final;
     Expected<void, StorageError> clear(IPC::Connection::UniqueID, StorageAreaImplIdentifier, const String& urlString) final;
 

--- a/Source/WebKit/NetworkProcess/storage/StorageAreaBase.h
+++ b/Source/WebKit/NetworkProcess/storage/StorageAreaBase.h
@@ -69,7 +69,7 @@ public:
     void notifyListenersAboutClear();
 
     virtual HashMap<String, String> allItems() = 0;
-    virtual Expected<void, StorageError> setItem(IPC::Connection::UniqueID, StorageAreaImplIdentifier, String&& key, String&& value, const String& urlString) = 0;
+    virtual Expected<void, StorageError> setItem(std::optional<IPC::Connection::UniqueID>, std::optional<StorageAreaImplIdentifier>, String&& key, String&& value, const String& urlString) = 0;
     virtual Expected<void, StorageError> removeItem(IPC::Connection::UniqueID, StorageAreaImplIdentifier, const String& key, const String& urlString) = 0;
     virtual Expected<void, StorageError> clear(IPC::Connection::UniqueID, StorageAreaImplIdentifier, const String& urlString) = 0;
 

--- a/Source/WebKit/Shared/WebsiteData/WebsiteDataType.h
+++ b/Source/WebKit/Shared/WebsiteData/WebsiteDataType.h
@@ -53,3 +53,35 @@ enum class WebsiteDataType : uint32_t {
 };
 
 } // namespace WebKit
+
+namespace WTF {
+
+template<> struct EnumTraitsForPersistence<WebKit::WebsiteDataType> {
+    using values = EnumValues<
+        WebKit::WebsiteDataType,
+        WebKit::WebsiteDataType::Cookies,
+        WebKit::WebsiteDataType::DiskCache,
+        WebKit::WebsiteDataType::MemoryCache,
+        WebKit::WebsiteDataType::OfflineWebApplicationCache,
+        WebKit::WebsiteDataType::SessionStorage,
+        WebKit::WebsiteDataType::LocalStorage,
+        WebKit::WebsiteDataType::WebSQLDatabases,
+        WebKit::WebsiteDataType::IndexedDBDatabases,
+        WebKit::WebsiteDataType::MediaKeys,
+        WebKit::WebsiteDataType::HSTSCache,
+        WebKit::WebsiteDataType::SearchFieldRecentSearches,
+        WebKit::WebsiteDataType::ResourceLoadStatistics,
+        WebKit::WebsiteDataType::Credentials,
+        WebKit::WebsiteDataType::ServiceWorkerRegistrations,
+        WebKit::WebsiteDataType::DOMCache,
+        WebKit::WebsiteDataType::DeviceIdHashSalt,
+        WebKit::WebsiteDataType::PrivateClickMeasurements,
+#if HAVE(ALTERNATIVE_SERVICE)
+        WebKit::WebsiteDataType::AlternativeServices,
+#endif
+        WebKit::WebsiteDataType::FileSystem,
+        WebKit::WebsiteDataType::BackgroundFetchStorage
+    >;
+};
+
+} // namespace WTF

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
@@ -155,7 +155,9 @@ typedef NS_ENUM(uint8_t, _WKRestrictedOpenerType) {
 
 - (void)_runningOrTerminatingServiceWorkerCountForTesting:(void(^)(NSUInteger))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
-- (void)_fetchDataOfTypes:(NSSet<NSString *> *)dataTypes completionHandler:(WK_SWIFT_UI_ACTOR void (^)(NSData *))completionHandler;
+// Supported data types are: WKWebsiteDataTypeLocalStorage.
+- (void)_fetchDataOfTypes:(NSSet<NSString *> *)dataTypes completionHandler:(WK_SWIFT_UI_ACTOR void(^)(NSData *))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)_restoreData:(NSData *)data completionHandler:(WK_SWIFT_UI_ACTOR void(^)(BOOL))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 @end
 

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -2003,11 +2003,12 @@ void NetworkProcessProxy::setEmulatedConditions(PAL::SessionID sessionID, std::o
 
 void NetworkProcessProxy::fetchLocalStorage(PAL::SessionID sessionID, CompletionHandler<void(HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&)>&& completionHandler)
 {
-    if (!canSendMessage()) {
-        completionHandler({ });
-    }
-
     sendWithAsyncReply(Messages::NetworkProcess::FetchLocalStorage(sessionID), WTFMove(completionHandler));
+}
+
+void NetworkProcessProxy::restoreLocalStorage(PAL::SessionID sessionID, HashMap<WebCore::ClientOrigin, HashMap<String, String>>&& localStorage, CompletionHandler<void(bool)>&& completionHandler)
+{
+    sendWithAsyncReply(Messages::NetworkProcess::RestoreLocalStorage(sessionID, WTFMove(localStorage)), WTFMove(completionHandler));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -342,6 +342,7 @@ public:
     void notifyMediaStreamingActivity(bool);
 
     void fetchLocalStorage(PAL::SessionID, CompletionHandler<void(HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&)>&&);
+    void restoreLocalStorage(PAL::SessionID, HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&, CompletionHandler<void(bool)>&&);
 
 private:
     explicit NetworkProcessProxy();

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2716,9 +2716,14 @@ void WebsiteDataStore::setRestrictedOpenerTypeForDomainForTesting(const WebCore:
     m_restrictedOpenerTypesForTesting.set(domain, type);
 }
 
-void WebsiteDataStore::fetchLocalStorage(CompletionHandler<void(HashMap<WebCore::ClientOrigin, HashMap<String, String>>)>&& completionHandler)
+void WebsiteDataStore::fetchLocalStorage(CompletionHandler<void(HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&)>&& completionHandler)
 {
     protectedNetworkProcess()->fetchLocalStorage(m_sessionID, WTFMove(completionHandler));
+}
+
+void WebsiteDataStore::restoreLocalStorage(HashMap<WebCore::ClientOrigin, HashMap<String, String>>&& localStorage, CompletionHandler<void(bool)>&& completionHandler)
+{
+    protectedNetworkProcess()->restoreLocalStorage(m_sessionID, WTFMove(localStorage), WTFMove(completionHandler));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -483,7 +483,8 @@ public:
 
     void getAppBadgeForTesting(CompletionHandler<void(std::optional<uint64_t>)>&&);
 
-    void fetchLocalStorage(CompletionHandler<void(HashMap<WebCore::ClientOrigin, HashMap<String, String>>)>&&);
+    void fetchLocalStorage(CompletionHandler<void(HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&)>&&);
+    void restoreLocalStorage(HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&, CompletionHandler<void(bool)>&&);
 
 private:
     enum class ForceReinitialization : bool { No, Yes };


### PR DESCRIPTION
#### b4877c19e09871c820b1b3aa103cff506defec42
<pre>
Add WKWebsiteDataStore SPI to restore Local Storage data
<a href="https://bugs.webkit.org/show_bug.cgi?id=284091">https://bugs.webkit.org/show_bug.cgi?id=284091</a>
<a href="https://rdar.apple.com/141009843">rdar://141009843</a>

Reviewed by Sihui Liu, Chris Dumez, and Brady Eidson.

Some clients may want to restore the local storage of ephemeral
data stores. (For example, Safari restoring the local storage of
private browsing tabs).

The restoration process will have two parts:
1. Client fetches the local storage data from WebKit and holds onto it.
2. Client gives back the data to WebKit to restore it.

The first part (fetch) has already landed: <a href="https://commits.webkit.org/287349@main.">https://commits.webkit.org/287349@main.</a>

This patch adds an SPI (which will eventually go through API
review) that does the second part of the restoration (restore).

The SPI works for both ephemeral and persistent data stores,
so there is an API test for each.

The SPI also works for both first party storage and for third party
storage, so there are API tests for each.

* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::restoreLocalStorage):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/NetworkProcess/storage/LocalStorageManager.cpp:
(WebKit::LocalStorageManager::ensureLocalStorageArea):
(WebKit::LocalStorageManager::connectToLocalStorageArea):
(WebKit::LocalStorageManager::ensureTransientLocalStorageArea):
(WebKit::LocalStorageManager::connectToTransientLocalStorageArea):
(WebKit::LocalStorageManager::populateStorageArea):
(WebKit::LocalStorageManager::protectedLocalStorageArea const): Deleted.
* Source/WebKit/NetworkProcess/storage/LocalStorageManager.h:
* Source/WebKit/NetworkProcess/storage/MemoryStorageArea.cpp:
(WebKit::MemoryStorageArea::setItem):
* Source/WebKit/NetworkProcess/storage/MemoryStorageArea.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::fetchLocalStorage):
(WebKit::NetworkStorageManager::restoreLocalStorage):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp:
(WebKit::SQLiteStorageArea::setItem):
* Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.h:
* Source/WebKit/NetworkProcess/storage/StorageAreaBase.h:
* Source/WebKit/Shared/WebsiteData/WebsiteDataType.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(filterSupportedTypes):
(-[WKWebsiteDataStore _fetchDataOfTypes:completionHandler:]):
(-[WKWebsiteDataStore _restoreData:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::fetchLocalStorage):
(WebKit::NetworkProcessProxy::restoreLocalStorage):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::fetchLocalStorage):
(WebKit::WebsiteDataStore::restoreLocalStorage):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/RestoreLocalStorage.mm:
(testRestoreLocalStorage):
(TEST(WebKit, RestoreLocalStorageFromPersistentDataStore)):
(TEST(WebKit, RestoreLocalStorageFromEphemeralDataStore)):
(item):
(RestoreLocalStorageFromPersistentDataStoreThirdPartyIFrame)):
(RestoreLocalStorageFromEphemeralDataStoreThirdPartyIFrame)):
(testFetchLocalStorage): Deleted.
(TEST(WebKit, FetchLocalStorageFromPersistentDataStore)): Deleted.
(TEST(WebKit, FetchLocalStorageFromEphemeralDataStore)): Deleted.
(setItem): Deleted.
(FetchLocalStorageFromPersistentDataStoreThirdPartyIFrame)): Deleted.
(FetchLocalStorageFromEphemeralDataStoreThirdPartyIFrame)): Deleted.

Canonical link: <a href="https://commits.webkit.org/287641@main">https://commits.webkit.org/287641@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ca11eb6cfbf20f97932907d609cb5eb4ab4d71d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80354 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59360 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33864 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84875 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31336 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82465 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68422 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7661 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62805 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20614 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83423 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52884 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73164 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43108 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/50204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27320 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29795 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/71342 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27836 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86309 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7579 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71087 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7754 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69003 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70327 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14320 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13268 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12434 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7541 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/13061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7380 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10900 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9186 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->