### PR TITLE
Drop IsDeprecatedTimerSmartPointerException for LegacyTileCache

### DIFF
--- a/Source/WebCore/platform/ios/LegacyTileCache.h
+++ b/Source/WebCore/platform/ios/LegacyTileCache.h
@@ -35,6 +35,7 @@
 #include <wtf/RetainPtr.h>
 #include <wtf/Threading.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakPtr.h>
 
 OBJC_CLASS CALayer;
 OBJC_CLASS LegacyTileCacheTombstone;
@@ -42,24 +43,18 @@ OBJC_CLASS LegacyTileLayer;
 OBJC_CLASS WAKWindow;
 
 namespace WebCore {
-class LegacyTileCache;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebCore::LegacyTileCache> : std::true_type { };
-}
-
-namespace WebCore {
 
 class Color;
 class LegacyTileGrid;
 
-class LegacyTileCache {
+class LegacyTileCache : public CanMakeWeakPtr<LegacyTileCache> {
     WTF_MAKE_NONCOPYABLE(LegacyTileCache);
 public:
     LegacyTileCache(WAKWindow *);
     ~LegacyTileCache();
+
+    void ref() const;
+    void deref() const;
 
     CGFloat screenScale() const;
 
@@ -97,7 +92,7 @@ public:
     void setCurrentScale(float);
     float currentScale() const;
     
-    bool tilesOpaque() const;
+    bool tilesOpaque() const { return m_tilesOpaque; }
     void setTilesOpaque(bool);
     
     enum TilingMode {
@@ -117,8 +112,8 @@ public:
         TilingDirectionLeft,
         TilingDirectionRight,
     };
-    void setTilingDirection(TilingDirection);
-    TilingDirection tilingDirection() const;
+    void setTilingDirection(TilingDirection tilingDirection) { m_tilingDirection = tilingDirection; }
+    TilingDirection tilingDirection() const { return m_tilingDirection; }
 
     void hostLayerSizeChanged();
 

--- a/Source/WebCore/platform/ios/LegacyTileCache.mm
+++ b/Source/WebCore/platform/ios/LegacyTileCache.mm
@@ -64,6 +64,16 @@
 
 namespace WebCore {
 
+void LegacyTileCache::ref() const
+{
+    [m_window retain];
+}
+
+void LegacyTileCache::deref() const
+{
+    [m_window release];
+}
+
 LegacyTileCache::LegacyTileCache(WAKWindow* window)
     : m_window(window)
     , m_tombstone(adoptNS([[LegacyTileCacheTombstone alloc] init]))
@@ -104,11 +114,6 @@ bool LegacyTileCache::setOverrideVisibleRect(const FloatRect& rect)
     if (activeTileGrid())
         coveredByExistingTiles = activeTileGrid()->tilesCover(enclosingIntRect(m_overrideVisibleRect.value()));
     return coveredByExistingTiles;
-}
-
-bool LegacyTileCache::tilesOpaque() const
-{
-    return m_tilesOpaque;
 }
     
 LegacyTileGrid* LegacyTileCache::activeTileGrid() const
@@ -717,16 +722,6 @@ void LegacyTileCache::setTilingMode(TilingMode tilingMode)
         m_hasPendingUpdateTilingMode = false;
         updateTilingMode();
     });
-}
-
-void LegacyTileCache::setTilingDirection(TilingDirection tilingDirection)
-{
-    m_tilingDirection = tilingDirection;
-}
-
-LegacyTileCache::TilingDirection LegacyTileCache::tilingDirection() const
-{
-    return m_tilingDirection;
 }
     
 float LegacyTileCache::zoomedOutScale() const

--- a/Source/WebCore/platform/ios/LegacyTileGrid.h
+++ b/Source/WebCore/platform/ios/LegacyTileGrid.h
@@ -37,6 +37,7 @@
 #include <wtf/RefPtr.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakRef.h>
 
 #define LOG_TILING 0
 
@@ -54,7 +55,8 @@ public:
     LegacyTileGrid(LegacyTileCache&, const IntSize&);
     ~LegacyTileGrid();
 
-    LegacyTileCache& tileCache() const { return m_tileCache; }
+    LegacyTileCache& tileCache() const { return m_tileCache.get(); }
+    Ref<LegacyTileCache> protectedTileCache() const { return tileCache(); }
 
     CALayer *tileHostLayer() const;
     IntRect bounds() const;
@@ -108,7 +110,7 @@ private:
     bool shouldUseMinimalTileCoverage() const;
 
 private:        
-    LegacyTileCache& m_tileCache;
+    WeakRef<LegacyTileCache> m_tileCache;
     RetainPtr<CALayer> m_tileHostLayer;
 
     IntPoint m_origin;

--- a/Source/WebCore/platform/ios/LegacyTileGridTile.mm
+++ b/Source/WebCore/platform/ios/LegacyTileGridTile.mm
@@ -53,7 +53,8 @@ LegacyTileGridTile::LegacyTileGridTile(LegacyTileGrid* tileGrid, const IntRect& 
 {
     ASSERT(!tileRect.isEmpty());
     IntSize pixelSize(m_rect.size());
-    const CGFloat screenScale = m_tileGrid->tileCache().screenScale();
+    Ref tileCache = m_tileGrid->tileCache();
+    const CGFloat screenScale = tileCache->screenScale();
     pixelSize.scale(screenScale);
     m_tileLayer = LegacyTileLayerPool::sharedPool()->takeLayerWithSize(pixelSize);
     if (!m_tileLayer) {
@@ -68,18 +69,18 @@ LegacyTileGridTile::LegacyTileGridTile(LegacyTileGrid* tileGrid, const IntRect& 
         layer.contentsFormat = formatString;
 
     [layer setTileGrid:tileGrid];
-    [layer setOpaque:m_tileGrid->tileCache().tilesOpaque()];
+    [layer setOpaque:tileCache->tilesOpaque()];
     [layer setEdgeAntialiasingMask:0];
     [layer setNeedsLayoutOnGeometryChange:NO];
     [layer setContentsScale:screenScale];
-    [layer setDrawsAsynchronously:m_tileGrid->tileCache().acceleratedDrawingEnabled()];
+    [layer setDrawsAsynchronously:tileCache->acceleratedDrawingEnabled()];
 
     // Host layer may have other sublayers. Keep the tile layers at the beginning of the array
     // so they are painted behind everything else.
     [tileGrid->tileHostLayer() insertSublayer:layer atIndex:tileGrid->tileCount()];
     [layer setFrame:m_rect];
     invalidateRect(m_rect);
-    showBorder(m_tileGrid->tileCache().tileBordersVisible());
+    showBorder(tileCache->tileBordersVisible());
 
 #if LOG_TILING
     ++totalTileCount;
@@ -124,7 +125,7 @@ void LegacyTileGridTile::showBorder(bool flag)
 {
     LegacyTileLayer* layer = m_tileLayer.get();
     if (flag) {
-        [layer setBorderColor:cachedCGColor(m_tileGrid->tileCache().colorForGridTileBorder(m_tileGrid)).get()];
+        [layer setBorderColor:cachedCGColor(m_tileGrid->protectedTileCache()->colorForGridTileBorder(m_tileGrid)).get()];
         [layer setBorderWidth:0.5f];
     } else {
         [layer setBorderColor:nil];

--- a/Source/WebCore/platform/ios/LegacyTileLayer.mm
+++ b/Source/WebCore/platform/ios/LegacyTileLayer.mm
@@ -59,15 +59,16 @@ using WebCore::LegacyTileCache;
         WebThreadLock();
 
     CGRect dirtyRect = CGContextGetClipBoundingBox(context);
-    auto useExistingTiles = _tileGrid->tileCache().setOverrideVisibleRect(WebCore::FloatRect(dirtyRect));
+    Ref tileCache = _tileGrid->tileCache();
+    auto useExistingTiles = tileCache->setOverrideVisibleRect(WebCore::FloatRect(dirtyRect));
     if (!useExistingTiles)
-        _tileGrid->tileCache().doLayoutTiles();
+        tileCache->doLayoutTiles();
 
     [super renderInContext:context];
 
-    _tileGrid->tileCache().clearOverrideVisibleRect();
+    tileCache->clearOverrideVisibleRect();
     if (!useExistingTiles)
-        _tileGrid->tileCache().doLayoutTiles();
+        tileCache->doLayoutTiles();
 }
 @end
 
@@ -92,7 +93,7 @@ using WebCore::LegacyTileCache;
         WebThreadLock();
     // This may trigger WebKit layout and generate more repaint rects.
     if (_tileGrid)
-        _tileGrid->tileCache().prepareToDraw();
+        _tileGrid->protectedTileCache()->prepareToDraw();
 }
 
 - (void)renderInContext:(CGContextRef)context
@@ -113,7 +114,7 @@ using WebCore::LegacyTileCache;
         WebThreadLock();
 
     if (_tileGrid)
-        _tileGrid->tileCache().drawLayer(self, context, self.isRenderingInContext ? LegacyTileCache::DrawingFlags::Snapshotting : LegacyTileCache::DrawingFlags::None);
+        _tileGrid->protectedTileCache()->drawLayer(self, context, self.isRenderingInContext ? LegacyTileCache::DrawingFlags::Snapshotting : LegacyTileCache::DrawingFlags::None);
 }
 
 - (id<CAAction>)actionForKey:(NSString *)key

--- a/Source/WebCore/platform/ios/wak/WAKWindow.mm
+++ b/Source/WebCore/platform/ios/wak/WAKWindow.mm
@@ -531,7 +531,7 @@ static RetainPtr<WebEvent>& currentEvent()
 {
     if (!_tileCache)
         return;
-    _tileCache->setTilingMode((LegacyTileCache::TilingMode)mode);
+    Ref { *_tileCache }->setTilingMode((LegacyTileCache::TilingMode)mode);
 }
 
 - (WAKWindowTilingMode)tilingMode
@@ -545,7 +545,7 @@ static RetainPtr<WebEvent>& currentEvent()
 {
     if (!_tileCache)
         return;
-    _tileCache->setTilingDirection((LegacyTileCache::TilingDirection)tilingDirection);
+    Ref { *_tileCache }->setTilingDirection((LegacyTileCache::TilingDirection)tilingDirection);
 }
 
 - (WAKTilingDirection)tilingDirection

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -4443,7 +4443,7 @@ float RenderLayerCompositor::zoomedOutPageScaleFactor() const
 float RenderLayerCompositor::contentsScaleMultiplierForNewTiles(const GraphicsLayer*) const
 {
 #if PLATFORM(IOS_FAMILY)
-    LegacyTileCache* tileCache = nullptr;
+    RefPtr<LegacyTileCache> tileCache;
     auto* localMainFrame = dynamicDowncast<LocalFrame>(page().mainFrame());
     if (auto* frameView = localMainFrame ? localMainFrame->view() : nullptr)
         tileCache = frameView->legacyTileCache();


### PR DESCRIPTION
#### 9da92f0e686c1df4024f718ad459d434166d7e6c
<pre>
Drop IsDeprecatedTimerSmartPointerException for LegacyTileCache
<a href="https://bugs.webkit.org/show_bug.cgi?id=284183">https://bugs.webkit.org/show_bug.cgi?id=284183</a>

Reviewed by Darin Adler.

* Source/WebCore/platform/ios/LegacyTileCache.h:
(WebCore::LegacyTileCache::tilesOpaque const):
(WebCore::LegacyTileCache::setTilingDirection):
(WebCore::LegacyTileCache::tilingDirection const):
* Source/WebCore/platform/ios/LegacyTileCache.mm:
(WebCore::LegacyTileCache::ref const):
(WebCore::LegacyTileCache::deref const):
(WebCore::LegacyTileCache::setOverrideVisibleRect):
(WebCore::LegacyTileCache::setTilingMode):
(WebCore::LegacyTileCache::tilesOpaque const): Deleted.
(WebCore::LegacyTileCache::setTilingDirection): Deleted.
(WebCore::LegacyTileCache::tilingDirection const): Deleted.
* Source/WebCore/platform/ios/LegacyTileGrid.h:
(WebCore::LegacyTileGrid::tileCache const):
(WebCore::LegacyTileGrid::protectedTileCache const):
* Source/WebCore/platform/ios/LegacyTileGrid.mm:
(WebCore::LegacyTileGrid::visibleRect const):
(WebCore::LegacyTileGrid::tileByteSize const):
(WebCore::LegacyTileGrid::dropDistantTiles):
(WebCore::LegacyTileGrid::updateTileOpacity):
(WebCore::LegacyTileGrid::updateTileBorderVisibility):
(WebCore::LegacyTileGrid::updateHostLayerSize):
(WebCore::LegacyTileGrid::invalidateTiles):
(WebCore::LegacyTileGrid::shouldUseMinimalTileCoverage const):
(WebCore::LegacyTileGrid::tileDistance2 const):
(WebCore::LegacyTileGrid::createTiles):
* Source/WebCore/platform/ios/LegacyTileGridTile.mm:
(WebCore::LegacyTileGridTile::LegacyTileGridTile):
(WebCore::LegacyTileGridTile::showBorder):
* Source/WebCore/platform/ios/LegacyTileLayer.mm:
(-[LegacyTileHostLayer renderInContext:]):
(-[LegacyTileLayer layoutSublayers]):
(-[LegacyTileLayer drawInContext:]):
* Source/WebCore/platform/ios/wak/WAKWindow.mm:
(-[WAKWindow setTilingMode:]):
(-[WAKWindow setTilingDirection:]):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::contentsScaleMultiplierForNewTiles const):

Canonical link: <a href="https://commits.webkit.org/287468@main">https://commits.webkit.org/287468@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5f331ce9fafd315609efb58491a8fe637efa080

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79808 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58809 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33207 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84333 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30810 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81917 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67883 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7099 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62378 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20218 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82876 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52434 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72676 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42684 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49774 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26825 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29258 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70902 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27296 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85759 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7039 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4931 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70638 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7213 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68516 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69879 "Found 3 new API test failures: /TestWebKit:WebKit.InjectedBundleBasic, /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginAndEndEditingEvents, /TestWebKit:WebKit.WillSendSubmitEvent (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13884 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12800 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12339 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6998 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6858 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10369 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8665 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->