### PR TITLE
GraphicsContextState::mergeLastChanges spends time figuring out which bit changed.

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -100,75 +100,75 @@ public:
     Gradient* fillGradient() const { return fillBrush().gradient(); }
     const AffineTransform& fillGradientSpaceTransform() const { return fillBrush().gradientSpaceTransform(); }
     Pattern* fillPattern() const { return fillBrush().pattern(); }
-    void setFillBrush(const SourceBrush& brush) { m_state.setFillBrush(brush); didUpdateState(m_state); }
-    void setFillColor(const Color& color) { m_state.setFillColor(color); didUpdateState(m_state); }
-    void setFillGradient(Ref<Gradient>&& gradient, const AffineTransform& spaceTransform = { }) { m_state.setFillGradient(WTFMove(gradient), spaceTransform); didUpdateState(m_state); }
-    void setFillPattern(Ref<Pattern>&& pattern) { m_state.setFillPattern(WTFMove(pattern)); didUpdateState(m_state); }
+    void setFillBrush(const SourceBrush& brush) { m_state.setFillBrush(brush); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::FillBrush)); }
+    void setFillColor(const Color& color) { m_state.setFillColor(color); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::FillBrush)); }
+    void setFillGradient(Ref<Gradient>&& gradient, const AffineTransform& spaceTransform = { }) { m_state.setFillGradient(WTFMove(gradient), spaceTransform); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::FillBrush)); }
+    void setFillPattern(Ref<Pattern>&& pattern) { m_state.setFillPattern(WTFMove(pattern)); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::FillBrush)); }
 
     WindRule fillRule() const { return m_state.fillRule(); }
-    void setFillRule(WindRule fillRule) { m_state.setFillRule(fillRule); didUpdateState(m_state); }
+    void setFillRule(WindRule fillRule) { m_state.setFillRule(fillRule); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::FillRule)); }
 
     const SourceBrush& strokeBrush() const { return m_state.strokeBrush(); }
     const Color& strokeColor() const { return strokeBrush().color(); }
     Gradient* strokeGradient() const { return strokeBrush().gradient(); }
     const AffineTransform& strokeGradientSpaceTransform() const { return strokeBrush().gradientSpaceTransform(); }
     Pattern* strokePattern() const { return strokeBrush().pattern(); }
-    void setStrokeBrush(const SourceBrush& brush) { m_state.setStrokeBrush(brush); didUpdateState(m_state); }
-    void setStrokeColor(const Color& color) { m_state.setStrokeColor(color); didUpdateState(m_state); }
-    void setStrokeGradient(Ref<Gradient>&& gradient, const AffineTransform& spaceTransform = { }) { m_state.setStrokeGradient(WTFMove(gradient), spaceTransform); didUpdateState(m_state); }
-    void setStrokePattern(Ref<Pattern>&& pattern) { m_state.setStrokePattern(WTFMove(pattern)); didUpdateState(m_state); }
+    void setStrokeBrush(const SourceBrush& brush) { m_state.setStrokeBrush(brush); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::StrokeBrush)); }
+    void setStrokeColor(const Color& color) { m_state.setStrokeColor(color); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::StrokeBrush)); }
+    void setStrokeGradient(Ref<Gradient>&& gradient, const AffineTransform& spaceTransform = { }) { m_state.setStrokeGradient(WTFMove(gradient), spaceTransform); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::StrokeBrush)); }
+    void setStrokePattern(Ref<Pattern>&& pattern) { m_state.setStrokePattern(WTFMove(pattern)); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::StrokeBrush)); }
 
     float strokeThickness() const { return m_state.strokeThickness(); }
-    void setStrokeThickness(float thickness) { m_state.setStrokeThickness(thickness); didUpdateState(m_state); }
+    void setStrokeThickness(float thickness) { m_state.setStrokeThickness(thickness); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::StrokeThickness)); }
 
     StrokeStyle strokeStyle() const { return m_state.strokeStyle(); }
-    void setStrokeStyle(StrokeStyle style) { m_state.setStrokeStyle(style); didUpdateState(m_state); }
+    void setStrokeStyle(StrokeStyle style) { m_state.setStrokeStyle(style); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::StrokeStyle)); }
 
     std::optional<GraphicsDropShadow> dropShadow() const { return m_state.dropShadow(); }
-    void setDropShadow(const GraphicsDropShadow& dropShadow) { m_state.setDropShadow(dropShadow); didUpdateState(m_state); }
-    void clearDropShadow() { m_state.setDropShadow(std::nullopt); didUpdateState(m_state); }
+    void setDropShadow(const GraphicsDropShadow& dropShadow) { m_state.setDropShadow(dropShadow); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::DropShadow)); }
+    void clearDropShadow() { m_state.setDropShadow(std::nullopt); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::DropShadow)); }
     bool hasBlurredDropShadow() const { return dropShadow() && dropShadow()->isBlurred(); }
     bool hasDropShadow() const { return dropShadow() && dropShadow()->hasOutsets(); }
 
     std::optional<GraphicsStyle> style() const { return m_state.style(); }
-    void setStyle(const std::optional<GraphicsStyle>& style) { m_state.setStyle(style); didUpdateState(m_state); }
+    void setStyle(const std::optional<GraphicsStyle>& style) { m_state.setStyle(style); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::Style)); }
 
     CompositeMode compositeMode() const { return m_state.compositeMode(); }
     CompositeOperator compositeOperation() const { return compositeMode().operation; }
     BlendMode blendMode() const { return compositeMode().blendMode; }
-    void setCompositeMode(CompositeMode compositeMode) { m_state.setCompositeMode(compositeMode); didUpdateState(m_state); }
+    void setCompositeMode(CompositeMode compositeMode) { m_state.setCompositeMode(compositeMode); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::CompositeMode)); }
     void setCompositeOperation(CompositeOperator operation, BlendMode blendMode = BlendMode::Normal) { setCompositeMode({ operation, blendMode }); }
 
     float alpha() const { return m_state.alpha(); }
-    void setAlpha(float alpha) { m_state.setAlpha(alpha); didUpdateState(m_state); }
+    void setAlpha(float alpha) { m_state.setAlpha(alpha); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::Alpha)); }
 
     TextDrawingModeFlags textDrawingMode() const { return m_state.textDrawingMode(); }
-    void setTextDrawingMode(TextDrawingModeFlags textDrawingMode) { m_state.setTextDrawingMode(textDrawingMode); didUpdateState(m_state); }
-    
+    void setTextDrawingMode(TextDrawingModeFlags textDrawingMode) { m_state.setTextDrawingMode(textDrawingMode); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::TextDrawingMode)); }
+
     InterpolationQuality imageInterpolationQuality() const { return m_state.imageInterpolationQuality(); }
-    void setImageInterpolationQuality(InterpolationQuality imageInterpolationQuality) { m_state.setImageInterpolationQuality(imageInterpolationQuality); didUpdateState(m_state); }
+    void setImageInterpolationQuality(InterpolationQuality imageInterpolationQuality) { m_state.setImageInterpolationQuality(imageInterpolationQuality); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::ImageInterpolationQuality)); }
 
     bool shouldAntialias() const { return m_state.shouldAntialias(); }
-    void setShouldAntialias(bool shouldAntialias) { m_state.setShouldAntialias(shouldAntialias); didUpdateState(m_state); }
+    void setShouldAntialias(bool shouldAntialias) { m_state.setShouldAntialias(shouldAntialias); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::ShouldAntialias)); }
 
     bool shouldSmoothFonts() const { return m_state.shouldSmoothFonts(); }
-    void setShouldSmoothFonts(bool shouldSmoothFonts) { m_state.setShouldSmoothFonts(shouldSmoothFonts); didUpdateState(m_state); }
+    void setShouldSmoothFonts(bool shouldSmoothFonts) { m_state.setShouldSmoothFonts(shouldSmoothFonts); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::ShouldSmoothFonts)); }
 
     // Normally CG enables subpixel-quantization because it improves the performance of aligning glyphs.
     // In some cases we have to disable to to ensure a high-quality output of the glyphs.
     bool shouldSubpixelQuantizeFonts() const { return m_state.shouldSubpixelQuantizeFonts(); }
-    void setShouldSubpixelQuantizeFonts(bool shouldSubpixelQuantizeFonts) { m_state.setShouldSubpixelQuantizeFonts(shouldSubpixelQuantizeFonts); didUpdateState(m_state); }
+    void setShouldSubpixelQuantizeFonts(bool shouldSubpixelQuantizeFonts) { m_state.setShouldSubpixelQuantizeFonts(shouldSubpixelQuantizeFonts); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::ShouldSubpixelQuantizeFonts)); }
 
     bool shadowsIgnoreTransforms() const { return m_state.shadowsIgnoreTransforms(); }
-    void setShadowsIgnoreTransforms(bool shadowsIgnoreTransforms) { m_state.setShadowsIgnoreTransforms(shadowsIgnoreTransforms); didUpdateState(m_state); }
+    void setShadowsIgnoreTransforms(bool shadowsIgnoreTransforms) { m_state.setShadowsIgnoreTransforms(shadowsIgnoreTransforms); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::ShadowsIgnoreTransforms)); }
     FloatSize platformShadowOffset(const FloatSize&) const;
 
     bool drawLuminanceMask() const { return m_state.drawLuminanceMask(); }
-    void setDrawLuminanceMask(bool drawLuminanceMask) { m_state.setDrawLuminanceMask(drawLuminanceMask); didUpdateState(m_state); }
+    void setDrawLuminanceMask(bool drawLuminanceMask) { m_state.setDrawLuminanceMask(drawLuminanceMask); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::DrawLuminanceMask)); }
 
 #if HAVE(OS_DARK_MODE_SUPPORT)
     bool useDarkAppearance() const { return m_state.useDarkAppearance(); }
-    void setUseDarkAppearance(bool useDarkAppearance) { m_state.setUseDarkAppearance(useDarkAppearance); didUpdateState(m_state); }
+    void setUseDarkAppearance(bool useDarkAppearance) { m_state.setUseDarkAppearance(useDarkAppearance); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::UseDarkAppearance)); }
 #endif
 
     virtual const GraphicsContextState& state() const { return m_state; }
@@ -178,6 +178,7 @@ public:
     // Called *after* any change to GraphicsContextState; generally used to propagate changes
     // to the platform context's state.
     virtual void didUpdateState(GraphicsContextState&) = 0;
+    virtual void didUpdateSingleState(GraphicsContextState& state, GraphicsContextState::ChangeIndex) { didUpdateState(state); }
 
     WEBCORE_EXPORT virtual void save(GraphicsContextState::Purpose = GraphicsContextState::Purpose::SaveRestore);
     WEBCORE_EXPORT virtual void restore(GraphicsContextState::Purpose = GraphicsContextState::Purpose::SaveRestore);

--- a/Source/WebCore/platform/graphics/GraphicsContextState.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContextState.cpp
@@ -83,82 +83,81 @@ bool GraphicsContextState::containsOnlyInlineStrokeChanges() const
     return true;
 }
 
-constexpr unsigned toIndex(GraphicsContextState::Change change)
-{
-    return WTF::ctzConstexpr(enumToUnderlyingType(change));
-}
-
 void GraphicsContextState::mergeLastChanges(const GraphicsContextState& state, const std::optional<GraphicsContextState>& lastDrawingState)
 {
-    for (auto change : state.changes()) {
-        auto mergeChange = [&](auto GraphicsContextState::*property) {
-            if (this->*property == state.*property)
-                return;
-            this->*property = state.*property;
-            m_changeFlags.set(change, !lastDrawingState || (*lastDrawingState).*property != this->*property);
-        };
+    for (auto change : state.changes())
+        mergeSingleChange(state, toIndex(change), lastDrawingState);
+}
 
-        switch (toIndex(change)) {
-        case toIndex(Change::FillBrush):
-            mergeChange(&GraphicsContextState::m_fillBrush);
-            break;
-        case toIndex(Change::FillRule):
-            mergeChange(&GraphicsContextState::m_fillRule);
-            break;
+void GraphicsContextState::mergeSingleChange(const GraphicsContextState& state, ChangeIndex changeIndex, const std::optional<GraphicsContextState>& lastDrawingState)
+{
+    auto mergeChange = [&](auto GraphicsContextState::*property) {
+        if (this->*property == state.*property)
+            return;
+        this->*property = state.*property;
+        m_changeFlags.set(changeIndex.toChange(), !lastDrawingState || (*lastDrawingState).*property != this->*property);
+    };
 
-        case toIndex(Change::StrokeBrush):
-            mergeChange(&GraphicsContextState::m_strokeBrush);
-            break;
-        case toIndex(Change::StrokeThickness):
-            mergeChange(&GraphicsContextState::m_strokeThickness);
-            break;
-        case toIndex(Change::StrokeStyle):
-            mergeChange(&GraphicsContextState::m_strokeStyle);
-            break;
+    switch (changeIndex.value) {
+    case toIndex(Change::FillBrush).value:
+        mergeChange(&GraphicsContextState::m_fillBrush);
+        break;
+    case toIndex(Change::FillRule).value:
+        mergeChange(&GraphicsContextState::m_fillRule);
+        break;
 
-        case toIndex(Change::CompositeMode):
-            mergeChange(&GraphicsContextState::m_compositeMode);
-            break;
-        case toIndex(Change::DropShadow):
-            mergeChange(&GraphicsContextState::m_dropShadow);
-            break;
-        case toIndex(Change::Style):
-            mergeChange(&GraphicsContextState::m_style);
-            break;
+    case toIndex(Change::StrokeBrush).value:
+        mergeChange(&GraphicsContextState::m_strokeBrush);
+        break;
+    case toIndex(Change::StrokeThickness).value:
+        mergeChange(&GraphicsContextState::m_strokeThickness);
+        break;
+    case toIndex(Change::StrokeStyle).value:
+        mergeChange(&GraphicsContextState::m_strokeStyle);
+        break;
 
-        case toIndex(Change::Alpha):
-            mergeChange(&GraphicsContextState::m_alpha);
-            break;
-        case toIndex(Change::TextDrawingMode):
-            mergeChange(&GraphicsContextState::m_textDrawingMode);
-            break;
-        case toIndex(Change::ImageInterpolationQuality):
-            mergeChange(&GraphicsContextState::m_imageInterpolationQuality);
-            break;
+    case toIndex(Change::CompositeMode).value:
+        mergeChange(&GraphicsContextState::m_compositeMode);
+        break;
+    case toIndex(Change::DropShadow).value:
+        mergeChange(&GraphicsContextState::m_dropShadow);
+        break;
+    case toIndex(Change::Style).value:
+        mergeChange(&GraphicsContextState::m_style);
+        break;
 
-        case toIndex(Change::ShouldAntialias):
-            mergeChange(&GraphicsContextState::m_shouldAntialias);
-            break;
-        case toIndex(Change::ShouldSmoothFonts):
-            mergeChange(&GraphicsContextState::m_shouldSmoothFonts);
-            break;
-        case toIndex(Change::ShouldSubpixelQuantizeFonts):
-            mergeChange(&GraphicsContextState::m_shouldSubpixelQuantizeFonts);
-            break;
-        case toIndex(Change::ShadowsIgnoreTransforms):
-            mergeChange(&GraphicsContextState::m_shadowsIgnoreTransforms);
-            break;
-        case toIndex(Change::DrawLuminanceMask):
-            mergeChange(&GraphicsContextState::m_drawLuminanceMask);
-            break;
+    case toIndex(Change::Alpha).value:
+        mergeChange(&GraphicsContextState::m_alpha);
+        break;
+    case toIndex(Change::TextDrawingMode).value:
+        mergeChange(&GraphicsContextState::m_textDrawingMode);
+        break;
+    case toIndex(Change::ImageInterpolationQuality).value:
+        mergeChange(&GraphicsContextState::m_imageInterpolationQuality);
+        break;
+
+    case toIndex(Change::ShouldAntialias).value:
+        mergeChange(&GraphicsContextState::m_shouldAntialias);
+        break;
+    case toIndex(Change::ShouldSmoothFonts).value:
+        mergeChange(&GraphicsContextState::m_shouldSmoothFonts);
+        break;
+    case toIndex(Change::ShouldSubpixelQuantizeFonts).value:
+        mergeChange(&GraphicsContextState::m_shouldSubpixelQuantizeFonts);
+        break;
+    case toIndex(Change::ShadowsIgnoreTransforms).value:
+        mergeChange(&GraphicsContextState::m_shadowsIgnoreTransforms);
+        break;
+    case toIndex(Change::DrawLuminanceMask).value:
+        mergeChange(&GraphicsContextState::m_drawLuminanceMask);
+        break;
 #if HAVE(OS_DARK_MODE_SUPPORT)
-        case toIndex(Change::UseDarkAppearance):
-            mergeChange(&GraphicsContextState::m_useDarkAppearance);
-            break;
+    case toIndex(Change::UseDarkAppearance).value:
+        mergeChange(&GraphicsContextState::m_useDarkAppearance);
+        break;
 #endif
-        default:
-            RELEASE_ASSERT_NOT_REACHED();
-        }
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
     }
 }
 

--- a/Source/WebCore/platform/graphics/GraphicsContextState.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextState.h
@@ -64,6 +64,13 @@ public:
     };
     using ChangeFlags = OptionSet<Change>;
 
+    struct ChangeIndex {
+        Change toChange() { return static_cast<Change>(1 << value); }
+
+        uint32_t value;
+    };
+    static constexpr ChangeIndex toIndex(GraphicsContextState::Change change) { return { WTF::ctzConstexpr(enumToUnderlyingType(change)) }; }
+
     static constexpr ChangeFlags basicChangeFlags { Change::StrokeThickness, Change::StrokeBrush, Change::FillBrush };
     static constexpr ChangeFlags strokeChangeFlags { Change::StrokeThickness, Change::StrokeBrush };
 
@@ -145,6 +152,7 @@ public:
     bool containsOnlyInlineChanges() const;
     bool containsOnlyInlineStrokeChanges() const;
     void mergeLastChanges(const GraphicsContextState&, const std::optional<GraphicsContextState>& lastDrawingState = std::nullopt);
+    void mergeSingleChange(const GraphicsContextState&, ChangeIndex, const std::optional<GraphicsContextState>& lastDrawingState = std::nullopt);
     void mergeAllChanges(const GraphicsContextState&);
 
     Purpose purpose() const { return m_purpose; }

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -146,6 +146,12 @@ void Recorder::didUpdateState(GraphicsContextState& state)
     state.didApplyChanges();
 }
 
+void Recorder::didUpdateSingleState(GraphicsContextState& state, GraphicsContextState::ChangeIndex changeIndex)
+{
+    ASSERT(state.changes() - changeIndex.toChange() == GraphicsContextState::ChangeFlags { });
+    currentState().state.mergeSingleChange(state, changeIndex, currentState().lastDrawingState);
+    state.didApplyChanges();
+}
 
 void Recorder::drawFilteredImageBuffer(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter& filter, FilterResults& results)
 {

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
@@ -176,6 +176,7 @@ private:
     WEBCORE_EXPORT const GraphicsContextState& state() const final;
 
     WEBCORE_EXPORT void didUpdateState(GraphicsContextState&) final;
+    WEBCORE_EXPORT void didUpdateSingleState(GraphicsContextState&, GraphicsContextState::ChangeIndex) final;
     WEBCORE_EXPORT void fillPath(const Path&) final;
     WEBCORE_EXPORT void strokePath(const Path&) final;
     WEBCORE_EXPORT void drawFilteredImageBuffer(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter&, FilterResults&) final;


### PR DESCRIPTION
#### aa50d27385a2533501f99bd7533d21912725e023
<pre>
GraphicsContextState::mergeLastChanges spends time figuring out which bit changed.
<a href="https://bugs.webkit.org/show_bug.cgi?id=284138">https://bugs.webkit.org/show_bug.cgi?id=284138</a>
&lt;<a href="https://rdar.apple.com/141014221">rdar://141014221</a>&gt;

Reviewed by Dan Glastonbury.

Add a new didUpdateSingleState virtual so that the index of the change (computed
at compile time) can be passed through to the merge function.

* Source/WebCore/platform/graphics/GraphicsContext.h:
(WebCore::GraphicsContext::setFillBrush):
(WebCore::GraphicsContext::setFillColor):
(WebCore::GraphicsContext::setFillGradient):
(WebCore::GraphicsContext::setFillPattern):
(WebCore::GraphicsContext::setFillRule):
(WebCore::GraphicsContext::setStrokeBrush):
(WebCore::GraphicsContext::setStrokeColor):
(WebCore::GraphicsContext::setStrokeGradient):
(WebCore::GraphicsContext::setStrokePattern):
(WebCore::GraphicsContext::setStrokeThickness):
(WebCore::GraphicsContext::setStrokeStyle):
(WebCore::GraphicsContext::setDropShadow):
(WebCore::GraphicsContext::clearDropShadow):
(WebCore::GraphicsContext::setStyle):
(WebCore::GraphicsContext::setCompositeMode):
(WebCore::GraphicsContext::setAlpha):
(WebCore::GraphicsContext::setTextDrawingMode):
(WebCore::GraphicsContext::setImageInterpolationQuality):
(WebCore::GraphicsContext::setShouldAntialias):
(WebCore::GraphicsContext::setShouldSmoothFonts):
(WebCore::GraphicsContext::setShouldSubpixelQuantizeFonts):
(WebCore::GraphicsContext::setShadowsIgnoreTransforms):
(WebCore::GraphicsContext::setDrawLuminanceMask):
(WebCore::GraphicsContext::setUseDarkAppearance):
(WebCore::GraphicsContext::didUpdateSingleState):
* Source/WebCore/platform/graphics/GraphicsContextState.cpp:
(WebCore::GraphicsContextState::mergeLastChanges):
(WebCore::GraphicsContextState::mergeSingleChange):
(WebCore::toIndex): Deleted.
* Source/WebCore/platform/graphics/GraphicsContextState.h:
(WebCore::GraphicsContextState::ChangeIndex::toChange):
(WebCore::GraphicsContextState::toIndex):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::drawFilteredImageBuffer):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h:

Canonical link: <a href="https://commits.webkit.org/287524@main">https://commits.webkit.org/287524@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0eefb700a64ef197349c40e9b318af4a4dd0f495

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79981 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58978 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33379 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84495 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30955 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82089 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68042 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7274 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62517 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20343 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83048 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52579 "Found 1 new test failure: media/audioSession/getUserMedia.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72841 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42826 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49917 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26994 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29417 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71037 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27485 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85927 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7197 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5064 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70788 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7374 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68682 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70032 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17445 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14028 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12963 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7161 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12695 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7008 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10520 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8812 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->