### PR TITLE
Adopt dispatched(From|To) for WebProcess<->Networking interfaces

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=Networking
+]
 messages -> NetworkBroadcastChannelRegistry {
     RegisterChannel(struct WebCore::ClientOrigin origin, String name)
     UnregisterChannel(struct WebCore::ClientOrigin origin, String name)

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=Networking
+]
 messages -> NetworkResourceLoader {
     ContinueDidReceiveResponse()
 }

--- a/Source/WebKit/NetworkProcess/NetworkSocketChannel.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkSocketChannel.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=Networking
+]
 messages -> NetworkSocketChannel {
     SendString(std::span<const uint8_t> message) -> ()
     SendData(std::span<const uint8_t> data) -> ()

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.messages.in
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=Networking
+]
 messages -> ServiceWorkerDownloadTask {
     DidFail(WebCore::ResourceError error)
     DidReceiveData(IPC::SharedBufferReference data, uint64_t encodedDataLength)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.messages.in
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=Networking
+]
 messages -> ServiceWorkerFetchTask {
     DidNotHandle()
     DidFail(WebCore::ResourceError error)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.messages.in
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=Networking
+]
 messages -> WebSWServerConnection {
     # When possible, these messages can be implemented directly by WebCore::SWClientConnection
     ScheduleJobInServer(struct WebCore::ServiceWorkerJobData jobData)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.messages.in
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=Networking
+]
 messages -> WebSWServerToContextConnection {
     # When possible, these messages can be implemented directly by WebCore::SWServerToContextConnection
 

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.messages.in
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=Networking
+]
 messages -> WebSharedWorkerServerConnection {
     RequestSharedWorker(struct WebCore::SharedWorkerKey sharedWorkerKey, WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, WebCore::TransferredMessagePort port, struct WebCore::WorkerOptions workerOptions)
     SharedWorkerObjectIsGoingAway(struct WebCore::SharedWorkerKey sharedWorkerKey, WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier)

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.messages.in
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=Networking
+]
 messages -> WebSharedWorkerServerToContextConnection {
     PostErrorToWorkerObject(WebCore::SharedWorkerIdentifier sharedWorkerIdentifier, String errorMessage, int lineNumber, int columnNumber, String sourceURL, bool isErrorEvent)
     SharedWorkerTerminated(WebCore::SharedWorkerIdentifier sharedWorkerIdentifier)

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
@@ -23,7 +23,11 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
  
- [SharedPreferencesNeedsConnection]
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=Networking,
+    SharedPreferencesNeedsConnection
+]
  messages -> NetworkStorageManager {
     Persisted(struct WebCore::ClientOrigin origin) -> (bool persisted)
     Persist(struct WebCore::ClientOrigin origin) -> (bool persisted)

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.messages.in
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.messages.in
@@ -22,6 +22,10 @@
 
 #if ENABLE(WEB_RTC)
 
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=Networking
+]
 messages -> NetworkMDNSRegister {
     UnregisterMDNSNames(WebCore::ScriptExecutionContextIdentifier documentIdentifier)
     RegisterMDNSName(WebCore::ScriptExecutionContextIdentifier documentIdentifier, String ipAddress) -> (String mdnsName, std::optional<WebCore::MDNSRegisterError> error)

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.messages.in
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.messages.in
@@ -22,6 +22,10 @@
 
 #if USE(LIBWEBRTC)
 
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=Networking
+]
 messages -> NetworkRTCMonitor {
     void StartUpdatingIfNeeded()
     void StopUpdating()

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.messages.in
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.messages.in
@@ -22,6 +22,10 @@
 
 #if USE(LIBWEBRTC)
 
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=Networking
+]
 messages -> NetworkRTCProvider {
     CreateUDPSocket(WebCore::LibWebRTCSocketIdentifier identifier, WebKit::RTC::Network::SocketAddress localAddress, uint16_t minPort, uint16_t maxPort, WebKit::WebPageProxyIdentifier pageIdentifier, bool isFirstParty, bool isRelayDisabled, WebCore::RegistrableDomain domain)
     CreateClientTCPSocket(WebCore::LibWebRTCSocketIdentifier identifier, WebKit::RTC::Network::SocketAddress localAddress, WebKit::RTC::Network::SocketAddress remoteAddress, String userAgent, int options, WebKit::WebPageProxyIdentifier pageIdentifier, bool isFirstParty, bool isRelayDisabled, WebCore::RegistrableDomain domain)

--- a/Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.messages.in
+++ b/Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.messages.in
@@ -22,6 +22,10 @@
 
 #if ENABLE(WEB_RTC)
 
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=Networking
+]
 messages -> RTCDataChannelRemoteManagerProxy {
     // To source
     SendData(struct WebCore::RTCDataChannelIdentifier source, bool isRaw, std::span<const uint8_t> text);

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.messages.in
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.messages.in
@@ -20,7 +20,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[EnabledBy=WebTransportEnabled]
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=Networking,
+    EnabledBy=WebTransportEnabled
+]
 messages -> NetworkTransportSession {
     SendDatagram(std::span<const uint8_t> datagram) -> ()
     CreateOutgoingUnidirectionalStream() -> (std::optional<WebKit::WebTransportStreamIdentifier> identifier)

--- a/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.messages.in
+++ b/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=Networking,
+    DispatchedTo=WebContent
+]
 messages -> WebIDBConnectionToServer {
     DidDeleteDatabase(WebCore::IDBResultData result)
     DidOpenDatabase(WebCore::IDBResultData result)

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.messages.in
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=Networking,
+    DispatchedTo=WebContent
+]
 messages -> NetworkProcessConnection WantsDispatchMessage {
 
 #if ENABLE(SHAREABLE_RESOURCE)

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.messages.in
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=Networking,
+    DispatchedTo=WebContent
+]
 messages -> WebResourceLoader {
     WillSendRequest(WebCore::ResourceRequest request, IPC::FormDataReference requestBody, WebCore::ResourceResponse redirectResponse) -> (WebCore::ResourceRequest newRequest, bool isAllowedToAskUserForCredentials)
     SetWorkerStart(MonotonicTime value)

--- a/Source/WebKit/WebProcess/Network/WebSocketChannel.messages.in
+++ b/Source/WebKit/WebProcess/Network/WebSocketChannel.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) A RISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=Networking,
+    DispatchedTo=WebContent
+]
 messages -> WebSocketChannel {
     DidConnect(String subprotocol, String extensions)
     DidClose(unsigned short code, String reason)

--- a/Source/WebKit/WebProcess/Network/WebTransportSession.messages.in
+++ b/Source/WebKit/WebProcess/Network/WebTransportSession.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=Networking,
+    DispatchedTo=WebContent
+]
 messages -> WebTransportSession {
     ReceiveDatagram(std::span<const uint8_t> datagram)
     ReceiveIncomingUnidirectionalStream(WebKit::WebTransportStreamIdentifier identifier)

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.messages.in
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.messages.in
@@ -22,6 +22,10 @@
 
 #if USE(LIBWEBRTC)
 
+[
+    DispatchedFrom=Networking,
+    DispatchedTo=WebContent
+]
 messages -> LibWebRTCNetwork {
     SignalReadPacket(WebCore::LibWebRTCSocketIdentifier socketIdentifier, std::span<const uint8_t> data, WebKit::RTC::Network::IPAddress address, uint16_t port, int64_t timestamp, WebKit::RTC::Network::EcnMarking ecn)
     SignalSentPacket(WebCore::LibWebRTCSocketIdentifier socketIdentifier, int64_t rtcPacketID, int64_t timestamp)

--- a/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.messages.in
+++ b/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.messages.in
@@ -22,6 +22,10 @@
 
 #if ENABLE(WEB_RTC)
 
+[
+    DispatchedFrom=Networking,
+    DispatchedTo=WebContent
+]
 messages -> RTCDataChannelRemoteManager {
     // To source
     SendData(struct WebCore::RTCDataChannelIdentifier source, bool isRaw, std::span<const uint8_t> text);

--- a/Source/WebKit/WebProcess/Network/webrtc/WebRTCMonitor.messages.in
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebRTCMonitor.messages.in
@@ -22,6 +22,10 @@
 
 #if USE(LIBWEBRTC)
 
+[
+    DispatchedFrom=Networking,
+    DispatchedTo=WebContent
+]
 messages -> WebRTCMonitor {
     void NetworksChanged(Vector<WebKit::RTCNetwork> networks, WebKit::RTC::Network::IPAddress defaultIPV4Address, WebKit::RTC::Network::IPAddress defaultIPV6Address)
 }

--- a/Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.messages.in
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.messages.in
@@ -22,6 +22,10 @@
 
 #if USE(LIBWEBRTC)
 
+[
+    DispatchedFrom=Networking,
+    DispatchedTo=WebContent
+]
 messages -> WebRTCResolver {
     void SetResolvedAddress(Vector<WebKit::RTC::Network::IPAddress> addresses)
     void ResolvedAddressError(int error)

--- a/Source/WebKit/WebProcess/Storage/WebSWClientConnection.messages.in
+++ b/Source/WebKit/WebProcess/Storage/WebSWClientConnection.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=Networking,
+    DispatchedTo=WebContent
+]
 messages -> WebSWClientConnection {
     # When possible, these messages can be implemented directly by WebCore::SWServer::Connection
     JobRejectedInServer(WebCore::ServiceWorkerJobIdentifier jobDataIdentifier, struct WebCore::ExceptionData exception)

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.messages.in
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+// Currently being DispatchedFrom both the UI and Networking Process
+[
+    DispatchedTo=WebContent
+]
 messages -> WebSWContextManagerConnection {
     InstallServiceWorker(struct WebCore::ServiceWorkerContextData contextData, struct WebCore::ServiceWorkerData workerData, String userAgent, enum:bool WebCore::WorkerThreadMode workerThreadMode, enum:bool WebCore::ServiceWorkerIsInspectable inspectable, OptionSet<WebCore::AdvancedPrivacyProtections> protections)
     UpdateAppInitiatedValue(WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, enum:bool WebCore::LastNavigationWasAppInitiated lastNavigationWasAppInitiated)

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.messages.in
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+// Currently DispatchedFrom both the UI and Network Process
+[
+    DispatchedTo=WebContent
+]
 messages -> WebSharedWorkerContextManagerConnection {
     LaunchSharedWorker(struct WebCore::ClientOrigin origin, WebCore::SharedWorkerIdentifier sharedWorkerIdentifier, struct WebCore::WorkerOptions workerOptions, struct WebCore::WorkerFetchResult workerFetchResult, struct WebCore::WorkerInitializationData workerInitializationData)
     PostConnectEvent(WebCore::SharedWorkerIdentifier sharedWorkerIdentifier, WebCore::TransferredMessagePort port, String sourceOrigin) -> (bool success)

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerObjectConnection.messages.in
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerObjectConnection.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=Networking,
+    DispatchedTo=WebContent
+]
 messages -> WebSharedWorkerObjectConnection {
     FetchScriptInClient(URL url, WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, struct WebCore::WorkerOptions workerOptions) -> (struct WebCore::WorkerFetchResult fetchResult, struct WebCore::WorkerInitializationData initializationData)
     NotifyWorkerObjectOfLoadCompletion(WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, WebCore::ResourceError error)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.messages.in
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=Networking,
+    DispatchedTo=WebContent
+]
 messages -> WebBroadcastChannelRegistry {
     PostMessageToRemote(struct WebCore::ClientOrigin origin, String name, struct WebCore::MessageWithMessagePorts message) -> ()
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.messages.in
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=Networking,
+    DispatchedTo=WebContent
+]
 messages -> WebFileSystemStorageConnection {
     InvalidateAccessHandle(WebCore::FileSystemSyncAccessHandleIdentifier identifier)
 }

--- a/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.messages.in
+++ b/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.messages.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[
+    DispatchedFrom=Networking,
+    DispatchedTo=WebContent
+]
 messages -> StorageAreaMap {
     DispatchStorageEvent(std::optional<WebKit::StorageAreaImplIdentifier> storageAreaImplID, String key, String oldValue, String newValue, String urlString, uint64_t messageIdentifier)
     ClearCache(uint64_t messageIdentifier)


### PR DESCRIPTION
#### 659af6db20c930bafc0b5a450e5e1a88aa28dedb
<pre>
Adopt dispatched(From|To) for WebProcess&lt;-&gt;Networking interfaces
<a href="https://bugs.webkit.org/show_bug.cgi?id=284293">https://bugs.webkit.org/show_bug.cgi?id=284293</a>
<a href="https://rdar.apple.com/141151476">rdar://141151476</a>

Reviewed by Sihui Liu.

Adopt the new dispatched(From|To) annotations across interfaces which bridge the
Networking and WebProcess boundary.

* Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.messages.in:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.messages.in:
* Source/WebKit/NetworkProcess/NetworkSocketChannel.messages.in:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.messages.in:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.messages.in:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.messages.in:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.messages.in:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.messages.in:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.messages.in:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in:
* Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.messages.in:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.messages.in:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.messages.in:
* Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.messages.in:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.messages.in:
* Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.messages.in:
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.messages.in:
* Source/WebKit/WebProcess/Network/WebResourceLoader.messages.in:
* Source/WebKit/WebProcess/Network/WebSocketChannel.messages.in:
* Source/WebKit/WebProcess/Network/WebTransportSession.messages.in:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.messages.in:
* Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.messages.in:
* Source/WebKit/WebProcess/Network/webrtc/WebRTCMonitor.messages.in:
* Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.messages.in:
* Source/WebKit/WebProcess/Storage/WebSWClientConnection.messages.in:
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.messages.in:
* Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.messages.in:
* Source/WebKit/WebProcess/Storage/WebSharedWorkerObjectConnection.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.messages.in:
* Source/WebKit/WebProcess/WebStorage/StorageAreaMap.messages.in:

Canonical link: <a href="https://commits.webkit.org/287605@main">https://commits.webkit.org/287605@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63b41763302d274970904bf7b88cad98026c7327

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80080 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59078 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33487 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84594 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31051 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68144 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7376 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62607 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20431 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83148 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52688 "Found 1 new test failure: media/audioSession/getUserMedia.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72935 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42908 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50018 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29513 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71141 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27599 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86024 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7296 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5171 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70882 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7477 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68776 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70113 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17490 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14119 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13059 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7260 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12782 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7102 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10625 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8909 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->