### PR TITLE
Cleanup visitorAdditionalChildren methods in Observables code

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1043,7 +1043,6 @@ dom/ImageOverlay.cpp
 dom/InlineStyleSheetOwner.cpp
 dom/InternalObserverDrop.cpp
 dom/InternalObserverFilter.cpp
-dom/InternalObserverFromScript.cpp
 dom/InternalObserverMap.cpp
 dom/InternalObserverTake.cpp
 dom/KeyboardEvent.cpp

--- a/Source/WebCore/dom/InternalObserver.h
+++ b/Source/WebCore/dom/InternalObserver.h
@@ -31,7 +31,6 @@
 namespace JSC {
 class AbstractSlotVisitor;
 class JSValue;
-class SlotVisitor;
 } // namespace JSC
 
 namespace WebCore {
@@ -52,7 +51,6 @@ public:
     virtual void error(JSC::JSValue);
 
     virtual void visitAdditionalChildren(JSC::AbstractSlotVisitor&) const = 0;
-    virtual void visitAdditionalChildren(JSC::SlotVisitor&) const = 0;
 
 protected:
     bool m_active { true };

--- a/Source/WebCore/dom/InternalObserverDrop.cpp
+++ b/Source/WebCore/dom/InternalObserverDrop.cpp
@@ -90,7 +90,7 @@ private:
     void next(JSC::JSValue value) final
     {
         if (!m_amount) {
-            m_subscriber->next(value);
+            protectedSubscriber()->next(value);
             return;
         }
 
@@ -99,24 +99,21 @@ private:
 
     void error(JSC::JSValue value) final
     {
-        m_subscriber->error(value);
+        protectedSubscriber()->error(value);
     }
 
     void complete() final
     {
         InternalObserver::complete();
-        m_subscriber->complete();
+        protectedSubscriber()->complete();
     }
 
     void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
     {
-        m_subscriber->visitAdditionalChildren(visitor);
+        protectedSubscriber()->visitAdditionalChildren(visitor);
     }
 
-    void visitAdditionalChildren(JSC::SlotVisitor& visitor) const final
-    {
-        m_subscriber->visitAdditionalChildren(visitor);
-    }
+    Ref<Subscriber> protectedSubscriber() const { return m_subscriber; }
 
     InternalObserverDrop(ScriptExecutionContext& context, Ref<Subscriber> subscriber, uint64_t amount)
         : InternalObserver(context)

--- a/Source/WebCore/dom/InternalObserverEvery.cpp
+++ b/Source/WebCore/dom/InternalObserverEvery.cpp
@@ -102,11 +102,6 @@ private:
         protectedCallback()->visitJSFunction(visitor);
     }
 
-    void visitAdditionalChildren(JSC::SlotVisitor& visitor) const final
-    {
-        protectedCallback()->visitJSFunction(visitor);
-    }
-
     Ref<AbortSignal> protectedSignal() const { return m_signal; }
     Ref<DeferredPromise> protectedPromise() const { return m_promise; }
     Ref<PredicateCallback> protectedCallback() const { return m_callback; }

--- a/Source/WebCore/dom/InternalObserverFind.cpp
+++ b/Source/WebCore/dom/InternalObserverFind.cpp
@@ -103,11 +103,6 @@ private:
         protectedCallback()->visitJSFunction(visitor);
     }
 
-    void visitAdditionalChildren(JSC::SlotVisitor& visitor) const final
-    {
-        protectedCallback()->visitJSFunction(visitor);
-    }
-
     Ref<DeferredPromise> protectedPromise() const { return m_promise; }
     Ref<PredicateCallback> protectedCallback() const { return m_callback; }
     Ref<AbortSignal> protectedSignal() const { return m_signal; }

--- a/Source/WebCore/dom/InternalObserverFirst.cpp
+++ b/Source/WebCore/dom/InternalObserverFirst.cpp
@@ -71,10 +71,6 @@ private:
     {
     }
 
-    void visitAdditionalChildren(JSC::SlotVisitor&) const final
-    {
-    }
-
     Ref<DeferredPromise> protectedPromise() const { return m_promise; }
 
     InternalObserverFirst(ScriptExecutionContext& context, Ref<AbortSignal>&& signal, Ref<DeferredPromise>&& promise)

--- a/Source/WebCore/dom/InternalObserverForEach.cpp
+++ b/Source/WebCore/dom/InternalObserverForEach.cpp
@@ -91,11 +91,6 @@ private:
         protectedCallback()->visitJSFunction(visitor);
     }
 
-    void visitAdditionalChildren(JSC::SlotVisitor& visitor) const final
-    {
-        protectedCallback()->visitJSFunction(visitor);
-    }
-
     Ref<DeferredPromise> protectedPromise() const { return m_promise; }
     Ref<VisitorCallback> protectedCallback() const { return m_callback; }
 

--- a/Source/WebCore/dom/InternalObserverFromScript.cpp
+++ b/Source/WebCore/dom/InternalObserverFromScript.cpp
@@ -48,50 +48,38 @@ Ref<InternalObserverFromScript> InternalObserverFromScript::create(ScriptExecuti
 
 void InternalObserverFromScript::next(JSC::JSValue value)
 {
-    if (m_next)
-        m_next->handleEvent(value);
+    if (RefPtr next = m_next)
+        next->handleEvent(value);
 }
 
-void InternalObserverFromScript::error(JSC::JSValue error)
+void InternalObserverFromScript::error(JSC::JSValue value)
 {
-    if (m_error) {
-        m_error->handleEvent(error);
+    if (RefPtr error = m_error) {
+        error->handleEvent(value);
         return;
     }
 
-    InternalObserver::error(error);
+    InternalObserver::error(value);
 }
 
 void InternalObserverFromScript::complete()
 {
-    if (m_complete)
-        m_complete->handleEvent();
+    if (RefPtr complete = m_complete)
+        complete->handleEvent();
 
     m_active = false;
 }
 
 void InternalObserverFromScript::visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const
 {
-    if (m_next)
-        m_next->visitJSFunction(visitor);
+    if (RefPtr next = m_next)
+        next->visitJSFunction(visitor);
 
-    if (m_error)
-        m_error->visitJSFunction(visitor);
+    if (RefPtr error = m_error)
+        error->visitJSFunction(visitor);
 
-    if (m_complete)
-        m_complete->visitJSFunction(visitor);
-}
-
-void InternalObserverFromScript::visitAdditionalChildren(JSC::SlotVisitor& visitor) const
-{
-    if (m_next)
-        m_next->visitJSFunction(visitor);
-
-    if (m_error)
-        m_error->visitJSFunction(visitor);
-
-    if (m_complete)
-        m_complete->visitJSFunction(visitor);
+    if (RefPtr complete = m_complete)
+        complete->visitJSFunction(visitor);
 }
 
 InternalObserverFromScript::InternalObserverFromScript(ScriptExecutionContext& context, RefPtr<JSSubscriptionObserverCallback> callback)

--- a/Source/WebCore/dom/InternalObserverFromScript.h
+++ b/Source/WebCore/dom/InternalObserverFromScript.h
@@ -49,7 +49,6 @@ public:
     void complete() final;
 
     void visitAdditionalChildren(JSC::AbstractSlotVisitor&) const final;
-    void visitAdditionalChildren(JSC::SlotVisitor&) const final;
 
 protected:
     // ActiveDOMObject

--- a/Source/WebCore/dom/InternalObserverInspect.cpp
+++ b/Source/WebCore/dom/InternalObserverInspect.cpp
@@ -173,8 +173,7 @@ private:
         protectedSubscriber()->complete();
     }
 
-    template<typename VisitorType>
-    void visitAdditionalChildrenInternal(VisitorType& visitor) const
+    void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
     {
         protectedSubscriber()->visitAdditionalChildren(visitor);
         if (RefPtr next = m_inspector.next)
@@ -187,16 +186,6 @@ private:
             subscribe->visitJSFunction(visitor);
         if (RefPtr abort = m_inspector.abort)
             abort->visitJSFunction(visitor);
-    }
-
-    void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
-    {
-        visitAdditionalChildrenInternal(visitor);
-    }
-
-    void visitAdditionalChildren(JSC::SlotVisitor& visitor) const final
-    {
-        visitAdditionalChildrenInternal(visitor);
     }
 
     void removeAbortHandler()

--- a/Source/WebCore/dom/InternalObserverLast.cpp
+++ b/Source/WebCore/dom/InternalObserverLast.cpp
@@ -77,10 +77,6 @@ private:
     {
     }
 
-    void visitAdditionalChildren(JSC::SlotVisitor&) const final
-    {
-    }
-
     InternalObserverLast(ScriptExecutionContext& context, Ref<DeferredPromise>&& promise)
         : InternalObserver(context)
         , m_promise(WTFMove(promise))

--- a/Source/WebCore/dom/InternalObserverSome.cpp
+++ b/Source/WebCore/dom/InternalObserverSome.cpp
@@ -103,11 +103,6 @@ private:
         protectedCallback()->visitJSFunction(visitor);
     }
 
-    void visitAdditionalChildren(JSC::SlotVisitor& visitor) const final
-    {
-        protectedCallback()->visitJSFunction(visitor);
-    }
-
     Ref<DeferredPromise> protectedPromise() const { return m_promise; }
     Ref<PredicateCallback> protectedCallback() const { return m_callback; }
     Ref<AbortSignal> protectedSignal() const { return m_signal; }

--- a/Source/WebCore/dom/InternalObserverTake.cpp
+++ b/Source/WebCore/dom/InternalObserverTake.cpp
@@ -92,32 +92,29 @@ private:
         if (!m_amount)
             return;
 
-        m_subscriber->next(value);
+        protectedSubscriber()->next(value);
         m_amount -= 1;
         if (!m_amount)
-            m_subscriber->complete();
+            protectedSubscriber()->complete();
     }
 
     void error(JSC::JSValue value) final
     {
-        m_subscriber->error(value);
+        protectedSubscriber()->error(value);
     }
 
     void complete() final
     {
         InternalObserver::complete();
-        m_subscriber->complete();
+        protectedSubscriber()->complete();
     }
 
     void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
     {
-        m_subscriber->visitAdditionalChildren(visitor);
+        protectedSubscriber()->visitAdditionalChildren(visitor);
     }
 
-    void visitAdditionalChildren(JSC::SlotVisitor& visitor) const final
-    {
-        m_subscriber->visitAdditionalChildren(visitor);
-    }
+    Ref<Subscriber> protectedSubscriber() const { return m_subscriber; }
 
     InternalObserverTake(ScriptExecutionContext& context, Ref<Subscriber> subscriber, uint64_t amount)
         : InternalObserver(context)

--- a/Source/WebCore/dom/Observable.idl
+++ b/Source/WebCore/dom/Observable.idl
@@ -35,14 +35,12 @@ interface Observable {
 
   [CallWith=CurrentScriptExecutionContext, RaisesException] undefined subscribe(optional ObserverUnion observer = {}, optional SubscribeOptions options = {});
 
+  // Observable-returning operators.
+
   [CallWith=CurrentScriptExecutionContext] Observable map(MapperCallback mapper);
-
   [CallWith=CurrentScriptExecutionContext] Observable filter(PredicateCallback predicate);
-
   [CallWith=CurrentScriptExecutionContext] Observable take(unsigned long long amount);
-
   [CallWith=CurrentScriptExecutionContext] Observable drop(unsigned long long amount);
-
   [CallWith=CurrentScriptExecutionContext] Observable inspect(optional ObservableInspectorUnion inspectorUnion = {});
 
   // Promise-returning operators.

--- a/Source/WebCore/dom/Subscriber.cpp
+++ b/Source/WebCore/dom/Subscriber.cpp
@@ -172,14 +172,6 @@ void Subscriber::visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor)
     observerConcurrently()->visitAdditionalChildren(visitor);
 }
 
-void Subscriber::visitAdditionalChildren(JSC::SlotVisitor& visitor)
-{
-    for (auto* teardown : teardownCallbacksConcurrently())
-        teardown->visitJSFunction(visitor);
-
-    observerConcurrently()->visitAdditionalChildren(visitor);
-}
-
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(Subscriber);
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Subscriber.h
+++ b/Source/WebCore/dom/Subscriber.h
@@ -62,7 +62,6 @@ public:
     Vector<VoidCallback*> teardownCallbacksConcurrently();
     InternalObserver* observerConcurrently();
     void visitAdditionalChildren(JSC::AbstractSlotVisitor&);
-    void visitAdditionalChildren(JSC::SlotVisitor&);
 
 private:
     explicit Subscriber(ScriptExecutionContext&, Ref<InternalObserver>&&, const SubscribeOptions&);


### PR DESCRIPTION
#### d2eb155406a34a0d0fda399a81d4667205a01271
<pre>
Cleanup visitorAdditionalChildren methods in Observables code
<a href="https://bugs.webkit.org/show_bug.cgi?id=284257">https://bugs.webkit.org/show_bug.cgi?id=284257</a>

Reviewed by Chris Dumez.

AbstractSlotVisitor is a bass class to SlotVisitor, as such
we have no need to house duplicate implementions of the
visitorAdditionalChildren methods that each accept one of those as
arguments; and instead just accept a AbstractSlotVisitor.

We also drive-by cleaned up some mac-safer things, for example created
stack variables for RefPtrs.

* Source/WebCore/dom/InternalObserver.h:
* Source/WebCore/dom/InternalObserverDrop.cpp:
* Source/WebCore/dom/InternalObserverEvery.cpp:
* Source/WebCore/dom/InternalObserverFilter.cpp:
* Source/WebCore/dom/InternalObserverFind.cpp:
* Source/WebCore/dom/InternalObserverFirst.cpp:
* Source/WebCore/dom/InternalObserverForEach.cpp:
* Source/WebCore/dom/InternalObserverFromScript.cpp:
* Source/WebCore/dom/InternalObserverFromScript.h:
* Source/WebCore/dom/InternalObserverInspect.cpp:
* Source/WebCore/dom/InternalObserverLast.cpp:
* Source/WebCore/dom/InternalObserverMap.cpp:
* Source/WebCore/dom/InternalObserverSome.cpp:
* Source/WebCore/dom/InternalObserverTake.cpp:
* Source/WebCore/dom/Observable.idl:
* Source/WebCore/dom/Subscriber.cpp:
* Source/WebCore/dom/Subscriber.h:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/287546@main">https://commits.webkit.org/287546@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d8d135a06b59a6f8d2f48c88d0d02b8c33d3c8b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80033 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59030 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33432 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84546 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31003 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82141 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68094 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7326 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62558 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20382 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83101 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52643 "Found 1 new test failure: media/audioSession/getUserMedia.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72885 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42867 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49961 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27038 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29467 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71081 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27534 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85976 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7248 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5108 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70829 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7425 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68726 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70072 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14071 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13007 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12380 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7212 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12739 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7055 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10572 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8861 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->