### PR TITLE
FontCustomPlatformSerializedData shouldn't copy fontFaceData buffer

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1652,7 +1652,6 @@ platform/graphics/coreimage/FEComponentTransferCoreImageApplier.mm
 platform/graphics/coreimage/FilterImageCoreImage.mm
 platform/graphics/coretext/ComplexTextControllerCoreText.mm
 platform/graphics/coretext/FontCascadeCoreText.cpp
-platform/graphics/coretext/FontCustomPlatformDataCoreText.cpp
 platform/graphics/coretext/FontPlatformDataCoreText.cpp
 platform/graphics/cv/GraphicsContextGLCVCocoa.mm
 platform/graphics/displaylists/DisplayListItem.cpp

--- a/Source/WebCore/platform/graphics/FontCustomPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontCustomPlatformData.h
@@ -58,7 +58,7 @@ template <typename T> class FontTaggedSettings;
 typedef FontTaggedSettings<int> FontFeatureSettings;
 
 struct FontCustomPlatformSerializedData {
-    Vector<uint8_t> fontFaceData;
+    Ref<SharedBuffer> fontFaceData;
     String itemInCollection;
     RenderingResourceIdentifier renderingResourceIdentifier;
 };

--- a/Source/WebCore/platform/graphics/coretext/FontCustomPlatformDataCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCustomPlatformDataCoreText.cpp
@@ -127,8 +127,7 @@ RefPtr<FontCustomPlatformData> FontCustomPlatformData::createMemorySafe(SharedBu
 
 std::optional<Ref<FontCustomPlatformData>> FontCustomPlatformData::tryMakeFromSerializationData(FontCustomPlatformSerializedData&& data, bool shouldUseLockdownFontParser )
 {
-    auto buffer = SharedBuffer::create(WTFMove(data.fontFaceData));
-    RefPtr fontCustomPlatformData = shouldUseLockdownFontParser ? FontCustomPlatformData::createMemorySafe(buffer, data.itemInCollection) : FontCustomPlatformData::create(buffer, data.itemInCollection);
+    RefPtr fontCustomPlatformData = shouldUseLockdownFontParser ? FontCustomPlatformData::createMemorySafe(WTFMove(data.fontFaceData), data.itemInCollection) : FontCustomPlatformData::create(WTFMove(data.fontFaceData), data.itemInCollection);
     if (!fontCustomPlatformData)
         return std::nullopt;
     fontCustomPlatformData->m_renderingResourceIdentifier = data.renderingResourceIdentifier;
@@ -137,7 +136,7 @@ std::optional<Ref<FontCustomPlatformData>> FontCustomPlatformData::tryMakeFromSe
 
 FontCustomPlatformSerializedData FontCustomPlatformData::serializedData() const
 {
-    return FontCustomPlatformSerializedData { { creationData.fontFaceData->span() }, creationData.itemInCollection, m_renderingResourceIdentifier };
+    return FontCustomPlatformSerializedData { creationData.fontFaceData, creationData.itemInCollection, m_renderingResourceIdentifier };
 }
 
 bool FontCustomPlatformData::supportsFormat(const String& format)

--- a/Source/WebCore/platform/graphics/freetype/FontCustomPlatformDataFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontCustomPlatformDataFreeType.cpp
@@ -221,7 +221,7 @@ std::optional<Ref<FontCustomPlatformData>> FontCustomPlatformData::tryMakeFromSe
 FontCustomPlatformSerializedData FontCustomPlatformData::serializedData() const
 {
     ASSERT_NOT_REACHED();
-    return FontCustomPlatformSerializedData { { creationData.fontFaceData->span() }, creationData.itemInCollection, m_renderingResourceIdentifier };
+    return FontCustomPlatformSerializedData { creationData.fontFaceData, creationData.itemInCollection, m_renderingResourceIdentifier };
 }
 
 }

--- a/Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp
@@ -142,8 +142,7 @@ bool FontCustomPlatformData::supportsTechnology(const FontTechnology&)
 
 std::optional<Ref<FontCustomPlatformData>> FontCustomPlatformData::tryMakeFromSerializationData(FontCustomPlatformSerializedData&& data, bool)
 {
-    auto buffer = SharedBuffer::create(WTFMove(data.fontFaceData));
-    RefPtr fontCustomPlatformData = FontCustomPlatformData::create(buffer, data.itemInCollection);
+    RefPtr fontCustomPlatformData = FontCustomPlatformData::create(WTFMove(data.fontFaceData), data.itemInCollection);
     if (!fontCustomPlatformData)
         return std::nullopt;
     fontCustomPlatformData->m_renderingResourceIdentifier = data.renderingResourceIdentifier;
@@ -152,7 +151,7 @@ std::optional<Ref<FontCustomPlatformData>> FontCustomPlatformData::tryMakeFromSe
 
 FontCustomPlatformSerializedData FontCustomPlatformData::serializedData() const
 {
-    return FontCustomPlatformSerializedData { { creationData.fontFaceData->span() }, creationData.itemInCollection, m_renderingResourceIdentifier };
+    return FontCustomPlatformSerializedData { creationData.fontFaceData, creationData.itemInCollection, m_renderingResourceIdentifier };
 }
 
 }

--- a/Source/WebCore/platform/graphics/win/FontCustomPlatformDataWin.cpp
+++ b/Source/WebCore/platform/graphics/win/FontCustomPlatformDataWin.cpp
@@ -99,8 +99,7 @@ bool FontCustomPlatformData::supportsTechnology(const FontTechnology& tech)
 
 std::optional<Ref<FontCustomPlatformData>> FontCustomPlatformData::tryMakeFromSerializationData(FontCustomPlatformSerializedData&& data, bool)
 {
-    auto buffer = SharedBuffer::create(WTFMove(data.fontFaceData));
-    RefPtr fontCustomPlatformData = FontCustomPlatformData::create(buffer, data.itemInCollection);
+    RefPtr fontCustomPlatformData = FontCustomPlatformData::create(WTFMove(data.fontFaceData), data.itemInCollection);
     if (!fontCustomPlatformData)
         return std::nullopt;
     fontCustomPlatformData->m_renderingResourceIdentifier = data.renderingResourceIdentifier;
@@ -109,7 +108,7 @@ std::optional<Ref<FontCustomPlatformData>> FontCustomPlatformData::tryMakeFromSe
 
 FontCustomPlatformSerializedData FontCustomPlatformData::serializedData() const
 {
-    return FontCustomPlatformSerializedData { { creationData.fontFaceData->span() }, creationData.itemInCollection, m_renderingResourceIdentifier };
+    return FontCustomPlatformSerializedData { creationData.fontFaceData, creationData.itemInCollection, m_renderingResourceIdentifier };
 }
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
@@ -82,13 +82,6 @@ header: <WebCore/FontPlatformData.h>
     RetainPtr<CFStringRef> postScriptName;
     std::optional<WebCore::FontPlatformSerializedAttributes> attributes;
 };
-
-header: <WebCore/FontCustomPlatformData.h>
-[CustomHeader] struct WebCore::FontCustomPlatformSerializedData {
-    Vector<uint8_t> fontFaceData;
-    String itemInCollection;
-    WebCore::RenderingResourceIdentifier renderingResourceIdentifier;
-};
 #endif // USE(CORE_TEXT)
 
 #if ENABLE(CONTENT_FILTERING)

--- a/Source/WebKit/Shared/WebCoreFont.serialization.in
+++ b/Source/WebKit/Shared/WebCoreFont.serialization.in
@@ -60,3 +60,10 @@ header: <WebCore/FontPlatformData.h>
     Vector<hb_feature_t> m_features;
 #endif
 };
+
+header: <WebCore/FontCustomPlatformData.h>
+[CustomHeader] struct WebCore::FontCustomPlatformSerializedData {
+    Ref<WebCore::SharedBuffer> fontFaceData;
+    String itemInCollection;
+    WebCore::RenderingResourceIdentifier renderingResourceIdentifier;
+};

--- a/Source/WebKit/Shared/cairo/WebCoreFontCairo.serialization.in
+++ b/Source/WebKit/Shared/cairo/WebCoreFontCairo.serialization.in
@@ -41,11 +41,4 @@ header: <WebCore/FontPlatformData.h>
 #endif
 };
 
-header: <WebCore/FontCustomPlatformData.h>
-[CustomHeader] struct WebCore::FontCustomPlatformSerializedData {
-    Vector<uint8_t> fontFaceData;
-    String itemInCollection;
-    WebCore::RenderingResourceIdentifier renderingResourceIdentifier;
-};
-
 #endif

--- a/Source/WebKit/Shared/skia/WebCoreArgumentCodersSkia.serialization.in
+++ b/Source/WebKit/Shared/skia/WebCoreArgumentCodersSkia.serialization.in
@@ -33,11 +33,4 @@ header: <WebCore/FontPlatformData.h>
     sk_sp<SkData> typefaceData;
 };
 
-header: <WebCore/FontCustomPlatformData.h>
-[CustomHeader] struct WebCore::FontCustomPlatformSerializedData {
-    Vector<uint8_t> fontFaceData;
-    String itemInCollection;
-    WebCore::RenderingResourceIdentifier renderingResourceIdentifier;
-};
-
 #endif


### PR DESCRIPTION
#### a793b6dee90dcc7ecde5dab788d92b679f25adc9
<pre>
FontCustomPlatformSerializedData shouldn&apos;t copy fontFaceData buffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=284146">https://bugs.webkit.org/show_bug.cgi?id=284146</a>

Reviewed by Alex Christensen.

It doesn&apos;t need to copy the buffer. Use `Ref&lt;SharedBuffer&gt;` instead of
`Vector&lt;uint8_t&gt;` for fontFaceData.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/platform/graphics/FontCustomPlatformData.h:
* Source/WebCore/platform/graphics/coretext/FontCustomPlatformDataCoreText.cpp:
(WebCore::FontCustomPlatformData::tryMakeFromSerializationData):
(WebCore::FontCustomPlatformData::serializedData const):
* Source/WebCore/platform/graphics/freetype/FontCustomPlatformDataFreeType.cpp:
(WebCore::FontCustomPlatformData::serializedData const):
* Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp:
(WebCore::FontCustomPlatformData::tryMakeFromSerializationData):
(WebCore::FontCustomPlatformData::serializedData const):
* Source/WebCore/platform/graphics/win/FontCustomPlatformDataWin.cpp:
(WebCore::FontCustomPlatformData::tryMakeFromSerializationData):
(WebCore::FontCustomPlatformData::serializedData const):
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in:
* Source/WebKit/Shared/WebCoreFont.serialization.in:
* Source/WebKit/Shared/cairo/WebCoreFontCairo.serialization.in:
* Source/WebKit/Shared/skia/WebCoreArgumentCodersSkia.serialization.in:

Canonical link: <a href="https://commits.webkit.org/287480@main">https://commits.webkit.org/287480@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/311d346c2e2d6f00c6f5062defd46ace61529200

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79822 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58823 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33221 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84347 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30823 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81931 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67897 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7113 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62393 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20232 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82890 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52454 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72694 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42701 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49794 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26843 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29272 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/70921 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27316 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85773 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7053 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70657 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7227 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68534 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69897 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13900 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12818 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12342 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7012 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6872 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10383 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8678 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->