### PR TITLE
[IFC][SVG text] Update line box dimensions

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2345,6 +2345,7 @@ imported/w3c/web-platform-tests/svg/text/reftests/text-complex-001.svg [ ImageOn
 imported/w3c/web-platform-tests/svg/text/reftests/text-complex-002.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/text/reftests/text-inline-size-001.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/text/reftests/text-inline-size-002.svg [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/svg/text/reftests/text-inline-size-003.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/text/reftests/text-inline-size-005.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/text/reftests/text-inline-size-006.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/text/reftests/text-inline-size-007.svg [ ImageOnlyFailure ]

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLine.h
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLine.h
@@ -107,6 +107,7 @@ public:
     void setIsFirstAfterPageBreak() { m_isFirstAfterPageBreak = true; }
     void setInkOverflow(const FloatRect inkOverflowRect) { m_inkOverflow = inkOverflowRect; }
     void setScrollableOverflow(const FloatRect scrollableOverflow) { m_scrollableOverflow = scrollableOverflow; }
+    void setLineBoxRectForSVGText(const FloatRect&);
 
 private:
     // FIXME: Move these to a side structure.
@@ -188,6 +189,17 @@ inline FloatRect Line::visibleRectIgnoringBlockDirection() const
     }
     auto visibleLineBoxLeft = std::max(m_lineBoxRect.x(), m_ellipsis->visualRect.x());
     return { FloatPoint { visibleLineBoxLeft, m_lineBoxRect.y() }, FloatPoint { m_lineBoxRect.maxX(), m_lineBoxRect.maxY() } };
+}
+
+inline void Line::setLineBoxRectForSVGText(const FloatRect& rect)
+{
+    m_lineBoxRect = rect;
+    m_scrollableOverflow = rect;
+    m_contentOverflow = rect;
+    m_inkOverflow = rect;
+    m_lineBoxLogicalRect = m_isHorizontal ? rect : rect.transposedRect();
+    m_enclosingLogicalTopAndBottom.top = m_lineBoxLogicalRect.y();
+    m_enclosingLogicalTopAndBottom.bottom = m_lineBoxLogicalRect.maxY();
 }
 
 }

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
@@ -42,6 +42,7 @@
 #include "RenderListItem.h"
 #include "RenderListMarker.h"
 #include "RenderMenuList.h"
+#include "RenderSVGInline.h"
 #include "RenderSlider.h"
 #include "RenderStyleSetters.h"
 #include "RenderTable.h"
@@ -177,7 +178,16 @@ void BoxTreeUpdater::adjustStyleIfNeeded(const RenderElement& renderer, RenderSt
                 styleToAdjust.resetBorderRight();
                 styleToAdjust.setPaddingRight(RenderStyle::initialPadding());
             }
-            if ((styleToAdjust.display() == DisplayType::RubyBase || styleToAdjust.display() == DisplayType::RubyAnnotation) && renderInline->parent()->style().display() != DisplayType::Ruby)
+
+            auto isSupportedInlineDisplay = [&] {
+                auto display = styleToAdjust.display();
+                if (display == DisplayType::RubyBase || display == DisplayType::RubyAnnotation)
+                    return renderInline->parent()->style().display() == DisplayType::Ruby;
+                if (is<RenderSVGInline>(*renderInline))
+                    return display == DisplayType::Inline;
+                return styleToAdjust.isDisplayInlineType();
+            };
+            if (!isSupportedInlineDisplay())
                 styleToAdjust.setDisplay(DisplayType::Inline);
             return;
         }

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -671,6 +671,7 @@ void LineLayout::updateRenderTreePositions(const Vector<LineAdjustment>& lineAdj
 FloatRect LineLayout::applySVGTextFragments(SVGTextFragmentMap&& fragmentMap)
 {
     auto& boxes = m_inlineContent->displayContent().boxes;
+    auto& lines = m_inlineContent->displayContent().lines;
     auto& fragments = m_inlineContent->svgTextFragmentsForBoxes();
     fragments.resize(m_inlineContent->displayContent().boxes.size());
 
@@ -719,6 +720,9 @@ FloatRect LineLayout::applySVGTextFragments(SVGTextFragmentMap&& fragmentMap)
         box.moveHorizontally(-fullBoundaries.x());
         box.moveVertically(-fullBoundaries.y());
     }
+
+    if (lines.size())
+        lines[0].setLineBoxRectForSVGText(FloatRect { { }, fullBoundaries.size() });
 
     return fullBoundaries;
 }

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp
@@ -462,6 +462,8 @@ void SVGTextLayoutEngine::layoutTextOnLineOrPath(InlineIterator::SVGTextBoxItera
         float y = data.y;
         auto previousBoxOnLine = textBox->previousOnLine();
 
+        bool hasXOrY = !SVGTextLayoutAttributes::isEmptyValue(x) || !SVGTextLayoutAttributes::isEmptyValue(y);
+
         // If we start a new chunk following an chunk that had a textLength set, use that
         // textLength to determine the chunk start position, instead of glyph advance values.
         auto moveToExpectedChunkStartPositionIfNeeded = [&]() {
@@ -613,7 +615,7 @@ void SVGTextLayoutEngine::layoutTextOnLineOrPath(InlineIterator::SVGTextBoxItera
         }
 
         // Determine whether we have to start a new fragment.
-        bool shouldStartNewFragment = m_dx || m_dy || m_isVerticalText || m_inPathLayout || angle || angle != lastAngle
+        bool shouldStartNewFragment = hasXOrY || m_dx || m_dy || m_isVerticalText || m_inPathLayout || angle || angle != lastAngle
             || orientationAngle || applySpacingToNextCharacter || definesTextLength;
 
         // If we already started a fragment, close it now.


### PR DESCRIPTION
#### bb0cfb47512fb5f69314bcda5f72180fd2776cc3
<pre>
[IFC][SVG text] Update line box dimensions
<a href="https://bugs.webkit.org/show_bug.cgi?id=284307">https://bugs.webkit.org/show_bug.cgi?id=284307</a>
<a href="https://rdar.apple.com/problem/141167251">rdar://problem/141167251</a>

Reviewed by Alan Baradlay.

Also other fixes.

* LayoutTests/TestExpectations:

imported/w3c/web-platform-tests/svg/text/reftests/text-inline-size-003.svg is a test for SVG line
breaking that no browser supports. We passed it spuriously because the ref was misrendered.

We now render the ref correctly matching other engines (which also fail the test).

* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLine.h:
(WebCore::InlineDisplay::Line::setLineBoxRectForSVGText):

Add setter.

* Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp:
(WebCore::LayoutIntegration::BoxTreeUpdater::adjustStyleIfNeeded):

Make sure inline boxes have inline display type when they get to IFC.

* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::applySVGTextFragments):

Update also line box dimensions.

* Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp:
(WebCore::SVGTextLayoutEngine::layoutTextOnLineOrPath):

Start a fragment if there is x/y attribute for a character. LegacyLineLayout used to
force inline boxes for these.

Canonical link: <a href="https://commits.webkit.org/287609@main">https://commits.webkit.org/287609@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7119f57d4da53120b1a5aef7fddf9a07e1b098c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80289 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59291 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33703 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 37650") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84806 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/31269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82400 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68352 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7591 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/62772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/31269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83358 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/52836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/33703 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 37650") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/43078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/50160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/33703 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 37650") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29726 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/71295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/33703 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 37650") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/86253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7509 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/86253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7684 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/33703 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 37650") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/86253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17489 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14281 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/33703 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 37650") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7473 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7312 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10832 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9117 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->