### PR TITLE
Shrink SetInlineStroke IPC message.

### DIFF
--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
@@ -111,18 +111,14 @@ void SetInlineFillColor::dump(TextStream& ts, OptionSet<AsTextFlag>) const
 
 void SetInlineStroke::apply(GraphicsContext& context) const
 {
-    if (auto color = this->color())
-        context.setStrokeColor(*color);
-    if (auto thickness = this->thickness())
-        context.setStrokeThickness(*thickness);
+    context.setStrokeColor(color());
+    context.setStrokeThickness(thickness());
 }
 
 void SetInlineStroke::dump(TextStream& ts, OptionSet<AsTextFlag>) const
 {
-    if (auto color = this->color())
-        ts.dumpProperty("color", *color);
-    if (auto thickness = this->thickness())
-        ts.dumpProperty("thickness", *thickness);
+    ts.dumpProperty("color", color());
+    ts.dumpProperty("thickness", thickness());
 }
 
 SetState::SetState(const GraphicsContextState& state)

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
@@ -190,33 +190,21 @@ class SetInlineStroke {
 public:
     static constexpr char name[] = "set-inline-stroke";
 
-    SetInlineStroke(std::optional<PackedColor::RGBA> colorData, std::optional<float> thickness = std::nullopt)
+    SetInlineStroke(PackedColor::RGBA colorData, float thickness)
         : m_colorData(colorData)
         , m_thickness(thickness)
-    {
-        ASSERT(m_colorData || m_thickness);
-    }
+    { }
 
-    SetInlineStroke(float thickness)
-        : m_thickness(thickness)
-    {
-    }
-
-    SetInlineStroke(SRGBA<uint8_t> colorData)
-        : m_colorData(PackedColor::RGBA(colorData))
-    {
-    }
-
-    std::optional<Color> color() const { return m_colorData ? std::optional<Color>(asSRGBA(*m_colorData)) : std::nullopt; }
-    std::optional<PackedColor::RGBA> colorData() const { return m_colorData; }
-    std::optional<float> thickness() const { return m_thickness; }
+    Color color() const { return asSRGBA(m_colorData); }
+    PackedColor::RGBA colorData() const { return m_colorData; }
+    float thickness() const { return m_thickness; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
 
 private:
-    std::optional<PackedColor::RGBA> m_colorData;
-    std::optional<float> m_thickness;
+    PackedColor::RGBA m_colorData;
+    float m_thickness;
 };
 
 class SetState {

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -122,16 +122,10 @@ void Recorder::appendStateChangeItemIfNecessary()
 
 SetInlineStroke Recorder::buildSetInlineStroke(const GraphicsContextState& state)
 {
-    ASSERT(state.containsOnlyInlineChanges());
+    ASSERT_UNUSED(state, state.containsOnlyInlineChanges());
     ASSERT(state.changes().containsAny({ GraphicsContextState::Change::StrokeBrush, GraphicsContextState::Change::StrokeThickness }));
 
-    if (!state.changes().contains(GraphicsContextState::Change::StrokeBrush))
-        return SetInlineStroke(strokeThickness());
-
     ASSERT(strokeColor().tryGetAsPackedInline());
-    if (!state.changes().contains(GraphicsContextState::Change::StrokeThickness))
-        return SetInlineStroke(*strokeColor().tryGetAsPackedInline());
-
     return SetInlineStroke(*strokeColor().tryGetAsPackedInline(), strokeThickness());
 }
 

--- a/Source/WebKit/Shared/DisplayListArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/DisplayListArgumentCoders.serialization.in
@@ -59,8 +59,8 @@ headers: <WebCore/DisplayListItems.h>
 }
 
 [CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::SetInlineStroke {
-    std::optional<WebCore::PackedColor::RGBA> colorData();
-    std::optional<float> thickness();
+    WebCore::PackedColor::RGBA colorData();
+    float thickness();
 };
 
 [CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::SetLineCap {

--- a/Tools/TestWebKitAPI/Tests/WebCore/DisplayListTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/DisplayListTests.cpp
@@ -72,7 +72,7 @@ TEST(DisplayListTests, AppendItems)
     auto path = createComplexPath();
 
     for (int i = 0; i < 50; ++i) {
-        list.append(SetInlineStroke(1.5));
+        list.append(SetInlineStroke(PackedColor::RGBA { Color::white }, 1.5));
         list.append(FillPath(path));
         list.append(FillRectWithGradient(FloatRect { 1., 1., 10., 10. }, gradient));
         list.append(SetInlineFillColor(Color::red));

--- a/Tools/TestWebKitAPI/Tests/WebCore/cg/DisplayListTestsCG.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cg/DisplayListTestsCG.cpp
@@ -61,7 +61,7 @@ TEST(DisplayListTests, ReplayWithMissingResource)
     list.append(SetInlineFillColor(Color::green));
     list.append(FillRect(contextBounds, GraphicsContext::RequiresClipToRect::Yes));
     list.append(DrawImageBuffer(imageBufferIdentifier, contextBounds, contextBounds, ImagePaintingOptions { }));
-    list.append(SetInlineStroke(Color::red));
+    list.append(SetInlineStroke(PackedColor::RGBA { Color::red }, 1.0));
     list.append(StrokeLine(FloatPoint { 0, contextHeight }, FloatPoint { contextWidth, 0 }));
 
     {


### PR DESCRIPTION
#### e8c7b59d28c06beea5a958837513ce4111f79a92
<pre>
Shrink SetInlineStroke IPC message.
<a href="https://bugs.webkit.org/show_bug.cgi?id=284254">https://bugs.webkit.org/show_bug.cgi?id=284254</a>
&lt;<a href="https://rdar.apple.com/141130014">rdar://141130014</a>&gt;

Reviewed by NOBODY (OOPS!).

This passes two values as optional, which doubles the size of the message (due to
alignment adjustments). It performs better to just pass both values
unconditionally.

* Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp:
(WebCore::DisplayList::SetInlineStroke::apply const):
(WebCore::DisplayList::SetInlineStroke::dump const):
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.h:
(WebCore::DisplayList::SetInlineStroke::SetInlineStroke):
(WebCore::DisplayList::SetInlineStroke::color const):
(WebCore::DisplayList::SetInlineStroke::colorData const):
(WebCore::DisplayList::SetInlineStroke::thickness const):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::buildSetInlineStroke):
* Source/WebKit/Shared/DisplayListArgumentCoders.serialization.in:
* Tools/TestWebKitAPI/Tests/WebCore/DisplayListTests.cpp:
(TestWebKitAPI::TEST(DisplayListTests, AppendItems)):
* Tools/TestWebKitAPI/Tests/WebCore/cg/DisplayListTestsCG.cpp:
(TestWebKitAPI::TEST(DisplayListTests, ReplayWithMissingResource)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8c7b59d28c06beea5a958837513ce4111f79a92

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79997 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58994 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33395 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84511 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30971 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82105 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68058 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7290 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62532 "Found 1 new test failure: css3/color/text.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20355 "Found 1 new test failure: fast/canvas/canvas-line-no-change-display-p3-stroke.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83064 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52594 "Found 2 new test failures: fast/canvas/canvas-line-no-change-display-p3-stroke.html media/audioSession/getUserMedia.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72855 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42841 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49931 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27008 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29433 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71051 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27500 "Found 1 new test failure: fast/canvas/canvas-line-no-change-display-p3-stroke.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85943 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7213 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5078 "Found 1 new test failure: fast/canvas/canvas-line-no-change-display-p3-stroke.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70805 "Found 2 new test failures: css3/color/text.html imported/w3c/web-platform-tests/css/css-view-transitions/old-content-captures-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7390 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68696 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70047 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14042 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12977 "Found 1 new test failure: fast/canvas/canvas-line-no-change-display-p3-stroke.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7176 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12711 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7022 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10536 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8827 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->