### PR TITLE
Reflected attribute change steps should clear explicit elements even when the attribute doesn't change

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popovertarget-reflection-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popovertarget-reflection-expected.txt
@@ -1,4 +1,4 @@
 toggle popover
 
-FAIL Element attribute reflection of popoverTargetElement/popovertarget should be kept in sync. assert_equals: Setting the popovertarget attribute to empty string right after setting explicit element does remove the explicit element. expected null but got Element node <div id="mypopover" popover="auto">popover</div>
+PASS Element attribute reflection of popoverTargetElement/popovertarget should be kept in sync.
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2270,8 +2270,8 @@ static inline AtomString makeIdForStyleResolution(const AtomString& value, bool 
 bool Element::isElementReflectionAttribute(const Settings& settings, const QualifiedName& name)
 {
     return name == HTMLNames::aria_activedescendantAttr
-        || (settings.popoverAttributeEnabled() && name == HTMLNames::popovertargetAttr)
-        || (settings.commandAttributesEnabled() && name == HTMLNames::commandforAttr);
+        || (name == HTMLNames::popovertargetAttr && settings.popoverAttributeEnabled())
+        || (name == HTMLNames::commandforAttr && settings.commandAttributesEnabled());
 }
 
 bool Element::isElementsArrayReflectionAttribute(const QualifiedName& name)
@@ -2346,6 +2346,12 @@ void Element::parserNotifyAttributeAdded(const QualifiedName& name, const AtomSt
 
 void Element::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason reason)
 {
+    Ref document = this->document();
+    if (isElementReflectionAttribute(document->settings(), name) || isElementsArrayReflectionAttribute(name)) {
+        if (auto* map = explicitlySetAttrElementsMapIfExists())
+            map->remove(name);
+    }
+
     if (oldValue == newValue)
         return;
 
@@ -2355,7 +2361,7 @@ void Element::attributeChanged(const QualifiedName& name, const AtomString& oldV
         break;
     case AttributeNames::idAttr: {
         AtomString oldId = elementData()->idForStyleResolution();
-        AtomString newId = makeIdForStyleResolution(newValue, document().inQuirksMode());
+        AtomString newId = makeIdForStyleResolution(newValue, document->inQuirksMode());
         if (newId != oldId) {
             Style::IdChangeInvalidation styleInvalidation(*this, oldId, newId);
             elementData()->setIdForStyleResolution(newId);
@@ -2400,7 +2406,7 @@ void Element::attributeChanged(const QualifiedName& name, const AtomString& oldV
         }
         break;
     case AttributeNames::accesskeyAttr:
-        document().invalidateAccessKeyCache();
+        document->invalidateAccessKeyCache();
         break;
     case AttributeNames::dirAttr:
         dirAttributeChanged(newValue);
@@ -2411,7 +2417,6 @@ void Element::attributeChanged(const QualifiedName& name, const AtomString& oldV
             setHasLangAttr(!newValue.isNull() && (isHTMLElement() || isSVGElement()));
         else
             setHasXMLLangAttr(!newValue.isNull());
-        Ref document = this->document();
         if (document->documentElement() == this)
             document->setDocumentElementLanguage(langFromAttribute());
         else
@@ -2422,14 +2427,8 @@ void Element::attributeChanged(const QualifiedName& name, const AtomString& oldV
         if (reason == AttributeModificationReason::Parser && !isDefinedCustomElement())
             setUsesNullCustomElementRegistry();
         break;
-    default: {
-        Ref document = this->document();
-        if (isElementReflectionAttribute(document->settings(), name) || isElementsArrayReflectionAttribute(name)) {
-            if (auto* map = explicitlySetAttrElementsMapIfExists())
-                map->remove(name);
-        }
+    default:
         break;
-    }
     }
 }
 


### PR DESCRIPTION
#### 3fb5b19f77bc7f7ea8df0bfa8d7e6722c677a001
<pre>
Reflected attribute change steps should clear explicit elements even when the attribute doesn&apos;t change
<a href="https://bugs.webkit.org/show_bug.cgi?id=284228">https://bugs.webkit.org/show_bug.cgi?id=284228</a>

Reviewed by NOBODY (OOPS!).

Update attribute changed steps to handle element reflection correctly.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popovertarget-reflection-expected.txt:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::isElementReflectionAttribute):
(WebCore::Element::attributeChanged):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3fb5b19f77bc7f7ea8df0bfa8d7e6722c677a001

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164310 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37794 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31365 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173339 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121562 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166179 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38128 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37795 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127660 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89839 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167269 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29955 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147692 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108205 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29002 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27626 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21103 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138904 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25408 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175865 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28686 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27076 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135971 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37465 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31744 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135940 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38251 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147203 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100609 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31251 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24059 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37061 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110105 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36457 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2116 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36707 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36607 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->