### PR TITLE
[WebGPU] Implement Buffer::getMappedRange in Swift

### DIFF
--- a/Source/WebGPU/WebGPU/Buffer.h
+++ b/Source/WebGPU/WebGPU/Buffer.h
@@ -73,7 +73,7 @@ public:
     ~Buffer();
 
     void destroy();
-    std::span<uint8_t> getMappedRange(size_t offset, size_t);
+    std::span<uint8_t> getMappedRange(size_t offset, size_t) HAS_SWIFTCXX_THUNK;
     void mapAsync(WGPUMapModeFlags, size_t offset, size_t, CompletionHandler<void(WGPUBufferMapAsyncStatus)>&& callback);
     void unmap();
     void setLabel(String&&);
@@ -126,7 +126,11 @@ private:
     Buffer(id<MTLBuffer>, uint64_t initialSize, WGPUBufferUsageFlags, State initialState, MappingRange initialMappingRange, Device&);
     Buffer(Device&);
 
+
+private PUBLIC_IN_WEBGPU_SWIFT:
     bool validateGetMappedRange(size_t offset, size_t rangeSize) const;
+
+private:
     NSString* errorValidatingMapAsync(WGPUMapModeFlags, size_t offset, size_t rangeSize) const;
     bool validateUnmap() const;
     void setState(State);
@@ -147,7 +151,9 @@ private:
     // [[mapping]] is unnecessary; we can just use m_device.contents.
     MappingRange m_mappingRange { 0, 0 };
     using MappedRanges = RangeSet<Range<size_t>>;
+private PUBLIC_IN_WEBGPU_SWIFT:
     MappedRanges m_mappedRanges;
+private:
     WGPUMapModeFlags m_mapMode { WGPUMapMode_None };
     struct IndirectArgsCache {
         uint64_t indirectOffset { UINT64_MAX };

--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -37,6 +37,7 @@
 #import "WebGPUSwiftInternal.h"
 
 DEFINE_SWIFTCXX_THUNK(WebGPU::Buffer, copyFrom, void, const std::span<const uint8_t>, const size_t);
+DEFINE_SWIFTCXX_THUNK(WebGPU::Buffer, getMappedRange, std::span<uint8_t>, size_t, size_t);
 #endif
 
 namespace WebGPU {
@@ -255,6 +256,7 @@ static size_t computeRangeSize(uint64_t size, size_t offset)
     return result.value();
 }
   
+#if !ENABLE(WEBGPU_SWIFT)
 std::span<uint8_t> Buffer::getMappedRange(size_t offset, size_t size)
 {
     // https://gpuweb.github.io/gpuweb/#dom-gpubuffer-getmappedrange
@@ -275,6 +277,7 @@ std::span<uint8_t> Buffer::getMappedRange(size_t offset, size_t size)
         return { };
     return getBufferContents().subspan(offset);
 }
+#endif
 
 std::span<uint8_t> Buffer::getBufferContents()
 {

--- a/Source/WebGPU/WebGPU/Internal/WebGPUSwiftInternal.h
+++ b/Source/WebGPU/WebGPU/Internal/WebGPUSwiftInternal.h
@@ -36,17 +36,34 @@
 #include "WebGPU.h"
 #include <cstdint>
 #include <span>
+#include <wtf/CheckedArithmetic.h>
 #include <wtf/StdLibExtras.h>
 
 using SpanConstUInt8 = std::span<const uint8_t>;
 using SpanUInt8 = std::span<uint8_t>;
-inline unsigned long roundUpToMultipleOfNonPowerOfTwoCheckedUInt32UnsignedLong(Checked<uint32_t> x, unsigned long y) { return WTF::roundUpToMultipleOfNonPowerOfTwo<unsigned long int, Checked<uint32_t>>(x, y); }
+using WTFRangeSizeT = WTF::Range<size_t>;
+
+__attribute__((used)) static const auto stdDynamicExtent = std::dynamic_extent;
+
+// FIXME: importing WTF::Range does not work
+namespace WTF {
+template<typename PassedType>
+class Range;
+}
 
 // FIXME: rdar://140819194
 constexpr unsigned long int WGPU_COPY_STRIDE_UNDEFINED_ = WGPU_COPY_STRIDE_UNDEFINED;
 
 // FIXME: rdar://140819448
 constexpr auto MTLBlitOptionNone_ = MTLBlitOptionNone;
+
+inline unsigned long roundUpToMultipleOfNonPowerOfTwoCheckedUInt32UnsignedLong(Checked<uint32_t> x, unsigned long y) { return WTF::roundUpToMultipleOfNonPowerOfTwo<unsigned long int, Checked<uint32_t>>(x, y); }
+
+inline Checked<size_t> checkedDifferenceSizeT(size_t left, size_t right)
+{
+    return WTF::checkedDifference<size_t>(left, right);
+}
+
 
 #ifndef __swift__
 #include "WebGPUSwift-Generated.h"


### PR DESCRIPTION
#### 857fda0f21dec394941acb716fa05dcbbceeb9da
<pre>
[WebGPU] Implement Buffer::getMappedRange in Swift
<a href="https://bugs.webkit.org/show_bug.cgi?id=284162">https://bugs.webkit.org/show_bug.cgi?id=284162</a>
<a href="https://rdar.apple.com/141045879">rdar://141045879</a>

Reviewed by Mike Wyrzykowski.

Add a Swift version of Buffer::getMappedRange and the computeRangeSize helper
function. The implementation is disabled by default. The patch forward declares
`wtf::Range` as a workaround, as importing `&lt;wtf/Range.h&gt;` caused build failures.

Verified that webgpu:api,validation,buffer,mapping:* passes. Also fixed the
precondition in Swift&apos;s Buffer::copy as some of the tests were crashing.

* Source/WebGPU/WebGPU/Buffer.h:
* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::Buffer::getMappedRange):
* Source/WebGPU/WebGPU/Buffer.swift:
(getMappedRange(_:offset:size:)):
(computeRangeSize(_:offset:)):
(WebGPU.getMappedRange(_:size:)):
* Source/WebGPU/WebGPU/Internal/WebGPUSwiftInternal.h:
(roundUpToMultipleOfNonPowerOfTwoCheckedUInt32UnsignedLong):
(checkedDifferenceUInt64):

Canonical link: <a href="https://commits.webkit.org/288015@main">https://commits.webkit.org/288015@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bffc7e5e4292f0f315e2a2ec022390060016a56e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81533 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1059 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35481 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86065 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32527 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1078 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8877 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63631 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21365 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84602 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/759 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74211 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43922 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/658 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30980 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72097 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28977 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87501 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8766 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6219 "Found 2 new test failures: http/wpt/mediarecorder/MediaRecorder-video-bitrate.html storage/indexeddb/modern/workers-enable.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71956 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8947 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70032 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71189 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17752 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15253 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14177 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8726 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14254 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8564 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12086 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10371 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->