### PR TITLE
Disable BackgroundProcessResponsivenessTimer when RunningBoard throttling is enabled

### DIFF
--- a/Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.cpp
+++ b/Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.cpp
@@ -143,7 +143,7 @@ void BackgroundProcessResponsivenessTimer::setResponsive(bool isResponsive)
 
 bool BackgroundProcessResponsivenessTimer::shouldBeActive() const
 {
-#if !PLATFORM(IOS_FAMILY)
+#if !USE(RUNNINGBOARD)
     auto webProcess = protectedWebProcessProxy();
     if (webProcess->visiblePageCount())
         return false;


### PR DESCRIPTION
#### fcb00789e9e97821473027e844e7bf12a32b8a99
<pre>
Disable BackgroundProcessResponsivenessTimer when RunningBoard throttling is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=284206">https://bugs.webkit.org/show_bug.cgi?id=284206</a>
<a href="https://rdar.apple.com/141073619">rdar://141073619</a>

Reviewed by Brady Eidson.

It looks like BackgroundProcessResponsivenessTimer is causing spurious background process kills on
oversubscribed systems. There is a comment in this class saying that it is already disabled on iOS
because we use RunningBoard on iOS to manage processes, and there is a good chance that the
background process is suspended, so the check is just unnecessary work. This is true on macOS as
well--we&apos;ve been using RunningBoard to manage processes on macOS for years. So let&apos;s just
disable this class on macOS as well.

We also still have CPUMonitor enabled, so a background process that uses a ton of CPU in the
background but does not suspend will be killed for ProcessTerminationReason::ExceededCPULimit. So
this shouldn&apos;t have a practical power impact.

* Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.cpp:
(WebKit::BackgroundProcessResponsivenessTimer::shouldBeActive const):

Canonical link: <a href="https://commits.webkit.org/287489@main">https://commits.webkit.org/287489@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/397d97467880ca2f08e96461fa90070a5b5e76ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79846 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58847 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33245 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84370 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30843 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67919 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7137 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62407 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20247 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82914 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52464 "Found 1 new test failure: media/audioSession/getUserMedia.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72715 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42718 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49804 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29295 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70931 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27339 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85796 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7076 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4958 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70671 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7250 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68555 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69914 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17423 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13920 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12837 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7034 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6892 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10404 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8698 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->