### PR TITLE
ASSERTION FAILED: !waiter->isOnList() in JavaScriptCore

### DIFF
--- a/JSTests/stress/waitasync-wait-timeout-with-canceled-tickets.js
+++ b/JSTests/stress/waitasync-wait-timeout-with-canceled-tickets.js
@@ -1,0 +1,22 @@
+//@ requireOptions("--thresholdForJITSoon=10 --thresholdForJITAfterWarmUp=10 --thresholdForOptimizeAfterWarmUp=100 --useConcurrentJIT=0")
+class C0 { }
+const v1 = new C0();
+for (let i = 0; i < 10; i++) {
+        const v25 = new SharedArrayBuffer(3614, {"maxByteLength": 3614,});
+        const v27 = new Int32Array(v25);
+        let originalPrototype = Object.getPrototypeOf(v27);
+        let handler = {
+            get(target, key, receiver) {
+                if ( receiver === v27) return originalPrototype;
+            }
+        };
+        let newPrototype = new Proxy(originalPrototype, handler);
+        Object.setPrototypeOf(v27, newPrototype);
+        function f28() {
+            try { v1.m(); } catch (e) {}
+            for (let v31 = 0; v31 < 5; v31++) {}
+        }
+        v27[Symbol.toPrimitive] = f28;
+        createGlobalObject().Atomics.waitAsync(v27, 200, v27, 200);
+}
+gc();

--- a/Source/JavaScriptCore/runtime/DeferredWorkTimer.cpp
+++ b/Source/JavaScriptCore/runtime/DeferredWorkTimer.cpp
@@ -65,6 +65,7 @@ inline VM& DeferredWorkTimer::TicketData::vm()
 
 inline void DeferredWorkTimer::TicketData::cancel()
 {
+    dataLogLnIf(DeferredWorkTimerInternal::verbose, "Canceling ticket: ", RawPointer(this));
     m_isCancelled = true;
 }
 
@@ -226,7 +227,6 @@ bool DeferredWorkTimer::cancelPendingWork(Ticket ticket)
 
     bool result = false;
     if (!ticket->isCancelled()) {
-        dataLogLnIf(DeferredWorkTimerInternal::verbose, "Canceling ticket: ", RawPointer(ticket));
         ticket->cancel();
         result = true;
     }
@@ -237,6 +237,8 @@ bool DeferredWorkTimer::cancelPendingWork(Ticket ticket)
 void DeferredWorkTimer::cancelPendingWorkSafe(JSGlobalObject* globalObject)
 {
     Locker locker { m_taskLock };
+
+    dataLogLnIf(DeferredWorkTimerInternal::verbose, "Cancel pending work for globalObject ", RawPointer(globalObject));
     for (Ref<TicketData> ticket : *globalObject->m_weakTickets) {
         if (!ticket->isCancelled())
             cancelPendingWork(ticket.ptr());
@@ -251,6 +253,7 @@ void DeferredWorkTimer::cancelPendingWork(VM& vm)
     ASSERT(vm.heap.isInPhase(CollectorPhase::End));
     Locker locker { m_taskLock };
 
+    dataLogLnIf(DeferredWorkTimerInternal::verbose, "Cancel pending work for vm ", RawPointer(&vm));
     auto isValid = [&](auto& ticket) {
         bool isTargetGlobalObjectLive = vm.heap.isMarked(ticket->target()->globalObject());
 #if ASSERT_ENABLED

--- a/Source/JavaScriptCore/runtime/WaiterListManager.h
+++ b/Source/JavaScriptCore/runtime/WaiterListManager.h
@@ -223,6 +223,7 @@ private:
     template <typename ValueType>
     JSValue waitAsyncImpl(JSGlobalObject*, VM&, ValueType* ptr, ValueType expectedValue, Seconds timeout);
 
+    // Notify the waiter if its ticket is not canceled.
     void notifyWaiterImpl(const AbstractLocker&, Ref<Waiter>&&, const ResolveResult);
 
     void timeoutAsyncWaiter(void* ptr, Ref<Waiter>&&);


### PR DESCRIPTION
#### 4769bb5d4e997406785f52500158011441dc5f3a
<pre>
ASSERTION FAILED: !waiter-&gt;isOnList() in JavaScriptCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=284244">https://bugs.webkit.org/show_bug.cgi?id=284244</a>
<a href="https://rdar.apple.com/141173936">rdar://141173936</a>

Reviewed by Yusuke Suzuki.

This patch simplify the log in WaiterListManager::timeoutAsyncWaiter
since the DeferredWorkTimer::TicketData can be canceled at any time.

* JSTests/stress/waitasync-wait-timeout-with-canceled-tickets.js: Added.
(C0):
(i.let.handler.get target):
(i.f28):
* Source/JavaScriptCore/runtime/DeferredWorkTimer.cpp:
(JSC::DeferredWorkTimer::TicketData::cancel):
(JSC::DeferredWorkTimer::cancelPendingWork):
(JSC::DeferredWorkTimer::cancelPendingWorkSafe):
* Source/JavaScriptCore/runtime/WaiterListManager.cpp:
(JSC::WaiterListManager::timeoutAsyncWaiter):
* Source/JavaScriptCore/runtime/WaiterListManager.h:

Canonical link: <a href="https://commits.webkit.org/287611@main">https://commits.webkit.org/287611@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47e8b9e9e5c20e772bbd57d06061e9b08dde2a9d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80133 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59135 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33546 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84650 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31109 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68196 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7433 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62645 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20466 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83202 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52767 "Found 1 new test failure: media/audioSession/getUserMedia.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72988 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42949 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50052 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27142 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29569 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/73109 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71180 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27649 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86082 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/79190 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7353 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5256 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70921 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7528 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68827 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70159 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14154 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13106 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/101598 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12415 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7317 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/24781 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7156 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10676 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8961 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->