### PR TITLE
Fix HTMLMediaElement "direction of playback" behavior

### DIFF
--- a/LayoutTests/media/media-ended-expected.txt
+++ b/LayoutTests/media/media-ended-expected.txt
@@ -1,14 +1,3 @@
 
-Test ended by:
-
-Play to the end.
-When 'ended' event fires, change the source.
-Verify that 'ended' event fires again on different source.
-EVENT(ended)
-EXPECTED (audio.ended == 'true') OK
-EXPECTED (audio.ended == 'false') OK
-
-EVENT(ended)
-EXPECTED (audio.ended == 'true') OK
-END OF TEST
+PASS Test "ended" event fires again after changing source after "ended" event.
 

--- a/LayoutTests/media/media-ended.html
+++ b/LayoutTests/media/media-ended.html
@@ -1,51 +1,44 @@
 <!DOCTYPE html>
-<html>
-    <head>
-        <script src=media-file.js></script>
-        <script src=video-test.js></script>
+<title>Test "ended" event fires again after changing source after "ended" event.</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<audio autoplay></audio>
+<script>
+async_test(function(t) {
+    var endedCount = 0;
+    var audio = document.querySelector("audio");
 
-        <script>
-            var endedCount = 0;
-            var canplaythroughCount = 0;
-            var audio;
+    audio.onended = t.step_func(function() {
+        switch (++endedCount)
+        {
+            case 1:
+                assert_greater_than(audio.playbackRate, 0);
+                assert_true(audio.ended);
 
-            function start()
-            {
-                audio = document.querySelector("audio");
-                waitForEvent("ended", ended);
+                // Verify ended stays true even if playbackRate == 0
+                // since that is technically still "forward".
+                audio.playbackRate = 0;
+                assert_true(audio.ended);
 
-                audio.src = findMediaFile("audio", "content/silence")
-            }
-
-            function ended()
-            {
-                switch (++endedCount)
-                {
-                    case 1:
-                        testExpected("audio.ended", true);
-
-                        // Change src but don't seek so that internal state isn't reset.
-                        audio.src = findMediaFile("audio", "content/silence")
-                        testExpected("audio.ended", false);
-
-                        consoleWrite("");
-                        break;
-                    case 2:
-                        testExpected("audio.ended", true);
-                        endTest();
-                        break;
+                try {
+                    audio.playbackRate = -0.1;
+                } catch (exception) {
+                    // "Backward" playback is not supported.
+                    assert_equals(exception.name, "NotSupportedError")
                 }
-            }
-        </script>
-    </head>
-    <body onload="start()">
-        <audio controls autoplay></audio>
-        <p><b>Test ended by:</b>
-        <ol>
-            <li>Play to the end.</li>
-            <li>When 'ended' event fires, change the source.</li>
-            <li>Verify that 'ended' event fires again on different source.</li>
-        </ol>
-        </p>
-    </body>
-</html>
+
+                // Change src but don't seek so that internal state isn't reset.
+                audio.src = "content/silence.mp3";
+                assert_false(audio.ended);
+
+                break;
+            case 2:
+                assert_true(audio.ended);
+                t.done();
+                break;
+        }
+    });
+
+    audio.src = "content/silence.mp3"
+});
+</script>

--- a/LayoutTests/media/video-seek-to-duration-with-playbackrate-zero-expected.txt
+++ b/LayoutTests/media/video-seek-to-duration-with-playbackrate-zero-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Test behavior when seeking to the duration and the playback rate equals 0.
+

--- a/LayoutTests/media/video-seek-to-duration-with-playbackrate-zero.html
+++ b/LayoutTests/media/video-seek-to-duration-with-playbackrate-zero.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<title>Test behavior when seeking to the duration and the playback rate equals 0.</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<video></video>
+<script>
+async_test(function(t) {
+    var video = document.querySelector("video");
+    video.onloadedmetadata = t.step_func(function() {
+        video.onloadedmetadata = null;
+        video.playbackRate = 0;
+        video.currentTime = video.duration;
+        video.onseeked = t.step_func(function() {
+            assert_equals(video.currentTime, video.duration);
+            video.onseeked = t.step_func(function() {
+                video.onseeked = t.step_func(function() {
+                    // Seek to duration completed. Waiting for a seek to the beginning.
+                    video.onseeked = t.step_func_done(function() {
+                        assert_equals(video.currentTime, 0);
+                    });
+                    video.play();
+                });
+                // Setting loop to true and seeking to duration.
+                video.loop = true;
+                video.currentTime = video.duration;
+            });
+
+            // Seeking to the middle of the video.
+            video.currentTime = video.duration / 2;
+        });
+    });
+    video.src = "content/test.mp4";
+});
+</script>

--- a/LayoutTests/platform/glib/media/video-seek-to-duration-with-playbackrate-zero-expected.txt
+++ b/LayoutTests/platform/glib/media/video-seek-to-duration-with-playbackrate-zero-expected.txt
@@ -1,0 +1,4 @@
+
+
+FAIL Test behavior when seeking to the duration and the playback rate equals 0. assert_equals: expected 0 but got 6.0272
+

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -670,6 +670,9 @@ webkit.org/b/61487 http/tests/media/video-cross-site.html [ Failure ]
 
 webkit.org/b/230708 [ Debug ] media/video-ended-seek-crash.html [ Pass Timeout ]
 
+# fails in `stress` test only but passes otherwise on macOS
+media/video-seek-to-duration-with-playbackrate-zero.html [ Failure Pass ]
+
 # https://bugs.webkit.org/show_bug.cgi?id=236113 mathml/presentation/fenced-mi.html is flakey when run with STIX Two
 mathml/presentation/fenced-mi.html [ Pass ImageOnlyFailure ]
 

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -4241,6 +4241,11 @@ void HTMLMediaElement::setPlaybackRate(double rate)
     }
 }
 
+HTMLMediaElement::DirectionOfPlayback HTMLMediaElement::directionOfPlayback() const
+{
+    return requestedPlaybackRate() >= 0 ? DirectionOfPlayback::Forward : DirectionOfPlayback::Backward;
+}
+
 void HTMLMediaElement::updatePlaybackRate()
 {
     double requestedRate = requestedPlaybackRate();
@@ -4278,7 +4283,7 @@ bool HTMLMediaElement::ended() const
     // 4.8.10.8 Playing the media resource
     // The ended attribute must return true if the media element has ended
     // playback and the direction of playback is forwards, and false otherwise.
-    return endedPlayback() && requestedPlaybackRate() > 0;
+    return endedPlayback() && directionOfPlayback() == DirectionOfPlayback::Forward;
 }
 
 bool HTMLMediaElement::autoplay() const
@@ -4880,7 +4885,7 @@ void HTMLMediaElement::playbackProgressTimerFired()
 {
     ASSERT(m_player);
 
-    if (m_fragmentEndTime.isValid() && currentMediaTime() >= m_fragmentEndTime && requestedPlaybackRate() > 0) {
+    if (m_fragmentEndTime.isValid() && currentMediaTime() >= m_fragmentEndTime && directionOfPlayback() == DirectionOfPlayback::Forward) {
         m_fragmentEndTime = MediaTime::invalidTime();
         if (!m_mediaController && !m_paused) {
             // changes paused to true and fires a simple event named pause at the media element.
@@ -5824,12 +5829,11 @@ void HTMLMediaElement::mediaPlayerTimeChanged()
 
     MediaTime now = currentMediaTime();
     MediaTime dur = durationMediaTime();
-    double playbackRate = requestedPlaybackRate();
 
     // When the current playback position reaches the end of the media resource then the user agent must follow these steps:
     if ((dur || (!dur && !now)) && dur.isValid() && !dur.isPositiveInfinite() && !dur.isNegativeInfinite()) {
         // If the media element has a loop attribute specified and does not have a current media controller,
-        if (loop() && !m_mediaController && playbackRate > 0) {
+        if (loop() && !m_mediaController && directionOfPlayback() == DirectionOfPlayback::Forward) {
             m_sentEndEvent = false;
             // then seek to the earliest possible position of the media resource and abort these steps when the direction of
             // playback is forwards,
@@ -5837,7 +5841,7 @@ void HTMLMediaElement::mediaPlayerTimeChanged()
                 ALWAYS_LOG(LOGIDENTIFIER, "current time (", now, ") is greater then duration (", dur, "), looping");
                 seekInternal(MediaTime::zeroTime());
             }
-        } else if ((now <= MediaTime::zeroTime() && playbackRate < 0) || (now >= dur && playbackRate > 0)) {
+        } else if ((now <= MediaTime::zeroTime() && directionOfPlayback() == DirectionOfPlayback::Backward) || (now >= dur && directionOfPlayback() == DirectionOfPlayback::Forward)) {
 
             ALWAYS_LOG(LOGIDENTIFIER, "current time (", now, ") is greater then duration (", dur, ") or <= 0, pausing");
 
@@ -6313,15 +6317,13 @@ bool HTMLMediaElement::endedPlayback() const
     // of playback is forwards, Either the media element does not have a loop attribute specified,
     // or the media element has a current media controller.
     MediaTime now = currentMediaTime();
-    if (requestedPlaybackRate() > 0)
+    if (directionOfPlayback() == DirectionOfPlayback::Forward)
         return dur > MediaTime::zeroTime() && now >= dur && (!loop() || m_mediaController);
 
     // or the current playback position is the earliest possible position and the direction
     // of playback is backwards
-    if (requestedPlaybackRate() < 0)
-        return now <= MediaTime::zeroTime();
-
-    return false;
+    ASSERT(directionOfPlayback() == DirectionOfPlayback::Backward);
+    return now <= MediaTime::zeroTime();
 }
 
 bool HTMLMediaElement::stoppedDueToErrors() const

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2007-2023 Apple Inc. All rights reserved.
- * Copyright (C) 2015 Google Inc. All rights reserved.
+ * Copyright (C) 2007-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2015 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -310,6 +310,10 @@ public:
     bool isAutoplaying() const { return m_autoplaying; }
     bool loop() const;
     void setLoop(bool b);
+
+    // Returns the "direction of playback" value as specified in the HTML5 spec.
+    enum class DirectionOfPlayback : uint8_t { Backward, Forward };
+    DirectionOfPlayback directionOfPlayback() const;
 
     void play(DOMPromiseDeferred<void>&&);
 


### PR DESCRIPTION
#### 69f3c86691277ae5e874119d711dcfafe565eff3
<pre>
Fix HTMLMediaElement &quot;direction of playback&quot; behavior
<a href="https://bugs.webkit.org/show_bug.cgi?id=284237">https://bugs.webkit.org/show_bug.cgi?id=284237</a>
<a href="https://rdar.apple.com/problem/141107660">rdar://problem/141107660</a>

Reviewed by NOBODY (OOPS!).

This change cleans up the code a little to make it easier to see that
the &quot;direction of playback&quot; is being used and corrects the definition of
&quot;forward&quot; to include playbackRate == 0.

Web Specification: <a href="https://html.spec.whatwg.org/multipage/media.html#direction-of-playback">https://html.spec.whatwg.org/multipage/media.html#direction-of-playback</a>

&quot;If the element&apos;s playbackRate is positive or zero, then the direction of playback is forwards.
Otherwise, it is backwards.&quot;

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::directionOfPlayback const):
(WebCore::HTMLMediaElement::ended const):
(WebCore::HTMLMediaElement::playbackProgressTimerFired):
(WebCore::HTMLMediaElement::mediaPlayerTimeChanged):
(WebCore::HTMLMediaElement::endedPlayback const):
* Source/WebCore/html/HTMLMediaElement.h:
* LayoutTests/media/media-ended.html:
* LayoutTests/media/media-ended-expected.txt:
* LayoutTests/media/video-seek-to-duration-with-playbackrate-zero.html:
* LayoutTests/media/video-seek-to-duration-with-playbackrate-zero-expected.txt:
* LayoutTests/platform/glib/media/video-seek-to-duration-with-playbackrate-zero-expected.txt: Add Platform Specific Expectation
* LayoutTests/platform/mac/TestExpectations: Ditto
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69f3c86691277ae5e874119d711dcfafe565eff3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79994 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58991 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33392 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84508 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30968 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82102 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68055 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7287 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62529 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20353 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83061 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52590 "Found 2 new test failures: media/audioSession/getUserMedia.html media/media-source/media-source-vp8-webm-error.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72850 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42838 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49927 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27003 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29430 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71047 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27494 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85940 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7210 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5073 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70799 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7387 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68691 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70043 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14038 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12972 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7173 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12708 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7019 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10533 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8824 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->