### PR TITLE
Implement ImageBufferCGPDFDocumentBackend

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -416,6 +416,7 @@ platform/graphics/cg/IOSurfacePool.cpp
 platform/graphics/cg/ImageBackingStoreCG.cpp
 platform/graphics/cg/ImageBufferCGBackend.cpp
 platform/graphics/cg/ImageBufferCGBitmapBackend.cpp
+platform/graphics/cg/ImageBufferCGPDFDocumentBackend.cpp
 platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
 platform/graphics/cg/ImageBufferUtilitiesCG.cpp
 platform/graphics/cg/ImageDecoderCG.cpp

--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -574,6 +574,22 @@ void BifurcatedGraphicsContext::drawDotsForDocumentMarker(const FloatRect& rect,
 {
     m_primaryContext.drawDotsForDocumentMarker(rect, markerStyle);
     m_secondaryContext.drawDotsForDocumentMarker(rect, markerStyle);
+
+    VERIFY_STATE_SYNCHRONIZATION();
+}
+
+void BifurcatedGraphicsContext::beginPage(const IntSize& pageSize)
+{
+    m_primaryContext.beginPage(pageSize);
+    m_secondaryContext.beginPage(pageSize);
+
+    VERIFY_STATE_SYNCHRONIZATION();
+}
+
+void BifurcatedGraphicsContext::endPage()
+{
+    m_primaryContext.endPage();
+    m_secondaryContext.endPage();
 
     VERIFY_STATE_SYNCHRONIZATION();
 }

--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -140,6 +140,9 @@ public:
     void drawLinesForText(const FloatPoint&, float thickness, const DashArray& widths, bool printing, bool doubleLines, StrokeStyle) final;
 
     void drawDotsForDocumentMarker(const FloatRect&, DocumentMarkerLineStyle) final;
+
+    void beginPage(const IntSize&) final;
+    void endPage() final;
 
     void setURLForRect(const URL&, const FloatRect&) final;
 

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2008-2009 Torch Mobile, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -354,6 +354,10 @@ public:
     virtual void applyDeviceScaleFactor(float factor) { scale(factor); }
     WEBCORE_EXPORT FloatSize scaleFactor() const;
     WEBCORE_EXPORT FloatSize scaleFactorForDrawing(const FloatRect& destRect, const FloatRect& srcRect) const;
+
+    // PDF, printing and snapshotting
+    virtual void beginPage(const IntSize&) { }
+    virtual void endPage() { }
 
     // Links
 

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2006 Nikolas Zimmermann <zimmermann@kde.org>
- * Copyright (C) 2007-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2010 Torch Mobile (Beijing) Co. Ltd. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -232,6 +232,8 @@ public:
 
     WEBCORE_EXPORT virtual RefPtr<PixelBuffer> getPixelBuffer(const PixelBufferFormat& outputFormat, const IntRect& srcRect, const ImageBufferAllocator& = ImageBufferAllocator()) const;
     WEBCORE_EXPORT virtual void putPixelBuffer(const PixelBuffer&, const IntRect& srcRect, const IntPoint& destPoint = { }, AlphaPremultiplication destFormat = AlphaPremultiplication::Premultiplied);
+
+    WEBCORE_EXPORT virtual RefPtr<SharedBuffer> sinkToPDFDocument();
 
     WEBCORE_EXPORT bool isInUse() const;
     WEBCORE_EXPORT virtual void releaseGraphicsContext();

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Apple Inc.  All rights reserved.
+ * Copyright (C) 2020-2024 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -142,6 +142,11 @@ void ImageBufferBackend::putPixelBuffer(const PixelBuffer& sourcePixelBuffer, co
     };
 
     convertImagePixels(source, destination, destinationRect.size());
+}
+
+RefPtr<SharedBuffer> ImageBufferBackend::sinkToPDFDocument()
+{
+    return nullptr;
 }
 
 AffineTransform ImageBufferBackend::calculateBaseTransform(const Parameters& parameters)

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Apple Inc.  All rights reserved.
+ * Copyright (C) 2020-2024 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -70,6 +70,7 @@ class Image;
 class NativeImage;
 class PixelBuffer;
 class ProcessIdentity;
+class SharedBuffer;
 
 enum class PreserveResolution : bool {
     No,
@@ -128,6 +129,8 @@ public:
 
     virtual void getPixelBuffer(const IntRect& srcRect, PixelBuffer& destination) = 0;
     virtual void putPixelBuffer(const PixelBuffer&, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat) = 0;
+
+    WEBCORE_EXPORT virtual RefPtr<SharedBuffer> sinkToPDFDocument();
 
 #if HAVE(IOSURFACE)
     virtual IOSurface* surface() { return nullptr; }

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2008 Eric Seidel <eric@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -1518,6 +1518,37 @@ void GraphicsContextCG::strokeEllipse(const FloatRect& ellipse)
 
     CGContextRef context = platformContext();
     CGContextStrokeEllipseInRect(context, ellipse);
+}
+
+void GraphicsContextCG::beginPage(const IntSize& pageSize)
+{
+    CGContextRef context = platformContext();
+
+    if (CGContextGetType(context) != kCGContextTypePDF) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    auto mediaBox = CGRectMake(0, 0, pageSize.width(), pageSize.height());
+    auto mediaBoxData = adoptCF(CFDataCreate(nullptr, (const UInt8 *)&mediaBox, sizeof(CGRect)));
+
+    const void* key = kCGPDFContextMediaBox;
+    const void* value = mediaBoxData.get();
+    auto pageInfo = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, &key, &value, 1, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+
+    CGPDFContextBeginPage(context, pageInfo.get());
+}
+
+void GraphicsContextCG::endPage()
+{
+    CGContextRef context = platformContext();
+
+    if (CGContextGetType(context) != kCGContextTypePDF) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    CGPDFContextEndPage(context);
 }
 
 bool GraphicsContextCG::supportsInternalLinks() const

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -121,6 +121,9 @@ public:
     void drawLinesForText(const FloatPoint&, float thickness, const DashArray& widths, bool printing, bool doubleLines, StrokeStyle) final;
 
     void drawDotsForDocumentMarker(const FloatRect&, DocumentMarkerLineStyle) final;
+
+    void beginPage(const IntSize& pageSize) final;
+    void endPage() final;
 
     void setURLForRect(const URL&, const FloatRect&) final;
 

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc.  All rights reserved.
+ * Copyright (C) 2020-2024 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,14 +28,8 @@
 
 #if USE(CG)
 
-#include "BitmapImage.h"
-#include "GraphicsContextCG.h"
-#include "ImageBufferUtilitiesCG.h"
 #include "IntRect.h"
-#include "PixelBuffer.h"
 #include <CoreGraphics/CoreGraphics.h>
-#include <pal/spi/cg/CoreGraphicsSPI.h>
-#include <wtf/RuntimeApplicationChecks.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
@@ -58,6 +52,14 @@ private:
     RetainPtr<CGContextRef> m_context;
 };
 
+ImageBufferCGBackend::ImageBufferCGBackend(const Parameters& parameters, std::unique_ptr<GraphicsContextCG>&& context)
+    : ImageBufferBackend(parameters)
+    , m_context(WTFMove(context))
+{
+}
+
+ImageBufferCGBackend::~ImageBufferCGBackend() = default;
+
 unsigned ImageBufferCGBackend::calculateBytesPerRow(const IntSize& backendSize)
 {
     ASSERT(!backendSize.isEmpty());
@@ -68,8 +70,6 @@ std::unique_ptr<ThreadSafeImageBufferFlusher> ImageBufferCGBackend::createFlushe
 {
     return makeUnique<ThreadSafeImageBufferFlusherCG>(context().platformContext());
 }
-
-ImageBufferCGBackend::~ImageBufferCGBackend() = default;
 
 void ImageBufferCGBackend::applyBaseTransform(GraphicsContextCG& context) const
 {

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc.  All rights reserved.
+ * Copyright (C) 2020-2024 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,13 +27,11 @@
 
 #if USE(CG)
 
+#include "GraphicsContextCG.h"
 #include "ImageBufferBackend.h"
-#include <memory>
 #include <wtf/Forward.h>
 
 namespace WebCore {
-
-class GraphicsContextCG;
 
 class WEBCORE_EXPORT ImageBufferCGBackend : public ImageBufferBackend {
 public:
@@ -41,14 +39,14 @@ public:
     static unsigned calculateBytesPerRow(const IntSize& backendSize);
 
 protected:
-    using ImageBufferBackend::ImageBufferBackend;
+    ImageBufferCGBackend(const Parameters&, std::unique_ptr<GraphicsContextCG>&& = nullptr);
     void applyBaseTransform(GraphicsContextCG&) const;
 
     std::unique_ptr<ThreadSafeImageBufferFlusher> createFlusher() override;
 
     String debugDescription() const override;
 
-    mutable std::unique_ptr<GraphicsContextCG> m_context;
+    std::unique_ptr<GraphicsContextCG> m_context;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp
@@ -96,13 +96,12 @@ std::unique_ptr<ImageBufferCGBitmapBackend> ImageBufferCGBitmapBackend::create(c
 }
 
 ImageBufferCGBitmapBackend::ImageBufferCGBitmapBackend(const Parameters& parameters, uint8_t* data, RetainPtr<CGDataProviderRef>&& dataProvider, std::unique_ptr<GraphicsContextCG>&& context)
-    : ImageBufferCGBackend(parameters)
+    : ImageBufferCGBackend(parameters, WTFMove(context))
     , m_data(data)
     , m_dataProvider(WTFMove(dataProvider))
 {
     ASSERT(m_data);
     ASSERT(m_dataProvider);
-    m_context = WTFMove(context);
     ASSERT(m_context);
     applyBaseTransform(*m_context);
 }

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGPDFDocumentBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGPDFDocumentBackend.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2024 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ImageBufferCGPDFDocumentBackend.h"
+
+#if USE(CG)
+
+#include "GraphicsContext.h"
+#include "GraphicsContextCG.h"
+#include <wtf/TZoneMallocInlines.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(ImageBufferCGPDFDocumentBackend);
+
+size_t ImageBufferCGPDFDocumentBackend::calculateMemoryCost(const Parameters& parameters)
+{
+    // FIXME: This is fairly meaningless, because we don't actually have a bitmap, and
+    // should really be based on the PDF document size.
+    return ImageBufferBackend::calculateMemoryCost(parameters.backendSize, calculateBytesPerRow(parameters.backendSize));
+}
+
+std::unique_ptr<ImageBufferCGPDFDocumentBackend> ImageBufferCGPDFDocumentBackend::create(const Parameters& parameters, const ImageBufferCreationContext&)
+{
+    auto data = adoptCF(CFDataCreateMutable(kCFAllocatorDefault, 0));
+
+    auto dataConsumer = adoptCF(CGDataConsumerCreateWithCFData(data.get()));
+
+    auto backendSize = parameters.backendSize;
+    auto mediaBox = CGRectMake(0, 0, backendSize.width(), backendSize.height());
+
+    auto pdfContext = adoptCF(CGPDFContextCreate(dataConsumer.get(), &mediaBox, nullptr));
+    auto context = makeUnique<GraphicsContextCG>(pdfContext.get());
+
+    return std::unique_ptr<ImageBufferCGPDFDocumentBackend>(new ImageBufferCGPDFDocumentBackend(parameters, WTFMove(data), WTFMove(context)));
+}
+
+ImageBufferCGPDFDocumentBackend::ImageBufferCGPDFDocumentBackend(const Parameters& parameters, RetainPtr<CFDataRef>&& data, std::unique_ptr<GraphicsContextCG>&& context)
+    : ImageBufferCGBackend(parameters, WTFMove(context))
+    , m_data(WTFMove(data))
+{
+    ASSERT(m_data);
+    ASSERT(m_context);
+}
+
+ImageBufferCGPDFDocumentBackend::~ImageBufferCGPDFDocumentBackend() = default;
+
+GraphicsContext& ImageBufferCGPDFDocumentBackend::context()
+{
+    return *m_context;
+}
+
+RefPtr<SharedBuffer> ImageBufferCGPDFDocumentBackend::sinkToPDFDocument()
+{
+    CGPDFContextClose(m_context->platformContext());
+    return SharedBuffer::create(m_data.get());
+}
+
+String ImageBufferCGPDFDocumentBackend::debugDescription() const
+{
+    TextStream stream;
+    stream << "ImageBufferCGPDFDocumentBackend " << this;
+    return stream.release();
+}
+
+} // namespace WebCore
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+#endif // USE(CG)

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGPDFDocumentBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGPDFDocumentBackend.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2024 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(CG)
+
+#include "ImageBuffer.h"
+#include "ImageBufferCGBackend.h"
+#include <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+
+class ImageBufferCGPDFDocumentBackend : public ImageBufferCGBackend {
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(ImageBufferCGPDFDocumentBackend);
+    WTF_MAKE_NONCOPYABLE(ImageBufferCGPDFDocumentBackend);
+public:
+    WEBCORE_EXPORT static size_t calculateMemoryCost(const Parameters&);
+    WEBCORE_EXPORT static std::unique_ptr<ImageBufferCGPDFDocumentBackend> create(const Parameters&, const ImageBufferCreationContext&);
+
+    ~ImageBufferCGPDFDocumentBackend();
+
+    static constexpr RenderingMode renderingMode = RenderingMode::PDFDocument;
+
+private:
+    ImageBufferCGPDFDocumentBackend(const Parameters&, RetainPtr<CFDataRef>&&, std::unique_ptr<GraphicsContextCG>&&);
+
+    bool canMapBackingStore() const { return false; }
+    unsigned bytesPerRow() const final { return 0; }
+    GraphicsContext& context() final;
+
+    RefPtr<NativeImage> copyNativeImage() final { return createNativeImageReference(); }
+    RefPtr<NativeImage> createNativeImageReference() final { return nullptr; }
+
+    void getPixelBuffer(const IntRect&, PixelBuffer&) final { ASSERT_NOT_REACHED(); }
+    void putPixelBuffer(const PixelBuffer&, const IntRect&, const IntPoint&, AlphaPremultiplication) final { ASSERT_NOT_REACHED(); }
+
+    RefPtr<SharedBuffer> sinkToPDFDocument() final;
+
+    String debugDescription() const final;
+
+    RetainPtr<CFDataRef> m_data;
+};
+
+} // namespace WebCore
+
+#endif // USE(CG)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -6537,7 +6537,7 @@ void WebPage::drawToPDF(FrameIdentifier frameID, const std::optional<FloatRect>&
         frameView->setBaseBackgroundColor(Color::transparentBlack);
     }
 
-    auto pdfData = pdfSnapshotAtSize(snapshotRect, snapshotSize, { });
+    auto buffer = pdfSnapshotAtSize(snapshotRect, snapshotSize, { });
 
     if (allowTransparentBackground) {
         frameView->setTransparent(false);
@@ -6547,7 +6547,7 @@ void WebPage::drawToPDF(FrameIdentifier frameID, const std::optional<FloatRect>&
     frameView->setLayoutViewportOverrideRect(originalLayoutViewportOverrideRect);
     frameView->setPaintBehavior(originalPaintBehavior);
 
-    completionHandler(SharedBuffer::create(pdfData.get()));
+    completionHandler(WTFMove(buffer));
 }
 
 void WebPage::drawRectToImage(FrameIdentifier frameID, const PrintInfo& printInfo, const IntRect& rect, const WebCore::IntSize& imageSize, CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>&&)>&& completionHandler)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -2342,7 +2342,7 @@ private:
     RefPtr<WebImage> snapshotAtSize(const WebCore::IntRect&, const WebCore::IntSize& bitmapSize, SnapshotOptions, WebCore::LocalFrame&, WebCore::LocalFrameView&);
     RefPtr<WebImage> snapshotNode(WebCore::Node&, SnapshotOptions, unsigned maximumPixelCount = std::numeric_limits<unsigned>::max());
 #if PLATFORM(COCOA)
-    RetainPtr<CFDataRef> pdfSnapshotAtSize(WebCore::IntRect, WebCore::IntSize bitmapSize, SnapshotOptions);
+    RefPtr<WebCore::SharedBuffer> pdfSnapshotAtSize(WebCore::IntRect, WebCore::IntSize bitmapSize, SnapshotOptions);
 #endif
 
 #if ENABLE(ATTACHMENT_ELEMENT)

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -5130,10 +5130,10 @@ void WebPage::drawToPDFiOS(WebCore::FrameIdentifier frameID, const PrintInfo& pr
         auto originalLayoutViewportOverrideRect = frameView.layoutViewportOverrideRect();
         frameView.setLayoutViewportOverrideRect(LayoutRect(snapshotRect));
 
-        auto pdfData = pdfSnapshotAtSize(snapshotRect, snapshotSize, { });
+        auto buffer = pdfSnapshotAtSize(snapshotRect, snapshotSize, { });
 
         frameView.setLayoutViewportOverrideRect(originalLayoutViewportOverrideRect);
-        reply(SharedBuffer::create(pdfData.get()));
+        reply(WTFMove(buffer));
         return;
     }
 


### PR DESCRIPTION
#### 1650060029d11c2236ed8cd004db04c55a9150ab
<pre>
Implement ImageBufferCGPDFDocumentBackend
<a href="https://bugs.webkit.org/show_bug.cgi?id=284211">https://bugs.webkit.org/show_bug.cgi?id=284211</a>
<a href="https://rdar.apple.com/141078672">rdar://141078672</a>

Reviewed by Simon Fraser.

This backend will be used to snapshotting the page into PDFDocument. It will be
used later by GPUProcess to do the snapshotting of the main frame remotely.

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp:
(WebCore::BifurcatedGraphicsContext::beginPage):
(WebCore::BifurcatedGraphicsContext::endPage):
* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h:
* Source/WebCore/platform/graphics/GraphicsContext.h:
(WebCore::GraphicsContext::beginPage):
(WebCore::GraphicsContext::endPage):
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::create):
(WebCore::ImageBuffer::sinkToPDFDocument):
* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebCore/platform/graphics/ImageBufferBackend.cpp:
(WebCore::ImageBufferBackend::sinkToPDFDocument):
* Source/WebCore/platform/graphics/ImageBufferBackend.h:
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::beginPage):
(WebCore::GraphicsContextCG::endPage):
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.h:
* Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp:
(WebCore::ImageBufferCGBackend::ImageBufferCGBackend):
* Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h:
* Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp:
(WebCore::ImageBufferCGBitmapBackend::ImageBufferCGBitmapBackend):
* Source/WebCore/platform/graphics/cg/ImageBufferCGPDFDocumentBackend.cpp: Added.
(WebCore::ImageBufferCGPDFDocumentBackend::calculateMemoryCost):
(WebCore::ImageBufferCGPDFDocumentBackend::create):
(WebCore::ImageBufferCGPDFDocumentBackend::ImageBufferCGPDFDocumentBackend):
(WebCore::ImageBufferCGPDFDocumentBackend::context):
(WebCore::ImageBufferCGPDFDocumentBackend::sinkToPDFDocument):
(WebCore::ImageBufferCGPDFDocumentBackend::debugDescription const):
* Source/WebCore/platform/graphics/cg/ImageBufferCGPDFDocumentBackend.h: Added.
(WebCore::ImageBufferCGPDFDocumentBackend::canMapBackingStore const):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::pdfSnapshotAtSize):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::drawToPDF):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::drawToPDFiOS):

Canonical link: <a href="https://commits.webkit.org/287644@main">https://commits.webkit.org/287644@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0668c7edaa43189beb743bbec1274dbd2ea415d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80374 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59380 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33891 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84895 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31356 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82485 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68442 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7683 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/62821 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/20631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83443 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52894 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73184 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43125 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50212 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27339 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29815 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71351 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27856 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86329 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7599 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71104 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7774 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69022 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70344 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17517 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14339 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13283 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7561 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/13081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7400 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10920 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9206 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->