### PR TITLE
[Navigation] navigation-history-entry/entries-after-blob-navigation.html is failing

### DIFF
--- a/LayoutTests/contentfiltering/block-after-add-data-expected.txt
+++ b/LayoutTests/contentfiltering/block-after-add-data-expected.txt
@@ -23,6 +23,8 @@ Frame: '<!--frame1-->'
 PASS
 
 ============== Back Forward List ==============
+        (file test):contentfiltering/block-after-add-data.html
+            about:blank (in frame "<!--frame1-->")
 curr->  (file test):contentfiltering/block-after-add-data.html
             (file test):contentfiltering/resources/fail.html (in frame "<!--frame1-->")
 ===============================================

--- a/LayoutTests/contentfiltering/block-after-add-data-then-allow-unblock-expected.txt
+++ b/LayoutTests/contentfiltering/block-after-add-data-then-allow-unblock-expected.txt
@@ -30,6 +30,8 @@ Frame: '<!--frame1-->'
 PASS
 
 ============== Back Forward List ==============
+        (file test):contentfiltering/block-after-add-data-then-allow-unblock.html
+            about:blank (in frame "<!--frame1-->")
 curr->  (file test):contentfiltering/block-after-add-data-then-allow-unblock.html
             (file test):contentfiltering/resources/pass.html (in frame "<!--frame1-->")
 ===============================================

--- a/LayoutTests/contentfiltering/block-after-add-data-then-deny-unblock-expected.txt
+++ b/LayoutTests/contentfiltering/block-after-add-data-then-deny-unblock-expected.txt
@@ -25,6 +25,8 @@ Frame: '<!--frame1-->'
 PASS
 
 ============== Back Forward List ==============
+        (file test):contentfiltering/block-after-add-data-then-deny-unblock.html
+            about:blank (in frame "<!--frame1-->")
 curr->  (file test):contentfiltering/block-after-add-data-then-deny-unblock.html
             (file test):contentfiltering/resources/fail.html (in frame "<!--frame1-->")
 ===============================================

--- a/LayoutTests/contentfiltering/block-after-finished-adding-data-expected.txt
+++ b/LayoutTests/contentfiltering/block-after-finished-adding-data-expected.txt
@@ -23,6 +23,8 @@ Frame: '<!--frame1-->'
 PASS
 
 ============== Back Forward List ==============
+        (file test):contentfiltering/block-after-finished-adding-data.html
+            about:blank (in frame "<!--frame1-->")
 curr->  (file test):contentfiltering/block-after-finished-adding-data.html
             (file test):contentfiltering/resources/fail.html (in frame "<!--frame1-->")
 ===============================================

--- a/LayoutTests/contentfiltering/block-after-finished-adding-data-then-allow-unblock-expected.txt
+++ b/LayoutTests/contentfiltering/block-after-finished-adding-data-then-allow-unblock-expected.txt
@@ -30,6 +30,8 @@ Frame: '<!--frame1-->'
 PASS
 
 ============== Back Forward List ==============
+        (file test):contentfiltering/block-after-finished-adding-data-then-allow-unblock.html
+            about:blank (in frame "<!--frame1-->")
 curr->  (file test):contentfiltering/block-after-finished-adding-data-then-allow-unblock.html
             (file test):contentfiltering/resources/pass.html (in frame "<!--frame1-->")
 ===============================================

--- a/LayoutTests/contentfiltering/block-after-finished-adding-data-then-deny-unblock-expected.txt
+++ b/LayoutTests/contentfiltering/block-after-finished-adding-data-then-deny-unblock-expected.txt
@@ -25,6 +25,8 @@ Frame: '<!--frame1-->'
 PASS
 
 ============== Back Forward List ==============
+        (file test):contentfiltering/block-after-finished-adding-data-then-deny-unblock.html
+            about:blank (in frame "<!--frame1-->")
 curr->  (file test):contentfiltering/block-after-finished-adding-data-then-deny-unblock.html
             (file test):contentfiltering/resources/fail.html (in frame "<!--frame1-->")
 ===============================================

--- a/LayoutTests/contentfiltering/block-after-response-expected.txt
+++ b/LayoutTests/contentfiltering/block-after-response-expected.txt
@@ -23,6 +23,8 @@ Frame: '<!--frame1-->'
 PASS
 
 ============== Back Forward List ==============
+        (file test):contentfiltering/block-after-response.html
+            about:blank (in frame "<!--frame1-->")
 curr->  (file test):contentfiltering/block-after-response.html
             (file test):contentfiltering/resources/fail.html (in frame "<!--frame1-->")
 ===============================================

--- a/LayoutTests/contentfiltering/block-after-response-then-allow-unblock-expected.txt
+++ b/LayoutTests/contentfiltering/block-after-response-then-allow-unblock-expected.txt
@@ -30,6 +30,8 @@ Frame: '<!--frame1-->'
 PASS
 
 ============== Back Forward List ==============
+        (file test):contentfiltering/block-after-response-then-allow-unblock.html
+            about:blank (in frame "<!--frame1-->")
 curr->  (file test):contentfiltering/block-after-response-then-allow-unblock.html
             (file test):contentfiltering/resources/pass.html (in frame "<!--frame1-->")
 ===============================================

--- a/LayoutTests/contentfiltering/block-after-will-send-request-expected.txt
+++ b/LayoutTests/contentfiltering/block-after-will-send-request-expected.txt
@@ -23,6 +23,8 @@ Frame: '<!--frame1-->'
 PASS
 
 ============== Back Forward List ==============
+        (file test):contentfiltering/block-after-will-send-request.html
+            about:blank (in frame "<!--frame1-->")
 curr->  (file test):contentfiltering/block-after-will-send-request.html
             about:blank (in frame "<!--frame1-->")
 ===============================================

--- a/LayoutTests/contentfiltering/block-after-will-send-request-then-allow-unblock-expected.txt
+++ b/LayoutTests/contentfiltering/block-after-will-send-request-then-allow-unblock-expected.txt
@@ -30,6 +30,8 @@ Frame: '<!--frame1-->'
 PASS
 
 ============== Back Forward List ==============
+        (file test):contentfiltering/block-after-will-send-request-then-allow-unblock.html
+            about:blank (in frame "<!--frame1-->")
 curr->  (file test):contentfiltering/block-after-will-send-request-then-allow-unblock.html
             (file test):contentfiltering/resources/pass.html (in frame "<!--frame1-->")
 ===============================================

--- a/LayoutTests/contentfiltering/block-after-will-send-request-then-deny-unblock-expected.txt
+++ b/LayoutTests/contentfiltering/block-after-will-send-request-then-deny-unblock-expected.txt
@@ -25,6 +25,8 @@ Frame: '<!--frame1-->'
 PASS
 
 ============== Back Forward List ==============
+        (file test):contentfiltering/block-after-will-send-request-then-deny-unblock.html
+            about:blank (in frame "<!--frame1-->")
 curr->  (file test):contentfiltering/block-after-will-send-request-then-deny-unblock.html
             about:blank (in frame "<!--frame1-->")
 ===============================================

--- a/LayoutTests/http/tests/navigation/javascriptlink-subframeload-expected.txt
+++ b/LayoutTests/http/tests/navigation/javascriptlink-subframeload-expected.txt
@@ -5,6 +5,9 @@
         http://127.0.0.1:8000/navigation/resources/frameset.pl?frameURL=otherpage.html
             http://127.0.0.1:8000/navigation/resources/otherpage.html (in frame "footer")
             http://127.0.0.1:8000/navigation/resources/otherpage.html (in frame "main")
+        http://127.0.0.1:8000/navigation/resources/frameset.pl?frameURL=otherpage.html
+            http://127.0.0.1:8000/navigation/resources/otherpage.html (in frame "footer")
+            http://127.0.0.1:8000/navigation/resources/javascriptlink.html (in frame "main")
 curr->  http://127.0.0.1:8000/navigation/resources/frameset.pl?frameURL=otherpage.html
             http://127.0.0.1:8000/navigation/resources/otherpage.html (in frame "footer")
             http://127.0.0.1:8000/navigation/resources/success200.html (in frame "main")

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/srcdoc/consecutive-srcdoc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/srcdoc/consecutive-srcdoc-expected.txt
@@ -1,4 +1,6 @@
 
-FAIL changing srcdoc does a replace navigation since the URL is still about:srcdoc assert_equals: expected 2 but got 1
-FAIL changing srcdoc to about:srcdoc#yo then another srcdoc does two push navigations and we can navigate back assert_equals: expected 2 but got 1
+Harness Error (TIMEOUT), message = null
+
+PASS changing srcdoc does a replace navigation since the URL is still about:srcdoc
+TIMEOUT changing srcdoc to about:srcdoc#yo then another srcdoc does two push navigations and we can navigate back Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/srcdoc/srcdoc-history-entries-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/srcdoc/srcdoc-history-entries-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL srcdoc history entries: the iframe itself navigates assert_equals: expected 2 but got 1
-FAIL srcdoc history entries: the container window navigates assert_equals: expected 2 but got 1
+FAIL srcdoc history entries: the iframe itself navigates assert_equals: srcdoc contents must be restored from history, not from the current value ('srcdoc2') of the content attribute expected "srcdoc1" but got "srcdoc2"
+FAIL srcdoc history entries: the container window navigates assert_equals: srcdoc contents must be restored from history, not from the current value of the (not-existing) content attribute expected (string) "srcdoc1" but got (undefined) undefined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-blob-navigation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-blob-navigation-expected.txt
@@ -1,6 +1,4 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT entries() after navigation to a blob: URL Test timed out
+PASS entries() after navigation to a blob: URL
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-blob-navigation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-blob-navigation.html
@@ -19,7 +19,7 @@ async_test(t => {
       assert_true(isUUID(entries[1].key));
       assert_true(isUUID(entries[1].id));
     });
-    i.src = URL.createObjectURL(new Blob(["<body></body>"]));
+    i.src = URL.createObjectURL(new Blob(["<body></body>"], { type: "text/html" }));
   });
 }, "entries() after navigation to a blob: URL");
 </script>

--- a/LayoutTests/platform/gtk/http/tests/navigation/javascriptlink-frames-expected.txt
+++ b/LayoutTests/platform/gtk/http/tests/navigation/javascriptlink-frames-expected.txt
@@ -124,6 +124,9 @@ layer at (0,0) size 800x600
 
 ============== Back Forward List ==============
         http://127.0.0.1:8000/navigation/javascriptlink-frames.html
+        http://127.0.0.1:8000/navigation/resources/frameset.pl?frameURL=javascriptlink.html
+            http://127.0.0.1:8000/navigation/resources/otherpage.html (in frame "footer")
+            http://127.0.0.1:8000/navigation/resources/javascriptlink.html (in frame "main")
 curr->  http://127.0.0.1:8000/navigation/resources/frameset.pl?frameURL=javascriptlink.html
             http://127.0.0.1:8000/navigation/resources/otherpage.html (in frame "footer")
             http://127.0.0.1:8000/navigation/resources/success200.html (in frame "main")

--- a/LayoutTests/platform/mac-ventura/http/tests/navigation/javascriptlink-frames-expected.txt
+++ b/LayoutTests/platform/mac-ventura/http/tests/navigation/javascriptlink-frames-expected.txt
@@ -124,6 +124,9 @@ layer at (0,0) size 800x600
 
 ============== Back Forward List ==============
         http://127.0.0.1:8000/navigation/javascriptlink-frames.html
+        http://127.0.0.1:8000/navigation/resources/frameset.pl?frameURL=javascriptlink.html
+            http://127.0.0.1:8000/navigation/resources/otherpage.html (in frame "footer")
+            http://127.0.0.1:8000/navigation/resources/javascriptlink.html (in frame "main")
 curr->  http://127.0.0.1:8000/navigation/resources/frameset.pl?frameURL=javascriptlink.html
             http://127.0.0.1:8000/navigation/resources/otherpage.html (in frame "footer")
             http://127.0.0.1:8000/navigation/resources/success200.html (in frame "main")

--- a/LayoutTests/platform/mac-wk1/contentfiltering/block-after-will-send-request-expected.txt
+++ b/LayoutTests/platform/mac-wk1/contentfiltering/block-after-will-send-request-expected.txt
@@ -13,10 +13,8 @@ frame "<!--frame1-->" - didFailProvisionalLoadWithError
 frame "<!--frame1-->" - didStartProvisionalLoadForFrame
 frame "<!--frame1-->" - didCommitLoadForFrame
 frame "<!--frame1-->" - didFinishDocumentLoadForFrame
-frame "<!--frame1-->" - willPerformClientRedirectToURL: x-apple-content-filter://mock-unblock
 frame "<!--frame1-->" - didHandleOnloadEventsForFrame
 frame "<!--frame1-->" - didFinishLoadForFrame
-frame "<!--frame1-->" - didCancelClientRedirectForFrame
 
 
 --------
@@ -25,8 +23,6 @@ Frame: '<!--frame1-->'
 PASS
 
 ============== Back Forward List ==============
-        (file test):contentfiltering/block-after-response-then-deny-unblock.html
+curr->  (file test):contentfiltering/block-after-will-send-request.html
             about:blank (in frame "<!--frame1-->")
-curr->  (file test):contentfiltering/block-after-response-then-deny-unblock.html
-            (file test):contentfiltering/resources/fail.html (in frame "<!--frame1-->")
 ===============================================

--- a/LayoutTests/platform/mac-wk1/contentfiltering/block-after-will-send-request-then-allow-unblock-expected.txt
+++ b/LayoutTests/platform/mac-wk1/contentfiltering/block-after-will-send-request-then-allow-unblock-expected.txt
@@ -4,7 +4,7 @@ frame "<!--frame1-->" - didCommitLoadForFrame
 frame "<!--frame1-->" - didFinishDocumentLoadForFrame
 frame "<!--frame1-->" - didHandleOnloadEventsForFrame
 frame "<!--frame1-->" - didFinishLoadForFrame
-frame "<!--frame1-->" - willPerformClientRedirectToURL: resources/fail.html
+frame "<!--frame1-->" - willPerformClientRedirectToURL: resources/pass.html
 main frame - didHandleOnloadEventsForFrame
 main frame - didFinishLoadForFrame
 frame "<!--frame1-->" - didStartProvisionalLoadForFrame
@@ -17,6 +17,11 @@ frame "<!--frame1-->" - willPerformClientRedirectToURL: x-apple-content-filter:/
 frame "<!--frame1-->" - didHandleOnloadEventsForFrame
 frame "<!--frame1-->" - didFinishLoadForFrame
 frame "<!--frame1-->" - didCancelClientRedirectForFrame
+frame "<!--frame1-->" - didStartProvisionalLoadForFrame
+frame "<!--frame1-->" - didCommitLoadForFrame
+frame "<!--frame1-->" - didFinishDocumentLoadForFrame
+frame "<!--frame1-->" - didHandleOnloadEventsForFrame
+frame "<!--frame1-->" - didFinishLoadForFrame
 
 
 --------
@@ -25,8 +30,6 @@ Frame: '<!--frame1-->'
 PASS
 
 ============== Back Forward List ==============
-        (file test):contentfiltering/block-after-response-then-deny-unblock.html
-            about:blank (in frame "<!--frame1-->")
-curr->  (file test):contentfiltering/block-after-response-then-deny-unblock.html
-            (file test):contentfiltering/resources/fail.html (in frame "<!--frame1-->")
+curr->  (file test):contentfiltering/block-after-will-send-request-then-allow-unblock.html
+            (file test):contentfiltering/resources/pass.html (in frame "<!--frame1-->")
 ===============================================

--- a/LayoutTests/platform/mac-wk1/contentfiltering/block-after-will-send-request-then-deny-unblock-expected.txt
+++ b/LayoutTests/platform/mac-wk1/contentfiltering/block-after-will-send-request-then-deny-unblock-expected.txt
@@ -25,8 +25,6 @@ Frame: '<!--frame1-->'
 PASS
 
 ============== Back Forward List ==============
-        (file test):contentfiltering/block-after-response-then-deny-unblock.html
+curr->  (file test):contentfiltering/block-after-will-send-request-then-deny-unblock.html
             about:blank (in frame "<!--frame1-->")
-curr->  (file test):contentfiltering/block-after-response-then-deny-unblock.html
-            (file test):contentfiltering/resources/fail.html (in frame "<!--frame1-->")
 ===============================================

--- a/LayoutTests/platform/mac/http/tests/navigation/javascriptlink-frames-expected.txt
+++ b/LayoutTests/platform/mac/http/tests/navigation/javascriptlink-frames-expected.txt
@@ -124,6 +124,9 @@ layer at (0,0) size 800x600
 
 ============== Back Forward List ==============
         http://127.0.0.1:8000/navigation/javascriptlink-frames.html
+        http://127.0.0.1:8000/navigation/resources/frameset.pl?frameURL=javascriptlink.html
+            http://127.0.0.1:8000/navigation/resources/otherpage.html (in frame "footer")
+            http://127.0.0.1:8000/navigation/resources/javascriptlink.html (in frame "main")
 curr->  http://127.0.0.1:8000/navigation/resources/frameset.pl?frameURL=javascriptlink.html
             http://127.0.0.1:8000/navigation/resources/otherpage.html (in frame "footer")
             http://127.0.0.1:8000/navigation/resources/success200.html (in frame "main")

--- a/LayoutTests/platform/wpe/http/tests/navigation/javascriptlink-frames-expected.txt
+++ b/LayoutTests/platform/wpe/http/tests/navigation/javascriptlink-frames-expected.txt
@@ -124,6 +124,9 @@ layer at (0,0) size 800x600
 
 ============== Back Forward List ==============
         http://127.0.0.1:8000/navigation/javascriptlink-frames.html
+        http://127.0.0.1:8000/navigation/resources/frameset.pl?frameURL=javascriptlink.html
+            http://127.0.0.1:8000/navigation/resources/otherpage.html (in frame "footer")
+            http://127.0.0.1:8000/navigation/resources/javascriptlink.html (in frame "main")
 curr->  http://127.0.0.1:8000/navigation/resources/frameset.pl?frameURL=javascriptlink.html
             http://127.0.0.1:8000/navigation/resources/otherpage.html (in frame "footer")
             http://127.0.0.1:8000/navigation/resources/success200.html (in frame "main")

--- a/Source/WebCore/html/HTMLFrameElementBase.cpp
+++ b/Source/WebCore/html/HTMLFrameElementBase.cpp
@@ -123,7 +123,7 @@ void HTMLFrameElementBase::attributeChanged(const QualifiedName& name, const Ato
         if (newValue.isNull())
             setLocation(attributeWithoutSynchronization(srcAttr).string().trim(isASCIIWhitespace));
         else
-            setLocation("about:srcdoc"_s);
+            setLocation(aboutSrcDocURL().string());
     } else if (name == srcAttr && !hasAttributeWithoutSynchronization(srcdocAttr))
         setLocation(newValue.string().trim(isASCIIWhitespace));
     else if (name == scrollingAttr && contentFrame())

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1672,7 +1672,7 @@ SubstituteData FrameLoader::defaultSubstituteDataForURL(const URL& url)
     CString encodedSrcdoc = srcdoc.string().utf8();
 
     ResourceResponse response(URL(), textHTMLContentTypeAtom(), encodedSrcdoc.length(), "UTF-8"_s);
-    return SubstituteData(SharedBuffer::create(encodedSrcdoc.span()), URL(), response, SubstituteData::SessionHistoryVisibility::Hidden);
+    return SubstituteData(SharedBuffer::create(encodedSrcdoc.span()), URL(), response, SubstituteData::SessionHistoryVisibility::Visible);
 }
 
 void FrameLoader::load(FrameLoadRequest&& request)

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -592,17 +592,6 @@ LockBackForwardList NavigationScheduler::mustLockBackForwardList(Frame& targetFr
         && !localTargetFrame->loader().documentLoader()->wasOnloadDispatched())
         return LockBackForwardList::Yes;
     
-    // Navigation of a subframe during loading of an ancestor frame does not create a new back/forward item.
-    // The definition of "during load" is any time before all handlers for the load event have been run.
-    // See https://bugs.webkit.org/show_bug.cgi?id=14957 for the original motivation for this.
-    for (auto* ancestor = targetFrame.tree().parent(); ancestor; ancestor = ancestor->tree().parent()) {
-        RefPtr localAncestor = dynamicDowncast<LocalFrame>(ancestor);
-        if (!localAncestor)
-            continue;
-        RefPtr document = localAncestor->document();
-        if (!localAncestor->loader().isComplete() || (document && document->processingLoadEvent()))
-            return LockBackForwardList::Yes;
-    }
     return LockBackForwardList::No;
 }
 


### PR DESCRIPTION
#### f183cbdda7131eaf27997de4a3e4e0905cc2203b
<pre>
[Navigation] navigation-history-entry/entries-after-blob-navigation.html is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=282609">https://bugs.webkit.org/show_bug.cgi?id=282609</a>
<a href="https://rdar.apple.com/139725684">rdar://139725684</a>

Reviewed by Rob Buis.

Resync entries-after-blob-navigation.html from upstream to get the fix so that the
blob&apos;s content type is provided. This allows the test to run though the test would
still fail. The test was navigating the iframe in the top frame&apos;s load event handler
and expecting a new HistoryItem to get created for the navigation. However, we had
non-standard logic in `NavigationScheduler::mustLockBackForwardList()` that would
lock the back/forward list if any of the iframe&apos;s ancestors is still loading. Since
this behavior doesn&apos;t match the HTML specification [1][2] or Blink, remove the logic
in mustLockBackForwardList().

The change above caused a different code path to get taken for
navigation-api/navigation-history-entry/entries-after-srcdoc-navigation.html, which
caused it to fail because it would fail to create a new HistoryItem for the srcdoc
navigation. After some investigation, I found that both the back/forward list and the
history list were unlocked. However. we would prevent the creation of a HistoryItem
for a srcdoc navigation because the substitute data created for the navigation had the
`SubstituteData::SessionHistoryVisibility::Hidden` parameter. As per the tests, we
expect srcdoc navigations to be visible in the History list so I am setting this
parameter to &quot;Visible&quot; instead. This got the test passing.

[1] <a href="https://html.spec.whatwg.org/#navigate-an-iframe-or-frame">https://html.spec.whatwg.org/#navigate-an-iframe-or-frame</a> (step 2)
[2] <a href="https://html.spec.whatwg.org/#completely-finish-loading">https://html.spec.whatwg.org/#completely-finish-loading</a>

* LayoutTests/contentfiltering/block-after-add-data-expected.txt:
* LayoutTests/contentfiltering/block-after-add-data-then-allow-unblock-expected.txt:
* LayoutTests/contentfiltering/block-after-add-data-then-deny-unblock-expected.txt:
* LayoutTests/contentfiltering/block-after-finished-adding-data-expected.txt:
* LayoutTests/contentfiltering/block-after-finished-adding-data-then-allow-unblock-expected.txt:
* LayoutTests/contentfiltering/block-after-finished-adding-data-then-deny-unblock-expected.txt:
* LayoutTests/contentfiltering/block-after-response-expected.txt:
* LayoutTests/contentfiltering/block-after-response-then-allow-unblock-expected.txt:
* LayoutTests/contentfiltering/block-after-response-then-deny-unblock-expected.txt:
* LayoutTests/contentfiltering/block-after-will-send-request-expected.txt:
* LayoutTests/contentfiltering/block-after-will-send-request-then-allow-unblock-expected.txt:
* LayoutTests/contentfiltering/block-after-will-send-request-then-deny-unblock-expected.txt:
* LayoutTests/http/tests/navigation/javascriptlink-subframeload-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/srcdoc/consecutive-srcdoc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/srcdoc/srcdoc-history-entries-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-blob-navigation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-blob-navigation.html:
* LayoutTests/platform/gtk/http/tests/navigation/javascriptlink-frames-expected.txt:
* LayoutTests/platform/mac-ventura/http/tests/navigation/javascriptlink-frames-expected.txt:
* LayoutTests/platform/mac-wk1/contentfiltering/block-after-will-send-request-expected.txt: Copied from LayoutTests/contentfiltering/block-after-will-send-request-expected.txt.
* LayoutTests/platform/mac-wk1/contentfiltering/block-after-will-send-request-then-allow-unblock-expected.txt: Copied from LayoutTests/contentfiltering/block-after-will-send-request-then-allow-unblock-expected.txt.
* LayoutTests/platform/mac-wk1/contentfiltering/block-after-will-send-request-then-deny-unblock-expected.txt: Copied from LayoutTests/contentfiltering/block-after-will-send-request-then-deny-unblock-expected.txt.
* LayoutTests/platform/mac/http/tests/navigation/javascriptlink-frames-expected.txt:
* LayoutTests/platform/wpe/http/tests/navigation/javascriptlink-frames-expected.txt:
* Source/WebCore/html/HTMLFrameElementBase.cpp:
(WebCore::HTMLFrameElementBase::attributeChanged):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::defaultSubstituteDataForURL):
* Source/WebCore/loader/NavigationScheduler.cpp:
(WebCore::NavigationScheduler::mustLockBackForwardList):

Canonical link: <a href="https://commits.webkit.org/287549@main">https://commits.webkit.org/287549@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c53b6d78f726e049b1286400fcfdae4d7adfb25

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80007 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59004 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33405 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84522 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30980 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82115 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68068 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7300 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62539 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20364 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83075 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52602 "Found 1 new test failure: media/audioSession/getUserMedia.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72863 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42848 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49940 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27016 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29443 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71060 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27508 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85954 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7223 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5086 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70811 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7400 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68704 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70053 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14050 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12985 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12383 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7186 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12718 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7032 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10546 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8836 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->