### PR TITLE
[JSC] Tweak `Array#toReversed` after 287431@main

### DIFF
--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -1931,7 +1931,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncToReversed, (JSGlobalObject* globalObject
     auto thisValue = callFrame->thisValue().toThis(globalObject, ECMAMode::strict());
     RETURN_IF_EXCEPTION(scope, { });
     if (UNLIKELY(thisValue.isUndefinedOrNull()))
-        return throwVMTypeError(globalObject, scope, "Array.prototype.fill requires that |this| not be null or undefined"_s);
+        return throwVMTypeError(globalObject, scope, "Array.prototype.toReversed requires that |this| not be null or undefined"_s);
     auto* thisObject = thisValue.toObject(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -1945,8 +1945,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncToReversed, (JSGlobalObject* globalObject
 
     if (isJSArray(thisObject)) {
         JSArray* thisArray = jsCast<JSArray*>(thisObject);
-        auto fastResult = thisArray->fastToReversed(globalObject, length);
-        if (fastResult)
+        if (auto fastResult = thisArray->fastToReversed(globalObject, length))
             return JSValue::encode(fastResult);
     }
 
@@ -1956,7 +1955,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncToReversed, (JSGlobalObject* globalObject
         return { };
     }
 
-    for (unsigned k = 0; k < length; k++) {
+    for (uint32_t k = 0; k < length; k++) {
         auto fromValue = thisObject->getIndex(globalObject, length - k - 1);
         RETURN_IF_EXCEPTION(scope, { });
         result->putDirectIndex(globalObject, k, fromValue, 0, PutDirectIndexShouldThrow);


### PR DESCRIPTION
#### acb1f9b576618e53b2f380266ec68bb72338a805
<pre>
[JSC] Tweak `Array#toReversed` after 287431@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=284217">https://bugs.webkit.org/show_bug.cgi?id=284217</a>

Reviewed by Darin Adler.

This patch addresses review comments[1] after 287431@main.

[1]: <a href="https://github.com/WebKit/WebKit/pull/37419#pullrequestreview-2485622203">https://github.com/WebKit/WebKit/pull/37419#pullrequestreview-2485622203</a>

* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/287512@main">https://commits.webkit.org/287512@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbe016c37cd4b6abdec0e80aac6035a3b517c700

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79898 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58896 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33296 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84413 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30874 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67960 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7188 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62437 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20268 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82966 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/52553 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72760 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42748 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49837 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26909 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29335 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/72880 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70958 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27387 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85845 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/78967 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7116 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4984 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70710 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7293 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68600 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69952 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17433 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13949 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12882 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/101364 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7079 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/24732 "Found 1 new JSC binary failure: testapi, Found 94 new JSC stress test failures: stress/json-stringify-inspector-check.js.no-llint, stress/sampling-profiler-anonymous-function.js.bytecode-cache, stress/sampling-profiler-anonymous-function.js.default, stress/sampling-profiler-anonymous-function.js.dfg-eager, stress/sampling-profiler-anonymous-function.js.dfg-eager-no-cjit-validate, stress/sampling-profiler-anonymous-function.js.eager-jettison-no-cjit, stress/sampling-profiler-anonymous-function.js.lockdown, stress/sampling-profiler-anonymous-function.js.mini-mode, stress/sampling-profiler-anonymous-function.js.no-cjit-collect-continuously, stress/sampling-profiler-anonymous-function.js.no-cjit-validate-phases ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6927 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10439 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8731 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->