### PR TITLE
[GStreamer][WebRTC] Start stats log timer only if WebRTC logs are enabled

### DIFF
--- a/Source/WTF/wtf/LogChannels.h
+++ b/Source/WTF/wtf/LogChannels.h
@@ -39,7 +39,7 @@ public:
     virtual ~LogChannels() = default;
     virtual String logLevelString() = 0;
 
-    bool isLogChannelEnabled(const String& name);
+    WTF_EXPORT_PRIVATE bool isLogChannelEnabled(const String& name);
     WTF_EXPORT_PRIVATE void setLogChannelToAccumulate(const String& name);
     WTF_EXPORT_PRIVATE void clearAllLogChannelsToAccumulate();
     WTF_EXPORT_PRIVATE void initializeLogChannelsIfNecessary(std::optional<String> = std::nullopt);

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -33,6 +33,7 @@
 #include "GStreamerWebRTCUtils.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSRTCStatsReport.h"
+#include "LogInitialization.h"
 #include "Logging.h"
 #include "MediaEndpointConfiguration.h"
 #include "NotImplemented.h"
@@ -2177,6 +2178,9 @@ void GStreamerMediaEndpoint::onStatsDelivered(const GstStructure* stats)
 
 void GStreamerMediaEndpoint::startLoggingStats()
 {
+    if (!WebCore::logChannels().isLogChannelEnabled("WebRTC"_s) && !m_peerConnectionBackend.isJSONLogStreamingEnabled() && !m_isGatheringRTCLogs)
+        return;
+
     if (m_statsLogTimer.isActive())
         m_statsLogTimer.stop();
     m_statsLogTimer.startRepeating(statsLogInterval(Seconds::nan()));


### PR DESCRIPTION
#### 940294f94e0c4f12078ec4e6c63ef55612669ced
<pre>
[GStreamer][WebRTC] Start stats log timer only if WebRTC logs are enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=284291">https://bugs.webkit.org/show_bug.cgi?id=284291</a>

Reviewed by Xabier Rodriguez-Calvar.

The timer implies a relevant amount of memory allocations in GstWebRTC so enable it only if the
corresponding log channel has been enabled with WEBKIT_DEBUG. There&apos;s no need to collect logs if
they&apos;re not going to be logged.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::startLoggingStats):

Canonical link: <a href="https://commits.webkit.org/287596@main">https://commits.webkit.org/287596@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7251e243820994f76c6e1d0f4b8151b14bf54fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80060 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59057 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33459 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84573 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31030 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82168 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68121 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7354 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62581 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20405 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83128 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52658 "Found 1 new test failure: media/audioSession/getUserMedia.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72910 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42890 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49986 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27063 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29494 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/73038 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71114 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27563 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86002 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/79115 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7275 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5134 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70852 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7452 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68751 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70095 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17482 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14097 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13032 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/101524 "Built successfully") | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/12412 "The change is no longer eligible for processing.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7239 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12772 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/24749 "Found 2 new JSC stress test failures: wasm.yaml/wasm/stress/struct-new_default-small-members.js.default-wasm, wasm.yaml/wasm/stress/struct-new_default-small-members.js.wasm-eager-jettison (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7081 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10599 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8887 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->