### PR TITLE
facebook.com: sidebar not visible at 100% while creating stories on 11" iPad in portrait mode

### DIFF
--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -45,6 +45,7 @@ class LocalFrame;
 class Node;
 class PlatformMouseEvent;
 class RegistrableDomain;
+class RenderStyle;
 class SecurityOriginData;
 class WeakPtrImplWithEventTargetData;
 
@@ -239,6 +240,8 @@ public:
     bool hideIGNVolumeSlider() const;
 #endif
 
+    bool needsFacebookStoriesCreationFormQuirk(const Element&, const RenderStyle&) const;
+
 private:
     bool needsQuirks() const;
     bool isDomain(const String&) const;
@@ -251,6 +254,7 @@ private:
     bool isAmazon() const;
     bool isCBSSports() const;
     bool isESPN() const;
+    bool isFacebook() const;
     bool isGoogleMaps() const;
     bool isGoogleDocs() const;
     bool isNetflix() const;
@@ -264,6 +268,7 @@ private:
     URL topDocumentURL() const;
 
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
+    mutable WeakPtr<const Element, WeakPtrImplWithEventTargetData> m_facebookStoriesCreationFormContainer;
 
     mutable QuirksData m_quirksData;
 

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -31,6 +31,7 @@ struct WEBCORE_EXPORT QuirksData {
     std::optional<bool> isAmazon;
     std::optional<bool> isCBSSports;
     std::optional<bool> isESPN;
+    std::optional<bool> isFacebook;
     std::optional<bool> isGoogleDocs;
     std::optional<bool> isGoogleMaps;
     std::optional<bool> isNetflix;

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -987,7 +987,9 @@ void Adjuster::adjustForSiteSpecificQuirks(RenderStyle& style) const
         if (is<HTMLBodyElement>(*m_element) && m_element->hasClassName(className))
             style.setUsedTouchActions({ TouchAction::Auto });
     }
-#endif
+    if (m_document->quirks().needsFacebookStoriesCreationFormQuirk(*m_element, style))
+        style.setEffectiveDisplay(DisplayType::Flex);
+#endif // PLATFORM(IOS_FAMILY)
 
 #if ENABLE(VIDEO)
     if (m_document->quirks().needsFullscreenDisplayNoneQuirk()) {


### PR DESCRIPTION
#### 399ba301396f2dd9440d5015c2d097575967f7e2
<pre>
facebook.com: sidebar not visible at 100% while creating stories on 11&quot; iPad in portrait mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=284235">https://bugs.webkit.org/show_bug.cgi?id=284235</a>
<a href="https://rdar.apple.com/98749450">rdar://98749450</a>

Reviewed by Richard Robinson.

On 11-inch iPad in portrait mode, the left sidebar in the Stories creation form is hidden using
`display: none;`, due to a media query targeting `@media (max-width: 899px)`, even though (1)
there&apos;s enough space to fit the sidebar on screen, and (2) the sidebar is fully functional. To fix
this, add a quirk to override the resolved `display: none;` CSS value with `display: flex;` instead
(the expected value at `&gt;= 900` viewport width).

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::isFacebook const):
(WebCore::Quirks::requiresUserGestureToPauseInPictureInPicture const):

Make this use the new `isFacebook()` helper method.

(WebCore::accessibilityRole):
(WebCore::Quirks::shouldIgnoreContentObservationForClick const):
(WebCore::Quirks::needsFacebookStoriesCreationFormQuirk const):

Add a new quirk (see above). The container can be identified using several criteria:

1. The document domain is `facebook.com`, and the path starts with `/stories/create`.
2. The element has `role=navigation`.
3. The element subtree contains a `textarea`.

I&apos;m also caching `m_facebookStoriesCreationFormContainer` here to avoid unnecessary DOM traversal
during style adjustment, once the container has been identified.

* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:

Add cached state to represent whether or not the top domain is `facebook.com`.

* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjustForSiteSpecificQuirks const):

Canonical link: <a href="https://commits.webkit.org/287513@main">https://commits.webkit.org/287513@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/690a1dc7686c984798c42f7d1a39124682c7b6a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79953 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58950 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33353 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84467 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30927 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82061 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68014 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7246 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62488 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20315 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83020 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52549 "Found 1 new test failure: media/audioSession/getUserMedia.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72815 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42798 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49890 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26966 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29389 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71010 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27446 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85899 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7169 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5036 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70759 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7346 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68655 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70004 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17434 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14000 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12937 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7133 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12667 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6980 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10492 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8784 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->