### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/html/track

### DIFF
--- a/Source/WebCore/html/track/TextTrackCueList.cpp
+++ b/Source/WebCore/html/track/TextTrackCueList.cpp
@@ -29,17 +29,17 @@
 #if ENABLE(VIDEO)
 
 #include "TextTrackCueList.h"
+#include <algorithm>
+#include <ranges>
 
 // Checking sorting is too slow for general use; turn it on explicitly when working on this class.
 #undef CHECK_SORTING
 
 #ifdef CHECK_SORTING
-#define ASSERT_SORTED(begin, end) ASSERT(std::is_sorted(begin, end, cueSortsBefore))
+#define ASSERT_SORTED(range) ASSERT(std::ranges::is_sorted(range, cueSortsBefore))
 #else
-#define ASSERT_SORTED(begin, end) ((void)0)
+#define ASSERT_SORTED(range) ((void)0)
 #endif
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 
@@ -94,7 +94,7 @@ TextTrackCueList& TextTrackCueList::activeCues()
         if (cue->isActive())
             activeCuesVector.append(cue);
     }
-    ASSERT_SORTED(activeCuesVector.begin(), activeCuesVector.end());
+    ASSERT_SORTED(activeCuesVector);
     m_activeCues->m_vector = WTFMove(activeCuesVector);
 
     // FIXME: This list of active cues is not updated as cues are added, removed, become active, and become inactive.
@@ -107,17 +107,17 @@ void TextTrackCueList::add(Ref<TextTrackCue>&& cue)
     ASSERT(!m_vector.contains(cue.ptr()));
 
     RefPtr<TextTrackCue> cueRefPtr { WTFMove(cue) };
-    unsigned insertionPosition = std::upper_bound(m_vector.begin(), m_vector.end(), cueRefPtr, cueSortsBefore) - m_vector.begin();
-    ASSERT_SORTED(m_vector.begin(), m_vector.end());
+    unsigned insertionPosition = std::ranges::upper_bound(m_vector, cueRefPtr, cueSortsBefore) - m_vector.begin();
+    ASSERT_SORTED(m_vector);
     m_vector.insert(insertionPosition, WTFMove(cueRefPtr));
-    ASSERT_SORTED(m_vector.begin(), m_vector.end());
+    ASSERT_SORTED(m_vector);
 }
 
 void TextTrackCueList::remove(TextTrackCue& cue)
 {
-    ASSERT_SORTED(m_vector.begin(), m_vector.end());
+    ASSERT_SORTED(m_vector);
     m_vector.remove(cueIndex(cue));
-    ASSERT_SORTED(m_vector.begin(), m_vector.end());
+    ASSERT_SORTED(m_vector);
 }
 
 void TextTrackCueList::clear()
@@ -129,26 +129,26 @@ void TextTrackCueList::clear()
 
 void TextTrackCueList::updateCueIndex(const TextTrackCue& cue)
 {
-    auto cuePosition = m_vector.begin() + cueIndex(cue);
-    auto afterCuePosition = cuePosition + 1;
+    auto vectorSpan = m_vector.mutableSpan();
+    auto cueIndex = this->cueIndex(cue);
+    auto valuesUntilCue = vectorSpan.first(cueIndex);
+    auto cuePosition = vectorSpan.subspan(cueIndex).begin();
+    auto valuesAfterCue = vectorSpan.subspan(cueIndex + 1);
+    ASSERT_SORTED(valuesUntilCue);
+    ASSERT_SORTED(valuesAfterCue);
 
-    ASSERT_SORTED(m_vector.begin(), cuePosition);
-    ASSERT_SORTED(afterCuePosition, m_vector.end());
-
-    auto reinsertionPosition = std::upper_bound(m_vector.begin(), cuePosition, *cuePosition, cueSortsBefore);
-    if (reinsertionPosition != cuePosition)
-        std::rotate(reinsertionPosition, cuePosition, afterCuePosition);
+    auto reinsertionPosition = std::ranges::upper_bound(valuesUntilCue, *cuePosition, cueSortsBefore);
+    if (std::to_address(reinsertionPosition) != std::to_address(cuePosition))
+        std::rotate(reinsertionPosition, cuePosition, valuesAfterCue.begin());
     else {
-        reinsertionPosition = std::upper_bound(afterCuePosition, m_vector.end(), *cuePosition, cueSortsBefore);
-        if (reinsertionPosition != afterCuePosition)
-            std::rotate(cuePosition, afterCuePosition, reinsertionPosition);
+        reinsertionPosition = std::ranges::upper_bound(valuesAfterCue, *cuePosition, cueSortsBefore);
+        if (std::to_address(reinsertionPosition) != valuesAfterCue.data())
+            std::rotate(cuePosition, valuesAfterCue.begin(), reinsertionPosition);
     }
 
-    ASSERT_SORTED(m_vector.begin(), m_vector.end());
+    ASSERT_SORTED(m_vector);
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -64,19 +64,17 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringBuilder.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(VTTCue);
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(VTTCueBox);
 
-static const CSSValueID displayWritingModeMap[] = {
+static constexpr std::array<CSSValueID, 3> displayWritingModeMap {
     CSSValueHorizontalTb, CSSValueVerticalRl, CSSValueVerticalLr
 };
 static_assert(std::size(displayWritingModeMap) == static_cast<size_t>(WebCore::VTTDirectionSetting::MaxValue) + 1, "displayWritingModeMap has wrong size");
 
-static const CSSValueID displayAlignmentMap[] = {
+static constexpr std::array<CSSValueID, 5> displayAlignmentMap {
     CSSValueStart, CSSValueCenter, CSSValueEnd, CSSValueLeft, CSSValueRight
 };
 static_assert(std::size(displayAlignmentMap) == static_cast<size_t>(WebCore::VTTAlignSetting::MaxValue) + 1, "displayAlignmentMap has wrong size");
@@ -1130,17 +1128,17 @@ std::pair<double, double> VTTCue::getPositionCoordinates() const
 VTTCue::CueSetting VTTCue::settingName(VTTScanner& input)
 {
     CueSetting parsedSetting = None;
-    if (input.scan("vertical"))
+    if (input.scan("vertical"_span))
         parsedSetting = Vertical;
-    else if (input.scan("line"))
+    else if (input.scan("line"_span))
         parsedSetting = Line;
-    else if (input.scan("position"))
+    else if (input.scan("position"_span))
         parsedSetting = Position;
-    else if (input.scan("size"))
+    else if (input.scan("size"_span))
         parsedSetting = Size;
-    else if (input.scan("align"))
+    else if (input.scan("align"_span))
         parsedSetting = Align;
-    else if (input.scan("region"))
+    else if (input.scan("region"_span))
         parsedSetting = Region;
 
     // Verify that a ':' follows.
@@ -1515,7 +1513,5 @@ void VTTCue::cancelSpeaking()
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif

--- a/Source/WebCore/html/track/VTTRegion.cpp
+++ b/Source/WebCore/html/track/VTTRegion.cpp
@@ -164,17 +164,17 @@ void VTTRegion::setRegionSettings(const String& inputString)
 
 VTTRegion::RegionSetting VTTRegion::scanSettingName(VTTScanner& input)
 {
-    if (input.scan("id:"))
+    if (input.scan("id:"_span))
         return Id;
-    if (input.scan("lines:"))
+    if (input.scan("lines:"_span))
         return Lines;
-    if (input.scan("width:"))
+    if (input.scan("width:"_span))
         return Width;
-    if (input.scan("viewportanchor:"))
+    if (input.scan("viewportanchor:"_span))
         return ViewportAnchor;
-    if (input.scan("regionanchor:"))
+    if (input.scan("regionanchor:"_span))
         return RegionAnchor;
-    if (input.scan("scroll:"))
+    if (input.scan("scroll:"_span))
         return Scroll;
 
     return None;

--- a/Source/WebCore/html/track/VTTScanner.cpp
+++ b/Source/WebCore/html/track/VTTScanner.cpp
@@ -32,21 +32,16 @@
 
 #include <wtf/text/StringToIntegerConversion.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 VTTScanner::VTTScanner(const String& line)
     : m_source(line)
     , m_is8Bit(line.is8Bit())
 {
-    if (m_is8Bit) {
-        m_data.characters8 = line.span8().data();
-        m_end.characters8 = m_data.characters8 + line.length();
-    } else {
-        m_data.characters16 = line.span16().data();
-        m_end.characters16 = m_data.characters16 + line.length();
-    }
+    if (m_is8Bit)
+        m_data.characters8 = line.span8();
+    else
+        m_data.characters16 = line.span16();
 }
 
 bool VTTScanner::scan(char c)
@@ -59,14 +54,14 @@ bool VTTScanner::scan(char c)
 
 bool VTTScanner::scan(std::span<const LChar> characters)
 {
-    unsigned matchLength = m_is8Bit ? m_end.characters8 - m_data.characters8 : m_end.characters16 - m_data.characters16;
+    auto matchLength = m_is8Bit ? m_data.characters8.size() : m_data.characters16.size();
     if (matchLength < characters.size())
         return false;
     bool matched;
     if (m_is8Bit)
-        matched = equal(m_data.characters8, characters);
+        matched = equal(m_data.characters8.first(characters.size()), characters);
     else
-        matched = equal(m_data.characters16, characters);
+        matched = equal(m_data.characters16.first(characters.size()), characters);
     if (matched)
         advance(characters.size());
     return matched;
@@ -83,11 +78,11 @@ bool VTTScanner::scanRun(const Run& run, const String& toMatch)
         return false;
     bool matched;
     if (m_is8Bit)
-        matched = equal(toMatch.impl(), { m_data.characters8, matchLength });
+        matched = equal(toMatch.impl(), m_data.characters8.first(matchLength));
     else
-        matched = equal(toMatch.impl(), { m_data.characters16, matchLength });
+        matched = equal(toMatch.impl(), m_data.characters16.first(matchLength));
     if (matched)
-        seekTo(run.end());
+        advance(run.length());
     return matched;
 }
 
@@ -107,17 +102,16 @@ String VTTScanner::extractString(const Run& run)
     ASSERT(run.end() <= end());
     String s;
     if (m_is8Bit)
-        s = std::span { m_data.characters8, run.length() };
+        s = run.span8();
     else
-        s = std::span { m_data.characters16, run.length() };
-    seekTo(run.end());
+        s = run.span16();
+    advance(run.length());
     return s;
 }
 
 String VTTScanner::restOfInputAsString()
 {
-    Run rest(position(), end(), m_is8Bit);
-    return extractString(rest);
+    return extractString(m_is8Bit ? Run { m_data.characters8 } : Run { m_data.characters16 });
 }
 
 unsigned VTTScanner::scanDigits(unsigned& number)
@@ -131,15 +125,15 @@ unsigned VTTScanner::scanDigits(unsigned& number)
     StringView string;
     unsigned numDigits = runOfDigits.length();
     if (m_is8Bit)
-        string = std::span { m_data.characters8, numDigits };
+        string = m_data.characters8.first(numDigits);
     else
-        string = std::span { m_data.characters16, numDigits };
+        string = m_data.characters16.first(numDigits);
 
     // Since these are ASCII digits, the only failure mode is overflow, so use the maximum unsigned value.
     number = parseInteger<unsigned>(string).value_or(std::numeric_limits<unsigned>::max());
 
     // Consume the digits.
-    seekTo(runOfDigits.end());
+    advance(runOfDigits.length());
     return numDigits;
 }
 
@@ -148,11 +142,11 @@ bool VTTScanner::scanFloat(float& number, bool* isNegative)
     bool negative = scan('-');
     Run integerRun = collectWhile<isASCIIDigit>();
 
-    seekTo(integerRun.end());
-    Run decimalRun(position(), position(), m_is8Bit);
+    advance(integerRun.length());
+    Run decimalRun = createRun(position(), position());
     if (scan('.')) {
         decimalRun = collectWhile<isASCIIDigit>();
-        seekTo(decimalRun.end());
+        advance(decimalRun.length());
     }
 
     // At least one digit required.
@@ -162,12 +156,12 @@ bool VTTScanner::scanFloat(float& number, bool* isNegative)
         return false;
     }
 
-    size_t lengthOfFloat = Run(integerRun.start(), position(), m_is8Bit).length();
+    Run floatRun = createRun(integerRun.start(), position());
     bool validNumber;
     if (m_is8Bit)
-        number = charactersToFloat({ integerRun.start(), lengthOfFloat }, &validNumber);
+        number = charactersToFloat(floatRun.span8(), &validNumber);
     else
-        number = charactersToFloat({ reinterpret_cast<const UChar*>(integerRun.start()), lengthOfFloat }, &validNumber);
+        number = charactersToFloat(floatRun.span16(), &validNumber);
 
     if (!validNumber)
         number = std::numeric_limits<float>::max();
@@ -180,6 +174,20 @@ bool VTTScanner::scanFloat(float& number, bool* isNegative)
     return true;
 }
 
+auto VTTScanner::createRun(Position start, Position end) const -> Run
+{
+    if (m_is8Bit) {
+        auto span8 = m_source.span8();
+        auto* start8 = static_cast<const LChar*>(start);
+        auto* end8 = static_cast<const LChar*>(end);
+        RELEASE_ASSERT(start8 >= span8.data());
+        return Run { span8.subspan(start8 - span8.data(), end8 - start8) };
+    }
+    auto span16 = m_source.span16();
+    auto* start16 = static_cast<const UChar*>(start);
+    auto* end16 = static_cast<const UChar*>(end);
+    RELEASE_ASSERT(start16 >= span16.data());
+    return Run { span16.subspan(start16 - span16.data(), end16 - start16) };
 }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+}

--- a/Source/WebCore/html/track/VTTScanner.h
+++ b/Source/WebCore/html/track/VTTScanner.h
@@ -32,8 +32,6 @@
 #include "ParsingUtilities.h"
 #include <wtf/text/WTFString.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 // Helper class for "scanning" an input string and performing parsing of
@@ -52,22 +50,49 @@ class VTTScanner {
 public:
     explicit VTTScanner(const String& line);
 
-    typedef const LChar* Position;
+    using Position = const void*;
 
     class Run {
     public:
-        Run(Position start, Position end, bool is8Bit)
-            : m_start(start), m_end(end), m_is8Bit(is8Bit) { }
+        explicit Run(std::span<const LChar> data)
+            : m_is8Bit(true)
+        {
+            m_data.characters8 = data;
+        }
 
-        Position start() const { return m_start; }
-        Position end() const { return m_end; }
+        explicit Run(std::span<const UChar> data)
+            : m_is8Bit(false)
+        {
+            m_data.characters16 = data;
+        }
 
-        bool isEmpty() const { return m_start == m_end; }
-        size_t length() const;
+        std::span<const LChar> span8() const { RELEASE_ASSERT(m_is8Bit); return m_data.characters8; }
+        std::span<const UChar> span16() const { RELEASE_ASSERT(!m_is8Bit); return m_data.characters16; }
+
+        Position start() const
+        {
+            if (m_is8Bit)
+                return m_data.characters8.data();
+            return m_data.characters16.data();
+        }
+        Position end() const
+        {
+            if (m_is8Bit)
+                return std::to_address(m_data.characters8.end());
+            return std::to_address(m_data.characters16.end());
+        }
+
+        bool isEmpty() const { return !length(); }
+        size_t length() const { return m_is8Bit ? m_data.characters8.size() : m_data.characters16.size(); }
 
     private:
-        Position m_start;
-        Position m_end;
+        union Characters {
+            Characters()
+                : characters8()
+            { }
+            std::span<const LChar> characters8;
+            std::span<const UChar> characters16;
+        } m_data;
         bool m_is8Bit;
     };
 
@@ -81,10 +106,6 @@ public:
     bool scan(char);
     // Scan the first |charactersCount| characters of the string |characters|.
     bool scan(std::span<const LChar> characters);
-
-    // Scan the literal |characters|.
-    template<unsigned charactersCount>
-    bool scan(const char (&characters)[charactersCount]);
 
     // Skip (advance the input pointer) as long as the specified
     // |characterPredicate| returns true, and the input pointer is not passed
@@ -131,105 +152,107 @@ public:
     bool scanFloat(float& number, bool* isNegative = nullptr);
 
 protected:
-    Position position() const { return m_data.characters8; }
-    Position end() const { return m_end.characters8; }
+    Run createRun(Position start, Position end) const;
+    Position position() const
+    {
+        if (m_is8Bit)
+            return m_data.characters8.data();
+        return m_data.characters16.data();
+    }
+    Position end() const
+    {
+        if (m_is8Bit)
+            return std::to_address(m_data.characters8.end());
+        return std::to_address(m_data.characters16.end());
+    }
     void seekTo(Position);
     UChar currentChar() const;
-    void advance(unsigned amount = 1);
+    void advance(size_t amount = 1);
     // Adapt a UChar-predicate to an LChar-predicate.
     // (For use with skipWhile/Until from ParsingUtilities.h).
     template<bool characterPredicate(UChar)>
     static inline bool LCharPredicateAdapter(LChar c) { return characterPredicate(c); }
-    union {
-        const LChar* characters8;
-        const UChar* characters16;
+    union Characters {
+        Characters()
+            : characters8()
+        { }
+        std::span<const LChar> characters8;
+        std::span<const UChar> characters16;
     } m_data;
-    union {
-        const LChar* characters8;
-        const UChar* characters16;
-    } m_end;
     const String m_source;
     bool m_is8Bit;
 };
-
-inline size_t VTTScanner::Run::length() const
-{
-    if (m_is8Bit)
-        return m_end - m_start;
-    return reinterpret_cast<const UChar*>(m_end) - reinterpret_cast<const UChar*>(m_start);
-}
-
-template<unsigned charactersCount>
-inline bool VTTScanner::scan(const char (&characters)[charactersCount])
-{
-    return scan({ byteCast<LChar>(&characters[0]), charactersCount - 1 });
-}
 
 template<bool characterPredicate(UChar)>
 inline void VTTScanner::skipWhile()
 {
     if (m_is8Bit)
-        WebCore::skipWhile<LCharPredicateAdapter<characterPredicate> >(m_data.characters8, m_end.characters8);
+        WebCore::skipWhile<LCharPredicateAdapter<characterPredicate>>(m_data.characters8);
     else
-        WebCore::skipWhile<characterPredicate>(m_data.characters16, m_end.characters16);
+        WebCore::skipWhile<characterPredicate>(m_data.characters16);
 }
 
 template<bool characterPredicate(UChar)>
 inline void VTTScanner::skipUntil()
 {
     if (m_is8Bit)
-        WebCore::skipUntil<LCharPredicateAdapter<characterPredicate> >(m_data.characters8, m_end.characters8);
+        WebCore::skipUntil<LCharPredicateAdapter<characterPredicate>>(m_data.characters8);
     else
-        WebCore::skipUntil<characterPredicate>(m_data.characters16, m_end.characters16);
+        WebCore::skipUntil<characterPredicate>(m_data.characters16);
 }
 
 template<bool characterPredicate(UChar)>
 inline VTTScanner::Run VTTScanner::collectWhile()
 {
     if (m_is8Bit) {
-        const LChar* current = m_data.characters8;
-        WebCore::skipWhile<LCharPredicateAdapter<characterPredicate>>(current, m_end.characters8);
-        return Run(position(), current, m_is8Bit);
+        auto current = m_data.characters8;
+        WebCore::skipWhile<LCharPredicateAdapter<characterPredicate>>(current);
+        return Run { m_data.characters8.first(current.data() - m_data.characters8.data()) };
     }
-    const UChar* current = m_data.characters16;
-    WebCore::skipWhile<characterPredicate>(current, m_end.characters16);
-    return Run(position(), reinterpret_cast<Position>(current), m_is8Bit);
+    auto current = m_data.characters16;
+    WebCore::skipWhile<characterPredicate>(current);
+    return Run { m_data.characters16.first(current.data() - m_data.characters16.data()) };
 }
 
 template<bool characterPredicate(UChar)>
 inline VTTScanner::Run VTTScanner::collectUntil()
 {
     if (m_is8Bit) {
-        const LChar* current = m_data.characters8;
-        WebCore::skipUntil<LCharPredicateAdapter<characterPredicate> >(current, m_end.characters8);
-        return Run(position(), current, m_is8Bit);
+        auto current = m_data.characters8;
+        WebCore::skipUntil<LCharPredicateAdapter<characterPredicate>>(current);
+        return Run { m_data.characters8.first(current.data() - m_data.characters8.data()) };
     }
-    const UChar* current = m_data.characters16;
-    WebCore::skipUntil<characterPredicate>(current, m_end.characters16);
-    return Run(position(), reinterpret_cast<Position>(current), m_is8Bit);
+    auto current = m_data.characters16;
+    WebCore::skipUntil<characterPredicate>(current);
+    return Run { m_data.characters16.first(current.data() - m_data.characters16.data()) };
 }
 
 inline void VTTScanner::seekTo(Position position)
 {
-    ASSERT(position <= end());
-    m_data.characters8 = position;
+    if (m_is8Bit) {
+        auto span8 = m_source.span8();
+        auto* position8 = static_cast<const LChar*>(position);
+        RELEASE_ASSERT(position8 >= span8.data());
+        m_data.characters8 = span8.subspan(position8 - span8.data());
+    } else {
+        auto span16 = m_source.span16();
+        auto* position16 = static_cast<const UChar*>(position);
+        RELEASE_ASSERT(position16 >= span16.data());
+        m_data.characters16 = span16.subspan(position16 - span16.data());
+    }
 }
 
 inline UChar VTTScanner::currentChar() const
 {
-    ASSERT(position() < end());
-    return m_is8Bit ? *m_data.characters8 : *m_data.characters16;
+    return m_is8Bit ? m_data.characters8.front() : m_data.characters16.front();
 }
 
-inline void VTTScanner::advance(unsigned amount)
+inline void VTTScanner::advance(size_t amount)
 {
-    ASSERT(position() < end());
     if (m_is8Bit)
-        m_data.characters8 += amount;
+        m_data.characters8 = m_data.characters8.subspan(amount);
     else
-        m_data.characters16 += amount;
+        m_data.characters16 = m_data.characters16.subspan(amount);
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/html/track/WebVTTParser.cpp
+++ b/Source/WebCore/html/track/WebVTTParser.cpp
@@ -446,7 +446,7 @@ WebVTTParser::ParseState WebVTTParser::collectTimingsAndSettings(const String& l
     input.skipWhile<isASCIIWhitespace<UChar>>();
 
     // Steps 6 - 9 - If the next three characters are not "-->", abort and return failure.
-    if (!input.scan("-->"))
+    if (!input.scan("-->"_span))
         return BadCue;
     
     input.skipWhile<isASCIIWhitespace<UChar>>();


### PR DESCRIPTION
#### a2319135abbdfa90bccd13139a4e45c68738d527
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/html/track
<a href="https://bugs.webkit.org/show_bug.cgi?id=284207">https://bugs.webkit.org/show_bug.cgi?id=284207</a>

Reviewed by Darin Adler.

* Source/WebCore/html/track/TextTrackCueList.cpp:
(WebCore::TextTrackCueList::activeCues):
(WebCore::TextTrackCueList::add):
(WebCore::TextTrackCueList::remove):
(WebCore::TextTrackCueList::updateCueIndex):
* Source/WebCore/html/track/VTTCue.cpp:
(WebCore::VTTCue::settingName):
* Source/WebCore/html/track/VTTRegion.cpp:
(WebCore::VTTRegion::scanSettingName):
* Source/WebCore/html/track/VTTScanner.h:
(WebCore::VTTScanner::scan): Deleted.
* Source/WebCore/html/track/WebVTTParser.cpp:
(WebCore::WebVTTParser::collectTimingsAndSettings):

Canonical link: <a href="https://commits.webkit.org/287510@main">https://commits.webkit.org/287510@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34233ebdc95cc06613c8679bc1ca552df0e49b58

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79947 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58944 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84461 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30921 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82055 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68008 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7240 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62482 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20310 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83014 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52542 "Found 1 new test failure: media/audioSession/getUserMedia.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72808 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42792 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49884 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26958 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29383 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71004 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27439 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85893 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7163 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5030 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70753 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7340 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68648 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69998 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13994 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12930 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12365 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7127 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12661 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6974 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10486 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8778 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->