### PR TITLE
Re-sync pointerlock WPTs

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/pointerlock/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerlock/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: pointer-lock
+  files: "**"

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerlock/pointerlock_promise.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerlock/pointerlock_promise.html
@@ -14,7 +14,7 @@
     <hr/>
 
     <button id="Button">lockTarget</button>
-    
+
     <div id="target">Target</div>
 
     <script type="text/javascript" >

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerlock/pointerlock_without_gesture.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerlock/pointerlock_without_gesture.html
@@ -12,13 +12,13 @@
     <h2>Description</h2>
     <p>This test validates that pointer lock does not work without user activation.</p>
     <hr/>
-    
+
     <div id="target">Target</div>
 
     <script type="text/javascript" >
         promise_test(async t => {
             const target = document.getElementById('target');
-            
+
             document.addEventListener('pointerlockchange', t.unreached_func("Must not acquire pointer lock."));
 
             // Request pointer lock twice to ensure two failing promises are returned and both are rejected.

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerlock/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerlock/w3c-import.log
@@ -15,10 +15,14 @@ None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/pointerlock/META.yml
+/LayoutTests/imported/w3c/web-platform-tests/pointerlock/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/pointerlock/constructor.html
 /LayoutTests/imported/w3c/web-platform-tests/pointerlock/idlharness.window.js
 /LayoutTests/imported/w3c/web-platform-tests/pointerlock/mouse_buttons_back_forward.html
 /LayoutTests/imported/w3c/web-platform-tests/pointerlock/movementX_Y_basic.html
+/LayoutTests/imported/w3c/web-platform-tests/pointerlock/pointerlock_promise.html
 /LayoutTests/imported/w3c/web-platform-tests/pointerlock/pointerlock_remove_target.html
 /LayoutTests/imported/w3c/web-platform-tests/pointerlock/pointerlock_remove_target_on_mouseup.html
 /LayoutTests/imported/w3c/web-platform-tests/pointerlock/pointerlock_shadow.html
+/LayoutTests/imported/w3c/web-platform-tests/pointerlock/pointerlock_unadjustedMovement.html
+/LayoutTests/imported/w3c/web-platform-tests/pointerlock/pointerlock_without_gesture.html

--- a/LayoutTests/tests-options.json
+++ b/LayoutTests/tests-options.json
@@ -5393,6 +5393,21 @@
     "imported/w3c/web-platform-tests/pointerevents/pointerlock/pointerevent_movementxy.html": [
         "slow"
     ],
+    "imported/w3c/web-platform-tests/pointerlock/movementX_Y_basic.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/pointerlock/pointerlock_promise.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/pointerlock/pointerlock_remove_target.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/pointerlock/pointerlock_shadow.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/pointerlock/pointerlock_without_gesture.html": [
+        "slow"
+    ],
     "imported/w3c/web-platform-tests/quirks/hashless-hex-color/limited-quirks.html": [
         "slow"
     ],


### PR DESCRIPTION
#### 0762c7c7ba19018b10a42ad88febcb09134b54e1
<pre>
Re-sync pointerlock WPTs
<a href="https://bugs.webkit.org/show_bug.cgi?id=284128">https://bugs.webkit.org/show_bug.cgi?id=284128</a>
<a href="https://rdar.apple.com/141013223">rdar://141013223</a>

Reviewed by Wenson Hsieh.

This patch imports pointerlock WPTs from upstream, if for nothing else
but to pick up the linting fixes landed while exporting the changes
introduced for webkit.org/b/218054.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/d73feabeb90500e663961e72333571aeb322eb07">https://github.com/web-platform-tests/wpt/commit/d73feabeb90500e663961e72333571aeb322eb07</a>

* LayoutTests/imported/w3c/web-platform-tests/pointerlock/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/pointerlock/pointerlock_promise.html:
* LayoutTests/imported/w3c/web-platform-tests/pointerlock/pointerlock_without_gesture.html:
* LayoutTests/imported/w3c/web-platform-tests/pointerlock/w3c-import.log:
* LayoutTests/tests-options.json:

Canonical link: <a href="https://commits.webkit.org/287438@main">https://commits.webkit.org/287438@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f053e3a3e16e8979ee3d4a82ea1ef8e4c5f70a7d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79654 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58651 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84196 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30693 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67741 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6940 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62262 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20111 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82720 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52317 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72549 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42570 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49660 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26701 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29124 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70799 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27160 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85610 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6902 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4813 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70513 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7071 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68395 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69759 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17399 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13768 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12688 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6852 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6739 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10234 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8537 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->