### PR TITLE
[WTF] Add countMatchedCharacters

### DIFF
--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.cpp
@@ -154,7 +154,7 @@ inline static WARN_UNUSED_RETURN size_t decodeHexImpl(std::span<CharacterType> s
     if (span.size() >= stride) {
         auto doStridedDecode = [&]() ALWAYS_INLINE_LAMBDA {
             if constexpr (sizeof(CharacterType) == 1) {
-                for (; cursor + (stride - 1) < end; cursor += stride, output += halfStride) {
+                for (; cursor + stride <= end; cursor += stride, output += halfStride) {
                     if (!vectorDecode8(SIMD::load(std::bit_cast<const uint8_t*>(cursor)), output))
                         return false;
                 }
@@ -170,7 +170,7 @@ inline static WARN_UNUSED_RETURN size_t decodeHexImpl(std::span<CharacterType> s
                     return vectorDecode8(input.val[0], output);
                 };
 
-                for (; cursor + (stride - 1) < end; cursor += stride, output += halfStride) {
+                for (; cursor + stride <= end; cursor += stride, output += halfStride) {
                     if (!vectorDecode16(simde_vld2q_u8(std::bit_cast<const uint8_t*>(cursor)), output))
                         return false;
                 }

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.cpp
@@ -260,7 +260,7 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeToHex, (JSGlobalObject* globalObject
 
         const auto* cursor = data;
         auto* output = buffer.data();
-        for (; cursor + (stride - 1) < end; cursor += stride, output += stride * 2)
+        for (; cursor + stride <= end; cursor += stride, output += stride * 2)
             simde_vst1q_u8(output, encodeVector(simde_vld1_u8(cursor)));
         if (cursor < end)
             simde_vst1q_u8(bufferEnd - stride * 2, encodeVector(simde_vld1_u8(end - stride)));

--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -1071,7 +1071,7 @@ static ALWAYS_INLINE bool stringCopySameType(std::span<const CharType> span, Cha
         const auto* end = ptr + span.size();
         auto* cursorEnd = cursor + span.size();
         BulkType accumulated { };
-        for (; ptr + (stride - 1) < end; ptr += stride, cursor += stride) {
+        for (; ptr + stride <= end; ptr += stride, cursor += stride) {
             auto input = SIMD::load(std::bit_cast<const UnsignedType*>(ptr));
             SIMD::store(input, std::bit_cast<UnsignedType*>(cursor));
             auto quotes = SIMD::equal(input, quoteMask);
@@ -1127,7 +1127,7 @@ static ALWAYS_INLINE bool stringCopyUpconvert(std::span<const LChar> span, UChar
         const auto* end = ptr + span.size();
         auto* cursorEnd = cursor + span.size();
         BulkType accumulated { };
-        for (; ptr + (stride - 1) < end; ptr += stride, cursor += stride) {
+        for (; ptr + stride <= end; ptr += stride, cursor += stride) {
             auto input = SIMD::load(std::bit_cast<const UnsignedType*>(ptr));
             simde_vst2q_u8(std::bit_cast<UnsignedType*>(cursor), (simde_uint8x16x2_t { input, zeros }));
             auto quotes = SIMD::equal(input, quoteMask);

--- a/Source/JavaScriptCore/runtime/RegExpObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/RegExpObjectInlines.h
@@ -223,18 +223,6 @@ JSValue collectMatches(VM& vm, JSGlobalObject* globalObject, JSString* string, c
     return array;
 }
 
-template<typename Char>
-ALWAYS_INLINE size_t countMatchedCharacters(std::span<const Char> input, Char pattern)
-{
-    size_t numberOfMatches = 0;
-    for (auto character : input) {
-        if (character != pattern)
-            continue;
-        numberOfMatches++;
-    }
-    return numberOfMatches;
-}
-
 template<typename SubjectChar, typename PatternChar>
 ALWAYS_INLINE void genericMatches(VM& vm, std::span<const SubjectChar> input, std::span<const PatternChar> pattern, size_t& numberOfMatches, size_t& startIndex)
 {
@@ -265,14 +253,14 @@ ALWAYS_INLINE JSValue collectGlobalAtomMatches(JSGlobalObject* globalObject, JSS
     if (pattern.is8Bit()) {
         if (input->is8Bit()) {
             if (pattern.length() == 1)
-                numberOfMatches = countMatchedCharacters(input->span8(), pattern.span8()[0]);
+                numberOfMatches = WTF::countMatchedCharacters(input->span8(), pattern.span8()[0]);
             else {
                 size_t startIndex = 0;
                 genericMatches(vm, input->span8(), pattern.span8(), numberOfMatches, startIndex);
             }
         } else {
             if (pattern.length() == 1)
-                numberOfMatches = countMatchedCharacters(input->span16(), pattern.characterAt(0));
+                numberOfMatches = WTF::countMatchedCharacters(input->span16(), pattern.characterAt(0));
             else {
                 size_t startIndex = 0;
                 genericMatches(vm, input->span16(), pattern.span8(), numberOfMatches, startIndex);
@@ -284,7 +272,7 @@ ALWAYS_INLINE JSValue collectGlobalAtomMatches(JSGlobalObject* globalObject, JSS
             genericMatches(vm, input->span8(), pattern.span16(), numberOfMatches, startIndex);
         } else {
             if (pattern.length() == 1)
-                numberOfMatches = countMatchedCharacters(input->span16(), pattern.characterAt(0));
+                numberOfMatches = WTF::countMatchedCharacters(input->span16(), pattern.characterAt(0));
             else {
                 size_t startIndex = 0;
                 genericMatches(vm, input->span16(), pattern.span16(), numberOfMatches, startIndex);

--- a/Source/JavaScriptCore/runtime/RegExpSubstringGlobalAtomCache.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpSubstringGlobalAtomCache.cpp
@@ -99,7 +99,7 @@ JSValue RegExpSubstringGlobalAtomCache::collectMatches(JSGlobalObject* globalObj
         if (input->is8Bit()) {
             if (pattern.length() == 1) {
                 if (input->length() >= startIndex) {
-                    numberOfMatches += countMatchedCharacters(input->span8().subspan(startIndex), pattern.span8()[0]);
+                    numberOfMatches += WTF::countMatchedCharacters(input->span8().subspan(startIndex), pattern.span8()[0]);
                     startIndex = input->length(); // Because the pattern atom is one character, it is ensured that we no longer find anything until this input string's end.
                 }
             } else {
@@ -110,7 +110,7 @@ JSValue RegExpSubstringGlobalAtomCache::collectMatches(JSGlobalObject* globalObj
         } else {
             if (pattern.length() == 1) {
                 if (input->length() >= startIndex) {
-                    numberOfMatches += countMatchedCharacters(input->span16().subspan(startIndex), pattern.characterAt(0));
+                    numberOfMatches += WTF::countMatchedCharacters(input->span16().subspan(startIndex), pattern.characterAt(0));
                     startIndex = input->length(); // Because the pattern atom is one character, it is ensured that we no longer find anything until this input string's end.
                 }
             } else {
@@ -127,7 +127,7 @@ JSValue RegExpSubstringGlobalAtomCache::collectMatches(JSGlobalObject* globalObj
         } else {
             if (pattern.length() == 1) {
                 if (input->length() >= startIndex) {
-                    numberOfMatches += countMatchedCharacters(input->span16().subspan(startIndex), pattern.characterAt(0));
+                    numberOfMatches += WTF::countMatchedCharacters(input->span16().subspan(startIndex), pattern.characterAt(0));
                     startIndex = input->length(); // Because the pattern atom is one character, it is ensured that we no longer find anything until this input string's end.
                 }
             } else {

--- a/Source/WTF/wtf/SIMDHelpers.h
+++ b/Source/WTF/wtf/SIMDHelpers.h
@@ -21,6 +21,30 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+/*
+ * SIMD::count algorithm is derived from https://github.com/llogiq/bytecount
+ * MIT License
+ *
+ * Copyright (c) 2017 The bytecount Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 
 #pragma once
 
@@ -138,6 +162,81 @@ ALWAYS_INLINE void store(simde_uint32x4_t value, uint32_t* ptr)
 ALWAYS_INLINE void store(simde_uint64x2_t value, uint64_t* ptr)
 {
     return simde_vst1q_u64(ptr, value);
+}
+
+ALWAYS_INLINE simde_uint8x16x4_t load4x(const uint8_t* ptr)
+{
+    return simde_vld4q_u8(ptr);
+}
+
+ALWAYS_INLINE simde_uint16x8x4_t load4x(const uint16_t* ptr)
+{
+    return simde_vld4q_u16(ptr);
+}
+
+ALWAYS_INLINE simde_uint32x4x4_t load4x(const uint32_t* ptr)
+{
+    return simde_vld4q_u32(ptr);
+}
+
+ALWAYS_INLINE simde_uint64x2x4_t load4x(const uint64_t* ptr)
+{
+    return simde_vld4q_u64(ptr);
+}
+
+ALWAYS_INLINE void store4x(simde_uint8x16x4_t value, uint8_t* ptr)
+{
+    return simde_vst4q_u8(ptr, value);
+}
+
+ALWAYS_INLINE void store4x(simde_uint16x8x4_t value, uint16_t* ptr)
+{
+    return simde_vst4q_u16(ptr, value);
+}
+
+ALWAYS_INLINE void store4x(simde_uint32x4x4_t value, uint32_t* ptr)
+{
+    return simde_vst4q_u32(ptr, value);
+}
+
+ALWAYS_INLINE void store4x(simde_uint64x2x4_t value, uint64_t* ptr)
+{
+    return simde_vst4q_u64(ptr, value);
+}
+
+ALWAYS_INLINE uint16_t sum(simde_uint8x16_t value)
+{
+    return simde_vaddlvq_u8(value);
+}
+
+ALWAYS_INLINE uint32_t sum(simde_uint16x8_t value)
+{
+    return simde_vaddlvq_u16(value);
+}
+
+ALWAYS_INLINE uint64_t sum(simde_uint32x4_t value)
+{
+    return simde_vaddlvq_u32(value);
+}
+
+ALWAYS_INLINE simde_uint8x16_t sub(simde_uint8x16_t left, simde_uint8x16_t right)
+{
+    return simde_vsubq_u8(left, right);
+}
+
+ALWAYS_INLINE simde_uint16x8_t sub(simde_uint16x8_t left, simde_uint16x8_t right)
+{
+    return simde_vsubq_u16(left, right);
+}
+
+ALWAYS_INLINE simde_uint32x4_t sub(simde_uint32x4_t left, simde_uint32x4_t right)
+{
+    return simde_vsubq_u32(left, right);
+}
+
+ALWAYS_INLINE simde_uint64x2_t sub(simde_uint64x2_t left, simde_uint64x2_t right)
+{
+    return simde_vsubq_u64(left, right);
 }
 
 ALWAYS_INLINE simde_uint8x16_t merge2(simde_uint8x16_t accumulated, simde_uint8x16_t input)
@@ -496,7 +595,7 @@ ALWAYS_INLINE const CharacterType* find(std::span<const CharacterType> span, con
     const auto* cursor = span.data();
     const auto* end = span.data() + span.size();
     if (span.size() >= threshold) {
-        for (; cursor + (stride - 1) < end; cursor += stride) {
+        for (; cursor + stride <= end; cursor += stride) {
             if (auto index = vectorMatch(SIMD::load(std::bit_cast<const UnsignedType*>(cursor))))
                 return cursor + index.value();
         }
@@ -524,7 +623,7 @@ ALWAYS_INLINE const CharacterType* findInterleaved(std::span<const CharacterType
     const auto* cursor = span.data();
     const auto* end = span.data() + span.size();
     if (span.size() >= threshold) {
-        for (; cursor + (stride - 1) < end; cursor += stride) {
+        for (; cursor + stride <= end; cursor += stride) {
             if (auto index = vectorMatch(simde_vld2q_u8(std::bit_cast<const uint8_t*>(cursor))))
                 return cursor + index.value();
         }
@@ -541,6 +640,62 @@ ALWAYS_INLINE const CharacterType* findInterleaved(std::span<const CharacterType
             return cursor;
     }
     return end;
+}
+
+template<typename CharacterType, size_t threshold = SIMD::stride<CharacterType>>
+ALWAYS_INLINE size_t count(std::span<const CharacterType> span, const auto& vectorMatch, const auto& scalarMatch)
+{
+    constexpr size_t stride = SIMD::stride<CharacterType>;
+    constexpr size_t bulkLoadCount = 4;
+    using UnsignedType = std::make_unsigned_t<CharacterType>;
+    static_assert(threshold >= stride);
+    const auto* cursor = span.data();
+    const auto* end = span.data() + span.size();
+    size_t result = 0;
+
+    // Per max * 4 * stride iteration (If CharacterType is uint8_t, it is 16320 (255 * 64)).
+    // We need to limit the each iteration up to std::numeric_limits<UnsignedType>::max() because count vector's lane will overflow.
+    for (; cursor + (bulkLoadCount * stride * std::numeric_limits<UnsignedType>::max()) <= end;) {
+        std::array<VectorType<UnsignedType>, bulkLoadCount> counts { };
+        for (size_t iteration = 0; iteration < std::numeric_limits<UnsignedType>::max(); ++iteration) {
+            auto vectorx4 = SIMD::load4x(std::bit_cast<const UnsignedType*>(cursor));
+            for (size_t i = 0; i < bulkLoadCount; ++i)
+                counts[i] = SIMD::sub(counts[i], vectorMatch(vectorx4.val[i]));
+            cursor += (bulkLoadCount * stride);
+        }
+        for (auto& count : counts)
+            result += SIMD::sum(count);
+    }
+
+    // Per 4 * stride iteration (If CharacterType is uint8_t, it is 64 (4 * 16)).
+    // At this point, the remaining size must be smaller than max * 4 * stride (If CharacterType is uint8_t, it is 16320 (255 * 64)).
+    // So we do not need to consider about counts lane's overflow. If it can be overflow, it is already handled in the previous loop.
+    {
+        std::array<VectorType<UnsignedType>, bulkLoadCount> counts { };
+        for (; cursor + (bulkLoadCount * stride) <= end; cursor += (bulkLoadCount * stride)) {
+            auto vectorx4 = SIMD::load4x(std::bit_cast<const UnsignedType*>(cursor));
+            for (size_t i = 0; i < bulkLoadCount; ++i)
+                counts[i] = SIMD::sub(counts[i], vectorMatch(vectorx4.val[i]));
+        }
+        for (auto& count : counts)
+            result += SIMD::sum(count);
+    }
+
+    // Per stride iteration (If CharacterType is uint8_t, it is 16).
+    // At this point, the remaining size must be smaller than 4 * stride (If CharacterType is uint8_t, it is 64).
+    {
+        auto count = SIMD::splat<UnsignedType>(0);
+        for (; cursor + stride <= end; cursor += stride) {
+            auto vector = SIMD::load(std::bit_cast<const UnsignedType*>(cursor));
+            count = SIMD::sub(count, vectorMatch(vector));
+        }
+        result += SIMD::sum(count);
+    }
+
+    for (; cursor < end; ++cursor)
+        result += !!scalarMatch(*std::bit_cast<const UnsignedType*>(cursor));
+
+    return result;
 }
 
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp
@@ -311,4 +311,148 @@ TEST(WTF_StringCommon, CharactersContain16)
     }
 }
 
+TEST(WTF_StringCommon, CountMatchedCharacters8)
+{
+    {
+        Vector<LChar> source;
+        EXPECT_EQ((WTF::countMatchedCharacters<LChar>(source.span(), 0)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<LChar>(source.span(), 1)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<LChar>(source.span(), 2)), 0U);
+    }
+
+    {
+        Vector<LChar> source;
+        for (unsigned i = 0; i < 15; ++i)
+            source.append(i);
+        EXPECT_EQ((WTF::countMatchedCharacters<LChar>(source.span(), 0)), 1U);
+        EXPECT_EQ((WTF::countMatchedCharacters<LChar>(source.span(), 1)), 1U);
+        EXPECT_EQ((WTF::countMatchedCharacters<LChar>(source.span(), 2)), 1U);
+        EXPECT_EQ((WTF::countMatchedCharacters<LChar>(source.span(), 3)), 1U);
+        EXPECT_EQ((WTF::countMatchedCharacters<LChar>(source.span(), 14)), 1U);
+        EXPECT_EQ((WTF::countMatchedCharacters<LChar>(source.span(), 15)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<LChar>(source.span(), 16)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<LChar>(source.span(), 17)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<LChar>(source.span(), 18)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<LChar>(source.span(), 0x81)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<LChar>(source.span(), 0x82)), 0U);
+    }
+
+    {
+        Vector<LChar> source;
+        for (unsigned i = 0; i < 250; ++i) {
+            if (i & 0x1)
+                source.append(i);
+        }
+        EXPECT_EQ((WTF::countMatchedCharacters<LChar>(source.span(), 0)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<LChar>(source.span(), 1)), 1U);
+        EXPECT_EQ((WTF::countMatchedCharacters<LChar>(source.span(), 0xff)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<LChar>(source.span(), 0x81)), 1U);
+        EXPECT_EQ((WTF::countMatchedCharacters<LChar>(source.span(), 250)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<LChar>(source.span(), 249)), 1U);
+    }
+
+    {
+        Vector<LChar> source;
+        for (unsigned c = 0; c < 1024; ++c) {
+            for (unsigned i = 0; i < 250; ++i) {
+                if (i & 0x1)
+                    source.append(i);
+            }
+        }
+        EXPECT_EQ((WTF::countMatchedCharacters<LChar>(source.span(), 0)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<LChar>(source.span(), 1)), 1024U);
+        EXPECT_EQ((WTF::countMatchedCharacters<LChar>(source.span(), 0xff)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<LChar>(source.span(), 0x81)), 1024U);
+        EXPECT_EQ((WTF::countMatchedCharacters<LChar>(source.span(), 250)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<LChar>(source.span(), 249)), 1024U);
+    }
+
+    {
+        Vector<LChar> source;
+        for (unsigned c = 0; c < 1024; ++c) {
+            for (unsigned i = 0; i < 250; ++i)
+                source.append(1);
+        }
+        source.append(1);
+        source.append(1);
+        source.append(1);
+
+        EXPECT_EQ((WTF::countMatchedCharacters<LChar>(source.span(), 0)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<LChar>(source.span(), 1)), source.size());
+        EXPECT_EQ((WTF::countMatchedCharacters<LChar>(source.span(), 0x81)), 0U);
+    }
+}
+
+TEST(WTF_StringCommon, CountMatchedCharacters16)
+{
+    {
+        Vector<UChar> source;
+        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 0)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 1)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 2)), 0U);
+    }
+
+    {
+        Vector<UChar> source;
+        for (unsigned i = 0; i < 15; ++i)
+            source.append(i);
+        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 0)), 1U);
+        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 1)), 1U);
+        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 2)), 1U);
+        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 3)), 1U);
+        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 14)), 1U);
+        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 15)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 16)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 17)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 18)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 0x81)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 0x82)), 0U);
+    }
+
+    {
+        Vector<UChar> source;
+        for (unsigned i = 0; i < 250; ++i) {
+            if (i & 0x1)
+                source.append(i);
+        }
+        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 0)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 1)), 1U);
+        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 0xff)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 0x81)), 1U);
+        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 250)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 249)), 1U);
+    }
+
+    {
+        Vector<UChar> source;
+        for (unsigned c = 0; c < 1024; ++c) {
+            for (unsigned i = 0; i < 250; ++i) {
+                if (i & 0x1)
+                    source.append(i);
+            }
+        }
+        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 0)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 1)), 1024U);
+        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 0xff)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 0x81)), 1024U);
+        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 250)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 249)), 1024U);
+    }
+
+    {
+        Vector<UChar> source;
+        for (unsigned c = 0; c < 0xffff; ++c) {
+            for (unsigned i = 0; i < 250; ++i)
+                source.append(1);
+        }
+        source.append(1);
+        source.append(1);
+        source.append(1);
+
+        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 0)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 1)), source.size());
+        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 0x81)), 0U);
+    }
+}
+
 } // namespace


### PR DESCRIPTION
#### 8b1d21ad4f48861d383244dc0b75c7356c9eedae
<pre>
[WTF] Add countMatchedCharacters
<a href="https://bugs.webkit.org/show_bug.cgi?id=284223">https://bugs.webkit.org/show_bug.cgi?id=284223</a>
<a href="https://rdar.apple.com/141088656">rdar://141088656</a>

Reviewed by Justin Michaud.

This patch implements countMatchedCharacters with SIMD. We deploy
the algorithm used in bytecount module (MIT license, see license
term in the SIMDHelpers.h), and implement countMatchedCharacters with
that algorithm. We extend it to support uint16_t / uint32_t too.

We also tweak our SIMD loop to make them faster. Since they are too hot,
this kind of small tweaking can affect actually.

* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.cpp:
(JSC::decodeHexImpl):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::stringCopySameType):
(JSC::stringCopyUpconvert):
* Source/JavaScriptCore/runtime/RegExpObjectInlines.h:
(JSC::collectGlobalAtomMatches):
(JSC::countMatchedCharacters): Deleted.
* Source/JavaScriptCore/runtime/RegExpSubstringGlobalAtomCache.cpp:
(JSC::RegExpSubstringGlobalAtomCache::collectMatches):
* Source/WTF/wtf/SIMDHelpers.h:
(WTF::SIMD::load4x):
(WTF::SIMD::store4x):
(WTF::SIMD::sum):
(WTF::SIMD::sub):
(WTF::SIMD::find):
(WTF::SIMD::findInterleaved):
(WTF::SIMD::count):
* Source/WTF/wtf/text/StringCommon.h:
(WTF::charactersContain):
(WTF::countMatchedCharacters):
* Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp:
(TestWebKitAPI::TEST(WTF_StringCommon, CountMatchedCharacters8)):
(TestWebKitAPI::TEST(WTF_StringCommon, CountMatchedCharacters16)):

Canonical link: <a href="https://commits.webkit.org/287526@main">https://commits.webkit.org/287526@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ed11af3154b5b17c42f770582a83ca9db349aae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79980 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58977 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33378 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84494 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30954 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82088 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68041 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7273 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62515 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20341 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83047 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52578 "Found 1 new test failure: media/audioSession/getUserMedia.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72840 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42824 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49916 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26993 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29416 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/72954 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71036 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27484 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85926 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/79039 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7196 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5063 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70787 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7373 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68681 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70031 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14027 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12962 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/101445 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12369 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7160 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/24735 "Found 2 new JSC stress test failures: wasm.yaml/wasm/stress/struct-new_default-small-members.js.default-wasm, wasm.yaml/wasm/stress/struct-new_default-small-members.js.wasm-bbq (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7007 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10519 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8811 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->