### PR TITLE
[iOS] Selection shows in the wrong place while scrolling if endpoints are in different subscrollable containers

### DIFF
--- a/LayoutTests/editing/selection/ios/hide-selection-in-separate-overflow-scrollers-expected.txt
+++ b/LayoutTests/editing/selection/ios/hide-selection-in-separate-overflow-scrollers-expected.txt
@@ -1,0 +1,16 @@
+Select me
+
+More text
+
+This test verifies that selection rects are hidden when scrolling an overflow scrollable container, if the selection spans across separate scroll views. To manually test, select the text below and scroll the red box; the selection should hide when scrolling and reappear when scrolling ends.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS Selection appeared
+PASS Scrolled down
+PASS Selection disappeared
+PASS Ended touch
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/hide-selection-in-separate-overflow-scrollers.html
+++ b/LayoutTests/editing/selection/ios/hide-selection-in-separate-overflow-scrollers.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true SelectionHonorsOverflowScrolling=false ] -->
+<html>
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+body, html {
+    font-family: system-ui;
+    font-size: 20px;
+    margin: 0;
+}
+
+.scroller {
+    overflow-y: scroll;
+    width: 300px;
+    height: 300px;
+    border: 1px solid tomato;
+}
+
+.tall-content {
+    height: 5000px;
+}
+
+.start {
+    border: 1px solid lightblue;
+}
+
+.end {
+    border: 1px solid teal;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("This test verifies that selection rects are hidden when scrolling an overflow scrollable container, if the selection spans across separate scroll views. To manually test, select the text below and scroll the red box; the selection should hide when scrolling and reappear when scrolling ends.")
+    if (!window.testRunner)
+        return;
+
+    const start = document.querySelector(".start");
+    const end = document.querySelector(".end");
+    const scroller = document.querySelector(".scroller");
+    const midpoint = UIHelper.midPointOfRect(scroller.getBoundingClientRect());
+
+    await UIHelper.longPressElement(start);
+    await UIHelper.waitForSelectionToAppear();
+    testPassed("Selection appeared");
+
+    // Make the selection start in the main scroll view and end in an overflow scroller.
+    getSelection().setBaseAndExtent(start, 0, end, 1);
+    await UIHelper.ensurePresentationUpdate();
+
+    await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+        .begin(midpoint.x, midpoint.y + 100)
+        .move(midpoint.x, midpoint.y - 100, 0.25)
+        .takeResult());
+    testPassed("Scrolled down");
+
+    await UIHelper.waitForSelectionToDisappear();
+    testPassed("Selection disappeared");
+
+    await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder().end().takeResult());
+    testPassed("Ended touch");
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <p><span class="start">Select</span> me</p>
+    <div class="scroller">
+        <p>More <span class="end">text</span></p>
+        <div class="tall-content"></div>
+    </div>
+    <pre id="description"></pre>
+    <pre id="console"></pre>
+</body>
+</html>

--- a/Source/WebKit/Shared/EditorState.h
+++ b/Source/WebKit/Shared/EditorState.h
@@ -159,6 +159,8 @@ struct EditorState {
         WebCore::IntRect markedTextCaretRectAtEnd;
         std::optional<WebCore::PlatformLayerIdentifier> enclosingLayerID;
         std::optional<WebCore::ScrollingNodeID> enclosingScrollingNodeID;
+        std::optional<WebCore::ScrollingNodeID> scrollingNodeIDAtStart;
+        std::optional<WebCore::ScrollingNodeID> scrollingNodeIDAtEnd;
         WebCore::ScrollPosition enclosingScrollPosition;
 #endif // PLATFORM(IOS_FAMILY)
     };

--- a/Source/WebKit/Shared/EditorState.serialization.in
+++ b/Source/WebKit/Shared/EditorState.serialization.in
@@ -129,6 +129,8 @@ using WebCore::ScrollPosition = WebCore::IntPoint;
     WebCore::IntRect markedTextCaretRectAtEnd;
     std::optional<WebCore::PlatformLayerIdentifier> enclosingLayerID;
     std::optional<WebCore::ScrollingNodeID> enclosingScrollingNodeID;
+    std::optional<WebCore::ScrollingNodeID> scrollingNodeIDAtStart;
+    std::optional<WebCore::ScrollingNodeID> scrollingNodeIDAtEnd;
     WebCore::ScrollPosition enclosingScrollPosition;
 #endif
 };

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.h
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.h
@@ -53,6 +53,7 @@
 @end
 
 @interface UIView (WebKitInternal)
+- (BOOL)_wk_isAncestorOf:(UIView *)view;
 @property (nonatomic, readonly) UIScrollView *_wk_parentScrollView;
 @property (nonatomic, readonly) UIViewController *_wk_viewControllerForFullScreenPresentation;
 @end

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
@@ -228,6 +228,15 @@ static UIAxis axesForDelta(WebCore::FloatSize delta)
     return nil;
 }
 
+- (BOOL)_wk_isAncestorOf:(UIView *)view
+{
+    for (RetainPtr parent = [view superview]; parent; parent = [parent superview]) {
+        if (parent == self)
+            return YES;
+    }
+    return NO;
+}
+
 - (UIViewController *)_wk_viewControllerForFullScreenPresentation
 {
     auto controller = self.window.rootViewController;

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -659,7 +659,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)_didExitStableState
 {
-    _needsDeferredEndScrollingSelectionUpdate = self.shouldHideSelectionWhenScrolling;
+    _needsDeferredEndScrollingSelectionUpdate = self.shouldHideSelectionInFixedPositionWhenScrolling;
     if (!_needsDeferredEndScrollingSelectionUpdate)
         return;
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -651,7 +651,7 @@ struct ImageAnalysisContextMenuActionData {
 
 @property (nonatomic, readonly) CGPoint lastInteractionLocation;
 @property (nonatomic, readonly) BOOL isEditable;
-@property (nonatomic, readonly) BOOL shouldHideSelectionWhenScrolling;
+@property (nonatomic, readonly) BOOL shouldHideSelectionInFixedPositionWhenScrolling;
 @property (nonatomic, readonly) BOOL shouldIgnoreKeyboardWillHideNotification;
 @property (nonatomic, readonly) const WebKit::InteractionInformationAtPosition& positionInformation;
 @property (nonatomic, readonly) const WebKit::WKAutoCorrectionData& autocorrectionData;
@@ -920,8 +920,9 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 
 - (ScopeExit<Function<void()>>)makeTextSelectionViewsNonInteractiveForScope;
 
+- (BOOL)_shouldHideSelectionDuringOverflowScroll:(UIScrollView *)scrollView;
+
 @property (nonatomic, readonly) BOOL shouldUseAsyncInteractions;
-@property (nonatomic, readonly) BOOL selectionHonorsOverflowScrolling;
 
 @end
 

--- a/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.h
+++ b/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.h
@@ -42,7 +42,7 @@
 - (void)didEndScrollingOverflow;
 - (void)selectionChanged;
 - (void)setGestureRecognizers;
-- (void)willStartScrollingOverflow;
+- (void)willStartScrollingOverflow:(UIScrollView *)scrollView;
 - (void)selectionChangedWithGestureAt:(CGPoint)point withGesture:(WKBEGestureType)gestureType withState:(UIGestureRecognizerState)gestureState withFlags:(WKBESelectionFlags)flags;
 - (void)selectionChangedWithTouchAt:(CGPoint)point withSelectionTouch:(WKBESelectionTouchPhase)touch withFlags:(WKBESelectionFlags)flags;
 - (void)lookup:(NSString *)textWithContext withRange:(NSRange)range fromRect:(CGRect)presentationRect;
@@ -56,6 +56,11 @@
 - (void)selectAll:(id)sender;
 - (void)translate:(NSString *)text fromRect:(CGRect)presentationRect;
 - (void)prepareToMoveSelectionContainer:(UIView *)newContainer;
+
+- (void)willBeginDragLift;
+- (void)didConcludeDrop;
+
+- (void)reset;
 
 #if USE(UICONTEXTMENU)
 - (void)setExternalContextMenuInteractionDelegate:(id<UIContextMenuInteractionDelegate>)delegate;


### PR DESCRIPTION
#### 0fd82dd1a7ef0bc8f9c79c1b908cfa721870e21a
<pre>
[iOS] Selection shows in the wrong place while scrolling if endpoints are in different subscrollable containers
<a href="https://bugs.webkit.org/show_bug.cgi?id=284168">https://bugs.webkit.org/show_bug.cgi?id=284168</a>
<a href="https://rdar.apple.com/140934400">rdar://140934400</a>

Reviewed by Richard Robinson and Abrar Rahman Protyasha.

When &quot;Selection Honors Overflow Scrolling&quot; is enabled, there&apos;s a remaining scenario where the
selection may show up in the wrong place while overflow scrolling — when one of the selection
endpoints is in a different scroller (compared to the scrollable container of the selection&apos;s common
ancestor), and this selection endpoint&apos;s container is scrolled separately from the rest of the
selection. In this case, selection UI will still be hosted in the compositing view above the common
ancestor, which means the selection rects in the nested overflow container won&apos;t be able to scroll
properly (i.e. detached from the rest of the selection).

To address this issue for now, fall back to the long-standing behavior of hiding the selection
during overflow scrolling, but only in this scenario where one part of the selection is being
scrolled separately from the rest of the selection; in practice, this should be rare enough of a
corner case, where most users would be unlikely to ever see this old behavior.

See below for more details.

* LayoutTests/editing/selection/ios/hide-selection-in-separate-overflow-scrollers-expected.txt: Added.
* LayoutTests/editing/selection/ios/hide-selection-in-separate-overflow-scrollers.html: Added.

Add a layout test to verify that the selection is still hidden while scrolling in this scenario,
even when `Selection Honors Overflow Scrolling` is enabled.

* Source/WebKit/Shared/EditorState.h:
* Source/WebKit/Shared/EditorState.serialization.in:

Add optional `ScrollingNodeID`s representing the innermost scrollable containers of the selection
start and end positions. Notably, this may differ from the `enclosingScrollingNodeID` in this
scenario where one of the endpoints exists in a nested subscrollable container.

* Source/WebKit/UIProcess/ios/UIKitUtilities.h:
* Source/WebKit/UIProcess/ios/UIKitUtilities.mm:
(-[UIView _wk_isAncestorOf:]):

Add a helper method to compute whether or not a view is a ancestor of another view.

* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _didExitStableState]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView shouldHideSelectionInFixedPositionWhenScrolling]):

Rename `shouldHideSelectionWhenScrolling` to `shouldHideSelectionInFixedPositionWhenScrolling`, to
more accurately reflect that this is just about hiding selection UI in fixed-position containers
when scrolling. This renaming is important to distinguish between the new method below that
determines whether we should hide the selection during overflow scrolling.

(-[WKContentView _scrollingNodeScrollingWillBegin:]):

Pass the target scroll view into `-willStartScrollingOverflow:`.

(-[WKContentView _scrollingNodeScrollingDidEnd:]):

Deploy `-_scrollViewForScrollingNodeID:` here to avoid duplicating some code.

(-[WKContentView _didCommitLoadForMainFrame]):

Stop suppressing the edit menu (and/or selection interaction) when navigating.

(-[WKContentView _reconcileEnclosingScrollViewContentOffset:]):
(-[WKContentView _scrollViewForScrollingNodeID:]):
(-[WKContentView _updateTargetedPreviewScrollViewUsingContainerScrollingNodeID:]):
(-[WKContentView _restoreEditMenuIfNeeded]):

Drive-by fix: rename `-didEndScrollingOverflow` to `-didConcludeDrop` and remove a FIXME.

(-[WKContentView dragInteraction:willAnimateLiftWithAnimator:session:]):

Drive-by fix: rename `-willStartScrollingOverflow` to `-willBeginDragLift` and remove a FIXME.

(-[WKContentView _shouldHideSelectionDuringOverflowScroll:]):

Add a new helper method that determines whether we should hide the selection when scrolling an
overflow container:

-   If &quot;Selection Honors Overflow Scrolling&quot; is disabled, we always hide the selection.
-   Otherwise, if scrolling will cause one of the selection endpoints to (visually) detach from the
    rest of the selection, we&apos;ll hide the selection (this is the fallback described above).
-   Otherwise, don&apos;t hide the selection.

(-[WKContentView shouldHideSelectionWhenScrolling]): Deleted.
* Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.h:
* Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm:
(WebKit::HideEditMenuScope::HideEditMenuScope):
(WebKit::HideEditMenuScope::~HideEditMenuScope):

Clean up logic to temporarily hide the selection during overflow scrolling, or when performing a
drag, using a new RAII object — `HideEditMenuScope`.

(-[WKTextInteractionWrapper view]):
(-[WKTextInteractionWrapper willBeginDragLift]):
(-[WKTextInteractionWrapper didConcludeDrop]):
(-[WKTextInteractionWrapper willStartScrollingOverflow:]):
(-[WKTextInteractionWrapper didEndScrollingOverflow]):
(-[WKTextInteractionWrapper reset]):

Add a helper method to reset state (currently, just `_hideEditMenuScope`) when committing a
mainframe navigation. Note that we force `_shouldRestoreEditMenuAfterOverflowScrolling := NO` here
to avoid presenting the edit menu after navigating.

(-[WKTextInteractionWrapper willStartScrollingOrZooming]):
(-[WKTextInteractionWrapper didEndScrollingOrZooming]):
(-[WKTextInteractionWrapper asyncTextInteraction]):
(-[WKTextInteractionWrapper willStartScrollingOverflow]): Deleted.
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::computeEnclosingLayerID const):

Refactor this code to also compute `scrollingNodeIDAtStart` and `scrollingNodeIDAtEnd`.

Canonical link: <a href="https://commits.webkit.org/287477@main">https://commits.webkit.org/287477@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eee4f4b875c590331331a8263fcef7c1918bf051

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79825 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58826 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33224 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84350 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30825 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67900 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7116 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62394 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20233 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82893 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52452 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72697 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42702 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49792 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26846 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29275 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70919 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27319 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85776 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7056 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70656 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7230 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68537 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69896 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17418 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13903 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12821 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7015 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6874 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10385 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8680 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->