### PR TITLE
[TextureMapper] Polygon clipping performance is extremely slow

### DIFF
--- a/Source/WebCore/platform/TextureMapper.cmake
+++ b/Source/WebCore/platform/TextureMapper.cmake
@@ -5,6 +5,7 @@ list(APPEND WebCore_PRIVATE_INCLUDE_DIRECTORIES
 list(APPEND WebCore_SOURCES
     platform/graphics/texmap/BitmapTexture.cpp
     platform/graphics/texmap/BitmapTexturePool.cpp
+    platform/graphics/texmap/ClipPath.cpp
     platform/graphics/texmap/ClipStack.cpp
     platform/graphics/texmap/FloatPlane3D.cpp
     platform/graphics/texmap/FloatPolygon3D.cpp
@@ -14,6 +15,7 @@ list(APPEND WebCore_SOURCES
     platform/graphics/texmap/TextureMapperBackingStore.cpp
     platform/graphics/texmap/TextureMapperFPSCounter.cpp
     platform/graphics/texmap/TextureMapperGCGLPlatformLayer.cpp
+    platform/graphics/texmap/TextureMapperGPUBuffer.cpp
     platform/graphics/texmap/TextureMapperLayer.cpp
     platform/graphics/texmap/TextureMapperLayer3DRenderingContext.cpp
     platform/graphics/texmap/TextureMapperPlatformLayer.cpp
@@ -23,6 +25,7 @@ list(APPEND WebCore_SOURCES
 list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/texmap/BitmapTexture.h
     platform/graphics/texmap/BitmapTexturePool.h
+    platform/graphics/texmap/ClipPath.h
     platform/graphics/texmap/ClipStack.h
     platform/graphics/texmap/FloatPlane3D.h
     platform/graphics/texmap/FloatPolygon3D.h
@@ -35,6 +38,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/texmap/TextureMapperFlags.h
     platform/graphics/texmap/TextureMapperFPSCounter.h
     platform/graphics/texmap/TextureMapperGLHeaders.h
+    platform/graphics/texmap/TextureMapperGPUBuffer.h
     platform/graphics/texmap/TextureMapperLayer.h
     platform/graphics/texmap/TextureMapperLayer3DRenderingContext.h
     platform/graphics/texmap/TextureMapperPlatformLayer.h

--- a/Source/WebCore/platform/graphics/texmap/ClipPath.cpp
+++ b/Source/WebCore/platform/graphics/texmap/ClipPath.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2024 Jani Hautakangas <jani@kodegood.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ClipPath.h"
+
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ClipPath);
+
+ClipPath::ClipPath(Vector<FloatPoint>&& vertices, unsigned bufferID, unsigned bufferOffsetInBytes)
+    : m_vertices(WTFMove(vertices))
+    , m_bufferID(bufferID)
+    , m_bufferOffsetInBytes(bufferOffsetInBytes)
+{
+    unsigned vertexCount = numberOfVertices();
+    if (vertexCount) {
+        m_bounds.setLocation(m_vertices.at(0));
+        for (size_t i = 1; i < vertexCount; i++)
+            m_bounds.extend(m_vertices.at(i));
+    }
+}
+
+const void* ClipPath::bufferDataOffsetAsPtr() const
+{
+    if (m_bufferID)
+        return reinterpret_cast<const void*>(m_bufferOffsetInBytes);
+
+    return nullptr;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/ClipPath.h
+++ b/Source/WebCore/platform/graphics/texmap/ClipPath.h
@@ -27,55 +27,32 @@
 
 #pragma once
 
-#include "FloatPolygon3D.h"
+#include "FloatPoint.h"
+#include "FloatRect.h"
 #include <wtf/TZoneMalloc.h>
+#include <wtf/Vector.h>
 
 namespace WebCore {
 
-class ClipPath;
-class FloatPlane3D;
-class TextureMapper;
-class TextureMapperLayer;
-
-class TextureMapperLayer3DRenderingContext final {
-    WTF_MAKE_TZONE_ALLOCATED(TextureMapperLayerPreserves3DContext);
+class ClipPath final {
+    WTF_MAKE_TZONE_ALLOCATED(ClipPath);
 public:
-    void paint(TextureMapper&, const Vector<TextureMapperLayer*>&,
-        const std::function<void(TextureMapperLayer*, const ClipPath&)>&);
+    ClipPath(Vector<FloatPoint>&& vertices, unsigned bufferID, unsigned bufferOffsetInBytes);
+
+    bool isEmpty() const { return m_vertices.isEmpty(); }
+    unsigned bufferID() const { return m_bufferID; }
+    const void* bufferDataOffsetAsPtr() const;
+    unsigned numberOfVertices() const { return m_vertices.size(); }
+
+    FloatRect bounds() const { return m_bounds; }
 
 private:
-    enum class PolygonPosition {
-        InFront,
-        Behind,
-        Coplanar,
-        Intersecting
-    };
 
-    struct TextureMapperLayerPolygon final {
-        FloatPolygon3D geometry;
-        TextureMapperLayer* layer = { nullptr };
-        bool isSplitted = { false };
-        unsigned clipVertexBufferOffset { 0 };
-    };
+    const Vector<FloatPoint> m_vertices;
+    unsigned m_bufferID;
+    unsigned m_bufferOffsetInBytes;
 
-    struct TextureMapperLayerNode final {
-        WTF_MAKE_STRUCT_FAST_ALLOCATED;
-
-        explicit TextureMapperLayerNode(TextureMapperLayerPolygon&& polygon)
-        {
-            polygons.append(WTFMove(polygon));
-        }
-
-        const TextureMapperLayerPolygon& firstPolygon() const  { return polygons[0]; }
-
-        Vector<TextureMapperLayerPolygon> polygons;
-        std::unique_ptr<TextureMapperLayerNode> frontNode;
-        std::unique_ptr<TextureMapperLayerNode> backNode;
-    };
-
-    void buildTree(TextureMapperLayerNode&, Deque<TextureMapperLayerPolygon>&);
-    void traverseTree(TextureMapperLayerNode&, const std::function<void(TextureMapperLayerNode&)>&);
-    static PolygonPosition classifyPolygon(const TextureMapperLayerPolygon&, const FloatPlane3D&);
+    FloatRect m_bounds;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.h
@@ -28,6 +28,7 @@
 #include "IntRect.h"
 #include "IntSize.h"
 #include "TextureMapperGLHeaders.h"
+#include "TextureMapperGPUBuffer.h"
 #include "TransformationMatrix.h"
 #include <array>
 #include <wtf/OptionSet.h>
@@ -39,10 +40,11 @@
 
 namespace WebCore {
 
+class ClipPath;
 class TextureMapperGLData;
+class TextureMapperGPUBuffer;
 class TextureMapperShaderProgram;
 class FilterOperations;
-class FloatPolygon;
 class FloatRoundedRect;
 enum class TextureMapperFlags : uint16_t;
 
@@ -78,7 +80,7 @@ public:
     void bindSurface(BitmapTexture* surface);
     BitmapTexture* currentSurface();
     void beginClip(const TransformationMatrix&, const FloatRoundedRect&);
-    void beginClip(const TransformationMatrix&, const FloatPolygon&);
+    void beginClip(const TransformationMatrix&, const ClipPath&);
     WEBCORE_EXPORT void beginPainting(FlipY = FlipY::No, BitmapTexture* = nullptr);
     WEBCORE_EXPORT void endPainting();
     void endClip();
@@ -97,6 +99,8 @@ public:
 #if USE(GRAPHICS_LAYER_WC)
     WEBCORE_EXPORT void releaseUnusedTexturesNow();
 #endif
+
+    Ref<TextureMapperGPUBuffer> acquireBufferFromPool(size_t, TextureMapperGPUBuffer::Type);
 
 private:
     bool isInMaskMode() const { return m_isMaskMode; }

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperGPUBuffer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperGPUBuffer.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2024 Jani Hautakangas <jani@kodegood.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TextureMapperGPUBuffer.h"
+
+namespace WebCore {
+
+TextureMapperGPUBuffer::TextureMapperGPUBuffer(size_t size, Type type, Usage usage)
+    : m_size(size)
+    , m_target((type == Type::Vertex) ? GL_ARRAY_BUFFER : GL_ELEMENT_ARRAY_BUFFER)
+    , m_usage((usage == Usage::Dynamic) ? GL_DYNAMIC_DRAW : GL_STATIC_DRAW)
+{
+    if (!size)
+        return;
+
+    glGenBuffers(1, &m_id);
+    if (m_id) {
+        glBindBuffer(m_target, m_id);
+        glBufferData(m_target, m_size, nullptr, m_usage);
+        if (glGetError() != GL_NO_ERROR) {
+            glDeleteBuffers(1, &m_id);
+            m_id = 0;
+        }
+    }
+}
+
+TextureMapperGPUBuffer::~TextureMapperGPUBuffer()
+{
+    if (m_id) {
+        glDeleteBuffers(1, &m_id);
+        m_id = 0;
+    }
+}
+
+bool TextureMapperGPUBuffer::updateData(const void* data, size_t offset, size_t size)
+{
+    if (m_id) {
+        glBindBuffer(m_target, m_id);
+        glBufferData(m_target, m_size, nullptr, m_usage); // Invalidate. No need to preserve previous content
+        if (glGetError() != GL_NO_ERROR)
+            return false;
+        glBufferSubData(m_target, offset, size, data);
+        return true;
+    }
+    return false;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperGPUBuffer.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperGPUBuffer.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2024 Jani Hautakangas <jani@kodegood.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "TextureMapperGLHeaders.h"
+#include <wtf/Ref.h>
+#include <wtf/ThreadSafeRefCounted.h>
+
+namespace WebCore {
+
+class TextureMapperGPUBuffer final : public ThreadSafeRefCounted<TextureMapperGPUBuffer> {
+    WTF_MAKE_NONCOPYABLE(TextureMapperGPUBuffer);
+public:
+    enum class Type : uint8_t {
+        Vertex,
+        Index
+    };
+
+    enum class Usage : uint8_t {
+        Dynamic,
+        Static
+    };
+
+    static Ref<TextureMapperGPUBuffer> create(size_t size, Type type, Usage usage)
+    {
+        return adoptRef(*new TextureMapperGPUBuffer(size, type, usage));
+    }
+
+    ~TextureMapperGPUBuffer();
+
+    GLuint bufferID() const { return m_id; }
+
+    bool updateData(const void*, size_t, size_t);
+
+private:
+    TextureMapperGPUBuffer(size_t, Type, Usage);
+
+    size_t m_size;
+    GLenum m_target;
+    GLenum m_usage;
+
+    GLuint m_id { 0 };
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
@@ -22,6 +22,7 @@
 #include "TextureMapperLayer.h"
 
 #include "BitmapTexture.h"
+#include "ClipPath.h"
 #include "FloatQuad.h"
 #include "Region.h"
 #include "TextureMapper.h"
@@ -1063,16 +1064,16 @@ void TextureMapperLayer::paintWith3DRenderingContext(TextureMapperPaintOptions& 
     collect3DRenderingContextLayers(layers);
 
     TextureMapperLayer3DRenderingContext context;
-    context.paint(layers, [&](TextureMapperLayer* layer, const FloatPolygon& clipArea) {
-        if (!clipArea.isEmpty())
-            options.textureMapper.beginClip(layer->toSurfaceTransform(), clipArea);
+    context.paint(options.textureMapper, layers, [&](TextureMapperLayer* layer, const ClipPath& clipPath) {
+        if (!clipPath.isEmpty())
+            options.textureMapper.beginClip(layer->toSurfaceTransform(), clipPath);
 
         if (layer->preserves3D())
             layer->paintSelf(options);
         else
             layer->paintRecursive(options);
 
-        if (!clipArea.isEmpty())
+        if (!clipPath.isEmpty())
             options.textureMapper.endClip();
     });
 }


### PR DESCRIPTION
#### 3440db247780d0361df3c48b07059f57ca86e92b
<pre>
[TextureMapper] Polygon clipping performance is extremely slow
<a href="https://bugs.webkit.org/show_bug.cgi?id=284027">https://bugs.webkit.org/show_bug.cgi?id=284027</a>

Reviewed by Fujii Hironori.

Rendering complex preserve-3D scenes might involve a lot of layer splitting.
These splits are handled using polygon clipping, but the current implementation
is inefficient. Each clip operation clears the full stencil buffer and masks
the clipped part using separate vertex buffer objects that are allocated on
demand. This places significant stress on the GPU and on hardware like rpi3 it
completely chokes the rendering pipeline.

To address this issue, polygon clip vertices for preserve-3d scenes should be
loaded to the GPU only once, leveraging cached VBOs. Additionally, stencil
buffer clearing should be optimized using scissors to restrict stencil clears to
relevant areas, avoiding full-buffer operations.

* Source/WebCore/platform/TextureMapper.cmake:
* Source/WebCore/platform/graphics/texmap/ClipPath.cpp: Added.
(WebCore::ClipPath::ClipPath):
(WebCore::ClipPath::data const):
* Source/WebCore/platform/graphics/texmap/ClipPath.h: Added.
* Source/WebCore/platform/graphics/texmap/TextureMapper.cpp:
(WebCore::nextPowerOf2):
(WebCore::TextureMapperGLData::initializeStencil):
(WebCore::TextureMapperGLData::getBufferFromPool):
(WebCore::TextureMapper::beginClip):
(WebCore::TextureMapper::updateProjectionMatrix):
(WebCore::TextureMapper::acquireBufferFromPool):
* Source/WebCore/platform/graphics/texmap/TextureMapper.h:
* Source/WebCore/platform/graphics/texmap/TextureMapperGPUBuffer.cpp: Added.
(WebCore::TextureMapperGPUBuffer::TextureMapperGPUBuffer):
(WebCore::TextureMapperGPUBuffer::~TextureMapperGPUBuffer):
(WebCore::TextureMapperGPUBuffer::updateData):
* Source/WebCore/platform/graphics/texmap/TextureMapperGPUBuffer.h: Added.
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
(WebCore::TextureMapperLayer::paintWith3DRenderingContext):
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer3DRenderingContext.cpp:
(WebCore::TextureMapperLayer3DRenderingContext::paint):
(WebCore::TextureMapperLayer3DRenderingContext::traverseTree):
(WebCore::TextureMapperLayer3DRenderingContext::traverseTreeAndPaint): Deleted.
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer3DRenderingContext.h:

Canonical link: <a href="https://commits.webkit.org/287519@main">https://commits.webkit.org/287519@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8638a340e7c8d4a4077e4faf2e7156fa659131de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79979 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58976 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33377 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84493 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30953 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82087 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68040 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7272 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62514 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20340 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83046 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/52577 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72839 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42823 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49915 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26992 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29415 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71035 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27483 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85925 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7195 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5062 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70786 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7372 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68680 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70030 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14026 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12961 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12368 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7159 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12693 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7006 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10518 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8810 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->