### PR TITLE
[GTK] Create WebKitWebExtensionMatchPattern

### DIFF
--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -194,6 +194,7 @@ set(WebKitGTK_HEADER_TEMPLATES
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitUserMediaPermissionRequest.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitUserMessage.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitWebContext.h.in
+    ${WEBKIT_DIR}/UIProcess/API/glib/WebKitWebExtensionMatchPattern.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitWebResource.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitWebView.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitWebViewSessionState.h.in

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -176,6 +176,7 @@ UIProcess/API/glib/WebKitUserContentManager.cpp @no-unify
 UIProcess/API/glib/WebKitUserMediaPermissionRequest.cpp @no-unify
 UIProcess/API/glib/WebKitVersion.cpp @no-unify
 UIProcess/API/glib/WebKitWebContext.cpp @no-unify
+UIProcess/API/glib/WebKitWebExtensionMatchPattern.cpp @no-unify
 UIProcess/API/glib/WebKitWebResource.cpp @no-unify
 UIProcess/API/glib/WebKitWebResourceLoadManager.cpp @no-unify
 UIProcess/API/glib/WebKitWebView.cpp @no-unify

--- a/Source/WebKit/UIProcess/API/glib/WebKitError.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitError.cpp
@@ -113,6 +113,18 @@ GQuark webkit_snapshot_error_quark()
 }
 
 /**
+ * webkit_web_extension_match_pattern_error_quark:
+ *
+ * Gets the quark for the domain of Web Extension Match Pattern errors.
+ *
+ * Returns: web extension match pattern error domain.
+ */
+GQuark webkit_web_extension_match_pattern_error_quark()
+{
+    return g_quark_from_static_string("WebKitWebExtensionMatchPatternError");
+}
+
+/**
  * webkit_user_content_filter_error_quark:
  *
  * Gets the quark for the domain of user content filter errors.

--- a/Source/WebKit/UIProcess/API/glib/WebKitError.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitError.h.in
@@ -27,22 +27,23 @@
 
 G_BEGIN_DECLS
 
-#define WEBKIT_NETWORK_ERROR             webkit_network_error_quark ()
-#define WEBKIT_POLICY_ERROR              webkit_policy_error_quark ()
+#define WEBKIT_NETWORK_ERROR                     webkit_network_error_quark ()
+#define WEBKIT_POLICY_ERROR                      webkit_policy_error_quark ()
 #if !ENABLE(2022_GLIB_API)
-#define WEBKIT_PLUGIN_ERROR              webkit_plugin_error_quark ()
+#define WEBKIT_PLUGIN_ERROR                      webkit_plugin_error_quark ()
 #endif
-#define WEBKIT_DOWNLOAD_ERROR            webkit_download_error_quark ()
-#define WEBKIT_JAVASCRIPT_ERROR          webkit_javascript_error_quark ()
-#define WEBKIT_SNAPSHOT_ERROR            webkit_snapshot_error_quark ()
-#define WEBKIT_USER_CONTENT_FILTER_ERROR webkit_user_content_filter_error_quark ()
+#define WEBKIT_DOWNLOAD_ERROR                    webkit_download_error_quark ()
+#define WEBKIT_JAVASCRIPT_ERROR                  webkit_javascript_error_quark ()
+#define WEBKIT_SNAPSHOT_ERROR                    webkit_snapshot_error_quark ()
+#define WEBKIT_USER_CONTENT_FILTER_ERROR         webkit_user_content_filter_error_quark ()
+#define WEBKIT_WEB_EXTENSION_MATCH_PATTERN_ERROR webkit_web_extension_error_quark ()
 
 #if PLATFORM(GTK)
-#define WEBKIT_PRINT_ERROR               webkit_print_error_quark ()
+#define WEBKIT_PRINT_ERROR                       webkit_print_error_quark ()
 #endif
 
 #if ENABLE(2022_GLIB_API)
-#define WEBKIT_MEDIA_ERROR               webkit_media_error_quark ()
+#define WEBKIT_MEDIA_ERROR                       webkit_media_error_quark ()
 #endif
 
 /**
@@ -158,6 +159,22 @@ typedef enum {
 } WebKitSnapshotError;
 
 /**
+ * WebKitWebExtensionMatchPatternError:
+ * @WEBKIT_WEB_EXTENSION_MATCH_PATTERN_ERROR_UNKNOWN: An unknown error occured.
+ * @WEBKIT_WEB_EXTENSION_MATCH_PATTERN_ERROR_INVALID_SCHEME: The scheme component was invalid.
+ * @WEBKIT_WEB_EXTENSION_MATCH_PATTERN_ERROR_INVALID_HOST: The host component was invalid.
+ * @WEBKIT_WEB_EXTENSION_MATCH_PATTERN_ERROR_INVALID_PATH: The path component was invalid.
+ *
+ * Enum values used to denote errors happening when creating a #WebKitWebExtensionMatchPattern
+ */
+typedef enum {
+    WEBKIT_WEB_EXTENSION_MATCH_PATTERN_ERROR_UNKNOWN = 899,
+    WEBKIT_WEB_EXTENSION_MATCH_PATTERN_ERROR_INVALID_SCHEME = 808,
+    WEBKIT_WEB_EXTENSION_MATCH_PATTERN_ERROR_INVALID_HOST = 809,
+    WEBKIT_WEB_EXTENSION_MATCH_PATTERN_ERROR_INVALID_PATH = 810,
+} WebKitWebExtensionMatchPatternError;
+
+/**
  * WebKitUserContentFilterError:
  * @WEBKIT_USER_CONTENT_FILTER_ERROR_INVALID_SOURCE: The JSON source for a content filter is invalid.
  * @WEBKIT_USER_CONTENT_FILTER_ERROR_NOT_FOUND: The requested content filter could not be found.
@@ -186,36 +203,39 @@ typedef enum {
 #endif
 
 WEBKIT_API GQuark
-webkit_network_error_quark             (void);
+webkit_network_error_quark                     (void);
 
 WEBKIT_API GQuark
-webkit_policy_error_quark              (void);
+webkit_policy_error_quark                      (void);
 
 #if !ENABLE(2022_GLIB_API)
 WEBKIT_API GQuark
-webkit_plugin_error_quark              (void);
+webkit_plugin_error_quark                      (void);
 #endif
 
 WEBKIT_API GQuark
-webkit_download_error_quark            (void);
+webkit_download_error_quark                    (void);
 
 #if PLATFORM(GTK)
 WEBKIT_API GQuark
-webkit_print_error_quark               (void);
+webkit_print_error_quark                       (void);
 #endif
 
 WEBKIT_API GQuark
-webkit_javascript_error_quark          (void);
+webkit_javascript_error_quark                  (void);
 
 WEBKIT_API GQuark
-webkit_snapshot_error_quark            (void);
+webkit_snapshot_error_quark                    (void);
 
 WEBKIT_API GQuark
-webkit_user_content_filter_error_quark (void);
+webkit_web_extension_match_pattern_error_quark (void);
+
+WEBKIT_API GQuark
+webkit_user_content_filter_error_quark         (void);
 
 #if ENABLE(2022_GLIB_API)
 WEBKIT_API GQuark
-webkit_media_error_quark               (void);
+webkit_media_error_quark                       (void);
 #endif
 
 G_END_DECLS

--- a/Source/WebKit/UIProcess/API/glib/WebKitPrivate.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitPrivate.cpp
@@ -30,6 +30,10 @@
 #include <wpe/wpe.h>
 #endif
 
+#if ENABLE(WK_WEB_EXTENSIONS)
+#include "WebExtensionMatchPattern.h"
+#endif
+
 #if PLATFORM(GTK)
 unsigned toPlatformModifiers(OptionSet<WebKit::WebEventModifier> wkModifiers)
 {
@@ -149,6 +153,25 @@ unsigned toWebKitError(unsigned webCoreError)
         return webCoreError;
     }
 }
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+unsigned toWebKitWebExtensionMatchPatternError(unsigned apiError)
+{
+    auto error = static_cast<WebKit::WebExtensionMatchPattern::Error>(apiError);
+
+    switch (error) {
+    case WebKit::WebExtensionMatchPattern::Error::InvalidScheme:
+        return WEBKIT_WEB_EXTENSION_MATCH_PATTERN_ERROR_INVALID_SCHEME;
+    case WebKit::WebExtensionMatchPattern::Error::InvalidHost:
+        return WEBKIT_WEB_EXTENSION_MATCH_PATTERN_ERROR_INVALID_HOST;
+    case WebKit::WebExtensionMatchPattern::Error::InvalidPath:
+        return WEBKIT_WEB_EXTENSION_MATCH_PATTERN_ERROR_INVALID_PATH;
+    case WebKit::WebExtensionMatchPattern::Error::Unknown:
+    default:
+        return WEBKIT_WEB_EXTENSION_MATCH_PATTERN_ERROR_UNKNOWN;
+    }
+}
+#endif
 
 unsigned toWebCoreError(unsigned webKitError)
 {

--- a/Source/WebKit/UIProcess/API/glib/WebKitPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitPrivate.h
@@ -33,6 +33,9 @@ unsigned toPlatformModifiers(OptionSet<WebKit::WebEventModifier>);
 WebKitNavigationType toWebKitNavigationType(WebCore::NavigationType);
 unsigned toWebKitMouseButton(WebKit::WebMouseEventButton);
 unsigned toWebKitError(unsigned webCoreError);
+#if ENABLE(WK_WEB_EXTENSIONS)
+unsigned toWebKitWebExtensionMatchPatternError(unsigned apiError);
+#endif
 unsigned toWebCoreError(unsigned webKitError);
 
 enum SnapshotRegion {

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebExtensionMatchPattern.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebExtensionMatchPattern.cpp
@@ -1,0 +1,471 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "WebKitWebExtensionMatchPattern.h"
+
+#include "WebExtensionMatchPattern.h"
+#include "WebKitError.h"
+#include "WebKitPrivate.h"
+
+#include <wtf/URLParser.h>
+
+using namespace WebKit;
+
+/**
+ * WebKitWebExtensionMatchPattern: (ref-func webkit_web_extension_match_pattern_ref) (unref-func webkit_web_extension_match_pattern_unref)
+ * 
+ * Represents a way to specify a group of URLs for use in WebExtensions.
+ * 
+ * All match patterns are specified as strings. Apart from the special `<all_urls>` pattern, match patterns
+ * consist of three parts: scheme, host, and path.
+ * 
+ * Generally, match patterns are returned from a #WebKitWebExtension.
+ *
+ * Since: 2.48
+ */
+struct _WebKitWebExtensionMatchPattern {
+#if ENABLE(WK_WEB_EXTENSIONS)
+    explicit _WebKitWebExtensionMatchPattern(RefPtr<WebExtensionMatchPattern>&& matchPattern)
+        : matchPattern(WTFMove(matchPattern))
+    {
+    }
+
+    RefPtr<WebExtensionMatchPattern> matchPattern;
+    CString string { matchPattern->string().utf8() };
+    CString scheme { matchPattern->scheme().utf8() };
+    CString host { matchPattern->host().utf8() };
+    CString path { matchPattern->path().utf8() };
+    bool matchesAllURLs { matchPattern->matchesAllURLs() };
+    bool matchesAllHosts { matchPattern->matchesAllHosts() };
+    int referenceCount { 1 };
+#else
+    _WebKitWebExtensionMatchPattern()
+    {
+    }
+#endif
+};
+
+G_DEFINE_BOXED_TYPE(WebKitWebExtensionMatchPattern, webkit_web_extension_match_pattern, webkit_web_extension_match_pattern_ref, webkit_web_extension_match_pattern_unref)
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+/**
+ * webkit_web_extension_match_pattern_register_custom_URL_scheme:
+ * @urlScheme: The custom URL scheme to register
+ *
+ * Registers a custom URL scheme that can be used in match patterns.
+ * 
+ * This method should be used to register any custom URL schemes used by the app for the extension base URLs,
+ * other than `webkit-extension`, or if extensions should have access to other supported URL schemes when using `<all_urls>`.
+ *
+ * Since: 2.48
+ */
+void webkit_web_extension_match_pattern_register_custom_URL_scheme(const gchar* urlScheme)
+{
+    g_return_if_fail(WTF::URLParser::maybeCanonicalizeScheme(String::fromUTF8(urlScheme)));
+
+    WebKit::WebExtensionMatchPattern::registerCustomURLScheme(String::fromUTF8(urlScheme));
+}
+
+WebKitWebExtensionMatchPattern* webkitWebExtensionMatchPatternCreate(const RefPtr<WebExtensionMatchPattern>& apiMatchPattern)
+{
+    if (!apiMatchPattern)
+        return nullptr;
+
+    ASSERT(API::Object::unwrap(static_cast<void*>(apiMatchPattern.get()))->type() == API::Object::Type::WebExtensionMatchPattern);
+    WebKitWebExtensionMatchPattern* matchPattern = static_cast<WebKitWebExtensionMatchPattern*>(fastMalloc(sizeof(WebKitWebExtensionMatchPattern)));
+    new (matchPattern) WebKitWebExtensionMatchPattern(static_pointer_cast<WebExtensionMatchPattern>(apiMatchPattern));
+    return matchPattern;
+}
+
+WebKitWebExtensionMatchPattern* webkitWebExtensionMatchPatternCreate(Ref<WebExtensionMatchPattern>& matchPattern)
+{
+    RefPtr<WebExtensionMatchPattern> apiMatchPattern = adoptRef(matchPattern.get());
+
+    return webkitWebExtensionMatchPatternCreate(apiMatchPattern);
+}
+
+/**
+ * webkit_web_extension_match_pattern_ref:
+ * @matchPattern: a #WebKitWebExtensionMatchPattern
+ *
+ * Atomically acquires a reference on the given @matchPattern.
+ *
+ * This function is MT-safe and may be called from any thread.
+ *
+ * Returns: The same @matchPattern with an additional reference.
+ *
+ * Since: 2.48
+ */
+WebKitWebExtensionMatchPattern* webkit_web_extension_match_pattern_ref(WebKitWebExtensionMatchPattern* matchPattern)
+{
+    g_return_val_if_fail(matchPattern, nullptr);
+    g_atomic_int_inc(&matchPattern->referenceCount);
+    return matchPattern;
+}
+
+/**
+ * webkit_web_extension_match_pattern_unref:
+ * @matchPattern: a #WebKitWebExtensionMatchPattern
+ *
+ * Atomically releases a reference on the given @matchPattern.
+ *
+ * If the reference was the last, the resources associated to the
+ * @matchPattern are freed. This function is MT-safe and may be called from
+ * any thread.
+ *
+ * Since: 2.48
+ */
+void webkit_web_extension_match_pattern_unref(WebKitWebExtensionMatchPattern* matchPattern)
+{
+    g_return_if_fail(matchPattern);
+    if (g_atomic_int_dec_and_test(&matchPattern->referenceCount)) {
+        matchPattern->~WebKitWebExtensionMatchPattern();
+        fastFree(matchPattern);
+    }
+}
+
+/**
+ * webkit_web_extension_match_pattern_new_all_urls:
+ *
+ * Returns a new #WebKitWebExtensionMatchPattern for `<all_urls>`.
+ *
+ * Returns: (transfer full): a newly created #WebKitWebExtensionMatchPattern
+ *
+ * Since: 2.48
+ */
+WebKitWebExtensionMatchPattern* webkit_web_extension_match_pattern_new_all_urls()
+{
+    return webkitWebExtensionMatchPatternCreate(WebExtensionMatchPattern::allURLsMatchPattern());
+}
+
+/**
+ * webkit_web_extension_match_pattern_new_all_hosts_and_schemes:
+ *
+ * Returns a new #WebKitWebExtensionMatchPattern that has `*` for scheme, host, and path.
+ *
+ * Returns: (transfer full): a newly created #WebKitWebExtensionMatchPattern
+ *
+ * Since: 2.48
+ */
+WebKitWebExtensionMatchPattern* webkit_web_extension_match_pattern_new_all_hosts_and_schemes()
+{
+    return webkitWebExtensionMatchPatternCreate(WebExtensionMatchPattern::allHostsAndSchemesMatchPattern());
+}
+
+/**
+ * webkit_web_extension_match_pattern_new_with_string:
+ * @string: A pattern string
+ * @error: The return location for a recoverable error.
+ *
+ * Returns a new #WebKitWebExtensionMatchPattern for the specified @string.
+ *
+ * Returns: (transfer full) (nullable): a newly created #WebKitWebExtensionMatchPattern, or %NULL
+ * if the pattern string is invalid.
+ *
+ * Since: 2.48
+ */
+WebKitWebExtensionMatchPattern* webkit_web_extension_match_pattern_new_with_string(const gchar* string, GError** error)
+{
+    if (!error)
+        return webkitWebExtensionMatchPatternCreate(WebExtensionMatchPattern::getOrCreate(String::fromUTF8(string)));
+
+    RefPtr<API::Error> internalError;
+    RefPtr matchPattern = WebKit::WebExtensionMatchPattern::create(String::fromUTF8(string), internalError);
+
+    if (error && internalError) {
+        g_set_error(error, webkit_web_extension_match_pattern_error_quark(),
+            toWebKitWebExtensionMatchPatternError(internalError->errorCode()), internalError->localizedDescription().utf8().data(), nullptr);
+    }
+
+    return webkitWebExtensionMatchPatternCreate(matchPattern);
+}
+
+/**
+ * webkit_web_extension_match_pattern_new_with_scheme:
+ * @scheme: A pattern URL scheme
+ * @host: A pattern URL host
+ * @path: A pattern URL path
+ * @error: The return location for a recoverable error.
+ *
+ * Returns a new #WebKitWebExtensionMatchPattern for the specified @scheme, @host, and @path strings.
+ *
+ * Returns: (transfer full) (nullable): a newly created #WebKitWebExtensionMatchPattern, or %NULL
+ * if any of the pattern strings are invalid.
+ *
+ * Since: 2.48 
+ */
+WebKitWebExtensionMatchPattern* webkit_web_extension_match_pattern_new_with_scheme(const gchar* scheme, const gchar* host, const gchar* path, GError** error)
+{
+    if (!error)
+        return webkitWebExtensionMatchPatternCreate(WebExtensionMatchPattern::getOrCreate(String::fromUTF8(scheme), String::fromUTF8(host), String::fromUTF8(path)));
+
+    RefPtr<API::Error> internalError;
+    RefPtr matchPattern = WebKit::WebExtensionMatchPattern::create(String::fromUTF8(scheme), String::fromUTF8(host), String::fromUTF8(path), internalError);
+
+    if (error && internalError) {
+        g_set_error(error, webkit_web_extension_match_pattern_error_quark(),
+            toWebKitWebExtensionMatchPatternError(internalError->errorCode()), internalError->localizedDescription().utf8().data(), nullptr);
+    }
+
+    return webkitWebExtensionMatchPatternCreate(matchPattern);
+}
+
+/**
+ * webkit_web_extension_match_pattern_get_string:
+ * @matchPattern: A #WebKitWebExtensionMatchPattern
+ *
+ * Gets the original pattern string.
+ * 
+ * Returns: (transfer none): The original pattern string.
+ *
+ * Since: 2.48
+ */
+const gchar* webkit_web_extension_match_pattern_get_string(WebKitWebExtensionMatchPattern* matchPattern)
+{
+    g_return_val_if_fail(matchPattern, nullptr);
+    return matchPattern->string.data();
+}
+
+/**
+ * webkit_web_extension_match_pattern_get_scheme:
+ * @matchPattern: A #WebKitWebExtensionMatchPattern
+ *
+ * Gets the scheme part of the pattern string, unless `webkit_web_extension_match_pattern_get_matches_all_urls` is %TRUE.
+ * 
+ * Returns: (transfer none): The scheme string.
+ *
+ * Since: 2.48
+ */
+const gchar* webkit_web_extension_match_pattern_get_scheme(WebKitWebExtensionMatchPattern* matchPattern)
+{
+    g_return_val_if_fail(matchPattern, nullptr);
+    return matchPattern->scheme.data();
+}
+
+/**
+ * webkit_web_extension_match_pattern_get_host:
+ * @matchPattern: A #WebKitWebExtensionMatchPattern
+ *
+ * Gets the host part of the pattern string, unless `webkit_web_extension_match_pattern_get_matches_all_urls` is %TRUE.
+ * 
+ * Returns: (transfer none): The host string.
+ *
+ * Since: 2.48
+ */
+const gchar* webkit_web_extension_match_pattern_get_host(WebKitWebExtensionMatchPattern* matchPattern)
+{
+    g_return_val_if_fail(matchPattern, nullptr);
+    return matchPattern->host.data();
+}
+
+/**
+ * webkit_web_extension_match_pattern_get_path:
+ * @matchPattern: A #WebKitWebExtensionMatchPattern
+ *
+ * Gets the path part of the pattern string, unless [method@WebExtensionMatchPattern.get_matches_all_urls] is %TRUE.
+ * 
+ * Returns: (transfer none): The path string.
+ *
+ * Since: 2.48
+ */
+const gchar* webkit_web_extension_match_pattern_get_path(WebKitWebExtensionMatchPattern* matchPattern)
+{
+    g_return_val_if_fail(matchPattern, nullptr);
+    return matchPattern->path.data();
+}
+
+/**
+ * webkit_web_extension_match_pattern_get_matches_all_urls:
+ * @matchPattern: A #WebKitWebExtensionMatchPattern
+ *
+ * Gets whether the match pattern matches all URLs, in other words, whether
+ * the pattern is `<all_urls>`.
+ * 
+ * Returns: Whether this match pattern matches all URLs.
+ *
+ * Since: 2.48
+ */
+gboolean webkit_web_extension_match_pattern_get_matches_all_urls(WebKitWebExtensionMatchPattern* matchPattern)
+{
+    g_return_val_if_fail(matchPattern, FALSE);
+    return matchPattern->matchesAllURLs;
+}
+
+/**
+ * webkit_web_extension_match_pattern_get_matches_all_hosts:
+ * @matchPattern: A #WebKitWebExtensionMatchPattern
+ *
+ * Gets whether the match pattern matches all host. This happens when
+ * the pattern is `<all_urls>`, or if `*` is set as the host string.
+ * 
+ * Returns: Whether this match pattern matches all hosts.
+ *
+ * Since: 2.48
+ */
+gboolean webkit_web_extension_match_pattern_get_matches_all_hosts(WebKitWebExtensionMatchPattern* matchPattern)
+{
+    g_return_val_if_fail(matchPattern, FALSE);
+    return matchPattern->matchesAllHosts;
+}
+
+static OptionSet<WebExtensionMatchPattern::Options> toImpl(WebKitWebExtensionMatchPatternOptions options)
+{
+    OptionSet<WebExtensionMatchPattern::Options> result;
+
+    if (options & WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_IGNORE_SCHEMES)
+        result.add(WebExtensionMatchPattern::Options::IgnoreSchemes);
+
+    if (options & WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_IGNORE_PATHS)
+        result.add(WebExtensionMatchPattern::Options::IgnorePaths);
+
+    if (options & WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_MATCH_BIDIRECTIONALLY)
+        result.add(WebExtensionMatchPattern::Options::MatchBidirectionally);
+
+    return result;
+}
+
+/**
+ * webkit_web_extension_match_pattern_matches_url:
+ * @matchPattern: A #WebKitWebExtensionMatchPattern
+ * @url: The URL to match against the pattern.
+ * @options: The #WebKitWebExtensionMatchPatternOptions use while matching.
+ *
+ * Matches the @matchPattern against the specified URL with options.
+ * 
+ * Returns: Whether the pattern matches the specified URL.
+ *
+ * Since: 2.48
+ */
+gboolean webkit_web_extension_match_pattern_matches_url(WebKitWebExtensionMatchPattern* matchPattern, const gchar* url, WebKitWebExtensionMatchPatternOptions  options)
+{
+    g_return_val_if_fail(matchPattern, FALSE);
+    g_return_val_if_fail(url, FALSE);
+
+    if (options & WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_MATCH_BIDIRECTIONALLY)
+        g_warning("Invalid parameter: WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_MATCH_BIDIRECTIONALLY is not valid when matching a URL");
+
+
+    return matchPattern->matchPattern->matchesURL(URL(String::fromUTF8(url)), toImpl(options));
+}
+
+/**
+ * webkit_web_extension_match_pattern_matches_pattern:
+ * @matchPattern: A #WebKitWebExtensionMatchPattern to match against.
+ * @pattern: The #WebKitWebExtensionMatchPattern to match with @matchPattern.
+ * @options: The #WebKitWebExtensionMatchPatternOptions use while matching.
+ *
+ * Matches the @matchPattern against the specified @pattern with options.
+ * 
+ * Returns: Whether the pattern matches the specified @pattern.
+ *
+ * Since: 2.48
+ */
+gboolean webkit_web_extension_match_pattern_matches_pattern(WebKitWebExtensionMatchPattern* matchPattern, WebKitWebExtensionMatchPattern* pattern, WebKitWebExtensionMatchPatternOptions  options)
+{
+    g_return_val_if_fail(matchPattern, FALSE);
+    g_return_val_if_fail(pattern, FALSE);
+
+    return matchPattern->matchPattern->matchesPattern(*(pattern->matchPattern), toImpl(options));
+}
+
+#else // ENABLE(WK_WEB_EXTENSIONS)
+
+void webkit_web_extension_match_pattern_register_custom_URL_scheme(const gchar* urlScheme)
+{
+    return nullptr;
+}
+
+WebKitWebExtensionMatchPattern* webkit_web_extension_match_pattern_ref(WebKitWebExtensionMatchPattern* matchPattern)
+{
+    return nullptr;
+}
+
+void webkit_web_extension_match_pattern_unref(WebKitWebExtensionMatchPattern* matchPattern)
+{
+    return;
+}
+
+WebKitWebExtensionMatchPattern* webkit_web_extension_match_pattern_new_all_urls()
+{
+    return nullptr;
+}
+
+WebKitWebExtensionMatchPattern* webkit_web_extension_match_pattern_new_all_hosts_and_schemes()
+{
+    return nullptr;
+}
+
+WebKitWebExtensionMatchPattern* webkit_web_extension_match_pattern_new_with_string(const gchar* string, GError** error)
+{
+    return nullptr;
+}
+
+WebKitWebExtensionMatchPattern* webkit_web_extension_match_pattern_new_with_scheme(const gchar* scheme, const gchar* host, const gchar* path, GError** error)
+{
+    return nullptr;
+}
+
+void webkit_web_extension_match_pattern_register_custom_URL_scheme(const gchar* urlScheme)
+{
+    return;
+}
+
+const gchar* webkit_web_extension_match_pattern_get_string(WebKitWebExtensionMatchPattern* matchPattern)
+{
+    return "";
+}
+
+const gchar* webkit_web_extension_match_pattern_get_scheme(WebKitWebExtensionMatchPattern* matchPattern)
+{
+    return "";
+}
+
+const gchar* webkit_web_extension_match_pattern_get_host(WebKitWebExtensionMatchPattern* matchPattern)
+{
+    return "";
+}
+
+const gchar* webkit_web_extension_match_pattern_get_path(WebKitWebExtensionMatchPattern* matchPattern)
+{
+    return "";
+}
+
+gboolean webkit_web_extension_match_pattern_get_matches_all_urls(WebKitWebExtensionMatchPattern* matchPattern)
+{
+    return 0;
+}
+
+gboolean webkit_web_extension_match_pattern_get_matches_all_hosts(WebKitWebExtensionMatchPattern* matchPattern)
+{
+    return 0;
+}
+
+gboolean webkit_web_extension_match_pattern_matches_url(WebKitWebExtensionMatchPattern* matchPattern, const gchar* url, WebKitWebExtensionMatchPatternOptions  options)
+{
+    return 0;
+}
+
+gboolean webkit_web_extension_match_pattern_matches_pattern(WebKitWebExtensionMatchPattern* matchPattern, WebKitWebExtensionMatchPattern* pattern, WebKitWebExtensionMatchPatternOptions  options)
+{
+    return 0;
+}
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebExtensionMatchPattern.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebExtensionMatchPattern.h.in
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+@API_SINGLE_HEADER_CHECK@
+
+#ifndef WebKitWebExtensionMatchPattern_h
+#define WebKitWebExtensionMatchPattern_h
+
+#include <glib-object.h>
+#include <gio/gio.h>
+#include <@API_INCLUDE_PREFIX@/WebKitDefines.h>
+
+G_BEGIN_DECLS
+
+/**
+ * WebKitWebExtensionMatchPatternOptions:
+ * @WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE: No special matching options.
+ * @WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_IGNORE_SCHEMES: The scheme components should be ignored while matching.
+ * @WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_IGNORE_PATHS: The host components should be ignored while matching.
+ * @WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_MATCH_BIDIRECTIONALLY: Two patterns should be checked in either direction while matching (A matches B, or B matches A). Invalid for matching URLs.
+ *
+ * Enum values representing matching options.
+ *
+ * Since: 2.48
+ */
+typedef enum {
+    WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE = 1 << 0,
+    WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_IGNORE_SCHEMES = 1 << 1,
+    WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_IGNORE_PATHS = 1 << 2,
+    WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_MATCH_BIDIRECTIONALLY = 1 << 3,
+} WebKitWebExtensionMatchPatternOptions;
+
+#define WEBKIT_TYPE_WEB_EXTENSION_MATCH_PATTERN            (webkit_web_extension_match_pattern_get_type ())
+
+typedef struct _WebKitWebExtensionMatchPattern WebKitWebExtensionMatchPattern;
+
+WEBKIT_API GType
+webkit_web_extension_match_pattern_get_type (void);
+
+WEBKIT_API WebKitWebExtensionMatchPattern *
+webkit_web_extension_match_pattern_ref (WebKitWebExtensionMatchPattern *matchPattern);
+
+WEBKIT_API void
+webkit_web_extension_match_pattern_unref (WebKitWebExtensionMatchPattern *matchPattern);
+
+WEBKIT_API WebKitWebExtensionMatchPattern*
+webkit_web_extension_match_pattern_new_all_urls ();
+
+WEBKIT_API WebKitWebExtensionMatchPattern*
+webkit_web_extension_match_pattern_new_all_hosts_and_schemes ();
+
+WEBKIT_API WebKitWebExtensionMatchPattern*
+webkit_web_extension_match_pattern_new_with_string (const gchar  *string,
+                                                    GError      **error);
+
+WEBKIT_API WebKitWebExtensionMatchPattern*
+webkit_web_extension_match_pattern_new_with_scheme (const gchar  *scheme,
+                                                    const gchar  *host,
+                                                    const gchar  *path,
+                                                    GError      **error);
+
+WEBKIT_API void
+webkit_web_extension_match_pattern_register_custom_URL_scheme (const gchar *urlScheme);
+
+WEBKIT_API const gchar *
+webkit_web_extension_match_pattern_get_string (WebKitWebExtensionMatchPattern *matchPattern);
+
+WEBKIT_API const gchar *
+webkit_web_extension_match_pattern_get_scheme (WebKitWebExtensionMatchPattern *matchPattern);
+
+WEBKIT_API const gchar *
+webkit_web_extension_match_pattern_get_host (WebKitWebExtensionMatchPattern *matchPattern);
+
+WEBKIT_API const gchar *
+webkit_web_extension_match_pattern_get_path (WebKitWebExtensionMatchPattern *matchPattern);
+
+WEBKIT_API gboolean
+webkit_web_extension_match_pattern_get_matches_all_urls (WebKitWebExtensionMatchPattern *matchPattern);
+
+WEBKIT_API gboolean
+webkit_web_extension_match_pattern_get_matches_all_hosts (WebKitWebExtensionMatchPattern *matchPattern);
+
+WEBKIT_API gboolean
+webkit_web_extension_match_pattern_matches_url (WebKitWebExtensionMatchPattern        *matchPattern,
+                                                const gchar                           *url,
+                                                WebKitWebExtensionMatchPatternOptions  options);
+
+WEBKIT_API gboolean
+webkit_web_extension_match_pattern_matches_pattern (WebKitWebExtensionMatchPattern        *matchPattern,
+                                                    WebKitWebExtensionMatchPattern        *pattern,
+                                                    WebKitWebExtensionMatchPatternOptions  options);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(WebKitWebExtensionMatchPattern, webkit_web_extension_match_pattern_unref)
+
+G_END_DECLS
+
+#endif

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebExtensionMatchPatternPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebExtensionMatchPatternPrivate.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#include "WebExtensionMatchPattern.h"
+#include "WebKitWebExtensionMatchPattern.h"
+#include <wtf/RefPtr.h>
+
+typedef struct _WebKitWebExtensionMatchPattern WebKitWebExtensionMatchPattern;
+
+WebKitWebExtensionMatchPattern* webkitWebExtensionMatchPatternCreate(Ref<WebKit::WebExtensionMatchPattern>&);
+WebKitWebExtensionMatchPattern* webkitWebExtensionMatchPatternCreate(const RefPtr<WebKit::WebExtensionMatchPattern>&);

--- a/Source/WebKit/UIProcess/API/glib/webkit.h.in
+++ b/Source/WebKit/UIProcess/API/glib/webkit.h.in
@@ -122,6 +122,9 @@
 #include <@API_INCLUDE_PREFIX@/WebKitUserMessage.h>
 #include <@API_INCLUDE_PREFIX@/WebKitVersion.h>
 #include <@API_INCLUDE_PREFIX@/WebKitWebContext.h>
+#if ENABLE(WK_WEB_EXTENSIONS)
+#include <@API_INCLUDE_PREFIX@/WebKitWebExtensionMatchPattern.h>
+#endif
 #if PLATFORM(GTK)
 #include <@API_INCLUDE_PREFIX@/WebKitWebInspector.h>
 #endif

--- a/Tools/Scripts/webkitpy/style/checker.py
+++ b/Tools/Scripts/webkitpy/style/checker.py
@@ -200,6 +200,12 @@ _PATH_RULES_SPECIFIER = [
      ["-runtime/wtf_make_unique", "-readability/naming/underscores", "-readability/naming/acronym"]),
 
     ([
+        # The MatchPattern API uses a lowercase "url" to match GObject standard naming schemes, and an
+        # underscored private struct similar to other Gtk APIs, yet the style checker only warns about MatchPattern
+        os.path.join('Source', 'WebKit', 'UIProcess', 'API', 'glib', 'WebKitWebExtensionMatchPattern.cpp')],
+     ["-readability/naming/acronym", "-readability/naming/underscores"]),
+
+    ([
       # The GTK+ and WPE APIs use upper case, underscore separated, words in
       # certain types of enums (e.g. signals, properties).
       os.path.join('Source', 'JavaScriptCore', 'API', 'glib'),

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebExtensionMatchPattern.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebExtensionMatchPattern.cpp
@@ -1,0 +1,995 @@
+/*
+ * Copyright (C) 2024 Igalia, S.L. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#include "TestMain.h"
+#include <WebKitWebExtensionMatchPattern.h>
+
+using namespace TestWebKitAPI;
+
+static WebKitWebExtensionMatchPattern* toPattern(const char* string, GError** error)
+{
+    return webkit_web_extension_match_pattern_new_with_string (string, error);
+}
+
+static WebKitWebExtensionMatchPattern* toPattern(const char* scheme, const char* host, const char* path, GError** error)
+{
+    return webkit_web_extension_match_pattern_new_with_scheme (scheme, host, path, error);
+}
+
+static void testPatternValidity(Test*, gconstpointer)
+{
+    GUniqueOutPtr<GError> error;
+
+    g_assert_null(toPattern("", &error.outPtr()));
+    g_assert_cmpstr(error.get()->message, ==, "\"\" cannot be parsed because it doesn't have a scheme.");
+
+    g_assert_null(toPattern("http://www.example.com", &error.outPtr()));
+    g_assert_cmpstr(error.get()->message, ==, "\"http://www.example.com\" cannot be parsed because it doesn't have a path.");
+
+    g_assert_null(toPattern("http://www.example.com:8080/", &error.outPtr()));
+    g_assert_cmpstr(error.get()->message, ==, "\"http://www.example.com:8080/\" cannot be parsed because the host \"www.example.com:8080\" is invalid.");
+
+    g_assert_null(toPattern("http://[::1]:8080/", &error.outPtr()));
+    g_assert_cmpstr(error.get()->message, ==, "\"http://[::1]:8080/\" cannot be parsed because the host \"[::1]:8080\" is invalid.");
+
+    g_assert_null(toPattern("http://user@www.example.com/", &error.outPtr()));
+    g_assert_cmpstr(error.get()->message, ==, "\"http://user@www.example.com/\" cannot be parsed because the host \"user@www.example.com\" is invalid.");
+
+    g_assert_null(toPattern("http://user:password@www.example.com/", &error.outPtr()));
+    g_assert_cmpstr(error.get()->message, ==, "\"http://user:password@www.example.com/\" cannot be parsed because the host \"user:password@www.example.com\" is invalid.");
+
+    g_assert_null(toPattern("file://localhost", &error.outPtr()));
+    g_assert_cmpstr(error.get()->message, ==, "\"file://localhost\" cannot be parsed because it doesn't have a path.");
+
+    g_assert_null(toPattern("file://", &error.outPtr()));
+    g_assert_cmpstr(error.get()->message, ==, "\"file://\" cannot be parsed because it doesn't have a path.");
+
+    g_assert_null(toPattern("http://*foo/bar", &error.outPtr()));
+    g_assert_cmpstr(error.get()->message, ==, "\"http://*foo/bar\" cannot be parsed because the host \"*foo\" is invalid.");
+
+    g_assert_null(toPattern("http://foo.*.bar/baz", &error.outPtr()));
+    g_assert_cmpstr(error.get()->message, ==, "\"http://foo.*.bar/baz\" cannot be parsed because the host \"foo.*.bar\" is invalid.");
+
+    g_assert_null(toPattern("http:/bar", &error.outPtr()));
+    g_assert_cmpstr(error.get()->message, ==, "\"http:/bar\" cannot be parsed because it doesn't have a scheme.");
+
+    g_assert_null(toPattern("foo://*", &error.outPtr()));
+    g_assert_cmpstr(error.get()->message, ==, "\"foo://*\" cannot be parsed because the scheme \"foo\" is invalid.");
+
+    g_assert_null(toPattern("foo", "*", "/", &error.outPtr()));
+    g_assert_cmpstr(error.get()->message, ==, "Scheme \"foo\" is invalid.");
+
+    g_assert_null(toPattern("https", "example.*", "/", &error.outPtr()));
+    g_assert_cmpstr(error.get()->message, ==, "Host \"example.*\" is invalid.");
+
+    g_assert_null(toPattern("https", "*.example.com:8080", "/", &error.outPtr()));
+    g_assert_cmpstr(error.get()->message, ==, "Host \"*.example.com:8080\" is invalid.");
+
+    g_assert_null(toPattern("https", "[::1]:8080", "/", &error.outPtr()));
+    g_assert_cmpstr(error.get()->message, ==, "Host \"[::1]:8080\" is invalid.");
+
+    g_assert_null(toPattern("https", "user@example.*", "/", &error.outPtr()));
+    g_assert_cmpstr(error.get()->message, ==, "Host \"user@example.*\" is invalid.");
+
+    g_assert_null(toPattern("https", "user@example.*", "/", &error.outPtr()));
+    g_assert_cmpstr(error.get()->message, ==, "Host \"user@example.*\" is invalid.");
+
+    g_assert_null(toPattern("https", "user:password@example.*", "/", &error.outPtr()));
+    g_assert_cmpstr(error.get()->message, ==, "Host \"user:password@example.*\" is invalid.");
+
+    g_assert_null(toPattern("https", "example.com", "*", &error.outPtr()));
+    g_assert_cmpstr(error.get()->message, ==, "Path \"*\" is invalid.");
+}
+
+static void testMatchesPattern(Test*, gconstpointer)
+{
+    // Matches any URL that uses the http scheme.
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("http://*/*", nullptr),
+        toPattern("http://www.example.com/", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("http://*/*", nullptr),
+        toPattern("http://example.com/foo/bar.html", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+
+    // Matches any URL that uses the http scheme, on any host, as long as the path starts with /foo.
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("http://*/foo*", nullptr),
+        toPattern("http://example.com/foo/bar.html", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("http://*/*", nullptr),
+        toPattern("http://example.com/foo", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+
+    // Matches any URL that uses the https scheme, is on a example.com host (such as www.example.com, bar.example.com,
+    // or example.com), as long as the path starts with /foo and ends with bar.
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("https://*.example.com/foo*bar", nullptr),
+        toPattern("https://www.example.com/foo/baz/bar", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("https://*.example.com/foo*bar", nullptr),
+        toPattern("https://bar.example.com/foobar", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+
+    // Matches the specified URL.
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("http://example.com/foo/bar.html", nullptr),
+        toPattern("http://example.com/foo/bar.html", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+
+    // Matches any file whose path starts with /foo.
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("file:///foo*", nullptr),
+        toPattern("file:///foo/bar.html", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("file:///foo*", nullptr),
+        toPattern("file:///foo", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("file://localhost/foo*", nullptr),
+        toPattern("file://localhost/foo", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("file://localhost/foo*", nullptr),
+        toPattern("file:///foo", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("file:///foo*", nullptr),
+        toPattern("file://localhost/foo", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("file://*/foo*", nullptr),
+        toPattern("file:///foo/bar.html", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("file://*/foo*", nullptr),
+        toPattern("file://localhost/foo/bar.html", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("file://*/foo*", nullptr),
+        toPattern("file://test.local/foo/bar.html", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("file://*/foo*", nullptr),
+        toPattern("file://apple.com/foo/bar.html", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("file://*.local/foo*", nullptr),
+        toPattern("file://test.local/foo", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("file://*.local/foo*", nullptr),
+        toPattern("file://apple.com/foo", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+
+    // Matches ignoring scheme.
+    g_assert_false(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("http://*.example.com/*", nullptr),
+        toPattern("https://*.example.com/*", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("https://*.example.com/*", nullptr),
+        toPattern("http://*.example.com/*", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("http://*.example.com/*", nullptr),
+        toPattern("*://*.example.com/*", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("http://*.example.com/*", nullptr),
+        toPattern("https://*.example.com/*", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_IGNORE_SCHEMES
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("https://*.example.com/*", nullptr),
+        toPattern("http://*.example.com/*", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_IGNORE_SCHEMES
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("http://*.example.com/*", nullptr),
+        toPattern("*://*.example.com/*", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_IGNORE_SCHEMES
+    ));
+
+    // Matches ignoring path.
+    g_assert_false(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("https://*.example.com/foo*bar", nullptr),
+        toPattern("https://www.example.com/baz", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("*://*.example.com/foo*bar", nullptr),
+        toPattern("http://www.example.com/test", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("*://*.example.com/test*", nullptr),
+        toPattern("*://*.example.com/bar", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("*://*.example.com/*bar", nullptr),
+        toPattern("*://example.com/baz", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("https://*.example.com/foo*bar", nullptr),
+        toPattern("https://www.example.com/baz", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_IGNORE_PATHS
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("*://*.example.com/foo*bar", nullptr),
+        toPattern("http://www.example.com/test", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_IGNORE_PATHS
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("*://*.example.com/test*", nullptr),
+        toPattern("*://*.example.com/bar", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_IGNORE_PATHS
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("*://*.example.com/*bar", nullptr),
+        toPattern("*://example.com/baz", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_IGNORE_PATHS
+    ));
+
+    // Matches any URL that uses the http scheme and is on the host 127.0.0.1.
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("http://127.0.0.1/*", nullptr),
+        toPattern("http://127.0.0.1/", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("http://127.0.0.1/*", nullptr),
+        toPattern("http://127.0.0.1/foo/bar.html", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+
+    // Matches any URL that uses the http scheme and is on the host [::1].
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("http://[::1]/*", nullptr),
+        toPattern("http://[::1]/", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("http://[::1]/*", nullptr),
+        toPattern("http://[::1]/foo/bar.html", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+
+    // Matches any URL that starts with http://foo.example.com or https://foo.example.com.
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("*://foo.example.com/*", nullptr),
+        toPattern("http://foo.example.com/foo/baz/bar", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("*://foo.example.com/*", nullptr),
+        toPattern("https://foo.example.com/foobar", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+
+    // Test missing hosts.
+    g_assert_false(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("*:///*", nullptr),
+        toPattern("https://example.com/foobar", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("https:///*", nullptr),
+        toPattern("https://example.com/foobar", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("ftp:///*", nullptr),
+        toPattern("ftp://example.com/foobar", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("file:///*", nullptr),
+        toPattern("file:///foobar", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+
+    // Matches any URL that uses a permitted scheme. (See the beginning of this section for the list of permitted schemes.)
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("<all_urls>", nullptr),
+        toPattern("http://example.com/foo/bar.html", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("<all_urls>", nullptr),
+        toPattern("file:///bar/baz.html", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+
+    // All matches.
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("<all_urls>", nullptr),
+        toPattern("<all_urls>", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("<all_urls>", nullptr),
+        toPattern("*://*/*", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("*://*/*", nullptr),
+        toPattern("<all_urls>", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("*://*/*", nullptr),
+        toPattern("*://*/*", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+
+    // Matching domain patterns.
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("*://*.example.com/*", nullptr),
+        toPattern("*://www.example.com/test/*", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("*://*/*", nullptr),
+        toPattern("*://*.example.com/*", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("*://*.example.com/*", nullptr),
+        toPattern("*://*/*", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("<all_urls>", nullptr),
+        toPattern("*://*.example.com/*", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("*://*.example.com/*", nullptr),
+        toPattern("*://www.example.com/test/*", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("*://*.example.com/*", nullptr),
+        toPattern("*://the-example.com/test/*", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("*://*.example.com/*", nullptr),
+        toPattern("*://www.the-example.com/test/*", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+
+    // Bidirectional matching.
+    g_assert_false(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("*://*.example.com/*", nullptr),
+        toPattern("*://*/*", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("*://*.example.com/*", nullptr),
+        toPattern("<all_urls>", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("http://*.example.com/*", nullptr),
+        toPattern("<all_urls>", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("ftp://*.example.com/*", nullptr),
+        toPattern("<all_urls>", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("*://*.en.wikipedia.org/*", nullptr),
+        toPattern("*://*.wikipedia.org/*", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("https://*.en.wikipedia.org/*", nullptr),
+        toPattern("*://*.wikipedia.org/*", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("*://*.en.wikipedia.org/*", nullptr),
+        toPattern("https://*.wikipedia.org/*", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("https://*/*", nullptr),
+        toPattern("*://*.example.com/*", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("http://*/*", nullptr),
+        toPattern("*://*.example.com/*", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("http://*/*", nullptr),
+        toPattern("*://*/foo*", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("*://*.example.com/*", nullptr),
+        toPattern("https://*/*", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("*://*.example.com/*", nullptr),
+        toPattern("http://*/*", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("*://*.example.com/*", nullptr),
+        toPattern("*://*/*", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_MATCH_BIDIRECTIONALLY
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("*://*.example.com/*", nullptr),
+        toPattern("<all_urls>", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_MATCH_BIDIRECTIONALLY
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("http://*.example.com/*", nullptr),
+        toPattern("<all_urls>", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_MATCH_BIDIRECTIONALLY
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("ftp://*.example.com/*", nullptr),
+        toPattern("<all_urls>", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_MATCH_BIDIRECTIONALLY
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("*://*.en.wikipedia.org/*", nullptr),
+        toPattern("*://*.wikipedia.org/*", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_MATCH_BIDIRECTIONALLY
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("https://*.en.wikipedia.org/*", nullptr),
+        toPattern("*://*.wikipedia.org/*", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_MATCH_BIDIRECTIONALLY
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("*://*.en.wikipedia.org/*", nullptr),
+        toPattern("https://*.wikipedia.org/*", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_MATCH_BIDIRECTIONALLY
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("https://*/*", nullptr),
+        toPattern("*://*.example.com/*", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_MATCH_BIDIRECTIONALLY
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("http://*/*", nullptr),
+        toPattern("*://*.example.com/*", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_MATCH_BIDIRECTIONALLY
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("http://*/*", nullptr),
+        toPattern("*://*/foo*", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_MATCH_BIDIRECTIONALLY
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("*://*.example.com/*", nullptr),
+        toPattern("https://*/*", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_MATCH_BIDIRECTIONALLY
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("*://*.example.com/*", nullptr),
+        toPattern("http://*/*", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_MATCH_BIDIRECTIONALLY
+    ));
+
+    // Matches with regex special characters in pattern.
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("*://*/foo?bar*", nullptr),
+        toPattern("*://*/foo?bar", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("*://*/foo?bar*", nullptr),
+        toPattern("*://*/fobar", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("*://*/foo[ba]r*", nullptr),
+        toPattern("*://*/foo[ba]r", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("*://*/foo[ba]r*", nullptr),
+        toPattern("*://*/fooar", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("*://*/foo|bar*", nullptr),
+        toPattern("*://*/foo|bar", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("*://*/foo|bar*", nullptr),
+        toPattern("*://*/foo", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+
+    // Matches a URL that is less permissive.
+    g_assert_false(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("https://www.apple.com/foo/bar/baz/*", nullptr),
+        toPattern("*://www.apple.com/foo/*", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(
+        toPattern("https://www.apple.com/foo/bar/baz/*", nullptr),
+        toPattern("*://www.apple.com/foo/*", nullptr),
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_MATCH_BIDIRECTIONALLY
+    ));
+
+    // Connivence methods
+    g_assert_cmpstr(webkit_web_extension_match_pattern_get_string(webkit_web_extension_match_pattern_new_all_urls()), ==, "<all_urls>");
+    g_assert_cmpstr(webkit_web_extension_match_pattern_get_string(webkit_web_extension_match_pattern_new_all_hosts_and_schemes()), ==, "*://*/*");
+}
+
+static void testMatchesURL(Test*, gconstpointer)
+{
+    // Matches any URL that uses the http scheme.
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("http://*/*", nullptr),
+        "http://www.example.com/",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("http://*/*", nullptr),
+        "http://example.com/foo/bar.html",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+
+    // Matches any URL that uses the http scheme, on any host, as long as the path starts with /foo.
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("http://*/foo*", nullptr),
+        "http://example.com/foo/bar.html",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("http://*/*", nullptr),
+        "http://www.example.com/foo",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+
+    // Matches any URL that uses the https scheme, is on a example.com host (such as www.example.com, bar.example.com,
+    // or example.com), as long as the path starts with /foo and ends with bar.
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("https://*.example.com/foo*bar", nullptr),
+        "https://www.example.com/foo/baz/bar",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("https://*.example.com/foo*bar", nullptr),
+        "https://bar.example.com/foobar",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+
+    // Matches the specified URL.
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("http://example.com/foo/bar.html", nullptr),
+        "http://example.com/foo/bar.html",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+
+    // Matches any file whose path starts with /foo.
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("file:///foo*", nullptr),
+        "file:///foo/bar.html",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("file:///foo*", nullptr),
+        "file:///foo",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("file://localhost/foo*", nullptr),
+        "file://localhost/foo",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("file://localhost/foo*", nullptr),
+        "file:///foo",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("file:///foo*", nullptr),
+        "file://localhost/foo",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("file://*/foo*", nullptr),
+        "file:///foo/bar.html",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("file://*/foo*", nullptr),
+        "file://localhost/foo/bar.html",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("file://*/foo*", nullptr),
+        "file://test.local/foo/bar.html",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("file://*/foo*", nullptr),
+        "file://apple.com/foo/bar.html",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("file://*.local/foo*", nullptr),
+        "file://test.local/foo",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_url(
+        toPattern("file://*.local/foo*", nullptr),
+        "file://apple.com/foo",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+
+    // Matches ignoring scheme.
+    g_assert_false(webkit_web_extension_match_pattern_matches_url(
+        toPattern("http://*.example.com/*", nullptr),
+        "https://example.com/",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_url(
+        toPattern("https://*.example.com/*", nullptr),
+        "http://example.com/",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_url(
+        toPattern("http://*.example.com/*", nullptr),
+        "ftp://example.com/",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("http://*.example.com/*", nullptr),
+        "https://example.com/",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_IGNORE_SCHEMES
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("https://*.example.com/*", nullptr),
+        "http://example.com/",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_IGNORE_SCHEMES
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("http://*.example.com/*", nullptr),
+        "ftp://example.com/",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_IGNORE_SCHEMES
+    ));
+
+    // Matches ignoring path.
+    g_assert_false(webkit_web_extension_match_pattern_matches_url(
+        toPattern("https://*.example.com/foo*bar", nullptr),
+        "https://www.example.com/baz",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_url(
+        toPattern("*://*.example.com/foo*bar", nullptr),
+        "http://www.example.com/test",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_url(
+        toPattern("*://*.example.com/test*", nullptr),
+        "https://www.example.com/bar",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_url(
+        toPattern("*://*.example.com/*bar", nullptr),
+        "http://example.com/baz",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("https://*.example.com/foo*bar", nullptr),
+        "https://www.example.com/baz",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_IGNORE_PATHS
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("*://*.example.com/foo*bar", nullptr),
+        "http://www.example.com/test",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_IGNORE_PATHS
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("*://*.example.com/test*", nullptr),
+        "https://www.example.com/bar",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_IGNORE_PATHS
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("*://*.example.com/*bar", nullptr),
+        "http://example.com/baz",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_IGNORE_PATHS
+    ));
+
+    // Matches host.
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("https://*.example.com/*", nullptr),
+        "https://example.com/",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("https://*.example.com/*", nullptr),
+        "https://www.example.com/",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_url(
+        toPattern("https://*.example.com/*", nullptr),
+        "https://the-example.com/",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_url(
+        toPattern("https://*.example.com/*", nullptr),
+        "https://www.the-example.com/",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+
+    // Matches any URL that uses the http scheme and is on the host 127.0.0.1.
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("http://127.0.0.1/*", nullptr),
+        "http://127.0.0.1/",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("http://127.0.0.1/*", nullptr),
+        "http://127.0.0.1/foo/bar.html",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("http://127.0.0.1/*", nullptr),
+        "http://127.0.0.1:8080/foo/bar.html",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+
+    // Matches any URL that uses the http scheme and is on the host [::1].
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("http://[::1]/*", nullptr),
+        "http://[::1]/",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("http://[::1]/*", nullptr),
+        "http://[::1]/foo/bar.html",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("http://[::1]/*", nullptr),
+        "http://[::1]:8080/foo/bar.html",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+
+    // Matches with username and password
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("https://*.example.com/*", nullptr),
+        "https://user@example.com/",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("https://*.example.com/*", nullptr),
+        "https://user:password@example.com/",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+
+    // Matches any URL that starts with http://foo.example.com or https://foo.example.com.
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("*://foo.example.com/*", nullptr),
+        "http://foo.example.com/foo/baz/bar",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("*://foo.example.com/*", nullptr),
+        "https://foo.example.com/foobar",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+
+    // Test missing hosts.
+    g_assert_false(webkit_web_extension_match_pattern_matches_url(
+        toPattern("*:///*", nullptr),
+        "https://example.com/foobar",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_url(
+        toPattern("https:///*", nullptr),
+        "https://example.com/foobar",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_url(
+        toPattern("ftp:///*", nullptr),
+        "ftp://example.com/foobar",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("file:///*", nullptr),
+        "file:///foobar",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+
+    // Matches any URL that uses a permitted scheme. (See the beginning of this section for the list of permitted schemes.)
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("<all_urls>", nullptr),
+        "http://example.com/foo/bar.html",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_url(
+        toPattern("<all_urls>", nullptr),
+        "file:///bar/baz.html",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_url(
+        toPattern("<all_urls>", nullptr),
+        "favorites://",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_url(
+        toPattern("<all_urls>", nullptr),
+        "bookmarks://",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_url(
+        toPattern("<all_urls>", nullptr),
+        "history://",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+
+    // Matches with regex and percent encoded special characters in pattern.
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("*://*/foo%3Fbar*", nullptr),
+        "https://example.com/foo%3Fbar",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_url(
+        toPattern("*://*/foo?bar*", nullptr),
+        "https://example.com/foo%3Fbar",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_url(
+        toPattern("*://*/foo?bar*", nullptr),
+        "https://example.com/fobar",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("*://*/foo%5Bba%5Dr*", nullptr),
+        "https://example.com/foo%5Bba%5Dr",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_url(
+        toPattern("*://*/foo[ba]r*", nullptr),
+        "https://example.com/foo%5Bba%5Dr",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_url(
+        toPattern("*://*/foo[ba]r*", nullptr),
+        "https://example.com/fooar",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_true(webkit_web_extension_match_pattern_matches_url(
+        toPattern("*://*/foo%7Cbar*", nullptr),
+        "https://example.com/foo%7Cbar",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_url(
+        toPattern("*://*/foo|bar*", nullptr),
+        "https://example.com/foo%7Cbar",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+    g_assert_false(webkit_web_extension_match_pattern_matches_url(
+        toPattern("*://*/foo|bar*", nullptr),
+        "https://example.com/foo",
+        WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE
+    ));
+}
+
+static void testMatchesAllHosts(Test*, gconstpointer)
+{
+    g_assert_true(webkit_web_extension_match_pattern_get_matches_all_hosts(toPattern("<all_urls>", nullptr)));
+    g_assert_true(webkit_web_extension_match_pattern_get_matches_all_hosts(toPattern("*://*/*", nullptr)));
+    g_assert_true(webkit_web_extension_match_pattern_get_matches_all_hosts(toPattern("http://*/*", nullptr)));
+    g_assert_true(webkit_web_extension_match_pattern_get_matches_all_hosts(toPattern("https://*/*", nullptr)));
+    g_assert_true(webkit_web_extension_match_pattern_get_matches_all_hosts(toPattern("file://*/*", nullptr)));
+    g_assert_false(webkit_web_extension_match_pattern_get_matches_all_hosts(toPattern("file:///*", nullptr)));
+}
+
+static void testMatchesAllURLs(Test*, gconstpointer)
+{
+    g_assert_true(webkit_web_extension_match_pattern_get_matches_all_urls(toPattern("<all_urls>", nullptr)));
+    g_assert_false(webkit_web_extension_match_pattern_get_matches_all_urls(toPattern("*://*/*", nullptr)));
+    g_assert_false(webkit_web_extension_match_pattern_get_matches_all_urls(toPattern("http://*/*", nullptr)));
+    g_assert_false(webkit_web_extension_match_pattern_get_matches_all_urls(toPattern("https://*/*", nullptr)));
+    g_assert_false(webkit_web_extension_match_pattern_get_matches_all_urls(toPattern("file://*/*", nullptr)));
+    g_assert_false(webkit_web_extension_match_pattern_get_matches_all_urls(toPattern("file:///*", nullptr)));
+}
+
+static void testCustomURLScheme(Test*, gconstpointer)
+{
+    GUniqueOutPtr<GError> error;
+    g_assert_null(toPattern("foo", "*", "/", &error.outPtr()));
+    g_assert_cmpstr(error.get()->message, ==, "Scheme \"foo\" is invalid.");
+
+    g_assert_null(toPattern("bar", "*", "/", &error.outPtr()));
+    g_assert_cmpstr(error.get()->message, ==, "Scheme \"bar\" is invalid.");
+
+    webkit_web_extension_match_pattern_register_custom_URL_scheme("foo");
+
+    g_assert_nonnull(toPattern("foo", "*", "/", &error.outPtr()));
+    g_assert_no_error(error.get());
+
+    g_assert_null(toPattern("bar", "*", "/", &error.outPtr()));
+    g_assert_cmpstr(error.get()->message, ==, "Scheme \"bar\" is invalid.");
+
+    webkit_web_extension_match_pattern_register_custom_URL_scheme("bar");
+
+    g_assert_nonnull(toPattern("foo", "*", "/", &error.outPtr()));
+    g_assert_no_error(error.get());
+
+    g_assert_nonnull(toPattern("bar", "*", "/", &error.outPtr()));
+    g_assert_no_error(error.get());
+}
+
+void beforeAll()
+{
+    Test::add("WebKitWebExtensionMatchPattern", "pattern-validity", testPatternValidity);
+    Test::add("WebKitWebExtensionMatchPattern", "matches-pattern", testMatchesPattern);
+    Test::add("WebKitWebExtensionMatchPattern", "matches-url", testMatchesURL);
+    Test::add("WebKitWebExtensionMatchPattern", "matches-all-hosts", testMatchesAllHosts);
+    Test::add("WebKitWebExtensionMatchPattern", "matches-all-urls", testMatchesAllURLs);
+    Test::add("WebKitWebExtensionMatchPattern", "custom-url-scheme", testCustomURLScheme);
+}
+
+void afterAll()
+{
+}
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Tools/TestWebKitAPI/glib/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/glib/CMakeLists.txt
@@ -188,6 +188,10 @@ ADD_WK2_TEST(TestDOMElement ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestDOME
 ADD_WK2_TEST(TestGeolocationManager ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestGeolocationManager.cpp)
 ADD_WK2_TEST(TestInputMethodContext ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestInputMethodContext.cpp)
 
+if (ENABLE_WK_WEB_EXTENSIONS)
+    ADD_WK2_TEST(TestWebKitWebExtensionMatchPattern ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebExtensionMatchPattern.cpp)
+endif ()
+
 if (ENABLE_2022_GLIB_API)
     ADD_WK2_TEST(TestWebKitNetworkSession ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestWebKitNetworkSession.cpp)
 endif ()


### PR DESCRIPTION
#### b2a4be47a0aa5938e31bb00b5c4ebfa5215077a3
<pre>
[GTK] Create WebKitWebExtensionMatchPattern
<a href="https://webkit.org/b/284216">https://webkit.org/b/284216</a>

Reviewed by Michael Catanzaro, Timothy Hatcher, and Adrian Perez de Castro.

This creates a GLib API of WebExtensionMatchPattern, which will then be used
by GLib APIs for WebExtensionContext and WebExtension itself.

* Source/WebKit/PlatformGTK.cmake:
* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/UIProcess/API/glib/WebKitError.cpp:
(webkit_web_extension_error_quark):
* Source/WebKit/UIProcess/API/glib/WebKitError.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitPrivate.cpp:
(toWebKitWebExtensionError):
* Source/WebKit/UIProcess/API/glib/WebKitPrivate.h:
* Source/WebKit/UIProcess/API/glib/WebKitWebExtensionMatchPattern.cpp: Added.
(_WebKitWebExtensionMatchPattern::_WebKitWebExtensionMatchPattern):
(webkit_web_extension_match_pattern_register_custom_url_scheme):
(webkitWebExtensionMatchPatternCreate):
(webkit_web_extension_match_pattern_ref):
(webkit_web_extension_match_pattern_unref):
(webkit_web_extension_match_pattern_new_all_urls):
(webkit_web_extension_match_pattern_new_all_hosts_and_schemes):
(webkit_web_extension_match_pattern_new_with_string):
(webkit_web_extension_match_pattern_new_with_scheme):
(webkit_web_extension_match_pattern_get_string):
(webkit_web_extension_match_pattern_get_scheme):
(webkit_web_extension_match_pattern_get_host):
(webkit_web_extension_match_pattern_get_path):
(webkit_web_extension_match_pattern_get_matches_all_urls):
(webkit_web_extension_match_pattern_get_matches_all_hosts):
(toImpl):
(webkit_web_extension_match_pattern_matches_url):
(webkit_web_extension_match_pattern_matches_pattern):
* Source/WebKit/UIProcess/API/glib/WebKitWebExtensionMatchPattern.h.in: Added.
* Source/WebKit/UIProcess/API/glib/WebKitWebExtensionMatchPatternPrivate.h: Added.
* Source/WebKit/UIProcess/API/glib/webkit.h.in:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebExtensionMatchPattern.cpp: Added.
(toPattern):
(testPatternValidity):
(testMatchesPattern):
(testMatchesURL):
(testMatchesAllHosts):
(testMatchesAllURLs):
(testCustomURLScheme):
(beforeAll):
(afterAll):

Canonical link: <a href="https://commits.webkit.org/288424@main">https://commits.webkit.org/288424@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/338da7183589a5a96b15f0f3d912044a64200a58

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82438 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2102 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87570 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33499 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84543 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2173 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9990 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64254 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22008 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85507 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1548 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75006 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44531 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/81891 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1446 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29192 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32540 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72738 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29827 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88927 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9744 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7006 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72656 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9970 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70820 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71873 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17944 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16012 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15018 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/1120 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9697 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15218 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9571 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13037 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11341 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->