### PR TITLE
Fix occasional crash in foundMixedContentInFrameTree with site isolation enabled

### DIFF
--- a/LayoutTests/http/tests/site-isolation/resources/child-frame.html
+++ b/LayoutTests/http/tests/site-isolation/resources/child-frame.html
@@ -1,0 +1,9 @@
+<iframe src="http://127.0.0.1:8000/site-isolation/resources/grandchild-frame.html" id=onlyiframe></iframe>
+<script>
+    onload = () => {
+        onlyiframe.parentNode.removeChild(onlyiframe);
+        setTimeout(()=>{
+            testRunner.notifyDone();
+        }, 100);
+    }
+</script>

--- a/LayoutTests/http/tests/site-isolation/resources/grandchild-frame.html
+++ b/LayoutTests/http/tests/site-isolation/resources/grandchild-frame.html
@@ -1,0 +1,1 @@
+<iframe src="http://127.0.0.1:8000/site-isolation/resources/great-grandchild-frame.html"></iframe>

--- a/LayoutTests/http/tests/site-isolation/resources/great-grandchild-frame.html
+++ b/LayoutTests/http/tests/site-isolation/resources/great-grandchild-frame.html
@@ -1,0 +1,5 @@
+<script>
+    addEventListener("pagehide", (event) => {
+        fetch('http://localhost:8000/site-isolation/resources/child-frame.html')
+    });
+</script>

--- a/LayoutTests/http/tests/site-isolation/unload-grandchild-fetch-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/unload-grandchild-fetch-expected.txt
@@ -1,0 +1,1 @@
+ This test passes if it does not crash.

--- a/LayoutTests/http/tests/site-isolation/unload-grandchild-fetch.html
+++ b/LayoutTests/http/tests/site-isolation/unload-grandchild-fetch.html
@@ -1,0 +1,6 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script>
+    if (window.testRunner) { testRunner.waitUntilDone(); testRunner.dumpAsText() }
+</script>
+<iframe src="http://localhost:8000/site-isolation/resources/child-frame.html"></iframe>
+This test passes if it does not crash.

--- a/Source/WebCore/loader/MixedContentChecker.cpp
+++ b/Source/WebCore/loader/MixedContentChecker.cpp
@@ -71,13 +71,15 @@ static bool foundMixedContentInFrameTree(const LocalFrame& frame, const URL& url
         if (!frame || frame->isMainFrame())
             break;
 
-        RefPtr abstractParentFrame = frame->tree().parent();
-        RELEASE_ASSERT_WITH_MESSAGE(abstractParentFrame, "Should never have a parentless non main frame");
-        if (auto* parentFrame = dynamicDowncast<LocalFrame>(abstractParentFrame.get()))
-            document = parentFrame->document();
+        RefPtr parentFrame = frame->tree().parent();
+        if (!parentFrame)
+            break;
+
+        if (RefPtr localParentFrame = dynamicDowncast<LocalFrame>(parentFrame.get()))
+            document = localParentFrame->document();
         else {
             // FIXME: <rdar://116259764> Make mixed content checks work correctly with site isolated iframes.
-            document = nullptr;
+            break;
         }
     }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1184,10 +1184,8 @@ void WebPage::didFinishLoadInAnotherProcess(WebCore::FrameIdentifier frameID)
 void WebPage::frameWasRemovedInAnotherProcess(WebCore::FrameIdentifier frameID)
 {
     RefPtr frame = WebProcess::singleton().webFrame(frameID);
-    if (!frame) {
-        ASSERT_NOT_REACHED();
+    if (!frame)
         return;
-    }
     ASSERT(frame->page() == this);
     frame->removeFromTree();
 }


### PR DESCRIPTION
#### 01812b56dd474ae6c2cda2af9f512be30ee906c1
<pre>
Fix occasional crash in foundMixedContentInFrameTree with site isolation enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=284173">https://bugs.webkit.org/show_bug.cgi?id=284173</a>

Reviewed by Pascoe.

I found a condition where the crash can happen with site isolation enabled if a pagehide event
handler initiates a fetch during teardown as a result of a frame being removed in another
process.  I added a unit test that hit the crash and changed the crash to an early return.

Along the way I found that the assertion in WebPage::frameWasRemovedInAnotherProcess can hit
if a race condition of multiple processes removing the same frame is hit.  In this case, the
frame has already been removed so there is nothing to do, so early returning is correct behavior.

I also found that WebProcessProxy::didDestroyFrame wasn&apos;t routing the message to the WebPageProxy
if a RemotePageProxy was communicating with the process that did the removing.  I added an
API test to verify the state is being handled properly once WebProcessProxy::didDestroyFrame is
redone in a way that behaves correctly in this case without breaking anything else.

* LayoutTests/http/tests/site-isolation/resources/child-frame.html: Added.
* LayoutTests/http/tests/site-isolation/resources/grandchild-frame.html: Added.
* LayoutTests/http/tests/site-isolation/resources/great-grandchild-frame.html: Added.
* LayoutTests/http/tests/site-isolation/unload-grandchild-fetch-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/unload-grandchild-fetch.html: Added.
* Source/WebCore/loader/MixedContentChecker.cpp:
(WebCore::foundMixedContentInFrameTree):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::didDestroyFrame):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::frameWasRemovedInAnotherProcess):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, RemoveFrameFromRemoteFrame)):

Canonical link: <a href="https://commits.webkit.org/287487@main">https://commits.webkit.org/287487@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/384bc3dec057e14ee217f2804917453e462e3811

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79795 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58796 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33194 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84320 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30800 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81904 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67870 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7087 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62370 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20212 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82863 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52425 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72670 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42674 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49767 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26818 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29245 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70895 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27289 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85746 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7029 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4922 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70631 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7203 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68509 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69871 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13875 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12795 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12348 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6987 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12571 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6849 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10359 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8656 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->