### PR TITLE
AX: [Site Isolation] support hit testing

### DIFF
--- a/LayoutTests/http/tests/site-isolation/accessibility/hit-test-resolving-remote-frame-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/accessibility/hit-test-resolving-remote-frame-expected.txt
@@ -1,0 +1,9 @@
+This test ensures that hit testing with site isolation enabled returns the right accessibility element when the remote element is resolved.
+
+iframe rect: 8, 8
+Element at (58, 58): Role: AXStaticText, Value: Hello, world!
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/accessibility/hit-test-resolving-remote-frame.html
+++ b/LayoutTests/http/tests/site-isolation/accessibility/hit-test-resolving-remote-frame.html
@@ -1,0 +1,35 @@
+<html><!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<style>
+</style>
+</head>
+<body id="body">
+
+<iframe id="iframe" onload="runTest()" src="http://localhost:8000/site-isolation/resources/iframe.html"></iframe>
+
+<script>
+var output = "This test ensures that hit testing with site isolation enabled returns the right accessibility element when the remote element is resolved.\n\n";
+
+function runTest() {
+    if (window.accessibilityController) {
+        window.jsTestIsAsync = true;
+
+        const iframeRect = document.getElementById("iframe").getBoundingClientRect();
+
+        output += `iframe rect: ${iframeRect.x}, ${iframeRect.y}\n`;
+
+        setTimeout(async function() {
+            var axElement = accessibilityController.rootElement.elementAtPointResolvingRemoteFrameForTesting(iframeRect.x + 50, iframeRect.y + 50, function (result) {
+                output += `Element at (${iframeRect.x + 50}, ${iframeRect.y + 50}): ${result}\n`;
+
+                debug(output);
+                finishJSTest();
+            });
+        }, 0);
+    }
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/http/tests/site-isolation/accessibility/hit-test-returns-remote-frame-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/accessibility/hit-test-returns-remote-frame-expected.txt
@@ -1,0 +1,13 @@
+This test ensures that hit testing with site isolation enabled returns a remote element.
+
+Heading rect: 8, 8
+iframe rect: 8, 66.4375
+Hit test at "heading" returns a remote element? NO
+Hit test at "iframe" returns a remote element? YES
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Example heading
+
+

--- a/LayoutTests/http/tests/site-isolation/accessibility/hit-test-returns-remote-frame.html
+++ b/LayoutTests/http/tests/site-isolation/accessibility/hit-test-returns-remote-frame.html
@@ -1,0 +1,39 @@
+<html><!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<style>
+</style>
+</head>
+<body id="body">
+
+<h1 id="heading">Example heading</h1>
+<iframe id="iframe" onload="runTest()" src="http://localhost:8000/site-isolation/resources/iframe.html"></iframe>
+
+<script>
+var output = "This test ensures that hit testing with site isolation enabled returns a remote element.\n\n";
+
+function runTest() {
+    if (window.accessibilityController) {
+        window.jsTestIsAsync = true;
+        
+        const headingRect = document.getElementById("heading").getBoundingClientRect();
+        const iframeRect = document.getElementById("iframe").getBoundingClientRect();
+
+        output += `Heading rect: ${headingRect.x}, ${headingRect.y}\n`;
+        output += `iframe rect: ${iframeRect.x}, ${iframeRect.y}\n`;
+
+        setTimeout(async function() {
+            var headingHitTest = accessibilityController.rootElement.elementAtPointWithRemoteElementForTesting(headingRect.x + 10, headingRect.y + 10);
+            output += `Hit test at "heading" returns a remote element? ${headingHitTest.isRemoteFrame ? "YES" : "NO"}\n`;
+            var iframeHitTest = accessibilityController.rootElement.elementAtPointWithRemoteElementForTesting(iframeRect.x + 50, iframeRect.y + 50);
+            output += `Hit test at "iframe" returns a remote element? ${iframeHitTest.isRemoteFrame ? "YES" : "NO"}\n`;
+
+            debug(output);
+            finishJSTest();
+        }, 0);
+    }
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/http/tests/site-isolation/resources/iframe.html
+++ b/LayoutTests/http/tests/site-isolation/resources/iframe.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Site Isolation frame test</title>
+    </head>
+    <body>
+        <h1 id="text" style="font-size: 200px; margin: 0;">Hello, world!</h1>
+    </body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -1366,6 +1366,9 @@ imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-pus
 # Needs special fuzziness on iOS.
 imported/w3c/web-platform-tests/css/css-view-transitions/rotated-cat-off-top-edge.html [ ImageOnlyFailure ]
 
+# Site isolation testing infrastructure for accessibility doesn't exist on iOS.
+http/tests/site-isolation/accessibility/ [ Skip ]
+
 ###
 # Known failures
 ##

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -931,6 +931,11 @@ String LineDecorationStyle::debugDescription() const
     );
 }
 
+String AXCoreObject::infoStringForTesting() const
+{
+    return makeString("Role: "_s, rolePlatformString(), ", Value: "_s, stringValue());
+}
+
 namespace Accessibility {
 
 bool inRenderTreeOrStyleUpdate(const Document& document)

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -765,6 +765,7 @@ struct AttributedStringStyle {
 
 enum class AXDebugStringOption {
     Ignored,
+    IsRemoteFrame,
     RelativeFrame,
     RemoteFrameOffset
 };
@@ -1441,6 +1442,8 @@ public:
 #if PLATFORM(COCOA) && ENABLE(MODEL_ELEMENT)
     virtual Vector<RetainPtr<id>> modelElementChildren() = 0;
 #endif
+
+    String infoStringForTesting() const;
 
 protected:
     AXCoreObject() = delete;

--- a/Source/WebCore/accessibility/AXRemoteFrame.h
+++ b/Source/WebCore/accessibility/AXRemoteFrame.h
@@ -40,6 +40,8 @@ public:
     std::span<const uint8_t> generateRemoteToken() const;
     RetainPtr<id> remoteFramePlatformElement() const final { return m_remoteFramePlatformElement; }
     pid_t processIdentifier() const { return m_processIdentifier; }
+    std::optional<FrameIdentifier> frameID() const { return m_frameID; }
+    void setFrameID(FrameIdentifier frameID) { m_frameID = frameID; }
 #endif
 
 private:
@@ -54,6 +56,7 @@ private:
 #if PLATFORM(COCOA)
     RetainPtr<id> m_remoteFramePlatformElement;
     pid_t m_processIdentifier { 0 };
+    std::optional<FrameIdentifier> m_frameID { };
 #endif
 };
 

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -2006,8 +2006,12 @@ AccessibilityObject* AccessibilityRenderObject::accessibilityHitTest(const IntPo
     if (!m_renderer || !m_renderer->hasLayer())
         return nullptr;
 
+    // Adjust point for the remoteFrameOffset
+    IntPoint adjustedPoint = point;
+    adjustedPoint.moveBy(-remoteFrameOffset());
+
     constexpr OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::AccessibilityHitTest };
-    HitTestResult hitTestResult { point };
+    HitTestResult hitTestResult { adjustedPoint };
 
     dynamicDowncast<RenderLayerModelObject>(*m_renderer)->layer()->hitTest(hitType, hitTestResult);
     RefPtr node = hitTestResult.innerNode();

--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -239,6 +239,7 @@ void AccessibilityScrollView::addRemoteFrameChild()
 #if PLATFORM(MAC)
         // Generate a new token and pass it back to the other remote frame so it can bind these objects together.
         Ref remoteFrame = remoteFrameView->frame();
+        m_remoteFrame->setFrameID(remoteFrame->frameID());
         remoteFrame->bindRemoteAccessibilityFrames(getpid(), { m_remoteFrame->generateRemoteToken() }, [this, &remoteFrame, protectedAccessbilityRemoteFrame = RefPtr { m_remoteFrame }] (Vector<uint8_t> token, int processIdentifier) mutable {
             protectedAccessbilityRemoteFrame->initializePlatformElementWithRemoteToken(token.span(), processIdentifier);
 

--- a/Source/WebCore/accessibility/AccessibilityScrollView.h
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "AXRemoteFrame.h"
 #include "AccessibilityObject.h"
 #include "ScrollView.h"
 
@@ -45,6 +46,8 @@ public:
 
     AccessibilityObject* webAreaObject() const final;
     void setNeedsToUpdateChildren() final { m_childrenDirty = true; }
+
+    RefPtr<AXRemoteFrame> remoteFrame() const { return m_remoteFrame; }
 
 private:
     explicit AccessibilityScrollView(AXID, ScrollView&);

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.h
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.h
@@ -137,6 +137,8 @@ extern "C" AXUIElementRef NSAccessibilityCreateAXUIElementRef(id element);
 
 // When a plugin uses a WebKit control to act as a surrogate view (e.g. PDF use WebKit to create text fields).
 - (id)_associatedPluginParent;
+// For testing use only.
+- (void)_accessibilityHitTestResolvingRemoteFrame:(NSPoint)point callback:(void(^)(NSString *))callback;
 
 @end
 

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -563,6 +563,8 @@ public:
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
     virtual void isAnyAnimationAllowedToPlayDidChange(bool /* anyAnimationCanPlay */) { };
 #endif
+    virtual void resolveAccessibilityHitTestForTesting(WebCore::FrameIdentifier, const IntPoint&, CompletionHandler<void(String)>&& callback) { callback(""_s); };
+
     virtual void isPlayingMediaDidChange(MediaProducerMediaStateFlags) { }
     virtual void handleAutoplayEvent(AutoplayEvent, OptionSet<AutoplayEventFlags>) { }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6373,6 +6373,11 @@ void WebPageProxy::updateRemoteFrameSize(WebCore::FrameIdentifier frameID, WebCo
     sendToProcessContainingFrame(frameID, Messages::WebPage::UpdateFrameSize(frameID, size));
 }
 
+void WebPageProxy::resolveAccessibilityHitTestForTesting(WebCore::FrameIdentifier frameID, WebCore::IntPoint point, CompletionHandler<void(String)>&& callback)
+{
+    sendWithAsyncReplyToProcessContainingFrame(frameID, Messages::WebPage::ResolveAccessibilityHitTestForTesting(point), WTFMove(callback));
+}
+
 void WebPageProxy::updateSandboxFlags(IPC::Connection& connection, WebCore::FrameIdentifier frameID, WebCore::SandboxFlags sandboxFlags)
 {
     if (RefPtr frame = WebFrameProxy::webFrame(frameID)) {

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2688,6 +2688,7 @@ private:
 #endif
 
     void updateRemoteFrameSize(WebCore::FrameIdentifier, WebCore::IntSize);
+    void resolveAccessibilityHitTestForTesting(WebCore::FrameIdentifier, WebCore::IntPoint, CompletionHandler<void(String)>&&);
     void updateSandboxFlags(IPC::Connection&, WebCore::FrameIdentifier, WebCore::SandboxFlags);
     void updateOpener(IPC::Connection&, WebCore::FrameIdentifier, WebCore::FrameIdentifier);
     void updateScrollingMode(IPC::Connection&, WebCore::FrameIdentifier, WebCore::ScrollbarMode);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -150,6 +150,7 @@ messages -> WebPageProxy {
     UpdateOpener(WebCore::FrameIdentifier frameID, WebCore::FrameIdentifier newOpener)
     [EnabledBy=SiteIsolationEnabled] UpdateScrollingMode(WebCore::FrameIdentifier frameID, enum:uint8_t WebCore::ScrollbarMode scrollingMode)
     [EnabledBy=SiteIsolationEnabled] UpdateRemoteFrameSize(WebCore::FrameIdentifier frameID, WebCore::IntSize size)
+    ResolveAccessibilityHitTestForTesting(WebCore::FrameIdentifier frameID, WebCore::IntPoint point) -> (String result)
 
     MainFramePluginHandlesPageScaleGestureDidChange(bool mainFramePluginHandlesPageScaleGesture, double minScale, double maxScale)
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1506,6 +1506,11 @@ void WebChromeClient::isAnyAnimationAllowedToPlayDidChange(bool anyAnimationCanP
 }
 #endif
 
+void WebChromeClient::resolveAccessibilityHitTestForTesting(FrameIdentifier frameID, const IntPoint& point, CompletionHandler<void(String)>&& callback)
+{
+    protectedPage()->sendWithAsyncReply(Messages::WebPageProxy::ResolveAccessibilityHitTestForTesting(frameID, point), WTFMove(callback));
+}
+
 void WebChromeClient::isPlayingMediaDidChange(MediaProducerMediaStateFlags state)
 {
     protectedPage()->isPlayingMediaDidChange(state);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -390,6 +390,7 @@ private:
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
     void isAnyAnimationAllowedToPlayDidChange(bool /* anyAnimationCanPlay */) final;
 #endif
+    void resolveAccessibilityHitTestForTesting(WebCore::FrameIdentifier, const WebCore::IntPoint&, CompletionHandler<void(String)>&&) final;
     void isPlayingMediaDidChange(WebCore::MediaProducerMediaStateFlags) final;
     void handleAutoplayEvent(WebCore::AutoplayEvent, OptionSet<WebCore::AutoplayEventFlags>) final;
 

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -473,6 +473,22 @@ void WebPage::bindRemoteAccessibilityFrames(int processIdentifier, WebCore::Fram
     completionHandler({ span(accessibilityRemoteTokenData().get()) }, getpid());
 }
 
+void WebPage::resolveAccessibilityHitTestForTesting(const WebCore::IntPoint& point, CompletionHandler<void(String)>&& completionHandler)
+{
+#if PLATFORM(MAC)
+    if (id coreObject = [m_mockAccessibilityElement accessibilityRootObjectWrapper]) {
+        if (id hitTestResult = [coreObject accessibilityHitTest:point]) {
+            ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+            completionHandler([hitTestResult accessibilityAttributeValue:@"AXInfoStringForTesting"]);
+            ALLOW_DEPRECATED_DECLARATIONS_END
+            return;
+        }
+    }
+#endif
+    UNUSED_PARAM(point);
+    completionHandler(makeString("NULL"_s));
+}
+
 #if ENABLE(APPLE_PAY)
 WebPaymentCoordinator* WebPage::paymentCoordinator()
 {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1634,6 +1634,10 @@ void WebPage::bindRemoteAccessibilityFrames(int, WebCore::FrameIdentifier, Vecto
 {
 }
 
+void WebPage::resolveAccessibilityHitTestForTesting(const WebCore::IntPoint&, CompletionHandler<void(String)>&&)
+{
+}
+
 void WebPage::updateRemotePageAccessibilityOffset(WebCore::FrameIdentifier, WebCore::IntPoint)
 {
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2381,6 +2381,7 @@ private:
     void frameTextForTesting(WebCore::FrameIdentifier, CompletionHandler<void(String&&)>&&);
     void bindRemoteAccessibilityFrames(int processIdentifier, WebCore::FrameIdentifier, Vector<uint8_t>, CompletionHandler<void(Vector<uint8_t>, int)>&&);
     void updateRemotePageAccessibilityOffset(WebCore::FrameIdentifier, WebCore::IntPoint);
+    void resolveAccessibilityHitTestForTesting(const WebCore::IntPoint&, CompletionHandler<void(String)>&&);
 
     void requestAllTextAndRects(CompletionHandler<void(Vector<std::pair<String, WebCore::FloatRect>>&&)>&&);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -495,6 +495,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
 
     BindRemoteAccessibilityFrames(int processIdentifier, WebCore::FrameIdentifier frameID, Vector<uint8_t> dataToken) -> (Vector<uint8_t> token, int processIdentifier) Synchronous
     UpdateRemotePageAccessibilityOffset(WebCore::FrameIdentifier frameID, WebCore::IntPoint offset);
+    ResolveAccessibilityHitTestForTesting(WebCore::IntPoint point) -> (String result)
 
 #if PLATFORM(COCOA)
     WindowAndViewFramesChanged(struct WebKit::ViewWindowCoordinates coordinates)

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp
@@ -134,6 +134,9 @@ unsigned AccessibilityUIElement::numberOfCharacters() const { return 0; }
 JSValueRef AccessibilityUIElement::columns(JSContextRef) { return { }; }
 JSRetainPtr<JSStringRef> AccessibilityUIElement::dateValue() { return nullptr; }
 RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::textMarkerRangeForLine(long) { return nullptr; }
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::elementAtPointWithRemoteElementForTesting(int x, int y) { return nullptr; }
+void AccessibilityUIElement::elementAtPointResolvingRemoteFrameForTesting(JSContextRef context, int x, int y, JSValueRef jsCallback) { }
+bool AccessibilityUIElement::isRemoteFrame() const { return false; }
 #endif // !PLATFORM(MAC)
 
 #if !PLATFORM(COCOA)

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
@@ -89,6 +89,9 @@ public:
     JSRetainPtr<JSStringRef> domIdentifier() const;
 
     RefPtr<AccessibilityUIElement> elementAtPoint(int x, int y);
+    RefPtr<AccessibilityUIElement> elementAtPointWithRemoteElementForTesting(int x, int y);
+    void elementAtPointResolvingRemoteFrameForTesting(JSContextRef, int x, int y, JSValueRef callback);
+
     JSValueRef children(JSContextRef);
     RefPtr<AccessibilityUIElement> childAtIndex(unsigned);
     unsigned indexOfChild(AccessibilityUIElement*);
@@ -417,6 +420,7 @@ public:
     bool isDeletion() const;
     bool isFirstItemInSuggestion() const;
     bool isLastItemInSuggestion() const;
+    bool isRemoteFrame() const;
     
     bool isMarkAnnotation() const;
 private:

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl
@@ -29,6 +29,8 @@ interface AccessibilityUIElement {
 
     // Element access.
     AccessibilityUIElement elementAtPoint(long x, long y);
+    AccessibilityUIElement elementAtPointWithRemoteElementForTesting(long x, long y);
+    undefined elementAtPointResolvingRemoteFrameForTesting(long x, long y, object callbackFunction);
     AccessibilityUIElement childAtIndex(unsigned long index);
     unsigned long indexOfChild(AccessibilityUIElement child);
     AccessibilityUIElement linkedUIElementAtIndex(unsigned long index);
@@ -120,6 +122,7 @@ interface AccessibilityUIElement {
     readonly attribute boolean isDeletion;
     readonly attribute boolean isFirstItemInSuggestion;
     readonly attribute boolean isLastItemInSuggestion;
+    readonly attribute boolean isRemoteFrame;
 
     readonly attribute long x;
     readonly attribute long y;


### PR DESCRIPTION
#### 3f3fcdbd0b96c559b4de3a53c56aefe356c09653
<pre>
AX: [Site Isolation] support hit testing
<a href="https://bugs.webkit.org/show_bug.cgi?id=284144">https://bugs.webkit.org/show_bug.cgi?id=284144</a>
<a href="https://rdar.apple.com/141022733">rdar://141022733</a>

Reviewed by Tyler Wilcock.

Two updates had to be made to hit testing to support site isolation/remote frames:
(1) Offset the hit test point by the remote frame offset.
(2) Return the remote frame, when applicable, from elementAccessibilityHitTest.

To validate hit testing works as expected, new AccessibilityUIElement APIs were added.
The first, `elementAtPointWithRemoteElementForTesting`, returns an AXRemoteElement
instead of a platform element, so that layout tests can check if something is a remote
element. The other, `elementAtPointResolvingRemoteFrameForTesting`, simulates how ATs
will resolve remote elements, by sending IPC messages to the remote frame via the UI
process. This method returns a debug string, to make validation easier.

Two new tests were added to verify hit testing behavior, using these new methods.

* LayoutTests/http/tests/site-isolation/accessibility/hit-test-resolving-remote-frame-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/accessibility/hit-test-resolving-remote-frame.html: Added.
* LayoutTests/http/tests/site-isolation/accessibility/hit-test-returns-remote-frame-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/accessibility/hit-test-returns-remote-frame.html: Added.
* LayoutTests/http/tests/site-isolation/resources/iframe.html: Added.
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::infoStringForTesting const):
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXRemoteFrame.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::dbgInternal const):
(WebCore::AccessibilityObject::elementAccessibilityHitTest const):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::accessibilityHitTest const):
* Source/WebCore/accessibility/AccessibilityScrollView.cpp:
(WebCore::AccessibilityScrollView::addRemoteFrameChild):
* Source/WebCore/accessibility/AccessibilityScrollView.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(attributeValueForTesting):
(-[WebAccessibilityObjectWrapper accessibilityHitTest:]):
(-[WebAccessibilityObjectWrapper _accessibilityHitTest:returnPlatformElements:]):
(-[WebAccessibilityObjectWrapper accessibilityHitTestResolvingRemoteFrame:callback:]):
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::resolveAccessibilityHitTestForTesting):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::resolveAccessibilityHitTestForTesting):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::resolveAccessibilityHitTestForTesting):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::resolveAccessibilityHitTestForTesting):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl:
* Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm:
(WTR::AccessibilityUIElement::elementAtPointWithRemoteElementForTesting):
(WTR::elementAtPointResolvingRemoteFrameForTesting):
(WTR::AccessibilityUIElement::isRemoteFrame const):
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
(WTR::attributeValue):
(WTR::AccessibilityUIElement::elementAtPointWithRemoteElementForTesting):
(WTR::AccessibilityUIElement::elementAtPointResolvingRemoteFrameForTesting):
(WTR::AccessibilityUIElement::isRemoteFrame const):

Canonical link: <a href="https://commits.webkit.org/287474@main">https://commits.webkit.org/287474@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47ece6607ae0c94241dd6de68316fb53d50398b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79791 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58792 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33190 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84316 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30797 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81900 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67866 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7083 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62366 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20209 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82859 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52424 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72667 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42707 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49766 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26815 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29241 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70894 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27286 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85742 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7025 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4921 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70644 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7199 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68506 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69865 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17415 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13874 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12792 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6983 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6846 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10355 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8653 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->