### PR TITLE
Stop using WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/editing

### DIFF
--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -65,6 +65,11 @@ inline std::span<const char> span(const char* string)
     return unsafeMakeSpan(string, string ? strlen(string) : 0);
 }
 
+inline std::span<const char> spanIncludingNullTerminator(const char* string)
+{
+    return unsafeMakeSpan(string, string ? strlen(string) + 1 : 0);
+}
+
 inline std::span<const LChar> span(const LChar* string)
 {
     return unsafeMakeSpan(string, string ? strlen(byteCast<char>(string)) : 0);
@@ -1216,6 +1221,7 @@ using WTF::equalLettersIgnoringASCIICase;
 using WTF::equalLettersIgnoringASCIICaseWithLength;
 using WTF::isLatin1;
 using WTF::span;
+using WTF::spanIncludingNullTerminator;
 using WTF::span8;
 using WTF::span8IncludingNullTerminator;
 using WTF::charactersContain;

--- a/Source/WebCore/editing/EditingStyle.cpp
+++ b/Source/WebCore/editing/EditingStyle.cpp
@@ -67,13 +67,11 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 // Editing style properties must be preserved during editing operation.
 // e.g. when a user inserts a new paragraph, all properties listed here must be copied to the new paragraph.
-static constexpr CSSPropertyID editingProperties[] = {
+static constexpr std::array editingProperties {
     CSSPropertyCaretColor,
     CSSPropertyColor,
     CSSPropertyFontFamily,
@@ -115,7 +113,7 @@ static Ref<MutableStyleProperties> copyEditingProperties(StyleDeclarationType* s
 {
     if (type == AllEditingProperties)
         return style->copyProperties(editingProperties);
-    return style->copyProperties({ editingProperties, numInheritableEditingProperties });
+    return style->copyProperties(std::span { editingProperties }.first(numInheritableEditingProperties));
 }
 
 static inline bool isEditingProperty(int id)
@@ -2019,5 +2017,3 @@ RefPtr<CSSValue> backgroundColorInEffect(Node* node)
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -59,8 +59,6 @@
 #include <wtf/URL.h>
 #include <wtf/unicode/CharacterNames.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 using namespace HTMLNames;
@@ -70,16 +68,16 @@ struct EntityDescription {
     std::optional<EntityMask> mask;
 };
 
-constexpr EntityDescription entitySubstitutionList[] = {
-    { ""_s, std::nullopt },
-    { "&amp;"_s, EntityMask::Amp },
-    { "&lt;"_s, EntityMask::Lt },
-    { "&gt;"_s, EntityMask::Gt },
-    { "&quot;"_s, EntityMask::Quot },
-    { "&nbsp;"_s, EntityMask::Nbsp },
-    { "&#9;"_s, EntityMask::Tab },
-    { "&#10;"_s, EntityMask::LineFeed },
-    { "&#13;"_s, EntityMask::CarriageReturn },
+constexpr std::array entitySubstitutionList {
+    EntityDescription { ""_s, std::nullopt },
+    EntityDescription { "&amp;"_s, EntityMask::Amp },
+    EntityDescription { "&lt;"_s, EntityMask::Lt },
+    EntityDescription { "&gt;"_s, EntityMask::Gt },
+    EntityDescription { "&quot;"_s, EntityMask::Quot },
+    EntityDescription { "&nbsp;"_s, EntityMask::Nbsp },
+    EntityDescription { "&#9;"_s, EntityMask::Tab },
+    EntityDescription { "&#10;"_s, EntityMask::LineFeed },
+    EntityDescription { "&#13;"_s, EntityMask::CarriageReturn },
 };
 
 namespace EntitySubstitutionIndex {
@@ -94,8 +92,8 @@ constexpr uint8_t LineFeed = 7;
 constexpr uint8_t CarriageReturn = 8;
 };
 
-static const unsigned maximumEscapedentityCharacter = noBreakSpace;
-static const uint8_t entityMap[maximumEscapedentityCharacter + 1] = {
+static constexpr unsigned maximumEscapedentityCharacter = noBreakSpace;
+static constexpr std::array<uint8_t, maximumEscapedentityCharacter + 1> entityMap {
     0, 0, 0, 0, 0, 0, 0, 0, 0,
     EntitySubstitutionIndex::Tab, // '\t'.
     EntitySubstitutionIndex::LineFeed, // '\n'.
@@ -884,5 +882,3 @@ bool MarkupAccumulator::shouldExcludeElement(const Element& element)
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -68,6 +68,7 @@
 #include "VisibleUnits.h"
 #include <unicode/unorm2.h>
 #include <wtf/Function.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>
@@ -80,8 +81,6 @@
 #include <unicode/usearch.h>
 #include <wtf/text/TextBreakIteratorInternalICU.h>
 #endif
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 
@@ -1999,7 +1998,7 @@ static bool isNonLatin1Separator(char32_t character)
 
 static inline bool isSeparator(char32_t character)
 {
-    static constexpr bool latin1SeparatorTable[256] = {
+    static constexpr std::array<bool, 256> latin1SeparatorTable {
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // space ! " # $ % & ' ( ) * + , - . /
@@ -2107,7 +2106,7 @@ inline size_t SearchBuffer::append(StringView text)
         m_prefixLength = 0;
         m_atBreak = false;
     } else if (m_buffer.size() == m_buffer.capacity()) {
-        memcpy(m_buffer.data(), m_buffer.data() + m_buffer.size() - m_overlap, m_overlap * sizeof(UChar));
+        memcpySpan(m_buffer.mutableSpan(), m_buffer.span().last(m_overlap));
         m_prefixLength -= std::min(m_prefixLength, m_buffer.size() - m_overlap);
         m_buffer.shrink(m_overlap);
     }
@@ -2171,51 +2170,48 @@ inline bool SearchBuffer::isBadMatch(const UChar* match, size_t matchLength) con
     // creating a new one each time.
     normalizeCharacters(match, matchLength, m_normalizedMatch);
 
-    const UChar* a = m_normalizedTarget.begin();
-    const UChar* aEnd = m_normalizedTarget.end();
-
-    const UChar* b = m_normalizedMatch.begin();
-    const UChar* bEnd = m_normalizedMatch.end();
+    auto a = m_normalizedTarget.span();
+    auto b = m_normalizedMatch.span();
 
     while (true) {
         // Skip runs of non-kana-letter characters. This is necessary so we can
         // correctly handle strings where the target and match have different-length
         // runs of characters that match, while still double checking the correctness
         // of matches of kana letters with other kana letters.
-        while (a != aEnd && !isKanaLetter(*a))
-            ++a;
-        while (b != bEnd && !isKanaLetter(*b))
-            ++b;
+        while (!a.empty() && !isKanaLetter(a.front()))
+            a = a.subspan(1);
+        while (!b.empty() && !isKanaLetter(b.front()))
+            b = b.subspan(1);
 
         // If we reached the end of either the target or the match, we should have
         // reached the end of both; both should have the same number of kana letters.
-        if (a == aEnd || b == bEnd) {
-            ASSERT(a == aEnd);
-            ASSERT(b == bEnd);
+        if (a.empty() || b.empty()) {
+            ASSERT(a.empty());
+            ASSERT(b.empty());
             return false;
         }
 
         // Check for differences in the kana letter character itself.
-        if (isSmallKanaLetter(*a) != isSmallKanaLetter(*b))
+        if (isSmallKanaLetter(a.front()) != isSmallKanaLetter(b.front()))
             return true;
-        if (composedVoicedSoundMark(*a) != composedVoicedSoundMark(*b))
+        if (composedVoicedSoundMark(a.front()) != composedVoicedSoundMark(b.front()))
             return true;
-        ++a;
-        ++b;
+        a = a.subspan(1);
+        b = b.subspan(1);
 
         // Check for differences in combining voiced sound marks found after the letter.
         while (1) {
-            if (!(a != aEnd && isCombiningVoicedSoundMark(*a))) {
-                if (b != bEnd && isCombiningVoicedSoundMark(*b))
+            if (!(!a.empty() && isCombiningVoicedSoundMark(a.front()))) {
+                if (!b.empty() && isCombiningVoicedSoundMark(b.front()))
                     return true;
                 break;
             }
-            if (!(b != bEnd && isCombiningVoicedSoundMark(*b)))
+            if (!(!b.empty() && isCombiningVoicedSoundMark(b.front())))
                 return true;
-            if (*a != *b)
+            if (a.front() != b.front())
                 return true;
-            ++a;
-            ++b;
+            a = a.subspan(1);
+            b = b.subspan(1);
         }
     }
 }
@@ -2241,11 +2237,12 @@ inline bool SearchBuffer::isWordStartMatch(size_t start, size_t length) const
     int size = m_buffer.size();
     int offset = start;
     char32_t firstCharacter;
-    U16_GET(m_buffer.data(), 0, offset, size, firstCharacter);
+    auto buffer = m_buffer.span();
+    U16_GET(buffer, 0, offset, size, firstCharacter);
 
     if (m_options.contains(FindOption::TreatMedialCapitalAsWordStart)) {
         char32_t previousCharacter;
-        U16_PREV(m_buffer.data(), 0, offset, previousCharacter);
+        U16_PREV(buffer, 0, offset, previousCharacter);
 
         if (isSeparator(firstCharacter)) {
             // The start of a separator run is a word start (".org" in "webkit.org").
@@ -2258,10 +2255,10 @@ inline bool SearchBuffer::isWordStartMatch(size_t start, size_t length) const
             // The last character of an uppercase run followed by a non-separator, non-digit
             // is a word start ("Request" in "XMLHTTPRequest").
             offset = start;
-            U16_FWD_1(m_buffer.data(), offset, size);
+            U16_FWD_1(buffer, offset, size);
             char32_t nextCharacter = 0;
             if (offset < size)
-                U16_GET(m_buffer.data(), 0, offset, size, nextCharacter);
+                U16_GET(buffer, 0, offset, size, nextCharacter);
             if (!isASCIIUpper(nextCharacter) && !isASCIIDigit(nextCharacter) && !isSeparator(nextCharacter))
                 return true;
         } else if (isASCIIDigit(firstCharacter)) {
@@ -2282,7 +2279,7 @@ inline bool SearchBuffer::isWordStartMatch(size_t start, size_t length) const
 
     size_t wordBreakSearchStart = start + length;
     while (wordBreakSearchStart > start)
-        wordBreakSearchStart = findNextWordFromIndex(m_buffer.span(), wordBreakSearchStart, false /* backwards */);
+        wordBreakSearchStart = findNextWordFromIndex(buffer, wordBreakSearchStart, false /* backwards */);
     return wordBreakSearchStart == start;
 }
 
@@ -2324,11 +2321,11 @@ nextMatch:
             // Ensure that there is sufficient context before matchStart the next time around for
             // determining if it is at a word boundary.
             unsigned wordBoundaryContextStart = matchStart;
-            U16_BACK_1(m_buffer.data(), 0, wordBoundaryContextStart);
+            U16_BACK_1(m_buffer.span(), 0, wordBoundaryContextStart);
             wordBoundaryContextStart = startOfLastWordBoundaryContext(m_buffer.subspan(0, wordBoundaryContextStart));
             overlap = std::min(size - 1, std::max(overlap, size - wordBoundaryContextStart));
         }
-        memcpy(m_buffer.data(), m_buffer.data() + size - overlap, overlap * sizeof(UChar));
+        memcpySpan(m_buffer.mutableSpan(), m_buffer.span().last(overlap));
         m_prefixLength -= std::min(m_prefixLength, size - overlap);
         m_buffer.shrink(overlap);
         return 0;
@@ -2338,7 +2335,7 @@ nextMatch:
     ASSERT_WITH_SECURITY_IMPLICATION(matchStart + matchedLength <= size);
 
     // If this match is "bad", move on to the next match.
-    if (isBadMatch(m_buffer.data() + matchStart, matchedLength)
+    if (isBadMatch(m_buffer.subspan(matchStart).data(), matchedLength)
         || (m_options.contains(FindOption::AtWordStarts) && !isWordStartMatch(matchStart, matchedLength))
         || (m_options.contains(FindOption::AtWordEnds) && !isWordEndMatch(matchStart, matchedLength))) {
         matchStart = usearch_next(searcher, &status);
@@ -2347,7 +2344,7 @@ nextMatch:
     }
 
     size_t newSize = size - (matchStart + 1);
-    memmove(m_buffer.data(), m_buffer.data() + matchStart + 1, newSize * sizeof(UChar));
+    memmoveSpan(m_buffer.mutableSpan(), m_buffer.subspan(matchStart + 1, newSize));
     m_prefixLength -= std::min<size_t>(m_prefixLength, matchStart + 1);
     m_buffer.shrink(newSize);
 
@@ -2714,5 +2711,3 @@ void showTree(const WebCore::TextIterator* pos)
 }
 
 #endif
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/editing/VisibleUnits.cpp
+++ b/Source/WebCore/editing/VisibleUnits.cpp
@@ -48,10 +48,9 @@
 #include "TextIterator.h"
 #include "VisibleSelection.h"
 #include <unicode/ubrk.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/TextBreakIterator.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 
@@ -424,7 +423,7 @@ static void prepend(Vector<UChar, 1024>& buffer, StringView string)
     unsigned oldSize = buffer.size();
     unsigned length = string.length();
     buffer.grow(oldSize + length);
-    memmove(buffer.data() + length, buffer.data(), oldSize * sizeof(UChar));
+    memmoveSpan(buffer.mutableSpan().subspan(length), buffer.span().first(oldSize));
     for (unsigned i = 0; i < length; ++i)
         buffer[i] = string[i];
 }
@@ -433,7 +432,7 @@ static void prependRepeatedCharacter(Vector<UChar, 1024>& buffer, UChar characte
 {
     unsigned oldSize = buffer.size();
     buffer.grow(oldSize + count);
-    memmove(buffer.data() + count, buffer.data(), oldSize * sizeof(UChar));
+    memmoveSpan(buffer.mutableSpan().subspan(count), buffer.span().first(oldSize));
     for (unsigned i = 0; i < count; ++i)
         buffer[i] = character;
 }
@@ -1838,7 +1837,7 @@ std::ptrdiff_t distanceBetweenPositions(const VisiblePosition& a, const VisibleP
 void charactersAroundPosition(const VisiblePosition& position, char32_t& oneAfter, char32_t& oneBefore, char32_t& twoBefore)
 {
     const int maxCharacters = 3;
-    char32_t characters[maxCharacters] = { 0 };
+    std::array<char32_t, maxCharacters> characters = { };
 
     if (position.isNull() || isStartOfDocument(position))
         return;
@@ -1997,5 +1996,3 @@ std::pair<VisiblePosition, WithinWordBoundary> wordBoundaryForPositionWithoutCro
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### 18f16b8c11853ddfe58a85074a51ee2481b43a9f
<pre>
Stop using WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/editing
<a href="https://bugs.webkit.org/show_bug.cgi?id=284272">https://bugs.webkit.org/show_bug.cgi?id=284272</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/text/StringCommon.h:
(WTF::spanIncludingNullTerminator):
* Source/WebCore/editing/EditingStyle.cpp:
(WebCore::copyEditingProperties):
* Source/WebCore/editing/MarkupAccumulator.cpp:
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::isSeparator):
(WebCore::SearchBuffer::append):
(WebCore::SearchBuffer::isBadMatch const):
(WebCore::SearchBuffer::isWordStartMatch const):
(WebCore::SearchBuffer::search):
* Source/WebCore/editing/VisibleUnits.cpp:
(WebCore::prepend):
(WebCore::prependRepeatedCharacter):
(WebCore::charactersAroundPosition):
* Source/WebCore/editing/cocoa/DataDetection.mm:
* Source/WebCore/editing/cocoa/HTMLConverter.mm:
(consume):
(read2DigitNumber):
(_dateForString):

Canonical link: <a href="https://commits.webkit.org/287559@main">https://commits.webkit.org/287559@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b85402608c3a7aeeecfef73ead68f4249604e1d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80073 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59071 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33475 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84602 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31044 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82182 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68135 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7369 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62618 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20432 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83141 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52680 "Found 1 new test failure: media/audioSession/getUserMedia.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72934 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42921 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50011 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27087 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29525 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/73047 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71134 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27598 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86017 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/79130 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7289 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5166 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70888 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7466 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68775 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70121 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14115 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13064 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/101538 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12389 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7253 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12775 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/24753 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/struct-new_default-small-members.js.wasm-eager-jettison (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7095 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10613 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8901 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->