### PR TITLE
Coalesce VisitedLinkTableController messages

### DIFF
--- a/Source/WebKit/UIProcess/VisitedLinkStore.cpp
+++ b/Source/WebKit/UIProcess/VisitedLinkStore.cpp
@@ -133,7 +133,7 @@ void VisitedLinkStore::didUpdateSharedStringHashes(const Vector<WebCore::SharedS
     for (Ref process : m_processes) {
         ASSERT(process->processPool().processes().containsIf([&](auto& item) { return item.ptr() == process.ptr(); }));
 
-        if (addedHashes.size() > 20 || !removedHashes.isEmpty())
+        if (addedHashes.size() > 20 || !removedHashes.isEmpty() || process->throttler().isSuspended())
             process->send(Messages::VisitedLinkTableController::AllVisitedLinkStateChanged(), identifier());
         else
             process->send(Messages::VisitedLinkTableController::VisitedLinkStateChanged(addedHashes), identifier());

--- a/Source/WebKit/WebProcess/WebPage/VisitedLinkTableController.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/VisitedLinkTableController.messages.in
@@ -23,6 +23,6 @@
 messages -> VisitedLinkTableController {
     SetVisitedLinkTable(WebCore::SharedMemory::Handle handle)
     VisitedLinkStateChanged(Vector<WebCore::SharedStringHash> linkHashes)
-    AllVisitedLinkStateChanged()
-    RemoveAllVisitedLinks()
+    [DeferSendingIfSuspended] AllVisitedLinkStateChanged()
+    [DeferSendingIfSuspended] RemoveAllVisitedLinks()
 }


### PR DESCRIPTION
#### e11de77febe887f97f694bb1cb29a14f25728f93
<pre>
Coalesce VisitedLinkTableController messages
<a href="https://bugs.webkit.org/show_bug.cgi?id=284180">https://bugs.webkit.org/show_bug.cgi?id=284180</a>
<a href="https://rdar.apple.com/141060207">rdar://141060207</a>

Reviewed by Ryan Reno.

When analyzing long-running traces of web usage, it looks like VisitedLinkTableController messages
are now the top contributor to spurious WebContent process wakeups. Fix this by marking the messages
as not being sent if the receiver is suspended, and by sending the AllVisitedLinkStateChanged
message (which is coalescable) if the receiver is suspended.

* Source/WebKit/UIProcess/VisitedLinkStore.cpp:
(WebKit::VisitedLinkStore::didUpdateSharedStringHashes):
* Source/WebKit/WebProcess/WebPage/VisitedLinkTableController.messages.in:

Canonical link: <a href="https://commits.webkit.org/287479@main">https://commits.webkit.org/287479@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/305e12e7daf1f6ae720067f1f3ceb7f3a2927340

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79796 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58797 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33195 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84321 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30801 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67871 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7088 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62371 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20214 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82864 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52427 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72668 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42675 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49769 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29246 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70897 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27287 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85747 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7030 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4923 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70630 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7204 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68507 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69870 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17419 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13878 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12793 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6988 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12572 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6850 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10360 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8657 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->