### PR TITLE
AX: Implement support for serving attributed strings off the main-thread for ranges that span multiple elements

### DIFF
--- a/LayoutTests/accessibility/ax-thread-text-apis/attributed-string-spanning-multiple-elements-expected.txt
+++ b/LayoutTests/accessibility/ax-thread-text-apis/attributed-string-spanning-multiple-elements-expected.txt
@@ -1,0 +1,63 @@
+This test ensures we return the right attributed string for text marker ranges that span multiple elements.
+
+"Attributes in range {0, 17}:
+AXFont: {
+    AXFontFamily = Helvetica;
+    AXFontName = Helvetica;
+    AXFontSize = 16;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+Attributes in range {17, 17}:
+AXFont: {
+    AXFontFamily = Monaco;
+    AXFontName = Monaco;
+    AXFontSize = 16;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+This is a test.
+
+Second paragraph."
+
+
+Final attributed string:
+
+Attributes in range {0, 17}:
+AXFont: {
+    AXFontFamily = Helvetica;
+    AXFontName = Helvetica;
+    AXFontSize = 16;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+Attributes in range {17, 19}:
+AXFont: {
+    AXFontFamily = Monaco;
+    AXFontName = Monaco;
+    AXFontSize = 16;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+Attributes in range {36, 16}:
+AXFont: {
+    AXFontFamily = Times;
+    AXFontName = "Times-Roman";
+    AXFontSize = 16;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+This is a test.
+
+Second paragraph.
+
+Third paragraph.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+This is a test.
+
+Second paragraph.
+
+Third paragraph.

--- a/LayoutTests/accessibility/ax-thread-text-apis/attributed-string-spanning-multiple-elements.html
+++ b/LayoutTests/accessibility/ax-thread-text-apis/attributed-string-spanning-multiple-elements.html
@@ -1,0 +1,40 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ runSingly=true AccessibilityThreadTextApisEnabled=true ] -->
+<!-- This is a new test added as part of the AccessibilityThreadTextApisEnabled effort. Move it to accessibility/mac after the feature is enabled by default. -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="p1" style="font-family: Helvetica">This is a test.</p>
+<p id="p2" style="font-family: Monaco">Second paragraph.</p>
+<p id="p3" style="display:none">Third paragraph.</p>
+
+<script>
+var output = "This test ensures we return the right attributed string for text marker ranges that span multiple elements.\n\n";
+
+if (accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var webArea = accessibilityController.rootElement.childAtIndex(0);
+    var range1 = webArea.textMarkerRangeForElement(webArea);
+    output += `"${webArea.attributedStringForTextMarkerRange(range1)}"\n`;
+
+    var finalAttributedString;
+    document.getElementById("p3").removeAttribute("style");
+    setTimeout(async function() {
+        await waitFor(() => {
+            range1 = webArea.textMarkerRangeForElement(webArea);
+            finalAttributedString = webArea.attributedStringForTextMarkerRange(range1);
+            return finalAttributedString && finalAttributedString.includes("Third paragraph.");
+        });
+        output += `\n\nFinal attributed string:\n\n${finalAttributedString}\n`;
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -770,6 +770,14 @@ enum class AXDebugStringOption {
     RemoteFrameOffset
 };
 
+enum class TextEmissionBehavior : uint8_t {
+    None,
+    Space,
+    Tab,
+    Newline,
+    DoubleNewline
+};
+
 class AXCoreObject : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<AXCoreObject> {
 public:
     virtual ~AXCoreObject() = default;
@@ -1113,7 +1121,8 @@ public:
     virtual std::optional<String> textContent() const = 0;
 #if ENABLE(AX_THREAD_TEXT_APIS)
     virtual bool hasTextRuns() = 0;
-    virtual bool shouldEmitNewlinesBeforeAndAfterNode() const = 0;
+    virtual TextEmissionBehavior emitTextAfterBehavior() const = 0;
+    bool emitsNewlineAfter() const;
 #endif
 
     // Methods for determining accessibility text.
@@ -1548,6 +1557,14 @@ inline Vector<AXID> AXCoreObject::childrenIDs(bool updateChildrenIfNeeded)
 {
     return axIDs(children(updateChildrenIfNeeded));
 }
+
+#if ENABLE(AX_THREAD_TEXT_APIS)
+inline bool AXCoreObject::emitsNewlineAfter() const
+{
+    auto behavior = emitTextAfterBehavior();
+    return behavior == TextEmissionBehavior::Newline || behavior == TextEmissionBehavior::DoubleNewline;
+}
+#endif // ENABLE(AX_THREAD_TEXT_APIS)
 
 namespace Accessibility {
 

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -749,6 +749,9 @@ TextStream& operator<<(WTF::TextStream& stream, AXPropertyName property)
     case AXPropertyName::EmbeddedImageDescription:
         stream << "EmbeddedImageDescription";
         break;
+    case AXPropertyName::EmitTextAfterBehavior:
+        stream << "EmitTextAfterBehavior";
+        break;
     case AXPropertyName::ExpandedTextValue:
         stream << "ExpandedTextValue";
         break;
@@ -1128,9 +1131,6 @@ TextStream& operator<<(WTF::TextStream& stream, AXPropertyName property)
         break;
     case AXPropertyName::SetSize:
         stream << "SetSize";
-        break;
-    case AXPropertyName::ShouldEmitNewlinesBeforeAndAfterNode:
-        stream << "ShouldEmitNewlinesBeforeAndAfterNode";
         break;
     case AXPropertyName::SortDirection:
         stream << "SortDirection";

--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -291,7 +291,7 @@ public:
     // Traverses from m_start to m_end, collecting all text along the way.
     String toString() const;
 #if PLATFORM(COCOA)
-    RetainPtr<NSAttributedString> toAttributedString() const;
+    RetainPtr<NSAttributedString> toAttributedString(AXCoreObject::SpellCheck) const;
 #endif // PLATFORM(COCOA)
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
 
@@ -341,5 +341,13 @@ inline bool operator>=(const AXTextMarkerRange& range1, const AXTextMarkerRange&
 {
     return range1 == range2 || range1 > range2;
 }
+
+namespace Accessibility {
+
+#if ENABLE(AX_THREAD_TEXT_APIS)
+AXIsolatedObject* findObjectWithRuns(AXIsolatedObject& start, AXDirection direction, std::optional<AXID> stopAtID = std::nullopt, const std::function<void(AXIsolatedObject&)>& exitObject = [] (AXIsolatedObject&) { });
+#endif // ENABLE(AX_THREAD_TEXT_APIS)
+
+} // namespace Accessibility
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.h
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.h
@@ -136,7 +136,7 @@ public:
     LayoutRect elementRect() const override;
 
 #if ENABLE(AX_THREAD_TEXT_APIS)
-    bool shouldEmitNewlinesBeforeAndAfterNode() const final;
+    TextEmissionBehavior emitTextAfterBehavior() const final;
 #endif
 
 protected:

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -398,7 +398,7 @@ public:
 #if ENABLE(AX_THREAD_TEXT_APIS)
     virtual AXTextRuns textRuns() { return { }; }
     bool hasTextRuns() final { return textRuns().size(); }
-    bool shouldEmitNewlinesBeforeAndAfterNode() const override { return false; }
+    TextEmissionBehavior emitTextAfterBehavior() const override { return TextEmissionBehavior::None; }
 #endif
 #if PLATFORM(COCOA)
     // Returns an array of strings and AXObject wrappers corresponding to the

--- a/Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm
@@ -36,6 +36,8 @@
 
 namespace WebCore {
 
+using namespace Accessibility;
+
 AXTextMarker::AXTextMarker(PlatformTextMarkerData platformData)
 {
     if (!platformData)
@@ -68,7 +70,8 @@ RetainPtr<PlatformTextMarkerData> AXTextMarker::platformData() const
 }
 
 #if ENABLE(AX_THREAD_TEXT_APIS)
-RetainPtr<NSAttributedString> AXTextMarkerRange::toAttributedString() const
+// FIXME: There's a lot of duplicated code between this function and AXTextMarkerRange::toString().
+RetainPtr<NSAttributedString> AXTextMarkerRange::toAttributedString(AXCoreObject::SpellCheck spellCheck) const
 {
     RELEASE_ASSERT(!isMainThread());
 
@@ -84,11 +87,36 @@ RetainPtr<NSAttributedString> AXTextMarkerRange::toAttributedString() const
         size_t maxOffset = std::max(start.offset(), end.offset());
         // FIXME: createAttributedString takes a StringView, but we create a full-fledged String. Could we create a
         // new substringView method that returns a StringView?
-        // FIXME: Should we be passing SpellCheck::Yes? Maybe we need to take `SpellCheck` as a function parameter?
-        return start.isolatedObject()->createAttributedString(start.runs()->substring(minOffset, maxOffset - minOffset), AXCoreObject::SpellCheck::No).autorelease();
+        return start.isolatedObject()->createAttributedString(start.runs()->substring(minOffset, maxOffset - minOffset), spellCheck).autorelease();
     }
-    // FIXME: Handle ranges that span multiple objects.
-    return nil;
+
+    RetainPtr<NSMutableAttributedString> result = start.isolatedObject()->createAttributedString(start.runs()->substring(start.offset()), spellCheck);
+    auto emitNewlineOnExit = [&] (AXIsolatedObject& object) {
+        // FIXME: This function should not just be emitting newlines, but instead handling every character type in TextEmissionBehavior.
+        auto behavior = object.emitTextAfterBehavior();
+        if (behavior != TextEmissionBehavior::Newline && behavior != TextEmissionBehavior::DoubleNewline)
+            return;
+
+        auto length = [result length];
+        // Like TextIterator, don't emit a newline if the most recently emitted character was already a newline.
+        if (length && [[result string] characterAtIndex:length - 1] != '\n') {
+            // FIXME: This is super inefficient. We are creating a whole new dictionary and attributed string just to append newline(s).
+            NSString *newlineString = behavior == TextEmissionBehavior::Newline ? @"\n" : @"\n\n";
+            NSDictionary *attributes = [result attributesAtIndex:length - 1 effectiveRange:nil];
+            [result appendAttributedString:adoptNS([[NSAttributedString alloc] initWithString:newlineString attributes:attributes]).get()];
+        }
+    };
+
+    // FIXME: If we've been given reversed markers, i.e. the end marker actually comes before the start marker,
+    // we may want to detect this and try searching AXDirection::Previous?
+    RefPtr current = findObjectWithRuns(*start.isolatedObject(), AXDirection::Next, std::nullopt, emitNewlineOnExit);
+    while (current && current->objectID() != end.objectID()) {
+        [result appendAttributedString:current->createAttributedString(current->textRuns()->toString(), spellCheck).autorelease()];
+        current = findObjectWithRuns(*current, AXDirection::Next, std::nullopt, emitNewlineOnExit);
+    }
+    [result appendAttributedString:end.isolatedObject()->createAttributedString(end.runs()->substring(0, end.offset()), spellCheck).autorelease()];
+
+    return result;
 }
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
 

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -429,7 +429,7 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
 
 #if ENABLE(AX_THREAD_TEXT_APIS)
     setProperty(AXPropertyName::TextRuns, object.textRuns());
-    setProperty(AXPropertyName::ShouldEmitNewlinesBeforeAndAfterNode, object.shouldEmitNewlinesBeforeAndAfterNode());
+    setProperty(AXPropertyName::EmitTextAfterBehavior, object.emitTextAfterBehavior());
 #endif
 
     // These properties are only needed on the AXCoreObject interface due to their use in ATSPI,
@@ -622,7 +622,8 @@ void AXIsolatedObject::setProperty(AXPropertyName propertyName, AXPropertyValueV
 #if ENABLE(AX_THREAD_TEXT_APIS)
         [](AXTextRuns& runs) { return !runs.size(); },
         [](RetainPtr<CTFontRef>& typedValue) { return !typedValue; },
-#endif
+        [](TextEmissionBehavior typedValue) { return typedValue == TextEmissionBehavior::None; },
+#endif // ENABLE(AX_THREAD_TEXT_APIS)
         [] (WallTime& time) { return !time; },
         [] (DateComponentsType& typedValue) { return typedValue == DateComponentsType::Invalid; },
         [](auto&) {

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -88,7 +88,7 @@ public:
         const auto* runs = textRuns();
         return runs && runs->size();
     }
-    bool shouldEmitNewlinesBeforeAndAfterNode() const final { return boolAttributeValue(AXPropertyName::ShouldEmitNewlinesBeforeAndAfterNode); }
+    TextEmissionBehavior emitTextAfterBehavior() const final { return propertyValue<TextEmissionBehavior>(AXPropertyName::EmitTextAfterBehavior); }
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
 
     AXTextMarkerRange textMarkerRange() const final;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -125,6 +125,7 @@ enum class AXPropertyName : uint16_t {
     DocumentLinks,
     DocumentURI,
     EmbeddedImageDescription,
+    EmitTextAfterBehavior,
     ExpandedTextValue,
     ExtendedDescription,
 #if PLATFORM(COCOA)
@@ -253,7 +254,6 @@ enum class AXPropertyName : uint16_t {
     SelectedChildren,
     SelectedTextRange,
     SetSize,
-    ShouldEmitNewlinesBeforeAndAfterNode,
     SortDirection,
     SpeechHint,
     StringValue,
@@ -300,6 +300,7 @@ using AXPropertyValueVariant = std::variant<std::nullptr_t, Markable<AXID>, Stri
 #if ENABLE(AX_THREAD_TEXT_APIS)
     , RetainPtr<CTFontRef>
     , AXTextRuns
+    , TextEmissionBehavior
 #endif
 >;
 using AXPropertyMap = UncheckedKeyHashMap<AXPropertyName, AXPropertyValueVariant, IntHash<AXPropertyName>, WTF::StrongEnumHashTraits<AXPropertyName>>;


### PR DESCRIPTION
#### 0d448f9e4bf09635515def81acc656df0fed5d31
<pre>
AX: Implement support for serving attributed strings off the main-thread for ranges that span multiple elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=284193">https://bugs.webkit.org/show_bug.cgi?id=284193</a>
<a href="https://rdar.apple.com/problem/141067345">rdar://problem/141067345</a>

Reviewed by Chris Fleizach.

This commit implements support for serving attributed strings off the main-thread for ranges that span multiple elements.
Similar to AXTextMarkerRange::toString(), we traverse from the object starting the range to the end, building an attributed
string as we go.

This patch also fixes a bug in the off-main-thread text marker implementation where we did not emit two newlines for
paragraph elements, and a tab for table cells as mandated by the spec (<a href="https://html.spec.whatwg.org/multipage/dom.html#the-innertext-idl-attribute).">https://html.spec.whatwg.org/multipage/dom.html#the-innertext-idl-attribute).</a>

* LayoutTests/accessibility/ax-thread-text-apis/attributed-string-spanning-multiple-elements-expected.txt: Added.
* LayoutTests/accessibility/ax-thread-text-apis/attributed-string-spanning-multiple-elements.html: Added.
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::AXCoreObject::emitsNewlineAfter const):
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarkerRange::toString const):
(WebCore::AXTextMarker::findMarker const):
(WebCore::Accessibility::findObjectWithRuns):
(WebCore::findObjectWithRuns): Deleted.
* Source/WebCore/accessibility/AXTextMarker.h:
(WebCore::Accessibility::findObjectWithRuns):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::emitTextAfter const):
(WebCore::AccessibilityNodeObject::shouldEmitNewlinesBeforeAndAfterNode const): Deleted.
* Source/WebCore/accessibility/AccessibilityNodeObject.h:
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm:
(WebCore::AXTextMarkerRange::toAttributedString const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::initializeProperties):
(WebCore::AXIsolatedObject::setProperty):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:forParameter:]):

Canonical link: <a href="https://commits.webkit.org/287745@main">https://commits.webkit.org/287745@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/edd645fe30992f1a1f37829bac1fde6618b419f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80089 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59091 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33501 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84606 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31063 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82198 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68152 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7389 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62612 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20438 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83157 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52694 "Found 1 new test failure: media/audioSession/getUserMedia.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72952 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42915 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50023 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27106 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29521 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71147 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27613 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86038 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7309 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5178 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70892 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7484 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68790 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70125 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17579 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14123 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13077 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7273 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12790 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7112 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10632 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8917 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->