### PR TITLE
[WTF] Remove more COMPILER(MSVC)

### DIFF
--- a/Source/WTF/wtf/Compiler.h
+++ b/Source/WTF/wtf/Compiler.h
@@ -128,7 +128,7 @@
 
 #endif
 
-#if !COMPILER(CLANG) && !COMPILER(MSVC)
+#if !COMPILER(CLANG)
 #define WTF_COMPILER_QUIRK_CONSIDERS_UNREACHABLE_CODE 1
 #endif
 
@@ -601,11 +601,7 @@
 
 /* UNREACHABLE */
 
-#if COMPILER(MSVC)
-#define WTF_UNREACHABLE(...) __assume(0)
-#else
 #define WTF_UNREACHABLE(...) __builtin_unreachable();
-#endif
 
 /* WTF_ALLOW_UNSAFE_BUFFER_USAGE */
 

--- a/Source/WTF/wtf/PlatformCallingConventions.h
+++ b/Source/WTF/wtf/PlatformCallingConventions.h
@@ -39,9 +39,7 @@
 #define SYSV_ABI
 #endif
 
-#if CPU(X86) && COMPILER(MSVC)
-#define JSC_HOST_CALL_ATTRIBUTES __fastcall
-#elif CPU(X86)
+#if CPU(X86)
 #define JSC_HOST_CALL_ATTRIBUTES __attribute__ ((fastcall))
 #else
 #define JSC_HOST_CALL_ATTRIBUTES SYSV_ABI
@@ -66,8 +64,6 @@
 #ifndef CDECL
 #if !OS(WINDOWS)
 #define CDECL
-#elif COMPILER(MSVC)
-#define CDECL __cdecl
 #else
 #define CDECL __attribute__ ((__cdecl))
 #endif
@@ -76,11 +72,7 @@
 #if CPU(X86)
 #define WTF_COMPILER_SUPPORTS_FASTCALL_CALLING_CONVENTION 1
 #ifndef FASTCALL
-#if COMPILER(MSVC)
-#define FASTCALL __fastcall
-#else
 #define FASTCALL  __attribute__ ((fastcall))
-#endif
 #endif
 #else
 #define WTF_COMPILER_SUPPORTS_FASTCALL_CALLING_CONVENTION 0

--- a/Source/WTF/wtf/PlatformEnable.h
+++ b/Source/WTF/wtf/PlatformEnable.h
@@ -941,7 +941,7 @@
    that executes each opcode. It cannot be supported by the CLoop since there's no way to embed the
    OpcodeID word in the CLoop's switch statement cases. It is also currently not implemented for MSVC.
 */
-#if !defined(ENABLE_LLINT_EMBEDDED_OPCODE_ID) && !ENABLE(C_LOOP) && !COMPILER(MSVC) && (CPU(X86) || CPU(X86_64) || CPU(ARM64) || (CPU(ARM_THUMB2) && OS(DARWIN)) || CPU(RISCV64))
+#if !defined(ENABLE_LLINT_EMBEDDED_OPCODE_ID) && !ENABLE(C_LOOP) && (CPU(X86) || CPU(X86_64) || CPU(ARM64) || (CPU(ARM_THUMB2) && OS(DARWIN)) || CPU(RISCV64))
 #define ENABLE_LLINT_EMBEDDED_OPCODE_ID 1
 #endif
 

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -36,11 +36,10 @@
 #include <wtf/text/StringCommon.h>
 #include <wtf/text/UTF8ConversionError.h>
 
-// FIXME: Enabling the StringView lifetime checking causes the MSVC build to fail. Figure out why.
-#if defined(NDEBUG) || COMPILER(MSVC)
-#define CHECK_STRINGVIEW_LIFETIME 0
-#else
+#if ASSERT_ENABLED
 #define CHECK_STRINGVIEW_LIFETIME 1
+#else
+#define CHECK_STRINGVIEW_LIFETIME 0
 #endif
 
 OBJC_CLASS NSString;


### PR DESCRIPTION
#### 0385b66e029191995a34bef379811e86641322a5
<pre>
[WTF] Remove more COMPILER(MSVC)
<a href="https://bugs.webkit.org/show_bug.cgi?id=284275">https://bugs.webkit.org/show_bug.cgi?id=284275</a>
<a href="https://rdar.apple.com/141139058">rdar://141139058</a>

Reviewed by Fujii Hironori.

Remove more COMPILER(MSVC) code in WTF.

* Source/WTF/wtf/Compiler.h:
* Source/WTF/wtf/PlatformCallingConventions.h:
* Source/WTF/wtf/PlatformEnable.h:
* Source/WTF/wtf/text/StringView.h:

Canonical link: <a href="https://commits.webkit.org/287582@main">https://commits.webkit.org/287582@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c59177a366d10f2e2e52b52dae9c5d213ab2ef7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80036 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59033 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33435 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84549 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31006 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7329 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62562 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20384 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83104 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52626 "Found 1 new test failure: media/audioSession/getUserMedia.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72887 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42871 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49962 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27040 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29470 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/73006 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71082 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27536 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85978 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/79091 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7251 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5110 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70835 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7428 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68728 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70078 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14073 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13009 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/101500 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12402 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7215 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/24748 "Found 4 jsc stress test failures: stress/json-stringify-inspector-check.js.no-llint, wasm.yaml/wasm/stress/cc-int-to-int-cross-module-with-exception.js.default-wasm, wasm.yaml/wasm/stress/struct-new_default-small-members.js.wasm-bbq, wasm.yaml/wasm/stress/struct-new_default-small-members.js.wasm-no-cjit") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7058 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10575 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8864 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->