### PR TITLE
Stop using deprecated PDFAnnotation subclasses, part 2

### DIFF
--- a/Source/WebKit/Shared/Cocoa/PDFKitSoftLink.h
+++ b/Source/WebKit/Shared/Cocoa/PDFKitSoftLink.h
@@ -38,11 +38,7 @@ SOFT_LINK_FRAMEWORK_FOR_HEADER(WebKit, PDFKit)
 SOFT_LINK_CLASS_FOR_HEADER(WebKit, PDFHostViewController)
 #endif
 
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 SOFT_LINK_CLASS_FOR_HEADER(WebKit, PDFActionResetForm)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, PDFAnnotationLink)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, PDFAnnotationPopup)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, PDFAnnotationText)
 SOFT_LINK_CLASS_FOR_HEADER(WebKit, PDFDocument)
 SOFT_LINK_CLASS_FOR_HEADER(WebKit, PDFLayerController)
 SOFT_LINK_CLASS_FOR_HEADER(WebKit, PDFSelection)
@@ -51,11 +47,13 @@ SOFT_LINK_CONSTANT_FOR_HEADER(WebKit, PDFKit, PDFViewCopyPermissionNotification,
 SOFT_LINK_CONSTANT_FOR_HEADER(WebKit, PDFKit, PDFDocumentCreationDateAttribute, PDFDocumentAttribute)
 SOFT_LINK_CONSTANT_FOR_HEADER(WebKit, PDFKit, PDFAnnotationKeySubtype, NSString *)
 SOFT_LINK_CONSTANT_FOR_HEADER(WebKit, PDFKit, PDFAnnotationKeyWidgetFieldType, NSString *)
+SOFT_LINK_CONSTANT_FOR_HEADER(WebKit, PDFKit, PDFAnnotationSubtypeLink, NSString *)
+SOFT_LINK_CONSTANT_FOR_HEADER(WebKit, PDFKit, PDFAnnotationSubtypePopup, NSString *)
+SOFT_LINK_CONSTANT_FOR_HEADER(WebKit, PDFKit, PDFAnnotationSubtypeText, NSString *)
 SOFT_LINK_CONSTANT_FOR_HEADER(WebKit, PDFKit, PDFAnnotationSubtypeWidget, NSString *)
 SOFT_LINK_CONSTANT_FOR_HEADER(WebKit, PDFKit, PDFAnnotationWidgetSubtypeButton, NSString *)
 SOFT_LINK_CONSTANT_FOR_HEADER(WebKit, PDFKit, PDFAnnotationWidgetSubtypeChoice, NSString *)
 SOFT_LINK_CONSTANT_FOR_HEADER(WebKit, PDFKit, PDFAnnotationWidgetSubtypeSignature, NSString *)
 SOFT_LINK_CONSTANT_FOR_HEADER(WebKit, PDFKit, PDFAnnotationWidgetSubtypeText, NSString *)
-ALLOW_DEPRECATED_DECLARATIONS_END
 
 #endif // HAVE(PDFKIT)

--- a/Source/WebKit/Shared/Cocoa/PDFKitSoftLink.mm
+++ b/Source/WebKit/Shared/Cocoa/PDFKitSoftLink.mm
@@ -36,11 +36,7 @@ SOFT_LINK_FRAMEWORK_FOR_SOURCE(WebKit, PDFKit)
 SOFT_LINK_CLASS_FOR_SOURCE(WebKit, PDFKit, PDFHostViewController)
 #endif
 
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 SOFT_LINK_CLASS_FOR_SOURCE(WebKit, PDFKit, PDFActionResetForm)
-SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL(WebKit, PDFKit, PDFAnnotationLink)
-SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL(WebKit, PDFKit, PDFAnnotationPopup)
-SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL(WebKit, PDFKit, PDFAnnotationText)
 SOFT_LINK_CLASS_FOR_SOURCE(WebKit, PDFKit, PDFDocument)
 SOFT_LINK_CLASS_FOR_SOURCE(WebKit, PDFKit, PDFLayerController)
 SOFT_LINK_CLASS_FOR_SOURCE(WebKit, PDFKit, PDFSelection)
@@ -49,11 +45,13 @@ SOFT_LINK_CONSTANT_FOR_SOURCE(WebKit, PDFKit, PDFViewCopyPermissionNotification,
 SOFT_LINK_CONSTANT_FOR_SOURCE(WebKit, PDFKit, PDFDocumentCreationDateAttribute, PDFDocumentAttribute)
 SOFT_LINK_CONSTANT_FOR_SOURCE(WebKit, PDFKit, PDFAnnotationKeySubtype, NSString *)
 SOFT_LINK_CONSTANT_FOR_SOURCE(WebKit, PDFKit, PDFAnnotationKeyWidgetFieldType, NSString *)
+SOFT_LINK_CONSTANT_FOR_SOURCE(WebKit, PDFKit, PDFAnnotationSubtypeLink, NSString *)
+SOFT_LINK_CONSTANT_FOR_SOURCE(WebKit, PDFKit, PDFAnnotationSubtypePopup, NSString *)
+SOFT_LINK_CONSTANT_FOR_SOURCE(WebKit, PDFKit, PDFAnnotationSubtypeText, NSString *)
 SOFT_LINK_CONSTANT_FOR_SOURCE(WebKit, PDFKit, PDFAnnotationSubtypeWidget, NSString *)
 SOFT_LINK_CONSTANT_FOR_SOURCE(WebKit, PDFKit, PDFAnnotationWidgetSubtypeButton, NSString *)
 SOFT_LINK_CONSTANT_FOR_SOURCE(WebKit, PDFKit, PDFAnnotationWidgetSubtypeChoice, NSString *)
 SOFT_LINK_CONSTANT_FOR_SOURCE(WebKit, PDFKit, PDFAnnotationWidgetSubtypeSignature, NSString *)
 SOFT_LINK_CONSTANT_FOR_SOURCE(WebKit, PDFKit, PDFAnnotationWidgetSubtypeText, NSString *)
-ALLOW_DEPRECATED_DECLARATIONS_END
 
 #endif // HAVE(PDFKIT)

--- a/Source/WebKit/UIProcess/mac/WKPrintingView.mm
+++ b/Source/WebKit/UIProcess/mac/WKPrintingView.mm
@@ -490,17 +490,14 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     }
 
     for (PDFAnnotation *annotation in [pdfPage annotations]) {
-        if (![annotation isKindOfClass:WebKit::getPDFAnnotationLinkClass()])
+        if (![[annotation valueForAnnotationKey:WebKit::get_PDFKit_PDFAnnotationKeySubtype()] isEqualToString:WebKit::get_PDFKit_PDFAnnotationSubtypeLink()])
             continue;
 
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        PDFAnnotationLink *linkAnnotation = (PDFAnnotationLink *)annotation;
-ALLOW_DEPRECATED_DECLARATIONS_END
-        NSURL *url = [linkAnnotation URL];
-        CGRect transformedRect = CGRectApplyAffineTransform(NSRectToCGRect([linkAnnotation bounds]), transform);
+        NSURL *url = annotation.URL;
+        CGRect transformedRect = CGRectApplyAffineTransform(NSRectToCGRect(annotation.bounds), transform);
 
         if (!url) {
-            PDFDestination *destination = [linkAnnotation destination];
+            PDFDestination *destination = annotation.destination;
             if (!destination)
                 continue;
             CGPDFContextSetDestinationForRect(context, (__bridge CFStringRef)linkDestinationName(pdfDocument, destination), transformedRect);
@@ -596,16 +593,13 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         for (unsigned i = 0; i < pageCount; i++) {
             PDFPage *page = [_printedPagesPDFDocument pageAtIndex:i];
             for (PDFAnnotation *annotation in page.annotations) {
-                if (![annotation isKindOfClass:WebKit::getPDFAnnotationLinkClass()])
+                if (![[annotation valueForAnnotationKey:WebKit::get_PDFKit_PDFAnnotationKeySubtype()] isEqualToString:WebKit::get_PDFKit_PDFAnnotationSubtypeLink()])
                     continue;
 
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-                PDFAnnotationLink *linkAnnotation = (PDFAnnotationLink *)annotation;
-ALLOW_DEPRECATED_DECLARATIONS_END
-                if (linkAnnotation.URL)
+                if (annotation.URL)
                     continue;
 
-                PDFDestination *destination = linkAnnotation.destination;
+                PDFDestination *destination = annotation.destination;
                 if (!destination)
                     continue;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFAnnotationTypeHelpers.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFAnnotationTypeHelpers.h
@@ -33,6 +33,13 @@ OBJC_CLASS PDFAnnotation;
 
 namespace WebKit::PDFAnnotationTypeHelpers {
 
+enum class AnnotationType : uint8_t {
+    Link,
+    Popup,
+    Text,
+    Widget,
+};
+
 enum class WidgetType : uint8_t {
     Button,
     Choice,
@@ -40,7 +47,8 @@ enum class WidgetType : uint8_t {
     Text,
 };
 
-bool annotationIsWidget(PDFAnnotation *);
+bool annotationIsOfType(PDFAnnotation *, AnnotationType);
+bool annotationIsOfType(PDFAnnotation *, std::initializer_list<AnnotationType>&&);
 bool annotationIsWidgetOfType(PDFAnnotation *, WidgetType);
 bool annotationIsWidgetOfType(PDFAnnotation *, std::initializer_list<WidgetType>&&);
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -1531,17 +1531,14 @@ std::pair<String, RetainPtr<PDFSelection>> PDFPlugin::textForImmediateActionHitT
     NSPoint pointInPageSpace = [[m_pdfLayerController layout] convertPoint:pointInLayoutSpace toPage:currentPage forScaleFactor:1.0];
 
     for (PDFAnnotation *annotation in currentPage.annotations) {
-        if (![annotation isKindOfClass:getPDFAnnotationLinkClass()])
+        if (!annotationIsOfType(annotation, AnnotationType::Link))
             continue;
 
         NSRect bounds = annotation.bounds;
         if (!NSPointInRect(pointInPageSpace, bounds))
             continue;
 
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        PDFAnnotationLink *linkAnnotation = (PDFAnnotationLink *)annotation;
-ALLOW_DEPRECATED_DECLARATIONS_END
-        NSURL *url = linkAnnotation.URL;
+        NSURL *url = annotation.URL;
         if (!url)
             continue;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -1755,7 +1755,7 @@ static TextStream& operator<<(TextStream& ts, UnifiedPDFPlugin::PDFElementType e
 
 static BOOL annotationIsExternalLink(PDFAnnotation *annotation)
 {
-    if (![annotation isKindOfClass:getPDFAnnotationLinkClass()])
+    if (!annotationIsOfType(annotation, AnnotationType::Link))
         return NO;
 
     return !![annotation URL];
@@ -1763,7 +1763,7 @@ static BOOL annotationIsExternalLink(PDFAnnotation *annotation)
 
 static BOOL annotationIsLinkWithDestination(PDFAnnotation *annotation)
 {
-    if (![annotation isKindOfClass:getPDFAnnotationLinkClass()])
+    if (!annotationIsOfType(annotation, AnnotationType::Link))
         return NO;
 
     return [annotation URL] || [annotation destination];
@@ -1820,10 +1820,10 @@ auto UnifiedPDFPlugin::pdfElementTypesForPluginPoint(const IntPoint& point) cons
         if (annotationIsLinkWithDestination(annotation))
             pdfElementTypes.add(PDFElementType::Link);
 
-        if ([annotation isKindOfClass:getPDFAnnotationPopupClass()])
+        if (annotationIsOfType(annotation, AnnotationType::Popup))
             pdfElementTypes.add(PDFElementType::Popup);
 
-        if ([annotation isKindOfClass:getPDFAnnotationTextClass()])
+        if (annotationIsOfType(annotation, AnnotationType::Text))
             pdfElementTypes.add(PDFElementType::Icon);
 
         if (![annotation isReadOnly]) {
@@ -2084,19 +2084,19 @@ RepaintRequirements UnifiedPDFPlugin::repaintRequirementsForAnnotation(PDFAnnota
     if (annotationIsWidgetOfType(annotation, WidgetType::Button))
         return RepaintRequirement::PDFContent;
 
-    if ([annotation isKindOfClass:getPDFAnnotationPopupClass()])
+    if (annotationIsOfType(annotation, AnnotationType::Popup))
         return RepaintRequirement::PDFContent;
 
     if (annotationIsWidgetOfType(annotation, WidgetType::Choice))
         return RepaintRequirement::PDFContent;
 
-    if ([annotation isKindOfClass:getPDFAnnotationTextClass()])
+    if (annotationIsOfType(annotation, AnnotationType::Text))
         return RepaintRequirement::PDFContent;
 
     if (annotationIsWidgetOfType(annotation, WidgetType::Text))
         return isAnnotationCommit == IsAnnotationCommit::Yes ? RepaintRequirement::PDFContent : RepaintRequirement::HoverOverlay;
 
-    // No visual feedback for getPDFAnnotationLinkClass at this time.
+    // No visual feedback for PDFAnnotationSubtypeLink at this time.
 
     return { };
 }

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -697,17 +697,14 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     CGAffineTransform transform = CGContextGetCTM(context);
 
     for (PDFAnnotation *annotation in [pdfPage annotations]) {
-        if (![annotation isKindOfClass:getPDFAnnotationLinkClass()])
+        if (![[annotation valueForAnnotationKey:get_PDFKit_PDFAnnotationKeySubtype()] isEqualToString:get_PDFKit_PDFAnnotationSubtypeLink()])
             continue;
 
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        PDFAnnotationLink *linkAnnotation = (PDFAnnotationLink *)annotation;
-ALLOW_DEPRECATED_DECLARATIONS_END
-        NSURL *url = [linkAnnotation URL];
+        NSURL *url = annotation.URL;
         if (!url)
             continue;
 
-        CGRect urlRect = NSRectToCGRect([linkAnnotation bounds]);
+        CGRect urlRect = NSRectToCGRect(annotation.bounds);
         CGRect transformedRect = CGRectApplyAffineTransform(urlRect, transform);
         CGPDFContextSetURLForRect(context, (CFURLRef)url, transformedRect);
     }


### PR DESCRIPTION
#### 2817e279dde1de080ac9044f30a44f998debf36b
<pre>
Stop using deprecated PDFAnnotation subclasses, part 2
<a href="https://bugs.webkit.org/show_bug.cgi?id=284156">https://bugs.webkit.org/show_bug.cgi?id=284156</a>
<a href="https://rdar.apple.com/141039815">rdar://141039815</a>

Reviewed by Tim Horton and Wenson Hsieh.

The PDFAnnotation[Link|Text|Popup] subclasses are deprecated on macOS
and unavailable on the iOS family. For the latter group of platforms,
this means that our annotation type checks were not meaningful.

In this patch, we migrate from directly using these deprecated classes
and instead leaning into key-value lookups on PDFAnnotation instances
using the PDFAnnotationSubType-and-adjacent interfaces. We also use the
new `URL` property exposed on the PDFAnnotation class (through a new
category in the PDFAnnotationUtilities.h), which should _just work_ for
link annotations, meaning we do not need to explicitly cast annotation
instances anymore.

This allows us to make our annotation type checks correct on all
platforms, as well as remove deprecation warning supressors in a few
places.

* Source/WebKit/Shared/Cocoa/PDFKitSoftLink.h:
* Source/WebKit/Shared/Cocoa/PDFKitSoftLink.mm:
* Source/WebKit/UIProcess/mac/WKPrintingView.mm:
(-[WKPrintingView _drawPDFDocument:page:atPoint:]):
(-[WKPrintingView drawRect:]):
* Source/WebKit/WebProcess/Plugins/PDF/PDFAnnotationTypeHelpers.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFAnnotationTypeHelpers.mm:
(WebKit::PDFAnnotationTypeHelpers::widgetType):
(WebKit::PDFAnnotationTypeHelpers::annotationType):
(WebKit::PDFAnnotationTypeHelpers::annotationCheckerInternal):
(WebKit::PDFAnnotationTypeHelpers::annotationIsOfType):
(WebKit::PDFAnnotationTypeHelpers::annotationIsWidgetOfType):
(WebKit::PDFAnnotationTypeHelpers::annotationIsWidget): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::textForImmediateActionHitTestAtPoint):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::annotationIsExternalLink):
(WebKit::annotationIsLinkWithDestination):
(WebKit::UnifiedPDFPlugin::pdfElementTypesForPluginPoint const):
(WebKit::UnifiedPDFPlugin::repaintRequirementsForAnnotation):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::drawPDFPage):

Canonical link: <a href="https://commits.webkit.org/287496@main">https://commits.webkit.org/287496@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1803a5bf3ef239a0c7fa5a9772129fcdb5feb37b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79858 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58858 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33256 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84377 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30849 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67926 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7148 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62415 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20251 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82926 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52471 "Found 1 new test failure: media/audioSession/getUserMedia.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72725 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42725 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49811 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29302 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70936 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27349 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85806 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7084 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4964 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70681 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/old-content-element-writing-modes.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7258 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68565 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69924 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13925 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12847 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12355 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7044 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12605 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6899 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10411 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8705 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->