### PR TITLE
Annotate endpoints with MediaCapabilityGrantedEnabled

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -4725,6 +4725,7 @@ MediaCapabilityGrantsEnabled:
     WebCore:
       "PLATFORM(IOS_FAMILY_SIMULATOR)": false
       default: true
+  sharedPreferenceForWebProcess: true
 
 MediaCaptionFormatTypesAllowedInLockdownMode:
   type: String

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in
@@ -67,7 +67,7 @@ messages -> GPUConnectionToWebProcess WantsDispatchMessage {
 #endif
 
 #if ENABLE(EXTENSION_CAPABILITIES)
-    SetMediaEnvironment(WebCore::PageIdentifier pageIdentifier, String mediaEnvironment);
+    [EnabledBy=MediaCapabilityGrantsEnabled] SetMediaEnvironment(WebCore::PageIdentifier pageIdentifier, String mediaEnvironment);
 #endif
 }
 


### PR DESCRIPTION
#### 3c96445e91be101db29ee19dad810b5bb744e869
<pre>
Annotate endpoints with MediaCapabilityGrantedEnabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=284325">https://bugs.webkit.org/show_bug.cgi?id=284325</a>
<a href="https://rdar.apple.com/141566623">rdar://141566623</a>

Reviewed by NOBODY (OOPS!).

Annotate endpoints with MediaCapabilityGrantedEnabled.

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c96445e91be101db29ee19dad810b5bb744e869

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93056 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12607 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2305 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98055 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43582 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12888 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21077 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71152 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28572 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96058 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9712 "Found 60 new test failures: animations/cross-fade-border-image-source.html compositing/tiling/tiled-reflection-inwindow.html editing/pasteboard/paste-create-fragment-crash.html fast/dom/HTMLAnchorElement/anchor-download-synthetic-click.html fast/dom/Window/Location/set-location-after-close.html fast/dom/Window/a-rel-noopener.html fast/dom/Window/area-rel-noopener.html fast/dom/Window/console-functions.html fast/dom/Window/dom-access-from-closure-window.html fast/dom/Window/open-zero-size-as-default.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84203 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51480 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9406 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/url/url-charset.window.html imported/w3c/web-platform-tests/FileAPI/url/url-in-tags-revoke.window.html imported/w3c/web-platform-tests/IndexedDB/back-forward-cache-open-connection.window.html imported/w3c/web-platform-tests/IndexedDB/back-forward-cache-open-transaction.window.html imported/w3c/web-platform-tests/IndexedDB/database-names-by-origin.html imported/w3c/web-platform-tests/IndexedDB/idb-partitioned-coverage.sub.html imported/w3c/web-platform-tests/content-security-policy/form-action/form-action-src-allowed-target-blank.sub.html imported/w3c/web-platform-tests/content-security-policy/form-action/form-action-src-redirect-allowed-target-frame.sub.html imported/w3c/web-platform-tests/content-security-policy/inheritance/blob-url-inherits-from-initiator.sub.html imported/w3c/web-platform-tests/content-security-policy/inheritance/history.sub.html ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1837 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42895 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/85766 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79697 "Found 23 new API test failures: TestWebKitAPI.SOAuthorizationPopUp.SOAuthorizationLoadPolicyAllowAsync, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedCloseByParent, TestWebKitAPI.SiteIsolation.CoordinateTransformation, TestWebKitAPI.WKNavigation.HTTPSOnlyWithHTTPRedirect, TestWebKitAPI.SiteIsolation.NavigateOpenerToProvisionalNavigationFailure, TestWebKitAPI.SiteIsolation.NavigationAfterWindowOpen, TestWebKitAPI.WebLocks.LockRequestWaitingOnAnotherPageInSameProcess, TestWebKitAPI.SiteIsolation.SandboxFlags, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedSuppressActiveSession, TestWebKitAPI.SiteIsolation.ParentOpener ... (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1814 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100081 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/91722 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20108 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14764 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80182 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/92637 "Build is in progress. Recent messages:") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20360 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80101 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79484 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24023 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1333 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13188 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20092 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25268 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/114371 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19779 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33006 "Found 15 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.mini-mode, microbenchmarks/memcpy-wasm-small.js.dfg-eager, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.default-wasm, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-collect-continuously, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-eager, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-slow-memory, wasm.yaml/wasm/spec-tests/float_exprs.wast.js.wasm-collect-continuously, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.wasm-collect-continuously, wasm.yaml/wasm/stress/ipint-bbq-osr-with-try5.js.default-wasm, wasm.yaml/wasm/stress/ipint-bbq-osr-with-try5.js.wasm-collect-continuously ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23239 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21520 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->