### PR TITLE
`git-webkit pr` raises when on detached HEAD

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
@@ -609,6 +609,13 @@ class Git(Scm):
             return sorted(result.get(remote, []))
         return result
 
+    def is_suitable_branch_for_pull_request(self, branch, source_remote):
+        if branch is None or branch in self.DEFAULT_BRANCHES or self.PROD_BRANCHES.match(branch):
+            return False
+        elif branch in self.branches_for(remote=source_remote) and not self.dev_branches.match(branch):
+            return False
+        return True
+
     def _is_on_default_branch(self, hash):
         branches = self.branches_for(remote=None)
         remote_keys = [None] + self.source_remotes()

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
@@ -251,10 +251,7 @@ class PullRequest(Command):
             source_remote = repository.source_remotes()[-1]
             args.remote = source_remote
 
-        if not repository.dev_branches.match(repository.branch) and (repository.branch is None or repository.branch in repository.DEFAULT_BRANCHES or
-                repository.PROD_BRANCHES.match(repository.branch) or \
-                repository.branch in repository.branches_for(remote=source_remote)):
-
+        if not repository.is_suitable_branch_for_pull_request(repository.branch, source_remote):
             if not args.issue:
                 head = repository.commit(include_log=True, include_identifier=False)
                 if run([

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py
@@ -599,6 +599,21 @@ CommitDate: {time_c}
                 '2@main',
             )
 
+    def test_is_suitable_branch_for_pull_request(self):
+        with mocks.local.Git(self.path, remotes={
+            'origin': 'git@github.example.com:WebKit/WebKit.git'
+        }):
+            repo = local.Git(self.path)
+            source_remote = repo.source_remotes()[0]
+            self.assertEqual(repo.is_suitable_branch_for_pull_request('eng/12345', source_remote=source_remote), True)
+            self.assertEqual(repo.is_suitable_branch_for_pull_request('eng/squash-branch', source_remote=source_remote), True)
+            self.assertEqual(repo.is_suitable_branch_for_pull_request('integration/branch', source_remote=source_remote), True)
+            self.assertEqual(repo.is_suitable_branch_for_pull_request('not-default-branch', source_remote=source_remote), True)
+            self.assertEqual(repo.is_suitable_branch_for_pull_request('main', source_remote=source_remote), False)
+            self.assertEqual(repo.is_suitable_branch_for_pull_request('safari-610-branch', source_remote=source_remote), False)
+            self.assertEqual(repo.is_suitable_branch_for_pull_request('branch-a', source_remote=source_remote), False)
+            self.assertEqual(repo.is_suitable_branch_for_pull_request(None, source_remote=source_remote), False)
+
 
 class TestGitHub(testing.TestCase):
     remote = 'https://github.example.com/WebKit/WebKit'


### PR DESCRIPTION
#### 58deabc6ad4703a9cc7bc54f7fdc0579f8f544cc
<pre>
`git-webkit pr` raises when on detached HEAD
<a href="https://bugs.webkit.org/show_bug.cgi?id=284312">https://bugs.webkit.org/show_bug.cgi?id=284312</a>
<a href="https://rdar.apple.com/141172754">rdar://141172754</a>

Reviewed by Sam Sneddon.

Move logic for validating whether a PR can be made on a branch
to Git.is_suitable_branch_for_pull_request.

A branch is invalid if:
1. It is None
2. It is a default branch (e.g. main)
3. It is a prod branch
4. It is a remote branch and does not match the dev branch pattern

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py:
(Git.is_suitable_branch_for_pull_request):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py:
(PullRequest.pull_request_branch_point):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py:

Canonical link: <a href="https://commits.webkit.org/288027@main">https://commits.webkit.org/288027@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6eaf6848d662754898128ab418ff2defa249ad13

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81312 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/837 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35255 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85841 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32298 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83422 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/855 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8653 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63477 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21242 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84381 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/579 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73998 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43772 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/80769 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/477 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28160 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30756 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71971 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28741 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87276 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8542 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6073 "Found 1 new test failure: imported/w3c/web-platform-tests/cookie-store/cookieStoreManager_getSubscriptions_empty.https.any.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71784 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-pseudo/marker-animate-002.html (failure)") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/80953 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8723 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69828 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71017 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15074 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13985 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12650 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8504 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8340 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11861 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10148 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->