### PR TITLE
[WPE] Increased memory consumption of WebProcess during regular video playback and RWI

### DIFF
--- a/Source/WebCore/inspector/NetworkResourcesData.cpp
+++ b/Source/WebCore/inspector/NetworkResourcesData.cpp
@@ -100,7 +100,7 @@ void NetworkResourcesData::ResourceData::appendData(const SharedBuffer& data)
     m_dataBuffer.append(data);
 }
 
-unsigned NetworkResourcesData::ResourceData::decodeDataToContent()
+void NetworkResourcesData::ResourceData::decodeDataToContent()
 {
     ASSERT(!hasContent());
 
@@ -114,7 +114,7 @@ unsigned NetworkResourcesData::ResourceData::decodeDataToContent()
         m_content = base64EncodeToString(buffer->span());
     }
 
-    return m_content.sizeInBytes() - buffer->size();
+    ASSERT(m_content.sizeInBytes() >= buffer->size());
 }
 
 NetworkResourcesData::NetworkResourcesData()
@@ -203,7 +203,7 @@ void NetworkResourcesData::setResourceContent(const String& requestId, const Str
         // We can not be sure that we didn't try to save this request data while it was loading, so remove it, if any.
         if (resourceData->hasContent() || resourceData->hasData())
             m_contentSize -= resourceData->removeContent();
-        m_requestIdsDeque.append(requestId);
+        m_requestIdsDeque.appendOrMoveToLast(requestId);
         resourceData->setContent(content, base64Encoded);
         m_contentSize += dataLength;
     }
@@ -239,7 +239,7 @@ NetworkResourcesData::ResourceData const* NetworkResourcesData::maybeAddResource
         return resourceData;
 
     if (ensureFreeSpace(data.size()) && !resourceData->isContentEvicted()) {
-        m_requestIdsDeque.append(requestId);
+        m_requestIdsDeque.appendOrMoveToLast(requestId);
         resourceData->appendData(data);
         m_contentSize += data.size();
     }
@@ -256,10 +256,18 @@ void NetworkResourcesData::maybeDecodeDataToContent(const String& requestId)
     if (!resourceData->hasData())
         return;
 
-    m_contentSize += resourceData->decodeDataToContent();
-    size_t dataLength = resourceData->content().sizeInBytes();
-    if (dataLength > m_maximumSingleResourceContentSize)
-        m_contentSize -= resourceData->evictContent();
+    auto byteCount = resourceData->dataLength();
+    m_contentSize -= byteCount;
+
+    resourceData->decodeDataToContent();
+    byteCount = resourceData->content().sizeInBytes();
+    if (byteCount > m_maximumSingleResourceContentSize) {
+        resourceData->evictContent();
+        return;
+    }
+
+    if (ensureFreeSpace(byteCount) && !resourceData->isContentEvicted())
+        m_contentSize += byteCount;
 }
 
 void NetworkResourcesData::addCachedResource(const String& requestId, CachedResource* cachedResource)
@@ -316,19 +324,23 @@ Vector<String> NetworkResourcesData::removeCachedResource(CachedResource* cached
 
 void NetworkResourcesData::clear(std::optional<String> preservedLoaderId)
 {
-    m_requestIdsDeque.clear();
-    m_contentSize = 0;
-
-    if (!preservedLoaderId)
+    if (!preservedLoaderId) {
         m_requestIdToResourceDataMap.clear();
-    else {
-        Vector<String> keysToRemove;
-        for (auto& [key, value] : m_requestIdToResourceDataMap) {
-            if (value->loaderId() != *preservedLoaderId)
-                keysToRemove.append(key);
+        m_requestIdsDeque.clear();
+        m_contentSize = 0;
+        return;
+    }
+
+    for (auto&& requestId : std::exchange(m_requestIdsDeque, { })) {
+        auto resourceData = resourceDataForRequestId(requestId);
+        if (!resourceData)
+            continue;
+        if (resourceData->loaderId() == *preservedLoaderId)
+            m_requestIdsDeque.add(requestId);
+        else {
+            m_contentSize -= resourceData->evictContent();
+            m_requestIdToResourceDataMap.remove(requestId);
         }
-        for (auto& keyToRemove : keysToRemove)
-            m_requestIdToResourceDataMap.remove(keyToRemove);
     }
 }
 
@@ -360,6 +372,7 @@ bool NetworkResourcesData::ensureFreeSpace(size_t size)
     if (size > m_maximumResourcesContentSize)
         return false;
 
+    ASSERT(m_maximumResourcesContentSize >= m_contentSize);
     while (size > m_maximumResourcesContentSize - m_contentSize) {
         String requestId = m_requestIdsDeque.takeFirst();
         ResourceData* resourceData = resourceDataForRequestId(requestId);

--- a/Source/WebCore/inspector/NetworkResourcesData.h
+++ b/Source/WebCore/inspector/NetworkResourcesData.h
@@ -31,7 +31,7 @@
 
 #include "InspectorPageAgent.h"
 #include "SharedBuffer.h"
-#include <wtf/Deque.h>
+#include <wtf/ListHashSet.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WallTime.h>
@@ -110,7 +110,7 @@ public:
         bool hasData() const;
         size_t dataLength() const;
         void appendData(const SharedBuffer&);
-        unsigned decodeDataToContent();
+        void decodeDataToContent();
 
         String m_requestId;
         String m_loaderId;
@@ -157,7 +157,7 @@ private:
     void ensureNoDataForRequestId(const String& requestId);
     bool ensureFreeSpace(size_t);
 
-    Deque<String> m_requestIdsDeque;
+    ListHashSet<String> m_requestIdsDeque;
     MemoryCompactRobinHoodHashMap<String, std::unique_ptr<ResourceData>> m_requestIdToResourceDataMap;
     size_t m_contentSize { 0 };
     size_t m_maximumResourcesContentSize;


### PR DESCRIPTION
#### d84062d7b5e2a29f7c29c1edf5bbfcf5eae6935b
<pre>
[WPE] Increased memory consumption of WebProcess during regular video playback and RWI
<a href="https://bugs.webkit.org/show_bug.cgi?id=284108">https://bugs.webkit.org/show_bug.cgi?id=284108</a>

Reviewed by Devin Rousso.

When WebInspector is used, the downloaded data is cached also for it in NetworkResourcesData.
The single resource data cannot be greater than maximumSingleResourceContentSize (50MB) and
the total size of resources content cannot be greater than maximumResourcesContentSize (200MB).
At the end of downloading the resource, the binary data is decoded to the string represantation
(base64 or other depends on decoder). Decoding process can increased the size of the kept resource
data. The limit maximumSingleResourceContentSize is checked but maximumResourcesContentSize limit
is not checked which can lead to situation that m_contentSize (the total size of resources content)
is greater than maximumResourcesContentSize. This causes that condition checked in
NetworkResourcesData::ensureFreeSpace is invalid because subtraction unsigned values where
first value(minuend) is smaller than the second one(subtrahend) gives a huge number (instead of
negative number).

This change ensures that after decoding binary data into string representation the total size of
resources content (m_contentSize) is not greater than maximumResourcesContentSize. The assert is
added in NetworkResourcesData::ensureFreeSpace to check that m_contentSize is not greater than
maximumResourcesContentSize.

I fixed implementation of function NetworkResourcesData::clear in case passing the preservedLoaderId.
In that case we should update m_requestIdsDeque and m_contentSize and not just clear them.

Additionally I changed the type of m_requestIdsDeque from Deque&lt;String&gt; to ListHashSet&lt;String&gt;.
This change fixes adding to m_requestIdsDeque the same requestId many times.

* Source/WebCore/inspector/NetworkResourcesData.cpp:
(WebCore::NetworkResourcesData::ResourceData::decodeDataToContent):
(WebCore::NetworkResourcesData::setResourceContent):
(WebCore::NetworkResourcesData::maybeAddResourceData):
(WebCore::NetworkResourcesData::maybeDecodeDataToContent):
(WebCore::NetworkResourcesData::clear):
(WebCore::NetworkResourcesData::ensureFreeSpace):
* Source/WebCore/inspector/NetworkResourcesData.h:

Canonical link: <a href="https://commits.webkit.org/289143@main">https://commits.webkit.org/289143@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07fe1f6d527f3c0b2e2f8e8afabf49bfbb801087

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85217 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4952 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39648 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90344 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36257 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87306 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5041 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12927 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66254 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24071 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88263 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3825 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77401 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46562 "Found 2 new API test failures: /WPE/TestSSL:/webkit/WebKitWebView/web-socket-client-side-certificate, /WPE/TestSSL:/webkit/WebKitWebView/web-socket-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3701 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31662 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35325 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74460 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32495 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91789 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12564 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9150 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74792 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12793 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73238 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73909 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18342 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18311 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16736 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4551 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12507 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17960 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12337 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15830 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14087 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->