### PR TITLE
Adopt dispatched(From|To) for WebProcess<->UI interfaces

### DIFF
--- a/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.messages.in
+++ b/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.messages.in
@@ -24,7 +24,11 @@
 
 #if ENABLE(APPLE_PAY)
 
-[EnabledBy=ApplePayEnabled]
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=UI,
+    EnabledBy=ApplePayEnabled
+]
 messages -> WebPaymentCoordinatorProxy {
 
     CanMakePayments() -> (bool result) Synchronous

--- a/Source/WebKit/Shared/AuxiliaryProcessMain.h
+++ b/Source/WebKit/Shared/AuxiliaryProcessMain.h
@@ -32,6 +32,7 @@
 #include "WebKit2Initialize.h"
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RunLoop.h>
+#include <wtf/RuntimeApplicationChecks.h>
 
 namespace WebKit {
 
@@ -58,7 +59,11 @@ public:
 
     int run(int argc, char** argv)
     {
+        // setAuxiliaryProcessType() should be called before we construct
+        // and initialize the AuxiliaryProcess. This is so isInXXXProcess()
+        // checks are valid.
         m_parameters.processType = AuxiliaryProcessType::processType;
+        setAuxiliaryProcessType(m_parameters.processType);
 
         if (!platformInitialize())
             return EXIT_FAILURE;

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.messages.in
@@ -21,6 +21,10 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #if PLATFORM(IOS_FAMILY) || (PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE))
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=UI
+]
 messages -> PlaybackSessionManagerProxy {
     CurrentTimeChanged(WebKit::PlaybackSessionContextIdentifier contextId, double currentTime, double hostTime)
     BufferedTimeChanged(WebKit::PlaybackSessionContextIdentifier contextId, double bufferedTime)

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.messages.in
@@ -23,7 +23,11 @@
 
 #if ENABLE(MEDIA_STREAM)
 
-[EnabledBy=MediaPlaybackEnabled]
+// rdar://140690546 - Can currently be dispatchedTo UI & GPU
+[
+    DispatchedFrom=WebContent,
+    EnabledBy=MediaPlaybackEnabled
+]
 messages -> UserMediaCaptureManagerProxy {
     CreateMediaSourceForCaptureDeviceWithConstraints(WebCore::RealtimeMediaSourceIdentifier id, WebCore::CaptureDevice device, struct WebCore::MediaDeviceHashSalts hashSalts, struct WebCore::MediaConstraints constraints, bool shouldUseGPUProcessRemoteFrames, WebCore::PageIdentifier pageIdentifier) -> (struct WebCore::CaptureSourceError error, WebCore::RealtimeMediaSourceSettings settings, WebCore::RealtimeMediaSourceCapabilities capabilities) Async
     StartProducingData(WebCore::RealtimeMediaSourceIdentifier id, WebCore::PageIdentifier pageIdentifier)

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.messages.in
@@ -21,6 +21,10 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=UI
+]
 messages -> VideoPresentationManagerProxy {
     SetHasVideo(WebKit::PlaybackSessionContextIdentifier contextId, bool hasVideo)
     SetDocumentVisibility(WebKit::PlaybackSessionContextIdentifier contextId, bool isDocumentVisible)

--- a/Source/WebKit/UIProcess/DigitalCredentials/DigitalCredentialsCoordinatorProxy.messages.in
+++ b/Source/WebKit/UIProcess/DigitalCredentials/DigitalCredentialsCoordinatorProxy.messages.in
@@ -24,7 +24,11 @@
 
 #if ENABLE(WEB_AUTHN)
 
-[EnabledBy=DigitalCredentialsEnabled]
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=UI,
+    EnabledBy=DigitalCredentialsEnabled
+]
 messages -> DigitalCredentialsCoordinatorProxy {
     RequestDigitalCredential(WebCore::FrameIdentifier frameID, struct WebKit::FrameInfoData frameInfo, struct WebCore::DigitalCredentialRequestOptions options) -> (struct WebCore::ExceptionData exception)
     Cancel() -> ()

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.messages.in
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=Networking,
+    DispatchedTo=UI
+]
 messages -> DownloadProxy {
     DidStart(WebCore::ResourceRequest request, String suggestedFilename)
     DidReceiveAuthenticationChallenge(WebCore::AuthenticationChallenge challenge, WebKit::AuthenticationChallengeIdentifier challengeID)

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.messages.in
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=UI
+]
 messages -> DrawingAreaProxy {
     EnterAcceleratedCompositingMode(uint64_t backingStoreStateID, WebKit::LayerTreeContext context)
     UpdateAcceleratedCompositingMode(uint64_t backingStoreStateID, WebKit::LayerTreeContext context)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -25,6 +25,10 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=UI
+]
 messages -> WebExtensionContext {
     // Action APIs
     [Validator=isActionMessageAllowed] ActionGetTitle(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (Expected<String, WebKit::WebExtensionError> result)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.messages.in
@@ -25,6 +25,10 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=UI
+]
 messages -> WebExtensionController {
     [Validator=hasLoadedContexts] DidStartProvisionalLoadForFrame(WebKit::WebPageProxyIdentifier pageID, struct WebKit::WebExtensionFrameParameters frameParameters, WallTime timestamp)
     [Validator=hasLoadedContexts] DidCommitLoadForFrame(WebKit::WebPageProxyIdentifier pageID, struct WebKit::WebExtensionFrameParameters frameParameters, WallTime timestamp)

--- a/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.messages.in
+++ b/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=UI
+]
 messages -> RemoteWebInspectorUIProxy {
     FrontendLoaded()
     FrontendDidClose()

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.messages.in
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.messages.in
@@ -22,6 +22,10 @@
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
 
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=UI
+]
 messages -> WebInspectorUIExtensionControllerProxy {
     DidShowExtensionTab(String extensionID, String extensionTabID, WebCore::FrameIdentifier frameID)
     DidHideExtensionTab(String extensionID, String extensionTabID)

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.messages.in
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=UI
+]
 messages -> WebInspectorUIProxy {
     OpenLocalInspectorFrontend(bool canAttach, bool underTest)
     SetFrontendConnection(IPC::ConnectionHandle connectionHandle)

--- a/Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.messages.in
+++ b/Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.messages.in
@@ -21,7 +21,11 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #if ENABLE(ROUTING_ARBITRATION)
-[EnabledBy=MediaPlaybackEnabled]
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=UI,
+    EnabledBy=MediaPlaybackEnabled
+]
 messages -> AudioSessionRoutingArbitratorProxy {
     BeginRoutingArbitrationWithCategory(enum:uint8_t WebCore::AudioSessionCategory category) -> (enum:uint8_t WebCore::AudioSessionRoutingArbitrationError error, enum:bool WebCore::AudioSessionRoutingArbitrationClient::DefaultRouteChanged defaultRouteChanged)
     EndRoutingArbitration();

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.messages.in
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.messages.in
@@ -24,7 +24,11 @@
 
 #if ENABLE(MEDIA_SESSION_COORDINATOR)
 
-[EnabledBy=MediaSessionCoordinatorEnabled]
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=UI,
+    EnabledBy=MediaSessionCoordinatorEnabled
+]
 messages -> RemoteMediaSessionCoordinatorProxy {
 
     Join() -> (std::optional<WebCore::ExceptionData> error)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.messages.in
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=UI
+]
 messages -> RemoteLayerTreeDrawingAreaProxy : DrawingAreaProxy {
     void SetPreferredFramesPerSecond(unsigned preferredFramesPerSecond)
     void WillCommitLayerTree(WebKit::TransactionID transactionID)

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.messages.in
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.messages.in
@@ -23,7 +23,11 @@
 
 #if ENABLE(MEDIA_STREAM)
 
-[EnabledBy=SpeechRecognitionEnabled]
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=UI,
+    EnabledBy=SpeechRecognitionEnabled
+]
 messages -> SpeechRecognitionRemoteRealtimeMediaSourceManager {
     RemoteAudioSamplesAvailable(WebCore::RealtimeMediaSourceIdentifier identifier, MediaTime time, uint64_t numberOfFrames)
     RemoteCaptureFailed(WebCore::RealtimeMediaSourceIdentifier identifier)

--- a/Source/WebKit/UIProcess/SpeechRecognitionServer.messages.in
+++ b/Source/WebKit/UIProcess/SpeechRecognitionServer.messages.in
@@ -23,7 +23,11 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
  
- [EnabledBy=SpeechRecognitionEnabled]
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=UI,
+    EnabledBy=SpeechRecognitionEnabled
+]
  messages -> SpeechRecognitionServer {
     Start(WebCore::SpeechRecognitionConnectionClientIdentifier identifier, String lang, bool continuous, bool interimResults, uint64_t maxAlternatives, struct WebCore::ClientOrigin origin, WebCore::FrameIdentifier frameIdentifier)
     Stop(WebCore::SpeechRecognitionConnectionClientIdentifier identifier)

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.messages.in
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.messages.in
@@ -23,6 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=UI
+]
 messages -> WebUserContentControllerProxy {
 DidPostMessage(WebKit::WebPageProxyIdentifier pageID, struct WebKit::FrameInfoData frameInfoData, WebKit::ScriptMessageHandlerIdentifier messageHandlerID, std::span<const uint8_t> message) -> (std::span<const uint8_t> resultValue, String errorMessage)
 }

--- a/Source/WebKit/UIProcess/ViewGestureController.messages.in
+++ b/Source/WebKit/UIProcess/ViewGestureController.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=UI
+]
 messages -> ViewGestureController {
 #if PLATFORM(MAC)
     DidCollectGeometryForSmartMagnificationGesture(WebCore::FloatPoint origin, WebCore::FloatRect renderRect, WebCore::FloatRect visibleContentBounds, bool fitEntireRect, double viewportMinimumScale, double viewportMaximumScale)

--- a/Source/WebKit/UIProcess/VisitedLinkStore.messages.in
+++ b/Source/WebKit/UIProcess/VisitedLinkStore.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=UI
+]
 messages -> VisitedLinkStore {
     AddVisitedLinkHashFromPage(WebKit::WebPageProxyIdentifier pageProxyID, WebCore::SharedStringHash linkHash)
 }

--- a/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.messages.in
@@ -24,7 +24,11 @@
 
 #if ENABLE(WEB_AUTHN)
 
-[EnabledBy=WebAuthenticationEnabled]
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=UI,
+    EnabledBy=WebAuthenticationEnabled
+]
 messages -> WebAuthenticatorCoordinatorProxy {
 
     MakeCredential(WebCore::FrameIdentifier frameID, struct WebKit::FrameInfoData frameInfo, struct WebCore::PublicKeyCredentialCreationOptions options, enum:uint8_t WebCore::MediationRequirement mediation) -> (struct WebCore::AuthenticatorResponseData data, enum:uint8_t WebCore::AuthenticatorAttachment attachment, struct WebCore::ExceptionData exception)

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.messages.in
@@ -21,7 +21,11 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #if ENABLE(FULLSCREEN_API)
-[EnabledBy=FullScreenEnabled || VideoFullscreenRequiresElementFullscreen]
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=UI,
+    EnabledBy=FullScreenEnabled || VideoFullscreenRequiresElementFullscreen
+]
 messages -> WebFullScreenManagerProxy {
     SupportsFullScreen(bool withKeyboard) -> (bool supportsFullScreen) Synchronous
     EnterFullScreen(bool blocksReturnToFullscreenFromPictureInPicture, struct WebKit::FullScreenMediaDetails mediaDetails)

--- a/Source/WebKit/UIProcess/WebGeolocationManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebGeolocationManagerProxy.messages.in
@@ -20,7 +20,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[SharedPreferencesNeedsConnection]
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=UI,
+    SharedPreferencesNeedsConnection
+]
 messages -> WebGeolocationManagerProxy {
     [EnabledBy=GeolocationAPIEnabled] StartUpdating(WebCore::RegistrableDomain registrableDomain, WebKit::WebPageProxyIdentifier pageProxyID, String authorizationToken, bool enableHighAccuracy)
     [EnabledBy=GeolocationAPIEnabled] StopUpdating(WebCore::RegistrableDomain registrableDomain)

--- a/Source/WebKit/UIProcess/WebLockRegistryProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebLockRegistryProxy.messages.in
@@ -20,7 +20,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[EnabledBy=WebLocksAPIEnabled]
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=UI,
+    EnabledBy=WebLocksAPIEnabled
+]
 messages -> WebLockRegistryProxy {
     RequestLock(struct WebCore::ClientOrigin clientOrigin, WebCore::WebLockIdentifier identifier, WebCore::ScriptExecutionContextIdentifier clientID, String name, enum:bool WebCore::WebLockMode mode, bool steal, bool ifAvailable)
     ReleaseLock(struct WebCore::ClientOrigin clientOrigin, WebCore::WebLockIdentifier identifier, WebCore::ScriptExecutionContextIdentifier clientID, String name)

--- a/Source/WebKit/UIProcess/WebPasteboardProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPasteboardProxy.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=UI
+]
 messages -> WebPasteboardProxy {
 #if PLATFORM(IOS_FAMILY)
     WriteURLToPasteboard(struct WebCore::PasteboardURL url, String pasteboardName, std::optional<WebCore::PageIdentifier> pageID)

--- a/Source/WebKit/UIProcess/WebPermissionControllerProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPermissionControllerProxy.messages.in
@@ -23,6 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=UI
+]
 messages -> WebPermissionControllerProxy {
     Query(struct WebCore::ClientOrigin origin, struct WebCore::PermissionDescriptor descriptor, std::optional<WebKit::WebPageProxyIdentifier> identifier, enum:uint8_t WebCore::PermissionQuerySource source) -> (std::optional<WebCore::PermissionState> state)
 }

--- a/Source/WebKit/UIProcess/WebProcessPool.messages.in
+++ b/Source/WebKit/UIProcess/WebProcessPool.messages.in
@@ -20,7 +20,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[SharedPreferencesNeedsConnection]
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=UI,
+    SharedPreferencesNeedsConnection
+]
 messages -> WebProcessPool {
     HandleMessage(String messageName, WebKit::UserData messageBody)
     HandleSynchronousMessage(String messageName, WebKit::UserData messageBody) -> (WebKit::UserData returnData) Synchronous

--- a/Source/WebKit/UIProcess/WebProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebProcessProxy.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=UI
+]
 messages -> WebProcessProxy WantsDispatchMessage {
     UpdateBackForwardItem(Ref<WebKit::FrameState> mainFrameState)
 

--- a/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.messages.in
@@ -23,7 +23,11 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[EnabledBy=ScreenOrientationAPIEnabled]
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=UI,
+    EnabledBy=ScreenOrientationAPIEnabled
+]
 messages -> WebScreenOrientationManagerProxy {
     CurrentOrientation() -> (enum:uint8_t WebCore::ScreenOrientationType orientation) Synchronous
     Lock(enum:uint8_t WebCore::ScreenOrientationLockType orientation) -> (std::optional<WebCore::Exception> exception)

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.messages.in
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.messages.in
@@ -25,7 +25,11 @@
  
 #if ENABLE(WEBXR)
 
-[EnabledBy=WebXREnabled]
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=UI,
+    EnabledBy=WebXREnabled
+]
 messages -> PlatformXRSystem {
     EnumerateImmersiveXRDevices() -> (Vector<WebKit::XRDeviceInfo> devicesInfos)
     RequestPermissionOnSessionFeatures(WebCore::SecurityOriginData origin, PlatformXR::SessionMode mode, Vector<PlatformXR::SessionFeature> granted, Vector<PlatformXR::SessionFeature> consentRequired, Vector<PlatformXR::SessionFeature> consentOptional, Vector<PlatformXR::SessionFeature> requiredFeaturesRequested, Vector<PlatformXR::SessionFeature> optionalFeaturesRequested) -> (std::optional<Vector<PlatformXR::SessionFeature>> userGranted)

--- a/Source/WebKit/UIProcess/ios/SmartMagnificationController.messages.in
+++ b/Source/WebKit/UIProcess/ios/SmartMagnificationController.messages.in
@@ -22,6 +22,10 @@
 
 #if PLATFORM(IOS_FAMILY)
 
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=UI
+]
 messages -> SmartMagnificationController {
     DidCollectGeometryForSmartMagnificationGesture(WebCore::FloatPoint origin, WebCore::FloatRect renderRect, WebCore::FloatRect visibleContentBounds, bool fitEntireRect, double viewportMinimumScale, double viewportMaximumScale)
     ScrollToRect(WebCore::FloatPoint origin, WebCore::FloatRect targetRect)

--- a/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.messages.in
+++ b/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.messages.in
@@ -21,6 +21,10 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(DEVICE_ORIENTATION)
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=UI
+]
 messages -> WebDeviceOrientationUpdateProviderProxy {
     StartUpdatingDeviceOrientation();
     StopUpdatingDeviceOrientation();

--- a/Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.messages.in
+++ b/Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.messages.in
@@ -24,6 +24,10 @@
 
 #if ENABLE(APPLE_PAY)
 
+[
+    DispatchedFrom=UI,
+    DispatchedTo=WebContent
+]
 messages -> WebPaymentCoordinator {
 
     ValidateMerchant(String validationURLString)

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.messages.in
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=UI,
+    DispatchedTo=WebContent
+]
 messages -> WebAutomationSessionProxy {
     EvaluateJavaScriptFunction(WebCore::PageIdentifier pageID, std::optional<WebCore::FrameIdentifier> frameID, String function, Vector<String> arguments, bool expectsImplicitCallbackArgument, bool forceUserGesture, std::optional<double> callbackTimeout) -> (String result, String errorType)
 

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
@@ -25,6 +25,10 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+[
+    DispatchedFrom=UI,
+    DispatchedTo=WebContent
+]
 messages -> WebExtensionContextProxy {
     // Action
     DispatchActionClickedEvent(std::optional<WebKit::WebExtensionTabParameters> tabParameters)

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.messages.in
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.messages.in
@@ -25,6 +25,10 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+[
+    DispatchedFrom=UI,
+    DispatchedTo=WebContent
+]
 messages -> WebExtensionControllerProxy {
     Load(struct WebKit::WebExtensionContextParameters contextParameters)
     Unload(WebKit::WebExtensionContextIdentifier contextIdentifier)

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.messages.in
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.messages.in
@@ -21,6 +21,10 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #if ENABLE(FULLSCREEN_API)
+[
+    DispatchedFrom=UI,
+    DispatchedTo=WebContent
+]
 messages -> WebFullScreenManager {
     RequestRestoreFullScreen() -> (bool succeeded) Async
     RequestExitFullScreen()

--- a/Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.messages.in
@@ -23,6 +23,10 @@
 
 #if ENABLE(GPU_PROCESS) && PLATFORM(IOS_FAMILY)
 
+[
+    DispatchedFrom=UI,
+    DispatchedTo=WebContent
+]
 messages -> RemoteMediaSessionHelper {
     ApplicationWillEnterForeground(enum:bool WebKit::RemoteMediaSessionHelper::SuspendedUnderLock suspendedUnderLock)
     ApplicationDidEnterBackground(enum:bool WebKit::RemoteMediaSessionHelper::SuspendedUnderLock suspendedUnderLock)

--- a/Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.messages.in
+++ b/Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=UI,
+    DispatchedTo=WebContent
+]
 messages -> RemoteWebInspectorUI {
     Initialize(struct WebKit::DebuggableInfoData debuggableInfo, String backendCommandsURL)
 

--- a/Source/WebKit/WebProcess/Inspector/WebInspector.messages.in
+++ b/Source/WebKit/WebProcess/Inspector/WebInspector.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=UI,
+    DispatchedTo=WebContent
+]
 messages -> WebInspector {
     Show()
     Close()

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorInterruptDispatcher.messages.in
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorInterruptDispatcher.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=UI,
+    DispatchedTo=WebContent
+]
 messages -> WebInspectorInterruptDispatcher {
     NotifyNeedDebuggerBreak()
 }

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUI.messages.in
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUI.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=UI,
+    DispatchedTo=WebContent
+]
 messages -> WebInspectorUI {
     EstablishConnection(WebKit::WebPageProxyIdentifier inspectedPageIdentifier, struct WebKit::DebuggableInfoData debuggableInfo, bool underTest, unsigned inspectionLevel)
     UpdateConnection()

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.messages.in
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.messages.in
@@ -22,6 +22,10 @@
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
 
+[
+    DispatchedFrom=UI,
+    DispatchedTo=WebContent
+]
 messages -> WebInspectorUIExtensionController {
     RegisterExtension(String extensionID, String extensionBundleIdentifier, String displayName) -> (Expected<void, Inspector::ExtensionError> result)
     UnregisterExtension(String extensionID) -> (Expected<void, Inspector::ExtensionError> result)

--- a/Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.messages.in
+++ b/Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.messages.in
@@ -25,6 +25,10 @@
 
 #if ENABLE(MEDIA_SESSION_COORDINATOR)
 
+[
+    DispatchedFrom=UI,
+    DispatchedTo=WebContent
+]
 messages -> RemoteMediaSessionCoordinator {
 
     SeekSessionToTime(double time) -> (bool result)

--- a/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.messages.in
+++ b/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.messages.in
@@ -23,6 +23,10 @@
 
 #if ENABLE(MEDIA_STREAM)
 
+[
+    DispatchedFrom=UI,
+    DispatchedTo=WebContent
+]
 messages -> SpeechRecognitionRealtimeMediaSourceManager {
     CreateSource(WebCore::RealtimeMediaSourceIdentifier identifier, WebCore::CaptureDevice device, WebCore::PageIdentifier pageIdentifier)
     DeleteSource(WebCore::RealtimeMediaSourceIdentifier identifier)

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.messages.in
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.messages.in
@@ -23,6 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+[
+    DispatchedFrom=UI,
+    DispatchedTo=WebContent
+]
 messages -> WebUserContentController {
     AddContentWorlds(Vector<WebKit::ContentWorldData> worlds);
     RemoveContentWorlds(Vector<WebKit::ContentWorldIdentifier> worldIdentifiers);

--- a/Source/WebKit/WebProcess/WebCoreSupport/RemoteWebLockRegistry.messages.in
+++ b/Source/WebKit/WebProcess/WebCoreSupport/RemoteWebLockRegistry.messages.in
@@ -23,6 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+[
+    DispatchedFrom=UI,
+    DispatchedTo=WebContent
+]
 messages -> RemoteWebLockRegistry {
     DidCompleteLockRequest(WebCore::WebLockIdentifier lockIdentifier, WebCore::ScriptExecutionContextIdentifier clientID, bool success);
     DidStealLock(WebCore::WebLockIdentifier lockIdentifier, WebCore::ScriptExecutionContextIdentifier clientID);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDeviceOrientationUpdateProvider.messages.in
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDeviceOrientationUpdateProvider.messages.in
@@ -21,6 +21,10 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(DEVICE_ORIENTATION)
+[
+    DispatchedFrom=UI,
+    DispatchedTo=WebContent
+]
 messages -> WebDeviceOrientationUpdateProvider {
     DeviceOrientationChanged(double alpha, double beta, double gamma, double compassHeading, double compassAccuracy)
     DeviceMotionChanged(double xAcceleration, double yAcceleration, double zAcceleration, double xAccelerationIncludingGravity, double yAccelerationIncludingGravity, double zAccelerationIncludingGravity, std::optional<double> xRotationRate, std::optional<double> yRotationRate, std::optional<double> zRotationRate)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.messages.in
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.messages.in
@@ -23,6 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+[
+    DispatchedFrom=UI,
+    DispatchedTo=WebContent
+]
 messages -> WebPermissionController {
     permissionChanged(enum:uint8_t WebCore::PermissionName permissionName, WebCore::SecurityOriginData topOrigin)
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.messages.in
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.messages.in
@@ -23,6 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+[
+    DispatchedFrom=UI,
+    DispatchedTo=WebContent
+]
 messages -> WebScreenOrientationManager {
     OrientationDidChange(enum:uint8_t WebCore::ScreenOrientationType orientation)
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechRecognitionConnection.messages.in
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechRecognitionConnection.messages.in
@@ -23,6 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
  
+ [
+    DispatchedFrom=UI,
+    DispatchedTo=WebContent
+]
  messages -> WebSpeechRecognitionConnection {
     DidReceiveUpdate(WebCore::SpeechRecognitionUpdate update)
  }

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.messages.in
@@ -22,6 +22,10 @@
 
 #if ENABLE(PLATFORM_DRIVEN_TEXT_CHECKING)
 
+[
+    DispatchedFrom=UI,
+    DispatchedTo=WebContent
+]
 messages -> TextCheckingControllerProxy {
     ReplaceRelativeToSelection(struct WebCore::AttributedString annotatedString, int64_t selectionOffset, uint64_t length, uint64_t relativeReplacementLocation, uint64_t relativeReplacementLength)
 

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=UI,
+    DispatchedTo=WebContent
+]
 messages -> DrawingArea {
 #if USE(COORDINATED_GRAPHICS) || USE(TEXTURE_MAPPER)
     UpdateGeometry(WebCore::IntSize size) -> ()

--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=UI,
+    DispatchedTo=WebContent
+]
 messages -> EventDispatcher {
     WheelEvent(WebCore::PageIdentifier pageID, WebKit::WebWheelEvent event, WebCore::RectEdges<bool> rubberBandableEdges)
 #if ENABLE(IOS_TOUCH_EVENTS)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.messages.in
@@ -22,6 +22,10 @@
 
 #if ENABLE(ASYNC_SCROLLING)
 
+[
+    DispatchedFrom=UI,
+    DispatchedTo=WebContent
+]
 messages -> RemoteScrollingCoordinator {
     ScrollPositionChangedForNode(WebCore::ScrollingNodeID nodeID, WebCore::FloatPoint scrollPosition, std::optional<WebCore::FloatPoint> layoutViewportOrigin, bool syncLayerPosition) -> ()
     AnimatedScrollDidEndForNode(WebCore::ScrollingNodeID nodeID);

--- a/Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=UI,
+    DispatchedTo=WebContent
+]
 messages -> ViewGestureGeometryCollector {
 #if PLATFORM(COCOA)
     CollectGeometryForSmartMagnificationGesture(WebCore::FloatPoint origin)

--- a/Source/WebKit/WebProcess/WebPage/ViewUpdateDispatcher.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/ViewUpdateDispatcher.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=UI,
+    DispatchedTo=WebContent
+]
 messages -> ViewUpdateDispatcher {
     VisibleContentRectUpdate(WebCore::PageIdentifier pageID, WebKit::VisibleContentRectUpdateInfo visibleContentRectUpdateInfo)
 }

--- a/Source/WebKit/WebProcess/WebPage/VisitedLinkTableController.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/VisitedLinkTableController.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=UI,
+    DispatchedTo=WebContent
+]
 messages -> VisitedLinkTableController {
     SetVisitedLinkTable(WebCore::SharedMemory::Handle handle)
     VisitedLinkStateChanged(Vector<WebCore::SharedStringHash> linkHashes)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+// Currently DispatchedFrom both the Networking and UI process
+[
+    DispatchedTo=WebContent
+]
 messages -> WebPage WantsAsyncDispatchMessage {
     SetInitialFocus(bool forward, bool isKeyboardEventValid, std::optional<WebKit::WebKeyboardEvent> event) -> ()
     SetActivityState(OptionSet<WebCore::ActivityState> activityState, WebKit::ActivityStateChangeID activityStateChangeID) -> ()

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=UI,
+    DispatchedTo=WebContent
+]
 messages -> WebPageTesting {
     SetDefersLoading(bool defersLoading)
     IsLayerTreeFrozen() -> (bool isFrozen)

--- a/Source/WebKit/WebProcess/WebProcess.messages.in
+++ b/Source/WebKit/WebProcess/WebProcess.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=UI,
+    DispatchedTo=WebContent
+]
 messages -> WebProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
     InitializeWebProcess(struct WebKit::WebProcessCreationParameters processCreationParameters) -> (WebCore::ProcessIdentity processIdentity)
     SetWebsiteDataStoreParameters(struct WebKit::WebProcessDataStoreParameters parameters)

--- a/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.messages.in
+++ b/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.messages.in
@@ -25,6 +25,10 @@
 
 #if ENABLE(WEBXR)
 
+[
+    DispatchedFrom=UI,
+    DispatchedTo=WebContent
+]
 messages -> PlatformXRSystemProxy {
     SessionDidEnd(WebKit::XRDeviceIdentifier deviceIdentifier)
     SessionDidUpdateVisibilityState(WebKit::XRDeviceIdentifier deviceIdentifier, PlatformXR::VisibilityState visibilityState)

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.messages.in
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.messages.in
@@ -22,6 +22,10 @@
 # THE POSSIBILITY OF SUCH DAMAGE.
 
 #if PLATFORM(IOS_FAMILY) || (PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE))
+[
+    DispatchedFrom=UI,
+    DispatchedTo=WebContent
+]
 messages -> PlaybackSessionManager {
     Play(WebKit::PlaybackSessionContextIdentifier contextId)
     Pause(WebKit::PlaybackSessionContextIdentifier contextId)

--- a/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.messages.in
+++ b/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.messages.in
@@ -23,6 +23,10 @@
 
 #if ENABLE(MEDIA_STREAM)
 
+// rdar://140690546 - Can currently be dispatchedFrom UI & GPU
+[
+    DispatchedTo=WebContent
+]
 messages -> RemoteCaptureSampleManager {
     AudioStorageChanged(WebCore::RealtimeMediaSourceIdentifier id, struct WebKit::ConsumerSharedCARingBufferHandle storageHandle, WebCore::CAAudioStreamDescription description, IPC::Semaphore captureSemaphore, MediaTime mediaTime, size_t frameChunkSize);
     VideoFrameAvailable(WebCore::RealtimeMediaSourceIdentifier id, struct WebKit::RemoteVideoFrameProxyProperties sample, struct WebCore::VideoFrameTimeMetadata metadata)

--- a/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.messages.in
+++ b/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.messages.in
@@ -23,6 +23,10 @@
 
 #if ENABLE(MEDIA_STREAM)
 
+// rdar://140690546 - Can currently be dispatchedFrom UI & GPU
+[
+    DispatchedTo=WebContent
+]
 messages -> UserMediaCaptureManager {
     SourceStopped(WebCore::RealtimeMediaSourceIdentifier id, bool didFail)
     SourceMutedChanged(WebCore::RealtimeMediaSourceIdentifier id, bool muted, bool interrupted)

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.messages.in
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.messages.in
@@ -21,6 +21,10 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
+[
+    DispatchedFrom=UI,
+    DispatchedTo=WebContent
+]
 messages -> VideoPresentationManager {
     RequestFullscreenMode(WebKit::PlaybackSessionContextIdentifier contextId, WebCore::MediaPlayerEnums::VideoFullscreenMode videoFullscreenMode, bool finishedWithMedia)
     RequestUpdateInlineRect(WebKit::PlaybackSessionContextIdentifier contextId)


### PR DESCRIPTION
#### f13720e3cc67bdd236a602fe65bb1e8d3b09fd37
<pre>
Adopt dispatched(From|To) for WebProcess&lt;-&gt;UI interfaces
<a href="https://bugs.webkit.org/show_bug.cgi?id=284292">https://bugs.webkit.org/show_bug.cgi?id=284292</a>
<a href="https://rdar.apple.com/141151138">rdar://141151138</a>

Reviewed by Timothy Hatcher.

Adopt the new dispatched(From|To) annotations across interfaces which bridge the
UI and WebProcess boundary.

* Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.messages.in:
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.messages.in:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.messages.in:
* Source/WebKit/UIProcess/DigitalCredentials/DigitalCredentialsCoordinatorProxy.messages.in:
* Source/WebKit/UIProcess/Downloads/DownloadProxy.messages.in:
* Source/WebKit/UIProcess/DrawingAreaProxy.messages.in:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in:
* Source/WebKit/UIProcess/Extensions/WebExtensionController.messages.in:
* Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.messages.in:
* Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.messages.in:
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.messages.in:
* Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.messages.in:
* Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.messages.in:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.messages.in:
* Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.messages.in:
* Source/WebKit/UIProcess/SpeechRecognitionServer.messages.in:
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.messages.in:
* Source/WebKit/UIProcess/ViewGestureController.messages.in:
* Source/WebKit/UIProcess/VisitedLinkStore.messages.in:
* Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.messages.in:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.messages.in:
* Source/WebKit/UIProcess/WebGeolocationManagerProxy.messages.in:
* Source/WebKit/UIProcess/WebLockRegistryProxy.messages.in:
* Source/WebKit/UIProcess/WebPasteboardProxy.messages.in:
* Source/WebKit/UIProcess/WebPermissionControllerProxy.messages.in:
* Source/WebKit/UIProcess/WebProcessPool.messages.in:
* Source/WebKit/UIProcess/WebProcessProxy.messages.in:
* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.messages.in:
* Source/WebKit/UIProcess/XR/PlatformXRSystem.messages.in:
* Source/WebKit/UIProcess/ios/SmartMagnificationController.messages.in:
* Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.messages.in:
* Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.messages.in:
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.messages.in:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in:
* Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.messages.in:
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.messages.in:
* Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.messages.in:
* Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.messages.in:
* Source/WebKit/WebProcess/Inspector/WebInspector.messages.in:
* Source/WebKit/WebProcess/Inspector/WebInspectorInterruptDispatcher.messages.in:
* Source/WebKit/WebProcess/Inspector/WebInspectorUI.messages.in:
* Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.messages.in:
* Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.messages.in:
* Source/WebKit/WebProcess/Notifications/WebNotificationManager.messages.in:
* Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.messages.in:
* Source/WebKit/WebProcess/UserContent/WebUserContentController.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/RemoteWebLockRegistry.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebDeviceOrientationUpdateProvider.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebSpeechRecognitionConnection.messages.in:
* Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.messages.in:
* Source/WebKit/WebProcess/WebPage/DrawingArea.messages.in:
* Source/WebKit/WebProcess/WebPage/EventDispatcher.messages.in:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.messages.in:
* Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.messages.in:
* Source/WebKit/WebProcess/WebPage/ViewUpdateDispatcher.messages.in:
* Source/WebKit/WebProcess/WebPage/VisitedLinkTableController.messages.in:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/WebPage/WebPageTesting.messages.in:
* Source/WebKit/WebProcess/WebProcess.messages.in:
* Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.messages.in:
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.messages.in:
* Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.messages.in:
* Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.messages.in:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.messages.in:

Canonical link: <a href="https://commits.webkit.org/287602@main">https://commits.webkit.org/287602@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25d8d6b393e4b9556713d37fa4c6aae066b6024b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80258 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59260 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33672 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84775 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31234 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68321 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7560 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62740 "Found 1 new test failure: media/modern-media-controls/css/transformed-media-crash.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20552 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83327 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52801 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73089 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43049 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50128 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29695 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71259 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27758 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86208 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7478 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5288 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71016 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7653 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68929 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70257 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17488 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14254 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13198 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7442 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12959 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7281 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10801 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9086 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->