### PR TITLE
[visionOS] Entering docked mode causes YouTube video playback to stall on ToT

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -286,11 +286,15 @@ private:
     void ensureVideoRenderer();
     void destroyVideoRenderer();
 
+    bool isUsingRenderlessMediaSampleRenderer() const;
+    void ensureRenderlessVideoMediaSampleRenderer();
+    MediaPlayerEnums::NeedsRenderingModeChanged destroyRenderlessVideoMediaSampleRenderer();
+
     bool shouldEnsureLayerOrVideoRenderer() const;
     void ensureLayerOrVideoRenderer(MediaPlayerEnums::NeedsRenderingModeChanged);
-    void destroyLayerOrVideoRendererAndCreateRenderlessVideoMediaSampleRenderer();
-    void configureLayerOrVideoRenderer(WebSampleBufferVideoRendering *);
+    void destroyLayerOrVideoRenderer();
     Ref<VideoMediaSampleRenderer> createVideoMediaSampleRendererForRendererer(WebSampleBufferVideoRendering *);
+    void configureLayerOrVideoRenderer(WebSampleBufferVideoRendering *);
 
     bool shouldBePlaying() const;
     void setSynchronizerRate(double, std::optional<MonotonicTime>&& = std::nullopt);
@@ -355,10 +359,8 @@ private:
     WeakPtrFactory<MediaPlayerPrivateMediaSourceAVFObjC> m_sizeChangeObserverWeakPtrFactory;
     RefPtr<MediaSourcePrivateAVFObjC> m_mediaSourcePrivate;
     RetainPtr<AVAsset> m_asset;
-    RetainPtr<AVSampleBufferDisplayLayer> m_sampleBufferDisplayLayer;
-    RefPtr<VideoMediaSampleRenderer> m_videoDisplayLayerRenderer;
-    RetainPtr<AVSampleBufferVideoRenderer> m_sampleBufferVideoRenderer;
-    RefPtr<VideoMediaSampleRenderer> m_videoRenderer;
+    RefPtr<VideoMediaSampleRenderer> m_sampleBufferDisplayLayer;
+    RefPtr<VideoMediaSampleRenderer> m_sampleBufferVideoRenderer;
 
     struct AudioRendererProperties {
         bool hasAudibleSample { false };

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
@@ -226,7 +226,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
     StdUnorderedMap<TrackID, RetainPtr<AVSampleBufferAudioRenderer>> m_audioRenderers;
 ALLOW_NEW_API_WITHOUT_GUARDS_END
-    Ref<WebAVSampleBufferListener> m_listener;
+    const Ref<WebAVSampleBufferListener> m_listener;
 #if PLATFORM(IOS_FAMILY)
     bool m_displayLayerWasInterrupted { false };
 #endif

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
@@ -79,6 +79,10 @@ public:
 
     WebSampleBufferVideoRendering *renderer() const;
 
+    template <typename T> T* as() const;
+    template <> AVSampleBufferVideoRenderer* as() const;
+    template <> AVSampleBufferDisplayLayer* as() const { return m_displayLayer.get(); }
+
     struct DisplayedPixelBufferEntry {
         RetainPtr<CVPixelBufferRef> pixelBuffer;
         MediaTime presentationTimeStamp;

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
@@ -689,6 +689,16 @@ WebSampleBufferVideoRendering *VideoMediaSampleRenderer::renderer() const
 #endif
 }
 
+template <>
+AVSampleBufferVideoRenderer* VideoMediaSampleRenderer::as() const
+{
+#if HAVE(AVSAMPLEBUFFERVIDEORENDERER)
+    return m_renderer.get();
+#else
+    return nil;
+#endif
+}
+
 WebSampleBufferVideoRendering *VideoMediaSampleRenderer::rendererOrDisplayLayer() const
 {
 #if HAVE(AVSAMPLEBUFFERVIDEORENDERER)


### PR DESCRIPTION
#### 60426119f37bc98b065277077dc63276afc3db24
<pre>
[visionOS] Entering docked mode causes YouTube video playback to stall on ToT
<a href="https://bugs.webkit.org/show_bug.cgi?id=284160">https://bugs.webkit.org/show_bug.cgi?id=284160</a>
<a href="https://rdar.apple.com/140946292">rdar://140946292</a>

Reviewed by Andy Estes.

When entering docked mode, the video stall because the GPU process crashed following a null deref
in SourceBufferPrivateAVFObjC::stageVideoRenderer. A regression introduced by 287259@main

Once this issue was fixed, it revealed a lot more issues.

This change is virtually a revert of 287259@main and a full-redo.

In 287259@main we considered three possible use cases:
1- We used an AVSampleBufferDisplayLayer with its associated VideoMediaSampleRenderer
2- We used an AVSampleBufferVideoRenderer with its associated VideoMediaSampleRenderer.
3- We used a render-less VideoMediaSampleRenderer in the situation where would we otherwise have a WebCoreDecompressionSession (video not in the dom or a canvas/WebGL attached).

To store 3, we used the same VideoMediaSampleRenderer member as in case 2.
This and others hasted optimisation shortcuts broke playback on visionOS.
Unfortunately, we have poor automated coverage for visionOS and we have no
ability to test some features (spatial mode, docking etc)

In this new version, we go back as close to what the MediaPlayerPrivateMediaSourceAVFObjC
was prior 287259@main.
We keep the same 3 use case above but we no longer separately store the AVFoundation objects.
Instead we only use VideoMediaSampleRenderer and use it as a holder for the original objects.
In the case where we would before have used a WebCoreDecompressionSession but
instead re-use the VideoMediaSampleRenderer containing the AVSampleBufferDisplayLayer
but instead set it without a render.

If the preference to prefer using a decompression session is set; case
number 3 will never be used. Instead we will just use either 1 or 2;
their associated VideoMediaSampleRenderer will be using a decompression session
internally as needed.

We can continue to use this VideoMediaSampleRenderer as if it had a layer, but
it will instead use internally a decompression session to keep track of the
decoded video frames.

The member name could do with a rename, they currently add to confusion.
However, to ease the transition and code review; I&apos;ve kept them the same for now.

Manually tested on visionOS. Covered by existing tests on other platforms.

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setPageIsVisible):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::updateDisplayLayer):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::ensureLayer):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::destroyLayer):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::ensureVideoRenderer):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::destroyVideoRenderer):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::isUsingRenderlessMediaSampleRenderer const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::ensureRenderlessVideoMediaSampleRenderer):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::destroyRenderlessVideoMediaSampleRenderer):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::destroyLayerOrVideoRenderer):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::configureLayerOrVideoRenderer):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setNeedsPlaceholderImage):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setShouldDisableHDR):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setShouldMaintainAspectRatio):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::updateSpatialTrackingLabel):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::hasVideoRenderer const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::layerOrVideoRenderer const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::displayLayer const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::destroyLayerOrVideoRendererAndCreateRenderlessVideoMediaSampleRenderer): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::setCDMInstance):
(WebCore::SourceBufferPrivateAVFObjC::enqueueSampleBuffer):
(WebCore::SourceBufferPrivateAVFObjC::configureVideoRenderer):
(WebCore::SourceBufferPrivateAVFObjC::invalidateVideoRenderer):
(WebCore::SourceBufferPrivateAVFObjC::setVideoRenderer):
(WebCore::SourceBufferPrivateAVFObjC::stageVideoRenderer):
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h:
(WebCore::VideoMediaSampleRenderer::as const): Convenience method to easily retrieve the original layer or render it was first created with.

Canonical link: <a href="https://commits.webkit.org/287484@main">https://commits.webkit.org/287484@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/233f8db28bbf6ab3de648e726ebdaba53836aed1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79854 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58854 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33252 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84374 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/30846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81963 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67923 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7144 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/62408 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/30846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82922 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/52474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72724 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42719 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/49814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26873 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29299 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/70939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27348 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85802 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7081 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/70677 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7255 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68564 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69920 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17420 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13922 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12846 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7040 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6896 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10408 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8702 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->