### PR TITLE
Update the import-map WPTs, in preparation for multiple import maps

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/dynamic-import-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/dynamic-import-expected.txt
@@ -1,5 +1,4 @@
 
-PASS After dynamic imports, import maps should fire error events
 PASS A dynamic import succeeds
-PASS After a dynamic import(), import maps are not effective
+FAIL After a dynamic import(), import maps work fine assert_array_equals: expected property 0 to be "log:B" but got "log:A" (expected array ["log:B"] got ["log:A"])
 

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/dynamic-import.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/dynamic-import.html
@@ -3,8 +3,6 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
-const t = async_test(
-  'After dynamic imports, import maps should fire error events');
 const log = [];
 // To ensure we are testing that the flag is cleared at the beginning of module
 // script loading unconditionally, not at the end of loading or not at the
@@ -14,7 +12,7 @@ const log = [];
 promise_test(() => import('../resources/empty.js?pipe=trickle(d1)'),
              "A dynamic import succeeds");
 </script>
-<script type="importmap" onload="t.assert_unreached('onload')" onerror="t.done()">
+<script type="importmap">
 {
   "imports": {
     "../resources/log.js?pipe=sub&name=A": "../resources/log.js?pipe=sub&name=B"
@@ -24,7 +22,6 @@ promise_test(() => import('../resources/empty.js?pipe=trickle(d1)'),
 <script>
 promise_test(() => {
   return import("../resources/log.js?pipe=sub&name=A")
-    .then(() => assert_array_equals(log, ["log:A"]))
-  },
-  'After a dynamic import(), import maps are not effective');
+    .then(() => assert_array_equals(log, ["log:B"]))
+  }, 'After a dynamic import(), import maps work fine');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload-link-header.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload-link-header.html
@@ -3,11 +3,9 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
-const t = async_test(
-  'With modulepreload link header, import maps should fire error events');
 const log = [];
 </script>
-<script type="importmap" onerror="t.done()">
+<script type="importmap">
 {
   "imports": {
     "../resources/log.js?pipe=sub&name=A": "../resources/log.js?pipe=sub&name=B"
@@ -17,7 +15,7 @@ const log = [];
 <script>
 promise_test(() => {
   return import("../resources/log.js?pipe=sub&name=A")
-    .then(() => assert_array_equals(log, ["log:A"]))
+    .then(() => assert_array_equals(log, ["log:B"]))
   },
-  'With modulepreload link header, import maps are not effective');
+  'With modulepreload link header, import maps work fine');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload.html
@@ -3,12 +3,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
-const t = async_test(
-  'After <link rel=modulepreload> import maps should fire error events');
 const log = [];
 </script>
 <link rel="modulepreload" href="../resources/empty.js?pipe=trickle(d1)"></link>
-<script type="importmap" onerror="t.done()">
+<script type="importmap">
 {
   "imports": {
     "../resources/log.js?pipe=sub&name=A": "../resources/log.js?pipe=sub&name=B"
@@ -18,7 +16,7 @@ const log = [];
 <script>
 promise_test(() => {
   return import("../resources/log.js?pipe=sub&name=A")
-    .then(() => assert_array_equals(log, ["log:A"]))
+    .then(() => assert_array_equals(log, ["log:B"]))
   },
-  'After <link rel=modulepreload> import maps are not effective');
+  'After <link rel=modulepreload> import maps should work fine');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/script-tag-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/script-tag-expected.txt
@@ -1,4 +1,3 @@
 
-PASS After <script type="module"> import maps should fire error events
-PASS After <script type="module"> import maps are not effective
+FAIL After <script type="module"> import maps work fine assert_array_equals: expected property 0 to be "log:B" but got "log:A" (expected array ["log:B"] got ["log:A"])
 

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/script-tag-inline-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/script-tag-inline-expected.txt
@@ -1,4 +1,3 @@
 
-PASS After inline <script type="module"> import maps should fire error events
-PASS After inline <script type="module"> import maps are not effective
+FAIL After inline <script type="module"> import maps work fine assert_array_equals: expected property 0 to be "log:B" but got "log:A" (expected array ["log:B"] got ["log:A"])
 

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/script-tag-inline.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/script-tag-inline.html
@@ -3,18 +3,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
-const t = async_test(
-  'After inline <script type="module"> import maps should fire error events');
 const log = [];
 </script>
 <script type="module">
-// While this inline module script doesn't have any specifiers and doesn't fetch
-// anything, this still disables subsequent import maps, because
-// https://wicg.github.io/import-maps/#wait-for-import-maps
-// is anyway called at the beginning of
-// https://html.spec.whatwg.org/multipage/webappapis.html#fetch-an-inline-module-script-graph
 </script>
-<script type="importmap" onerror="t.done()">
+<script type="importmap">
 {
   "imports": {
     "../resources/log.js?pipe=sub&name=A": "../resources/log.js?pipe=sub&name=B"
@@ -24,7 +17,7 @@ const log = [];
 <script>
 promise_test(() => {
   return import("../resources/log.js?pipe=sub&name=A")
-    .then(() => assert_array_equals(log, ["log:A"]))
+    .then(() => assert_array_equals(log, ["log:B"]))
   },
-  'After inline <script type="module"> import maps are not effective');
+  'After inline <script type="module"> import maps work fine');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/script-tag.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/script-tag.html
@@ -3,12 +3,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
-const t = async_test(
-  'After <script type="module"> import maps should fire error events');
 const log = [];
 </script>
 <script type="module" src="../resources/empty.js?pipe=trickle(d1)"></script>
-<script type="importmap" onerror="t.done()">
+<script type="importmap">
 {
   "imports": {
     "../resources/log.js?pipe=sub&name=A": "../resources/log.js?pipe=sub&name=B"
@@ -18,7 +16,7 @@ const log = [];
 <script>
 promise_test(() => {
   return import("../resources/log.js?pipe=sub&name=A")
-    .then(() => assert_array_equals(log, ["log:A"]))
+    .then(() => assert_array_equals(log, ["log:B"]))
   },
-  'After <script type="module"> import maps are not effective');
+  'After <script type="module"> import maps work fine');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/already-resolved-dropped-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/already-resolved-dropped-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Rules for already resolved modules are dropped
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/already-resolved-dropped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/already-resolved-dropped.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/import-maps/resources/test-helper.js"></script>
+<script>
+// Simulate resolving a module before import maps are processed
+import("../resources/log.js?pipe=sub&name=ModuleA").catch(() => {});
+</script>
+<script type="importmap">
+{
+   "imports": {
+    "../resources/log.js?pipe=sub&name=ModuleA": "../resources/log.js?pipe=sub&name=ModuleB",
+    "http:/": "../resources/log.js?pipe=sub&name=scheme",
+    "https:/": "../resources/log.js?pipe=sub&name=scheme"
+  }
+}
+</script>
+<script>
+test_loaded(
+  "../resources/log.js?pipe=sub&name=ModuleA",
+  ["log:ModuleA"],
+  "Rules for already resolved modules are dropped"
+);
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/basic-expected.txt
@@ -1,3 +1,3 @@
 
-PASS Second import map should be rejected
+FAIL Second import map should be used for resolution assert_array_equals: lengths differ, expected array ["log:B1", "log:B2", "log:C3"] length 3, got ["onerror 2", "log:B1", "log:B2", "log:A3"] length 4
 

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/basic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/basic.html
@@ -22,15 +22,13 @@ const log = [];
 }
 </script>
 <script>
-// Currently the spec doesn't allow multiple import maps, by setting acquiring
-// import maps to false on preparing the first import map.
 promise_test(() => {
   return import("../resources/log.js?pipe=sub&name=A1")
     .then(() => import("../resources/log.js?pipe=sub&name=A2"))
     .then(() => import("../resources/log.js?pipe=sub&name=A3"))
     .then(() => assert_array_equals(
                     log,
-                    ["onerror 2", "log:B1", "log:B2", "log:A3"]))
+                    ["log:B1", "log:B2", "log:C3"]))
   },
-  "Second import map should be rejected");
+  "Second import map should be used for resolution");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/conflict-first-persists-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/conflict-first-persists-expected.txt
@@ -1,0 +1,5 @@
+
+PASS First defined rule persists in case of conflict
+PASS First defined rule persists in case of conflict - prefixed bare specifiers
+FAIL First defined rule persists in case of conflict - non-prefix bare specifier promise_test: Unhandled rejection with value: object "TypeError: Module name, 'module-b' does not resolve to a valid URL."
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/conflict-first-persists.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/conflict-first-persists.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script type="importmap">
+{
+   "imports": {
+    "module-a": "../resources/log.js?pipe=sub&name=ModuleA",
+    "module-b/something": "../resources/log.js?pipe=sub&name=ModuleB"
+  }
+}
+</script>
+<script type="importmap">
+{
+  "imports": {
+    "module-a": "../resources/log.js?pipe=sub&name=OtherModuleA",
+    "module-b/": "../resources/log.js?pipe=sub&name=PrefixModuleB",
+    "module-b": "../resources/log.js?pipe=sub&name=OtherModuleB"
+  }
+}
+</script>
+<script>
+const test_loaded = (specifier, expected_log, description) => {
+  promise_test(async t => {
+    log = [];
+    await import(specifier);
+    assert_array_equals(log, expected_log);
+  }, description);
+};
+
+test_loaded(
+  "module-a",
+  ["log:ModuleA"],
+  "First defined rule persists in case of conflict"
+);
+
+test_loaded(
+  "module-b/something",
+  ["log:ModuleB"],
+  "First defined rule persists in case of conflict - prefixed bare specifiers"
+);
+
+test_loaded(
+  "module-b",
+  ["log:OtherModuleB"],
+  "First defined rule persists in case of conflict - non-prefix bare specifier"
+);
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/resolution-consistency-in-module-tree-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/resolution-consistency-in-module-tree-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Module tree that started to download before a new import map should still take it into account assert_array_equals: Import should use the new import map expected property 0 to be "log:B" but got "log:A" (expected array ["log:B"] got ["log:A"])
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/resolution-consistency-in-module-tree-inline-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/resolution-consistency-in-module-tree-inline-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Module tree that started to download before a new import map should still take it into account assert_array_equals: Import should use the new import map expected property 0 to be "log:B" but got "log:A" (expected array ["log:B"] got ["log:A"])
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/resolution-consistency-in-module-tree-inline.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/resolution-consistency-in-module-tree-inline.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+function waitForBool(boolName) {
+  return new Promise((resolve) => {
+    const checkVariable = setInterval(() => {
+      if (window[boolName]) {
+        clearInterval(checkVariable);
+        resolve();
+      }
+    }, 0);
+  });
+}
+
+step_timeout(() => {
+  const importMapScript = document.createElement('script');
+  importMapScript.type = 'importmap';
+  importMapScript.textContent = JSON.stringify({
+    imports: {
+      "../resources/log.sub.js?name=A": "../resources/log.sub.js?name=B"
+    }
+  });
+  document.head.appendChild(importMapScript);
+}, 100);
+const log = [];
+</script>
+<script type="module">
+import "../resources/importer.sub.js?pipe=trickle(d0.5)&name=..%2Fresources%2Flog.sub.js%3Fname%3DA";
+</script>
+<script type="module">
+test(() => {
+  assert_array_equals(log, ["log:B"], "Import should use the new import map");
+}, "Module tree that started to download before a new import map should still take it into account");
+</script>
+</body>
+</html>
+
+
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/resolution-consistency-in-module-tree.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/resolution-consistency-in-module-tree.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script type="module" async>
+step_timeout(() => {
+  const importMapScript = document.createElement('script');
+  importMapScript.type = 'importmap';
+  importMapScript.textContent = JSON.stringify({
+    imports: {
+      "../resources/log.sub.js?name=A": "../resources/log.sub.js?name=B"
+    }
+  });
+  document.head.appendChild(importMapScript);
+}, 100);
+</script>
+<script>
+const log = [];
+</script>
+<script type="module" src="../resources/importer.sub.js?pipe=trickle(d0.5)&name=..%2Fresources%2Flog.sub.js%3Fname%3DA"></script>
+<script type="module">
+test(() => {
+  assert_array_equals(log, ["log:B"], "Import should use the new import map");
+}, "Module tree that started to download before a new import map should still take it into account");
+</script>
+</body>
+</html>
+
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/url-resolution-conflict-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/url-resolution-conflict-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Second import map should not override same resolved URL
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/url-resolution-conflict.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/url-resolution-conflict.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+const log = [];
+</script>
+<script type="importmap">
+{
+  "scopes": {
+    "/": {
+      "../resources/../resources/app.js": "../resources/log.js?pipe=sub&name=first"
+    }
+  }
+}
+</script>
+<script type="importmap">
+{
+  "scopes": {
+    "/": {
+      "../resources/app.js": "../resources/log.js?pipe=sub&name=second"
+    }
+  }
+}
+</script>
+<script type="module">
+promise_test(async () => {
+  await import("../resources/app.js");
+  assert_array_equals(log, ["log:first"]);
+},
+"Second import map should not override same resolved URL");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/w3c-import.log
@@ -14,5 +14,10 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/already-resolved-dropped.html
 /LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/basic.html
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/conflict-first-persists.html
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/resolution-consistency-in-module-tree-inline.html
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/resolution-consistency-in-module-tree.html
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/url-resolution-conflict.html
 /LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/with-errors.html

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/with-errors-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/with-errors-expected.txt
@@ -1,4 +1,4 @@
 CONSOLE MESSAGE: ImportMap has invalid JSON
 
-PASS Second import map should be rejected after an import map with errors
+FAIL Second import map should be used for resolution even after an import map with errors assert_array_equals: lengths differ, expected array ["log:C"] length 1, got ["onerror 2", "log:A"] length 2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/with-errors.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/with-errors.html
@@ -18,15 +18,11 @@ Parse Error
 }
 </script>
 <script>
-// Currently the spec doesn't allow multiple import maps, by setting acquiring
-// import maps to false on preparing the first import map.
-// Even the first import map has errors and thus Document's import map is not
-// updated, the second import map is still rejected at preparationg.
 promise_test(() => {
   return import("../resources/log.js?pipe=sub&name=A")
     .then(() => assert_array_equals(
                     log,
-                    ["onerror 2", "log:A"]))
+                    ["log:C"]))
   },
-  "Second import map should be rejected after an import map with errors");
+  "Second import map should be used for resolution even after an import map with errors");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/dynamic-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Initial import before import map
+PASS Resolution after import map should not be redefined
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/dynamic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/dynamic.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+const log = [];
+
+// First, use a module specifier
+promise_test(() => {
+  return import("../resources/log.js?pipe=sub&name=A")
+    .then(() => {
+      assert_array_equals(log, ["log:A"], "First import should use original module");
+    });
+}, "Initial import before import map");
+
+// Now try to redefine it with multiple import map rules
+</script>
+<script type="importmap">
+{
+  "imports": {
+    "../resources/log.js?pipe=sub&name=A": "../resources/log.js?pipe=sub&name=B",
+    "http:/": "../resources/log.js?pipe=sub&name=scheme",
+    "https:/": "../resources/log.js?pipe=sub&name=scheme"
+  }
+}
+</script>
+<script type="module">
+// Testing that the resolution is correct using `resolve`, as you can't import
+// the same module twice.
+test(() => {
+  assert_true(import.meta.resolve("../resources/log.js?pipe=sub&name=A")
+              .endsWith("/resources/log.js?pipe=sub&name=A"));
+}, "Resolution after import map should not be redefined");
+</script>
+</body>
+</html>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/external-script-bare-descendent-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/external-script-bare-descendent-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Resolution after import map should not be redefined
+PASS Resolution after import map should not be redefined for bare prefixes or exact matches
+FAIL Resolution after import map should be redefined for non-prefixes Module name, 'foo' does not resolve to a valid URL.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/external-script-bare-descendent.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/external-script-bare-descendent.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script type="importmap">
+{
+  "imports": {
+    "a": "../resources/log.sub.js?name=A",
+    "foo/bar": "../resources/log.sub.js?name=FOOBAR"
+  }
+}
+</script>
+<script type="module" src="../resources/importer.sub.js?name=a"></script>
+<script type="module" src="../resources/importer.sub.js?name=foo/bar"></script>
+<script>
+const log = [];
+
+// Try to redefine the descendent with an import map
+</script>
+<script type="importmap">
+{
+  "imports": {
+    "a": "../resources/log.sub.js?name=B",
+    "foo/bar": "../resources/log.sub.js?name=OtherFoobar",
+    "foo/": "../resources/log.sub.js?name=OtherFoo",
+    "foo": "../resources/log.sub.js?name=foo"
+  }
+}
+</script>
+<script type="module">
+// Testing that the resolution is correct using `resolve`, as you can't import
+// the same module twice.
+test(() => {
+  assert_true(import.meta.resolve("a").endsWith("/resources/log.sub.js?name=A"));
+}, "Resolution after import map should not be redefined");
+
+test(() => {
+  assert_true(import.meta.resolve("foo/bar").endsWith("/resources/log.sub.js?name=FOOBAR"));
+}, "Resolution after import map should not be redefined for bare prefixes or exact matches");
+
+test(() => {
+  assert_true(import.meta.resolve("foo").endsWith("/resources/log.sub.js?name=foo"));
+}, "Resolution after import map should be redefined for non-prefixes");
+</script>
+</body>
+</html>
+
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/external-script-descendent-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/external-script-descendent-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Resolution after import map should not be redefined
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/external-script-descendent-with-scope-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/external-script-descendent-with-scope-expected.txt
@@ -1,0 +1,5 @@
+
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT Testing descendent resolution with scopes Test timed out
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/external-script-descendent-with-scope.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/external-script-descendent-with-scope.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script type="importmap">
+{
+  "imports": {
+    "a": "../resources/log.sub.js?name=A"
+  }
+}
+</script>
+<script type="module" src="../resources/importer.sub.js?name=a"></script>
+<script>
+const variable_defined = (variable) => {
+  return new Promise((resolve) => {
+    const interval = setInterval(() => {
+      if (eval(variable) !== undefined) {
+        clearInterval(interval);
+        resolve(variable);
+      }
+    }, 10);
+  });
+};
+const log = [];
+promise_test(async () => {
+  await variable_defined("log[0]");
+  // Try to redefine the descendent with an import map
+  const importMapScript = document.createElement('script');
+  importMapScript.type = 'importmap';
+  importMapScript.textContent =
+`{
+  "scopes": {
+    "/import-maps/resources/": {
+      "a": "../resources/log.sub.js?name=B"
+    },
+    "/resources/": {
+      "a": "../resources/log.sub.js?name=D",
+       "../resources/": "/foobar/"
+    }
+  },
+  "imports": {
+    "a": "../resources/log.sub.js?name=C"
+  }
+}`;
+  document.head.appendChild(importMapScript);
+
+  const inScopeModule = document.createElement('script');
+  inScopeModule.src = "../resources/in-scope-test.js";
+  inScopeModule.type = 'module';
+  document.head.appendChild(inScopeModule);
+  await variable_defined("window.inscope_test_result");
+  assert_true(window.inscope_test_result
+              .endsWith("/resources/log.sub.js?name=A"), "inscope");
+
+  const outOfScopeModule = document.createElement('script');
+  outOfScopeModule.src = "/resources/out-of-scope-test.js";
+  outOfScopeModule.type = 'module';
+  document.head.appendChild(outOfScopeModule);
+  await variable_defined("window.outscope_test_result");
+  assert_true(window.outscope_test_result
+              .endsWith("/resources/log.sub.js?name=D"), "out of scope 1");
+  assert_true(window.outscope_test_result2
+              .endsWith("/resources/log.sub.js?name=E"), "out of scope 2");
+
+  const inlineModule = document.createElement('script');
+  inlineModule.type = 'module';
+  inlineModule.innerHTML = `window.inline_test_result = import.meta.resolve("a");`;
+  document.head.appendChild(inlineModule);
+  await variable_defined("window.inline_test_result");
+  assert_true(window.inline_test_result
+              .endsWith("/resources/log.sub.js?name=A"), "inline");
+}, "Testing descendent resolution with scopes");
+</script>
+</body>
+</html>
+
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/external-script-descendent.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/external-script-descendent.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script type="module" src="../resources/importer.sub.js?name=..%2Fresources%2Flog.sub.js%3Fname%3DA"></script>
+<script>
+const log = [];
+(async (variable) => {
+  await new Promise((resolve) => {
+    const interval = setInterval(() => {
+      if (variable.length > 0) {
+        clearInterval(interval);
+        resolve(variable);
+      }
+    }, 10);
+  });
+  const importMapScript = document.createElement('script');
+  importMapScript.type = 'importmap';
+  importMapScript.textContent = JSON.stringify({
+    imports: {
+      "../resources/log.sub.js?name=A": "../resources/log.sub.js?name=B"
+    }
+  });
+  document.head.appendChild(importMapScript);
+
+  const inlineModule = document.createElement('script');
+  inlineModule.type = 'module';
+  inlineModule.innerHTML = `test(() => {
+  assert_true(import.meta.resolve("../resources/log.sub.js?name=A").endsWith("/resources/log.sub.js?name=A"));
+}, "Resolution after import map should not be redefined");`;
+  document.head.appendChild(inlineModule);
+})(log);
+</script>
+</body>
+</html>
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/failed-resolution-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/failed-resolution-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Resolution after import map should not be redefined Module name, 'a' does not resolve to a valid URL.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/failed-resolution.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/failed-resolution.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/import-maps/resources/test-helper.js"></script>
+</head>
+<body>
+<script type="module">
+const log = [];
+// Import specifiers that were not yet mapped.
+try {
+  await import("../resources/importer.sub.js?name=a")
+} catch (error) {
+  // Import failed because "a" is not yet defined as a specifier.
+}
+try {
+  await import("../resources/importer.sub.js?name=foo/bar")
+} catch (error) {
+  // Import failed because "foo/bar" is not yet defined as a specifier.
+}
+// Try to define the previous failed-to-resolve specifiers.
+const importMapScript = document.createElement('script');
+importMapScript.type = 'importmap';
+importMapScript.textContent =
+`{
+  "imports": {
+    "a": "../resources/log.sub.js?name=B",
+    "foo/bar": "../resources/log.sub.js?name=OtherFoobar",
+    "foo/": "../resources/log.sub.js?name=OtherFoo/",
+    "foo": "../resources/log.sub.js?name=foo"
+  }
+}`;
+document.head.appendChild(importMapScript);
+
+// Testing that the resolution is correct using `resolve`, as you can't import
+// the same module twice.
+test(() => {
+  assert_true(import.meta.resolve("a").endsWith("/resources/log.sub.js?name=B"));
+}, "Resolution after import map should not be redefined");
+
+test(() => {
+  assert_true(import.meta.resolve("foo/bar").endsWith("/resources/log.sub.js?name=OtherFoobar"));
+}, "Resolution after import map should not be redefined for bare prefixes or exact matches");
+
+test(() => {
+  assert_true(import.meta.resolve("foo").endsWith("/resources/log.sub.js?name=foo"));
+}, "Resolution after import map should be redefined for non-prefixes");
+
+test_loaded(
+  "../resources/log.sub.js?name=a",
+  ["log:a"],
+  "Rules for failed resolution are not dropped"
+);
+</script>
+</body>
+</html>
+
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/integrity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/integrity-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Static script loaded as its integrity check passed
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/integrity.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/integrity.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+const log = [];
+</script>
+<script type="importmap">
+{
+  "imports": {
+    "../resources/log.js?pipe=sub&name=A": "../resources/log.js?pipe=sub&name=B"
+  },
+  "integrity": {
+    "../resources/log.js?pipe=sub&name=B": "sha384-PeZ0Scqs60QjpuvHAyomddrpcCuox9hUwAff1yx1Lv2HtPIAfsSuHi6VKGK3nH3w"
+  }
+}
+</script>
+<script type="importmap">
+{
+  "integrity": {
+    "../resources/log.js?pipe=sub&name=B": "sha384-foobar"
+  }
+}
+</script>
+<script type="module">
+import '../resources/log.js?pipe=sub&name=A';
+</script>
+<script type="module">
+test(t => {
+  assert_array_equals(log, ["log:B"]);
+}, 'Static script loaded as its integrity check passed');
+</script>
+</body>
+</html>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/modulepreload-header.html.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/modulepreload-header.html.headers
@@ -1,0 +1,2 @@
+Link: <../resources/log.js?pipe=sub&name=A>;rel=modulepreload
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/prefix-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/prefix-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Initial import before import map
+PASS Prefix resolution after import map should not be redefined
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/prefix.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/prefix.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+const log = [];
+
+// First, use a module specifier
+promise_test(() => {
+  return import("../resources/log.js?pipe=sub&name=A")
+    .then(() => {
+      assert_array_equals(log, ["log:A"], "First import should use original module");
+    });
+}, "Initial import before import map");
+
+// Now try to redefine it with an import map
+</script>
+<script type="importmap">
+{
+  "imports": {
+    "../resources/": "/foobar/"
+  }
+}
+</script>
+<script type="module">
+// Testing that the resolution is correct using `resolve`, as you can't import
+// the same module twice.
+test(() => {
+  assert_false(import.meta.resolve("../resources/log.js?pipe=sub&name=A")
+              .endsWith("/foobar/log.js?pipe=sub&name=A"));
+  assert_true(import.meta.resolve("../resources/log.js?pipe=sub&name=A")
+              .endsWith("/resources/log.js?pipe=sub&name=A"));
+}, "Prefix resolution after import map should not be redefined");
+</script>
+</body>
+</html>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/script-descendent-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/script-descendent-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Resolution after import map should not be redefined
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/script-descendent.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/script-descendent.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script type="module">
+import "../resources/log.js?pipe=sub&name=A";
+</script>
+<script>
+const log = [];
+
+// Try to redefine the descendent with an import map
+</script>
+<script type="importmap">
+{
+  "imports": {
+    "../resources/log.js?pipe=sub&name=A": "../resources/log.js?pipe=sub&name=B"
+  }
+}
+</script>
+<script type="module">
+// Testing that the resolution is correct using `resolve`, as you can't import
+// the same module twice.
+test(() => {
+  assert_true(import.meta.resolve("../resources/log.js?pipe=sub&name=A")
+              .endsWith("/resources/log.js?pipe=sub&name=A"));
+}, "Resolution after import map should not be redefined");
+</script>
+</body>
+</html>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/url-resolution-conflict-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/url-resolution-conflict-expected.txt
@@ -1,0 +1,3 @@
+
+PASS import map should not override already resolved URL, even if spelled differently
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/url-resolution-conflict.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/url-resolution-conflict.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+const log = [];
+</script>
+</script>
+<script type="module">
+import '../resources/../resources/log.js?pipe=sub&name=a';
+</script>
+<script type="importmap">
+{
+  "scopes": {
+    "/": {
+      "../resources/log.js?pipe=sub&name=a": "../resources/log.js?pipe=sub&name=b"
+    }
+  }
+}
+</script>
+<script type="module">
+promise_test(async () => {
+  await import("../resources/log.js?pipe=sub&name=a");
+  assert_array_equals(log, ["log:a"]);
+},
+"import map should not override already resolved URL, even if spelled differently");
+</script>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/w3c-import.log
@@ -1,0 +1,26 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/dynamic.html
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/external-script-bare-descendent.html
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/external-script-descendent-with-scope.html
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/external-script-descendent.html
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/failed-resolution.html
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/integrity.html
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/modulepreload-header.html.headers
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/prefix.html
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/script-descendent.html
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/url-resolution-conflict.html

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/importer.sub.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/importer.sub.js
@@ -1,0 +1,1 @@
+import "{{GET[name]}}";

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/in-scope-test.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/in-scope-test.js
@@ -1,0 +1,3 @@
+// Testing that the resolution is correct using `resolve`, as you can't import
+// the same module twice.
+window.inscope_test_result = import.meta.resolve("a");

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/log.sub.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/log.sub.js
@@ -1,0 +1,2 @@
+log.push("log:{{GET[name]}}");
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/test-helper.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/test-helper.js
@@ -244,3 +244,11 @@ function doTests(importMapString, importMapBaseURL, tests) {
     });
   }, { explicit_done: true });
 }
+
+function test_loaded(specifier, expected_log, description) {
+  promise_test(async t => {
+    log = [];
+    await import(specifier);
+    assert_array_equals(log, expected_log);
+  }, description);
+};

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/w3c-import.log
@@ -15,7 +15,10 @@ None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/empty.js
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/importer.sub.js
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/in-scope-test.js
 /LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/inject-base.js
 /LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/log.js
 /LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/log.js.headers
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/log.sub.js
 /LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/test-helper.js


### PR DESCRIPTION
#### 6d04bab3553f81b38e25f08de5ff6290db8c403b
<pre>
Update the import-map WPTs, in preparation for multiple import maps

<a href="https://bugs.webkit.org/show_bug.cgi?id=279025">https://bugs.webkit.org/show_bug.cgi?id=279025</a>

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/6e5a52d2d1bf4cc67ef6a96bd1a4b956fd5123e1">https://github.com/web-platform-tests/wpt/commit/6e5a52d2d1bf4cc67ef6a96bd1a4b956fd5123e1</a>

Reviewed by Chris Dumez.

* LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/dynamic-import-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/dynamic-import.html:
* LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload-link-header.html:
* LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload.html:
* LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/script-tag-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/script-tag-inline-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/script-tag-inline.html:
* LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/script-tag.html:
* LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/already-resolved-dropped-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/already-resolved-dropped.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/basic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/basic.html:
* LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/conflict-first-persists-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/conflict-first-persists.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/resolution-consistency-in-module-tree-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/resolution-consistency-in-module-tree-inline-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/resolution-consistency-in-module-tree-inline.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/resolution-consistency-in-module-tree.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/url-resolution-conflict-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/url-resolution-conflict.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/with-errors-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/with-errors.html:
* LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/dynamic-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/dynamic.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/external-script-bare-descendent-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/external-script-bare-descendent.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/external-script-descendent-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/external-script-descendent-with-scope-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/external-script-descendent-with-scope.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/external-script-descendent.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/failed-resolution-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/failed-resolution.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/integrity-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/integrity.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/modulepreload-header.html.headers: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/prefix-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/prefix.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/script-descendent-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/script-descendent.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/url-resolution-conflict-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/url-resolution-conflict.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/w3c-import.log: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/importer.sub.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/in-scope-test.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/log.sub.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/test-helper.js:
(async test_loaded):
* LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/287450@main">https://commits.webkit.org/287450@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9024da7961ccaf94f7b9a03b4f449259740f380

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79735 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58730 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33125 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84266 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30749 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67808 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7022 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62321 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20161 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82803 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52374 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72609 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42628 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49715 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26761 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29187 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70849 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27226 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85689 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6972 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4863 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70575 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7142 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68455 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69818 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17405 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13828 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12738 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6926 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6795 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10298 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8598 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->