### PR TITLE
Drop usage of IsDeprecatedTimerSmartPointerException in Tools/

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WTF/RunLoop.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/RunLoop.cpp
@@ -27,20 +27,10 @@
 
 #include "Test.h"
 #include "Utilities.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/RunLoop.h>
 #include <wtf/Threading.h>
 #include <wtf/threads/BinarySemaphore.h>
-
-namespace TestWebKitAPI {
-class DerivedOneShotTimer;
-class DerivedRepeatingTimer;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<TestWebKitAPI::DerivedOneShotTimer> : std::true_type { };
-template<> struct IsDeprecatedTimerSmartPointerException<TestWebKitAPI::DerivedRepeatingTimer> : std::true_type { };
-}
 
 namespace TestWebKitAPI {
 
@@ -130,7 +120,9 @@ TEST(WTF_RunLoop, CallOnMainCrossThreadWhileNested)
     Util::run(&done);
 }
 
-class DerivedOneShotTimer : public RunLoop::Timer {
+class DerivedOneShotTimer : public RunLoop::Timer, public CanMakeCheckedPtr<DerivedOneShotTimer> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DerivedOneShotTimer);
 public:
     DerivedOneShotTimer(bool& testFinished)
         : RunLoop::Timer(RunLoop::current(), this, &DerivedOneShotTimer::fired)
@@ -162,7 +154,9 @@ TEST(WTF_RunLoop, OneShotTimer)
     Util::run(&testFinished);
 }
 
-class DerivedRepeatingTimer : public RunLoop::Timer {
+class DerivedRepeatingTimer : public RunLoop::Timer, public CanMakeCheckedPtr<DerivedRepeatingTimer> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DerivedRepeatingTimer);
 public:
     DerivedRepeatingTimer(bool& testFinished)
         : RunLoop::Timer(RunLoop::current(), this, &DerivedRepeatingTimer::fired)

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -206,6 +206,7 @@ public:
 
     bool isCurrentInvocation(TestInvocation* invocation) const { return invocation == m_currentInvocation.get(); }
     TestInvocation* currentInvocation() { return m_currentInvocation.get(); }
+    RefPtr<TestInvocation> protectedCurrentInvocation();
 
     void setShouldDecideNavigationPolicyAfterDelay(bool value) { m_shouldDecideNavigationPolicyAfterDelay = value; }
     void setShouldDecideResponsePolicyAfterDelay(bool value) { m_shouldDecideResponsePolicyAfterDelay = value; }
@@ -631,7 +632,7 @@ private:
     void setTracksRepaints(bool);
 
     WKRetainPtr<WKURLRef> m_mainResourceURL;
-    std::unique_ptr<TestInvocation> m_currentInvocation;
+    RefPtr<TestInvocation> m_currentInvocation;
 #if PLATFORM(COCOA)
     std::unique_ptr<ClassMethodSwizzler> m_calendarSwizzler;
     std::pair<RetainPtr<NSString>, RetainPtr<NSString>> m_overriddenCalendarAndLocaleIdentifiers;

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -76,6 +76,11 @@ static void postPageMessage(const char* name)
     postPageMessage(name, WKRetainPtr<WKTypeRef> { });
 }
 
+Ref<TestInvocation> TestInvocation::create(WKURLRef url, const TestOptions& options)
+{
+    return adoptRef(*new TestInvocation(url, options));
+}
+
 TestInvocation::TestInvocation(WKURLRef url, const TestOptions& options)
     : m_options(options)
     , m_url(url)
@@ -92,11 +97,6 @@ TestInvocation::~TestInvocation()
 {
     if (m_pendingUIScriptInvocationData)
         m_pendingUIScriptInvocationData->testInvocation = nullptr;
-}
-
-WKURLRef TestInvocation::url() const
-{
-    return m_url.get();
 }
 
 bool TestInvocation::urlContains(StringView searchString) const

--- a/Tools/WebKitTestRunner/TestInvocation.h
+++ b/Tools/WebKitTestRunner/TestInvocation.h
@@ -32,29 +32,21 @@
 #include <WebKit/WKRetainPtr.h>
 #include <string>
 #include <wtf/Noncopyable.h>
+#include <wtf/RefCounted.h>
 #include <wtf/RunLoop.h>
 #include <wtf/Seconds.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WTR {
-class TestInvocation;
-}
 
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WTR::TestInvocation> : std::true_type { };
-}
-
-namespace WTR {
-
-class TestInvocation final : public UIScriptContextDelegate {
+class TestInvocation final : public RefCounted<TestInvocation>, public UIScriptContextDelegate {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(TestInvocation);
 public:
-    explicit TestInvocation(WKURLRef, const TestOptions&);
+    static Ref<TestInvocation> create(WKURLRef, const TestOptions&);
     ~TestInvocation();
 
-    WKURLRef url() const;
+    WKURLRef url() const { return m_url.get(); }
     bool urlContains(StringView) const;
     
     const TestOptions& options() const { return m_options; }
@@ -94,6 +86,8 @@ public:
     void dumpResourceLoadStatisticsIfNecessary();
 
 private:
+    TestInvocation(WKURLRef, const TestOptions&);
+
     WKRetainPtr<WKMutableDictionaryRef> createTestSettingsDictionary();
 
     void waitToDumpWatchdogTimerFired();


### PR DESCRIPTION
#### 4730d5a57cb071f24675d86c2903ad81f470c1d6
<pre>
Drop usage of IsDeprecatedTimerSmartPointerException in Tools/
<a href="https://bugs.webkit.org/show_bug.cgi?id=284148">https://bugs.webkit.org/show_bug.cgi?id=284148</a>

Reviewed by Darin Adler.

* Tools/TestWebKitAPI/Tests/WTF/RunLoop.cpp:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::createOtherPlatformWebView):
(WTR::TestController::resetStateToConsistentValues):
(WTR::TestController::runTest):
(WTR::TestController::didReceiveMessageFromInjectedBundle):
(WTR::TestController::protectedCurrentInvocation):
(WTR::TestController::didReceiveAsyncMessageFromInjectedBundle):
(WTR::TestController::didReceiveSynchronousMessageFromInjectedBundle):
(WTR::TestController::canAuthenticateAgainstProtectionSpace):
(WTR::TestController::didReceiveAuthenticationChallenge):
(WTR::TestController::downloadDidStart):
(WTR::TestController::decideDestinationWithSuggestedFilename):
(WTR::TestController::downloadDidFinish):
(WTR::TestController::downloadDidReceiveServerRedirectToURL):
(WTR::TestController::downloadDidFail):
(WTR::TestController::receivedServiceWorkerConsoleMessage):
(WTR::TestController::webProcessDidTerminate):
(WTR::TestController::didBeginNavigationGesture):
(WTR::TestController::willEndNavigationGesture):
(WTR::TestController::didEndNavigationGesture):
(WTR::TestController::didRemoveNavigationGestureSnapshot):
(WTR::TestController::handleDeviceOrientationAndMotionAccessRequest):
(WTR::TestController::decidePolicyForNavigationAction):
(WTR::TestController::decidePolicyForNavigationResponse):
(WTR::TestController::didNavigateWithNavigationData):
(WTR::TestController::didPerformClientRedirect):
(WTR::TestController::didPerformServerRedirect):
(WTR::TestController::didUpdateHistoryTitle):
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::create):
(WTR::TestInvocation::url const): Deleted.
* Tools/WebKitTestRunner/TestInvocation.h:

Canonical link: <a href="https://commits.webkit.org/287466@main">https://commits.webkit.org/287466@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41dd8f72b90bede6eeb50151a3e3ccdbffafe183

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 win ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 win-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-2-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12337 "Built successfully and passed tests") | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-18-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-11-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-11-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
<!--EWS-Status-Bubble-End-->