### PR TITLE
Implement Observable#reduce

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-reduce.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-reduce.any-expected.txt
@@ -1,21 +1,10 @@
 
-FAIL reduce(): Reduces the values of the Observable, starting with the initial seed value promise_test: Unhandled rejection with value: object "TypeError: source.reduce is not a function. (In 'source.reduce((acc, value, index) => {
-    reducerArguments.push([acc, value, index]);
-    return acc + value;
-  }, 0)', 'source.reduce' is undefined)"
-FAIL reduce(): Rejects if the source observable emits an error assert_equals: expected object "Error: from the source" but got object "TypeError: source.reduce is not a function. (In 'source.reduce((acc, value) => acc + value, 0)', 'source.reduce' is undefined)"
-FAIL reduce(): Seeds with the first value of the source, if no initial value is provided promise_test: Unhandled rejection with value: object "TypeError: source.reduce is not a function. (In 'source.reduce((acc, value, index) => {
-    reducerArguments.push([acc, value, index]);
-    return acc + value;
-  })', 'source.reduce' is undefined)"
-FAIL reduce(): Errors thrown in reducer reject the promise and abort the source assert_equals: expected object "Error: from the reducer" but got object "TypeError: source.reduce is not a function. (In 'source.reduce((acc, value) => {
-      if (value === 2) {
-        logs.push('throw error');
-        throw error;
-      }
-      return acc + value;
-    }, 0)', 'source.reduce' is undefined)"
-FAIL reduce(): When source is empty, promise resolves with initial value promise_test: Unhandled rejection with value: object "TypeError: source.reduce is not a function. (In 'source.reduce(() => 'reduced', 'seed')', 'source.reduce' is undefined)"
+PASS reduce(): Reduces the values of the Observable, starting with the initial seed value
+PASS reduce(): Rejects if the source observable emits an error
+PASS reduce(): Seeds with the first value of the source, if no initial value is provided
+PASS reduce(): Errors thrown in reducer reject the promise and abort the source
+PASS reduce(): When source is empty, promise resolves with initial value
 PASS reduce(): When source is empty, AND no seed value is provided, the promise rejects with a TypeError
-FAIL reduce(): Reject with an AbortError if the subscription is aborted before the source completes assert_true: expected true got false
+PASS reduce(): Reject with an AbortError if the subscription is aborted before the source completes
+PASS reduce(): Reduces the values for different objects
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-reduce.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-reduce.any.worker-expected.txt
@@ -1,21 +1,10 @@
 
-FAIL reduce(): Reduces the values of the Observable, starting with the initial seed value promise_test: Unhandled rejection with value: object "TypeError: source.reduce is not a function. (In 'source.reduce((acc, value, index) => {
-    reducerArguments.push([acc, value, index]);
-    return acc + value;
-  }, 0)', 'source.reduce' is undefined)"
-FAIL reduce(): Rejects if the source observable emits an error assert_equals: expected object "Error: from the source" but got object "TypeError: source.reduce is not a function. (In 'source.reduce((acc, value) => acc + value, 0)', 'source.reduce' is undefined)"
-FAIL reduce(): Seeds with the first value of the source, if no initial value is provided promise_test: Unhandled rejection with value: object "TypeError: source.reduce is not a function. (In 'source.reduce((acc, value, index) => {
-    reducerArguments.push([acc, value, index]);
-    return acc + value;
-  })', 'source.reduce' is undefined)"
-FAIL reduce(): Errors thrown in reducer reject the promise and abort the source assert_equals: expected object "Error: from the reducer" but got object "TypeError: source.reduce is not a function. (In 'source.reduce((acc, value) => {
-      if (value === 2) {
-        logs.push('throw error');
-        throw error;
-      }
-      return acc + value;
-    }, 0)', 'source.reduce' is undefined)"
-FAIL reduce(): When source is empty, promise resolves with initial value promise_test: Unhandled rejection with value: object "TypeError: source.reduce is not a function. (In 'source.reduce(() => 'reduced', 'seed')', 'source.reduce' is undefined)"
+PASS reduce(): Reduces the values of the Observable, starting with the initial seed value
+PASS reduce(): Rejects if the source observable emits an error
+PASS reduce(): Seeds with the first value of the source, if no initial value is provided
+PASS reduce(): Errors thrown in reducer reject the promise and abort the source
+PASS reduce(): When source is empty, promise resolves with initial value
 PASS reduce(): When source is empty, AND no seed value is provided, the promise rejects with a TypeError
-FAIL reduce(): Reject with an AbortError if the subscription is aborted before the source completes assert_true: expected true got false
+PASS reduce(): Reject with an AbortError if the subscription is aborted before the source completes
+PASS reduce(): Reduces the values for different objects
 

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1190,6 +1190,7 @@ set(WebCore_NON_SVG_IDL_FILES
     dom/Range+CSSOMView.idl
     dom/Range+DOMParsing.idl
     dom/Range.idl
+    dom/ReducerCallback.idl
     dom/RequestAnimationFrameCallback.idl
     dom/SecurityPolicyViolationEvent.idl
     dom/SecurityPolicyViolationEventDisposition.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1511,6 +1511,7 @@ $(PROJECT_DIR)/dom/PromiseRejectionEvent.idl
 $(PROJECT_DIR)/dom/Range+CSSOMView.idl
 $(PROJECT_DIR)/dom/Range+DOMParsing.idl
 $(PROJECT_DIR)/dom/Range.idl
+$(PROJECT_DIR)/dom/ReducerCallback.idl
 $(PROJECT_DIR)/dom/RequestAnimationFrameCallback.idl
 $(PROJECT_DIR)/dom/SecurityPolicyViolationEvent.idl
 $(PROJECT_DIR)/dom/SecurityPolicyViolationEventDisposition.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -2515,6 +2515,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSReadableStreamSource.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSReadableStreamSource.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRedEyeReduction.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRedEyeReduction.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSReducerCallback.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSReducerCallback.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRegistrationResponseJSON.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRegistrationResponseJSON.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRemotePlayback.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1204,6 +1204,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/dom/Range+CSSOMView.idl \
     $(WebCore)/dom/Range+DOMParsing.idl \
     $(WebCore)/dom/Range.idl \
+    $(WebCore)/dom/ReducerCallback.idl \
     $(WebCore)/dom/RequestAnimationFrameCallback.idl \
     $(WebCore)/dom/SecurityPolicyViolationEvent.idl \
     $(WebCore)/dom/SecurityPolicyViolationEventDisposition.idl \

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1289,6 +1289,7 @@ dom/InternalObserverFromScript.cpp
 dom/InternalObserverInspect.cpp
 dom/InternalObserverLast.cpp
 dom/InternalObserverMap.cpp
+dom/InternalObserverReduce.cpp
 dom/InternalObserverSome.cpp
 dom/InternalObserverTake.cpp
 dom/KeyboardEvent.cpp
@@ -4354,6 +4355,7 @@ JSPushSubscriptionJSON.cpp
 JSPushSubscriptionOptions.cpp
 JSPushSubscriptionOptionsInit.cpp
 JSRedEyeReduction.cpp
+JSReducerCallback.cpp
 JSRTCAnswerOptions.cpp
 JSRTCLogsCallback.cpp
 JSRTCCertificate.cpp

--- a/Source/WebCore/dom/InternalObserverReduce.cpp
+++ b/Source/WebCore/dom/InternalObserverReduce.cpp
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2024 Marais Rossouw <me@marais.co>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "InternalObserverReduce.h"
+
+#include "AbortSignal.h"
+#include "Exception.h"
+#include "ExceptionCode.h"
+#include "InternalObserver.h"
+#include "JSDOMPromiseDeferred.h"
+#include "JSValueInWrappedObject.h"
+#include "Observable.h"
+#include "ReducerCallback.h"
+#include "ScriptExecutionContext.h"
+#include "SubscribeOptions.h"
+#include "Subscriber.h"
+#include "SubscriberCallback.h"
+#include <JavaScriptCore/JSCJSValueInlines.h>
+
+namespace WebCore {
+
+class InternalObserverReduce final : public InternalObserver {
+public:
+    static Ref<InternalObserverReduce> create(ScriptExecutionContext& context, Ref<AbortSignal>&& signal, Ref<ReducerCallback>&& callback, JSC::JSValue initialValue, Ref<DeferredPromise>&& promise)
+    {
+        Ref internalObserver = adoptRef(*new InternalObserverReduce(context, WTFMove(signal), WTFMove(callback), initialValue, WTFMove(promise)));
+        internalObserver->suspendIfNeeded();
+        return internalObserver;
+    }
+
+private:
+    void next(JSC::JSValue value) final
+    {
+        if (!m_accumulator) {
+            m_index++;
+            m_accumulator.setWeakly(value);
+            return;
+        }
+
+        auto* globalObject = protectedScriptExecutionContext()->globalObject();
+        ASSERT(globalObject);
+
+        Ref vm = globalObject->vm();
+
+        JSC::JSLockHolder lock(vm);
+        auto scope = DECLARE_CATCH_SCOPE(vm);
+
+        auto result = protectedCallback()->handleEventRethrowingException(m_accumulator.getValue(), value, m_index++);
+
+        JSC::Exception* exception = scope.exception();
+        if (UNLIKELY(exception)) {
+            scope.clearException();
+            auto value = exception->value();
+            protectedPromise()->reject<IDLAny>(value);
+            Ref { m_signal }->signalAbort(value);
+        }
+
+        if (result.type() == CallbackResultType::Success)
+            m_accumulator.setWeakly(result.releaseReturnValue());
+    }
+
+    void error(JSC::JSValue value) final
+    {
+        protectedPromise()->reject<IDLAny>(value);
+    }
+
+    void complete() final
+    {
+        InternalObserver::complete();
+
+        if (UNLIKELY(!m_accumulator)) {
+            protectedPromise()->reject(Exception { ExceptionCode::TypeError, "No inital value for Observable with no values"_s });
+            return;
+        }
+
+        protectedPromise()->resolve<IDLAny>(m_accumulator.getValue());
+    }
+
+    void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
+    {
+        protectedCallback()->visitJSFunction(visitor);
+        m_accumulator.visit(visitor);
+    }
+
+    Ref<DeferredPromise> protectedPromise() const { return m_promise; }
+    Ref<ReducerCallback> protectedCallback() const { return m_callback; }
+
+    InternalObserverReduce(ScriptExecutionContext& context, Ref<AbortSignal>&& signal, Ref<ReducerCallback>&& callback, JSC::JSValue initialValue, Ref<DeferredPromise>&& promise)
+        : InternalObserver(context)
+        , m_signal(WTFMove(signal))
+        , m_callback(WTFMove(callback))
+        , m_promise(WTFMove(promise))
+    {
+        if (UNLIKELY(!initialValue.isUndefined()))
+            m_accumulator.setWeakly(initialValue);
+    }
+
+    uint64_t m_index { 0 };
+    Ref<AbortSignal> m_signal;
+    Ref<ReducerCallback> m_callback;
+    JSValueInWrappedObject m_accumulator;
+    Ref<DeferredPromise> m_promise;
+};
+
+void createInternalObserverOperatorReduce(ScriptExecutionContext& context, Observable& observable, Ref<ReducerCallback>&& callback, JSC::JSValue initialValue, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)
+{
+    Ref signal = AbortSignal::create(&context);
+
+    Vector<Ref<AbortSignal>> dependentSignals = { signal };
+    if (options.signal)
+        dependentSignals.append(Ref { *options.signal });
+    Ref dependentSignal = AbortSignal::any(context, dependentSignals);
+
+    if (dependentSignal->aborted())
+        return promise->reject<IDLAny>(dependentSignal->reason().getValue());
+
+    dependentSignal->addAlgorithm([promise](JSC::JSValue reason) {
+        promise->reject<IDLAny>(reason);
+    });
+
+    Ref observer = InternalObserverReduce::create(context, WTFMove(signal), WTFMove(callback), initialValue, WTFMove(promise));
+    observable.subscribeInternal(context, WTFMove(observer), SubscribeOptions { .signal = WTFMove(dependentSignal) });
+}
+
+} // namespace WebCore

--- a/Source/WebCore/dom/InternalObserverReduce.h
+++ b/Source/WebCore/dom/InternalObserverReduce.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2024 Marais Rossouw <me@marais.co>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+class DeferredPromise;
+class Observable;
+class ReducerCallback;
+class ScriptExecutionContext;
+struct SubscribeOptions;
+
+void createInternalObserverOperatorReduce(ScriptExecutionContext&, Observable&, Ref<ReducerCallback>&&, JSC::JSValue, const SubscribeOptions&, Ref<DeferredPromise>&&);
+
+} // namespace WebCore

--- a/Source/WebCore/dom/Observable.cpp
+++ b/Source/WebCore/dom/Observable.cpp
@@ -40,6 +40,7 @@
 #include "InternalObserverInspect.h"
 #include "InternalObserverLast.h"
 #include "InternalObserverMap.h"
+#include "InternalObserverReduce.h"
 #include "InternalObserverSome.h"
 #include "InternalObserverTake.h"
 #include "JSDOMPromiseDeferred.h"
@@ -47,6 +48,7 @@
 #include "MapperCallback.h"
 #include "ObservableInspector.h"
 #include "PredicateCallback.h"
+#include "ReducerCallback.h"
 #include "SubscribeOptions.h"
 #include "Subscriber.h"
 #include "SubscriberCallback.h"
@@ -167,6 +169,11 @@ void Observable::every(ScriptExecutionContext& context, Ref<PredicateCallback>&&
 void Observable::some(ScriptExecutionContext& context, Ref<PredicateCallback>&& callback, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)
 {
     return createInternalObserverOperatorSome(context, *this, WTFMove(callback), options, WTFMove(promise));
+}
+
+void Observable::reduce(ScriptExecutionContext& context, Ref<ReducerCallback>&& callback, JSC::JSValue initialValue, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)
+{
+    return createInternalObserverOperatorReduce(context, *this, WTFMove(callback), initialValue, options, WTFMove(promise));
 }
 
 Observable::Observable(Ref<SubscriberCallback> callback)

--- a/Source/WebCore/dom/Observable.h
+++ b/Source/WebCore/dom/Observable.h
@@ -38,6 +38,7 @@ class InternalObserver;
 class JSSubscriptionObserverCallback;
 class MapperCallback;
 class PredicateCallback;
+class ReducerCallback;
 class ScriptExecutionContext;
 class VisitorCallback;
 struct ObservableInspector;
@@ -72,6 +73,7 @@ public:
     void find(ScriptExecutionContext&, Ref<PredicateCallback>&&, const SubscribeOptions&, Ref<DeferredPromise>&&);
     void every(ScriptExecutionContext&, Ref<PredicateCallback>&&, const SubscribeOptions&, Ref<DeferredPromise>&&);
     void some(ScriptExecutionContext&, Ref<PredicateCallback>&&, const SubscribeOptions&, Ref<DeferredPromise>&&);
+    void reduce(ScriptExecutionContext&, Ref<ReducerCallback>&&, JSC::JSValue, const SubscribeOptions&, Ref<DeferredPromise>&&);
 
 private:
     Ref<SubscriberCallback> m_subscriberCallback;

--- a/Source/WebCore/dom/Observable.idl
+++ b/Source/WebCore/dom/Observable.idl
@@ -51,4 +51,5 @@ interface Observable {
   [CallWith=CurrentScriptExecutionContext] Promise<any> find(PredicateCallback callback, optional SubscribeOptions options = {});
   [CallWith=CurrentScriptExecutionContext] Promise<boolean> every(PredicateCallback callback, optional SubscribeOptions options = {});
   [CallWith=CurrentScriptExecutionContext] Promise<boolean> some(PredicateCallback callback, optional SubscribeOptions options = {});
+  [CallWith=CurrentScriptExecutionContext] Promise<any> reduce(ReducerCallback callback, optional any initialValue, optional SubscribeOptions options = {});
 };

--- a/Source/WebCore/dom/ReducerCallback.h
+++ b/Source/WebCore/dom/ReducerCallback.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2024 Marais Rossouw <me@marais.co>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ActiveDOMCallback.h"
+#include "CallbackResult.h"
+#include <wtf/RefCounted.h>
+
+namespace WebCore {
+
+class ReducerCallback : public RefCounted<ReducerCallback>, public ActiveDOMCallback {
+public:
+    using ActiveDOMCallback::ActiveDOMCallback;
+
+    virtual CallbackResult<JSC::JSValue> handleEvent(JSC::JSValue, JSC::JSValue, uint64_t) = 0;
+    virtual CallbackResult<JSC::JSValue> handleEventRethrowingException(JSC::JSValue, JSC::JSValue, uint64_t) = 0;
+
+private:
+    virtual bool hasCallback() const = 0;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/dom/ReducerCallback.idl
+++ b/Source/WebCore/dom/ReducerCallback.idl
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2024 Marais Rossouw <me@marais.co>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://wicg.github.io/observable/#callbackdef-reducer
+callback ReducerCallback = any (any accumulator, any currentValue, unsigned long long index);


### PR DESCRIPTION
#### 5799af7ea9f2c0f39b9857651240967129be2900
<pre>
Implement Observable#reduce
<a href="https://bugs.webkit.org/show_bug.cgi?id=284287">https://bugs.webkit.org/show_bug.cgi?id=284287</a>

Reviewed by Darin Adler.

This change introduces the `.reduce` promise-returning operator
for Observables, using the InternalObserver and subscribing immediately.

Unlike our MapperCallback, we need to pass an accumulator as well. As
such, we also introduce a new ReducerCallback IDL.

Spec: &lt;<a href="https://wicg.github.io/observable/#dom-observable-reduce">https://wicg.github.io/observable/#dom-observable-reduce</a>&gt;

* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-reduce.any-expected.txt: Rebaseline.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-reduce.any.js: Rebaseline.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-reduce.any.worker-expected.txt: Rebaseline.
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/InternalObserverReduce.cpp: Added.
(WebCore::createInternalObserverOperatorReduce):
* Source/WebCore/dom/InternalObserverReduce.h: Added.
* Source/WebCore/dom/Observable.cpp:
(WebCore::Observable::reduce):
* Source/WebCore/dom/Observable.h:
* Source/WebCore/dom/Observable.idl:
Exposes `Promise&lt;any&gt; reduce(reducer, initialValue, options)` as a promise-returning operator.
* Source/WebCore/dom/ReducerCallback.h: Added.
* Source/WebCore/dom/ReducerCallback.idl: Added.

Canonical link: <a href="https://commits.webkit.org/287595@main">https://commits.webkit.org/287595@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc06f250f53bf7c3067cb825c79ed54c0cca64c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80200 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59202 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33613 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84717 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31176 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82311 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68263 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7501 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62692 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20504 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83269 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52760 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73038 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43000 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50090 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27192 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29637 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71219 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27702 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86149 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7420 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5249 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70963 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7595 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68878 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70207 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17481 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14199 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13150 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7384 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12901 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7223 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10743 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9028 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->