### PR TITLE
Remove prefixed `webkitImageSmoothingEnabled`

### DIFF
--- a/LayoutTests/fast/canvas/canvas-imageSmoothingEnabled-expected.txt
+++ b/LayoutTests/fast/canvas/canvas-imageSmoothingEnabled-expected.txt
@@ -26,15 +26,6 @@ Test that restoring actually changes smoothing and not just the attribute value.
 PASS left_of_center_pixel.data[0] is 0
 PASS left_of_center_pixel.data[1] is 0
 PASS left_of_center_pixel.data[2] is 0
-Test that the prefixed attribute mirrors the unprefixed attribute.
-PASS ctx.imageSmoothingEnabled is false
-PASS ctx.webkitImageSmoothingEnabled is false
-PASS ctx.imageSmoothingEnabled is true
-PASS ctx.webkitImageSmoothingEnabled is true
-PASS ctx.imageSmoothingEnabled is false
-PASS ctx.webkitImageSmoothingEnabled is false
-PASS ctx.imageSmoothingEnabled is true
-PASS ctx.webkitImageSmoothingEnabled is true
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/canvas/canvas-imageSmoothingEnabled.html
+++ b/LayoutTests/fast/canvas/canvas-imageSmoothingEnabled.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <script src="../../resources/js-test-pre.js"></script>
+  <script src="../../resources/js-test.js"></script>
 </head>
 <body>
   <script>
@@ -82,21 +82,6 @@
   shouldBe("left_of_center_pixel.data[0]", "0");
   shouldBe("left_of_center_pixel.data[1]", "0");
   shouldBe("left_of_center_pixel.data[2]", "0");
-  
-  debug("Test that the prefixed attribute mirrors the unprefixed attribute.");
-  ctx.imageSmoothingEnabled = false;
-  shouldBe("ctx.imageSmoothingEnabled", "false");
-  shouldBe("ctx.webkitImageSmoothingEnabled", "false");
-  ctx.imageSmoothingEnabled = true;
-  shouldBe("ctx.imageSmoothingEnabled", "true");
-  shouldBe("ctx.webkitImageSmoothingEnabled", "true");
-  ctx.webkitImageSmoothingEnabled = false;
-  shouldBe("ctx.imageSmoothingEnabled", "false");
-  shouldBe("ctx.webkitImageSmoothingEnabled", "false");
-  ctx.webkitImageSmoothingEnabled = true;
-  shouldBe("ctx.imageSmoothingEnabled", "true");
-  shouldBe("ctx.webkitImageSmoothingEnabled", "true");
   </script>
-  <script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/inspector/canvas/recording-2d-full-expected.txt
+++ b/LayoutTests/inspector/canvas/recording-2d-full-expected.txt
@@ -962,16 +962,6 @@ frames:
         1: (anonymous function)
         2: executeFrameFunction
   70: (duration)
-    0: webkitImageSmoothingEnabled
-      trace:
-        0: (anonymous function)
-        1: executeFrameFunction
-    1: webkitImageSmoothingEnabled = true
-      swizzleTypes: [Boolean]
-      trace:
-        0: (anonymous function)
-        1: executeFrameFunction
-  71: (duration)
     0: webkitLineDash
       trace:
         0: (anonymous function)
@@ -981,7 +971,7 @@ frames:
       trace:
         0: (anonymous function)
         1: executeFrameFunction
-  72: (duration)
+  71: (duration)
     0: webkitLineDashOffset
       trace:
         0: (anonymous function)
@@ -991,7 +981,7 @@ frames:
       trace:
         0: (anonymous function)
         1: executeFrameFunction
-  73: (duration)
+  72: (duration)
     0: width
       trace:
         0: (anonymous function)
@@ -1001,7 +991,7 @@ frames:
       trace:
         0: (anonymous function)
         1: executeFrameFunction
-  74: (duration)
+  73: (duration)
     0: height
       trace:
         0: (anonymous function)
@@ -1011,7 +1001,7 @@ frames:
       trace:
         0: (anonymous function)
         1: executeFrameFunction
-  75: (duration)
+  74: (duration)
     0: roundRect(0, 0, 50, 50, 42)
       swizzleTypes: [Number, Number, Number, Number, Number]
       trace:

--- a/LayoutTests/inspector/canvas/recording-html-2d-expected.txt
+++ b/LayoutTests/inspector/canvas/recording-html-2d-expected.txt
@@ -56,7 +56,7 @@ let frames = [
         context.textAlign = "start";
         context.textBaseline = "alphabetic";
         context.transform(1, 0, 0, 1, 0, 0);
-        context.webkitImageSmoothingEnabled = true;
+        context.webkitImageSmoothingEnabled = undefined;
         context.webkitLineDash = [];
         context.webkitLineDashOffset = 0;
         if ("setPath" in context)
@@ -84,7 +84,7 @@ let frames = [
         context.textAlign = "start";
         context.textBaseline = "alphabetic";
         context.transform(1, 0, 0, 1, 0, 0);
-        context.webkitImageSmoothingEnabled = true;
+        context.webkitImageSmoothingEnabled = undefined;
         context.webkitLineDash = [];
         context.webkitLineDashOffset = 0;
         if ("setPath" in context)
@@ -112,7 +112,7 @@ let frames = [
         context.textAlign = "start";
         context.textBaseline = "alphabetic";
         context.transform(1, 0, 0, 1, 0, 0);
-        context.webkitImageSmoothingEnabled = true;
+        context.webkitImageSmoothingEnabled = undefined;
         context.webkitLineDash = [];
         context.webkitLineDashOffset = 0;
         if ("setPath" in context)

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.idl
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -57,9 +57,6 @@ enum RenderingMode {
     undefined setFillColor(DOMString color, optional unrestricted float alpha);
     undefined setFillColor(unrestricted float grayLevel, optional unrestricted float alpha = 1);
     undefined setFillColor(unrestricted float r, unrestricted float g, unrestricted float b, unrestricted float a);
-
-    // Non-standard legacy alias (CanvasImageSmoothing).
-    [ImplementedAs=imageSmoothingEnabled] attribute boolean webkitImageSmoothingEnabled;
 
     // Non-standard legacy aliases (CanvasPathDrawingStyles).
     undefined setLineWidth(optional unrestricted float width = NaN);


### PR DESCRIPTION
#### 92f4d0454bbc0f1ef14374e5b3ccb1e3a13cf721
<pre>
Remove prefixed `webkitImageSmoothingEnabled`

<a href="https://bugs.webkit.org/show_bug.cgi?id=284252">https://bugs.webkit.org/show_bug.cgi?id=284252</a>
<a href="https://rdar.apple.com/141128458">rdar://141128458</a>

Reviewed by Tim Nguyen.

This patch is to align WebKit with Gecko / Firefox and Blink / Chromium.

We have our current implementation based on unprefixed while marked as
alias for prefixed version, this patch aims to get rid of prefixed version
`webkitImageSmoothingEnabled`.

Blink removed the prefixed version as well in 2016 in below commit:

Commit: <a href="https://chromium.googlesource.com/chromium/src.git/+/4aea48e6e30f02eb912a2aa5c66103243db62d2f">https://chromium.googlesource.com/chromium/src.git/+/4aea48e6e30f02eb912a2aa5c66103243db62d2f</a>

From MDN data, Safari / WebKit has supported unprefixed one since Safari 9.1,
so this is about time to try to get rid of prefixed one.

* Source/WebCore/html/canvas/CanvasRenderingContext2D.idl:

Updated / Rebaselined:
* LayoutTests/fast/canvas/canvas-imageSmoothingEnabled-expected.txt:
* LayoutTests/fast/canvas/canvas-imageSmoothingEnabled.html:
* LayoutTests/inspector/canvas/recording-2d-full-expected.txt:
* LayoutTests/inspector/canvas/recording-html-2d-expected.txt:

Canonical link: <a href="https://commits.webkit.org/287552@main">https://commits.webkit.org/287552@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54ef748ebeb0b01ded3047b3aabe51eb2b734cb3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80001 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58998 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33399 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84515 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30975 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82109 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68062 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7294 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62533 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20358 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83068 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52596 "Found 1 new test failure: media/audioSession/getUserMedia.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72857 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42842 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49933 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27010 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29437 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71053 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27502 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85949 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7217 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5081 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70808 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7394 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68698 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70058 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17452 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14044 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12979 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7180 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12715 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7026 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10540 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8831 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->