### PR TITLE
[CoordinatedGraphics] Rename GraphicsContextGLTextureMapperANGLENicosia.cpp as GraphicsContextGLTextureMapperANGLECoordinated.cpp

### DIFF
--- a/Source/WebCore/platform/SourcesNicosia.txt
+++ b/Source/WebCore/platform/SourcesNicosia.txt
@@ -34,5 +34,3 @@ page/scrolling/nicosia/ScrollingTreeStickyNodeNicosia.cpp
 
 platform/graphics/nicosia/NicosiaScene.cpp
 platform/graphics/nicosia/NicosiaSceneIntegration.cpp
-
-platform/graphics/texmap/GraphicsContextGLTextureMapperANGLENicosia.cpp

--- a/Source/WebCore/platform/TextureMapper.cmake
+++ b/Source/WebCore/platform/TextureMapper.cmake
@@ -68,6 +68,7 @@ if (USE_COORDINATED_GRAPHICS)
         platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.cpp
         platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.cpp
         platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp
+        platform/graphics/texmap/coordinated/GraphicsContextGLTextureMapperANGLECoordinated.cpp
     )
     list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
         platform/graphics/texmap/coordinated/CoordinatedAnimatedBackingStoreClient.h

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
@@ -318,7 +318,7 @@ bool GraphicsContextGLTextureMapperANGLE::platformInitialize()
 #endif
 
     GLenum textureTarget = drawingBufferTextureTarget();
-#if USE(NICOSIA)
+#if USE(COORDINATED_GRAPHICS) && USE(LIBEPOXY)
     GL_BindTexture(textureTarget, m_texture);
     m_textureID = setupCurrentTexture();
 #endif
@@ -329,7 +329,7 @@ bool GraphicsContextGLTextureMapperANGLE::platformInitialize()
     GL_TexParameteri(textureTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     GL_TexParameteri(textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     GL_TexParameteri(textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-#if USE(NICOSIA)
+#if USE(COORDINATED_GRAPHICS) && USE(LIBEPOXY)
     m_compositorTextureID = setupCurrentTexture();
 #endif
     GL_BindTexture(textureTarget, 0);
@@ -340,7 +340,7 @@ bool GraphicsContextGLTextureMapperANGLE::platformInitialize()
 void GraphicsContextGLTextureMapperANGLE::swapCompositorTexture()
 {
     std::swap(m_texture, m_compositorTexture);
-#if USE(NICOSIA)
+#if USE(COORDINATED_GRAPHICS) && USE(LIBEPOXY)
     std::swap(m_textureID, m_compositorTextureID);
 #endif
     m_isCompositorTextureInitialized = true;

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h
@@ -72,7 +72,7 @@ private:
 
     void swapCompositorTexture();
 
-#if USE(NICOSIA)
+#if USE(COORDINATED_GRAPHICS) && USE(LIBEPOXY)
     GCGLuint setupCurrentTexture();
 #endif
 
@@ -88,7 +88,7 @@ private:
     std::unique_ptr<GLFence> m_frameFence;
 #endif
 
-#if USE(NICOSIA)
+#if USE(COORDINATED_GRAPHICS) && USE(LIBEPOXY)
     GCGLuint m_textureID { 0 };
     GCGLuint m_compositorTextureID { 0 };
 #endif

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsContextGLTextureMapperANGLECoordinated.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsContextGLTextureMapperANGLECoordinated.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "GraphicsContextGLTextureMapperANGLE.h"
 
-#if ENABLE(WEBGL) && USE(TEXTURE_MAPPER) && USE(NICOSIA)
+#if ENABLE(WEBGL) && USE(TEXTURE_MAPPER) && USE(COORDINATED_GRAPHICS) && USE(LIBEPOXY)
 #include <epoxy/gl.h>
 
 namespace WebCore {
@@ -51,4 +51,4 @@ GCGLuint GraphicsContextGLTextureMapperANGLE::setupCurrentTexture()
 
 } // namespace WebCore
 
-#endif // ENABLE(WEBGL) && USE(TEXTURE_MAPPER) && USE(NICOSIA)
+#endif // ENABLE(WEBGL) && USE(TEXTURE_MAPPER) && USE(COORDINATED_GRAPHICS) && USE(LIBEPOXY)


### PR DESCRIPTION
#### a6aecb7cb3614074b11d5db8390698e4ef53b110
<pre>
[CoordinatedGraphics] Rename GraphicsContextGLTextureMapperANGLENicosia.cpp as GraphicsContextGLTextureMapperANGLECoordinated.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=284285">https://bugs.webkit.org/show_bug.cgi?id=284285</a>

Reviewed by Nikolas Zimmermann.

It&apos;s used by ports using coordinated graphics when epoxy is available.

* Source/WebCore/platform/SourcesNicosia.txt:
* Source/WebCore/platform/TextureMapper.cmake:
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp:
(WebCore::GraphicsContextGLTextureMapperANGLE::platformInitialize):
(WebCore::GraphicsContextGLTextureMapperANGLE::swapCompositorTexture):
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h:
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsContextGLTextureMapperANGLECoordinated.cpp: Renamed from Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLENicosia.cpp.
(WebCore::GraphicsContextGLTextureMapperANGLE::setupCurrentTexture):

Canonical link: <a href="https://commits.webkit.org/287593@main">https://commits.webkit.org/287593@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c2c82268d07286f49fc3c94d41803280ad8b5d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80046 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59043 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33445 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84559 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31016 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82154 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68107 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7339 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62568 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20393 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83114 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52638 "Found 1 new test failure: media/audioSession/getUserMedia.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72900 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42877 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49973 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27053 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29480 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71093 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27553 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85988 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7261 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5122 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70841 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7438 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68741 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70084 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14084 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13022 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12411 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7225 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12749 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7068 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10585 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8874 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->