### PR TITLE
Introduce iframe resource monitoring.

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3443,6 +3443,22 @@ ICECandidateFilteringEnabled:
     WebCore:
       default: true
 
+IFrameResourceMonitoringEnabled:
+  type: bool
+  status: unstable
+  category: networking
+  condition: ENABLE(CONTENT_EXTENSIONS)
+  defaultsOverridable: true
+  humanReadableName: "Frame Resource Monitoring Support"
+  humanReadableDescription: "Enable Usage Monitoring of Frame Resource Support"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 IPAddressAndLocalhostMixedContentUpgradeTestingEnabled:
   type: bool
   status: testable

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2018,6 +2018,8 @@ loader/ResourceLoadNotifier.cpp
 loader/ResourceLoadObserver.cpp
 loader/ResourceLoadStatistics.cpp
 loader/ResourceLoader.cpp
+loader/ResourceMonitor.cpp
+loader/ResourceMonitorChecker.cpp
 loader/ResourceTiming.cpp
 loader/ResourceTimingInformation.cpp
 loader/ServerTiming.cpp

--- a/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
@@ -372,6 +372,31 @@ ContentRuleListResults ContentExtensionsBackend::processContentRuleListsForPingL
     return results;
 }
 
+bool ContentExtensionsBackend::processContentRuleListsForResourceMonitoring(const URL& url, const URL& mainDocumentURL, const URL& frameURL, OptionSet<ResourceType> resourceType)
+{
+    ResourceLoadInfo resourceLoadInfo { url, mainDocumentURL, frameURL, resourceType };
+    auto actions = actionsForResourceLoad(resourceLoadInfo);
+
+    bool matched = false;
+    for (const auto& actionsFromContentRuleList : actions) {
+        for (const auto& action : actionsFromContentRuleList.actions) {
+            std::visit(WTF::makeVisitor([&](const BlockLoadAction&) {
+                matched = true;
+            }, [&](const BlockCookiesAction&) {
+            }, [&](const CSSDisplayNoneSelectorAction&) {
+            }, [&](const NotifyAction&) {
+            }, [&](const MakeHTTPSAction&) {
+            }, [&](const IgnorePreviousRulesAction&) {
+                RELEASE_ASSERT_NOT_REACHED();
+            }, [&] (const ModifyHeadersAction&) {
+            }, [&] (const RedirectAction&) {
+            }), action.data());
+        }
+    }
+
+    return matched;
+}
+
 const String& ContentExtensionsBackend::displayNoneCSSRule()
 {
     static NeverDestroyed<const String> rule(MAKE_STATIC_STRING_IMPL("display:none !important;"));

--- a/Source/WebCore/contentextensions/ContentExtensionsBackend.h
+++ b/Source/WebCore/contentextensions/ContentExtensionsBackend.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(CONTENT_EXTENSIONS)
 
+#include "CompiledContentExtension.h"
 #include "ContentExtension.h"
 #include "ContentExtensionRule.h"
 #include <wtf/HashMap.h>
@@ -43,7 +44,6 @@ struct ContentRuleListResults;
 
 namespace ContentExtensions {
 
-class CompiledContentExtension;
 struct ResourceLoadInfo;
 
 // The ContentExtensionsBackend is the internal model of all the content extensions.
@@ -76,6 +76,7 @@ public:
 
     ContentRuleListResults processContentRuleListsForLoad(Page&, const URL&, OptionSet<ResourceType>, DocumentLoader& initiatingDocumentLoader, const URL& redirectFrom, const RuleListFilter&);
     WEBCORE_EXPORT ContentRuleListResults processContentRuleListsForPingLoad(const URL&, const URL& mainDocumentURL, const URL& frameURL);
+    bool processContentRuleListsForResourceMonitoring(const URL&, const URL& mainDocumentURL, const URL& frameURL, OptionSet<ResourceType>);
 
     static const String& displayNoneCSSRule();
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -233,6 +233,7 @@
 #include "ResizeObserverEntry.h"
 #include "ResolvedStyle.h"
 #include "ResourceLoadObserver.h"
+#include "ResourceMonitor.h"
 #include "SVGDocumentExtensions.h"
 #include "SVGElementFactory.h"
 #include "SVGElementTypeHelpers.h"
@@ -11131,6 +11132,28 @@ void Document::securityOriginDidChange()
 {
     m_permissionsPolicy = nullptr;
 }
+
+#if ENABLE(CONTENT_EXTENSIONS)
+
+ResourceMonitor* Document::resourceMonitor()
+{
+    return m_resourceMonitor.get();
+}
+
+void Document::setResourceMonitor(RefPtr<ResourceMonitor>&& resourceMonitor)
+{
+    m_resourceMonitor = WTFMove(resourceMonitor);
+}
+
+ResourceMonitor* Document::parentResourceMonitor()
+{
+    if (RefPtr parent = parentDocument())
+        return parent->resourceMonitor();
+
+    return nullptr;
+}
+
+#endif
 
 } // namespace WebCore
 

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -216,6 +216,7 @@ class RenderView;
 class ReportingScope;
 class RequestAnimationFrameCallback;
 class ResizeObserver;
+class ResourceMonitor;
 class SVGDocumentExtensions;
 class SVGElement;
 class SVGSVGElement;
@@ -1983,6 +1984,12 @@ public:
 
     unsigned unloadCounter() const { return m_unloadCounter; }
 
+#if ENABLE(CONTENT_EXTENSIONS)
+    ResourceMonitor* resourceMonitor();
+    void setResourceMonitor(RefPtr<ResourceMonitor>&&);
+    ResourceMonitor* parentResourceMonitor();
+#endif
+
 protected:
     enum class ConstructionFlag : uint8_t {
         Synthesized = 1 << 0,
@@ -2688,6 +2695,10 @@ private:
 
     mutable std::unique_ptr<CSSParserContext> m_cachedCSSParserContext;
     mutable std::unique_ptr<PermissionsPolicy> m_permissionsPolicy;
+
+#if ENABLE(CONTENT_EXTENSIONS)
+    RefPtr<ResourceMonitor> m_resourceMonitor;
+#endif
 };
 
 Element* eventTargetElementForDocument(Document*);

--- a/Source/WebCore/loader/ResourceLoadInfo.h
+++ b/Source/WebCore/loader/ResourceLoadInfo.h
@@ -94,6 +94,8 @@ struct ResourceLoadInfo {
 
     bool isThirdParty() const;
     ResourceFlags getResourceFlags() const;
+    ResourceLoadInfo isolatedCopy() const & { return { resourceURL.isolatedCopy(), mainDocumentURL.isolatedCopy(), frameURL.isolatedCopy(), type, mainFrameContext }; }
+    ResourceLoadInfo isolatedCopy() && { return { WTFMove(resourceURL).isolatedCopy(), WTFMove(mainDocumentURL).isolatedCopy(), WTFMove(frameURL).isolatedCopy(), type, mainFrameContext }; }
 };
 
 } // namespace WebCore::ContentExtensions

--- a/Source/WebCore/loader/ResourceLoader.h
+++ b/Source/WebCore/loader/ResourceLoader.h
@@ -60,6 +60,10 @@ class LegacyPreviewLoader;
 class LocalFrame;
 class NetworkLoadMetrics;
 
+#if ENABLE(CONTENT_EXTENSIONS)
+class ResourceMonitor;
+#endif
+
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(ResourceLoader);
 class ResourceLoader : public RefCountedAndCanMakeWeakPtr<ResourceLoader>, protected ResourceHandleClient {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(ResourceLoader);
@@ -225,6 +229,10 @@ private:
     void receivedCancellation(ResourceHandle*, const AuthenticationChallenge& challenge) override { receivedCancellation(challenge); }
 #if PLATFORM(IOS_FAMILY)
     RetainPtr<CFDictionaryRef> connectionProperties(ResourceHandle*) override;
+#endif
+
+#if ENABLE(CONTENT_EXTENSIONS)
+    ResourceMonitor* resourceMonitor();
 #endif
 
 #if USE(SOUP)

--- a/Source/WebCore/loader/ResourceMonitor.cpp
+++ b/Source/WebCore/loader/ResourceMonitor.cpp
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ResourceMonitor.h"
+
+#include "Document.h"
+#include "LocalFrame.h"
+#include "ResourceMonitorChecker.h"
+#include <wtf/CryptographicallyRandomNumber.h>
+#include <wtf/StdLibExtras.h>
+
+namespace WebCore {
+
+#if ENABLE(CONTENT_EXTENSIONS)
+
+static constexpr size_t networkUsageThreshold = 4 * MB;
+static constexpr size_t networkUsageThresholdRandomness = 1303 * KB;
+
+static size_t networkUsageThresholdWithRandomNoise()
+{
+    return networkUsageThreshold + static_cast<size_t>(cryptographicallyRandomUnitInterval() * networkUsageThresholdRandomness);
+}
+
+RefPtr<ResourceMonitor> ResourceMonitor::create(LocalFrame& frame, URL&& url)
+{
+    if (url.isEmpty() || !url.protocolIsInHTTPFamily())
+        return nullptr;
+
+    return adoptRef(*new ResourceMonitor(frame, WTFMove(url)));
+}
+
+ResourceMonitor::ResourceMonitor(LocalFrame& frame, URL&& documentURL)
+    : m_frame(frame)
+    , m_frameURL(WTFMove(documentURL))
+    , m_networkUsageThreshold { networkUsageThresholdWithRandomNoise() }
+{
+    if (RefPtr parentMonitor = parentResourceMonitor())
+        setEligibility(parentMonitor->eligibility());
+
+    didReceiveResponse(m_frameURL, ContentExtensions::ResourceType::Document);
+}
+
+void ResourceMonitor::setEligibility(Eligibility eligibility)
+{
+    if (m_eligibility == eligibility || m_eligibility == Eligibility::Eligible)
+        return;
+
+    m_eligibility = eligibility;
+
+    if (RefPtr parentMonitor = parentResourceMonitor())
+        parentMonitor->setEligibility(eligibility);
+    else
+        checkNetworkUsageExcessIfNecessary();
+}
+
+void ResourceMonitor::didReceiveResponse(const URL& url, OptionSet<ContentExtensions::ResourceType> resourceType)
+{
+    ASSERT(isMainThread());
+
+    if (m_eligibility == Eligibility::Eligible)
+        return;
+
+    RefPtr page = protectedFrame()->mainFrame().page();
+    if (!page)
+        return;
+
+    ContentExtensions::ResourceLoadInfo info = {
+        .resourceURL = url,
+        .mainDocumentURL = page->mainFrameURL(),
+        .frameURL = m_frameURL,
+        .type = resourceType
+    };
+
+    ResourceMonitorChecker::singleton().checkEligibility(WTFMove(info), [weakThis = WeakPtr { *this }](Eligibility eligibility) {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->setEligibility(eligibility);
+    });
+}
+
+void ResourceMonitor::addNetworkUsage(size_t bytes)
+{
+    if (m_networkUsageExceed)
+        return;
+
+    m_networkUsage += bytes;
+
+    if (RefPtr parentMonitor = parentResourceMonitor())
+        parentMonitor->addNetworkUsage(bytes);
+    else
+        checkNetworkUsageExcessIfNecessary();
+}
+
+void ResourceMonitor::checkNetworkUsageExcessIfNecessary()
+{
+    ASSERT(!parentResourceMonitor());
+    if (m_eligibility != Eligibility::Eligible || m_networkUsageExceed)
+        return;
+
+    if (m_networkUsage.hasOverflowed() || m_networkUsage >= m_networkUsageThreshold) {
+        m_networkUsageExceed = true;
+        protectedFrame()->networkUsageDidExceedThreshold();
+    }
+}
+
+Ref<LocalFrame> ResourceMonitor::protectedFrame() const
+{
+    return m_frame.get();
+}
+
+ResourceMonitor* ResourceMonitor::parentResourceMonitor() const
+{
+    RefPtr document = protectedFrame()->document();
+    return document ? document->parentResourceMonitor() : nullptr;
+}
+
+#endif
+
+} // namespace WebCore

--- a/Source/WebCore/loader/ResourceMonitor.h
+++ b/Source/WebCore/loader/ResourceMonitor.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(CONTENT_EXTENSIONS)
+
+#include <wtf/CheckedArithmetic.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
+
+namespace WebCore {
+
+class LocalFrame;
+
+class ResourceMonitor final : public RefCountedAndCanMakeWeakPtr<ResourceMonitor> {
+public:
+    enum class Eligibility : uint8_t { Unsure, NotEligible, Eligible };
+
+    static RefPtr<ResourceMonitor> create(LocalFrame&, URL&&);
+
+    Eligibility eligibility() const { return m_eligibility; }
+    void setEligibility(Eligibility);
+
+    void didReceiveResponse(const URL&, OptionSet<ContentExtensions::ResourceType>);
+    void addNetworkUsage(size_t);
+
+private:
+    explicit ResourceMonitor(LocalFrame&, URL&&);
+
+    void checkNetworkUsageExcessIfNecessary();
+    Ref<LocalFrame> protectedFrame() const;
+    ResourceMonitor* parentResourceMonitor() const;
+
+    WeakRef<LocalFrame> m_frame;
+    URL m_frameURL;
+    Eligibility m_eligibility { Eligibility::Unsure };
+    bool m_networkUsageExceed { false };
+    size_t m_networkUsageThreshold { 0 };
+    CheckedSize m_networkUsage;
+};
+
+} // namespace WebCore
+
+#endif

--- a/Source/WebCore/loader/ResourceMonitorChecker.cpp
+++ b/Source/WebCore/loader/ResourceMonitorChecker.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ResourceMonitorChecker.h"
+
+#include <wtf/CryptographicallyRandomNumber.h>
+#include <wtf/StdLibExtras.h>
+
+namespace WebCore {
+
+#if ENABLE(CONTENT_EXTENSIONS)
+
+ResourceMonitorChecker& ResourceMonitorChecker::singleton()
+{
+    static MainThreadNeverDestroyed<ResourceMonitorChecker> globalChecker;
+    return globalChecker;
+}
+
+ResourceMonitorChecker::ResourceMonitorChecker()
+    : m_workQueue { WorkQueue::create("ResourceMonitorChecker Work Queue"_s) }
+{
+}
+
+void ResourceMonitorChecker::checkEligibility(ContentExtensions::ResourceLoadInfo&& info, CompletionHandler<void(Eligibility)>&& completionHandler)
+{
+    ASSERT(isMainThread());
+
+    protectedWorkQueue()->dispatch([this, info = crossThreadCopy(WTFMove(info)), completionHandler = WTFMove(completionHandler)] mutable {
+        Eligibility eligibility = Eligibility::Unsure;
+        {
+            Locker locker { m_lock };
+            eligibility = checkEligibilityWithLock(info);
+        }
+
+        callOnMainRunLoop([eligibility, completionHandler = WTFMove(completionHandler)] mutable {
+            completionHandler(eligibility);
+        });
+    });
+}
+
+ResourceMonitor::Eligibility ResourceMonitorChecker::checkEligibilityForTesting(const ContentExtensions::ResourceLoadInfo& info)
+{
+    ASSERT(isMainThread());
+
+    Locker locker { m_lock };
+    return checkEligibilityWithLock(info);
+}
+
+ResourceMonitor::Eligibility ResourceMonitorChecker::checkEligibilityWithLock(const ContentExtensions::ResourceLoadInfo& info)
+{
+    if (!m_ruleList)
+        return Eligibility::Unsure;
+
+    auto matched = m_ruleList->processContentRuleListsForResourceMonitoring(info.resourceURL, info.mainDocumentURL, info.frameURL, info.type);
+    return matched ? Eligibility::Eligible : Eligibility::NotEligible;
+}
+
+void ResourceMonitorChecker::setContentRuleList(ContentExtensions::ContentExtensionsBackend&& backend)
+{
+    ASSERT(isMainThread());
+
+    Locker locker { m_lock };
+    m_ruleList = makeUnique<ContentExtensions::ContentExtensionsBackend>(WTFMove(backend));
+}
+
+#endif
+
+} // namespace WebCore

--- a/Source/WebCore/loader/ResourceMonitorChecker.h
+++ b/Source/WebCore/loader/ResourceMonitorChecker.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(CONTENT_EXTENSIONS)
+
+#include "ContentExtensionsBackend.h"
+#include "ResourceMonitor.h"
+#include <wtf/CompletionHandler.h>
+#include <wtf/Lock.h>
+#include <wtf/NeverDestroyed.h>
+#include <wtf/OptionSet.h>
+#include <wtf/WorkQueue.h>
+
+namespace WebCore {
+
+class LocalFrame;
+
+class ResourceMonitorChecker final {
+    friend MainThreadNeverDestroyed<ResourceMonitorChecker>;
+public:
+    using Eligibility = ResourceMonitor::Eligibility;
+
+    static ResourceMonitorChecker& singleton();
+
+    void checkEligibility(ContentExtensions::ResourceLoadInfo&&, CompletionHandler<void(Eligibility)>&&);
+    Eligibility checkEligibilityForTesting(const ContentExtensions::ResourceLoadInfo&);
+
+    void setContentRuleList(ContentExtensions::ContentExtensionsBackend&&);
+
+private:
+    ResourceMonitorChecker();
+
+    Ref<WorkQueue> protectedWorkQueue() { return m_workQueue; }
+
+    Eligibility checkEligibilityWithLock(const ContentExtensions::ResourceLoadInfo&) WTF_REQUIRES_LOCK(m_lock);
+
+    Ref<WorkQueue> m_workQueue;
+    std::unique_ptr<ContentExtensions::ContentExtensionsBackend> m_ruleList WTF_GUARDED_BY_LOCK(m_lock);
+    Lock m_lock;
+};
+
+} // namespace WebCore
+
+#endif

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -93,6 +93,7 @@ class Page;
 class RenderLayer;
 class RenderView;
 class RenderWidget;
+class ResourceMonitor;
 class ScriptController;
 class SecurityOrigin;
 class VisiblePosition;
@@ -332,6 +333,10 @@ public:
     WEBCORE_EXPORT void updateScrollingMode() final;
     WEBCORE_EXPORT void setScrollingMode(ScrollbarMode);
 
+#if ENABLE(CONTENT_EXTENSIONS)
+    void networkUsageDidExceedThreshold();
+#endif
+
 protected:
     void frameWasDisconnectedFromOwner() const final;
 
@@ -353,6 +358,10 @@ private:
     void reinitializeDocumentSecurityContext() final;
     FrameLoaderClient& loaderClient() final;
     void documentURLForConsoleLog(CompletionHandler<void(const URL&)>&&) final;
+
+#if ENABLE(CONTENT_EXTENSIONS)
+    void showResourceMonitoringError(String&& htmlContent);
+#endif
 
     WeakHashSet<FrameDestructionObserver> m_destructionObservers;
 


### PR DESCRIPTION
#### 8b87453fe510be3928eefdb1dc1995632915525c
<pre>
Introduce iframe resource monitoring.
<a href="https://bugs.webkit.org/show_bug.cgi?id=284198">https://bugs.webkit.org/show_bug.cgi?id=284198</a>
<a href="https://rdar.apple.com/137691088">rdar://137691088</a>

Reviewed by Ben Nham.

Introduce new feature to monitor resource usage of iframe and its subresources.
The new class ResourceMonitor is the class to manage resource usage and existing
classes cooperate to send update to the class.

Monitoring is initiated by using ContentExtensionsBackend&apos;s ContentRuleList against
the urls of main frame document and subresources.

The feature is off by default.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/contentextensions/ContentExtensionsBackend.cpp:
(WebCore::ContentExtensions::ContentExtensionsBackend::processContentRuleListsForResourceMonitoring):
* Source/WebCore/contentextensions/ContentExtensionsBackend.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::resourceMonitor):
(WebCore::Document::setResourceMonitor):
(WebCore::Document::parentResourceMonitor):
* Source/WebCore/dom/Document.h:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::shouldEnableResourceMonitor):
(WebCore::DocumentLoader::commitData):
* Source/WebCore/loader/ResourceLoadInfo.h:
(WebCore::ContentExtensions::ResourceLoadInfo::isolatedCopy const):
(WebCore::ContentExtensions::ResourceLoadInfo::isolatedCopy):
* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::didReceiveResponse):
(WebCore::ResourceLoader::didReceiveBuffer):
(WebCore::ResourceLoader::resourceMonitor):
* Source/WebCore/loader/ResourceLoader.h:
* Source/WebCore/loader/ResourceMonitor.cpp: Added.
(WebCore::networkUsageThresholdWithRandomNoise):
(WebCore::ResourceMonitor::create):
(WebCore::ResourceMonitor::ResourceMonitor):
(WebCore::ResourceMonitor::setEligibility):
(WebCore::ResourceMonitor::didReceiveResponse):
(WebCore::ResourceMonitor::addNetworkUsage):
(WebCore::ResourceMonitor::checkNetworkUsageExcessIfNecessary):
(WebCore::ResourceMonitor::protectedFrame const):
(WebCore::ResourceMonitor::parentResourceMonitor const):
* Source/WebCore/loader/ResourceMonitor.h: Added.
* Source/WebCore/loader/ResourceMonitorChecker.cpp: Added.
(WebCore::ResourceMonitorChecker::singleton):
(WebCore::ResourceMonitorChecker::ResourceMonitorChecker):
(WebCore::ResourceMonitorChecker::checkEligibility):
(WebCore::ResourceMonitorChecker::checkEligibilityForTesting):
(WebCore::ResourceMonitorChecker::checkEligibilityWithLock):
(WebCore::ResourceMonitorChecker::setContentRuleList):
* Source/WebCore/loader/ResourceMonitorChecker.h: Added.
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::networkUsageDidExceedThreshold):
(WebCore::LocalFrame::showResourceMonitoringError):
* Source/WebCore/page/LocalFrame.h:

Canonical link: <a href="https://commits.webkit.org/287667@main">https://commits.webkit.org/287667@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74f34f3fc8a2e5e29882143ff1a806dc70163f23

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80328 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59334 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33791 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84849 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31310 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82439 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68396 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7635 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62793 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20606 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83397 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52867 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73153 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43096 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50188 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27308 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29769 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/73308 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71325 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27823 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86283 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/79387 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7553 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5349 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71074 "Found 5 new test failures: compositing/animation/keyframe-order.html fast/text/crash-letter-spacing-infinite.html imported/w3c/web-platform-tests/css/css-transforms/animation/translate-percent-with-width-and-height-separate.html webanimations/accelerated-animation-addition-lower-in-effect-stack.html webanimations/accelerated-animation-easing-update-steps-after-pause.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7728 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68991 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70314 "Found 1 new API test failure: /TestWebKit:WebKit.PageLoadState (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17534 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14307 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13260 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/101794 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7515 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13035 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/24808 "Found 3 new JSC stress test failures: wasm.yaml/wasm/stress/struct-new_default-small-members.js.wasm-collect-continuously, wasm.yaml/wasm/stress/struct-new_default-small-members.js.wasm-eager, wasm.yaml/wasm/stress/struct-new_default-small-members.js.wasm-eager-jettison (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7354 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10874 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9160 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->