### PR TITLE
Video loses audio after entering light spill

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
@@ -94,7 +94,7 @@ VideoMediaSampleRenderer::~VideoMediaSampleRenderer()
 
     flushCompressedSampleQueue();
 
-    if (auto renderer = rendererOrDisplayLayer()) {
+    if (auto renderer = this->renderer()) {
         [renderer flush];
         [renderer stopRequestingMediaData];
     }
@@ -163,31 +163,26 @@ bool VideoMediaSampleRenderer::areSamplesQueuesReadyForMoreMediaData(size_t wate
 
 void VideoMediaSampleRenderer::maybeBecomeReadyForMoreMediaData()
 {
-    ensureOnDispatcher([weakThis = ThreadSafeWeakPtr { *this }, this] {
-        RefPtr protectedThis = weakThis.get();
-        if (!protectedThis)
-            return;
-        RetainPtr renderer = rendererOrDisplayLayer();
-        if (renderer && ![renderer isReadyForMoreMediaData]) {
-            if (m_decompressionSession) {
-                ThreadSafeWeakPtr weakThis { *this };
-                [renderer requestMediaDataWhenReadyOnQueue:dispatchQueue() usingBlock:^{
-                    if (RefPtr protectedThis = weakThis.get()) {
-                        [protectedThis->rendererOrDisplayLayer() stopRequestingMediaData];
-                        protectedThis->maybeBecomeReadyForMoreMediaData();
-                    }
-                }];
+    assertIsCurrent(dispatcher().get());
+
+    RetainPtr renderer = rendererOrDisplayLayer();
+    if (renderer && ![renderer isReadyForMoreMediaData]) {
+        ThreadSafeWeakPtr weakThis { *this };
+        [renderer requestMediaDataWhenReadyOnQueue:dispatchQueue() usingBlock:^{
+            if (RefPtr protectedThis = weakThis.get()) {
+                [protectedThis->rendererOrDisplayLayer() stopRequestingMediaData];
+                protectedThis->maybeBecomeReadyForMoreMediaData();
             }
-            return;
-        }
+        }];
+        return;
+    }
 
-        if (!areSamplesQueuesReadyForMoreMediaData(SampleQueueLowWaterMark))
-            return;
+    if (!areSamplesQueuesReadyForMoreMediaData(SampleQueueLowWaterMark))
+        return;
 
-        callOnMainThread([weakThis = ThreadSafeWeakPtr { *this }] {
-            if (RefPtr protectedThis = weakThis.get(); protectedThis && protectedThis->m_readyForMoreSampleFunction)
-                protectedThis->m_readyForMoreSampleFunction();
-        });
+    callOnMainThread([weakThis = ThreadSafeWeakPtr { *this }] {
+        if (RefPtr protectedThis = weakThis.get(); protectedThis && protectedThis->m_readyForMoreSampleFunction)
+            protectedThis->m_readyForMoreSampleFunction();
     });
 }
 
@@ -197,15 +192,15 @@ void VideoMediaSampleRenderer::stopRequestingMediaData()
 
     m_readyForMoreSampleFunction = nil;
 
-    auto stopRequestingMediaData = [weakThis = ThreadSafeWeakPtr { *this }] {
-        if (RefPtr protectedThis = weakThis.get())
-            [protectedThis->rendererOrDisplayLayer() stopRequestingMediaData];
-    };
-
-    if (m_decompressionSession)
-        dispatcher()->dispatch(WTFMove(stopRequestingMediaData)); // stopRequestingMediaData may deadlock if used on the main thread while enqueuing on the workqueue
-    else
-        stopRequestingMediaData();
+    if (m_decompressionSession) {
+        // stopRequestingMediaData may deadlock if used on the main thread while enqueuing on the workqueue
+        dispatcher()->dispatch([weakThis = ThreadSafeWeakPtr { *this }] {
+            if (RefPtr protectedThis = weakThis.get())
+                [protectedThis->rendererOrDisplayLayer() stopRequestingMediaData];
+        });
+        return;
+    }
+    [renderer() stopRequestingMediaData];
 }
 
 void VideoMediaSampleRenderer::setPrefersDecompressionSession(bool prefers)
@@ -643,14 +638,23 @@ void VideoMediaSampleRenderer::resetReadyForMoreSample()
     assertIsMainThread();
 
     if (!rendererOrDisplayLayer() || m_decompressionSession) {
-        maybeBecomeReadyForMoreMediaData();
+        dispatcher()->dispatch([weakThis = ThreadSafeWeakPtr { *this }] {
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->maybeBecomeReadyForMoreMediaData();
+        });
         return;
     }
 
     ThreadSafeWeakPtr weakThis { *this };
-    [rendererOrDisplayLayer() requestMediaDataWhenReadyOnQueue:dispatchQueue() usingBlock:^{
-        if (RefPtr protectedThis = weakThis.get())
-            protectedThis->maybeBecomeReadyForMoreMediaData();
+    [renderer() requestMediaDataWhenReadyOnQueue:dispatch_get_main_queue() usingBlock:^{
+        assertIsMainThread();
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return;
+        if (![protectedThis->renderer() isReadyForMoreMediaData])
+            return;
+        if (protectedThis->m_readyForMoreSampleFunction)
+            protectedThis->m_readyForMoreSampleFunction();
     }];
 }
 


### PR DESCRIPTION
#### 70b4f4295cbcc2c71152c8e42479c39386a41dfb
<pre>
Video loses audio after entering light spill
<a href="https://rdar.apple.com/140805541">rdar://140805541</a>

Reviewed by Jer Noble.

In 286853@main we switched to use an AVSampleBufferVideoRenderer if available
and use it on a workqueue.
However, it has since appeared that its use over multiple thread is broken (<a href="https://rdar.apple.com/139910776">rdar://139910776</a>)

For now, if we do not use a decompression session, only ever use the
renderer given on construction (either an AVSampleBufferVideoRenderer if in
light spill, or an AVSampleBufferDisplayLayer any other time) on the main thread.

If a decompression session is set, then we will only ever accessed the AVSampleBufferVideoRenderer
on our queue.

Manually tested.

* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm:
(WebCore::VideoMediaSampleRenderer::~VideoMediaSampleRenderer):
(WebCore::VideoMediaSampleRenderer::maybeBecomeReadyForMoreMediaData):
(WebCore::VideoMediaSampleRenderer::stopRequestingMediaData):
(WebCore::VideoMediaSampleRenderer::resetReadyForMoreSample):

Canonical link: <a href="https://commits.webkit.org/287422@main">https://commits.webkit.org/287422@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9974b624167c883cf99e68db6b519edd1037482d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79656 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58653 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33049 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84198 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30695 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81765 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6942 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62263 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20115 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82722 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52319 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72539 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42571 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49662 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26691 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29126 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70801 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27149 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85612 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6904 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4815 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/70518 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7073 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68384 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69764 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17391 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13771 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12678 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6854 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/6741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10236 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8539 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->