### PR TITLE
[IFC][SVG text] Use iterator in SVGTextQuery

### DIFF
--- a/Source/WebCore/rendering/svg/SVGTextMetrics.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextMetrics.cpp
@@ -25,7 +25,7 @@
 
 namespace WebCore {
 
-SVGTextMetrics::SVGTextMetrics(RenderSVGInlineText& textRenderer, const TextRun& run)
+SVGTextMetrics::SVGTextMetrics(const RenderSVGInlineText& textRenderer, const TextRun& run)
 {
     float scalingFactor = textRenderer.scalingFactor();
     ASSERT(scalingFactor);
@@ -43,7 +43,7 @@ SVGTextMetrics::SVGTextMetrics(RenderSVGInlineText& textRenderer, const TextRun&
     m_length = static_cast<unsigned>(run.length());
 }
 
-TextRun SVGTextMetrics::constructTextRun(RenderSVGInlineText& text, unsigned position, unsigned length)
+TextRun SVGTextMetrics::constructTextRun(const RenderSVGInlineText& text, unsigned position, unsigned length)
 {
     const RenderStyle& style = text.style();
 
@@ -59,12 +59,12 @@ TextRun SVGTextMetrics::constructTextRun(RenderSVGInlineText& text, unsigned pos
     return run;
 }
 
-SVGTextMetrics SVGTextMetrics::measureCharacterRange(RenderSVGInlineText& text, unsigned position, unsigned length)
+SVGTextMetrics SVGTextMetrics::measureCharacterRange(const RenderSVGInlineText& text, unsigned position, unsigned length)
 {
     return SVGTextMetrics(text, constructTextRun(text, position, length));
 }
 
-SVGTextMetrics::SVGTextMetrics(RenderSVGInlineText& text, unsigned length, float width)
+SVGTextMetrics::SVGTextMetrics(const RenderSVGInlineText& text, unsigned length, float width)
 {
     float scalingFactor = text.scalingFactor();
     ASSERT(scalingFactor);

--- a/Source/WebCore/rendering/svg/SVGTextMetrics.h
+++ b/Source/WebCore/rendering/svg/SVGTextMetrics.h
@@ -35,15 +35,15 @@ public:
     explicit SVGTextMetrics(MetricsType)
         : m_length(1)
     { }
-    SVGTextMetrics(RenderSVGInlineText&, unsigned length, float width);
+    SVGTextMetrics(const RenderSVGInlineText&, unsigned length, float width);
     SVGTextMetrics(unsigned length, float scaledWidth, float scaledHeight)
         : m_width(scaledWidth)
         , m_height(scaledHeight)
         , m_length(length)
     { }
 
-    static SVGTextMetrics measureCharacterRange(RenderSVGInlineText&, unsigned position, unsigned length);
-    static TextRun constructTextRun(RenderSVGInlineText&, unsigned position = 0, unsigned length = std::numeric_limits<unsigned>::max());
+    static SVGTextMetrics measureCharacterRange(const RenderSVGInlineText&, unsigned position, unsigned length);
+    static TextRun constructTextRun(const RenderSVGInlineText&, unsigned position = 0, unsigned length = std::numeric_limits<unsigned>::max());
 
     bool isEmpty() const { return !m_width && !m_height && !m_glyph.isValid && m_length == 1; }
 
@@ -68,7 +68,7 @@ public:
     const Glyph& glyph() const { return m_glyph; }
 
 private:
-    SVGTextMetrics(RenderSVGInlineText&, const TextRun&);
+    SVGTextMetrics(const RenderSVGInlineText&, const TextRun&);
 
     float m_width { 0 };
     float m_height { 0 };

--- a/Source/WebCore/rendering/svg/SVGTextQuery.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextQuery.cpp
@@ -29,6 +29,7 @@
 #include "RenderSVGText.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGInlineTextBoxInlines.h"
+#include "SVGTextBoxPainter.h"
 #include "VisiblePosition.h"
 
 #include <wtf/MathExtras.h>
@@ -37,66 +38,55 @@ namespace WebCore {
 
 // Base structure for callback user data
 struct SVGTextQuery::Data {
-    Data()
-        : isVerticalText(false)
-        , processedCharacters(0)
-        , textRenderer(0)
-        , textBox(0)
-    {
-    }
-
-    bool isVerticalText;
-    unsigned processedCharacters;
-    RenderSVGInlineText* textRenderer;
-    const SVGInlineTextBox* textBox;
+    bool isVerticalText { false };
+    unsigned processedCharacters { 0 };
+    CheckedPtr<const RenderSVGInlineText> textRenderer;
+    InlineIterator::SVGTextBoxIterator textBox;
 };
 
-static inline LegacyInlineFlowBox* flowBoxForRenderer(RenderObject* renderer)
+static inline InlineIterator::InlineBoxIterator inlineBoxForRenderer(RenderObject* renderer)
 {
     if (!renderer)
-        return nullptr;
+        return { };
 
     if (CheckedPtr renderBlock = dynamicDowncast<RenderBlockFlow>(*renderer)) {
         // If we're given a block element, it has to be a RenderSVGText.
         ASSERT(is<RenderSVGText>(*renderBlock));
-        return renderBlock->legacyRootBox();
+        return InlineIterator::firstRootInlineBoxFor(*renderBlock);
     }
 
-    if (CheckedPtr renderInline = dynamicDowncast<RenderInline>(*renderer)) {
-        // We're given a RenderSVGInline or objects that derive from it (RenderSVGTSpan / RenderSVGTextPath)
-        // RenderSVGInline only ever contains a single line box.
-        // FIXME: While the above statment is correct, RenderInline's line box list is about the boxes it generates and not about the single line root inline box.
-        auto* flowBox = renderInline->firstLegacyInlineBox();
-        ASSERT(flowBox == renderInline->lastLegacyInlineBox());
-        return flowBox;
-    }
+    if (CheckedPtr renderInline = dynamicDowncast<RenderInline>(*renderer))
+        return InlineIterator::firstInlineBoxFor(*renderInline);
 
     ASSERT_NOT_REACHED();
-    return nullptr;
+    return { };
 }
 
 SVGTextQuery::SVGTextQuery(RenderObject* renderer)
 {
-    collectTextBoxesInFlowBox(flowBoxForRenderer(renderer));
+    collectTextBoxesInInlineBox(inlineBoxForRenderer(renderer));
 }
 
-void SVGTextQuery::collectTextBoxesInFlowBox(LegacyInlineFlowBox* flowBox)
+void SVGTextQuery::collectTextBoxesInInlineBox(InlineIterator::InlineBoxIterator parent)
 {
-    if (!flowBox)
+    if (!parent)
         return;
 
-    for (auto* child = flowBox->firstChild(); child; child = child->nextOnLine()) {
-        if (auto* flowBox = dynamicDowncast<LegacyInlineFlowBox>(*child)) {
+    auto descendants = parent->descendants();
+    for (auto box = descendants.begin(), end = descendants.end(); box != end;) {
+        if (auto* flowBox = dynamicDowncast<InlineIterator::InlineBox>(*box)) {
             // Skip generated content.
             if (!flowBox->renderer().element())
-                continue;
-
-            collectTextBoxesInFlowBox(flowBox);
+                box.traverseNextOnLineSkippingChildren();
+            else
+                box.traverseNextOnLine();
             continue;
         }
 
-        if (auto* inlineTextBox = dynamicDowncast<SVGInlineTextBox>(*child))
-            m_textBoxes.append(inlineTextBox);
+        if (auto* inlineTextBox = dynamicDowncast<InlineIterator::SVGTextBoxIterator>(box))
+            m_textBoxes.append(*inlineTextBox);
+
+        box.traverseNextOnLine();
     }
 }
 
@@ -150,7 +140,7 @@ bool SVGTextQuery::mapStartEndPositionsIntoFragmentCoordinates(Data* queryData, 
         return false;
 
     modifyStartEndPositionsRespectingLigatures(queryData, fragment, startPosition, endPosition);
-    if (!queryData->textBox->mapStartEndPositionsIntoFragmentCoordinates(fragment, startPosition, endPosition))
+    if (!WebCore::mapStartEndPositionsIntoFragmentCoordinates(queryData->textBox->start(), fragment, startPosition, endPosition))
         return false;
 
     ASSERT_WITH_SECURITY_IMPLICATION(startPosition < endPosition);
@@ -159,8 +149,8 @@ bool SVGTextQuery::mapStartEndPositionsIntoFragmentCoordinates(Data* queryData, 
 
 void SVGTextQuery::modifyStartEndPositionsRespectingLigatures(Data* queryData, const SVGTextFragment& fragment, unsigned& startPosition, unsigned& endPosition) const
 {
-    SVGTextLayoutAttributes* layoutAttributes = queryData->textRenderer->layoutAttributes();
-    Vector<SVGTextMetrics>& textMetricsValues = layoutAttributes->textMetricsValues();
+    const SVGTextLayoutAttributes* layoutAttributes = queryData->textRenderer->layoutAttributes();
+    const Vector<SVGTextMetrics>& textMetricsValues = layoutAttributes->textMetricsValues();
 
     unsigned textMetricsOffset = fragment.metricsListOffset;
 

--- a/Source/WebCore/rendering/svg/SVGTextQuery.h
+++ b/Source/WebCore/rendering/svg/SVGTextQuery.h
@@ -21,6 +21,8 @@
 #pragma once
 
 #include "FloatRect.h"
+#include "InlineIteratorInlineBox.h"
+#include "InlineIteratorSVGTextBox.h"
 #include "SVGTextFragment.h"
 #include <wtf/Vector.h>
 
@@ -50,7 +52,7 @@ private:
     typedef bool (SVGTextQuery::*ProcessTextFragmentCallback)(Data*, const SVGTextFragment&) const;
     bool executeQuery(Data*, ProcessTextFragmentCallback) const;
 
-    void collectTextBoxesInFlowBox(LegacyInlineFlowBox*);
+    void collectTextBoxesInInlineBox(InlineIterator::InlineBoxIterator);
     bool mapStartEndPositionsIntoFragmentCoordinates(Data*, const SVGTextFragment&, unsigned& startPosition, unsigned& endPosition) const;
     void modifyStartEndPositionsRespectingLigatures(Data*, const SVGTextFragment&, unsigned& startPosition, unsigned& endPosition) const;
 
@@ -65,7 +67,7 @@ private:
     bool characterNumberAtPositionCallback(Data*, const SVGTextFragment&) const;
 
 private:
-    Vector<SVGInlineTextBox*> m_textBoxes;
+    Vector<InlineIterator::SVGTextBoxIterator> m_textBoxes;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### e301beb9ed820ee0eef0747aa79303b93b1807a4
<pre>
[IFC][SVG text] Use iterator in SVGTextQuery
<a href="https://bugs.webkit.org/show_bug.cgi?id=284282">https://bugs.webkit.org/show_bug.cgi?id=284282</a>
<a href="https://rdar.apple.com/141144163">rdar://141144163</a>

Reviewed by Alan Baradlay.

This type implements some SVG API text measuring functions.

* Source/WebCore/rendering/svg/SVGTextMetrics.cpp:
(WebCore::SVGTextMetrics::SVGTextMetrics):
(WebCore::SVGTextMetrics::constructTextRun):
(WebCore::SVGTextMetrics::measureCharacterRange):
* Source/WebCore/rendering/svg/SVGTextMetrics.h:
* Source/WebCore/rendering/svg/SVGTextQuery.cpp:
(WebCore::inlineBoxForRenderer):
(WebCore::SVGTextQuery::SVGTextQuery):
(WebCore::SVGTextQuery::collectTextBoxesInInlineBox):
(WebCore::SVGTextQuery::mapStartEndPositionsIntoFragmentCoordinates const):
(WebCore::SVGTextQuery::modifyStartEndPositionsRespectingLigatures const):
(WebCore::SVGTextQuery::Data::Data): Deleted.
(WebCore::flowBoxForRenderer): Deleted.
(WebCore::SVGTextQuery::collectTextBoxesInFlowBox): Deleted.
* Source/WebCore/rendering/svg/SVGTextQuery.h:

Canonical link: <a href="https://commits.webkit.org/287545@main">https://commits.webkit.org/287545@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c32c6ad74b3ad5fccc311172e023c0898de15bc5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80044 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59041 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33443 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84557 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31014 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82152 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68105 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7337 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62566 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20389 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83112 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52636 "Found 1 new test failure: media/audioSession/getUserMedia.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72892 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42875 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49971 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27045 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29478 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71091 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27541 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85986 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7259 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5117 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70842 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7436 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68733 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70085 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17451 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14079 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13014 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7223 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12747 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7066 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10583 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8872 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->