### PR TITLE
[SwiftUI] Support the functionality of `WKPreferences.isElementFullscreenEnabled`

### DIFF
--- a/Source/WebKit/UIProcess/API/Swift/View+WebViewModifiers.swift
+++ b/Source/WebKit/UIProcess/API/Swift/View+WebViewModifiers.swift
@@ -34,6 +34,8 @@ extension EnvironmentValues {
     @Entry var webViewAllowsTabFocusingLinks = false
 
     @Entry var webViewAllowsTextInteraction = true
+
+    @Entry var webViewAllowsElementFullscreen = false
 }
 
 extension View {
@@ -55,6 +57,11 @@ extension View {
     @_spi(Private)
     public func webViewAllowsTextInteraction(_ value: Bool = true) -> some View {
         environment(\.webViewAllowsTextInteraction, value)
+    }
+
+    @_spi(Private)
+    public func webViewAllowsElementFullscreen(_ value: Bool = true) -> some View {
+        environment(\.webViewAllowsElementFullscreen, value)
     }
 }
 

--- a/Source/WebKit/UIProcess/API/Swift/WebView.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebView.swift
@@ -114,6 +114,7 @@ fileprivate struct WebViewRepresentable {
 
         webView.configuration.preferences.isTextInteractionEnabled = environment.webViewAllowsTextInteraction
         webView.configuration.preferences.tabFocusesLinks = environment.webViewAllowsTabFocusingLinks
+        webView.configuration.preferences.isElementFullscreenEnabled = environment.webViewAllowsElementFullscreen
     }
 }
 

--- a/Tools/SwiftBrowser/Source/ContentView.swift
+++ b/Tools/SwiftBrowser/Source/ContentView.swift
@@ -75,6 +75,7 @@ struct ContentView: View {
             WebView_v0(viewModel.page)
                 .webViewAllowsBackForwardNavigationGestures()
                 .webViewAllowsTabFocusingLinks()
+                .webViewAllowsElementFullscreen()
                 .task {
                     for await event in viewModel.page.navigations {
                         viewModel.didReceiveNavigationEvent(event)


### PR DESCRIPTION
#### a542f6c9c8b1f812fe86dea9055334e1ddf4a0d1
<pre>
[SwiftUI] Support the functionality of `WKPreferences.isElementFullscreenEnabled`
<a href="https://bugs.webkit.org/show_bug.cgi?id=284323">https://bugs.webkit.org/show_bug.cgi?id=284323</a>
<a href="https://rdar.apple.com/140728591">rdar://140728591</a>

Reviewed by Abrar Rahman Protyasha.

Support the equivalent of `WKPreferences.isElementFullscreenEnabled` in SwiftUI as a view modifier.

* Source/WebKit/UIProcess/API/Swift/View+WebViewModifiers.swift:
(View.webViewAllowsElementFullscreen(_:)):
* Source/WebKit/UIProcess/API/Swift/WebView.swift:
(WebViewRepresentable.updatePlatformView(_:context:)):
* Tools/SwiftBrowser/Source/ContentView.swift:
(ContentView.body):

Canonical link: <a href="https://commits.webkit.org/287573@main">https://commits.webkit.org/287573@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af56545836cb3779f29b1fa6b9ca922547bdc052

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80141 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59143 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33554 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84658 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/31117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82252 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68204 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7441 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/62654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/31117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83210 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/52726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/72998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/42958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/50055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/27152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29577 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/71184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/27659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86090 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7361 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/70932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/7536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/68837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/70170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/13116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12397 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7325 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/7164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/10684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8969 "Failed to checkout and rebase branch from PR 37661") | | | 
<!--EWS-Status-Bubble-End-->