### PR TITLE
Implement imperative invoker changes to popover APIs

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/imperative-invokers-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/imperative-invokers-expected.txt
@@ -1,13 +1,12 @@
-popover 2
 
 PASS normal opening
 PASS showPopover(unrelated)
-FAIL showPopover(popover) assert_true: popovers should be related to each other expected true got false
-FAIL showPopover(contained) assert_true: popovers should be related to each other expected true got false
+PASS showPopover(popover)
+PASS showPopover(contained)
 PASS togglePopover(true)
 PASS togglePopover({force})
 PASS togglePopover(unrelated)
-FAIL togglePopover(popover) assert_true: popovers should be related to each other expected true got false
-FAIL togglePopover({force, popover}) assert_true: popovers should be related to each other expected true got false
-FAIL null isn't a valid Element assert_throws_js: showPopover(null) function "() => popover2.showPopover({source: null})" did not throw
+PASS togglePopover(popover)
+PASS togglePopover({force, popover})
+PASS null isn't a valid Element
 

--- a/Source/WebCore/dom/PopoverData.h
+++ b/Source/WebCore/dom/PopoverData.h
@@ -53,8 +53,8 @@ public:
 
     Ref<ToggleEventTask> ensureToggleEventTask(Element&);
 
-    HTMLFormControlElement* invoker() const { return m_invoker.get(); }
-    void setInvoker(const HTMLFormControlElement* element) { m_invoker = element; }
+    HTMLElement* invoker() const { return m_invoker.get(); }
+    void setInvoker(const HTMLElement* element) { m_invoker = element; }
 
     class ScopedStartShowingOrHiding {
     public:
@@ -81,7 +81,7 @@ private:
     PopoverVisibilityState m_visibilityState;
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_previouslyFocusedElement;
     RefPtr<ToggleEventTask> m_toggleEventTask;
-    WeakPtr<HTMLFormControlElement, WeakPtrImplWithEventTargetData> m_invoker;
+    WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData> m_invoker;
     bool m_isHidingOrShowingPopover = false;
 };
 

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -148,11 +148,20 @@ public:
 
     WEBCORE_EXPORT ExceptionOr<Ref<ElementInternals>> attachInternals();
 
+    struct ShowPopoverOptions {
+        RefPtr<HTMLElement> source;
+    };
+
+    struct TogglePopoverOptions : public ShowPopoverOptions {
+        std::optional<bool> force;
+    };
+
     void queuePopoverToggleEventTask(ToggleState oldState, ToggleState newState);
-    ExceptionOr<void> showPopover(const HTMLFormControlElement* = nullptr);
+    ExceptionOr<void> showPopover(const ShowPopoverOptions&);
+    ExceptionOr<void> showPopoverInternal(const HTMLElement* = nullptr);
     ExceptionOr<void> hidePopover();
     ExceptionOr<void> hidePopoverInternal(FocusPreviousElement, FireEvents);
-    ExceptionOr<bool> togglePopover(std::optional<bool> force);
+    ExceptionOr<bool> togglePopover(std::optional<std::variant<WebCore::HTMLElement::TogglePopoverOptions, bool>>);
 
     PopoverState popoverState() const;
     const AtomString& popover() const;

--- a/Source/WebCore/html/HTMLElement.idl
+++ b/Source/WebCore/html/HTMLElement.idl
@@ -55,9 +55,9 @@
     [CEReactions=Needed, Reflect] attribute boolean inert;
 
     // The popover API
-    [EnabledBySetting=PopoverAttributeEnabled] undefined showPopover();
+    [EnabledBySetting=PopoverAttributeEnabled] undefined showPopover(optional ShowPopoverOptions options = {});
     [EnabledBySetting=PopoverAttributeEnabled] undefined hidePopover();
-    [EnabledBySetting=PopoverAttributeEnabled] boolean togglePopover(optional boolean force);
+    [EnabledBySetting=PopoverAttributeEnabled] boolean togglePopover(optional (TogglePopoverOptions or boolean) options = {});
     [CEReactions=Needed, EnabledBySetting=PopoverAttributeEnabled] attribute [AtomString] DOMString? popover;
 
     // Non-standard: IE extension. May get added to the specification (https://github.com/whatwg/html/issues/668).
@@ -70,6 +70,14 @@
     [CEReactions=Needed, Reflect] attribute DOMString webkitdropzone;
 
     [Conditional=WRITING_SUGGESTIONS, CEReactions=Needed] attribute boolean writingsuggestions;
+};
+
+dictionary ShowPopoverOptions {
+    HTMLElement source;
+};
+
+dictionary TogglePopoverOptions : ShowPopoverOptions {
+    boolean force;
 };
 
 HTMLElement includes GlobalEventHandlers;

--- a/Source/WebCore/html/HTMLFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLFormControlElement.cpp
@@ -417,7 +417,7 @@ void HTMLFormControlElement::handlePopoverTargetAction(const EventTarget* eventT
     if (shouldHide)
         popover->hidePopover();
     else if (shouldShow)
-        popover->showPopover(this);
+        popover->showPopoverInternal(this);
 }
 
 RefPtr<Element> HTMLFormControlElement::commandForElement() const

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -73,7 +73,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(FocusController);
 
 using namespace HTMLNames;
 
-static HTMLFormControlElement* invokerForOpenPopover(const Node* candidatePopover)
+static HTMLElement* invokerForOpenPopover(const Node* candidatePopover)
 {
     RefPtr popover = dynamicDowncast<HTMLElement>(candidatePopover);
     if (popover && popover->isPopoverShowing())


### PR DESCRIPTION
#### 899ca0cd494c188aeb6bf1566f35e7b29bab8869
<pre>
Implement imperative invoker changes to popover APIs
<a href="https://bugs.webkit.org/show_bug.cgi?id=282337">https://bugs.webkit.org/show_bug.cgi?id=282337</a>

Reviewed by Tim Nguyen.

Update showPopover() and togglePopover() to be able to set
a popover invoker relationship imperatively.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/imperative-invokers-expected.txt:
* Source/WebCore/dom/PopoverData.h:
(WebCore::PopoverData::invoker const):
(WebCore::PopoverData::setInvoker):
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::showPopover):
(WebCore::HTMLElement::showPopoverInternal):
(WebCore::HTMLElement::togglePopover):
(WebCore::HTMLElement::handleCommandInternal):
* Source/WebCore/html/HTMLElement.h:
* Source/WebCore/html/HTMLElement.idl:
* Source/WebCore/html/HTMLFormControlElement.cpp:
(WebCore::HTMLFormControlElement::handlePopoverTargetAction const):
* Source/WebCore/page/FocusController.cpp:
(WebCore::invokerForOpenPopover):

Canonical link: <a href="https://commits.webkit.org/287624@main">https://commits.webkit.org/287624@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86acf079c1572e962b051fcaf4e108362d3bfa59

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80264 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59266 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33678 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84781 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31240 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82375 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68327 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7566 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62751 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20560 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83333 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52807 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73096 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43057 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50134 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27251 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29701 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71265 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27765 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86214 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7484 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5308 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71029 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7659 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68936 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70272 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17503 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14260 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13205 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7448 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12965 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7287 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10807 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9092 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->