### PR TITLE
Non-unified source build fix of December 2024 (part 3)

### DIFF
--- a/Source/JavaScriptCore/bytecode/SuperSampler.cpp
+++ b/Source/JavaScriptCore/bytecode/SuperSampler.cpp
@@ -29,6 +29,7 @@
 #include "Options.h"
 #include <wtf/DataLog.h>
 #include <wtf/Lock.h>
+#include <wtf/Seconds.h>
 #include <wtf/Threading.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/dfg/DFGBasicBlock.h
+++ b/Source/JavaScriptCore/dfg/DFGBasicBlock.h
@@ -163,7 +163,7 @@ struct BasicBlock : RefCounted<BasicBlock> {
     void removePredecessor(BasicBlock* block);
     void replacePredecessor(BasicBlock* from, BasicBlock* to);
 
-    Node* cloneAndAppend(Graph&, const Node*);
+    inline Node* cloneAndAppend(Graph&, const Node*);
 
     template<typename... Params>
     Node* appendNode(Graph&, SpeculatedType, Params...);

--- a/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
@@ -29,7 +29,7 @@
 #if ENABLE(DFG_JIT)
 
 #include "CodeOrigin.h"
-#include "DFGBasicBlock.h"
+#include "DFGBasicBlockInlines.h"
 #include "DFGBlockInsertionSet.h"
 #include "DFGCFAPhase.h"
 #include "DFGGraph.h"

--- a/Source/JavaScriptCore/heap/IsoMemoryAllocatorBase.cpp
+++ b/Source/JavaScriptCore/heap/IsoMemoryAllocatorBase.cpp
@@ -27,6 +27,7 @@
 #include "IsoMemoryAllocatorBase.h"
 
 #include "MarkedBlock.h"
+#include <wtf/text/CString.h>
 
 namespace JSC {
 

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStreamSink.cpp
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStreamSink.cpp
@@ -27,6 +27,7 @@
 #include "FileSystemWritableFileStreamSink.h"
 
 #include "FileSystemFileHandle.h"
+#include "FileSystemWritableFileStream.h"
 #include "JSBlob.h"
 #include <JavaScriptCore/ArrayBufferView.h>
 #include <JavaScriptCore/JSArrayBuffer.h>

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheCoders.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheCoders.cpp
@@ -28,6 +28,7 @@
 
 #include "NetworkCacheKey.h"
 #include "NetworkCacheSubresourcesEntry.h"
+#include <wtf/persistence/PersistentCoders.h>
 #include <wtf/persistence/PersistentDecoder.h>
 #include <wtf/persistence/PersistentEncoder.h>
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
@@ -39,6 +39,7 @@
 #include <wtf/PageBlock.h>
 #include <wtf/RunLoop.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/persistence/PersistentCoders.h>
 #include <wtf/persistence/PersistentDecoder.h>
 #include <wtf/persistence/PersistentEncoder.h>
 #include <wtf/text/CString.h>


### PR DESCRIPTION
#### 0161a00aabaed339ac9d60a8208743e47ae4436a
<pre>
Non-unified source build fix of December 2024 (part 3)
<a href="https://bugs.webkit.org/show_bug.cgi?id=283880">https://bugs.webkit.org/show_bug.cgi?id=283880</a>

Unreviewed non-unified build fix. Added missing #include.

* Source/JavaScriptCore/bytecode/SuperSampler.cpp:
* Source/JavaScriptCore/dfg/DFGBasicBlock.h:
* Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp:
* Source/JavaScriptCore/heap/IsoMemoryAllocatorBase.cpp:
* Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStreamSink.cpp:
* Source/WebKit/NetworkProcess/cache/NetworkCacheCoders.cpp:
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp:

Canonical link: <a href="https://commits.webkit.org/287501@main">https://commits.webkit.org/287501@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09509d08a68aa25d761141bd40532dd6b0a00ffe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79857 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58857 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33255 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84376 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30848 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81966 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67925 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7147 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62414 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20250 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82925 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52468 "Found 1 new test failure: media/audioSession/getUserMedia.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72728 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42724 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49808 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26877 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29301 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/72857 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70934 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27352 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85805 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/78944 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7083 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4963 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70679 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7257 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68568 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69922 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13926 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12850 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/101324 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12358 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7043 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12604 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/24703 "Found 2 new JSC stress test failures: wasm.yaml/wasm/stress/struct-new_default-small-members.js.default-wasm, wasm.yaml/wasm/stress/struct-new_default-small-members.js.wasm-bbq (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6898 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10410 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8704 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->