### PR TITLE
Make aggressive suspension on memory pressure threshold configurable

### DIFF
--- a/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.cpp
@@ -85,7 +85,7 @@ Ref<ProcessPoolConfiguration> ProcessPoolConfiguration::copy()
     copy->m_memoryFootprintPollIntervalForTesting = this->m_memoryFootprintPollIntervalForTesting;
     copy->m_memoryFootprintNotificationThresholds = this->m_memoryFootprintNotificationThresholds;
 #if ENABLE(WEB_PROCESS_SUSPENSION_DELAY)
-    copy->m_suspendsWebProcessesAggressivelyOnCriticalMemoryPressure = this->m_suspendsWebProcessesAggressivelyOnCriticalMemoryPressure;
+    copy->m_suspendsWebProcessesAggressivelyOnMemoryPressure = this->m_suspendsWebProcessesAggressivelyOnMemoryPressure;
 #endif
     return copy;
 }

--- a/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.h
@@ -165,8 +165,8 @@ public:
     const Vector<size_t>& memoryFootprintNotificationThresholds() const { return m_memoryFootprintNotificationThresholds; }
 
 #if ENABLE(WEB_PROCESS_SUSPENSION_DELAY)
-    void setSuspendsWebProcessesAggressivelyOnCriticalMemoryPressure(bool enabled) { m_suspendsWebProcessesAggressivelyOnCriticalMemoryPressure = enabled; }
-    bool suspendsWebProcessesAggressivelyOnCriticalMemoryPressure() { return m_suspendsWebProcessesAggressivelyOnCriticalMemoryPressure; }
+    void setSuspendsWebProcessesAggressivelyOnMemoryPressure(bool enabled) { m_suspendsWebProcessesAggressivelyOnMemoryPressure = enabled; }
+    bool suspendsWebProcessesAggressivelyOnMemoryPressure() { return m_suspendsWebProcessesAggressivelyOnMemoryPressure; }
 #endif
 
 private:
@@ -212,7 +212,7 @@ private:
     Seconds m_memoryFootprintPollIntervalForTesting;
     Vector<size_t> m_memoryFootprintNotificationThresholds;
 #if ENABLE(WEB_PROCESS_SUSPENSION_DELAY)
-    bool m_suspendsWebProcessesAggressivelyOnCriticalMemoryPressure { false };
+    bool m_suspendsWebProcessesAggressivelyOnMemoryPressure { false };
 #endif
 };
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.h
@@ -81,7 +81,7 @@ WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
 @property (nonatomic) NSTimeInterval memoryFootprintPollIntervalForTesting;
 @property (nonatomic, copy) NSArray<NSNumber *> *memoryFootprintNotificationThresholds WK_API_AVAILABLE(macos(14.5));
 
-@property (nonatomic) BOOL suspendsWebProcessesAggressivelyOnCriticalMemoryPressure WK_API_AVAILABLE(macos(WK_MAC_TBA));
+@property (nonatomic) BOOL suspendsWebProcessesAggressivelyOnMemoryPressure WK_API_AVAILABLE(macos(WK_MAC_TBA));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
@@ -405,19 +405,19 @@
     _processPoolConfiguration->setMemoryFootprintNotificationThresholds(WTFMove(sizes));
 }
 
-- (BOOL)suspendsWebProcessesAggressivelyOnCriticalMemoryPressure
+- (BOOL)suspendsWebProcessesAggressivelyOnMemoryPressure
 {
 #if ENABLE(WEB_PROCESS_SUSPENSION_DELAY)
-    return _processPoolConfiguration->suspendsWebProcessesAggressivelyOnCriticalMemoryPressure();
+    return _processPoolConfiguration->suspendsWebProcessesAggressivelyOnMemoryPressure();
 #else
     return NO;
 #endif
 }
 
-- (void)setSuspendsWebProcessesAggressivelyOnCriticalMemoryPressure:(BOOL)enabled
+- (void)setSuspendsWebProcessesAggressivelyOnMemoryPressure:(BOOL)enabled
 {
 #if ENABLE(WEB_PROCESS_SUSPENSION_DELAY)
-    _processPoolConfiguration->setSuspendsWebProcessesAggressivelyOnCriticalMemoryPressure(enabled);
+    _processPoolConfiguration->setSuspendsWebProcessesAggressivelyOnMemoryPressure(enabled);
 #endif
 }
 

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -947,7 +947,7 @@ private:
     bool m_webProcessStateUpdatesForPageClientEnabled { false };
 
 #if ENABLE(WEB_PROCESS_SUSPENSION_DELAY)
-    ApproximateTime m_lastCriticalMemoryPressureStatusTime;
+    ApproximateTime m_lastMemoryPressureStatusTime;
     RunLoop::Timer m_checkMemoryPressureStatusTimer;
 #endif
 


### PR DESCRIPTION
#### 96038ad69f61fbe76b76256503b9b83e2b244173
<pre>
Make aggressive suspension on memory pressure threshold configurable
<a href="https://bugs.webkit.org/show_bug.cgi?id=284306">https://bugs.webkit.org/show_bug.cgi?id=284306</a>
<a href="https://rdar.apple.com/141165580">rdar://141165580</a>

Reviewed by Ryan Reno.

To make it easier to experiment with aggressively suspending on memory pressure, make all of the
tunables (including the memory pressure threshold at which to begin aggressively suspending)
configurable. This makes it easier to experiment with tuning the policy.

As part of this, rename the property from suspendsWebProcessesAggressivelyOnCriticalMemoryPressure
to suspendsWebProcessesAggressivelyOnMemoryPressure, since the threshold is now configurable.

* Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.cpp:
(API::ProcessPoolConfiguration::copy):
* Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm:
(-[_WKProcessPoolConfiguration suspendsWebProcessesAggressivelyOnMemoryPressure]):
(-[_WKProcessPoolConfiguration setSuspendsWebProcessesAggressivelyOnMemoryPressure:]):
(-[_WKProcessPoolConfiguration suspendsWebProcessesAggressivelyOnCriticalMemoryPressure]): Deleted.
(-[_WKProcessPoolConfiguration setSuspendsWebProcessesAggressivelyOnCriticalMemoryPressure:]): Deleted.
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::memoryPressureCheckInterval):
(WebKit::systemMemoryPressureStatus):
(WebKit::shouldSuspendAggressivelyBasedOnSystemMemoryPressureStatus):
(WebKit::WebProcessPool::checkMemoryPressureStatus):
(WebKit::WebProcessPool::webProcessSuspensionDelay const):
(WebKit::WebProcessPool::memoryPressureStatusChangedForProcess):
(WebKit::criticalMemoryPressureCheckInterval): Deleted.
(WebKit::isSystemUnderCriticalMemoryPressure): Deleted.
* Source/WebKit/UIProcess/WebProcessPool.h:

Canonical link: <a href="https://commits.webkit.org/287612@main">https://commits.webkit.org/287612@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa4bf7d96c6c1bd9ad70b23052bc4c9fb1ef3cc6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80112 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59114 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33524 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84629 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31088 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68175 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7412 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62630 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20457 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83181 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52707 "Found 1 new test failure: media/audioSession/getUserMedia.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72966 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42934 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50033 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29548 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71161 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27627 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86061 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7332 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5193 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70912 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-pseudo/marker-animate-002.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7507 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68805 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70148 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17496 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14143 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13088 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7296 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12813 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7135 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10655 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8940 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->