### PR TITLE
[iOS] MediaRecorder fails to generate a mp4

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/AVAssetWriterSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/AVAssetWriterSPI.h
@@ -48,6 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 #if !HAVE(AVASSETWRITERDELEGATE_API)
 @property (weak, nullable) id <AVAssetWriterDelegate> delegate SPI_AVAILABLE(macos(10.15), ios(13.0), tvos(13.0), watchos(6.0));
 #endif
+@property (nonatomic) BOOL requiresInProcessOperation SPI_AVAILABLE(ios(16.4), tvos(16.4), watchos(9.4), visionos(1.0)) API_UNAVAILABLE(macos, macCatalyst);
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.mm
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.mm
@@ -140,6 +140,9 @@ bool MediaRecorderPrivateWriterAVFObjC::allTracksAdded()
     // AVFileTypeProfileMPEG4AppleHLS allows muxed audio and video inputs
     // AVFileTypeProfileMPEG4CMAFCompliant allows only a single audio or video input
     [m_writer setOutputFileTypeProfile:m_currentTrackIndex > 1 ? AVFileTypeProfileMPEG4AppleHLS : AVFileTypeProfileMPEG4CMAFCompliant];
+#if PLATFORM(IOS_FAMILY) && !PLATFORM(MACCATALYST)
+    [m_writer setRequiresInProcessOperation:YES];
+#endif
 
     BEGIN_BLOCK_OBJC_EXCEPTIONS
     if (![m_writer startWriting]) {


### PR DESCRIPTION
#### 08cb3b1c6e552aa8a691398cbb555418cb841f53
<pre>
[iOS] MediaRecorder fails to generate a mp4
<a href="https://bugs.webkit.org/show_bug.cgi?id=284141">https://bugs.webkit.org/show_bug.cgi?id=284141</a>
<a href="https://rdar.apple.com/141017179">rdar://141017179</a>

Reviewed by Andy Estes.

Make the AVAssetWriter works in process.

Manually tested. Our automated tests are using simulator which doesn&apos;t use
out of process operations.

* Source/WebCore/PAL/pal/spi/cocoa/AVAssetWriterSPI.h:
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.mm:
(WebCore::MediaRecorderPrivateWriterAVFObjC::allTracksAdded):

Canonical link: <a href="https://commits.webkit.org/287432@main">https://commits.webkit.org/287432@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c31424f8682701be2d61366bb73ab2d5b4dbee95

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79697 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58692 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33087 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84230 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30720 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81805 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67775 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6984 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62286 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20142 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82764 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52345 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72571 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42594 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49689 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26722 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29154 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/70826 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27185 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85651 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6936 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4837 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70540 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7106 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68416 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69784 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17394 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13800 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6889 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6766 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10269 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8570 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->