### PR TITLE
Callers of RenderStyle::setFontDescription() should not have to manually call fontCascade().update()

### DIFF
--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -2735,12 +2735,10 @@ private:
         if (!context.isDiscrete)
             blendedFontItalic = blendFunc(fromFontItalic, toFontItalic, context);
 
-        auto* currentFontSelector = destination.fontCascade().fontSelector();
         auto description = destination.fontDescription();
         description.setItalic(blendedFontItalic);
         description.setFontStyleAxis(blendedStyleAxis);
         destination.setFontDescription(WTFMove(description));
-        destination.fontCascade().update(currentFontSelector);
     }
 };
 
@@ -3281,12 +3279,10 @@ private:
     void blend(RenderStyle& destination, const RenderStyle& from, const RenderStyle& to, const CSSPropertyBlendingContext& context) const override
     {
         ASSERT(!context.progress || context.progress == 1.0);
-        FontSelector* currentFontSelector = destination.fontCascade().fontSelector();
         auto destinationDescription = destination.fontDescription();
         auto& sourceDescription = (context.progress ? to : from).fontDescription();
         setPropertiesInFontDescription(sourceDescription, destinationDescription);
         destination.setFontDescription(WTFMove(destinationDescription));
-        destination.fontCascade().update(currentFontSelector);
     }
 
 #if !LOG_DISABLED

--- a/Source/WebCore/css/query/MediaQueryEvaluator.cpp
+++ b/Source/WebCore/css/query/MediaQueryEvaluator.cpp
@@ -87,7 +87,6 @@ bool MediaQueryEvaluator::evaluate(const MediaQuery& query) const
         fontDescription.setComputedSize(size);
         fontDescription.setSpecifiedSize(size);
         defaultStyle.setFontDescription(WTFMove(fontDescription));
-        defaultStyle.fontCascade().update();
 
         FeatureEvaluationContext context { *document, { *m_rootElementStyle, &defaultStyle, nullptr, document->renderView() }, nullptr };
         return evaluateCondition(*query.condition, context);

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4447,7 +4447,7 @@ void Page::recomputeTextAutoSizingInAllFrames()
                 if (RefPtr element = renderer.element()) {
                     if (auto adjustment = Style::Adjuster::adjustmentForTextAutosizing(renderer.style(), *element)) {
                         auto newStyle = RenderStyle::clone(renderer.style());
-                        Style::Adjuster::adjustForTextAutosizing(newStyle, *element, adjustment);
+                        Style::Adjuster::adjustForTextAutosizing(newStyle, adjustment);
                         renderer.setStyle(WTFMove(newStyle));
                     }
                 }

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -1906,9 +1906,11 @@ TextStream& operator<<(TextStream& ts, const FontCascade& fontCascade)
 {
     ts << fontCascade.fontDescription();
 
-    ts << ", font selector " << fontCascade.fonts()->fontSelector();
-    ts << ", font selector version " << fontCascade.fonts()->fontSelectorVersion();
-    ts << ", generation " << fontCascade.fonts()->generation();
+    if (fontCascade.fonts()) {
+        ts << ", font selector " << fontCascade.fonts()->fontSelector();
+        ts << ", font selector version " << fontCascade.fonts()->fontSelectorVersion();
+        ts << ", generation " << fontCascade.fonts()->generation();
+    }
 
     return ts;
 }

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -530,7 +530,7 @@ static void logStyleDifference(const RenderElement& renderer, const RenderStyle&
     diffStream.increaseIndent(2);
     style1.dumpDifferences(diffStream, style2);
     if (!diffStream.isEmpty())
-        LOG_WITH_STREAM(Style, stream << renderer << " style diff " << diff << " (context sensitive changes " << contextSensitiveProperties << "):\n" << diffStream.release());
+        LOG_WITH_STREAM(Style, stream << renderer << " style diff [" << diff << "] (context sensitive changes " << contextSensitiveProperties << "):\n" << diffStream.release());
 }
 #endif
 

--- a/Source/WebCore/rendering/RenderListItem.cpp
+++ b/Source/WebCore/rendering/RenderListItem.cpp
@@ -80,7 +80,6 @@ RenderStyle RenderListItem::computeMarkerStyle() const
     auto fontDescription = style().fontDescription();
     fontDescription.setVariantNumericSpacing(FontVariantNumericSpacing::TabularNumbers);
     markerStyle.setFontDescription(WTFMove(fontDescription));
-    markerStyle.fontCascade().update(&document().fontSelector());
     markerStyle.setUnicodeBidi(UnicodeBidi::Isolate);
     markerStyle.setWhiteSpaceCollapse(WhiteSpaceCollapse::Preserve);
     markerStyle.setTextWrapMode(TextWrapMode::NoWrap);

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -1323,8 +1323,7 @@ void RenderTheme::adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle
     if (auto themeFont = Theme::singleton().controlFont(appearance, style.fontCascade(), style.usedZoom())) {
         // If overriding the specified font with the theme font, also override the line height with the standard line height.
         style.setLineHeight(RenderStyle::initialLineHeight());
-        if (style.setFontDescription(WTFMove(themeFont.value())))
-            style.fontCascade().update(nullptr);
+        style.setFontDescription(WTFMove(themeFont.value()));
     }
 
     // Special style that tells enabled default buttons in active windows to use the ActiveButtonText color.

--- a/Source/WebCore/rendering/TextAutoSizing.cpp
+++ b/Source/WebCore/rendering/TextAutoSizing.cpp
@@ -134,7 +134,6 @@ auto TextAutoSizingValue::adjustTextNodeSizes() -> StillHasNodes
         auto fontDescription = style.fontDescription();
         fontDescription.setComputedSize(averageSize);
         style.setFontDescription(FontCascadeDescription { fontDescription });
-        style.fontCascade().update(&node->document().fontSelector());
         parentRenderer->setStyle(WTFMove(style));
 
         if (parentRenderer->isAnonymousBlock())
@@ -144,7 +143,6 @@ auto TextAutoSizingValue::adjustTextNodeSizes() -> StillHasNodes
         if (auto* listMarkerRenderer = dynamicDowncast<RenderListMarker>(*parentRenderer->firstChild())) {
             auto style = cloneRenderStyleWithState(listMarkerRenderer->style());
             style.setFontDescription(FontCascadeDescription { fontDescription });
-            style.fontCascade().update(&node->document().fontSelector());
             listMarkerRenderer->setStyle(WTFMove(style));
         }
 
@@ -167,7 +165,6 @@ auto TextAutoSizingValue::adjustTextNodeSizes() -> StillHasNodes
         newParentStyle.setLineHeight(lineHeightLength.isNormal() ? Length(lineHeightLength) : Length(lineHeight, LengthType::Fixed));
         newParentStyle.setSpecifiedLineHeight(Length { lineHeightLength });
         newParentStyle.setFontDescription(WTFMove(fontDescription));
-        newParentStyle.fontCascade().update(&node->document().fontSelector());
         parentRenderer->setStyle(WTFMove(newParentStyle));
 
         builder.updateAfterDescendants(*parentRenderer);
@@ -192,7 +189,6 @@ auto TextAutoSizingValue::adjustTextNodeSizes() -> StillHasNodes
             auto fontDescription = firstLetterStyle->fontDescription();
             fontDescription.setComputedSize(averageSize * fontDescription.specifiedSize() / parentStyle.fontDescription().specifiedSize());
             firstLetterStyle->setFontDescription(FontCascadeDescription { fontDescription });
-            firstLetterStyle->fontCascade().update(&node->document().fontSelector());
         }
 
         builder.updateAfterDescendants(*block);
@@ -224,7 +220,6 @@ void TextAutoSizingValue::reset()
             fontDescription.setComputedSize(originalSize);
             auto style = cloneRenderStyleWithState(renderer->style());
             style.setFontDescription(FontCascadeDescription { fontDescription });
-            style.fontCascade().update(&node->document().fontSelector());
             parentRenderer->setStyle(WTFMove(style));
         }
 
@@ -240,7 +235,6 @@ void TextAutoSizingValue::reset()
         auto newParentStyle = cloneRenderStyleWithState(parentStyle);
         newParentStyle.setLineHeight(Length { originalLineHeight });
         newParentStyle.setFontDescription(WTFMove(fontDescription));
-        newParentStyle.fontCascade().update(&node->document().fontSelector());
         parentRenderer->setStyle(WTFMove(newParentStyle));
     }
 }

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -900,9 +900,7 @@ static void setFontFromControlSize(RenderStyle& style, NSControlSize controlSize
 
     // Reset line height
     style.setLineHeight(RenderStyle::initialLineHeight());
-
-    if (style.setFontDescription(WTFMove(fontDescription)))
-        style.fontCascade().update(nullptr);
+    style.setFontDescription(WTFMove(fontDescription));
 }
 
 #if ENABLE(DATALIST_ELEMENT)

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2767,10 +2767,24 @@ void RenderStyle::setFontCascade(FontCascade&& fontCascade)
     m_inheritedData.access().fontCascade = fontCascade;
 }
 
-bool RenderStyle::setFontDescription(FontCascadeDescription&& description)
+void RenderStyle::setFontDescription(FontCascadeDescription&& description)
+{
+    if (fontDescription() == description)
+        return;
+
+    auto existingFontCascade = this->fontCascade();
+    RefPtr fontSelector = existingFontCascade.fontSelector();
+
+    auto newCascade = FontCascade { WTFMove(description), existingFontCascade };
+    newCascade.update(WTFMove(fontSelector));
+    setFontCascade(WTFMove(newCascade));
+}
+
+bool RenderStyle::setFontDescriptionWithoutUpdate(FontCascadeDescription&& description)
 {
     if (fontDescription() == description)
         return false;
+
     auto& cascade = m_inheritedData.access().fontCascade;
     cascade = { WTFMove(description), cascade };
     return true;
@@ -2855,11 +2869,9 @@ void RenderStyle::setLetterSpacing(Length&& spacing)
     // Switching letter-spacing between zero and non-zero requires updating fonts (to enable/disable ligatures)
     bool shouldDisableLigatures = fontCascade().letterSpacing();
     if (oldShouldDisableLigatures != shouldDisableLigatures) {
-        auto* selector = fontCascade().fontSelector();
         auto description = fontDescription();
         description.setShouldDisableLigaturesForSpacing(fontCascade().letterSpacing());
         setFontDescription(WTFMove(description));
-        fontCascade().update(selector);
     }
 }
 
@@ -2874,22 +2886,16 @@ void RenderStyle::setWordSpacing(Length&& spacing)
 
 void RenderStyle::setTextSpacingTrim(TextSpacingTrim value)
 {
-    auto selector = fontCascade().fontSelector();
     auto description = fontDescription();
     description.setTextSpacingTrim(value);
-
     setFontDescription(WTFMove(description));
-    fontCascade().update(selector);
 }
 
 void RenderStyle::setTextAutospace(TextAutospace value)
 {
-    auto selector = fontCascade().fontSelector();
     auto description = fontDescription();
     description.setTextAutospace(value);
-
     setFontDescription(WTFMove(description));
-    fontCascade().update(selector);
 }
 
 void RenderStyle::setFontSize(float size)
@@ -2903,83 +2909,59 @@ void RenderStyle::setFontSize(float size)
     else
         size = std::min(maximumAllowedFontSize, size);
 
-    auto selector = fontCascade().fontSelector();
     auto description = fontDescription();
     description.setSpecifiedSize(size);
     description.setComputedSize(size);
-
     setFontDescription(WTFMove(description));
-    fontCascade().update(selector);
 }
 
 void RenderStyle::setFontSizeAdjust(FontSizeAdjust sizeAdjust)
 {
-    auto selector = fontCascade().fontSelector();
     auto description = fontDescription();
     description.setFontSizeAdjust(sizeAdjust);
-
     setFontDescription(WTFMove(description));
-    fontCascade().update(selector);
 }
 
 void RenderStyle::setFontOpticalSizing(FontOpticalSizing opticalSizing)
 {
-    auto selector = fontCascade().fontSelector();
     auto description = fontDescription();
     description.setOpticalSizing(opticalSizing);
-
     setFontDescription(WTFMove(description));
-    fontCascade().update(selector);
 }
 
 void RenderStyle::setFontVariationSettings(FontVariationSettings settings)
 {
-    auto selector = fontCascade().fontSelector();
     auto description = fontDescription();
     description.setVariationSettings(WTFMove(settings));
-
     setFontDescription(WTFMove(description));
-    fontCascade().update(selector);
 }
 
 void RenderStyle::setFontWeight(FontSelectionValue value)
 {
-    auto selector = fontCascade().fontSelector();
     auto description = fontDescription();
     description.setWeight(value);
-
     setFontDescription(WTFMove(description));
-    fontCascade().update(selector);
 }
 
 void RenderStyle::setFontStretch(FontSelectionValue value)
 {
-    auto selector = fontCascade().fontSelector();
     auto description = fontDescription();
     description.setStretch(value);
-
     setFontDescription(WTFMove(description));
-    fontCascade().update(selector);
 }
 
 void RenderStyle::setFontItalic(std::optional<FontSelectionValue> value)
 {
-    auto selector = fontCascade().fontSelector();
     auto description = fontDescription();
     description.setItalic(value);
-
     setFontDescription(WTFMove(description));
-    fontCascade().update(selector);
 }
 
 void RenderStyle::setFontPalette(const FontPalette& value)
 {
-    auto selector = fontCascade().fontSelector();
     auto description = fontDescription();
     description.setFontPalette(value);
-
     setFontDescription(WTFMove(description));
-    fontCascade().update(selector);
 }
 
 void RenderStyle::getShadowHorizontalExtent(const ShadowData* shadow, LayoutUnit &left, LayoutUnit &right)

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -1269,7 +1269,8 @@ public:
     void setFieldSizing(FieldSizing);
 
     void setFontCascade(FontCascade&&);
-    WEBCORE_EXPORT bool setFontDescription(FontCascadeDescription&&);
+    WEBCORE_EXPORT void setFontDescription(FontCascadeDescription&&);
+    bool setFontDescriptionWithoutUpdate(FontCascadeDescription&&);
 
     // Only used for blending font sizes when animating, for MathML anonymous blocks, and for text autosizing.
     void setFontSize(float);

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
@@ -73,7 +73,6 @@ static std::optional<RenderStyle> styleForFirstLetter(const RenderElement& first
         newFontDescription.setSpecifiedSize(startingFontSize);
         newFontDescription.setComputedSize(startingFontSize);
         firstLetterStyle.setFontDescription(WTFMove(newFontDescription));
-        firstLetterStyle.fontCascade().update(firstLetterStyle.fontCascade().fontSelector());
 
         int desiredCapHeight = (firstLetterStyle.initialLetterHeight() - 1) * lineHeight + paragraph->style().metricsOfPrimaryFont().intCapHeight();
         int actualCapHeight = firstLetterStyle.metricsOfPrimaryFont().intCapHeight();
@@ -82,7 +81,6 @@ static std::optional<RenderStyle> styleForFirstLetter(const RenderElement& first
             newFontDescription.setSpecifiedSize(newFontDescription.specifiedSize() - 1);
             newFontDescription.setComputedSize(newFontDescription.computedSize() -1);
             firstLetterStyle.setFontDescription(WTFMove(newFontDescription));
-            firstLetterStyle.fontCascade().update(firstLetterStyle.fontCascade().fontSelector());
             actualCapHeight = firstLetterStyle.metricsOfPrimaryFont().intCapHeight();
         }
     }

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -1155,14 +1155,13 @@ auto Adjuster::adjustmentForTextAutosizing(const RenderStyle& style, const Eleme
     return adjustmentForTextAutosizing;
 }
 
-bool Adjuster::adjustForTextAutosizing(RenderStyle& style, const Element& element, AdjustmentForTextAutosizing adjustment)
+bool Adjuster::adjustForTextAutosizing(RenderStyle& style, AdjustmentForTextAutosizing adjustment)
 {
     AutosizeStatus::updateStatus(style);
     if (auto newFontSize = adjustment.newFontSize) {
         auto fontDescription = style.fontDescription();
         fontDescription.setComputedSize(*newFontSize);
         style.setFontDescription(WTFMove(fontDescription));
-        style.fontCascade().update(&element.document().fontSelector());
     }
     if (auto newLineHeight = adjustment.newLineHeight)
         style.setLineHeight({ *newLineHeight, LengthType::Fixed });
@@ -1173,7 +1172,7 @@ bool Adjuster::adjustForTextAutosizing(RenderStyle& style, const Element& elemen
 
 bool Adjuster::adjustForTextAutosizing(RenderStyle& style, const Element& element)
 {
-    return adjustForTextAutosizing(style, element, adjustmentForTextAutosizing(style, element));
+    return adjustForTextAutosizing(style, adjustmentForTextAutosizing(style, element));
 }
 #endif
 

--- a/Source/WebCore/style/StyleAdjuster.h
+++ b/Source/WebCore/style/StyleAdjuster.h
@@ -66,7 +66,7 @@ public:
         explicit operator bool() const { return newFontSize || newLineHeight || newStatus; }
     };
     static AdjustmentForTextAutosizing adjustmentForTextAutosizing(const RenderStyle&, const Element&);
-    static bool adjustForTextAutosizing(RenderStyle&, const Element&, AdjustmentForTextAutosizing);
+    static bool adjustForTextAutosizing(RenderStyle&, AdjustmentForTextAutosizing);
     static bool adjustForTextAutosizing(RenderStyle&, const Element&);
 #endif
 

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -200,7 +200,7 @@ void BuilderState::updateFontForTextSizeAdjust()
     else
         newFontDescription.setComputedSize(newFontDescription.specifiedSize());
 
-    m_style.setFontDescription(WTFMove(newFontDescription));
+    m_style.setFontDescriptionWithoutUpdate(WTFMove(newFontDescription));
 }
 #endif
 
@@ -213,7 +213,7 @@ void BuilderState::updateFontForZoomChange()
     auto newFontDescription = childFont;
     setFontSize(newFontDescription, childFont.specifiedSize());
 
-    m_style.setFontDescription(WTFMove(newFontDescription));
+    m_style.setFontDescriptionWithoutUpdate(WTFMove(newFontDescription));
 }
 
 void BuilderState::updateFontForGenericFamilyChange()
@@ -243,7 +243,7 @@ void BuilderState::updateFontForGenericFamilyChange()
 
     auto newFontDescription = childFont;
     setFontSize(newFontDescription, size);
-    m_style.setFontDescription(WTFMove(newFontDescription));
+    m_style.setFontDescriptionWithoutUpdate(WTFMove(newFontDescription));
 }
 
 void BuilderState::updateFontForOrientationChange()
@@ -257,7 +257,7 @@ void BuilderState::updateFontForOrientationChange()
     auto newFontDescription = fontDescription;
     newFontDescription.setNonCJKGlyphOrientation(glyphOrientation);
     newFontDescription.setOrientation(fontOrientation);
-    m_style.setFontDescription(WTFMove(newFontDescription));
+    m_style.setFontDescriptionWithoutUpdate(WTFMove(newFontDescription));
 }
 
 void BuilderState::setFontSize(FontCascadeDescription& fontDescription, float size)

--- a/Source/WebCore/style/StyleBuilderStateInlines.h
+++ b/Source/WebCore/style/StyleBuilderStateInlines.h
@@ -34,7 +34,7 @@ namespace Style {
 inline const FontCascadeDescription& BuilderState::fontDescription() { return m_style.fontDescription(); }
 inline const FontCascadeDescription& BuilderState::parentFontDescription() { return parentStyle().fontDescription(); }
 inline void BuilderState::setUsedZoom(float zoom) { m_fontDirty |= m_style.setUsedZoom(zoom); }
-inline void BuilderState::setFontDescription(FontCascadeDescription&& description) { m_fontDirty |= m_style.setFontDescription(WTFMove(description)); }
+inline void BuilderState::setFontDescription(FontCascadeDescription&& description) { m_fontDirty |= m_style.setFontDescriptionWithoutUpdate(WTFMove(description)); }
 inline void BuilderState::setTextOrientation(TextOrientation orientation) { m_fontDirty |= m_style.setTextOrientation(orientation); }
 inline void BuilderState::setWritingMode(StyleWritingMode mode) { m_fontDirty |= m_style.setWritingMode(mode); }
 inline void BuilderState::setZoom(float zoom) { m_fontDirty |= m_style.setZoom(zoom); }

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -592,8 +592,6 @@ std::unique_ptr<RenderStyle> Resolver::defaultStyleForElement(const Element* ele
     fontDescription.setShouldAllowUserInstalledFonts(settings().shouldAllowUserInstalledFonts() ? AllowUserInstalledFonts::Yes : AllowUserInstalledFonts::No);
     style->setFontDescription(WTFMove(fontDescription));
 
-    style->fontCascade().update(&document().fontSelector());
-
     return style;
 }
 


### PR DESCRIPTION
#### 68c05597505a5eb712c742bfed10d35be8db2654
<pre>
Callers of RenderStyle::setFontDescription() should not have to manually call fontCascade().update()
<a href="https://bugs.webkit.org/show_bug.cgi?id=284139">https://bugs.webkit.org/show_bug.cgi?id=284139</a>
<a href="https://rdar.apple.com/141019117">rdar://141019117</a>

Reviewed by Alan Baradlay.

`RenderStyle::setFontDescription()` is written in a way that requires callers to
subsequently call `fontCascade().update()`, because `setFontDescription` computes a new
FontCascade that is lacking a FontCascadeFonts. A call to update() is needed to compute
the fonts, and in addition the callers has to get a FontSelector from somewhere to pass
in.

Fix by having `RenderStyle::setFontDescription()` call FontCascade::update() internally.

There is only one caller who cares about batching, which is Style::BuilderState. For it,
we expose `setFontDescriptionWithoutUpdate()` which has the old behavior.

We also need to ensure that `Style::resolveForDocument()` builds a FontCascade in a way
that provides the fontSelector.

* Source/WebCore/animation/CSSPropertyAnimation.cpp:
* Source/WebCore/css/query/MediaQueryEvaluator.cpp:
(WebCore::MQ::MediaQueryEvaluator::evaluate const):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::recomputeTextAutoSizingInAllFrames):
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/RenderCombineText.cpp:
(WebCore::RenderCombineText::combineTextIfNeeded):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::logStyleDifference):
* Source/WebCore/rendering/RenderListItem.cpp:
(WebCore::RenderListItem::computeMarkerStyle const):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle const):
* Source/WebCore/rendering/TextAutoSizing.cpp:
(WebCore::TextAutoSizingValue::adjustTextNodeSizes):
(WebCore::TextAutoSizingValue::reset):
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
(WebCore::setFontFromControlSize):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::setFontDescription):
(WebCore::RenderStyle::setFontDescriptionWithoutUpdate):
(WebCore::RenderStyle::setLetterSpacing):
(WebCore::RenderStyle::setTextSpacingTrim):
(WebCore::RenderStyle::setTextAutospace):
(WebCore::RenderStyle::setFontSize):
(WebCore::RenderStyle::setFontSizeAdjust):
(WebCore::RenderStyle::setFontOpticalSizing):
(WebCore::RenderStyle::setFontVariationSettings):
(WebCore::RenderStyle::setFontWeight):
(WebCore::RenderStyle::setFontStretch):
(WebCore::RenderStyle::setFontItalic):
(WebCore::RenderStyle::setFontPalette):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp:
(WebCore::styleForFirstLetter):
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjustForTextAutosizing):
* Source/WebCore/style/StyleAdjuster.h:
* Source/WebCore/style/StyleBuilderState.cpp:
(WebCore::Style::BuilderState::updateFontForTextSizeAdjust):
(WebCore::Style::BuilderState::updateFontForZoomChange):
(WebCore::Style::BuilderState::updateFontForGenericFamilyChange):
(WebCore::Style::BuilderState::updateFontForOrientationChange):
* Source/WebCore/style/StyleBuilderStateInlines.h:
(WebCore::Style::BuilderState::setFontDescription):
* Source/WebCore/style/StyleResolveForDocument.cpp:
(WebCore::Style::resolveForDocument):
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::defaultStyleForElement):

Canonical link: <a href="https://commits.webkit.org/287465@main">https://commits.webkit.org/287465@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36308af5a481e47a9c30733f54a3e3a5b27a2d86

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79778 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58779 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33177 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84303 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30785 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81887 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67853 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7070 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62361 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20198 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82846 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52413 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72656 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42665 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49755 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26804 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29228 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70884 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27275 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85729 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7013 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4911 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70619 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7186 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68495 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69858 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17409 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13863 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12781 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6970 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12560 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6834 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10342 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8641 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->