### PR TITLE
Move drawing the ImageBuffer from GraphicsContext to ImageBuffer and ImageBufferBackend

### DIFF
--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
@@ -419,6 +419,14 @@ void BifurcatedGraphicsContext::drawPattern(NativeImage& nativeImage, const Floa
     VERIFY_STATE_SYNCHRONIZATION();
 }
 
+void BifurcatedGraphicsContext::drawPattern(ImageBuffer& image, const FloatRect& destRect, const FloatRect& source, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions options)
+{
+    m_primaryContext.drawPattern(image, destRect, source, patternTransform, phase, spacing, options);
+    m_secondaryContext.drawPattern(image, destRect, source, patternTransform, phase, spacing, options);
+
+    VERIFY_STATE_SYNCHRONIZATION();
+}
+
 ImageDrawResult BifurcatedGraphicsContext::drawImage(Image& image, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions options)
 {
     auto result = m_primaryContext.drawImage(image, destination, source, options);
@@ -447,6 +455,22 @@ ImageDrawResult BifurcatedGraphicsContext::drawTiledImage(Image& image, const Fl
     VERIFY_STATE_SYNCHRONIZATION();
 
     return result;
+}
+
+void BifurcatedGraphicsContext::drawImageBuffer(ImageBuffer& image, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions options)
+{
+    m_primaryContext.drawImageBuffer(image, destination, source, options);
+    m_secondaryContext.drawImageBuffer(image, destination, source, options);
+
+    VERIFY_STATE_SYNCHRONIZATION();
+}
+
+void BifurcatedGraphicsContext::drawConsumingImageBuffer(RefPtr<ImageBuffer> image, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions options)
+{
+    m_primaryContext.drawConsumingImageBuffer(image, destination, source, options);
+    m_secondaryContext.drawConsumingImageBuffer(image, destination, source, options);
+
+    VERIFY_STATE_SYNCHRONIZATION();
 }
 
 #if ENABLE(VIDEO)

--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
@@ -109,9 +109,12 @@ public:
     void drawNativeImageInternal(NativeImage&, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions = { }) final;
     void drawSystemImage(SystemImage&, const FloatRect&) final;
     void drawPattern(NativeImage&, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions = { }) final;
+    void drawPattern(ImageBuffer&, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions = { }) final;
     ImageDrawResult drawImage(Image&, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions = { ImageOrientation::Orientation::FromImage }) final;
     ImageDrawResult drawTiledImage(Image&, const FloatRect& destination, const FloatPoint& source, const FloatSize& tileSize, const FloatSize& spacing, ImagePaintingOptions = { }) final;
     ImageDrawResult drawTiledImage(Image&, const FloatRect& destination, const FloatRect& source, const FloatSize& tileScaleFactor, Image::TileRule, Image::TileRule, ImagePaintingOptions = { }) final;
+    void drawImageBuffer(ImageBuffer&, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions = { }) final;
+    void drawConsumingImageBuffer(RefPtr<ImageBuffer>, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions = { }) final;
     void drawControlPart(ControlPart&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) final;
 
 #if ENABLE(VIDEO)

--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -351,13 +351,6 @@ ImageDrawResult GraphicsContext::drawTiledImage(Image& image, const FloatRect& d
     return image.drawTiled(*this, destination, source, tileScaleFactor, hRule, vRule, { options.compositeOperator() });
 }
 
-RefPtr<NativeImage> GraphicsContext::nativeImageForDrawing(ImageBuffer& imageBuffer)
-{
-    if (m_isDeferred == IsDeferred::Yes || &imageBuffer.context() == this)
-        return imageBuffer.copyNativeImage();
-    return imageBuffer.createNativeImageReference();
-}
-
 void GraphicsContext::drawImageBuffer(ImageBuffer& image, const FloatPoint& destination, ImagePaintingOptions imagePaintingOptions)
 {
     drawImageBuffer(image, FloatRect(destination, image.logicalSize()), FloatRect({ }, image.logicalSize()), imagePaintingOptions);
@@ -371,10 +364,7 @@ void GraphicsContext::drawImageBuffer(ImageBuffer& image, const FloatRect& desti
 void GraphicsContext::drawImageBuffer(ImageBuffer& image, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions options)
 {
     InterpolationQualityMaintainer interpolationQualityForThisScope(*this, options.interpolationQuality());
-    FloatRect sourceScaled = source;
-    sourceScaled.scale(image.resolutionScale());
-    if (auto nativeImage = nativeImageForDrawing(image))
-        drawNativeImageInternal(*nativeImage, destination, sourceScaled, options);
+    image.draw(*this, destination, source, options);
 }
 
 void GraphicsContext::drawConsumingImageBuffer(RefPtr<ImageBuffer> image, const FloatPoint& destination, ImagePaintingOptions imagePaintingOptions)
@@ -397,12 +387,8 @@ void GraphicsContext::drawConsumingImageBuffer(RefPtr<ImageBuffer> image, const 
 {
     if (!image)
         return;
-    ASSERT(this != &image->context());
     InterpolationQualityMaintainer interpolationQualityForThisScope(*this, options.interpolationQuality());
-    FloatRect scaledSource = source;
-    scaledSource.scale(image->resolutionScale());
-    if (auto nativeImage = ImageBuffer::sinkIntoNativeImage(WTFMove(image)))
-        drawNativeImageInternal(*nativeImage, destination, scaledSource, options);
+    return image->drawConsuming(*this, destination, source, options);
 }
 
 void GraphicsContext::drawFilteredImageBuffer(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter& filter, FilterResults& results)
@@ -422,10 +408,7 @@ void GraphicsContext::drawFilteredImageBuffer(ImageBuffer* sourceImage, const Fl
 
 void GraphicsContext::drawPattern(ImageBuffer& image, const FloatRect& destRect, const FloatRect& source, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions options)
 {
-    FloatRect scaledSource = source;
-    scaledSource.scale(image.resolutionScale());
-    if (auto nativeImage = nativeImageForDrawing(image))
-        drawPattern(*nativeImage, destRect, source, patternTransform, phase, spacing, options);
+    image.drawPattern(*this, destRect, source, patternTransform, phase, spacing, options);
 }
 
 void GraphicsContext::drawControlPart(ControlPart& part, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -70,7 +70,7 @@ class GraphicsContext {
     friend class BifurcatedGraphicsContext;
     friend class DisplayList::DrawNativeImage;
     friend class NativeImage;
-    friend class ImageBuffer;
+    friend class ImageBufferBackend;
 public:
     // Indicates if draw operations read the sources such as NativeImage backing stores immediately
     // during draw operations.
@@ -81,6 +81,8 @@ public:
     WEBCORE_EXPORT GraphicsContext(IsDeferred = IsDeferred::No, const GraphicsContextState::ChangeFlags& = { }, InterpolationQuality = InterpolationQuality::Default);
     WEBCORE_EXPORT GraphicsContext(IsDeferred, const GraphicsContextState&);
     WEBCORE_EXPORT virtual ~GraphicsContext();
+
+    IsDeferred isDeferred() const { return m_isDeferred; }
 
     virtual bool hasPlatformContext() const { return false; }
     virtual PlatformGraphicsContext* platformContext() const { return nullptr; }
@@ -383,7 +385,6 @@ private:
     virtual void drawNativeImageInternal(NativeImage&, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions = { }) = 0;
 
 protected:
-    WEBCORE_EXPORT RefPtr<NativeImage> nativeImageForDrawing(ImageBuffer&);
     WEBCORE_EXPORT void fillEllipseAsPath(const FloatRect&);
     WEBCORE_EXPORT void strokeEllipseAsPath(const FloatRect&);
 

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -318,15 +318,26 @@ IntSize ImageBuffer::backendSize() const
 
 RefPtr<NativeImage> ImageBuffer::copyNativeImage() const
 {
-    if (auto* backend = ensureBackend())
+    if (auto* backend = ensureBackend()) {
+        const_cast<ImageBuffer&>(*this).flushDrawingContext();
         return backend->copyNativeImage();
+    }
     return nullptr;
 }
 
 RefPtr<NativeImage> ImageBuffer::createNativeImageReference() const
 {
-    if (auto* backend = ensureBackend())
+    if (auto* backend = ensureBackend()) {
+        const_cast<ImageBuffer&>(*this).flushDrawingContext();
         return backend->createNativeImageReference();
+    }
+    return nullptr;
+}
+
+RefPtr<NativeImage> ImageBuffer::nativeImageForDrawing(GraphicsContext& destContext)
+{
+    if (auto* backend = ensureBackend())
+        return backend->nativeImageForDrawing(destContext);
     return nullptr;
 }
 
@@ -487,6 +498,30 @@ RefPtr<NativeImage> ImageBuffer::sinkIntoNativeImage(RefPtr<ImageBuffer> source)
     if (!source)
         return nullptr;
     return source->sinkIntoNativeImage();
+}
+
+void ImageBuffer::draw(GraphicsContext& destContext, const FloatRect& destRect, const FloatRect& srcRect, const ImagePaintingOptions options)
+{
+    if (auto* backend = ensureBackend()) {
+        flushDrawingContext();
+        backend->draw(destContext, destRect, srcRect, options);
+    }
+}
+
+void ImageBuffer::drawConsuming(GraphicsContext& destContext, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions options)
+{
+    if (auto* backend = ensureBackend()) {
+        flushDrawingContext();
+        backend->drawConsuming(destContext, destRect, srcRect, options);
+    }
+}
+
+void ImageBuffer::drawPattern(GraphicsContext& destContext, const FloatRect& destRect, const FloatRect& srcRect, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions options)
+{
+    if (auto* backend = ensureBackend()) {
+        flushDrawingContext();
+        backend->drawPattern(destContext, destRect, srcRect, patternTransform, phase, spacing, options);
+    }
 }
 
 void ImageBuffer::convertToLuminanceMask()

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -173,6 +173,8 @@ public:
     // Useful when caller can guarantee the use of the NativeImage ends "immediately", before the next draw to this ImageBuffer.
     WEBCORE_EXPORT virtual RefPtr<NativeImage> createNativeImageReference() const;
 
+    RefPtr<NativeImage> nativeImageForDrawing(GraphicsContext& destContext);
+
     WEBCORE_EXPORT virtual RefPtr<NativeImage> filteredNativeImage(Filter&);
     RefPtr<NativeImage> filteredNativeImage(Filter&, Function<void(GraphicsContext&)> drawCallback);
 
@@ -220,6 +222,10 @@ public:
     static RefPtr<ImageBuffer> sinkIntoImageBufferAfterCrossThreadTransfer(RefPtr<ImageBuffer>);
 #endif
     static std::unique_ptr<SerializedImageBuffer> sinkIntoSerializedImageBuffer(RefPtr<ImageBuffer>&&);
+
+    WEBCORE_EXPORT void draw(GraphicsContext& destContext, const FloatRect& destRect, const FloatRect& srcRect, const ImagePaintingOptions);
+    WEBCORE_EXPORT void drawConsuming(GraphicsContext& destContext, const FloatRect& destRect, const FloatRect& srcRect, const ImagePaintingOptions);
+    WEBCORE_EXPORT void drawPattern(GraphicsContext& destContext, const FloatRect& destRect, const FloatRect& srcRect, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, const ImagePaintingOptions);
 
     WEBCORE_EXPORT virtual void convertToLuminanceMask();
     WEBCORE_EXPORT virtual void transformToColorSpace(const DestinationColorSpace& newColorSpace);

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
@@ -51,9 +51,41 @@ ImageBufferBackend::ImageBufferBackend(const Parameters& parameters)
 
 ImageBufferBackend::~ImageBufferBackend() = default;
 
+RefPtr<NativeImage> ImageBufferBackend::nativeImageForDrawing(GraphicsContext& destContext)
+{
+    if (destContext.isDeferred() == GraphicsContext::IsDeferred::Yes || &context() == &destContext)
+        return copyNativeImage();
+    return createNativeImageReference();
+}
+
 RefPtr<NativeImage> ImageBufferBackend::sinkIntoNativeImage()
 {
     return createNativeImageReference();
+}
+
+void ImageBufferBackend::draw(GraphicsContext& destContext, const FloatRect& destRect, const FloatRect& srcRect, const ImagePaintingOptions options)
+{
+    FloatRect srcRectScaled = srcRect;
+    srcRectScaled.scale(resolutionScale());
+    if (auto nativeImage = nativeImageForDrawing(destContext))
+        destContext.drawNativeImageInternal(*nativeImage, destRect, srcRectScaled, options);
+}
+
+void ImageBufferBackend::drawConsuming(GraphicsContext& destContext, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions options)
+{
+    ASSERT(&destContext != &context());
+    FloatRect srcRectScaled = srcRect;
+    srcRectScaled.scale(resolutionScale());
+    if (auto nativeImage = sinkIntoNativeImage())
+        destContext.drawNativeImageInternal(*nativeImage, destRect, srcRectScaled, options);
+}
+
+void ImageBufferBackend::drawPattern(GraphicsContext& destContext, const FloatRect& destRect, const FloatRect& srcRect, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions options)
+{
+    FloatRect srcRectScaled = srcRect;
+    srcRectScaled.scale(resolutionScale());
+    if (auto nativeImage = nativeImageForDrawing(destContext))
+        destContext.drawPattern(*nativeImage, destRect, srcRectScaled, patternTransform, phase, spacing, options);
 }
 
 void ImageBufferBackend::convertToLuminanceMask()

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.h
@@ -122,7 +122,12 @@ public:
 
     virtual RefPtr<NativeImage> copyNativeImage() = 0;
     virtual RefPtr<NativeImage> createNativeImageReference() = 0;
+    RefPtr<NativeImage> nativeImageForDrawing(GraphicsContext& destContext);
     WEBCORE_EXPORT virtual RefPtr<NativeImage> sinkIntoNativeImage();
+
+    WEBCORE_EXPORT virtual void draw(GraphicsContext& destContext, const FloatRect& destRect, const FloatRect& srcRect, const ImagePaintingOptions);
+    WEBCORE_EXPORT virtual void drawConsuming(GraphicsContext& destContext, const FloatRect& destRect, const FloatRect& srcRect, const ImagePaintingOptions);
+    WEBCORE_EXPORT virtual void drawPattern(GraphicsContext& destContext, const FloatRect& destRect, const FloatRect& srcRect, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, const ImagePaintingOptions);
 
     WEBCORE_EXPORT void convertToLuminanceMask();
     virtual void transformToColorSpace(const DestinationColorSpace&) { }

--- a/Source/WebCore/platform/graphics/cairo/CairoOperations.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperations.cpp
@@ -174,14 +174,14 @@ enum PathDrawingStyle {
 
 static void drawShadowLayerBuffer(GraphicsContextCairo& platformContext, ImageBuffer& layerImage, const FloatPoint& layerOrigin, const FloatSize& layerSize, const ShadowState& shadowState)
 {
-    if (auto nativeImage = platformContext.nativeImageForDrawing(layerImage))
+    if (auto nativeImage = layerImage.nativeImageForDrawing(platformContext))
         drawPlatformImage(platformContext, nativeImage->platformImage().get(), FloatRect(roundedIntPoint(layerOrigin), layerSize), FloatRect(FloatPoint(), layerSize), { shadowState.globalCompositeOperator }, shadowState.globalAlpha, ShadowState());
 }
 
 // FIXME: This is mostly same as drawShadowLayerBuffer, so we should merge two.
 static void drawShadowImage(GraphicsContextCairo& platformContext, ImageBuffer& layerImage, const FloatRect& destRect, const FloatRect& srcRect, const ShadowState& shadowState)
 {
-    if (auto nativeImage = platformContext.nativeImageForDrawing(layerImage))
+    if (auto nativeImage = layerImage.nativeImageForDrawing(platformContext))
         drawPlatformImage(platformContext, nativeImage->platformImage().get(), destRect, srcRect, { shadowState.globalCompositeOperator }, shadowState.globalAlpha, ShadowState());
 }
 
@@ -189,7 +189,7 @@ static void fillShadowBuffer(GraphicsContextCairo& platformContext, ImageBuffer&
 {
     platformContext.save();
 
-    if (auto nativeImage = platformContext.nativeImageForDrawing(layerImage))
+    if (auto nativeImage = layerImage.nativeImageForDrawing(platformContext))
         clipToImageBuffer(platformContext, nativeImage->platformImage().get(), FloatRect(layerOrigin, expandedIntSize(layerSize)));
 
     FillSource fillSource;

--- a/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp
@@ -220,7 +220,7 @@ IntRect GraphicsContextCairo::clipBounds() const
 
 void GraphicsContextCairo::clipToImageBuffer(ImageBuffer& buffer, const FloatRect& destRect)
 {
-    if (auto nativeImage = nativeImageForDrawing(buffer))
+    if (auto nativeImage = buffer.nativeImageForDrawing(*this))
         Cairo::clipToImageBuffer(*this, nativeImage->platformImage().get(), destRect);
 }
 

--- a/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.h
+++ b/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.h
@@ -109,8 +109,6 @@ public:
     Vector<float>& layers();
     void pushImageMask(cairo_surface_t*, const FloatRect&);
 
-    // Exposed as public because freestanding functions use this.
-    using GraphicsContext::nativeImageForDrawing;
 private:
     RefPtr<cairo_t> m_cr;
 

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
@@ -647,7 +647,7 @@ IntRect GraphicsContextSkia::clipBounds() const
 
 void GraphicsContextSkia::clipToImageBuffer(ImageBuffer& buffer, const FloatRect& destRect)
 {
-    if (auto nativeImage = nativeImageForDrawing(buffer))
+    if (auto nativeImage = buffer.nativeImageForDrawing(*this))
         m_canvas.clipShader(nativeImage->platformImage()->makeShader(SkTileMode::kDecal, SkTileMode::kDecal, { }, SkMatrix::Translate(SkFloatToScalar(destRect.x()), SkFloatToScalar(destRect.y()))));
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
@@ -143,6 +143,10 @@ void RemoteImageBufferProxy::backingStoreWillChange()
 void RemoteImageBufferProxy::didCreateBackend(std::optional<ImageBufferBackendHandle> backendHandle)
 {
     ASSERT(!m_backend);
+    RefPtr remoteRenderingBackendProxy = m_remoteRenderingBackendProxy.get();
+    if (!remoteRenderingBackendProxy)
+        return;
+
     // This should match RemoteImageBufferProxy::create<>() call site and RemoteImageBuffer::create<>() call site.
     // FIXME: this will be removed and backend be constructed in the contructor.
     std::unique_ptr<ImageBufferBackend> backend;
@@ -153,7 +157,7 @@ void RemoteImageBufferProxy::didCreateBackend(std::optional<ImageBufferBackendHa
             if (RemoteRenderingBackendProxy::canMapRemoteImageBufferBackendBackingStore())
                 backend = ImageBufferShareableMappedIOSurfaceBackend::create(backendParameters, WTFMove(*backendHandle));
             else
-                backend = ImageBufferRemoteIOSurfaceBackend::create(backendParameters, WTFMove(*backendHandle));
+                backend = ImageBufferRemoteIOSurfaceBackend::create(backendParameters, WTFMove(*backendHandle), *remoteRenderingBackendProxy, renderingResourceIdentifier());
         }
 #endif
         if (std::holds_alternative<ShareableBitmap::Handle>(*backendHandle)) {
@@ -165,7 +169,6 @@ void RemoteImageBufferProxy::didCreateBackend(std::optional<ImageBufferBackendHa
     }
     if (!backend) {
         m_remoteDisplayList.disconnect();
-        RefPtr remoteRenderingBackendProxy = m_remoteRenderingBackendProxy.get();
         remoteRenderingBackendProxy->remoteResourceCacheProxy().forgetImageBuffer(renderingResourceIdentifier());
         remoteRenderingBackendProxy->releaseImageBuffer(renderingResourceIdentifier());
         m_remoteRenderingBackendProxy = nullptr;
@@ -190,37 +193,6 @@ ImageBufferBackend* RemoteImageBufferProxy::ensureBackend() const
         }
     }
     return m_backend.get();
-}
-
-RefPtr<NativeImage> RemoteImageBufferProxy::copyNativeImage() const
-{
-    auto* backend = ensureBackend();
-    if (!backend)
-        return { };
-    if (backend->canMapBackingStore()) {
-        const_cast<RemoteImageBufferProxy*>(this)->flushDrawingContext();
-        return ImageBuffer::copyNativeImage();
-    }
-    RefPtr remoteRenderingBackendProxy = m_remoteRenderingBackendProxy.get();
-    if (UNLIKELY(!remoteRenderingBackendProxy))
-        return { };
-
-    auto bitmap = remoteRenderingBackendProxy->getShareableBitmap(m_renderingResourceIdentifier, PreserveResolution::Yes);
-    if (!bitmap)
-        return { };
-    return NativeImage::create(bitmap->createPlatformImage(DontCopyBackingStore));
-}
-
-RefPtr<NativeImage> RemoteImageBufferProxy::createNativeImageReference() const
-{
-    auto* backend = ensureBackend();
-    if (!backend)
-        return { };
-    if (backend->canMapBackingStore()) {
-        const_cast<RemoteImageBufferProxy*>(this)->flushDrawingContext();
-        return ImageBuffer::createNativeImageReference();
-    }
-    return copyNativeImage();
 }
 
 RefPtr<NativeImage> RemoteImageBufferProxy::sinkIntoNativeImage()

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
@@ -76,8 +76,6 @@ public:
 private:
     RemoteImageBufferProxy(Parameters, const WebCore::ImageBufferBackend::Info&, RemoteRenderingBackendProxy&, std::unique_ptr<WebCore::ImageBufferBackend>&& = nullptr, WebCore::RenderingResourceIdentifier = WebCore::RenderingResourceIdentifier::generate());
 
-    RefPtr<WebCore::NativeImage> copyNativeImage() const final;
-    RefPtr<WebCore::NativeImage> createNativeImageReference() const final;
     RefPtr<WebCore::NativeImage> sinkIntoNativeImage() final;
 
     RefPtr<ImageBuffer> sinkIntoBufferForDifferentThread() final;

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.cpp
@@ -29,6 +29,7 @@
 #if HAVE(IOSURFACE)
 
 #include "Logging.h"
+#include "RemoteRenderingBackendProxy.h"
 #include <WebCore/GraphicsContextCG.h>
 #include <WebCore/ImageBufferIOSurfaceBackend.h>
 #include <WebCore/PixelBuffer.h>
@@ -51,14 +52,22 @@ size_t ImageBufferRemoteIOSurfaceBackend::calculateMemoryCost(const Parameters& 
     return ImageBufferIOSurfaceBackend::calculateMemoryCost(parameters);
 }
 
-std::unique_ptr<ImageBufferRemoteIOSurfaceBackend> ImageBufferRemoteIOSurfaceBackend::create(const Parameters& parameters, ImageBufferBackendHandle handle)
+std::unique_ptr<ImageBufferRemoteIOSurfaceBackend> ImageBufferRemoteIOSurfaceBackend::create(const Parameters& parameters, ImageBufferBackendHandle handle, RemoteRenderingBackendProxy& remoteRenderingBackendProxy, RenderingResourceIdentifier renderingResourceIdentifier)
 {
     if (!std::holds_alternative<MachSendRight>(handle)) {
         RELEASE_ASSERT_NOT_REACHED();
         return nullptr;
     }
 
-    return makeUnique<ImageBufferRemoteIOSurfaceBackend>(parameters, WTFMove(std::get<MachSendRight>(handle)));
+    return makeUnique<ImageBufferRemoteIOSurfaceBackend>(parameters, WTFMove(std::get<MachSendRight>(handle)), remoteRenderingBackendProxy, renderingResourceIdentifier);
+}
+
+ImageBufferRemoteIOSurfaceBackend::ImageBufferRemoteIOSurfaceBackend(const Parameters& parameters, MachSendRight&& handle, RemoteRenderingBackendProxy& remoteRenderingBackendProxy, RenderingResourceIdentifier renderingResourceIdentifier)
+    : ImageBufferBackend(parameters)
+    , m_handle(WTFMove(handle))
+    , m_remoteRenderingBackendProxy(remoteRenderingBackendProxy)
+    , m_renderingResourceIdentifier(renderingResourceIdentifier)
+{
 }
 
 std::optional<ImageBufferBackendHandle> ImageBufferRemoteIOSurfaceBackend::createBackendHandle(SharedMemory::Protection) const
@@ -103,14 +112,19 @@ unsigned ImageBufferRemoteIOSurfaceBackend::bytesPerRow() const
 
 RefPtr<NativeImage> ImageBufferRemoteIOSurfaceBackend::copyNativeImage()
 {
-    RELEASE_ASSERT_NOT_REACHED();
-    return { };
+    RefPtr remoteRenderingBackendProxy = m_remoteRenderingBackendProxy.get();
+    if (UNLIKELY(!remoteRenderingBackendProxy))
+        return { };
+
+    auto bitmap = remoteRenderingBackendProxy->getShareableBitmap(m_renderingResourceIdentifier, PreserveResolution::Yes);
+    if (!bitmap)
+        return { };
+    return NativeImage::create(bitmap->createPlatformImage(DontCopyBackingStore));
 }
 
 RefPtr<NativeImage> ImageBufferRemoteIOSurfaceBackend::createNativeImageReference()
 {
-    RELEASE_ASSERT_NOT_REACHED();
-    return { };
+    return copyNativeImage();
 }
 
 void ImageBufferRemoteIOSurfaceBackend::getPixelBuffer(const IntRect&, PixelBuffer&)

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.h
@@ -34,6 +34,8 @@
 
 namespace WebKit {
 
+class RemoteRenderingBackendProxy;
+
 class ImageBufferRemoteIOSurfaceBackend final : public WebCore::ImageBufferBackend, public ImageBufferBackendHandleSharing {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(ImageBufferRemoteIOSurfaceBackend);
     WTF_MAKE_NONCOPYABLE(ImageBufferRemoteIOSurfaceBackend);
@@ -41,13 +43,9 @@ public:
     static WebCore::IntSize calculateSafeBackendSize(const Parameters&);
     static size_t calculateMemoryCost(const Parameters&);
 
-    static std::unique_ptr<ImageBufferRemoteIOSurfaceBackend> create(const Parameters&, ImageBufferBackendHandle);
+    static std::unique_ptr<ImageBufferRemoteIOSurfaceBackend> create(const Parameters&, ImageBufferBackendHandle, RemoteRenderingBackendProxy&, WebCore::RenderingResourceIdentifier);
 
-    ImageBufferRemoteIOSurfaceBackend(const Parameters& parameters, MachSendRight&& handle)
-        : ImageBufferBackend(parameters)
-        , m_handle(WTFMove(handle))
-    {
-    }
+    ImageBufferRemoteIOSurfaceBackend(const Parameters&, MachSendRight&&, RemoteRenderingBackendProxy&, WebCore::RenderingResourceIdentifier);
 
     static constexpr WebCore::RenderingMode renderingMode = WebCore::RenderingMode::Accelerated;
     bool canMapBackingStore() const final;
@@ -76,6 +74,8 @@ private:
     String debugDescription() const final;
 
     MachSendRight m_handle;
+    WeakPtr<RemoteRenderingBackendProxy> m_remoteRenderingBackendProxy;
+    WebCore::RenderingResourceIdentifier m_renderingResourceIdentifier;
 
     WebCore::VolatilityState m_volatilityState { WebCore::VolatilityState::NonVolatile };
 };


### PR DESCRIPTION
#### dd2e4c2e289b51e663e4d5ff59647bddebd0e51c
<pre>
Move drawing the ImageBuffer from GraphicsContext to ImageBuffer and ImageBufferBackend
<a href="https://bugs.webkit.org/show_bug.cgi?id=284179">https://bugs.webkit.org/show_bug.cgi?id=284179</a>
<a href="https://rdar.apple.com/141060759">rdar://141060759</a>

Reviewed by NOBODY (OOPS!).

The current drawing function GraphicsContext::drawImageBuffer() assumes all
ImageBuffers have to create NativeImage before drawing.

We need to add an DisplayList ImageBufferBackend. To draw the container of this
backend, we will need to replay back the display list of its backend.

GraphicsContext::drawImageBuffer() should direct the drawing to the ImageBuffer
which will delegate it to its backend.

* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp:
(WebCore::BifurcatedGraphicsContext::drawPattern):
(WebCore::BifurcatedGraphicsContext::drawImageBuffer):
(WebCore::BifurcatedGraphicsContext::drawConsumingImageBuffer):
* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h:
* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::drawImageBuffer):
(WebCore::GraphicsContext::drawConsumingImageBuffer):
(WebCore::GraphicsContext::drawPattern):
(WebCore::GraphicsContext::nativeImageForDrawing): Deleted.
* Source/WebCore/platform/graphics/GraphicsContext.h:
(WebCore::GraphicsContext::isDeferred const):
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::copyNativeImage const):
(WebCore::ImageBuffer::createNativeImageReference const):
(WebCore::ImageBuffer::nativeImageForDrawing):
(WebCore::ImageBuffer::draw):
(WebCore::ImageBuffer::drawConsuming):
(WebCore::ImageBuffer::drawPattern):
* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebCore/platform/graphics/ImageBufferBackend.cpp:
(WebCore::ImageBufferBackend::nativeImageForDrawing):
(WebCore::ImageBufferBackend::draw):
(WebCore::ImageBufferBackend::drawConsuming):
(WebCore::ImageBufferBackend::drawPattern):
* Source/WebCore/platform/graphics/ImageBufferBackend.h:
* Source/WebCore/platform/graphics/cairo/CairoOperations.cpp:
(WebCore::Cairo::drawShadowLayerBuffer):
(WebCore::Cairo::drawShadowImage):
(WebCore::Cairo::fillShadowBuffer):
* Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp:
(WebCore::GraphicsContextCairo::clipToImageBuffer):
* Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.h:
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
(WebCore::GraphicsContextSkia::clipToImageBuffer):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::didCreateBackend):
(WebKit::RemoteImageBufferProxy::copyNativeImage const): Deleted.
(WebKit::RemoteImageBufferProxy::createNativeImageReference const): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.cpp:
(WebKit::ImageBufferRemoteIOSurfaceBackend::create):
(WebKit::ImageBufferRemoteIOSurfaceBackend::ImageBufferRemoteIOSurfaceBackend):
(WebKit::ImageBufferRemoteIOSurfaceBackend::copyNativeImage):
(WebKit::ImageBufferRemoteIOSurfaceBackend::createNativeImageReference):
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd2e4c2e289b51e663e4d5ff59647bddebd0e51c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80988 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/513 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34931 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85517 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31974 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83098 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/529 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8314 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63232 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20997 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84057 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/307 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73711 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43530 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/201 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27869 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30432 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71753 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28420 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86952 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8218 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5803 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71529 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8395 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69544 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70763 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14805 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13730 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8179 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13702 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8016 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11536 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9824 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->