### PR TITLE
Implement Observable#inspect

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-inspect.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-inspect.any-expected.txt
@@ -1,79 +1,16 @@
+CONSOLE MESSAGE: Error: error from source
 
-FAIL inspect(): Provides a pre-subscription subscribe callback source.inspect is not a function. (In 'source.inspect({
-    subscribe: () => {
-      inspectSubscribeCall++;
-      results.push(`inspect() subscribe ${inspectSubscribeCall}`);
-    },
-    next: (value) => results.push(`inspect() next ${value}`),
-    error: (e) => results.push(`inspect() error ${e.message}`),
-    complete: () => results.push(`inspect() complete`),
-  })', 'source.inspect' is undefined)
-FAIL inspect(): Provides a way to tap into the values and completions of the source observable using an observer source.inspect is not a function. (In 'source.inspect({
-    next: value => results.push(value),
-    error: e => results.push(e),
-    complete: () => results.push("complete"),
-  })', 'source.inspect' is undefined)
-FAIL inspect(): Error handler does not stop error from being reported to the global, when subscriber does not pass error handler source.inspect is not a function. (In 'source.inspect({
-    next: value => results.push(value),
-    error: e => results.push(e),
-    complete: () => results.push("complete"),
-  })', 'source.inspect' is undefined)
-FAIL inspect(): Provides a way to tap into the values and errors of the source observable using an observer. Errors are passed through source.inspect is not a function. (In 'source.inspect({
-    next: value => results.push(value),
-    error: e => results.push(e),
-    complete: () => results.push("complete"),
-  })', 'source.inspect' is undefined)
-FAIL inspect(): ObserverCallback passed in source.inspect is not a function. (In 'source.inspect(value => results.push(value))', 'source.inspect' is undefined)
-FAIL inspect(): Throwing an error in the observer next handler is caught and sent to the error callback of the result observable source.inspect is not a function. (In 'source.inspect({
-    next: (value) => {
-      if (value === 2) {
-        throw error;
-      }
-    },
-  })', 'source.inspect' is undefined)
-FAIL inspect(): Throwing an error in the observer error handler in inspect() is caught and sent to the error callback of the result observable source.inspect is not a function. (In 'source.inspect({
-    error: () => {
-      throw inspectError;
-    },
-  })', 'source.inspect' is undefined)
-FAIL inspect(): Throwing an error in the observer complete handler is caught and sent to the error callback of the result observable source.inspect is not a function. (In 'source.inspect({
-    complete: () => {
-      throw error;
-    },
-  })', 'source.inspect' is undefined)
-FAIL inspect(): Throwing an error in the next handler function in do should be caught and sent to the error callback of the result observable source.inspect is not a function. (In 'source.inspect({
-    next: (value) => {
-      if (value === 2) {
-        throw error;
-      }
-    },
-  })', 'source.inspect' is undefined)
-FAIL inspect(): Errors thrown in subscribe() Inspector handler subscribe handler are caught and sent to error callback source.inspect is not a function. (In 'source.inspect({
-    subscribe: () => {
-      throw new Error("error from do subscribe handler");
-    },
-  })', 'source.inspect' is undefined)
-FAIL inspect(): Provides a way to tap into the moment a source observable is unsubscribed from source.inspect is not a function. (In 'source.inspect({
-    abort: (reason) => {
-      doUnsubscribeCall++;
-      results.push(`inspect() abort ${doUnsubscribeCall} ${reason}`);
-    },
-    next: (value) => results.push(`inspect() next ${value}`),
-    error: (e) => results.push(`inspect() error ${e.message}`),
-    complete: () => results.push(`inspect() complete`),
-  })', 'source.inspect' is undefined)
-FAIL inspect(): Inspector abort() handler is not called if the source completes before the result is unsubscribed from source.inspect is not a function. (In 'source.inspect({
-    next: (value) => results.push(`inspect() next ${value}`),
-    complete: () => results.push(`inspect() complete`),
-    abort: (reason) => {
-      inspectUnsubscribeCall++;
-      results.push(`inspect() abort ${inspectUnsubscribeCall} ${reason}`);
-    },
-  })', 'source.inspect' is undefined)
-FAIL inspect(): Errors thrown from inspect()'s abort() handler are caught and reported to the global, because the subscription is already closed by the time the handler runs source.inspect is not a function. (In 'source.inspect({
-    abort: () => {
-      results.push('abort() handler run');
-      throw new Error("error from inspect() subscribe handler");
-    },
-  })', 'source.inspect' is undefined)
+PASS inspect(): Provides a pre-subscription subscribe callback
+PASS inspect(): Provides a way to tap into the values and completions of the source observable using an observer
+PASS inspect(): Error handler does not stop error from being reported to the global, when subscriber does not pass error handler
+PASS inspect(): Provides a way to tap into the values and errors of the source observable using an observer. Errors are passed through
+PASS inspect(): ObserverCallback passed in
+PASS inspect(): Throwing an error in the observer next handler is caught and sent to the error callback of the result observable
+PASS inspect(): Throwing an error in the observer error handler in inspect() is caught and sent to the error callback of the result observable
+PASS inspect(): Throwing an error in the observer complete handler is caught and sent to the error callback of the result observable
+PASS inspect(): Throwing an error in the next handler function in do should be caught and sent to the error callback of the result observable
+PASS inspect(): Errors thrown in subscribe() Inspector handler subscribe handler are caught and sent to error callback
+PASS inspect(): Provides a way to tap into the moment a source observable is unsubscribed from
+PASS inspect(): Inspector abort() handler is not called if the source completes before the result is unsubscribed from
+FAIL inspect(): Errors thrown from inspect()'s abort() handler are caught and reported to the global, because the subscription is already closed by the time the handler runs self.when is not a function. (In 'self.when('error')', 'self.when' is undefined)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-inspect.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-inspect.any.worker-expected.txt
@@ -1,79 +1,15 @@
 
-FAIL inspect(): Provides a pre-subscription subscribe callback source.inspect is not a function. (In 'source.inspect({
-    subscribe: () => {
-      inspectSubscribeCall++;
-      results.push(`inspect() subscribe ${inspectSubscribeCall}`);
-    },
-    next: (value) => results.push(`inspect() next ${value}`),
-    error: (e) => results.push(`inspect() error ${e.message}`),
-    complete: () => results.push(`inspect() complete`),
-  })', 'source.inspect' is undefined)
-FAIL inspect(): Provides a way to tap into the values and completions of the source observable using an observer source.inspect is not a function. (In 'source.inspect({
-    next: value => results.push(value),
-    error: e => results.push(e),
-    complete: () => results.push("complete"),
-  })', 'source.inspect' is undefined)
-FAIL inspect(): Error handler does not stop error from being reported to the global, when subscriber does not pass error handler source.inspect is not a function. (In 'source.inspect({
-    next: value => results.push(value),
-    error: e => results.push(e),
-    complete: () => results.push("complete"),
-  })', 'source.inspect' is undefined)
-FAIL inspect(): Provides a way to tap into the values and errors of the source observable using an observer. Errors are passed through source.inspect is not a function. (In 'source.inspect({
-    next: value => results.push(value),
-    error: e => results.push(e),
-    complete: () => results.push("complete"),
-  })', 'source.inspect' is undefined)
-FAIL inspect(): ObserverCallback passed in source.inspect is not a function. (In 'source.inspect(value => results.push(value))', 'source.inspect' is undefined)
-FAIL inspect(): Throwing an error in the observer next handler is caught and sent to the error callback of the result observable source.inspect is not a function. (In 'source.inspect({
-    next: (value) => {
-      if (value === 2) {
-        throw error;
-      }
-    },
-  })', 'source.inspect' is undefined)
-FAIL inspect(): Throwing an error in the observer error handler in inspect() is caught and sent to the error callback of the result observable source.inspect is not a function. (In 'source.inspect({
-    error: () => {
-      throw inspectError;
-    },
-  })', 'source.inspect' is undefined)
-FAIL inspect(): Throwing an error in the observer complete handler is caught and sent to the error callback of the result observable source.inspect is not a function. (In 'source.inspect({
-    complete: () => {
-      throw error;
-    },
-  })', 'source.inspect' is undefined)
-FAIL inspect(): Throwing an error in the next handler function in do should be caught and sent to the error callback of the result observable source.inspect is not a function. (In 'source.inspect({
-    next: (value) => {
-      if (value === 2) {
-        throw error;
-      }
-    },
-  })', 'source.inspect' is undefined)
-FAIL inspect(): Errors thrown in subscribe() Inspector handler subscribe handler are caught and sent to error callback source.inspect is not a function. (In 'source.inspect({
-    subscribe: () => {
-      throw new Error("error from do subscribe handler");
-    },
-  })', 'source.inspect' is undefined)
-FAIL inspect(): Provides a way to tap into the moment a source observable is unsubscribed from source.inspect is not a function. (In 'source.inspect({
-    abort: (reason) => {
-      doUnsubscribeCall++;
-      results.push(`inspect() abort ${doUnsubscribeCall} ${reason}`);
-    },
-    next: (value) => results.push(`inspect() next ${value}`),
-    error: (e) => results.push(`inspect() error ${e.message}`),
-    complete: () => results.push(`inspect() complete`),
-  })', 'source.inspect' is undefined)
-FAIL inspect(): Inspector abort() handler is not called if the source completes before the result is unsubscribed from source.inspect is not a function. (In 'source.inspect({
-    next: (value) => results.push(`inspect() next ${value}`),
-    complete: () => results.push(`inspect() complete`),
-    abort: (reason) => {
-      inspectUnsubscribeCall++;
-      results.push(`inspect() abort ${inspectUnsubscribeCall} ${reason}`);
-    },
-  })', 'source.inspect' is undefined)
-FAIL inspect(): Errors thrown from inspect()'s abort() handler are caught and reported to the global, because the subscription is already closed by the time the handler runs source.inspect is not a function. (In 'source.inspect({
-    abort: () => {
-      results.push('abort() handler run');
-      throw new Error("error from inspect() subscribe handler");
-    },
-  })', 'source.inspect' is undefined)
+PASS inspect(): Provides a pre-subscription subscribe callback
+PASS inspect(): Provides a way to tap into the values and completions of the source observable using an observer
+PASS inspect(): Error handler does not stop error from being reported to the global, when subscriber does not pass error handler
+PASS inspect(): Provides a way to tap into the values and errors of the source observable using an observer. Errors are passed through
+PASS inspect(): ObserverCallback passed in
+PASS inspect(): Throwing an error in the observer next handler is caught and sent to the error callback of the result observable
+PASS inspect(): Throwing an error in the observer error handler in inspect() is caught and sent to the error callback of the result observable
+PASS inspect(): Throwing an error in the observer complete handler is caught and sent to the error callback of the result observable
+PASS inspect(): Throwing an error in the next handler function in do should be caught and sent to the error callback of the result observable
+PASS inspect(): Errors thrown in subscribe() Inspector handler subscribe handler are caught and sent to error callback
+PASS inspect(): Provides a way to tap into the moment a source observable is unsubscribed from
+PASS inspect(): Inspector abort() handler is not called if the source completes before the result is unsubscribed from
+FAIL inspect(): Errors thrown from inspect()'s abort() handler are caught and reported to the global, because the subscription is already closed by the time the handler runs self.when is not a function. (In 'self.when('error')', 'self.when' is undefined)
 

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1169,6 +1169,8 @@ set(WebCore_NON_SVG_IDL_FILES
     dom/NonDocumentTypeChildNode.idl
     dom/NonElementParentNode.idl
     dom/Observable.idl
+    dom/ObservableInspector.idl
+    dom/ObservableInspectorAbortCallback.idl
     dom/PageRevealEvent.idl
     dom/PageSwapEvent.idl
     dom/PageTransitionEvent.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1494,6 +1494,8 @@ $(PROJECT_DIR)/dom/NodeList.idl
 $(PROJECT_DIR)/dom/NonDocumentTypeChildNode.idl
 $(PROJECT_DIR)/dom/NonElementParentNode.idl
 $(PROJECT_DIR)/dom/Observable.idl
+$(PROJECT_DIR)/dom/ObservableInspector.idl
+$(PROJECT_DIR)/dom/ObservableInspectorAbortCallback.idl
 $(PROJECT_DIR)/dom/PageRevealEvent.idl
 $(PROJECT_DIR)/dom/PageSwapEvent.idl
 $(PROJECT_DIR)/dom/PageTransitionEvent.idl

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1187,6 +1187,8 @@ JS_BINDING_IDLS := \
     $(WebCore)/dom/NonDocumentTypeChildNode.idl \
     $(WebCore)/dom/NonElementParentNode.idl \
     $(WebCore)/dom/Observable.idl \
+    $(WebCore)/dom/ObservableInspector.idl \
+    $(WebCore)/dom/ObservableInspectorAbortCallback.idl \
     $(WebCore)/dom/PageRevealEvent.idl \
     $(WebCore)/dom/PageSwapEvent.idl \
     $(WebCore)/dom/PageTransitionEvent.idl \

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1278,6 +1278,7 @@ dom/InternalObserverFind.cpp
 dom/InternalObserverFirst.cpp
 dom/InternalObserverForEach.cpp
 dom/InternalObserverFromScript.cpp
+dom/InternalObserverInspect.cpp
 dom/InternalObserverLast.cpp
 dom/InternalObserverMap.cpp
 dom/InternalObserverSome.cpp
@@ -4211,6 +4212,8 @@ JSOESTextureHalfFloat.cpp
 JSOESTextureHalfFloatLinear.cpp
 JSOESVertexArrayObject.cpp
 JSObservable.cpp
+JSObservableInspector.cpp
+JSObservableInspectorAbortCallback.cpp
 JSOfflineAudioCompletionEvent.cpp
 JSOfflineAudioCompletionEventInit.cpp
 JSOfflineAudioContext.cpp

--- a/Source/WebCore/dom/InternalObserverInspect.cpp
+++ b/Source/WebCore/dom/InternalObserverInspect.cpp
@@ -1,0 +1,251 @@
+/*
+ * Copyright (C) 2024 Marais Rossouw <me@marais.co>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "InternalObserverInspect.h"
+
+#include "InternalObserver.h"
+#include "JSSubscriptionObserverCallback.h"
+#include "Observable.h"
+#include "ObservableInspector.h"
+#include "ScriptExecutionContext.h"
+#include "SubscribeOptions.h"
+#include "Subscriber.h"
+#include "SubscriberCallback.h"
+#include <JavaScriptCore/JSCJSValueInlines.h>
+
+namespace WebCore {
+
+class InternalObserverInspect final : public InternalObserver {
+public:
+    static Ref<InternalObserverInspect> create(ScriptExecutionContext& context, Ref<Subscriber>&& subscriber, ObservableInspector&& inspector)
+    {
+        Ref internalObserver = adoptRef(*new InternalObserverInspect(context, WTFMove(subscriber), WTFMove(inspector)));
+        internalObserver->suspendIfNeeded();
+        return internalObserver;
+    }
+
+    class SubscriberCallbackInspect final : public SubscriberCallback {
+    public:
+        static Ref<SubscriberCallbackInspect> create(ScriptExecutionContext& context, Ref<Observable>&& source, ObservableInspector&& inspector)
+        {
+            return adoptRef(*new SubscriberCallbackInspect(context, WTFMove(source), WTFMove(inspector)));
+        }
+
+        CallbackResult<void> handleEvent(Subscriber& subscriber) final
+        {
+            RefPtr context = scriptExecutionContext();
+
+            if (!context) {
+                subscriber.complete();
+                return { };
+            }
+
+            if (RefPtr subscribe = m_inspector.subscribe) {
+                auto* globalObject = protectedScriptExecutionContext()->globalObject();
+                ASSERT(globalObject);
+
+                Ref vm = globalObject->vm();
+
+                JSC::JSLockHolder lock(vm);
+                auto scope = DECLARE_CATCH_SCOPE(vm);
+
+                subscribe->handleEventRethrowingException();
+
+                JSC::Exception* exception = scope.exception();
+                if (UNLIKELY(exception)) {
+                    scope.clearException();
+                    subscriber.error(exception->value());
+                    return { };
+                }
+            }
+
+            Ref inspect = InternalObserverInspect::create(*context, subscriber, ObservableInspector { m_inspector });
+            Ref { m_sourceObservable }->subscribeInternal(*context, WTFMove(inspect), SubscribeOptions { &subscriber.signal() });
+
+            return { };
+        }
+
+        CallbackResult<void> handleEventRethrowingException(Subscriber& subscriber) final
+        {
+            return handleEvent(subscriber);
+        }
+
+    private:
+        bool hasCallback() const final { return true; }
+
+        SubscriberCallbackInspect(ScriptExecutionContext& context, Ref<Observable>&& source, ObservableInspector&& inspector)
+            : SubscriberCallback(&context)
+            , m_sourceObservable(WTFMove(source))
+            , m_inspector(WTFMove(inspector))
+        { }
+
+        Ref<Observable> m_sourceObservable;
+        ObservableInspector m_inspector;
+    };
+
+private:
+    void next(JSC::JSValue value) final
+    {
+        if (RefPtr next = m_inspector.next) {
+            Ref vm = this->vm();
+            JSC::JSLockHolder lock(vm);
+            auto scope = DECLARE_CATCH_SCOPE(vm);
+
+            next->handleEventRethrowingException(value);
+
+            JSC::Exception* exception = scope.exception();
+            if (UNLIKELY(exception)) {
+                scope.clearException();
+                protectedSubscriber()->error(exception->value());
+                return;
+            }
+        }
+
+        protectedSubscriber()->next(value);
+    }
+
+    void error(JSC::JSValue value) final
+    {
+        removeAbortHandler();
+
+        if (RefPtr error = m_inspector.error) {
+            Ref vm = this->vm();
+            JSC::JSLockHolder lock(vm);
+            auto scope = DECLARE_CATCH_SCOPE(vm);
+
+            error->handleEventRethrowingException(value);
+
+            JSC::Exception* exception = scope.exception();
+            if (UNLIKELY(exception)) {
+                scope.clearException();
+                protectedSubscriber()->error(exception->value());
+                return;
+            }
+        }
+
+        protectedSubscriber()->error(value);
+    }
+
+    void complete() final
+    {
+        InternalObserver::complete();
+
+        removeAbortHandler();
+
+        if (RefPtr complete = m_inspector.complete) {
+            Ref vm = this->vm();
+            JSC::JSLockHolder lock(vm);
+            auto scope = DECLARE_CATCH_SCOPE(vm);
+
+            complete->handleEventRethrowingException();
+
+            JSC::Exception* exception = scope.exception();
+            if (UNLIKELY(exception)) {
+                scope.clearException();
+                protectedSubscriber()->error(exception->value());
+                return;
+            }
+        }
+
+        protectedSubscriber()->complete();
+    }
+
+    template<typename VisitorType>
+    void visitAdditionalChildrenInternal(VisitorType& visitor) const
+    {
+        protectedSubscriber()->visitAdditionalChildren(visitor);
+        if (RefPtr next = m_inspector.next)
+            next->visitJSFunction(visitor);
+        if (RefPtr error = m_inspector.error)
+            error->visitJSFunction(visitor);
+        if (RefPtr complete = m_inspector.complete)
+            complete->visitJSFunction(visitor);
+        if (RefPtr subscribe = m_inspector.subscribe)
+            subscribe->visitJSFunction(visitor);
+        if (RefPtr abort = m_inspector.abort)
+            abort->visitJSFunction(visitor);
+    }
+
+    void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
+    {
+        visitAdditionalChildrenInternal(visitor);
+    }
+
+    void visitAdditionalChildren(JSC::SlotVisitor& visitor) const final
+    {
+        visitAdditionalChildrenInternal(visitor);
+    }
+
+    void removeAbortHandler()
+    {
+        if (!m_abortAlgorithmHandler)
+            return;
+
+        auto handle = std::exchange(m_abortAlgorithmHandler, std::nullopt);
+        protectedSubscriber()->protectedSignal()->removeAlgorithm(*handle);
+    }
+
+    JSC::VM& vm() const
+    {
+        auto* globalObject = protectedScriptExecutionContext()->globalObject();
+        ASSERT(globalObject);
+        return globalObject->vm();
+    }
+
+    Ref<Subscriber> protectedSubscriber() const
+    {
+        return m_subscriber;
+    }
+
+    InternalObserverInspect(ScriptExecutionContext& context, Ref<Subscriber>&& subscriber, ObservableInspector&& inspector)
+        : InternalObserver(context)
+        , m_subscriber(WTFMove(subscriber))
+        , m_inspector(WTFMove(inspector))
+    {
+        if (RefPtr abort = m_inspector.abort) {
+            Ref signal = protectedSubscriber()->signal();
+            m_abortAlgorithmHandler = signal->addAlgorithm([abort = WTFMove(abort)](JSC::JSValue reason) {
+                abort->handleEvent(reason);
+            });
+        }
+    }
+
+    Ref<Subscriber> m_subscriber;
+    ObservableInspector m_inspector;
+    std::optional<uint32_t> m_abortAlgorithmHandler;
+};
+
+Ref<SubscriberCallback> createSubscriberCallbackInspect(ScriptExecutionContext& context, Ref<Observable>&& observable, RefPtr<JSSubscriptionObserverCallback>&& next)
+{
+    return InternalObserverInspect::SubscriberCallbackInspect::create(context, WTFMove(observable), ObservableInspector { .next = WTFMove(next) });
+}
+
+Ref<SubscriberCallback> createSubscriberCallbackInspect(ScriptExecutionContext& context, Ref<Observable>&& observable, ObservableInspector&& inspector)
+{
+    return InternalObserverInspect::SubscriberCallbackInspect::create(context, WTFMove(observable), WTFMove(inspector));
+}
+
+} // namespace WebCore

--- a/Source/WebCore/dom/InternalObserverInspect.h
+++ b/Source/WebCore/dom/InternalObserverInspect.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2024 Marais Rossouw <me@marais.co>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+class JSSubscriptionObserverCallback;
+class Observable;
+class ScriptExecutionContext;
+class SubscriberCallback;
+struct ObservableInspector;
+
+Ref<SubscriberCallback> createSubscriberCallbackInspect(ScriptExecutionContext&, Ref<Observable>&&, RefPtr<JSSubscriptionObserverCallback>&&);
+Ref<SubscriberCallback> createSubscriberCallbackInspect(ScriptExecutionContext&, Ref<Observable>&&, ObservableInspector&&);
+
+} // namespace WebCore

--- a/Source/WebCore/dom/Observable.h
+++ b/Source/WebCore/dom/Observable.h
@@ -40,6 +40,7 @@ class MapperCallback;
 class PredicateCallback;
 class ScriptExecutionContext;
 class VisitorCallback;
+struct ObservableInspector;
 struct SubscribeOptions;
 struct SubscriptionObserver;
 
@@ -48,6 +49,7 @@ class Observable final : public ScriptWrappable, public RefCounted<Observable> {
 
 public:
     using ObserverUnion = std::variant<RefPtr<JSSubscriptionObserverCallback>, SubscriptionObserver>;
+    using InspectorUnion = std::variant<RefPtr<JSSubscriptionObserverCallback>, ObservableInspector>;
 
     static Ref<Observable> create(Ref<SubscriberCallback>);
 
@@ -57,12 +59,10 @@ public:
     void subscribeInternal(ScriptExecutionContext&, Ref<InternalObserver>&&, const SubscribeOptions&);
 
     Ref<Observable> map(ScriptExecutionContext&, MapperCallback&);
-
     Ref<Observable> filter(ScriptExecutionContext&, PredicateCallback&);
-
     Ref<Observable> take(ScriptExecutionContext&, uint64_t);
-
     Ref<Observable> drop(ScriptExecutionContext&, uint64_t);
+    Ref<Observable> inspect(ScriptExecutionContext&, std::optional<InspectorUnion>&&);
 
     // Promise-returning operators.
 

--- a/Source/WebCore/dom/Observable.idl
+++ b/Source/WebCore/dom/Observable.idl
@@ -24,6 +24,7 @@
  */
 // https://github.com/WICG/observable
 typedef (SubscriptionObserverCallback or SubscriptionObserver) ObserverUnion;
+typedef (SubscriptionObserverCallback or ObservableInspector) ObservableInspectorUnion;
 
 [
   Exposed=(Window,Worker),
@@ -41,6 +42,8 @@ interface Observable {
   [CallWith=CurrentScriptExecutionContext] Observable take(unsigned long long amount);
 
   [CallWith=CurrentScriptExecutionContext] Observable drop(unsigned long long amount);
+
+  [CallWith=CurrentScriptExecutionContext] Observable inspect(optional ObservableInspectorUnion inspectorUnion = {});
 
   // Promise-returning operators.
 

--- a/Source/WebCore/dom/ObservableInspector.h
+++ b/Source/WebCore/dom/ObservableInspector.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2024 Marais Rossouw <me@marais.co>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ObservableInspectorAbortCallback.h"
+#include "SubscriptionObserverCallback.h"
+#include "VoidCallback.h"
+
+namespace WebCore {
+
+struct ObservableInspector {
+    RefPtr<SubscriptionObserverCallback> next = nullptr;
+    RefPtr<SubscriptionObserverCallback> error = nullptr;
+    RefPtr<VoidCallback> complete = nullptr;
+    RefPtr<VoidCallback> subscribe = nullptr;
+    RefPtr<ObservableInspectorAbortCallback> abort = nullptr;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/dom/ObservableInspector.idl
+++ b/Source/WebCore/dom/ObservableInspector.idl
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2024 Marais Rossouw <me@marais.co>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+// https://github.com/WICG/observable
+
+dictionary ObservableInspector {
+  SubscriptionObserverCallback next;
+  SubscriptionObserverCallback error;
+  VoidCallback complete;
+  VoidCallback subscribe;
+  ObservableInspectorAbortCallback abort;
+};

--- a/Source/WebCore/dom/ObservableInspectorAbortCallback.h
+++ b/Source/WebCore/dom/ObservableInspectorAbortCallback.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2024 Marais Rossouw <me@marais.co>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ActiveDOMCallback.h"
+#include "CallbackResult.h"
+#include <wtf/RefCounted.h>
+
+namespace WebCore {
+
+class ObservableInspectorAbortCallback : public RefCounted<ObservableInspectorAbortCallback>, public ActiveDOMCallback {
+public:
+    using ActiveDOMCallback::ActiveDOMCallback;
+
+    virtual CallbackResult<void> handleEvent(JSC::JSValue) = 0;
+    virtual CallbackResult<void> handleEventRethrowingException(JSC::JSValue) = 0;
+
+private:
+    virtual bool hasCallback() const = 0;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/dom/ObservableInspectorAbortCallback.idl
+++ b/Source/WebCore/dom/ObservableInspectorAbortCallback.idl
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2024 Marais Rossouw <me@marais.co>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+// https://github.com/WICG/observable
+
+callback ObservableInspectorAbortCallback = undefined (any value);


### PR DESCRIPTION
#### 8b80739ea60b5d9b0a7cd7a9152c4e5b15ff8137
<pre>
Implement Observable#inspect
<a href="https://bugs.webkit.org/show_bug.cgi?id=282083">https://bugs.webkit.org/show_bug.cgi?id=282083</a>

Reviewed by Chris Dumez.

This change introduces the .inspect operator for Observables, using the
InternalObserver, and a new SubscriberCallbackInspect. .inspect is meant to act
as a pass-through operator, so there are no mutations on events.

Spec: &lt;<a href="https://wicg.github.io/observable/#dom-observable-inspect">https://wicg.github.io/observable/#dom-observable-inspect</a>&gt;

There is also a new ObservableInspector IDL dictionary created, as well as a
ObservableInspectorAbortCallback. We could not just have used some generic
callback IDL, given we require a callback that accepts a JSC::Value, as we
forward abort reasons to this callback.

* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-inspect.any-expected.txt: Rebaseline.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-inspect.any.worker-expected.txt: Rebaseline.
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/InternalObserverInspect.cpp: Added.
(WebCore::createSubscriberCallbackInspect):
* Source/WebCore/dom/InternalObserverInspect.h: Added.
* Source/WebCore/dom/Observable.cpp:
(WebCore::Observable::inspect):
* Source/WebCore/dom/Observable.h:
* Source/WebCore/dom/Observable.idl:
Exposes a `Observable inspect(inspectorUnion)` operator.
* Source/WebCore/dom/ObservableInspector.h: Added.
* Source/WebCore/dom/ObservableInspector.idl: Added.
* Source/WebCore/dom/ObservableInspectorAbortCallback.h: Added.
* Source/WebCore/dom/ObservableInspectorAbortCallback.idl: Added.

Canonical link: <a href="https://commits.webkit.org/287504@main">https://commits.webkit.org/287504@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5050ffd1e0605dd9a9a120371e81ef749630e7a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79889 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58887 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33287 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84404 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30869 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81998 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67951 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7179 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62432 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20264 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82957 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52515 "Found 1 new test failure: media/audioSession/getUserMedia.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72753 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42743 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49831 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26902 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29326 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70952 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27379 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85836 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7107 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4980 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70705 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7284 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68593 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69947 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13947 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12875 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12361 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7071 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12620 "Found 1 new failure in JSWebCodecsEncodedVideoChunk.cpp") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6921 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10432 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8726 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->