### PR TITLE
JSC::JSValue convert of JSConverter<IDLRecord<K, V>> crashes when converting an input WebCore::IDLRecord<WebCore::IDLUSVString, WebCore::IDLUnion<WebCore::IDLUndefined, WebCore::IDLUSVString>>

### DIFF
--- a/LayoutTests/js/dom/webidl-type-mapping-expected.txt
+++ b/LayoutTests/js/dom/webidl-type-mapping-expected.txt
@@ -1205,6 +1205,11 @@ PASS converter.testLongRecord()['key'] is 1
 PASS converter.testLongRecord().hasOwnProperty('otherKey') is true
 PASS converter.testLongRecord()['otherKey'] is 2
 PASS var o = { otherKey: 2 }; Object.defineProperty(o, 'key', { get: function() { throw new Error(); }, enumerable: true }); converter.setTestLongRecord(o); threw exception Error.
+converter.setTestLongRecord({ '1': 1 })
+PASS converter.testLongRecord() is an instance of Object
+PASS converter.testLongRecord().hasOwnProperty('1') is true
+PASS '1' in converter.testLongRecord() is true
+PASS converter.testLongRecord()['1'] is 1
 converter.setTestNodeRecord({ key: document, key2: document.documentElement })
 PASS converter.testNodeRecord().hasOwnProperty('key') is true
 PASS 'key' in converter.testNodeRecord() is true

--- a/LayoutTests/js/dom/webidl-type-mapping.html
+++ b/LayoutTests/js/dom/webidl-type-mapping.html
@@ -733,6 +733,11 @@ shouldBe("converter.testLongRecord()['key']", "1");
 shouldBeTrue("converter.testLongRecord().hasOwnProperty('otherKey')");
 shouldBe("converter.testLongRecord()['otherKey']", "2");
 shouldThrow("var o = { otherKey: 2 }; Object.defineProperty(o, 'key', { get: function() { throw new Error(); }, enumerable: true }); converter.setTestLongRecord(o);");
+evalAndLog("converter.setTestLongRecord({ '1': 1 })");
+shouldBeType("converter.testLongRecord()", "Object");
+shouldBeTrue("converter.testLongRecord().hasOwnProperty('1')");
+shouldBeTrue("'1' in converter.testLongRecord()");
+shouldBe("converter.testLongRecord()['1']", "1");
 
 evalAndLog("converter.setTestNodeRecord({ key: document, key2: document.documentElement })");
 shouldBeTrue("converter.testNodeRecord().hasOwnProperty('key')");

--- a/Source/WebCore/bindings/js/JSDOMConvertRecord.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertRecord.h
@@ -198,7 +198,7 @@ template<typename K, typename V> struct JSConverter<IDLRecord<K, V>> {
             auto esValue = toJS<V>(lexicalGlobalObject, globalObject, keyValuePair.value);
 
             // 3. Let created be ! CreateDataProperty(result, esKey, esValue).
-            bool created = result->putDirect(vm, JSC::Identifier::fromString(vm, keyValuePair.key), esValue);
+            bool created = result->createDataProperty(&lexicalGlobalObject, JSC::Identifier::fromString(vm, keyValuePair.key), esValue, true);
 
             // 4. Assert: created is true.
             ASSERT_UNUSED(created, created);


### PR DESCRIPTION
#### d78f8ae748e3103d954fcf113a4496a5385f2853
<pre>
JSC::JSValue convert of JSConverter&lt;IDLRecord&lt;K, V&gt;&gt; crashes when converting an input WebCore::IDLRecord&lt;WebCore::IDLUSVString, WebCore::IDLUnion&lt;WebCore::IDLUndefined, WebCore::IDLUSVString&gt;&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=284132">https://bugs.webkit.org/show_bug.cgi?id=284132</a>
<a href="https://rdar.apple.com/141017497">rdar://141017497</a>

Reviewed by Chris Dumez and Sihui Liu.

According to spec <a href="https://webidl.spec.whatwg.org/#js-record">https://webidl.spec.whatwg.org/#js-record</a>, we should use &lt;bool createDataProperty(JSGlobalObject*, PropertyName, JSValue, bool shouldThrow)&gt; to convert a native object to a IDL Record, not putDirect which is what&apos;s currently implemented and incorrectly assumes that the input property name is not an index.

* LayoutTests/js/dom/webidl-type-mapping-expected.txt:
* LayoutTests/js/dom/webidl-type-mapping.html:
* Source/WebCore/bindings/js/JSDOMConvertRecord.h:

Canonical link: <a href="https://commits.webkit.org/287506@main">https://commits.webkit.org/287506@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9815bff47dcaea93161281b163e69b36cb1b4e68

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79848 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58849 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33247 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84371 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30844 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81957 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67920 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7195 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62413 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20248 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82916 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52470 "Found 1 new test failure: media/audioSession/getUserMedia.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72716 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42721 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49810 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26865 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29296 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/72853 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70935 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27340 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85797 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/78940 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7077 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4989 "Found 1 new test failure: media/video-replaces-poster.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70674 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7251 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68556 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69917 "Found 1 new API test failure: /TestWebKit:WebKit.EnumerateDevicesCrash (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13921 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12838 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/101316 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12363 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7035 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12601 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/24702 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/struct-new_default-small-members.js.wasm-no-cjit (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6893 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10405 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8699 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->