### PR TITLE
Adopt dispatched(From|To) for UI<->(Networking|GPU|Model) interfaces

### DIFF
--- a/Source/WebKit/GPUProcess/GPUProcess.messages.in
+++ b/Source/WebKit/GPUProcess/GPUProcess.messages.in
@@ -22,7 +22,11 @@
 
 #if ENABLE(GPU_PROCESS)
 
-[ExceptionForEnabledBy]
+[
+    DispatchedFrom=UI,
+    DispatchedTo=GPU,
+    ExceptionForEnabledBy
+]
 messages -> GPUProcess : AuxiliaryProcess {
     InitializeGPUProcess(struct WebKit::GPUProcessCreationParameters processCreationParameters) -> ()
 

--- a/Source/WebKit/ModelProcess/ModelProcess.messages.in
+++ b/Source/WebKit/ModelProcess/ModelProcess.messages.in
@@ -22,7 +22,11 @@
 
 #if ENABLE(MODEL_PROCESS)
 
-[ExceptionForEnabledBy]
+[
+    DispatchedFrom=UI,
+    DispatchedTo=Model,
+    ExceptionForEnabledBy
+]
 messages -> ModelProcess : AuxiliaryProcess {
     InitializeModelProcess(struct WebKit::ModelProcessCreationParameters processCreationParameters) -> ()
 

--- a/Source/WebKit/NetworkProcess/Authentication/AuthenticationManager.messages.in
+++ b/Source/WebKit/NetworkProcess/Authentication/AuthenticationManager.messages.in
@@ -20,7 +20,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[ExceptionForEnabledBy]
+[
+    DispatchedFrom=UI,
+    DispatchedTo=Networking,
+    ExceptionForEnabledBy
+]
 messages -> AuthenticationManager {
     void CompleteAuthenticationChallenge(WebKit::AuthenticationChallengeIdentifier challengeID, enum:uint8_t WebKit::AuthenticationChallengeDisposition disposition, WebCore::Credential credential);
 }

--- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.messages.in
+++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.messages.in
@@ -23,7 +23,11 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
  
-[ExceptionForEnabledBy]
+[
+    DispatchedFrom=UI,
+    DispatchedTo=Networking,
+    ExceptionForEnabledBy
+]
 messages -> WebCookieManager {
     void GetHostnamesWithCookies(PAL::SessionID sessionID) -> (Vector<String> hostnames)
     void DeleteCookiesForHostnames(PAL::SessionID sessionID, Vector<String> hostnames) -> ()

--- a/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.messages.in
+++ b/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.messages.in
@@ -20,7 +20,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[ExceptionForEnabledBy]
+[
+    DispatchedFrom=UI,
+    DispatchedTo=Networking,
+    ExceptionForEnabledBy
+]
 messages -> LegacyCustomProtocolManager {
     DidFailWithError(WebKit::LegacyCustomProtocolID customProtocolID, WebCore::ResourceError error)
     DidLoadData(WebKit::LegacyCustomProtocolID customProtocolID, std::span<const uint8_t> data)

--- a/Source/WebKit/NetworkProcess/NetworkContentRuleListManager.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkContentRuleListManager.messages.in
@@ -22,7 +22,11 @@
 
 #if ENABLE(CONTENT_EXTENSIONS)
 
-[ExceptionForEnabledBy]
+[
+    DispatchedFrom=UI,
+    DispatchedTo=Networking,
+    ExceptionForEnabledBy
+]
 messages -> NetworkContentRuleListManager {
     Remove(WebKit::UserContentControllerIdentifier identifier)
     AddContentRuleLists(WebKit::UserContentControllerIdentifier identifier, Vector<std::pair<WebKit::WebCompiledContentRuleListData, URL>> contentFilters)

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -20,7 +20,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[ExceptionForEnabledBy]
+[
+    DispatchedFrom=UI,
+    DispatchedTo=Networking,
+    ExceptionForEnabledBy
+]
 messages -> NetworkProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
     InitializeNetworkProcess(struct WebKit::NetworkProcessCreationParameters processCreationParameters) -> ()
 

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.messages.in
@@ -22,7 +22,11 @@
 
 #if ENABLE(GPU_PROCESS)
 
-[ExceptionForEnabledBy]
+[
+    DispatchedFrom=GPU,
+    DispatchedTo=UI,
+    ExceptionForEnabledBy
+]
 messages -> GPUProcessProxy {
 
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)

--- a/Source/WebKit/UIProcess/Model/ModelProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/Model/ModelProcessProxy.messages.in
@@ -22,7 +22,11 @@
 
 #if ENABLE(MODEL_PROCESS)
 
-[ExceptionForEnabledBy]
+[
+    DispatchedFrom=Model,
+    DispatchedTo=UI,
+    ExceptionForEnabledBy
+]
 messages -> ModelProcessProxy {
 
     TerminateWebProcess(WebCore::ProcessIdentifier webProcessIdentifier)

--- a/Source/WebKit/UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.messages.in
@@ -20,7 +20,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[ExceptionForEnabledBy]
+[
+    DispatchedFrom=Networking,
+    DispatchedTo=UI,
+    ExceptionForEnabledBy
+]
 messages -> LegacyCustomProtocolManagerProxy {
     StartLoading(WebKit::LegacyCustomProtocolID customProtocolID, WebCore::ResourceRequest request)
     StopLoading(WebKit::LegacyCustomProtocolID customProtocolID)

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in
@@ -20,7 +20,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[ExceptionForEnabledBy]
+[
+    DispatchedFrom=Networking,
+    DispatchedTo=UI,
+    ExceptionForEnabledBy
+]
 messages -> NetworkProcessProxy WantsDispatchMessage {
     DidReceiveAuthenticationChallenge(PAL::SessionID sessionID, WebKit::WebPageProxyIdentifier pageID, std::optional<WebCore::SecurityOriginData> topOrigin, WebCore::AuthenticationChallenge challenge, bool negotiatedLegacyTLS, WebKit::AuthenticationChallengeIdentifier challengeID)
     NegotiatedLegacyTLS(WebKit::WebPageProxyIdentifier pageID)

--- a/Source/WebKit/UIProcess/mac/SecItemShimProxy.messages.in
+++ b/Source/WebKit/UIProcess/mac/SecItemShimProxy.messages.in
@@ -20,7 +20,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[ExceptionForEnabledBy]
+[
+    DispatchedFrom=Networking,
+    DispatchedTo=UI,
+    ExceptionForEnabledBy
+]
 messages -> SecItemShimProxy {
 
 #if ENABLE(SEC_ITEM_SHIM)

--- a/Source/WebKit/WebProcess/Model/ModelProcessConnection.messages.in
+++ b/Source/WebKit/WebProcess/Model/ModelProcessConnection.messages.in
@@ -22,7 +22,11 @@
 
 #if ENABLE(MODEL_PROCESS)
 
-[ExceptionForEnabledBy]
+[
+    DispatchedFrom=Model,
+    DispatchedTo=WebContent,
+    ExceptionForEnabledBy
+]
 messages -> ModelProcessConnection WantsDispatchMessage {
     DidInitialize(std::optional<WebKit::ModelProcessConnectionInfo> info) CanDispatchOutOfOrder
 }

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.messages.in
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.messages.in
@@ -22,7 +22,11 @@
 
 #if ENABLE(MODEL_PROCESS)
 
-[ExceptionForEnabledBy]
+[
+    DispatchedFrom=Model,
+    DispatchedTo=WebContent,
+    ExceptionForEnabledBy
+]
 messages -> ModelProcessModelPlayer {
     DidCreateLayer(WebCore::LayerHostingContextIdentifier identifier)
     DidFinishLoading(WebCore::FloatPoint3D center, WebCore::FloatPoint3D extents)


### PR DESCRIPTION
#### 328432b3267402f79ca8e83d7916fb9c5126c6e3
<pre>
Adopt dispatched(From|To) for UI&lt;-&gt;(Networking|GPU|Model) interfaces
<a href="https://bugs.webkit.org/show_bug.cgi?id=284297">https://bugs.webkit.org/show_bug.cgi?id=284297</a>
<a href="https://rdar.apple.com/141152485">rdar://141152485</a>

Reviewed by Alex Christensen.

Adopt the new dispatched(From|To) annotations across interfaces which bridge the
UI and Networking/GPU/Model boundary.

* Source/WebKit/GPUProcess/GPUProcess.messages.in:
* Source/WebKit/ModelProcess/ModelProcess.messages.in:
* Source/WebKit/NetworkProcess/Authentication/AuthenticationManager.messages.in:
* Source/WebKit/NetworkProcess/Cookies/WebCookieManager.messages.in:
* Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.messages.in:
* Source/WebKit/NetworkProcess/NetworkContentRuleListManager.messages.in:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.messages.in:
* Source/WebKit/UIProcess/Model/ModelProcessProxy.messages.in:
* Source/WebKit/UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.messages.in:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in:
* Source/WebKit/UIProcess/mac/SecItemShimProxy.messages.in:
* Source/WebKit/WebProcess/Model/ModelProcessConnection.messages.in:
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.messages.in:

Canonical link: <a href="https://commits.webkit.org/289727@main">https://commits.webkit.org/289727@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb0d9ae3f96385babbfe5a98c0d2e54c349ebd4e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87504 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7017 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41879 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92366 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38244 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7399 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15186 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67598 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25329 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90506 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5643 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79185 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47935 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5429 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37359 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75856 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34443 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94251 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14669 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10773 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76413 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14923 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75040 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75640 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18657 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20019 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18440 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7614 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14687 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19982 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14430 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17874 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16213 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->