### PR TITLE
Make to sure to reregister service worker clients when launching a service worker after a network process crash

### DIFF
--- a/LayoutTests/http/tests/workers/service/registerServiceWorkerClient-after-network-process-crash-expected.txt
+++ b/LayoutTests/http/tests/workers/service/registerServiceWorkerClient-after-network-process-crash-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Verify service worker clients reregister in case service worker is relaunched after a network process crash
+

--- a/LayoutTests/http/tests/workers/service/registerServiceWorkerClient-after-network-process-crash.html
+++ b/LayoutTests/http/tests/workers/service/registerServiceWorkerClient-after-network-process-crash.html
@@ -1,0 +1,70 @@
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+if (window.testRunner) {
+    testRunner.setUseSeparateServiceWorkerProcess(true);
+    testRunner.grantWebNotificationPermission("http://127.0.0.1:8000");
+}
+
+async function waitForActive(registration)
+{
+    if (registration.active)
+        return registration.active;
+
+    let resolveCallback;
+    const promise = new Promise((resolve, reject) => {
+        resolveCallback = resolve;
+        setTimeout(() => reject("waitForActive timed out"), 5000);
+    });
+
+    const worker = registration.installing;
+    worker.addEventListener("statechange", () => {
+        if (worker.state  === "activated")
+            resolveCallback(worker);
+    });
+    return promise;
+}
+
+async function registerServiceWorker() {
+    const registration = await navigator.serviceWorker.register('resources/registerServiceWorkerClient-after-network-process-crash-worker.js');
+
+    if (!registration)
+        return Promise.reject("No registration");
+
+    if (registration.active) {
+        registration.active.postMessage("start");
+        return;
+    }
+
+    const worker = await waitForActive(registration);
+    worker.postMessage("start");
+
+    const data = await new Promise((resolve, reject) => {
+        navigator.serviceWorker.onmessage = e => resolve(e.data);
+        setTimeout(() => reject("worker started timed out"), 5000);
+    });
+    assert_equals(data, "started");
+}
+
+promise_test(async t => {
+    await registerServiceWorker();
+
+    if (window.internals)
+        await internals.storeRegistrationsOnDisk();
+    if (window.testRunner)
+        testRunner.terminateNetworkProcess();
+
+    if (testRunner)
+        testRunner.simulateWebNotificationClickForServiceWorkerNotifications();
+
+    const promise = new Promise((resolve, reject) => {
+        navigator.serviceWorker.onmessage = e => resolve(e.data);
+        setTimeout(() => reject("onmessage timed out"), 5000);
+    });
+    assert_equals(await promise, "click");
+}, "Verify service worker clients reregister in case service worker is relaunched after a network process crash");
+</script>
+</body>

--- a/LayoutTests/http/tests/workers/service/resources/registerServiceWorkerClient-after-network-process-crash-worker.js
+++ b/LayoutTests/http/tests/workers/service/resources/registerServiceWorkerClient-after-network-process-crash-worker.js
@@ -1,0 +1,33 @@
+let messageClients = async function(msg) {
+    const allClients = await clients.matchAll({
+        includeUncontrolled: true
+    });
+
+    if (!allClients.length) {
+        await new Promise(resolve => setTimeout(resolve, 50));
+        return messageClients(msg);
+    }
+
+    for (const client of allClients)
+        client.postMessage(msg);
+}
+
+self.addEventListener('message', async () => {
+    const title = "my title";
+    const body = "my body";
+    const tag = "my tag";
+    const data = "my data";
+
+    try {
+        await registration.showNotification(title, { body, tag, data });
+    } catch(error) {
+        await messageClients("showFailed");
+        return;
+    }
+
+    await messageClients("started");
+});
+
+self.addEventListener('notificationclick', async function(event) {
+    await messageClients("click");
+});

--- a/LayoutTests/http/tests/workers/service/shownotification-allowed.html
+++ b/LayoutTests/http/tests/workers/service/shownotification-allowed.html
@@ -54,9 +54,6 @@ navigator.serviceWorker.addEventListener('message', async event => {
             await internals.storeRegistrationsOnDisk();
         if (window.testRunner)
             testRunner.terminateNetworkProcess();
-        // After a network process crash, we do a fetch to register as a service worker client to the new network process.
-        await fetch("").then(() => { }, () => { });
-        await fetch("").then(() => { }, () => { });
 
         if (testRunner)
             testRunner.simulateWebNotificationClickForServiceWorkerNotifications();

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3679,6 +3679,7 @@ webkit.org/b/240579 http/tests/workers/service/getnotifications-stop.html [ Skip
 webkit.org/b/240579 http/tests/workers/service/getnotifications.html [ Skip ]
 webkit.org/b/240579 http/tests/push-api [ Skip ]
 webkit.org/b/240579 http/wpt/push-api [ Skip ]
+http/tests/workers/service/registerServiceWorkerClient-after-network-process-crash.html [ Skip ]
 
 # These tests finish with unfired UI script callbacks, causing crashes. See webkit.org/b/236794
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-047.html

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -975,6 +975,7 @@ http/wpt/service-workers/fetch-service-worker-preload-changing-request.https.htm
 
 webkit.org/b/212532 http/wpt/service-workers/service-worker-crashing-while-fetching.https.html [ Pass Failure ]
 
+http/tests/workers/service/registerServiceWorkerClient-after-network-process-crash.html [ Failure ]
 http/wpt/push-api [ Skip ]
 
 webkit.org/b/282475 http/wpt/navigation-api/transition-promises.html [ Failure Pass ]

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -338,6 +338,7 @@ private:
     void establishSWContextConnection(WebPageProxyIdentifier, WebCore::Site&&, std::optional<WebCore::ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, CompletionHandler<void()>&&);
     void closeSWContextConnection();
     void unregisterSWConnection();
+    void pingPongForServiceWorkers(CompletionHandler<void(bool)>&& callback) { callback(true); }
 
     void establishSharedWorkerContextConnection(WebPageProxyIdentifier, WebCore::Site&&, CompletionHandler<void()>&&);
     void closeSharedWorkerContextConnection();

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -97,6 +97,7 @@ messages -> NetworkConnectionToWebProcess WantsDispatchMessage {
 
     EstablishSWContextConnection(WebKit::WebPageProxyIdentifier webPageProxyID, WebCore::Site site, std::optional<WebCore::ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier) -> ()
     CloseSWContextConnection()
+    PingPongForServiceWorkers() -> (bool isSuccess)
 
     EstablishSharedWorkerContextConnection(WebKit::WebPageProxyIdentifier webPageProxyID, WebCore::Site site) -> ()
     CloseSharedWorkerContextConnection()

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -526,6 +526,10 @@ public:
 
     bool isAlwaysOnLoggingAllowed() const;
 
+    bool shouldRegisterServiceWorkerClients(const WebCore::Site&, PAL::SessionID) const;
+    void registerServiceWorkerClients(CompletionHandler<void()>&&);
+    void resetHasRegisteredServiceWorkerClients() { m_hasRegisteredServiceWorkerClients = false; }
+
 private:
     Type type() const final { return Type::WebContent; }
 
@@ -815,6 +819,8 @@ private:
     Seconds m_totalBackgroundTime;
     Seconds m_totalSuspendedTime;
     WebCore::ProcessIdentity m_processIdentity;
+
+    bool m_hasRegisteredServiceWorkerClients { true };
 
 #if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
     IPC::ScopedActiveMessageReceiveQueue<LogStream> m_logStream;

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -2052,6 +2052,11 @@ void WebProcess::establishRemoteWorkerContextConnectionToNetworkProcess(RemoteWo
     }
 }
 
+void WebProcess::registerServiceWorkerClients(CompletionHandler<void(bool)>&& completionHandler)
+{
+    ensureNetworkProcessConnection().protectedConnection()->sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::PingPongForServiceWorkers { }, WTFMove(completionHandler));
+}
+
 void WebProcess::addServiceWorkerRegistration(WebCore::ServiceWorkerRegistrationIdentifier identifier)
 {
     m_swRegistrationCounts.add(identifier);

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -557,6 +557,7 @@ private:
 #endif
 
     void establishRemoteWorkerContextConnectionToNetworkProcess(RemoteWorkerType, PageGroupIdentifier, WebPageProxyIdentifier, WebCore::PageIdentifier, const WebPreferencesStore&, WebCore::Site&&, std::optional<WebCore::ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, RemoteWorkerInitializationData&&, CompletionHandler<void()>&&);
+    void registerServiceWorkerClients(CompletionHandler<void(bool)>&&);
 
     void fetchWebsiteData(OptionSet<WebsiteDataType>, CompletionHandler<void(WebsiteData&&)>&&);
     void deleteWebsiteData(OptionSet<WebsiteDataType>, WallTime modifiedSince, CompletionHandler<void()>&&);

--- a/Source/WebKit/WebProcess/WebProcess.messages.in
+++ b/Source/WebKit/WebProcess/WebProcess.messages.in
@@ -113,6 +113,8 @@ messages -> WebProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
 
     EstablishRemoteWorkerContextConnectionToNetworkProcess(enum:uint8_t WebKit::RemoteWorkerType workerType, WebKit::PageGroupIdentifier pageGroupID, WebKit::WebPageProxyIdentifier webPageProxyID, WebCore::PageIdentifier pageID, struct WebKit::WebPreferencesStore store, WebCore::Site site, std::optional<WebCore::ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, struct WebKit::RemoteWorkerInitializationData initializationData) -> ()
 
+    RegisterServiceWorkerClients() -> (bool isSuccess)
+
     SetHasSuspendedPageProxy(bool hasSuspendedPageProxy);
     SetIsInProcessCache(bool isInProcessCache) -> ()
     MarkIsNoLongerPrewarmed()


### PR DESCRIPTION
#### b707db9ba55dbed587a5c6043c17216efcddc612
<pre>
Make to sure to reregister service worker clients when launching a service worker after a network process crash
<a href="https://rdar.apple.com/141159225">rdar://141159225</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=284302">https://bugs.webkit.org/show_bug.cgi?id=284302</a>

Reviewed by Ben Nham.

When a network process crashes, web processes only create a connection to the network process when needed.
The consequence is that service worker clients may not all be registered until the process owning these clients creates a connection to the network process.

To fix that issue, when we launch a service worker process, we will make sure that all processes that have pages related to the service worker top origin recreate their network process connection.

Covered by added test and updated test.
Skipping added test on iOS like other tests using showNotification in service worker.

* LayoutTests/http/tests/workers/service/registerServiceWorkerClient-after-network-process-crash-expected.txt: Added.
* LayoutTests/http/tests/workers/service/registerServiceWorkerClient-after-network-process-crash.html: Added.
* LayoutTests/http/tests/workers/service/resources/registerServiceWorkerClient-after-network-process-crash-worker.js: Added.
(async const):
(let.messageClients):
(async await):
* LayoutTests/http/tests/workers/service/shownotification-allowed.html:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::networkProcessDidTerminate):
(WebKit::WebProcessPool::establishRemoteWorkerContextConnectionToNetworkProcess):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::shouldRegisterServiceWorkerClients const):
(WebKit::WebProcessProxy::registerServiceWorkerClients):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::registerServiceWorkerClients):
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/WebProcess.messages.in:

Canonical link: <a href="https://commits.webkit.org/287757@main">https://commits.webkit.org/287757@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/852be66501c532e766e9cc49fd153e6afd07733f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80711 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/233 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34647 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85238 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31695 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/250 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8030 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63036 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20829 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83780 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/94 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/73467 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43338 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30 "Build is in progress. Recent messages:") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27627 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30152 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/71592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28158 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86670 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7938 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5610 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71329 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8115 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69303 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70570 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17583 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14591 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/13538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7900 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13421 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7739 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11258 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9545 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->