### PR TITLE
AX: accessibilityAttributeNames does several unnecessary NSArray copies and ancestry traversals

### DIFF
--- a/LayoutTests/accessibility/display-contents/role-row-headers-expected.txt
+++ b/LayoutTests/accessibility/display-contents/role-row-headers-expected.txt
@@ -33,13 +33,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 6}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {0, 1}
 AXColumnIndexRange: NSRange: {0, 1}
 AXColumnHeaderUIElements: <array of size 0>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------
@@ -77,13 +77,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 4}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {0, 1}
 AXColumnIndexRange: NSRange: {1, 1}
 AXColumnHeaderUIElements: <array of size 0>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------

--- a/LayoutTests/accessibility/image-link-expected.txt
+++ b/LayoutTests/accessibility/image-link-expected.txt
@@ -34,10 +34,10 @@ AXFocusableAncestor: <AXLink: 'Delicious cake'>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 0}
+AXElementBusy: 0
 AXURL: http://www.wowhead.com/?item=33924
 AXAccessKey: (null)
 AXLinkRelationshipType:
-AXElementBusy: 0
 
 
 Child 0:
@@ -72,10 +72,10 @@ AXFocusableAncestor: <AXImage>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 0}
+AXElementBusy: 0
 AXImageOverlayElements: (null)
 AXEmbeddedImageDescription:
 AXURL: LayoutTests/accessibility/resources/cake.png
-AXElementBusy: 0
 
 
 

--- a/LayoutTests/accessibility/image-map2-expected.txt
+++ b/LayoutTests/accessibility/image-map2-expected.txt
@@ -65,10 +65,10 @@ AXFocusableAncestor: <AXLink>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 0}
+AXElementBusy: 0
 AXURL: http://www.apple.com/
 AXAccessKey: (null)
 AXLinkRelationshipType:
-AXElementBusy: 0
 AXPath: <AXLink>
 
 ------------
@@ -103,10 +103,10 @@ AXFocusableAncestor: <AXLink>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 0}
+AXElementBusy: 0
 AXURL: http://www.apple.com/
 AXAccessKey: (null)
 AXLinkRelationshipType:
-AXElementBusy: 0
 AXPath: <AXLink>
 
 ------------

--- a/LayoutTests/accessibility/mac/aria-columnrowheaders-expected.txt
+++ b/LayoutTests/accessibility/mac/aria-columnrowheaders-expected.txt
@@ -37,13 +37,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 19}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {0, 1}
 AXColumnIndexRange: NSRange: {0, 1}
 AXColumnHeaderUIElements: <array of size 0>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------
@@ -78,13 +78,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 8}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {0, 1}
 AXColumnIndexRange: NSRange: {1, 1}
 AXColumnHeaderUIElements: <array of size 0>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------
@@ -119,13 +119,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 8}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {0, 1}
 AXColumnIndexRange: NSRange: {2, 1}
 AXColumnHeaderUIElements: <array of size 0>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------
@@ -161,13 +161,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 4}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {1, 1}
 AXColumnIndexRange: NSRange: {0, 1}
 AXColumnHeaderUIElements: <array of size 0>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------
@@ -202,13 +202,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 4}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {2, 1}
 AXColumnIndexRange: NSRange: {0, 1}
 AXColumnHeaderUIElements: <array of size 0>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------

--- a/LayoutTests/accessibility/mac/bounds-for-range-expected.txt
+++ b/LayoutTests/accessibility/mac/bounds-for-range-expected.txt
@@ -30,8 +30,8 @@ AXFocusableAncestor: <AXStaticText>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 162}
-AXIntersectionWithSelectionRange: (null)
 AXElementBusy: 0
+AXIntersectionWithSelectionRange: (null)
 AXPath: (null)
 
 ----------------------

--- a/LayoutTests/accessibility/mac/document-attributes-expected.txt
+++ b/LayoutTests/accessibility/mac/document-attributes-expected.txt
@@ -30,6 +30,7 @@ AXLanguage:
 AXDOMIdentifier:
 AXDOMClassList: <array of size 0>
 AXVisibleCharacterRange: NSRange: {9223372036854775807, 0}
+AXElementBusy: 0
 AXLinkUIElements: <array of size 0>
 AXLoaded: 1
 AXLayoutCount: 2
@@ -37,7 +38,6 @@ AXLoadingProgress: 1
 AXURL: LayoutTests/accessibility/mac/document-attributes.html
 AXCaretBrowsingEnabled: 0
 AXPreventKeyboardDOMEventDispatch: 0
-AXElementBusy: 0
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/accessibility/mac/document-links-expected.txt
+++ b/LayoutTests/accessibility/mac/document-links-expected.txt
@@ -34,10 +34,10 @@ AXFocusableAncestor: <AXLink>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 0}
+AXElementBusy: 0
 AXURL: LayoutTests/accessibility/mac/document-links.html#Link1
 AXAccessKey: (null)
 AXLinkRelationshipType:
-AXElementBusy: 0
 AXPath: <AXLink>
 
 ------------
@@ -72,10 +72,10 @@ AXFocusableAncestor: <AXLink>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 0}
+AXElementBusy: 0
 AXURL: LayoutTests/accessibility/mac/document-links.html#Link2
 AXAccessKey: (null)
 AXLinkRelationshipType:
-AXElementBusy: 0
 AXPath: <AXLink>
 
 ------------
@@ -110,10 +110,10 @@ AXFocusableAncestor: <AXLink: 'Link3'>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 5}
+AXElementBusy: 0
 AXURL: LayoutTests/accessibility/mac/document-links.html#Link3
 AXAccessKey: (null)
 AXLinkRelationshipType:
-AXElementBusy: 0
 
 ------------
 AXHasDocumentRoleAncestor: 0
@@ -147,10 +147,10 @@ AXFocusableAncestor: <AXLink: 'Link4'>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 5}
+AXElementBusy: 0
 AXURL: LayoutTests/accessibility/mac/document-links.html#Link4
 AXAccessKey: (null)
 AXLinkRelationshipType:
-AXElementBusy: 0
 
 ------------
 

--- a/LayoutTests/accessibility/mac/internal-link-anchors-expected.txt
+++ b/LayoutTests/accessibility/mac/internal-link-anchors-expected.txt
@@ -31,8 +31,8 @@ AXFocusableAncestor: <AXStaticText>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 9}
-AXIntersectionWithSelectionRange: (null)
 AXElementBusy: 0
+AXIntersectionWithSelectionRange: (null)
 AXPath: (null)
 
 ------------

--- a/LayoutTests/accessibility/table-attributes-expected.txt
+++ b/LayoutTests/accessibility/table-attributes-expected.txt
@@ -29,13 +29,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 28}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {0, 2}
 AXColumnIndexRange: NSRange: {0, 2}
 AXColumnHeaderUIElements: <array of size 0>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -71,13 +71,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 28}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {0, 2}
 AXColumnIndexRange: NSRange: {0, 2}
 AXColumnHeaderUIElements: <array of size 0>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -113,13 +113,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 11}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {0, 2}
 AXColumnIndexRange: NSRange: {2, 1}
 AXColumnHeaderUIElements: <array of size 0>
 AXRowHeaderUIElements: <array of size 1>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -155,13 +155,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 9}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {0, 1}
 AXColumnIndexRange: NSRange: {3, 2}
 AXColumnHeaderUIElements: <array of size 0>
 AXRowHeaderUIElements: <array of size 1>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -197,13 +197,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 9}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {0, 1}
 AXColumnIndexRange: NSRange: {3, 2}
 AXColumnHeaderUIElements: <array of size 0>
 AXRowHeaderUIElements: <array of size 1>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -240,13 +240,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 11}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {2, 2}
 AXColumnIndexRange: NSRange: {0, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -282,13 +282,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 5}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {3, 1}
 AXColumnIndexRange: NSRange: {1, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 1>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------
@@ -324,11 +324,11 @@ AXFocusableAncestor: <AXColumn>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {9223372036854775807, 0}
+AXElementBusy: 0
 AXIndex: 0
 AXHeader: <AXColumn>
 AXRows: <array of size 2>
 AXVisibleRows: <array of size 2>
-AXElementBusy: 0
 
 ------------
 AXHasDocumentRoleAncestor: 0
@@ -362,11 +362,11 @@ AXFocusableAncestor: <AXColumn>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {9223372036854775807, 0}
+AXElementBusy: 0
 AXIndex: 1
 AXHeader: <AXColumn>
 AXRows: <array of size 3>
 AXVisibleRows: <array of size 3>
-AXElementBusy: 0
 
 ------------
 AXHasDocumentRoleAncestor: 0
@@ -400,11 +400,11 @@ AXFocusableAncestor: <AXColumn>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {9223372036854775807, 0}
+AXElementBusy: 0
 AXIndex: 2
 AXHeader: <AXColumn>
 AXRows: <array of size 3>
 AXVisibleRows: <array of size 3>
-AXElementBusy: 0
 
 ------------
 AXHasDocumentRoleAncestor: 0
@@ -438,11 +438,11 @@ AXFocusableAncestor: <AXColumn>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {9223372036854775807, 0}
+AXElementBusy: 0
 AXIndex: 3
 AXHeader: <AXColumn>
 AXRows: <array of size 4>
 AXVisibleRows: <array of size 4>
-AXElementBusy: 0
 
 ------------
 AXHasDocumentRoleAncestor: 0
@@ -476,11 +476,11 @@ AXFocusableAncestor: <AXColumn>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {9223372036854775807, 0}
+AXElementBusy: 0
 AXIndex: 4
 AXHeader: <AXColumn>
 AXRows: <array of size 4>
 AXVisibleRows: <array of size 4>
-AXElementBusy: 0
 
 ------------
 
@@ -515,8 +515,8 @@ AXFocusableAncestor: <AXRow>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 50}
-AXIndex: 0
 AXElementBusy: 0
+AXIndex: 0
 
 ------------
 AXHasDocumentRoleAncestor: 0
@@ -550,8 +550,8 @@ AXFocusableAncestor: <AXRow>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 13}
-AXIndex: 1
 AXElementBusy: 0
+AXIndex: 1
 
 ------------
 AXHasDocumentRoleAncestor: 0
@@ -585,8 +585,8 @@ AXFocusableAncestor: <AXRow>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 32}
-AXIndex: 2
 AXElementBusy: 0
+AXIndex: 2
 
 ------------
 AXHasDocumentRoleAncestor: 0
@@ -620,8 +620,8 @@ AXFocusableAncestor: <AXRow>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 20}
-AXIndex: 3
 AXElementBusy: 0
+AXIndex: 3
 
 ------------
 
@@ -656,13 +656,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 28}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {0, 2}
 AXColumnIndexRange: NSRange: {0, 2}
 AXColumnHeaderUIElements: <array of size 0>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -698,13 +698,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 11}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {0, 2}
 AXColumnIndexRange: NSRange: {2, 1}
 AXColumnHeaderUIElements: <array of size 0>
 AXRowHeaderUIElements: <array of size 1>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -740,13 +740,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 9}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {0, 1}
 AXColumnIndexRange: NSRange: {3, 2}
 AXColumnHeaderUIElements: <array of size 0>
 AXRowHeaderUIElements: <array of size 1>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -782,13 +782,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 5}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {1, 1}
 AXColumnIndexRange: NSRange: {3, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 1>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------
@@ -823,13 +823,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 7}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {1, 1}
 AXColumnIndexRange: NSRange: {4, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 1>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------
@@ -864,13 +864,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 11}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {2, 2}
 AXColumnIndexRange: NSRange: {0, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -906,13 +906,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 5}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {2, 1}
 AXColumnIndexRange: NSRange: {1, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 1>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------
@@ -947,13 +947,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 4}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {2, 1}
 AXColumnIndexRange: NSRange: {2, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 1>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------
@@ -988,13 +988,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 4}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {2, 1}
 AXColumnIndexRange: NSRange: {3, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 1>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------
@@ -1029,13 +1029,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 4}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {2, 1}
 AXColumnIndexRange: NSRange: {4, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 1>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------
@@ -1070,13 +1070,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 5}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {3, 1}
 AXColumnIndexRange: NSRange: {1, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 1>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------
@@ -1111,13 +1111,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 4}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {3, 1}
 AXColumnIndexRange: NSRange: {2, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 1>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------
@@ -1152,13 +1152,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 4}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {3, 1}
 AXColumnIndexRange: NSRange: {3, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 1>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------
@@ -1193,13 +1193,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 4}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {3, 1}
 AXColumnIndexRange: NSRange: {4, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 1>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------

--- a/LayoutTests/accessibility/table-cell-spans-expected.txt
+++ b/LayoutTests/accessibility/table-cell-spans-expected.txt
@@ -39,13 +39,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 30}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {0, 2}
 AXColumnIndexRange: NSRange: {0, 2}
 AXColumnHeaderUIElements: <array of size 0>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 {0, 2}, {0, 2}
@@ -83,13 +83,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 30}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {0, 2}
 AXColumnIndexRange: NSRange: {0, 2}
 AXColumnHeaderUIElements: <array of size 0>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 {0, 2}, {0, 2}
@@ -127,13 +127,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 18}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {2, 2}
 AXColumnIndexRange: NSRange: {0, 1}
 AXColumnHeaderUIElements: <array of size 0>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 {2, 2}, {0, 1}
@@ -171,13 +171,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 18}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {2, 2}
 AXColumnIndexRange: NSRange: {0, 1}
 AXColumnHeaderUIElements: <array of size 0>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 {2, 2}, {0, 1}
@@ -215,13 +215,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 3}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {2, 1}
 AXColumnIndexRange: NSRange: {3, 1}
 AXColumnHeaderUIElements: <array of size 0>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 {2, 1}, {3, 1}

--- a/LayoutTests/accessibility/table-cells-expected.txt
+++ b/LayoutTests/accessibility/table-cells-expected.txt
@@ -41,13 +41,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 28}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {0, 2}
 AXColumnIndexRange: NSRange: {0, 2}
 AXColumnHeaderUIElements: <array of size 0>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -84,13 +84,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 5}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {1, 1}
 AXColumnIndexRange: NSRange: {3, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 1>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------------------
@@ -126,13 +126,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 28}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {0, 2}
 AXColumnIndexRange: NSRange: {0, 2}
 AXColumnHeaderUIElements: <array of size 0>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -169,13 +169,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 4}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {2, 1}
 AXColumnIndexRange: NSRange: {2, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 1>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------------------
@@ -211,13 +211,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 4}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {5, 1}
 AXColumnIndexRange: NSRange: {3, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 1>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------------------

--- a/LayoutTests/accessibility/table-multiple-tbodies-expected.txt
+++ b/LayoutTests/accessibility/table-multiple-tbodies-expected.txt
@@ -30,13 +30,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {0, 1}
 AXColumnIndexRange: NSRange: {0, 1}
 AXColumnHeaderUIElements: <array of size 0>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -72,13 +72,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {0, 1}
 AXColumnIndexRange: NSRange: {1, 1}
 AXColumnHeaderUIElements: <array of size 0>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -114,13 +114,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {0, 1}
 AXColumnIndexRange: NSRange: {2, 1}
 AXColumnHeaderUIElements: <array of size 0>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -157,13 +157,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {0, 1}
 AXColumnIndexRange: NSRange: {0, 1}
 AXColumnHeaderUIElements: <array of size 0>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -199,13 +199,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {1, 1}
 AXColumnIndexRange: NSRange: {0, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -241,13 +241,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {2, 1}
 AXColumnIndexRange: NSRange: {0, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -283,13 +283,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {3, 1}
 AXColumnIndexRange: NSRange: {0, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -325,13 +325,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {4, 1}
 AXColumnIndexRange: NSRange: {0, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -367,13 +367,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {5, 1}
 AXColumnIndexRange: NSRange: {0, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -409,13 +409,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {6, 1}
 AXColumnIndexRange: NSRange: {0, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -452,11 +452,11 @@ AXFocusableAncestor: <AXColumn>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {9223372036854775807, 0}
+AXElementBusy: 0
 AXIndex: 0
 AXHeader: <AXColumn>
 AXRows: <array of size 8>
 AXVisibleRows: <array of size 8>
-AXElementBusy: 0
 
 ------------
 AXHasDocumentRoleAncestor: 0
@@ -490,11 +490,11 @@ AXFocusableAncestor: <AXColumn>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {9223372036854775807, 0}
+AXElementBusy: 0
 AXIndex: 1
 AXHeader: <AXColumn>
 AXRows: <array of size 8>
 AXVisibleRows: <array of size 8>
-AXElementBusy: 0
 
 ------------
 AXHasDocumentRoleAncestor: 0
@@ -528,11 +528,11 @@ AXFocusableAncestor: <AXColumn>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {9223372036854775807, 0}
+AXElementBusy: 0
 AXIndex: 2
 AXHeader: <AXColumn>
 AXRows: <array of size 8>
 AXVisibleRows: <array of size 8>
-AXElementBusy: 0
 
 ------------
 
@@ -567,8 +567,8 @@ AXFocusableAncestor: <AXRow>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 5}
+AXElementBusy: 0
 AXIndex: 0
-AXElementBusy: 0
 
 ------------
 AXHasDocumentRoleAncestor: 0
@@ -602,8 +602,8 @@ AXFocusableAncestor: <AXRow>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 5}
+AXElementBusy: 0
 AXIndex: 1
-AXElementBusy: 0
 
 ------------
 AXHasDocumentRoleAncestor: 0
@@ -637,8 +637,8 @@ AXFocusableAncestor: <AXRow>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 7}
+AXElementBusy: 0
 AXIndex: 2
-AXElementBusy: 0
 
 ------------
 AXHasDocumentRoleAncestor: 0
@@ -672,8 +672,8 @@ AXFocusableAncestor: <AXRow>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 5}
+AXElementBusy: 0
 AXIndex: 3
-AXElementBusy: 0
 
 ------------
 AXHasDocumentRoleAncestor: 0
@@ -707,8 +707,8 @@ AXFocusableAncestor: <AXRow>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 7}
+AXElementBusy: 0
 AXIndex: 4
-AXElementBusy: 0
 
 ------------
 AXHasDocumentRoleAncestor: 0
@@ -742,8 +742,8 @@ AXFocusableAncestor: <AXRow>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 5}
-AXIndex: 5
 AXElementBusy: 0
+AXIndex: 5
 
 ------------
 AXHasDocumentRoleAncestor: 0
@@ -777,8 +777,8 @@ AXFocusableAncestor: <AXRow>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 7}
-AXIndex: 6
 AXElementBusy: 0
+AXIndex: 6
 
 ------------
 AXHasDocumentRoleAncestor: 0
@@ -812,8 +812,8 @@ AXFocusableAncestor: <AXRow>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 5}
+AXElementBusy: 0
 AXIndex: 7
-AXElementBusy: 0
 
 ------------
 
@@ -848,13 +848,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {0, 1}
 AXColumnIndexRange: NSRange: {0, 1}
 AXColumnHeaderUIElements: <array of size 0>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -890,13 +890,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {0, 1}
 AXColumnIndexRange: NSRange: {1, 1}
 AXColumnHeaderUIElements: <array of size 0>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -932,13 +932,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {0, 1}
 AXColumnIndexRange: NSRange: {2, 1}
 AXColumnHeaderUIElements: <array of size 0>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -974,13 +974,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {1, 1}
 AXColumnIndexRange: NSRange: {0, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -1016,13 +1016,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {1, 1}
 AXColumnIndexRange: NSRange: {1, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 1>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------
@@ -1057,13 +1057,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {1, 1}
 AXColumnIndexRange: NSRange: {2, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 1>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------
@@ -1098,13 +1098,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {2, 1}
 AXColumnIndexRange: NSRange: {0, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -1140,13 +1140,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 2}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {2, 1}
 AXColumnIndexRange: NSRange: {1, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 1>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------
@@ -1181,13 +1181,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 2}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {2, 1}
 AXColumnIndexRange: NSRange: {2, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 1>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------
@@ -1222,13 +1222,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {3, 1}
 AXColumnIndexRange: NSRange: {0, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -1264,13 +1264,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {3, 1}
 AXColumnIndexRange: NSRange: {1, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 1>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------
@@ -1305,13 +1305,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {3, 1}
 AXColumnIndexRange: NSRange: {2, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 1>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------
@@ -1346,13 +1346,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {4, 1}
 AXColumnIndexRange: NSRange: {0, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -1388,13 +1388,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 2}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {4, 1}
 AXColumnIndexRange: NSRange: {1, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 1>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------
@@ -1429,13 +1429,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 2}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {4, 1}
 AXColumnIndexRange: NSRange: {2, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 1>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------
@@ -1470,13 +1470,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {5, 1}
 AXColumnIndexRange: NSRange: {0, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -1512,13 +1512,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {5, 1}
 AXColumnIndexRange: NSRange: {1, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 1>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------
@@ -1553,13 +1553,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {5, 1}
 AXColumnIndexRange: NSRange: {2, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 1>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------
@@ -1594,13 +1594,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {6, 1}
 AXColumnIndexRange: NSRange: {0, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -1636,13 +1636,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 2}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {6, 1}
 AXColumnIndexRange: NSRange: {1, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 1>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------
@@ -1677,13 +1677,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 2}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {6, 1}
 AXColumnIndexRange: NSRange: {2, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 1>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------
@@ -1718,13 +1718,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {7, 1}
 AXColumnIndexRange: NSRange: {0, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------
@@ -1759,13 +1759,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {7, 1}
 AXColumnIndexRange: NSRange: {1, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------
@@ -1800,13 +1800,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {7, 1}
 AXColumnIndexRange: NSRange: {2, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------

--- a/LayoutTests/accessibility/table-thead-tfoot-expected.txt
+++ b/LayoutTests/accessibility/table-thead-tfoot-expected.txt
@@ -30,13 +30,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {0, 1}
 AXColumnIndexRange: NSRange: {0, 1}
 AXColumnHeaderUIElements: <array of size 0>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -72,13 +72,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {0, 1}
 AXColumnIndexRange: NSRange: {1, 1}
 AXColumnHeaderUIElements: <array of size 0>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -114,13 +114,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {0, 1}
 AXColumnIndexRange: NSRange: {2, 1}
 AXColumnHeaderUIElements: <array of size 0>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -157,13 +157,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {0, 1}
 AXColumnIndexRange: NSRange: {0, 1}
 AXColumnHeaderUIElements: <array of size 0>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -199,13 +199,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {1, 1}
 AXColumnIndexRange: NSRange: {0, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -241,13 +241,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {2, 1}
 AXColumnIndexRange: NSRange: {0, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -284,11 +284,11 @@ AXFocusableAncestor: <AXColumn>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {9223372036854775807, 0}
+AXElementBusy: 0
 AXIndex: 0
 AXHeader: <AXColumn>
 AXRows: <array of size 4>
 AXVisibleRows: <array of size 4>
-AXElementBusy: 0
 
 ------------
 AXHasDocumentRoleAncestor: 0
@@ -322,11 +322,11 @@ AXFocusableAncestor: <AXColumn>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {9223372036854775807, 0}
+AXElementBusy: 0
 AXIndex: 1
 AXHeader: <AXColumn>
 AXRows: <array of size 4>
 AXVisibleRows: <array of size 4>
-AXElementBusy: 0
 
 ------------
 AXHasDocumentRoleAncestor: 0
@@ -360,11 +360,11 @@ AXFocusableAncestor: <AXColumn>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {9223372036854775807, 0}
+AXElementBusy: 0
 AXIndex: 2
 AXHeader: <AXColumn>
 AXRows: <array of size 4>
 AXVisibleRows: <array of size 4>
-AXElementBusy: 0
 
 ------------
 
@@ -399,8 +399,8 @@ AXFocusableAncestor: <AXRow>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 5}
+AXElementBusy: 0
 AXIndex: 0
-AXElementBusy: 0
 
 ------------
 AXHasDocumentRoleAncestor: 0
@@ -434,8 +434,8 @@ AXFocusableAncestor: <AXRow>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 5}
-AXIndex: 1
 AXElementBusy: 0
+AXIndex: 1
 
 ------------
 AXHasDocumentRoleAncestor: 0
@@ -469,8 +469,8 @@ AXFocusableAncestor: <AXRow>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 7}
-AXIndex: 2
 AXElementBusy: 0
+AXIndex: 2
 
 ------------
 AXHasDocumentRoleAncestor: 0
@@ -504,8 +504,8 @@ AXFocusableAncestor: <AXRow>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 5}
+AXElementBusy: 0
 AXIndex: 3
-AXElementBusy: 0
 
 ------------
 
@@ -540,13 +540,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {0, 1}
 AXColumnIndexRange: NSRange: {0, 1}
 AXColumnHeaderUIElements: <array of size 0>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -582,13 +582,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {0, 1}
 AXColumnIndexRange: NSRange: {1, 1}
 AXColumnHeaderUIElements: <array of size 0>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -624,13 +624,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {0, 1}
 AXColumnIndexRange: NSRange: {2, 1}
 AXColumnHeaderUIElements: <array of size 0>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -666,13 +666,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {1, 1}
 AXColumnIndexRange: NSRange: {0, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -708,13 +708,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {1, 1}
 AXColumnIndexRange: NSRange: {1, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 1>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------
@@ -749,13 +749,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {1, 1}
 AXColumnIndexRange: NSRange: {2, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 1>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------
@@ -790,13 +790,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {2, 1}
 AXColumnIndexRange: NSRange: {0, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 AXSortDirection: AXUnknownSortDirection
 
@@ -832,13 +832,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 2}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {2, 1}
 AXColumnIndexRange: NSRange: {1, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 1>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------
@@ -873,13 +873,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 2}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {2, 1}
 AXColumnIndexRange: NSRange: {2, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 1>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------
@@ -914,13 +914,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {3, 1}
 AXColumnIndexRange: NSRange: {0, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------
@@ -955,13 +955,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {3, 1}
 AXColumnIndexRange: NSRange: {1, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------
@@ -996,13 +996,13 @@ AXFocusableAncestor: <AXCell>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 1}
+AXElementBusy: 0
 AXRowIndexRange: NSRange: {3, 1}
 AXColumnIndexRange: NSRange: {2, 1}
 AXColumnHeaderUIElements: <array of size 1>
 AXRowHeaderUIElements: <array of size 0>
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
-AXElementBusy: 0
 AXRequired: 0
 
 ------------

--- a/LayoutTests/accessibility/table-with-rules-expected.txt
+++ b/LayoutTests/accessibility/table-with-rules-expected.txt
@@ -36,6 +36,7 @@ AXFocusableAncestor: <AXTable>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 10}
+AXElementBusy: 0
 AXRows: <array of size 1>
 AXVisibleRows: <array of size 1>
 AXColumns: <array of size 2>
@@ -51,7 +52,6 @@ AXARIARowCount: 0
 AXSelectedCells: <array of size 0>
 AXSelectedChildren: (null)
 AXTableLevel: 1
-AXElementBusy: 0
 
 
 AXHasDocumentRoleAncestor: 0
@@ -85,6 +85,7 @@ AXFocusableAncestor: <AXTable>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 10}
+AXElementBusy: 0
 AXRows: <array of size 1>
 AXVisibleRows: <array of size 1>
 AXColumns: <array of size 2>
@@ -100,7 +101,6 @@ AXARIARowCount: 0
 AXSelectedCells: <array of size 0>
 AXSelectedChildren: (null)
 AXTableLevel: 1
-AXElementBusy: 0
 
 
 AXHasDocumentRoleAncestor: 0
@@ -134,6 +134,7 @@ AXFocusableAncestor: <AXTable>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 10}
+AXElementBusy: 0
 AXRows: <array of size 1>
 AXVisibleRows: <array of size 1>
 AXColumns: <array of size 2>
@@ -149,7 +150,6 @@ AXARIARowCount: 0
 AXSelectedCells: <array of size 0>
 AXSelectedChildren: (null)
 AXTableLevel: 1
-AXElementBusy: 0
 
 
 AXHasDocumentRoleAncestor: 0
@@ -183,8 +183,8 @@ AXFocusableAncestor: <AXGroup>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 4}
-AXInlineText: 0
 AXElementBusy: 0
+AXInlineText: 0
 
 
 AXHasDocumentRoleAncestor: 0
@@ -218,8 +218,8 @@ AXFocusableAncestor: <AXGroup>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 4}
-AXInlineText: 0
 AXElementBusy: 0
+AXInlineText: 0
 
 
 

--- a/LayoutTests/platform/mac/accessibility/lists-expected.txt
+++ b/LayoutTests/platform/mac/accessibility/lists-expected.txt
@@ -42,12 +42,12 @@ AXFocusableAncestor: <AXList>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 14}
+AXElementBusy: 0
 AXActiveElement: (null)
 AXSelectedChildren: (null)
 AXVisibleChildren: <array of size 2>
 AXOrientation: AXVerticalOrientation
 AXActiveElement: (null)
-AXElementBusy: 0
 
 ------------
 AXHasDocumentRoleAncestor: 0
@@ -81,12 +81,12 @@ AXFocusableAncestor: <AXList>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 14}
+AXElementBusy: 0
 AXActiveElement: (null)
 AXSelectedChildren: (null)
 AXVisibleChildren: <array of size 2>
 AXOrientation: AXVerticalOrientation
 AXActiveElement: (null)
-AXElementBusy: 0
 
 ------------
 AXHasDocumentRoleAncestor: 0
@@ -120,11 +120,11 @@ AXFocusableAncestor: <AXList>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 44}
+AXElementBusy: 0
 AXActiveElement: (null)
 AXSelectedChildren: (null)
 AXVisibleChildren: <array of size 5>
 AXOrientation: AXVerticalOrientation
-AXElementBusy: 0
 
 ------------
 
@@ -160,8 +160,8 @@ AXFocusableAncestor: <AXGroup>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 6}
-AXInlineText: 0
 AXElementBusy: 0
+AXInlineText: 0
 
 ------------
 AXHasDocumentRoleAncestor: 0
@@ -195,8 +195,8 @@ AXFocusableAncestor: <AXGroup>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 6}
-AXInlineText: 0
 AXElementBusy: 0
+AXInlineText: 0
 
 ------------
 
@@ -232,8 +232,8 @@ AXFocusableAncestor: <AXGroup>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 6}
-AXInlineText: 0
 AXElementBusy: 0
+AXInlineText: 0
 
 ------------
 AXHasDocumentRoleAncestor: 0
@@ -267,8 +267,8 @@ AXFocusableAncestor: <AXGroup>
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 6}
-AXInlineText: 0
 AXElementBusy: 0
+AXInlineText: 0
 
 ------------
 

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -1036,6 +1036,7 @@ public:
     virtual AccessibilityChildrenVector radioButtonGroup() const = 0;
 
     bool hasPopup() const;
+    bool selfOrAncestorLinkHasPopup() const;
     virtual String popupValue() const = 0;
     virtual bool supportsHasPopup() const = 0;
     virtual bool pressedIsPresent() const = 0;
@@ -1043,6 +1044,7 @@ public:
     virtual bool supportsExpanded() const = 0;
     virtual bool supportsChecked() const = 0;
     virtual AccessibilitySortDirection sortDirection() const = 0;
+    AccessibilitySortDirection sortDirectionIncludingAncestors() const;
     virtual bool supportsRangeValue() const = 0;
     virtual String identifierAttribute() const = 0;
     virtual String linkRelValue() const = 0;
@@ -1332,7 +1334,6 @@ public:
     static bool liveRegionStatusIsEnabled(const AtomString&);
     bool supportsLiveRegion(bool excludeIfOff = true) const;
     virtual AXCoreObject* liveRegionAncestor(bool excludeIfOff = true) const = 0;
-    bool isInsideLiveRegion(bool excludeIfOff = true) const;
     virtual const String liveRegionStatus() const = 0;
     virtual const String liveRegionRelevant() const = 0;
     virtual bool liveRegionAtomic() const = 0;
@@ -1513,11 +1514,6 @@ inline SpinButtonType AXCoreObject::spinButtonType()
 {
     ASSERT_WITH_MESSAGE(isSpinButton(), "spinButtonType() should only be called on spinbuttons.");
     return incrementButton() || decrementButton() ? SpinButtonType::Composite : SpinButtonType::Standalone;
-}
-
-inline bool AXCoreObject::isInsideLiveRegion(bool excludeIfOff) const
-{
-    return liveRegionAncestor(excludeIfOff);
 }
 
 inline bool AXCoreObject::canSetTextRangeAttributes() const

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -3259,15 +3259,13 @@ void AccessibilityObject::setFocused(bool focus)
 
 AccessibilitySortDirection AccessibilityObject::sortDirection() const
 {
-    // Only objects that are descendant of column or row headers are allowed to have sort direction.
-    auto* header = Accessibility::findAncestor<AccessibilityObject>(*this, true, [] (const AccessibilityObject& object) {
-        auto role = object.roleValue();
-        return role == AccessibilityRole::ColumnHeader || role == AccessibilityRole::RowHeader;
-    });
-    if (!header)
+    auto role = roleValue();
+    // Only row and column headers are allowed to have aria-sort.
+    // https://w3c.github.io/aria/#aria-sort
+    if (role != AccessibilityRole::ColumnHeader && role != AccessibilityRole::RowHeader)
         return AccessibilitySortDirection::Invalid;
 
-    auto& sortAttribute = header->getAttribute(aria_sortAttr);
+    auto& sortAttribute = getAttribute(aria_sortAttr);
     if (sortAttribute.isNull())
         return AccessibilitySortDirection::None;
 
@@ -3934,10 +3932,9 @@ AccessibilityRole AccessibilityObject::buttonRoleType() const
     // https://www.w3.org/TR/wai-aria#aria-pressed
     if (pressedIsPresent())
         return AccessibilityRole::ToggleButton;
-    if (hasPopup())
+    if (selfOrAncestorLinkHasPopup())
         return AccessibilityRole::PopUpButton;
-    // We don't contemplate AccessibilityRole::RadioButton, as it depends on the input
-    // type.
+    // We don't contemplate AccessibilityRole::RadioButton, as it depends on the input type.
 
     return AccessibilityRole::Button;
 }

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -2140,7 +2140,7 @@ AccessibilityRole AccessibilityRenderObject::determineAccessibilityRole()
         return AccessibilityRole::ImageMap;
     if (m_renderer->isImage()) {
         if (is<HTMLInputElement>(node))
-            return hasPopup() ? AccessibilityRole::PopUpButton : AccessibilityRole::Button;
+            return selfOrAncestorLinkHasPopup() ? AccessibilityRole::PopUpButton : AccessibilityRole::Button;
 
         if (auto* svgRoot = remoteSVGRootElement(Create)) {
             if (svgRoot->hasAccessibleContent())

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
@@ -793,7 +793,7 @@ OptionSet<Atspi::State> AccessibilityObjectAtspi::states() const
     if (m_coreObject->isExpanded())
         states.add(Atspi::State::Expanded);
 
-    if (m_coreObject->hasPopup())
+    if (m_coreObject->selfOrAncestorLinkHasPopup())
         states.add(Atspi::State::HasPopup);
 
     if (shouldIncludeOrientationState(*m_coreObject)) {
@@ -919,7 +919,7 @@ UncheckedKeyHashMap<String, String> AccessibilityObjectAtspi::attributes() const
 
     // The Core AAM states that an explicitly-set value should be exposed, including "none".
     if (static_cast<AccessibilityObject*>(m_coreObject.get())->hasAttribute(HTMLNames::aria_sortAttr)) {
-        switch (m_coreObject->sortDirection()) {
+        switch (m_coreObject->sortDirectionIncludingAncestors()) {
         case AccessibilitySortDirection::Invalid:
             break;
         case AccessibilitySortDirection::Ascending:

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -497,7 +497,7 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
     if (![self _prepareAccessibilityCall])
         return NO;
     
-    return self.axBackingObject->hasPopup();
+    return self.axBackingObject->selfOrAncestorLinkHasPopup();
 }
 
 - (NSString *)accessibilityPopupValue
@@ -2962,7 +2962,7 @@ static RenderObject* rendererForView(WAKView* view)
     if (![self _prepareAccessibilityCall])
         return nil;
 
-    switch (self.axBackingObject->sortDirection()) {
+    switch (self.axBackingObject->sortDirectionIncludingAncestors()) {
     case AccessibilitySortDirection::Ascending:
         return @"AXAscendingSortDirection";
     case AccessibilitySortDirection::Descending:

--- a/Source/WebCore/inspector/InspectorAuditAccessibilityObject.cpp
+++ b/Source/WebCore/inspector/InspectorAuditAccessibilityObject.cpp
@@ -191,7 +191,7 @@ ExceptionOr<std::optional<InspectorAuditAccessibilityObject::ComputedProperties>
         else
             computedProperties.invalidStatus = "true"_s;
 
-        computedProperties.isPopUpButton = axObject->isPopUpButton() || axObject->hasPopup();
+        computedProperties.isPopUpButton = axObject->isPopUpButton() || axObject->selfOrAncestorLinkHasPopup();
         computedProperties.label = axObject->computedLabel();
 
         if (axObject->supportsLiveRegion()) {

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -2426,7 +2426,7 @@ Ref<Inspector::Protocol::DOM::AccessibilityProperties> InspectorDOMAgent::buildO
             hierarchicalLevel = axObject->hierarchicalLevel();
             
             level = hierarchicalLevel ? hierarchicalLevel : headingLevel;
-            isPopupButton = axObject->isPopUpButton() || axObject->hasPopup();
+            isPopupButton = axObject->isPopUpButton() || axObject->selfOrAncestorLinkHasPopup();
         }
     }
     


### PR DESCRIPTION
#### e6f95871da78d511ad2bdb4a1bb135818288d4d4
<pre>
AX: accessibilityAttributeNames does several unnecessary NSArray copies and ancestry traversals
<a href="https://bugs.webkit.org/show_bug.cgi?id=284212">https://bugs.webkit.org/show_bug.cgi?id=284212</a>
<a href="https://rdar.apple.com/141080358">rdar://141080358</a>

Reviewed by Chris Fleizach.

Prior to this commit, -[WebAccessibilityObjectWrapperMac accessibilityAttributeNames] would unnecessarily call
arrayByAddingObjectsFromArray several times, which makes a copy of the NSArray (at least 2 unnecessary copies were made
for every object, with as many as 4 possible depending on the ARIA attributes and role combination). With this commit,
we are guaranteed to do at most 1, and significantly more often will not need to do any copy at all (e.g. for static
text objects, which are obviously one of the most common types). This saves 230 samples on a slow webpage.

This patch further optimizes -[WebAccessibilityObjectWrapperMac accessibilityAttributeNames] by combining three separate
ancestry traversals into one. This saves ~400 samples on a slow webpage.

Finally, this patch optimizes AXIsolatedObject creation. Prior to this patch, computing AXPropertyName::SortDirection
did an ancestry traversal for every single object in search of a row or column header, the only objects that are valid
to have aria-sort. With this commit, each object only checks its own role and aria-sort presence, saving an ancestry traversal.
Furthermore, this decreases memory usage, as prior to this patch, every descendant of a row or column header with aria-sort
would store that aria-sort value (since every object iterated upwards to find a sort-direction-having ancestor).

* LayoutTests/accessibility/display-contents/role-row-headers-expected.txt:
* LayoutTests/accessibility/image-link-expected.txt:
* LayoutTests/accessibility/image-map2-expected.txt:
* LayoutTests/accessibility/mac/aria-columnrowheaders-expected.txt:
* LayoutTests/accessibility/mac/bounds-for-range-expected.txt:
* LayoutTests/accessibility/mac/document-attributes-expected.txt:
* LayoutTests/accessibility/mac/document-links-expected.txt:
* LayoutTests/accessibility/mac/internal-link-anchors-expected.txt:
* LayoutTests/accessibility/table-attributes-expected.txt:
* LayoutTests/accessibility/table-cell-spans-expected.txt:
* LayoutTests/accessibility/table-cells-expected.txt:
* LayoutTests/accessibility/table-multiple-tbodies-expected.txt:
* LayoutTests/accessibility/table-thead-tfoot-expected.txt:
* LayoutTests/accessibility/table-with-rules-expected.txt:
* LayoutTests/platform/mac/accessibility/lists-expected.txt:
AXBusy is reordered in attribute name lists.

* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::hasPopup const):
(WebCore::AXCoreObject::selfOrAncestorLinkHasPopup const):
(WebCore::AXCoreObject::sortDirectionIncludingAncestors const):
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::AXCoreObject::isInsideLiveRegion const): Deleted.
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::sortDirection const):
(WebCore::AccessibilityObject::buttonRoleType const):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::determineAccessibilityRole):
* Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::states const):
(WebCore::AccessibilityObjectAtspi::attributes const):
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper accessibilityHasPopup]):
(-[WebAccessibilityObjectWrapper accessibilitySortDirection]):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper _additionalAccessibilityAttributeNames:]):
(-[WebAccessibilityObjectWrapper ALLOW_DEPRECATED_IMPLEMENTATIONS_END]):
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:]):
* Source/WebCore/inspector/InspectorAuditAccessibilityObject.cpp:
(WebCore::InspectorAuditAccessibilityObject::getComputedProperties):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::buildObjectForAccessibilityProperties):

Canonical link: <a href="https://commits.webkit.org/287686@main">https://commits.webkit.org/287686@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa458f5eb4769d36164824b785fff71b7f262bea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79884 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58882 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33282 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84399 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30865 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81993 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67947 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7174 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62430 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20263 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82952 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52484 "Found 1 new test failure: media/audioSession/getUserMedia.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72751 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42741 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49827 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26900 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29321 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70949 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27383 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85831 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7103 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4976 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70706 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7280 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68591 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69948 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17546 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13944 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12873 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7066 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12616 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6917 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10428 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8722 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->