### PR TITLE
[WebGPU] out of bounds access to shaderStage array in Device::createBindGroup

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-284335-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-284335-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-284335.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-284335.html
@@ -1,0 +1,12675 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = console.log;
+
+async function gc() {
+  await 0;
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUComputePassEncoder} computePassEncoder
+ */
+function clearResourceUsages(device, computePassEncoder) {
+  let code = `@compute @workgroup_size(1) fn c() {}`;
+  let module = device.createShaderModule({code});
+  computePassEncoder.setPipeline(device.createComputePipeline(
+    {
+      layout: 'auto',
+      compute: {module},
+    }));
+  computePassEncoder.dispatchWorkgroups(1);
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+const videoUrls = [
+
+];
+
+/**
+ * @param {number} index
+ * @returns {Promise<HTMLVideoElement>}
+ */
+function videoWithData(index) {
+  let video = document.createElement('video');
+  video.src = videoUrls[index % videoUrls.length];
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+/**
+ * @param {string} payload
+ * @returns {string}
+ */
+function toBlobUrl(payload) {
+  let blob = new Blob([payload], {type: 'text/javascript'});
+  return URL.createObjectURL(blob);
+}
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+let adapter0 = await navigator.gpu.requestAdapter({});
+let adapter1 = await navigator.gpu.requestAdapter({});
+let device0 = await adapter0.requestDevice({
+  requiredFeatures: [
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxBindGroups: 4,
+    maxColorAttachmentBytesPerSample: 32,
+    maxVertexAttributes: 16,
+    maxUniformBufferBindingSize: 55140410,
+    maxStorageBufferBindingSize: 177240353,
+  },
+});
+try {
+adapter1.label = '\u{1f766}\u8eee\ud59b\u049e\uc5aa\u694c';
+} catch {}
+let commandEncoder0 = device0.createCommandEncoder();
+let texture0 = device0.createTexture({
+  size: {width: 2020, height: 64, depthOrArrayLayers: 1},
+  format: 'astc-10x8-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView0 = texture0.createView({dimension: '2d-array', baseArrayLayer: 0});
+let textureView1 = texture0.createView({mipLevelCount: 1});
+let computePassEncoder0 = commandEncoder0.beginComputePass();
+let videoFrame0 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'smpte240m', transfer: 'iec6196624'} });
+let textureView2 = texture0.createView({});
+let sampler0 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 88.65});
+let textureView3 = texture0.createView({aspect: 'all', format: 'astc-10x8-unorm-srgb', baseMipLevel: 0});
+let sampler1 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 49.01,
+  compare: 'equal',
+});
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 260, y: 8, z: 0},
+  aspect: 'all',
+}, new Uint8Array(19).fill(103), /* required buffer size: 19 */
+{offset: 19}, {width: 540, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture1 = device0.createTexture({
+  label: '\u0d69\u{1fefa}\ue584\ueb6b\u{1fa97}\u00d1\u0e9d\ua9e9\u2426\u679c',
+  size: [262, 1, 1],
+  mipLevelCount: 1,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView4 = texture1.createView({});
+let textureView5 = texture1.createView({baseMipLevel: 0, baseArrayLayer: 0});
+let texture2 = device0.createTexture({
+  size: [262, 1, 26],
+  mipLevelCount: 1,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let sampler2 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', lodMaxClamp: 99.51});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+await gc();
+let imageData0 = new ImageData(24, 16);
+let textureView6 = texture2.createView({format: 'r32sint', baseArrayLayer: 8, arrayLayerCount: 2});
+let commandEncoder1 = device0.createCommandEncoder({});
+let commandBuffer0 = commandEncoder1.finish({});
+let sampler3 = device0.createSampler({});
+let device1 = await adapter1.requestDevice({
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {maxUniformBufferBindingSize: 82563843, maxStorageBufferBindingSize: 241006407},
+});
+let commandEncoder2 = device0.createCommandEncoder({});
+let computePassEncoder1 = commandEncoder2.beginComputePass({});
+let videoFrame1 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'smpte240m', transfer: 'linear'} });
+let commandEncoder3 = device0.createCommandEncoder({});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView7 = texture0.createView({});
+let computePassEncoder2 = commandEncoder3.beginComputePass({label: '\u{1fb82}\u{1f7f0}\ub922'});
+let buffer0 = device1.createBuffer({
+  size: 9712,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder4 = device1.createCommandEncoder({});
+let computePassEncoder3 = commandEncoder4.beginComputePass({});
+try {
+device1.queue.submit([]);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let veryExplicitBindGroupLayout0 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 93,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let pipelineLayout0 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let commandEncoder5 = device0.createCommandEncoder();
+let commandBuffer1 = commandEncoder5.finish();
+let texture3 = device0.createTexture({
+  size: [262, 1, 1],
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+device0.queue.submit([commandBuffer0, commandBuffer1]);
+} catch {}
+let veryExplicitBindGroupLayout1 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 154,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder6 = device1.createCommandEncoder({});
+let commandEncoder7 = device1.createCommandEncoder({});
+let texture4 = device1.createTexture({size: {width: 1728}, dimension: '1d', format: 'r32float', usage: GPUTextureUsage.STORAGE_BINDING});
+await gc();
+let commandEncoder8 = device1.createCommandEncoder({});
+let texture5 = device1.createTexture({
+  size: [48, 1, 96],
+  dimension: '2d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture6 = device1.createTexture({
+  size: [135, 2, 514],
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView8 = texture6.createView({});
+let renderPassEncoder0 = commandEncoder7.beginRenderPass({
+  colorAttachments: [{
+  view: textureView8,
+  depthSlice: 183,
+  clearValue: { r: 907.8, g: 401.3, b: -783.4, a: 811.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let renderBundleEncoder0 = device1.createRenderBundleEncoder({colorFormats: ['r16uint', 'rgba16float'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderPassEncoder0.setVertexBuffer(5, buffer0, 0, 375);
+} catch {}
+let veryExplicitBindGroupLayout2 = device0.createBindGroupLayout({
+  label: '\ub674\u056c\u{1fbfc}\ucb35\u{1ff81}\u{1ff63}\ue3ea\u156f',
+  entries: [
+    {
+      binding: 93,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let pipelineLayout1 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let buffer1 = device0.createBuffer({
+  size: 2163,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture7 = device0.createTexture({
+  size: {width: 525, height: 1, depthOrArrayLayers: 13},
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView9 = texture5.createView({dimension: '2d', baseArrayLayer: 82});
+let textureView10 = texture4.createView({});
+let renderPassEncoder1 = commandEncoder6.beginRenderPass({
+  colorAttachments: [{
+  view: textureView8,
+  depthSlice: 201,
+  clearValue: { r: -316.2, g: 113.4, b: 682.0, a: -127.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 252925358,
+});
+let renderBundle0 = renderBundleEncoder0.finish({});
+let querySet0 = device0.createQuerySet({type: 'occlusion', count: 674});
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+await gc();
+let buffer2 = device0.createBuffer({
+  size: 5705,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let textureView11 = texture7.createView({label: '\u{1fde1}\u0e4e\u{1fedf}\uee12'});
+let sampler4 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', lodMaxClamp: 13.37});
+try {
+buffer1.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 576, new DataView(new ArrayBuffer(3049)), 62, 48);
+} catch {}
+let commandEncoder9 = device0.createCommandEncoder({});
+let computePassEncoder4 = commandEncoder9.beginComputePass({});
+let veryExplicitBindGroupLayout3 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 10,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'write-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let textureView12 = texture3.createView({dimension: '2d-array', format: 'r32sint'});
+let commandEncoder10 = device1.createCommandEncoder();
+let textureView13 = texture4.createView({mipLevelCount: 1, arrayLayerCount: 1});
+let renderPassEncoder2 = commandEncoder10.beginRenderPass({
+  colorAttachments: [{
+  view: textureView8,
+  depthSlice: 354,
+  clearValue: { r: 94.53, g: -116.6, b: 168.3, a: 828.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder4.pushDebugGroup('\u54da');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame2 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'film', transfer: 'log'} });
+let pipelineLayout2 = device1.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout1]});
+let texture8 = device1.createTexture({
+  size: {width: 864, height: 6, depthOrArrayLayers: 1},
+  format: 'astc-6x6-unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder5 = commandEncoder8.beginComputePass({});
+let renderBundleEncoder1 = device1.createRenderBundleEncoder({colorFormats: ['r16uint', 'rgba16float'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderBundleEncoder1.setVertexBuffer(1, buffer0, 0);
+} catch {}
+try {
+renderPassEncoder2.insertDebugMarker('\ue8ee');
+} catch {}
+let bindGroup0 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 93, resource: {buffer: buffer1, offset: 0, size: 275}}],
+});
+let texture9 = device0.createTexture({
+  size: [64, 64, 21],
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint'], stencilReadOnly: true});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+computePassEncoder2.setBindGroup(0, bindGroup0, new Uint32Array(138), 7, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let sampler5 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'mirror-repeat', minFilter: 'nearest', lodMaxClamp: 91.42});
+try {
+computePassEncoder4.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(3, bindGroup0, new Uint32Array(1262), 97, 0);
+} catch {}
+try {
+renderBundleEncoder2.setIndexBuffer(buffer1, 'uint16', 334, 34);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+await gc();
+try {
+computePassEncoder1.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder2.setIndexBuffer(buffer1, 'uint32', 164, 221);
+} catch {}
+try {
+renderBundleEncoder2.setVertexBuffer(6, buffer1, 88, 428);
+} catch {}
+let bindGroup1 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 154, resource: {buffer: buffer0, offset: 2048}}],
+});
+let commandEncoder11 = device1.createCommandEncoder({});
+let textureView14 = texture8.createView({aspect: 'all'});
+let renderBundle1 = renderBundleEncoder1.finish({});
+let sampler6 = device1.createSampler({addressModeU: 'clamp-to-edge', addressModeV: 'mirror-repeat', addressModeW: 'repeat', compare: 'never'});
+let imageData1 = new ImageData(80, 76);
+let bindGroup2 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 154, resource: {buffer: buffer0, offset: 0, size: 2884}}],
+});
+let commandEncoder12 = device1.createCommandEncoder({});
+let sampler7 = device1.createSampler({addressModeU: 'repeat', mipmapFilter: 'nearest', lodMaxClamp: 87.64});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(3, buffer0, 0, 2_112);
+} catch {}
+let img0 = await imageWithData(4, 39, '#10101010', '#20202020');
+let bindGroup3 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 154, resource: {buffer: buffer0, offset: 256, size: 2636}}],
+});
+let buffer3 = device1.createBuffer({
+  size: 1216,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder13 = device1.createCommandEncoder({});
+let computePassEncoder6 = commandEncoder12.beginComputePass();
+let renderPassEncoder3 = commandEncoder13.beginRenderPass({
+  colorAttachments: [{
+  view: textureView8,
+  depthSlice: 133,
+  clearValue: { r: -365.3, g: -556.0, b: -407.8, a: 210.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 421111204,
+});
+let texture10 = device0.createTexture({
+  size: [525, 1, 117],
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture11 = device0.createTexture({
+  size: [525],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder2.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(2, bindGroup0, []);
+} catch {}
+try {
+renderBundleEncoder2.setIndexBuffer(buffer1, 'uint16', 166, 357);
+} catch {}
+try {
+renderBundleEncoder2.setVertexBuffer(5, buffer1);
+} catch {}
+let veryExplicitBindGroupLayout4 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 57,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 87,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let bindGroup4 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 154, resource: {buffer: buffer0, offset: 2048}}],
+});
+let renderPassEncoder4 = commandEncoder11.beginRenderPass({
+  colorAttachments: [{
+  view: textureView8,
+  depthSlice: 210,
+  clearValue: { r: 309.5, g: -402.7, b: -227.9, a: -856.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let sampler8 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 70.02,
+  lodMaxClamp: 87.78,
+  compare: 'greater-equal',
+  maxAnisotropy: 15,
+});
+try {
+renderPassEncoder4.setVertexBuffer(4, buffer0, 404);
+} catch {}
+let pipelineLayout3 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout2]});
+let commandEncoder14 = device0.createCommandEncoder({});
+let textureView15 = texture10.createView({});
+let renderBundle2 = renderBundleEncoder2.finish();
+try {
+computePassEncoder2.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+commandEncoder14.copyTextureToBuffer({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2404 */
+  offset: 2404,
+  buffer: buffer2,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let computePassEncoder7 = commandEncoder14.beginComputePass({});
+let pipelineLayout4 = device1.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout4]});
+let commandEncoder15 = device1.createCommandEncoder({});
+let texture12 = device1.createTexture({
+  size: [540],
+  dimension: '1d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView16 = texture5.createView({dimension: '2d'});
+let computePassEncoder8 = commandEncoder15.beginComputePass({});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup2, new Uint32Array(988), 169, 0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(1, undefined);
+} catch {}
+try {
+computePassEncoder3.insertDebugMarker('\u{1fde4}');
+} catch {}
+try {
+device1.queue.writeBuffer(buffer3, 196, new DataView(new ArrayBuffer(10070)), 879, 472);
+} catch {}
+let promise0 = device1.queue.onSubmittedWorkDone();
+let bindGroup5 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 93, resource: {buffer: buffer2, offset: 1024, size: 32}}],
+});
+let textureView17 = texture0.createView({dimension: '2d-array'});
+try {
+computePassEncoder4.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 1, y: 3, z: 6},
+  aspect: 'all',
+}, new Uint8Array(85_887).fill(67), /* required buffer size: 85_887 */
+{offset: 259, bytesPerRow: 252, rowsPerImage: 113}, {width: 25, height: 1, depthOrArrayLayers: 4});
+} catch {}
+try {
+  await promise0;
+} catch {}
+let commandEncoder16 = device0.createCommandEncoder();
+try {
+commandEncoder16.resolveQuerySet(querySet0, 207, 99, buffer2, 1280);
+} catch {}
+let imageData2 = new ImageData(12, 76);
+let veryExplicitBindGroupLayout5 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 205,
+      visibility: 0,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let texture13 = device1.createTexture({
+  size: [432, 3, 1],
+  mipLevelCount: 4,
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder6.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 39, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(199).fill(73), /* required buffer size: 199 */
+{offset: 199, bytesPerRow: 213}, {width: 22, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout5 = device1.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout4, veryExplicitBindGroupLayout4]});
+let commandEncoder17 = device1.createCommandEncoder({});
+let texture14 = device1.createTexture({
+  size: [48, 1, 14],
+  dimension: '2d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+computePassEncoder5.setBindGroup(0, bindGroup3, new Uint32Array(386), 17, 0);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(6, buffer3, 144);
+} catch {}
+let querySet1 = device1.createQuerySet({type: 'occlusion', count: 1861});
+let textureView18 = texture13.createView({mipLevelCount: 1});
+let computePassEncoder9 = commandEncoder17.beginComputePass();
+try {
+renderPassEncoder4.setVertexBuffer(2, buffer3, 0, 604);
+} catch {}
+let bindGroup6 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [{binding: 93, resource: {buffer: buffer1, offset: 0, size: 792}}],
+});
+let commandEncoder18 = device0.createCommandEncoder({});
+let texture15 = device0.createTexture({
+  size: [65],
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder10 = commandEncoder16.beginComputePass();
+try {
+computePassEncoder0.setBindGroup(1, bindGroup5, new Uint32Array(2692), 576, 0);
+} catch {}
+let videoFrame3 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'smpteRp431', transfer: 'iec61966-2-1'} });
+let bindGroup7 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [{binding: 93, resource: {buffer: buffer2, offset: 512, size: 925}}],
+});
+let computePassEncoder11 = commandEncoder18.beginComputePass({});
+let bindGroup8 = device1.createBindGroup({layout: veryExplicitBindGroupLayout5, entries: [{binding: 205, resource: textureView9}]});
+let texture16 = device1.createTexture({
+  size: {width: 432, height: 3, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16uint', 'r16uint', 'r16uint'],
+});
+try {
+device1.queue.writeBuffer(buffer3, 72, new BigUint64Array(3943), 1176, 8);
+} catch {}
+let commandEncoder19 = device0.createCommandEncoder({});
+document.body.prepend(img0);
+let textureView19 = texture7.createView({aspect: 'all'});
+let sampler9 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+});
+try {
+computePassEncoder4.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(928_537).fill(144), /* required buffer size: 928_537 */
+{offset: 211, bytesPerRow: 217, rowsPerImage: 186}, {width: 52, height: 0, depthOrArrayLayers: 24});
+} catch {}
+let texture17 = device0.createTexture({
+  size: [131],
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+computePassEncoder4.setBindGroup(3, bindGroup6, new Uint32Array(1788), 122, 0);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+let commandEncoder20 = device1.createCommandEncoder();
+let textureView20 = texture14.createView({arrayLayerCount: 3});
+let sampler10 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  compare: 'less-equal',
+});
+try {
+computePassEncoder6.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+computePassEncoder3.end();
+} catch {}
+let querySet2 = device0.createQuerySet({type: 'occlusion', count: 306});
+let textureView21 = texture17.createView({dimension: '1d'});
+let texture18 = device0.createTexture({
+  size: {width: 131, height: 1, depthOrArrayLayers: 1},
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+computePassEncoder0.setBindGroup(0, bindGroup0, new Uint32Array(974), 648, 0);
+} catch {}
+try {
+computePassEncoder9.setBindGroup(1, bindGroup3, new Uint32Array(947), 98, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 29, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(102).fill(114), /* required buffer size: 102 */
+{offset: 102}, {width: 258, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer4 = device0.createBuffer({size: 30504, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder21 = device0.createCommandEncoder({});
+let computePassEncoder12 = commandEncoder21.beginComputePass();
+let sampler11 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 99.78});
+try {
+computePassEncoder11.setBindGroup(3, bindGroup7);
+} catch {}
+let bindGroup9 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 93, resource: {buffer: buffer1, offset: 256, size: 360}}],
+});
+let commandEncoder22 = device0.createCommandEncoder({});
+let computePassEncoder13 = commandEncoder22.beginComputePass();
+let sampler12 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'mirror-repeat', addressModeW: 'repeat'});
+let bindGroup10 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 93, resource: {buffer: buffer1, offset: 0, size: 297}}],
+});
+let computePassEncoder14 = commandEncoder19.beginComputePass({});
+let sampler13 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 57.01});
+let externalTexture0 = device0.importExternalTexture({source: videoFrame3});
+try {
+computePassEncoder4.setBindGroup(1, bindGroup6, new Uint32Array(824), 56, 0);
+} catch {}
+let buffer5 = device0.createBuffer({
+  size: 1689,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder23 = device0.createCommandEncoder();
+let texture19 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 21},
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let externalTexture1 = device0.importExternalTexture({source: videoFrame2});
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder23.copyBufferToBuffer(buffer2, 740, buffer5, 140, 528);
+} catch {}
+document.body.append(img0);
+let buffer6 = device1.createBuffer({
+  size: 10545,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView22 = texture13.createView({mipLevelCount: 1});
+try {
+commandEncoder20.clearBuffer(buffer3);
+} catch {}
+let bindGroup11 = device0.createBindGroup({layout: veryExplicitBindGroupLayout3, entries: [{binding: 10, resource: textureView12}]});
+let commandEncoder24 = device0.createCommandEncoder({});
+let textureView23 = texture7.createView({baseArrayLayer: 0});
+let computePassEncoder15 = commandEncoder24.beginComputePass({});
+let externalTexture2 = device0.importExternalTexture({source: videoFrame1});
+try {
+computePassEncoder12.setBindGroup(3, bindGroup5, new Uint32Array(2253), 181, 0);
+} catch {}
+try {
+commandEncoder23.copyBufferToTexture({
+  /* bytesInLastRow: 784 widthInBlocks: 49 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 3104 */
+  offset: 3104,
+  buffer: buffer2,
+}, {
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 49, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView24 = texture6.createView({format: 'r32float'});
+let texture20 = device1.createTexture({
+  size: [96, 1, 1],
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder16 = commandEncoder4.beginComputePass({label: '\u7ef9\u3f81\u9862\u027c\u050f\u9e9d\ubd63'});
+try {
+computePassEncoder6.setBindGroup(1, bindGroup3, []);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup8, []);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 108, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData2,
+  origin: { x: 4, y: 1 },
+  flipY: true,
+}, {
+  texture: texture13,
+  mipLevel: 2,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder25 = device0.createCommandEncoder({});
+let texture21 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 21},
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder17 = commandEncoder23.beginComputePass({});
+let sampler14 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'mirror-repeat', minFilter: 'linear', lodMaxClamp: 96.32});
+document.body.append(img0);
+let textureView25 = texture21.createView({baseArrayLayer: 4, arrayLayerCount: 4});
+let textureView26 = texture10.createView({aspect: 'all'});
+try {
+computePassEncoder12.setBindGroup(2, bindGroup6, new Uint32Array(3068), 1_050, 0);
+} catch {}
+try {
+commandEncoder25.copyBufferToBuffer(buffer2, 1104, buffer4, 6816, 732);
+} catch {}
+try {
+commandEncoder25.copyTextureToBuffer({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 224 widthInBlocks: 28 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2704 */
+  offset: 2704,
+  bytesPerRow: 41984,
+  buffer: buffer2,
+}, {width: 28, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let querySet3 = device0.createQuerySet({type: 'occlusion', count: 58});
+let texture22 = device0.createTexture({
+  size: [525, 1, 44],
+  mipLevelCount: 1,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView27 = texture9.createView({dimension: 'cube', format: 'rgba16uint', baseArrayLayer: 6});
+let computePassEncoder18 = commandEncoder25.beginComputePass({});
+let commandEncoder26 = device0.createCommandEncoder();
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint']});
+let sampler15 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 85.20,
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder14.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(2, bindGroup10, new Uint32Array(1700), 201, 0);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(2, buffer5);
+} catch {}
+try {
+device1.queue.label = '\u67ac\u4d91\u004a\u0dd3\u0e23\u{1f663}';
+} catch {}
+let texture23 = device1.createTexture({
+  size: [384, 1, 135],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView28 = texture13.createView({mipLevelCount: 1});
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup3);
+} catch {}
+let bindGroup12 = device0.createBindGroup({layout: veryExplicitBindGroupLayout3, entries: [{binding: 10, resource: textureView6}]});
+let buffer7 = device0.createBuffer({
+  size: 37301,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let computePassEncoder19 = commandEncoder26.beginComputePass({});
+try {
+buffer2.unmap();
+} catch {}
+let imageBitmap0 = await createImageBitmap(videoFrame3);
+let buffer8 = device0.createBuffer({
+  size: 8892,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder27 = device0.createCommandEncoder({});
+try {
+renderBundleEncoder3.setBindGroup(0, bindGroup11, new Uint32Array(3116), 5, 0);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let computePassEncoder20 = commandEncoder27.beginComputePass({});
+let renderBundle3 = renderBundleEncoder3.finish({});
+let sampler16 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat'});
+let bindGroup13 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [{binding: 93, resource: {buffer: buffer5, offset: 256, size: 46}}],
+});
+let commandEncoder28 = device0.createCommandEncoder({});
+let textureView29 = texture9.createView({dimension: '2d', baseArrayLayer: 4});
+let renderPassEncoder5 = commandEncoder28.beginRenderPass({
+  colorAttachments: [{
+  view: textureView29,
+  clearValue: { r: 283.3, g: -647.0, b: -528.2, a: -620.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 210, y: 8, z: 0},
+  aspect: 'all',
+}, new Uint8Array(8).fill(16), /* required buffer size: 8 */
+{offset: 8}, {width: 330, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame4 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'smpte432', transfer: 'smpte240m'} });
+let bindGroup14 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [{binding: 93, resource: {buffer: buffer2, offset: 0, size: 2778}}],
+});
+let commandEncoder29 = device0.createCommandEncoder({});
+let computePassEncoder21 = commandEncoder29.beginComputePass({});
+try {
+computePassEncoder18.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup11, new Uint32Array(693), 74, 0);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(6, buffer1, 992);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 8412, new DataView(new ArrayBuffer(13434)), 2036, 4040);
+} catch {}
+let videoFrame5 = videoFrame3.clone();
+let veryExplicitBindGroupLayout6 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 539,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '1d' },
+    },
+  ],
+});
+let bindGroup15 = device0.createBindGroup({layout: veryExplicitBindGroupLayout6, entries: [{binding: 539, resource: textureView21}]});
+let commandEncoder30 = device0.createCommandEncoder({});
+let querySet4 = device0.createQuerySet({type: 'occlusion', count: 2275});
+let textureView30 = texture18.createView({});
+let computePassEncoder22 = commandEncoder30.beginComputePass();
+let externalTexture3 = device0.importExternalTexture({source: videoFrame2, colorSpace: 'display-p3'});
+try {
+computePassEncoder15.setBindGroup(3, bindGroup14, []);
+} catch {}
+try {
+renderPassEncoder5.setScissorRect(8, 7, 2, 14);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(3, buffer8, 0, 465);
+} catch {}
+let commandEncoder31 = device1.createCommandEncoder();
+let sampler17 = device1.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 94.48});
+let texture24 = device1.createTexture({
+  size: {width: 96},
+  dimension: '1d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder23 = commandEncoder20.beginComputePass({});
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup8, new Uint32Array(12), 0, 0);
+} catch {}
+let bindGroup16 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 154, resource: {buffer: buffer0, offset: 0}}],
+});
+let textureView31 = texture16.createView({baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 0});
+let renderBundleEncoder4 = device1.createRenderBundleEncoder({colorFormats: ['r32float']});
+let sampler18 = device1.createSampler({addressModeV: 'repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 61.47});
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+commandEncoder31.resolveQuerySet(querySet1, 622, 60, buffer0, 1536);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 43, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(0).fill(35), /* required buffer size: 0 */
+{offset: 0}, {width: 13, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame6 = new VideoFrame(videoFrame1, {timestamp: 0});
+let texture25 = device1.createTexture({
+  size: [1080],
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder6 = commandEncoder31.beginRenderPass({
+  colorAttachments: [{
+  view: textureView22,
+  clearValue: { r: -275.6, g: 753.5, b: 320.5, a: 923.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let renderBundle4 = renderBundleEncoder4.finish({});
+try {
+computePassEncoder8.setBindGroup(1, bindGroup16, new Uint32Array(3182), 184, 0);
+} catch {}
+document.body.append(img0);
+let imageData3 = new ImageData(52, 40);
+let commandEncoder32 = device0.createCommandEncoder({});
+let texture26 = device0.createTexture({
+  size: [65],
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder24 = commandEncoder32.beginComputePass({});
+let sampler19 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  lodMaxClamp: 65.98,
+  compare: 'always',
+});
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup12, new Uint32Array(758), 221, 0);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle3, renderBundle2, renderBundle3, renderBundle2]);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+try {
+computePassEncoder24.pushDebugGroup('\u49c9');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'stencil-only',
+}, new Uint8Array(13_464).fill(62), /* required buffer size: 13_464 */
+{offset: 267, bytesPerRow: 576, rowsPerImage: 22}, {width: 525, height: 1, depthOrArrayLayers: 2});
+} catch {}
+document.body.prepend(img0);
+let bindGroup17 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 154, resource: {buffer: buffer0, offset: 3072}}],
+});
+let pipelineLayout6 = device1.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout5]});
+let texture27 = device1.createTexture({
+  size: [135, 2, 18],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture28 = device1.createTexture({size: [48, 1, 1], mipLevelCount: 1, format: 'r16uint', usage: GPUTextureUsage.COPY_SRC});
+let textureView32 = texture12.createView({});
+try {
+computePassEncoder23.setBindGroup(3, bindGroup16, new Uint32Array(112), 3, 0);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { console.log('device1.uncapturederror'); console.log(e); e.label = device1.label; });
+} catch {}
+try {
+device1.queue.writeBuffer(buffer3, 500, new Int16Array(9829), 909, 72);
+} catch {}
+let promise1 = device1.queue.onSubmittedWorkDone();
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 216, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture13,
+  mipLevel: 1,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture29 = device0.createTexture({
+  size: [1580, 95, 1],
+  mipLevelCount: 2,
+  format: 'astc-10x5-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler20 = device0.createSampler({
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 84.32,
+  maxAnisotropy: 8,
+});
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup0, new Uint32Array(161), 11, 0);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(0, undefined, 0);
+} catch {}
+let videoFrame7 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'fcc', primaries: 'bt709', transfer: 'bt709'} });
+let textureView33 = texture9.createView({dimension: '2d', baseArrayLayer: 1});
+try {
+computePassEncoder21.setBindGroup(3, bindGroup6, new Uint32Array(414), 40, 0);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(7, buffer1, 548, 342);
+} catch {}
+let buffer9 = device1.createBuffer({size: 42142, usage: GPUBufferUsage.INDEX});
+let commandEncoder33 = device1.createCommandEncoder({});
+let textureView34 = texture12.createView({dimension: '1d', aspect: 'all'});
+try {
+computePassEncoder23.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup16);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer9, 'uint32', 4_404, 13);
+} catch {}
+let commandEncoder34 = device1.createCommandEncoder({});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+commandEncoder34.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 145},
+  aspect: 'all',
+},
+{
+  texture: texture13,
+  mipLevel: 1,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder34.clearBuffer(buffer3);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer3, 64, new Float32Array(9818), 1848, 36);
+} catch {}
+let commandEncoder35 = device0.createCommandEncoder({});
+let computePassEncoder25 = commandEncoder35.beginComputePass({});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData4 = new ImageData(60, 88);
+let commandEncoder36 = device1.createCommandEncoder({});
+let computePassEncoder26 = commandEncoder33.beginComputePass({});
+let sampler21 = device1.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', lodMinClamp: 74.51, lodMaxClamp: 98.02});
+let commandEncoder37 = device0.createCommandEncoder({});
+try {
+computePassEncoder14.setBindGroup(3, bindGroup7, new Uint32Array(2566), 16, 0);
+} catch {}
+try {
+commandEncoder37.copyTextureToBuffer({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 328 widthInBlocks: 41 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1256 */
+  offset: 1256,
+  bytesPerRow: 512,
+  buffer: buffer2,
+}, {width: 41, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder38 = device1.createCommandEncoder({});
+let texture30 = device1.createTexture({
+  size: [864, 6, 98],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder27 = commandEncoder36.beginComputePass({});
+try {
+computePassEncoder5.setBindGroup(2, bindGroup3, new Uint32Array(1541), 122, 0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(0, buffer6, 724);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { console.log('device1.uncapturederror'); console.log(e); e.label = device1.label; });
+} catch {}
+try {
+device1.queue.writeBuffer(buffer3, 248, new Int16Array(13972), 271, 32);
+} catch {}
+let buffer10 = device0.createBuffer({size: 55460, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let sampler22 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 69.85,
+});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup13, new Uint32Array(2655), 72, 0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup6, new Uint32Array(1738), 239, 0);
+} catch {}
+document.body.prepend(img0);
+let videoFrame8 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'unspecified', primaries: 'jedecP22Phosphors', transfer: 'logSqrt'} });
+let commandEncoder39 = device0.createCommandEncoder({});
+let computePassEncoder28 = commandEncoder37.beginComputePass({});
+let sampler23 = device0.createSampler({
+  label: '\u0a1c\ud427\u{1fe2d}\u0877\u048f\u588c\uc2d5\ua483\u{1f794}\u{1fb73}',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMaxClamp: 90.39,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+commandEncoder39.copyTextureToBuffer({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 560 */
+  offset: 560,
+  buffer: buffer2,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(63).fill(46), /* required buffer size: 63 */
+{offset: 63, bytesPerRow: 255}, {width: 16, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture31 = device0.createTexture({size: [131], sampleCount: 1, dimension: '1d', format: 'rgba16uint', usage: GPUTextureUsage.COPY_DST});
+let textureView35 = texture0.createView({dimension: '2d-array'});
+let computePassEncoder29 = commandEncoder39.beginComputePass({});
+try {
+computePassEncoder28.setBindGroup(0, bindGroup0, new Uint32Array(2409), 398, 0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup11, new Uint32Array(325), 74, 0);
+} catch {}
+let canvas0 = document.createElement('canvas');
+let veryExplicitBindGroupLayout7 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 47,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'bgra8unorm', access: 'read-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let buffer11 = device0.createBuffer({size: 13874, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let sampler24 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 76.38,
+  maxAnisotropy: 19,
+});
+try {
+renderPassEncoder5.setIndexBuffer(buffer10, 'uint16', 14_272);
+} catch {}
+let buffer12 = device0.createBuffer({
+  size: 62534,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder40 = device0.createCommandEncoder({});
+let textureView36 = texture2.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 1});
+let sampler25 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 93.44,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder24.setBindGroup(1, bindGroup11, []);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup10, new Uint32Array(1484), 495, 0);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(6, buffer5, 376, 9);
+} catch {}
+try {
+commandEncoder40.copyBufferToBuffer(buffer2, 668, buffer5, 20, 72);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 80, new Float32Array(22215), 696, 200);
+} catch {}
+let bindGroup18 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 93, resource: {buffer: buffer10, offset: 0}}],
+});
+let commandEncoder41 = device0.createCommandEncoder();
+let textureView37 = texture11.createView({dimension: '1d', format: 'rgba16uint'});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({colorFormats: ['rg8uint'], depthReadOnly: false, stencilReadOnly: true});
+let externalTexture4 = device0.importExternalTexture({source: videoFrame1, colorSpace: 'srgb'});
+try {
+renderPassEncoder5.setVertexBuffer(3, buffer5, 0);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(2, bindGroup15);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let gpuCanvasContext0 = canvas0.getContext('webgpu');
+let buffer13 = device1.createBuffer({
+  size: 874,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let texture32 = device1.createTexture({
+  size: [540, 10, 1],
+  dimension: '2d',
+  format: 'r32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let computePassEncoder30 = commandEncoder38.beginComputePass({});
+let sampler26 = device1.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.55,
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder16.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+computePassEncoder16.setBindGroup(2, bindGroup16, new Uint32Array(979), 12, 0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let texture33 = device1.createTexture({
+  size: {width: 128, height: 128, depthOrArrayLayers: 47},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup3, new Uint32Array(159), 60, 0);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(1, buffer13);
+} catch {}
+try {
+commandEncoder34.copyBufferToTexture({
+  /* bytesInLastRow: 64 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2480 */
+  offset: 2480,
+  buffer: buffer6,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder42 = device1.createCommandEncoder();
+let querySet5 = device1.createQuerySet({type: 'occlusion', count: 846});
+let renderPassEncoder7 = commandEncoder34.beginRenderPass({
+  colorAttachments: [{
+  view: textureView28,
+  clearValue: { r: -108.1, g: 495.5, b: -672.5, a: -268.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let sampler27 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 71.67,
+  compare: 'greater-equal',
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder8.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let bindGroup19 = device0.createBindGroup({layout: veryExplicitBindGroupLayout3, entries: [{binding: 10, resource: textureView12}]});
+let computePassEncoder31 = commandEncoder40.beginComputePass();
+let renderBundle5 = renderBundleEncoder5.finish({});
+try {
+commandEncoder41.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1432 */
+  offset: 1432,
+  bytesPerRow: 2816,
+  buffer: buffer7,
+}, {
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder41.clearBuffer(buffer12, 33280, 4920);
+} catch {}
+document.body.append(img0);
+let canvas1 = document.createElement('canvas');
+let videoFrame9 = new VideoFrame(videoFrame5, {timestamp: 0});
+let buffer14 = device0.createBuffer({size: 27026, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture34 = device0.createTexture({
+  size: [525],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder32 = commandEncoder41.beginComputePass({});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+computePassEncoder2.setBindGroup(2, bindGroup14, new Uint32Array(615), 37, 0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup9, new Uint32Array(437), 148, 0);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer1, 'uint16', 464, 464);
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer11, 5940, new BigUint64Array(5913), 2542, 200);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let computePassEncoder33 = commandEncoder42.beginComputePass({});
+try {
+renderPassEncoder0.executeBundles([renderBundle4]);
+} catch {}
+let videoFrame10 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'fcc', primaries: 'film', transfer: 'log'} });
+let commandEncoder43 = device1.createCommandEncoder({});
+let textureView38 = texture14.createView({aspect: 'all', format: 'r16uint', arrayLayerCount: 1});
+let computePassEncoder34 = commandEncoder43.beginComputePass({});
+let sampler28 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 83.30,
+});
+try {
+renderPassEncoder0.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder7.setStencilReference(1000);
+} catch {}
+let buffer15 = device0.createBuffer({size: 8731, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({colorFormats: ['rg8uint'], stencilReadOnly: true});
+try {
+computePassEncoder20.setBindGroup(2, bindGroup9);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(7, buffer5, 172, 152);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 724, new BigUint64Array(1971));
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'stencil-only',
+}, new Uint8Array(101).fill(6), /* required buffer size: 101 */
+{offset: 101}, {width: 525, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer5, 'uint32', 664, 383);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(3, bindGroup11, new Uint32Array(1989), 58, 0);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(7, buffer11);
+} catch {}
+let gpuCanvasContext1 = canvas1.getContext('webgpu');
+let bindGroup20 = device1.createBindGroup({layout: veryExplicitBindGroupLayout5, entries: [{binding: 205, resource: textureView16}]});
+let textureView39 = texture16.createView({aspect: 'all', format: 'r16uint', mipLevelCount: 1});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle4, renderBundle4, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer9, 'uint32', 1_024, 29_351);
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 8},
+  aspect: 'all',
+}, new Uint8Array(1_400).fill(51), /* required buffer size: 1_400 */
+{offset: 410, bytesPerRow: 5, rowsPerImage: 66}, {width: 0, height: 0, depthOrArrayLayers: 4});
+} catch {}
+try {
+  await promise1;
+} catch {}
+try {
+computePassEncoder33.setBindGroup(1, bindGroup8);
+} catch {}
+let bindGroup21 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 93, resource: {buffer: buffer2, offset: 0, size: 958}}],
+});
+let texture35 = device0.createTexture({
+  size: [64, 64, 21],
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16uint'],
+});
+let textureView40 = texture1.createView({dimension: '2d-array', aspect: 'all'});
+let sampler29 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', addressModeW: 'mirror-repeat'});
+try {
+computePassEncoder21.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer10, 'uint32', 5_388, 245);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(3, bindGroup18);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(1, bindGroup10, new Uint32Array(6247), 895, 0);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer8, 'uint32', 272, 1_617);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(2, buffer1, 1_216, 122);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+document.body.append(canvas1);
+let videoFrame11 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'smpteSt4281', transfer: 'bt2020_10bit'} });
+let bindGroup22 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [{binding: 57, resource: textureView14}, {binding: 87, resource: sampler18}],
+});
+let texture36 = device1.createTexture({
+  size: {width: 1080},
+  dimension: '1d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let texture37 = gpuCanvasContext1.getCurrentTexture();
+let externalTexture5 = device1.importExternalTexture({source: videoFrame7, colorSpace: 'srgb'});
+try {
+computePassEncoder26.setBindGroup(1, bindGroup22);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup22);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer9, 'uint16', 5_052, 9_232);
+} catch {}
+try {
+renderPassEncoder3.insertDebugMarker('\u1c6c');
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 54, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame11,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture13,
+  mipLevel: 3,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(2, 149);
+let commandEncoder44 = device0.createCommandEncoder({});
+let texture38 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 99},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let texture39 = gpuCanvasContext1.getCurrentTexture();
+let computePassEncoder35 = commandEncoder44.beginComputePass({});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+renderPassEncoder5.setBlendConstant({ r: 435.8, g: 683.3, b: 494.5, a: 761.0, });
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer1, 'uint32', 308, 276);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(4, buffer1, 320, 78);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let renderBundle6 = renderBundleEncoder6.finish({});
+let sampler30 = device0.createSampler({addressModeW: 'repeat', mipmapFilter: 'linear', lodMaxClamp: 70.30});
+try {
+renderPassEncoder5.setIndexBuffer(buffer1, 'uint16', 494, 567);
+} catch {}
+let commandEncoder45 = device0.createCommandEncoder({});
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup12);
+} catch {}
+let bindGroup23 = device1.createBindGroup({layout: veryExplicitBindGroupLayout5, entries: [{binding: 205, resource: textureView16}]});
+let texture40 = device1.createTexture({
+  size: {width: 48, height: 1, depthOrArrayLayers: 423},
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture41 = device1.createTexture({
+  size: [540],
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView41 = texture6.createView({});
+let sampler31 = device1.createSampler({
+  label: '\u7fd1\u{1fe5c}\u{1fd7e}\u{1f8e4}\uee30\u0959\u96d4\u0137\uedeb',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 81.83,
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder9.setBindGroup(0, bindGroup2, new Uint32Array(1338), 188, 0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup23, new Uint32Array(1159), 26, 0);
+} catch {}
+try {
+renderPassEncoder3.insertDebugMarker('\u{1f8fa}');
+} catch {}
+try {
+adapter0.label = '\u{1f90a}\u80a6\u{1f7ca}\u0cfb';
+} catch {}
+let bindGroup24 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 93, resource: {buffer: buffer2, offset: 0, size: 1046}}],
+});
+let textureView42 = texture10.createView({});
+try {
+computePassEncoder7.setBindGroup(2, bindGroup15);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+let querySet6 = device0.createQuerySet({type: 'occlusion', count: 1118});
+let texture42 = device0.createTexture({
+  size: {width: 131},
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder36 = commandEncoder45.beginComputePass({});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint']});
+let sampler32 = device0.createSampler({addressModeW: 'repeat'});
+try {
+renderPassEncoder5.setViewport(17.322397546857445, 56.14715213759463, 26.127839403384716, 1.2479538820372271, 0.26021502750620373, 0.6515224520871482);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer1, 'uint32', 52, 570);
+} catch {}
+try {
+computePassEncoder24.popDebugGroup();
+} catch {}
+let bindGroup25 = device0.createBindGroup({layout: veryExplicitBindGroupLayout3, entries: [{binding: 10, resource: textureView12}]});
+let textureView43 = texture17.createView({});
+try {
+computePassEncoder20.setBindGroup(1, bindGroup9, new Uint32Array(402), 128, 0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup25, new Uint32Array(3019), 78, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+let commandEncoder46 = device0.createCommandEncoder({});
+let texture43 = device0.createTexture({size: [131], dimension: '1d', format: 'rgba16uint', usage: GPUTextureUsage.COPY_SRC});
+let computePassEncoder37 = commandEncoder46.beginComputePass({});
+try {
+computePassEncoder29.setBindGroup(0, bindGroup10, new Uint32Array(1029), 57, 0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup14);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup9, new Uint32Array(780), 281, 0);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(1, buffer5, 848);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture38,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(905).fill(69), /* required buffer size: 905 */
+{offset: 196, bytesPerRow: 47}, {width: 2, height: 16, depthOrArrayLayers: 1});
+} catch {}
+let bindGroup26 = device0.createBindGroup({layout: veryExplicitBindGroupLayout7, entries: [{binding: 47, resource: textureView25}]});
+let commandEncoder47 = device0.createCommandEncoder({});
+let texture44 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 21},
+  mipLevelCount: 2,
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder37.setBindGroup(3, bindGroup6, new Uint32Array(2809), 260, 0);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer1, 'uint16', 278, 145);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(2, buffer1, 0, 95);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let buffer16 = device0.createBuffer({
+  size: 6179,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let commandEncoder48 = device0.createCommandEncoder();
+let textureView44 = texture10.createView({});
+let computePassEncoder38 = commandEncoder47.beginComputePass({});
+try {
+renderPassEncoder5.setVertexBuffer(2, buffer11, 2_844, 5_060);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(1, bindGroup9, new Uint32Array(460), 2, 0);
+} catch {}
+await gc();
+let commandEncoder49 = device1.createCommandEncoder({});
+let querySet7 = device1.createQuerySet({type: 'occlusion', count: 580});
+let texture45 = device1.createTexture({
+  size: [384, 1, 2],
+  mipLevelCount: 1,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder39 = commandEncoder49.beginComputePass({});
+try {
+computePassEncoder34.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+computePassEncoder6.setBindGroup(3, bindGroup23, new Uint32Array(1735), 80, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup8, new Uint32Array(125), 9, 0);
+} catch {}
+try {
+renderPassEncoder7.setScissorRect(96, 0, 36, 0);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(2, buffer13, 20, 43);
+} catch {}
+let promise2 = device1.queue.onSubmittedWorkDone();
+let veryExplicitBindGroupLayout8 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 117,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 307,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder50 = device1.createCommandEncoder();
+let texture46 = device1.createTexture({
+  size: {width: 96, height: 1, depthOrArrayLayers: 194},
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler33 = device1.createSampler({addressModeW: 'mirror-repeat', magFilter: 'nearest', lodMinClamp: 28.39});
+try {
+computePassEncoder6.end();
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(2159);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer3, 520, new Int16Array(2670), 320, 32);
+} catch {}
+let commandEncoder51 = device1.createCommandEncoder({});
+let commandBuffer2 = commandEncoder12.finish();
+let texture47 = device1.createTexture({
+  size: [96, 1, 1],
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture48 = device1.createTexture({
+  size: {width: 384, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView45 = texture47.createView({dimension: '2d-array', mipLevelCount: 1});
+let renderBundleEncoder8 = device1.createRenderBundleEncoder({colorFormats: ['r16uint', 'rgba16float'], depthReadOnly: true});
+try {
+renderPassEncoder2.setIndexBuffer(buffer13, 'uint32', 4, 247);
+} catch {}
+try {
+commandEncoder51.copyTextureToBuffer({
+  texture: texture36,
+  mipLevel: 0,
+  origin: {x: 40, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 376 widthInBlocks: 47 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 72 */
+  offset: 72,
+  bytesPerRow: 4352,
+  buffer: buffer3,
+}, {width: 47, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise2;
+} catch {}
+let veryExplicitBindGroupLayout9 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 205,
+      visibility: 0,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let commandEncoder52 = device1.createCommandEncoder({});
+let textureView46 = texture45.createView({arrayLayerCount: 1});
+let texture49 = device1.createTexture({
+  size: {width: 135},
+  dimension: '1d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView47 = texture8.createView({dimension: '2d-array', mipLevelCount: 1});
+let renderPassEncoder8 = commandEncoder50.beginRenderPass({
+  colorAttachments: [{view: textureView28, loadOp: 'load', storeOp: 'discard'}],
+  occlusionQuerySet: querySet1,
+});
+let renderBundle7 = renderBundleEncoder8.finish({});
+let sampler34 = device1.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.36,
+});
+try {
+computePassEncoder16.setBindGroup(0, bindGroup3, new Uint32Array(1551), 466, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup8, new Uint32Array(569), 91, 0);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(2, buffer6);
+} catch {}
+try {
+commandEncoder52.clearBuffer(buffer3);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let videoFrame12 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'film', transfer: 'hlg'} });
+let buffer17 = device0.createBuffer({
+  size: 3608,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture50 = device0.createTexture({
+  size: [64, 64, 21],
+  dimension: '2d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder5.setVertexBuffer(0, buffer8);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer17, 716, new Float32Array(30325), 11554, 92);
+} catch {}
+let buffer18 = device0.createBuffer({size: 18853, usage: GPUBufferUsage.STORAGE});
+let textureView48 = texture50.createView({dimension: '2d', baseMipLevel: 0, baseArrayLayer: 9});
+let computePassEncoder40 = commandEncoder48.beginComputePass({});
+let sampler35 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', addressModeW: 'clamp-to-edge'});
+try {
+computePassEncoder29.setBindGroup(0, bindGroup7, []);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup13, new Uint32Array(1003), 180, 0);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(1, bindGroup25, new Uint32Array(1828), 382, 0);
+} catch {}
+let commandEncoder53 = device1.createCommandEncoder({});
+let textureView49 = texture46.createView({});
+let texture51 = gpuCanvasContext0.getCurrentTexture();
+let textureView50 = texture16.createView({dimension: '2d-array', mipLevelCount: 1});
+let renderPassEncoder9 = commandEncoder52.beginRenderPass({
+  colorAttachments: [{
+  view: textureView28,
+  clearValue: { r: -564.4, g: -785.1, b: -385.4, a: 128.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder34.setBindGroup(3, bindGroup22);
+} catch {}
+try {
+computePassEncoder8.setBindGroup(2, bindGroup3, new Uint32Array(89), 10, 0);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer13, 'uint32', 188, 150);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 72, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(19).fill(44), /* required buffer size: 19 */
+{offset: 19}, {width: 94, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture52 = device1.createTexture({
+  size: {width: 1080, height: 20, depthOrArrayLayers: 1},
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder41 = commandEncoder51.beginComputePass({});
+let sampler36 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 72.59,
+  lodMaxClamp: 78.05,
+});
+try {
+computePassEncoder9.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(4, buffer0);
+} catch {}
+try {
+commandEncoder53.resolveQuerySet(querySet7, 10, 4, buffer13, 0);
+} catch {}
+let buffer19 = device1.createBuffer({size: 12895, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+let textureView51 = texture41.createView({aspect: 'all'});
+let texture53 = device1.createTexture({
+  size: [135, 2, 1],
+  mipLevelCount: 2,
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder42 = commandEncoder53.beginComputePass({});
+let sampler37 = device1.createSampler({
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 80.95,
+  lodMaxClamp: 88.94,
+});
+try {
+computePassEncoder42.setBindGroup(3, bindGroup3, new Uint32Array(378), 100, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(4, undefined, 571_122_702, 182_375_049);
+} catch {}
+let imageData5 = new ImageData(68, 144);
+let bindGroup27 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [{binding: 93, resource: {buffer: buffer10, offset: 1792}}],
+});
+let texture54 = device0.createTexture({
+  size: [64],
+  dimension: '1d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler38 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.81,
+  compare: 'not-equal',
+  maxAnisotropy: 5,
+});
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer10, 'uint16', 9_224, 3_163);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(2, bindGroup13, new Uint32Array(163), 5, 0);
+} catch {}
+document.body.prepend(canvas1);
+let bindGroup28 = device1.createBindGroup({layout: veryExplicitBindGroupLayout9, entries: [{binding: 205, resource: textureView9}]});
+let texture55 = device1.createTexture({
+  size: {width: 192, height: 1, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'r32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder8.setVertexBuffer(1, buffer13, 36, 135);
+} catch {}
+try {
+device1.queue.submit([commandBuffer2]);
+} catch {}
+document.body.append(img0);
+let commandEncoder54 = device0.createCommandEncoder({});
+let texture56 = device0.createTexture({
+  size: {width: 525, height: 1, depthOrArrayLayers: 325},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView52 = texture38.createView({mipLevelCount: 1});
+let computePassEncoder43 = commandEncoder54.beginComputePass();
+let renderBundle8 = renderBundleEncoder7.finish({});
+try {
+computePassEncoder18.setBindGroup(2, bindGroup21, new Uint32Array(794), 91, 0);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer16, 'uint32', 1_792, 1_637);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(2, buffer17, 636, 859);
+} catch {}
+let buffer20 = device1.createBuffer({
+  size: 13157,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture57 = device1.createTexture({
+  size: [384, 1, 1],
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture58 = device1.createTexture({
+  size: [270, 5, 1],
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture59 = gpuCanvasContext0.getCurrentTexture();
+let textureView53 = texture40.createView({aspect: 'all'});
+let externalTexture6 = device1.importExternalTexture({source: videoFrame8});
+try {
+computePassEncoder33.setBindGroup(0, bindGroup23);
+} catch {}
+try {
+computePassEncoder5.setBindGroup(0, bindGroup3, new Uint32Array(1417), 137, 0);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer3, 32, 869);
+} catch {}
+let bindGroup29 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout8,
+  entries: [
+    {binding: 307, resource: {buffer: buffer0, offset: 1536}},
+    {binding: 117, resource: {buffer: buffer0, offset: 1536}},
+  ],
+});
+let commandEncoder55 = device1.createCommandEncoder();
+let textureView54 = texture20.createView({format: 'rgba16float'});
+try {
+commandEncoder55.copyBufferToBuffer(buffer20, 1548, buffer3, 420, 240);
+} catch {}
+let commandEncoder56 = device1.createCommandEncoder({});
+let textureView55 = texture52.createView({dimension: '2d-array'});
+let textureView56 = texture41.createView({});
+let computePassEncoder44 = commandEncoder55.beginComputePass();
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup3, new Uint32Array(706), 14, 0);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle4, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer13, 'uint32', 188, 126);
+} catch {}
+try {
+commandEncoder56.copyTextureToBuffer({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 912 */
+  offset: 912,
+  bytesPerRow: 16640,
+  buffer: buffer20,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder57 = device1.createCommandEncoder({});
+let texture60 = device1.createTexture({size: [216, 1, 10], format: 'r16uint', usage: GPUTextureUsage.COPY_SRC, viewFormats: []});
+let renderPassEncoder10 = commandEncoder56.beginRenderPass({
+  colorAttachments: [{
+  view: textureView28,
+  clearValue: { r: -611.3, g: -777.3, b: -489.4, a: -87.35, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 68888953,
+});
+try {
+commandEncoder57.copyTextureToTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 43, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 25, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder8.pushDebugGroup('\u9d42');
+} catch {}
+try {
+renderPassEncoder1.insertDebugMarker('\u402a');
+} catch {}
+let buffer21 = device1.createBuffer({
+  size: 2196,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder58 = device1.createCommandEncoder();
+let computePassEncoder45 = commandEncoder57.beginComputePass();
+try {
+computePassEncoder44.setBindGroup(0, bindGroup3, new Uint32Array(919), 582, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup22);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(0, buffer20);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer3, 36, new BigUint64Array(8795), 1063, 16);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 54, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData5,
+  origin: { x: 12, y: 4 },
+  flipY: false,
+}, {
+  texture: texture13,
+  mipLevel: 3,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder7.setBindGroup(1, bindGroup15, new Uint32Array(1507), 28, 0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup26, new Uint32Array(2915), 219, 0);
+} catch {}
+try {
+renderPassEncoder5.setViewport(55.25404412191587, 35.41381023710391, 7.8834206240301326, 22.140607138354184, 0.17883624107272122, 0.6774517585844716);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+offscreenCanvas0.getContext('webgpu');
+} catch {}
+let bindGroup30 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 154, resource: {buffer: buffer0, offset: 0, size: 3672}}],
+});
+let renderPassEncoder11 = commandEncoder58.beginRenderPass({
+  colorAttachments: [{
+  view: textureView22,
+  clearValue: { r: -575.4, g: -405.4, b: -502.8, a: 93.92, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder6.executeBundles([renderBundle4, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder6.setViewport(352.86426331644395, 0.6665159781898511, 37.826619755933734, 1.4603516584651546, 0.7017894788368267, 0.97928333946269);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(1, buffer20, 120, 71);
+} catch {}
+let bindGroup31 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 154, resource: {buffer: buffer20, offset: 768, size: 3144}}],
+});
+let buffer22 = device1.createBuffer({size: 23592, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE});
+try {
+computePassEncoder34.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup28);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(0, buffer6, 0, 668);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(218).fill(0), /* required buffer size: 218 */
+{offset: 218}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder59 = device1.createCommandEncoder({});
+let computePassEncoder46 = commandEncoder59.beginComputePass({});
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup8, new Uint32Array(1504), 126, 0);
+} catch {}
+try {
+renderPassEncoder8.beginOcclusionQuery(44);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer22, 'uint16', 7_884, 647);
+} catch {}
+try {
+device1.queue.submit([]);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let sampler39 = device0.createSampler({
+  label: '\u09e8\u0ece\u0981',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 66.00,
+});
+let textureView57 = texture45.createView({aspect: 'all', baseMipLevel: 0, arrayLayerCount: 1});
+try {
+computePassEncoder45.setBindGroup(0, bindGroup30);
+} catch {}
+try {
+computePassEncoder27.setBindGroup(2, bindGroup2, new Uint32Array(1757), 175, 0);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer13, 'uint16', 34, 47);
+} catch {}
+try {
+renderPassEncoder8.popDebugGroup();
+} catch {}
+let textureView58 = texture15.createView({});
+try {
+computePassEncoder25.setBindGroup(0, bindGroup19);
+} catch {}
+try {
+renderPassEncoder5.setViewport(3.3115548975553324, 51.85366031915099, 19.414637762005366, 8.011522182338554, 0.10607521097707728, 0.358734685004499);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer17, 'uint32', 800, 209);
+} catch {}
+let commandEncoder60 = device0.createCommandEncoder({});
+let computePassEncoder47 = commandEncoder60.beginComputePass({});
+try {
+computePassEncoder25.setBindGroup(1, bindGroup10, new Uint32Array(250), 43, 0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup9, new Uint32Array(2172), 745, 0);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer1, 'uint16', 476, 18);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(2, buffer17, 40, 33);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 596, new Int16Array(10193), 2756, 60);
+} catch {}
+await gc();
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup19);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle8, renderBundle3]);
+} catch {}
+let bindGroup32 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 154, resource: {buffer: buffer22, offset: 8448, size: 8504}}],
+});
+let pipelineLayout7 = device1.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout1, veryExplicitBindGroupLayout9]});
+let texture61 = device1.createTexture({
+  size: [48, 1, 1],
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture62 = device1.createTexture({
+  size: [270],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView59 = texture55.createView({dimension: '2d-array', aspect: 'all'});
+let sampler40 = device1.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'mirror-repeat', magFilter: 'linear'});
+try {
+device1.queue.writeBuffer(buffer3, 104, new DataView(new ArrayBuffer(41895)), 1663, 176);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let texture63 = device1.createTexture({
+  size: {width: 384, height: 1, depthOrArrayLayers: 3},
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture64 = device1.createTexture({
+  size: {width: 864, height: 6, depthOrArrayLayers: 98},
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder9.setBindGroup(2, bindGroup8, new Uint32Array(282), 6, 0);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup23, []);
+} catch {}
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let imageBitmap1 = await createImageBitmap(videoFrame4);
+let texture65 = device1.createTexture({
+  size: [270, 5, 1],
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder26.setBindGroup(0, bindGroup8, new Uint32Array(1623), 488, 0);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 1568, new BigUint64Array(2894), 20, 272);
+} catch {}
+let texture66 = device1.createTexture({
+  size: {width: 540, height: 10, depthOrArrayLayers: 1},
+  mipLevelCount: 10,
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture67 = device1.createTexture({
+  size: {width: 1080, height: 20, depthOrArrayLayers: 889},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView60 = texture23.createView({});
+let sampler41 = device1.createSampler({addressModeU: 'repeat', magFilter: 'linear', minFilter: 'linear', lodMaxClamp: 64.45, maxAnisotropy: 1});
+try {
+computePassEncoder46.setBindGroup(3, bindGroup32, new Uint32Array(2381), 1_034, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup28, new Uint32Array(1087), 220, 0);
+} catch {}
+try {
+renderPassEncoder8.beginOcclusionQuery(246);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+let buffer23 = device0.createBuffer({
+  size: 6577,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let texture68 = device0.createTexture({
+  size: {width: 65, height: 1, depthOrArrayLayers: 13},
+  sampleCount: 1,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({colorFormats: ['rg8uint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder2.setBindGroup(0, bindGroup5, new Uint32Array(2736), 145, 0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer16, 'uint32', 980, 363);
+} catch {}
+let veryExplicitBindGroupLayout10 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 68,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let commandEncoder61 = device0.createCommandEncoder({});
+let texture69 = device0.createTexture({
+  size: [262],
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder48 = commandEncoder61.beginComputePass({});
+try {
+computePassEncoder22.setBindGroup(3, bindGroup15, new Uint32Array(395), 34, 0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup15, new Uint32Array(1284), 393, 0);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(4, buffer16, 544);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(2, bindGroup9);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer10, 'uint32', 1_760, 13_080);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(3, buffer17);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let textureView61 = texture23.createView({});
+let texture70 = device1.createTexture({
+  size: {width: 135, height: 2, depthOrArrayLayers: 1},
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup16, new Uint32Array(1064), 162, 0);
+} catch {}
+try {
+device1.lost.then(({reason, message}) => { console.log('device1 lost!'); console.log(message, reason); });
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let texture71 = device1.createTexture({
+  size: [48, 1, 13],
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView62 = texture41.createView({});
+try {
+computePassEncoder26.setBindGroup(3, bindGroup23, new Uint32Array(722), 131, 0);
+} catch {}
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer22, 'uint16', 9_058, 1_755);
+} catch {}
+document.body.append(canvas1);
+let buffer24 = device0.createBuffer({size: 10960, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+try {
+computePassEncoder19.setBindGroup(2, bindGroup7, new Uint32Array(509), 46, 0);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(1, bindGroup7, new Uint32Array(325), 4, 0);
+} catch {}
+let texture72 = device0.createTexture({
+  size: {width: 262, height: 1, depthOrArrayLayers: 49},
+  mipLevelCount: 2,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder24.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup6, new Uint32Array(1605), 170, 0);
+} catch {}
+try {
+renderPassEncoder5.setViewport(59.569711324842736, 1.7164725823063804, 3.9485826917536144, 35.55197063830984, 0.494543747576899, 0.7723423077619703);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer16, 'uint16', 156, 316);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(3, buffer11);
+} catch {}
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({colorFormats: ['rgba8unorm'], stencilReadOnly: true});
+let renderBundle9 = renderBundleEncoder10.finish();
+try {
+renderPassEncoder5.setVertexBuffer(3, buffer1);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(0, buffer5, 0, 87);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let bindGroup33 = device0.createBindGroup({layout: veryExplicitBindGroupLayout3, entries: [{binding: 10, resource: textureView12}]});
+try {
+computePassEncoder17.setBindGroup(1, bindGroup18);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(2, buffer17, 0, 486);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(2, bindGroup33);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(3, bindGroup0, new Uint32Array(1349), 201, 0);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(5, buffer16, 60, 3_929);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let commandEncoder62 = device1.createCommandEncoder();
+let texture73 = device1.createTexture({
+  size: [128, 128, 13],
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView63 = texture36.createView({aspect: 'all'});
+let sampler42 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 56.51,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder27.setBindGroup(3, bindGroup8, new Uint32Array(628), 9, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup28, new Uint32Array(3066), 102, 0);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(7, buffer3, 0, 403);
+} catch {}
+try {
+device1.queue.submit([]);
+} catch {}
+document.body.append(canvas1);
+let commandEncoder63 = device0.createCommandEncoder();
+let querySet8 = device0.createQuerySet({type: 'occlusion', count: 82});
+let computePassEncoder49 = commandEncoder63.beginComputePass({});
+let sampler43 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.03,
+  maxAnisotropy: 6,
+});
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(3, buffer23, 0, 3_238);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(3, bindGroup18, new Uint32Array(105), 23, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 64, new Float32Array(4384), 1157, 480);
+} catch {}
+let promise3 = device0.queue.onSubmittedWorkDone();
+let commandEncoder64 = device0.createCommandEncoder({});
+let textureView64 = texture15.createView({arrayLayerCount: 1});
+let renderBundle10 = renderBundleEncoder9.finish();
+try {
+computePassEncoder2.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup15, new Uint32Array(800), 100, 0);
+} catch {}
+try {
+commandEncoder64.insertDebugMarker('\u0ac8');
+} catch {}
+try {
+adapter0.label = '\ufe8d\u7f14\ud8d1\u566e\u082c\u0f1c\u7ebb\u21f7\u1fc7\u5528\uf50e';
+} catch {}
+let texture74 = device1.createTexture({
+  size: [384, 1, 1],
+  mipLevelCount: 2,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder12 = commandEncoder62.beginRenderPass({
+  colorAttachments: [{
+  view: textureView22,
+  clearValue: { r: 718.7, g: 574.3, b: 160.3, a: -780.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet1,
+  maxDrawCount: 4191613,
+});
+try {
+computePassEncoder23.setBindGroup(1, bindGroup20);
+} catch {}
+try {
+computePassEncoder34.setBindGroup(1, bindGroup16, new Uint32Array(128), 31, 0);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(2, buffer20);
+} catch {}
+let buffer25 = device1.createBuffer({size: 2690, usage: GPUBufferUsage.COPY_SRC});
+let textureView65 = texture73.createView({
+  label: '\u81b7\ue7a4\u5efe\u01c1\u980b\u06ad\u{1f9ae}\u0a66',
+  dimension: 'cube-array',
+  baseMipLevel: 0,
+  arrayLayerCount: 6,
+});
+let textureView66 = texture62.createView({});
+try {
+computePassEncoder23.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup23, new Uint32Array(1432), 218, 0);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer22, 'uint16', 3_506, 653);
+} catch {}
+try {
+renderPassEncoder10.pushDebugGroup('\u98d8');
+} catch {}
+try {
+renderPassEncoder10.popDebugGroup();
+} catch {}
+await gc();
+let commandEncoder65 = device0.createCommandEncoder({});
+let computePassEncoder50 = commandEncoder65.beginComputePass({});
+try {
+renderPassEncoder5.executeBundles([]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 1, y: 2, z: 1},
+  aspect: 'all',
+}, new Uint8Array(122).fill(129), /* required buffer size: 122 */
+{offset: 122}, {width: 33, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await promise3;
+} catch {}
+let querySet9 = device1.createQuerySet({type: 'occlusion', count: 375});
+let textureView67 = texture47.createView({dimension: '2d-array'});
+let texture75 = device1.createTexture({
+  size: [96],
+  dimension: '1d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder11 = device1.createRenderBundleEncoder({colorFormats: ['r16uint', 'rgba16float'], stencilReadOnly: true});
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderPassEncoder6.setViewport(390.62747211136013, 1.6777238674924029, 5.21415529435185, 0.07962386397978329, 0.12345886734974021, 0.557702372718994);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer22, 'uint32', 3_368, 4_460);
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 108, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture13,
+  mipLevel: 2,
+  origin: {x: 21, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap2 = await createImageBitmap(imageData5);
+let commandEncoder66 = device1.createCommandEncoder({});
+let computePassEncoder51 = commandEncoder66.beginComputePass({});
+let sampler44 = device1.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'mirror-repeat'});
+try {
+renderPassEncoder12.beginOcclusionQuery(286);
+} catch {}
+let textureView68 = texture42.createView({mipLevelCount: 1});
+let renderPassEncoder13 = commandEncoder64.beginRenderPass({
+  colorAttachments: [{
+  view: textureView29,
+  clearValue: { r: -55.87, g: -573.4, b: -629.6, a: -142.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 261779776,
+});
+try {
+computePassEncoder18.setBindGroup(1, bindGroup24);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup21, new Uint32Array(555), 19, 0);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(4, buffer1, 0);
+} catch {}
+let imageData6 = new ImageData(44, 28);
+let commandEncoder67 = device1.createCommandEncoder({});
+let computePassEncoder52 = commandEncoder67.beginComputePass({});
+try {
+computePassEncoder23.setBindGroup(2, bindGroup31, new Uint32Array(8948), 448, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup28, new Uint32Array(1435), 332, 0);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle4, renderBundle4, renderBundle4, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer13, 'uint32', 84, 40);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(2, bindGroup32);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(1, buffer20, 2_072, 2_391);
+} catch {}
+try {
+buffer22.unmap();
+} catch {}
+await gc();
+let bindGroup34 = device0.createBindGroup({layout: veryExplicitBindGroupLayout10, entries: [{binding: 68, resource: textureView48}]});
+let texture76 = device0.createTexture({
+  size: {width: 262},
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler45 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 86.47,
+});
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup24);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(3, buffer11, 0);
+} catch {}
+let bindGroup35 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 154, resource: {buffer: buffer20, offset: 1024, size: 3004}}],
+});
+try {
+renderPassEncoder6.executeBundles([renderBundle4, renderBundle4]);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer13, 'uint32', 84, 57);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 680, new Int16Array(10650), 80, 80);
+} catch {}
+let buffer26 = device1.createBuffer({
+  size: 10766,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup30, new Uint32Array(960), 462, 0);
+} catch {}
+try {
+renderPassEncoder6.setBlendConstant({ r: 462.8, g: 379.4, b: -883.0, a: 293.8, });
+} catch {}
+try {
+renderPassEncoder12.setStencilReference(124);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(0, bindGroup8, new Uint32Array(4834), 253, 0);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+offscreenCanvas0.width = 246;
+let veryExplicitBindGroupLayout11 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 68,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let bindGroup36 = device0.createBindGroup({layout: veryExplicitBindGroupLayout11, entries: [{binding: 68, resource: textureView48}]});
+let commandEncoder68 = device0.createCommandEncoder({});
+let textureView69 = texture3.createView({dimension: '2d-array'});
+let computePassEncoder53 = commandEncoder68.beginComputePass({});
+let sampler46 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'not-equal',
+});
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup7, new Uint32Array(3659), 137, 0);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle2, renderBundle2]);
+} catch {}
+try {
+computePassEncoder19.pushDebugGroup('\u10fa');
+} catch {}
+let promise4 = device0.queue.onSubmittedWorkDone();
+try {
+computePassEncoder36.setBindGroup(3, bindGroup13, new Uint32Array(1730), 228, 0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup36);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup25, new Uint32Array(465), 18, 0);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle2, renderBundle3]);
+} catch {}
+let veryExplicitBindGroupLayout12 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 68,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let bindGroup37 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 93, resource: {buffer: buffer11, offset: 1024, size: 271}}],
+});
+let buffer27 = device0.createBuffer({size: 18119, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+let textureView70 = texture9.createView({dimension: 'cube', baseMipLevel: 0, baseArrayLayer: 1});
+let texture77 = device0.createTexture({
+  size: [64, 64, 21],
+  sampleCount: 1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let textureView71 = texture48.createView({dimension: '2d-array', mipLevelCount: 1});
+let sampler47 = device1.createSampler({addressModeU: 'clamp-to-edge', addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 74.09});
+try {
+computePassEncoder52.setBindGroup(3, bindGroup35);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(1, bindGroup3);
+} catch {}
+let commandEncoder69 = device0.createCommandEncoder({});
+let renderPassEncoder14 = commandEncoder69.beginRenderPass({
+  colorAttachments: [{
+  view: textureView33,
+  clearValue: { r: -477.1, g: -843.5, b: 453.7, a: 276.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder2.setBindGroup(0, bindGroup18, new Uint32Array(1475), 472, 0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup11, new Uint32Array(36), 9, 0);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer17, 'uint16', 532, 24);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer12, 10120, new Int16Array(16259), 397, 3720);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 64, height: 64, depthOrArrayLayers: 21}
+*/
+{
+  source: imageData0,
+  origin: { x: 13, y: 3 },
+  flipY: false,
+}, {
+  texture: texture77,
+  mipLevel: 0,
+  origin: {x: 8, y: 47, z: 5},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 9, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let buffer28 = device0.createBuffer({size: 4135, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture78 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 21},
+  dimension: '2d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture79 = gpuCanvasContext1.getCurrentTexture();
+let textureView72 = texture34.createView({arrayLayerCount: 1});
+try {
+computePassEncoder32.setBindGroup(1, bindGroup24, new Uint32Array(5114), 3_131, 0);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer8, 'uint32', 20, 326);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(4, buffer11, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+computePassEncoder14.pushDebugGroup('\u056b');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 100, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(637).fill(120), /* required buffer size: 637 */
+{offset: 637, bytesPerRow: 709}, {width: 440, height: 20, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder70 = device1.createCommandEncoder();
+let querySet10 = device1.createQuerySet({type: 'occlusion', count: 833});
+let renderPassEncoder15 = commandEncoder70.beginRenderPass({
+  colorAttachments: [{
+  view: textureView8,
+  depthSlice: 84,
+  clearValue: { r: -984.6, g: -893.1, b: -167.0, a: -495.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 144729000,
+});
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup28);
+} catch {}
+try {
+renderPassEncoder12.endOcclusionQuery();
+} catch {}
+let bindGroup38 = device0.createBindGroup({layout: veryExplicitBindGroupLayout12, entries: [{binding: 68, resource: textureView48}]});
+try {
+computePassEncoder50.setBindGroup(3, bindGroup21, []);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(2, buffer16);
+} catch {}
+try {
+buffer13.label = '\u0b4d\u{1fec6}\u5ebf\ua9af';
+} catch {}
+let pipelineLayout8 = device1.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout4]});
+let commandEncoder71 = device1.createCommandEncoder({});
+let textureView73 = texture73.createView({dimension: 'cube-array', baseMipLevel: 0, arrayLayerCount: 6});
+let texture80 = device1.createTexture({size: [384, 1, 1], format: 'rgba16float', usage: GPUTextureUsage.STORAGE_BINDING});
+let renderPassEncoder16 = commandEncoder71.beginRenderPass({
+  colorAttachments: [{
+  view: textureView24,
+  depthSlice: 389,
+  clearValue: { r: 263.2, g: -633.4, b: -457.3, a: -848.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let sampler48 = device1.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', lodMaxClamp: 90.19, compare: 'less'});
+try {
+computePassEncoder44.setBindGroup(2, bindGroup31, new Uint32Array(1296), 303, 0);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(6, buffer20, 0, 2_120);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(2, bindGroup30, new Uint32Array(283), 70, 0);
+} catch {}
+await gc();
+let commandEncoder72 = device1.createCommandEncoder({});
+let texture81 = device1.createTexture({
+  size: {width: 1728, height: 12, depthOrArrayLayers: 196},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder5.setBindGroup(2, bindGroup2, new Uint32Array(3544), 799, 0);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(2, bindGroup20, new Uint32Array(830), 371, 0);
+} catch {}
+try {
+  await promise4;
+} catch {}
+try {
+globalThis.someLabel = externalTexture3.label;
+} catch {}
+try {
+computePassEncoder36.setBindGroup(2, bindGroup21, []);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer16, 'uint32', 1_856, 468);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let pipelineLayout9 = device1.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout5]});
+let computePassEncoder54 = commandEncoder72.beginComputePass({});
+try {
+device1.queue.writeBuffer(buffer20, 1920, new DataView(new ArrayBuffer(15090)), 4183, 1696);
+} catch {}
+let commandEncoder73 = device0.createCommandEncoder({});
+try {
+computePassEncoder20.setBindGroup(1, bindGroup38, []);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup19);
+} catch {}
+let buffer29 = device1.createBuffer({size: 5005, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let texture82 = device1.createTexture({
+  size: {width: 216, height: 1, depthOrArrayLayers: 1},
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler49 = device1.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'mirror-repeat', mipmapFilter: 'linear', compare: 'equal'});
+try {
+renderPassEncoder11.setScissorRect(159, 0, 46, 0);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(1, bindGroup16, new Uint32Array(2430), 967, 0);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 270, height: 5, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame8,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 33, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture83 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 21},
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder55 = commandEncoder73.beginComputePass({});
+try {
+computePassEncoder17.setBindGroup(2, bindGroup36, new Uint32Array(4360), 1_216, 0);
+} catch {}
+try {
+renderPassEncoder13.setViewport(49.889625102945956, 43.5900273945978, 8.956677784046946, 16.9271590487667, 0.4161731759349132, 0.9453731876445362);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(0, buffer11, 0, 982);
+} catch {}
+try {
+computePassEncoder19.popDebugGroup();
+} catch {}
+let imageData7 = new ImageData(16, 32);
+let bindGroup39 = device1.createBindGroup({layout: veryExplicitBindGroupLayout5, entries: [{binding: 205, resource: textureView16}]});
+let buffer30 = device1.createBuffer({size: 19417, usage: GPUBufferUsage.MAP_WRITE});
+let commandEncoder74 = device1.createCommandEncoder();
+let sampler50 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.52,
+  maxAnisotropy: 6,
+});
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup35, []);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer26, 'uint32', 2_976, 1_224);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(7, buffer3, 0, 146);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture75,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(459).fill(251), /* required buffer size: 459 */
+{offset: 459}, {width: 16, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder75 = device0.createCommandEncoder();
+let textureView74 = texture29.createView({mipLevelCount: 1});
+let computePassEncoder56 = commandEncoder75.beginComputePass({});
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+computePassEncoder10.pushDebugGroup('\u00de');
+} catch {}
+let veryExplicitBindGroupLayout13 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 117,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 307,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder76 = device1.createCommandEncoder({});
+let textureView75 = texture75.createView({aspect: 'all'});
+let computePassEncoder57 = commandEncoder76.beginComputePass({});
+let sampler51 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 85.91,
+  lodMaxClamp: 87.26,
+});
+try {
+commandEncoder74.copyTextureToTexture({
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture64,
+  mipLevel: 0,
+  origin: {x: 89, y: 0, z: 20},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup40 = device0.createBindGroup({layout: veryExplicitBindGroupLayout11, entries: [{binding: 68, resource: textureView48}]});
+let textureView76 = texture83.createView({dimension: '2d', baseArrayLayer: 1});
+let texture84 = gpuCanvasContext1.getCurrentTexture();
+let texture85 = device0.createTexture({
+  size: [64, 64, 21],
+  sampleCount: 1,
+  format: 'r32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture86 = device0.createTexture({
+  size: {width: 525, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView77 = texture10.createView({format: 'rgba8unorm'});
+let sampler52 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 97.09,
+});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup33, new Uint32Array(1051), 121, 0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(6, buffer16, 0, 1_288);
+} catch {}
+let promise5 = device0.queue.onSubmittedWorkDone();
+let veryExplicitBindGroupLayout14 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 453,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let texture87 = device0.createTexture({
+  size: {width: 65, height: 1, depthOrArrayLayers: 42},
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView78 = texture50.createView({baseArrayLayer: 1, arrayLayerCount: 1});
+let sampler53 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 58.78,
+  compare: 'not-equal',
+});
+try {
+computePassEncoder49.setBindGroup(2, bindGroup0, new Uint32Array(3847), 355, 0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup37);
+} catch {}
+let promise6 = device0.queue.onSubmittedWorkDone();
+let buffer31 = device0.createBuffer({
+  size: 4535,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture88 = device0.createTexture({
+  size: [262, 1, 31],
+  mipLevelCount: 2,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler54 = device0.createSampler({
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 47.55,
+  lodMaxClamp: 54.28,
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder7.setBindGroup(3, bindGroup14);
+} catch {}
+let commandEncoder77 = device1.createCommandEncoder();
+let texture89 = device1.createTexture({size: {width: 48}, sampleCount: 1, dimension: '1d', format: 'r16uint', usage: GPUTextureUsage.COPY_SRC});
+try {
+buffer22.unmap();
+} catch {}
+try {
+commandEncoder74.copyBufferToTexture({
+  /* bytesInLastRow: 136 widthInBlocks: 34 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1468 */
+  offset: 1468,
+  bytesPerRow: 7424,
+  buffer: buffer21,
+}, {
+  texture: texture13,
+  mipLevel: 2,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 34, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder78 = device0.createCommandEncoder({});
+let texture90 = device0.createTexture({
+  size: [131, 1, 16],
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let externalTexture7 = device0.importExternalTexture({source: videoFrame7});
+try {
+computePassEncoder29.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup18);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await promise6;
+} catch {}
+let buffer32 = device0.createBuffer({size: 1501, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder79 = device0.createCommandEncoder({});
+let textureView79 = texture90.createView({});
+let computePassEncoder58 = commandEncoder78.beginComputePass({});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+renderPassEncoder13.end();
+} catch {}
+try {
+commandEncoder64.insertDebugMarker('\u0b36');
+} catch {}
+try {
+computePassEncoder24.insertDebugMarker('\u04f9');
+} catch {}
+let computePassEncoder59 = commandEncoder77.beginComputePass({label: '\u4d52\u6575\u{1f970}\u5d5c\u09c3\u{1fc82}\u09e3'});
+let renderPassEncoder17 = commandEncoder74.beginRenderPass({
+  colorAttachments: [{
+  view: textureView8,
+  depthSlice: 502,
+  clearValue: { r: -515.1, g: 982.4, b: 135.6, a: -197.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 228695642,
+});
+let renderBundle11 = renderBundleEncoder11.finish();
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let commandEncoder80 = device0.createCommandEncoder({});
+let texture91 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 21},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder32.setBindGroup(0, bindGroup38);
+} catch {}
+try {
+computePassEncoder50.setBindGroup(3, bindGroup40, new Uint32Array(3722), 713, 0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup34);
+} catch {}
+try {
+renderPassEncoder14.setBlendConstant({ r: 48.70, g: 634.2, b: 74.51, a: -521.3, });
+} catch {}
+let bindGroup41 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout8,
+  entries: [
+    {binding: 117, resource: {buffer: buffer26, offset: 1536, size: 672}},
+    {binding: 307, resource: {buffer: buffer21, offset: 256}},
+  ],
+});
+let textureView80 = texture20.createView({aspect: 'all', baseMipLevel: 0});
+let promise7 = device1.queue.onSubmittedWorkDone();
+let bindGroup42 = device0.createBindGroup({layout: veryExplicitBindGroupLayout12, entries: [{binding: 68, resource: textureView48}]});
+let commandEncoder81 = device0.createCommandEncoder({});
+let textureView81 = texture91.createView({dimension: 'cube', baseMipLevel: 0, mipLevelCount: 1});
+let texture92 = device0.createTexture({
+  size: {width: 525, height: 1, depthOrArrayLayers: 38},
+  mipLevelCount: 4,
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder60 = commandEncoder80.beginComputePass({});
+try {
+computePassEncoder21.setBindGroup(2, bindGroup18);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle4, renderBundle4, renderBundle4, renderBundle4, renderBundle4, renderBundle4, renderBundle4, renderBundle4]);
+} catch {}
+let bindGroup43 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout14,
+  entries: [{binding: 453, resource: {buffer: buffer18, offset: 512, size: 7296}}],
+});
+let textureView82 = texture83.createView({dimension: 'cube', mipLevelCount: 1});
+let computePassEncoder61 = commandEncoder79.beginComputePass({});
+let externalTexture8 = device0.importExternalTexture({source: videoFrame7, colorSpace: 'srgb'});
+try {
+computePassEncoder2.setBindGroup(3, bindGroup40);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, new Uint8Array(65_454).fill(33), /* required buffer size: 65_454 */
+{offset: 9, bytesPerRow: 541, rowsPerImage: 24}, {width: 525, height: 1, depthOrArrayLayers: 6});
+} catch {}
+canvas1.height = 272;
+let texture93 = device1.createTexture({
+  size: [270],
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler55 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 84.76,
+  maxAnisotropy: 1,
+});
+let externalTexture9 = device1.importExternalTexture({source: videoFrame4});
+try {
+renderPassEncoder15.setBindGroup(1, bindGroup8, new Uint32Array(2709), 290, 0);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle4, renderBundle4]);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { console.log('device1.uncapturederror'); console.log(e); e.label = device1.label; });
+} catch {}
+try {
+device1.lost.then(({reason, message}) => { console.log('device1 lost!'); console.log(message, reason); });
+} catch {}
+try {
+buffer25.unmap();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let texture94 = device0.createTexture({
+  size: [65, 1, 1],
+  format: 'rg8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder62 = commandEncoder81.beginComputePass();
+try {
+commandEncoder64.copyTextureToBuffer({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 102, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 364 widthInBlocks: 91 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1136 */
+  offset: 1136,
+  buffer: buffer5,
+}, {width: 91, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup44 = device0.createBindGroup({
+  label: '\u8358\u{1fe45}\u9d5b\uf31d\uf070\u4956',
+  layout: veryExplicitBindGroupLayout12,
+  entries: [{binding: 68, resource: textureView74}],
+});
+let buffer33 = device0.createBuffer({
+  size: 5350,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false,
+});
+let commandEncoder82 = device0.createCommandEncoder();
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup21, new Uint32Array(50), 0, 0);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer1, 'uint16', 2_162, 0);
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+try {
+commandEncoder64.resolveQuerySet(querySet8, 9, 3, buffer8, 2304);
+} catch {}
+let bindGroup45 = device0.createBindGroup({layout: veryExplicitBindGroupLayout10, entries: [{binding: 68, resource: textureView74}]});
+let buffer34 = device0.createBuffer({
+  size: 5376,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let commandEncoder83 = device0.createCommandEncoder({});
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup33);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer16, 'uint32', 288, 690);
+} catch {}
+try {
+commandEncoder82.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 4, y: 2, z: 0},
+  aspect: 'all',
+},
+{width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture44,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(50_559).fill(230), /* required buffer size: 50_559 */
+{offset: 125, bytesPerRow: 34, rowsPerImage: 163}, {width: 6, height: 17, depthOrArrayLayers: 10});
+} catch {}
+let commandEncoder84 = device0.createCommandEncoder();
+let texture95 = device0.createTexture({
+  size: {width: 131, height: 1, depthOrArrayLayers: 101},
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8unorm'],
+});
+let textureView83 = texture92.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 2});
+let renderPassEncoder18 = commandEncoder64.beginRenderPass({
+  colorAttachments: [{view: textureView29, loadOp: 'clear', storeOp: 'store'}],
+  occlusionQuerySet: querySet6,
+});
+try {
+computePassEncoder11.setBindGroup(1, bindGroup40, new Uint32Array(1521), 1_210, 0);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+globalThis.someLabel = externalTexture5.label;
+} catch {}
+let bindGroup46 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [{binding: 57, resource: textureView54}, {binding: 87, resource: sampler51}],
+});
+let buffer35 = device1.createBuffer({size: 7223, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView84 = texture93.createView({arrayLayerCount: 1});
+try {
+computePassEncoder23.setBindGroup(2, bindGroup20);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup35);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(5, buffer6, 856, 313);
+} catch {}
+try {
+  await promise5;
+} catch {}
+let imageData8 = new ImageData(36, 96);
+let bindGroup47 = device0.createBindGroup({layout: veryExplicitBindGroupLayout7, entries: [{binding: 47, resource: textureView78}]});
+let commandEncoder85 = device0.createCommandEncoder({});
+try {
+computePassEncoder15.setBindGroup(1, bindGroup38);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle8]);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer5, 'uint16', 102, 362);
+} catch {}
+try {
+commandEncoder82.copyBufferToBuffer(buffer12, 24944, buffer33, 1480, 404);
+} catch {}
+try {
+commandEncoder85.copyTextureToBuffer({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 372 widthInBlocks: 93 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 6424 */
+  offset: 6424,
+  bytesPerRow: 25600,
+  rowsPerImage: 104,
+  buffer: buffer12,
+}, {width: 93, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas0);
+let computePassEncoder63 = commandEncoder82.beginComputePass({});
+let renderPassEncoder19 = commandEncoder83.beginRenderPass({
+  colorAttachments: [{view: textureView33, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet3,
+  maxDrawCount: 89115450,
+});
+try {
+commandEncoder85.copyBufferToBuffer(buffer23, 1548, buffer4, 2536, 1548);
+} catch {}
+document.body.prepend(canvas0);
+let texture96 = device1.createTexture({
+  size: [864],
+  dimension: '1d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler56 = device1.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'repeat', magFilter: 'linear'});
+let externalTexture10 = device1.importExternalTexture({source: videoFrame3});
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(4, buffer3);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+let bindGroup48 = device1.createBindGroup({layout: veryExplicitBindGroupLayout5, entries: [{binding: 205, resource: textureView9}]});
+let buffer36 = device1.createBuffer({
+  size: 28230,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let sampler57 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMaxClamp: 34.64,
+  compare: 'less',
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup48, new Uint32Array(2809), 321, 0);
+} catch {}
+try {
+renderPassEncoder15.setViewport(31.917061648045475, 1.1450122081948504, 15.142435833822216, 0.4758500632960294, 0.9236088184053012, 0.9390526285905312);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(75).fill(161), /* required buffer size: 75 */
+{offset: 75, rowsPerImage: 75}, {width: 27, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView85 = texture75.createView({mipLevelCount: 1});
+let externalTexture11 = device1.importExternalTexture({source: videoFrame3, colorSpace: 'srgb'});
+try {
+computePassEncoder16.setBindGroup(2, bindGroup20);
+} catch {}
+try {
+computePassEncoder34.setBindGroup(2, bindGroup2, new Uint32Array(62), 19, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup39, new Uint32Array(1058), 53, 0);
+} catch {}
+let promise8 = device1.queue.onSubmittedWorkDone();
+let renderPassEncoder20 = commandEncoder85.beginRenderPass({
+  colorAttachments: [{
+  view: textureView83,
+  clearValue: { r: -772.0, g: -724.0, b: 38.48, a: -17.42, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let sampler58 = device0.createSampler({addressModeW: 'repeat', lodMinClamp: 35.43, lodMaxClamp: 53.97});
+try {
+computePassEncoder14.setBindGroup(2, bindGroup45, new Uint32Array(2018), 177, 0);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(3, buffer31, 0);
+} catch {}
+try {
+  await promise8;
+} catch {}
+let imageBitmap3 = await createImageBitmap(img0);
+let textureView86 = texture50.createView({arrayLayerCount: 5});
+let texture97 = device0.createTexture({
+  size: {width: 131, height: 1, depthOrArrayLayers: 613},
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderPassEncoder21 = commandEncoder84.beginRenderPass({
+  colorAttachments: [{
+  view: textureView83,
+  clearValue: { r: 820.0, g: -550.4, b: 253.4, a: -599.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder14.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer8, 'uint16', 1_558, 152);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(4, buffer16);
+} catch {}
+try {
+buffer31.unmap();
+} catch {}
+try {
+  await promise7;
+} catch {}
+let buffer37 = device0.createBuffer({size: 3314, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+let texture98 = device0.createTexture({
+  size: {width: 262},
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint'], depthReadOnly: true});
+try {
+computePassEncoder49.setBindGroup(3, bindGroup12);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(3, bindGroup6, new Uint32Array(1226), 516, 0);
+} catch {}
+let bindGroup49 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 154, resource: {buffer: buffer22, offset: 1024, size: 7252}}],
+});
+let buffer38 = device1.createBuffer({size: 13753, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+try {
+renderPassEncoder12.setVertexBuffer(5, buffer3, 0, 557);
+} catch {}
+try {
+device1.pushErrorScope('validation');
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 135, height: 2, depthOrArrayLayers: 18}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 5},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture99 = device0.createTexture({
+  size: [131],
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(5, buffer31, 1_356);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(canvas0);
+let buffer39 = device1.createBuffer({
+  size: 57,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup31);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(6, buffer36, 1_456);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(1_000).fill(223), /* required buffer size: 1_000 */
+{offset: 1000, bytesPerRow: 239}, {width: 23, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup50 = device0.createBindGroup({layout: veryExplicitBindGroupLayout12, entries: [{binding: 68, resource: textureView74}]});
+let textureView87 = texture92.createView({dimension: '2d', aspect: 'all', mipLevelCount: 1, baseArrayLayer: 3});
+let textureView88 = texture85.createView({dimension: 'cube-array', baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 6});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({colorFormats: ['rgba8unorm'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderBundleEncoder12.setBindGroup(1, bindGroup33);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer5, 'uint16', 20, 27);
+} catch {}
+try {
+buffer28.unmap();
+} catch {}
+let textureView89 = texture87.createView({dimension: '2d', baseMipLevel: 0});
+try {
+computePassEncoder17.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+computePassEncoder56.setBindGroup(0, bindGroup42, new Uint32Array(1916), 244, 0);
+} catch {}
+try {
+renderPassEncoder19.beginOcclusionQuery(9);
+} catch {}
+try {
+renderPassEncoder21.setBlendConstant({ r: 819.9, g: 895.0, b: -959.1, a: 519.7, });
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer16, 'uint32', 1_224, 350);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(0, bindGroup12, new Uint32Array(4888), 207, 0);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(5, buffer16, 520);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 36},
+  aspect: 'all',
+}, new Uint8Array(208_167).fill(129), /* required buffer size: 208_167 */
+{offset: 15, bytesPerRow: 126, rowsPerImage: 7}, {width: 18, height: 0, depthOrArrayLayers: 237});
+} catch {}
+let commandEncoder86 = device0.createCommandEncoder({});
+let textureView90 = texture99.createView({baseArrayLayer: 0});
+let computePassEncoder64 = commandEncoder86.beginComputePass();
+let renderBundle12 = renderBundleEncoder12.finish({});
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup12);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(1, bindGroup50, new Uint32Array(1029), 48, 0);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(1, bindGroup47, new Uint32Array(386), 141, 0);
+} catch {}
+try {
+renderBundleEncoder13.setIndexBuffer(buffer1, 'uint32', 408, 24);
+} catch {}
+let imageData9 = new ImageData(84, 48);
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup31);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle4, renderBundle4, renderBundle4, renderBundle4, renderBundle4, renderBundle4, renderBundle4]);
+} catch {}
+let querySet11 = device0.createQuerySet({type: 'occlusion', count: 1385});
+let texture100 = device0.createTexture({
+  size: [131, 1, 1],
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture101 = device0.createTexture({
+  size: [64, 64, 1483],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderPassEncoder20.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(0, bindGroup21);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(3, buffer31, 284);
+} catch {}
+try {
+globalThis.someLabel = externalTexture6.label;
+} catch {}
+let bindGroup51 = device1.createBindGroup({layout: veryExplicitBindGroupLayout9, entries: [{binding: 205, resource: textureView16}]});
+let commandEncoder87 = device1.createCommandEncoder({});
+let sampler59 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 74.31,
+  compare: 'greater',
+});
+try {
+renderPassEncoder6.setVertexBuffer(1, buffer3, 0, 53);
+} catch {}
+let bindGroup52 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [{binding: 57, resource: textureView80}, {binding: 87, resource: sampler21}],
+});
+let pipelineLayout10 = device1.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout8]});
+let renderPassEncoder22 = commandEncoder87.beginRenderPass({
+  colorAttachments: [{
+  view: textureView24,
+  depthSlice: 147,
+  clearValue: { r: 456.7, g: 106.1, b: -366.9, a: -172.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 146180445,
+});
+let sampler60 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  lodMaxClamp: 57.13,
+});
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup22, new Uint32Array(757), 282, 0);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer38, 'uint16', 9_096, 2_237);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 4872, new Int16Array(24944), 4703, 48);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture27,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(77).fill(77), /* required buffer size: 77 */
+{offset: 77, rowsPerImage: 0}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+globalThis.someLabel = textureView64.label;
+} catch {}
+let buffer40 = device0.createBuffer({size: 2475, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView91 = texture31.createView({});
+let renderBundle13 = renderBundleEncoder13.finish({});
+try {
+renderPassEncoder20.setBindGroup(0, bindGroup25);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(0, bindGroup47, new Uint32Array(2642), 94, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 131, height: 1, depthOrArrayLayers: 101}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 0, y: 1 },
+  flipY: false,
+}, {
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 18},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle9, renderBundle13, renderBundle13, renderBundle9, renderBundle13, renderBundle13]);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer16, 'uint16', 46, 1_420);
+} catch {}
+try {
+device0.label = '\u{1fd59}\u4a3e\u5e08\u{1f741}\u0532';
+} catch {}
+let bindGroup53 = device0.createBindGroup({layout: veryExplicitBindGroupLayout12, entries: [{binding: 68, resource: textureView87}]});
+let texture102 = device0.createTexture({
+  size: {width: 525, height: 1, depthOrArrayLayers: 47},
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder14.setBindGroup(1, bindGroup38);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup19);
+} catch {}
+try {
+renderPassEncoder19.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(4, buffer16, 0);
+} catch {}
+try {
+computePassEncoder35.insertDebugMarker('\ufee2');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 131, height: 1, depthOrArrayLayers: 613}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 0, y: 8 },
+  flipY: true,
+}, {
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 16},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer41 = device0.createBuffer({
+  size: 5463,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView92 = texture56.createView({mipLevelCount: 1});
+try {
+device0.queue.writeTexture({
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(100).fill(176), /* required buffer size: 100 */
+{offset: 100}, {width: 18, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas0);
+let buffer42 = device0.createBuffer({size: 6570, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let texture103 = device0.createTexture({
+  size: [131],
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView93 = texture22.createView({dimension: '2d', baseArrayLayer: 5, arrayLayerCount: 1});
+let sampler61 = device0.createSampler({
+  label: '\u{1fe04}\u{1f9c8}\u4ccd',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+});
+document.body.append(img0);
+let bindGroup54 = device0.createBindGroup({layout: veryExplicitBindGroupLayout3, entries: [{binding: 10, resource: textureView12}]});
+let commandEncoder88 = device0.createCommandEncoder({});
+let texture104 = device0.createTexture({
+  size: {width: 131, height: 1, depthOrArrayLayers: 2},
+  mipLevelCount: 2,
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder65 = commandEncoder88.beginComputePass({});
+try {
+computePassEncoder14.setBindGroup(3, bindGroup50, new Uint32Array(1647), 175, 0);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(2, bindGroup40, new Uint32Array(511), 104, 0);
+} catch {}
+try {
+renderPassEncoder21.setScissorRect(32, 0, 66, 0);
+} catch {}
+try {
+renderPassEncoder18.insertDebugMarker('\u0507');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 67, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(451).fill(84), /* required buffer size: 451 */
+{offset: 451, rowsPerImage: 11}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+document.body.append(canvas1);
+let commandEncoder89 = device1.createCommandEncoder({});
+let querySet12 = device1.createQuerySet({type: 'occlusion', count: 405});
+try {
+computePassEncoder51.setBindGroup(0, bindGroup49, new Uint32Array(3352), 25, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup2, new Uint32Array(2027), 927, 0);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer38, 'uint32', 952, 830);
+} catch {}
+let bindGroup55 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 154, resource: {buffer: buffer19, offset: 2048, size: 3760}}],
+});
+let textureView94 = texture57.createView({});
+let sampler62 = device1.createSampler({
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 86.64,
+  compare: 'never',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder23.setBindGroup(0, bindGroup31);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup48, new Uint32Array(672), 106, 0);
+} catch {}
+try {
+renderPassEncoder1.pushDebugGroup('\u7a14');
+} catch {}
+let promise9 = device1.queue.onSubmittedWorkDone();
+try {
+adapter1.label = '\ufa6e\u0bf8\u057a\u582d\u{1f76a}\u004a\u{1fa76}\u{1f89a}\u3d57\u3872';
+} catch {}
+let bindGroup56 = device1.createBindGroup({layout: veryExplicitBindGroupLayout5, entries: [{binding: 205, resource: textureView9}]});
+let textureView95 = texture36.createView({});
+let renderBundleEncoder14 = device1.createRenderBundleEncoder({colorFormats: ['r16uint', 'rgba16float'], depthReadOnly: false, stencilReadOnly: true});
+try {
+computePassEncoder33.setBindGroup(3, bindGroup52, new Uint32Array(633), 99, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup3, new Uint32Array(2877), 213, 0);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(4, buffer39, 0, 3);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(1, bindGroup22);
+} catch {}
+try {
+renderPassEncoder1.popDebugGroup();
+} catch {}
+try {
+device1.queue.submit([]);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 1836, new Int16Array(19828), 2444, 940);
+} catch {}
+let promise10 = device1.queue.onSubmittedWorkDone();
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 135, height: 2, depthOrArrayLayers: 18}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 25, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture105 = device1.createTexture({
+  size: {width: 270, height: 5, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView96 = texture41.createView({});
+let computePassEncoder66 = commandEncoder89.beginComputePass({});
+let renderBundle14 = renderBundleEncoder14.finish({});
+let externalTexture12 = device1.importExternalTexture({source: videoFrame9});
+try {
+computePassEncoder34.setBindGroup(2, bindGroup22, new Uint32Array(1071), 45, 0);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 99, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(245).fill(214), /* required buffer size: 245 */
+{offset: 245}, {width: 61, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup22, new Uint32Array(3709), 159, 0);
+} catch {}
+try {
+renderPassEncoder7.setBlendConstant({ r: -28.81, g: -924.5, b: -728.9, a: -904.0, });
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(6, buffer20);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 33, height: 1, depthOrArrayLayers: 4}
+*/
+{
+  source: imageData4,
+  origin: { x: 5, y: 29 },
+  flipY: false,
+}, {
+  texture: texture27,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup57 = device1.createBindGroup({layout: veryExplicitBindGroupLayout9, entries: [{binding: 205, resource: textureView16}]});
+let buffer43 = device1.createBuffer({
+  size: 3933,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder90 = device1.createCommandEncoder({label: '\u007a\uef5b\u9a4d\u{1fa24}'});
+let querySet13 = device1.createQuerySet({type: 'occlusion', count: 1092});
+let texture106 = device1.createTexture({
+  size: {width: 270, height: 5, depthOrArrayLayers: 354},
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler63 = device1.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', addressModeW: 'repeat'});
+try {
+renderPassEncoder6.executeBundles([renderBundle4, renderBundle4, renderBundle4]);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 15},
+  aspect: 'all',
+}, new Uint8Array(88_261).fill(89), /* required buffer size: 88_261 */
+{offset: 63, bytesPerRow: 211, rowsPerImage: 38}, {width: 23, height: 0, depthOrArrayLayers: 12});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let bindGroup58 = device0.createBindGroup({layout: veryExplicitBindGroupLayout12, entries: [{binding: 68, resource: textureView83}]});
+let textureView97 = texture88.createView({dimension: '2d', format: 'rgba16sint', baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 3});
+let sampler64 = device0.createSampler({addressModeW: 'repeat', lodMaxClamp: 90.42});
+try {
+renderPassEncoder18.setVertexBuffer(2, buffer16);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer41, 1196, new Int16Array(18670), 644, 368);
+} catch {}
+let bindGroup59 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout13,
+  entries: [
+    {binding: 117, resource: {buffer: buffer43, offset: 256, size: 387}},
+    {binding: 307, resource: {buffer: buffer36, offset: 12288, size: 3216}},
+  ],
+});
+let texture107 = gpuCanvasContext1.getCurrentTexture();
+let textureView98 = texture27.createView({mipLevelCount: 1});
+let computePassEncoder67 = commandEncoder90.beginComputePass({});
+let renderBundleEncoder15 = device1.createRenderBundleEncoder({colorFormats: ['r16uint', 'rgba16float'], depthReadOnly: true});
+try {
+computePassEncoder26.setBindGroup(3, bindGroup48, []);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(2, buffer13);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 270, height: 5, depthOrArrayLayers: 354}
+*/
+{
+  source: videoFrame9,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 13, y: 1, z: 6},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer44 = device0.createBuffer({
+  size: 6511,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView99 = texture83.createView({dimension: 'cube-array', baseArrayLayer: 1, arrayLayerCount: 6});
+try {
+computePassEncoder50.setBindGroup(2, bindGroup15, new Uint32Array(3731), 260, 0);
+} catch {}
+try {
+renderPassEncoder19.setViewport(11.525570980419403, 28.399247602048852, 5.249473909059042, 23.959151672533284, 0.1333327675464684, 0.4720103670339954);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer17, 'uint16', 16, 2_735);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(6, buffer16, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder91 = device1.createCommandEncoder({});
+let textureView100 = texture24.createView({dimension: '1d'});
+let computePassEncoder68 = commandEncoder91.beginComputePass();
+let renderBundle15 = renderBundleEncoder15.finish({});
+try {
+computePassEncoder67.setBindGroup(3, bindGroup52);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup51);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer38, 'uint16', 1_298, 274);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(6, buffer3, 0, 128);
+} catch {}
+try {
+buffer39.unmap();
+} catch {}
+let bindGroup60 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 154, resource: {buffer: buffer20, offset: 2560, size: 3660}}],
+});
+let buffer45 = device1.createBuffer({
+  size: 18180,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder92 = device1.createCommandEncoder({});
+let texture108 = device1.createTexture({
+  size: [864, 6, 1],
+  sampleCount: 1,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView101 = texture25.createView({format: 'r32float'});
+let computePassEncoder69 = commandEncoder92.beginComputePass();
+let sampler65 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 0.9504,
+  compare: 'always',
+  maxAnisotropy: 13,
+});
+let externalTexture13 = device1.importExternalTexture({source: videoFrame7, colorSpace: 'srgb'});
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup2, new Uint32Array(66), 4, 0);
+} catch {}
+let commandEncoder93 = device1.createCommandEncoder();
+try {
+computePassEncoder51.setBindGroup(2, bindGroup56);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(4, buffer39, 12);
+} catch {}
+try {
+commandEncoder93.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 756 */
+  offset: 756,
+  bytesPerRow: 3072,
+  buffer: buffer29,
+}, {
+  texture: texture13,
+  mipLevel: 2,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder93.resolveQuerySet(querySet1, 571, 4, buffer21, 768);
+} catch {}
+let buffer46 = device1.createBuffer({size: 1419, usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let texture109 = device1.createTexture({
+  size: [1080, 20, 1],
+  mipLevelCount: 4,
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderPassEncoder17.setBindGroup(2, bindGroup16);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(4, buffer45, 1_192, 1_059);
+} catch {}
+try {
+commandEncoder93.clearBuffer(buffer36, 2224, 4468);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer26, 12, new Float32Array(6854), 1804, 1232);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 270, height: 5, depthOrArrayLayers: 354}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 32, y: 0, z: 7},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+textureView7.label = '\u{1fe76}\u87c4\u2a5b\u6f45\u0267';
+} catch {}
+let commandEncoder94 = device0.createCommandEncoder({});
+let textureView102 = texture77.createView({dimension: 'cube', baseMipLevel: 0, baseArrayLayer: 1});
+try {
+computePassEncoder38.setBindGroup(1, bindGroup38);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup38, new Uint32Array(2219), 372, 0);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(5, buffer31, 0, 393);
+} catch {}
+try {
+computePassEncoder14.popDebugGroup();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let computePassEncoder70 = commandEncoder94.beginComputePass({});
+try {
+computePassEncoder63.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle8]);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer42, 'uint32', 892, 1_418);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let videoFrame13 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'rgb', primaries: 'unspecified', transfer: 'bt709'} });
+let textureView103 = texture72.createView({dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 3, arrayLayerCount: 4});
+try {
+computePassEncoder18.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+computePassEncoder70.end();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let buffer47 = device1.createBuffer({
+  size: 755,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder95 = device1.createCommandEncoder();
+let computePassEncoder71 = commandEncoder93.beginComputePass({});
+let renderPassEncoder23 = commandEncoder95.beginRenderPass({
+  colorAttachments: [{
+  view: textureView28,
+  clearValue: { r: 121.7, g: -819.5, b: -134.8, a: 560.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+gpuCanvasContext0.configure({device: device1, format: 'rgba16float', usage: GPUTextureUsage.COPY_SRC, alphaMode: 'premultiplied'});
+} catch {}
+let commandEncoder96 = device1.createCommandEncoder({});
+let computePassEncoder72 = commandEncoder96.beginComputePass({});
+let sampler66 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 21.14,
+});
+let commandEncoder97 = device0.createCommandEncoder({});
+let renderPassEncoder24 = commandEncoder97.beginRenderPass({
+  colorAttachments: [{
+  view: textureView87,
+  clearValue: { r: -880.5, g: -725.0, b: 211.0, a: 67.22, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder7.setBindGroup(0, bindGroup6, new Uint32Array(3148), 492, 0);
+} catch {}
+try {
+computePassEncoder10.popDebugGroup();
+} catch {}
+let buffer48 = device1.createBuffer({size: 32070, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX});
+try {
+renderPassEncoder9.setScissorRect(13, 0, 14, 1);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(5, buffer3, 0, 29);
+} catch {}
+let bindGroup61 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [{binding: 93, resource: {buffer: buffer41, offset: 1024, size: 52}}],
+});
+let texture110 = device0.createTexture({
+  size: [65, 1, 1],
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder25 = commandEncoder94.beginRenderPass({
+  colorAttachments: [{
+  view: textureView87,
+  clearValue: { r: 531.0, g: -271.7, b: 230.4, a: 159.1, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 65872630,
+});
+let sampler67 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 88.06});
+try {
+computePassEncoder49.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+renderPassEncoder21.setBlendConstant({ r: 665.2, g: 124.0, b: 391.0, a: 210.8, });
+} catch {}
+try {
+  await promise9;
+} catch {}
+await gc();
+let bindGroup62 = device0.createBindGroup({layout: veryExplicitBindGroupLayout10, entries: [{binding: 68, resource: textureView87}]});
+let commandEncoder98 = device0.createCommandEncoder({});
+let textureView104 = texture31.createView({});
+let renderPassEncoder26 = commandEncoder98.beginRenderPass({
+  colorAttachments: [{
+  view: textureView83,
+  clearValue: { r: 658.1, g: 60.91, b: 570.1, a: -998.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet3,
+});
+let externalTexture14 = device0.importExternalTexture({source: videoFrame6, colorSpace: 'srgb'});
+try {
+computePassEncoder65.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup62, new Uint32Array(962), 141, 0);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'all',
+}, new Uint8Array(1_117).fill(208), /* required buffer size: 1_117 */
+{offset: 220, bytesPerRow: 75}, {width: 18, height: 12, depthOrArrayLayers: 1});
+} catch {}
+let texture111 = device0.createTexture({
+  size: {width: 131, height: 1, depthOrArrayLayers: 1},
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView105 = texture42.createView({dimension: '1d'});
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({colorFormats: ['rg8uint'], stencilReadOnly: true});
+let renderBundle16 = renderBundleEncoder16.finish();
+let sampler68 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 60.33,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+computePassEncoder14.setBindGroup(1, bindGroup44, new Uint32Array(1065), 78, 0);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup14, new Uint32Array(206), 57, 0);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(6, buffer23, 256, 1_199);
+} catch {}
+document.body.append(canvas1);
+await gc();
+try {
+globalThis.someLabel = textureView96.label;
+} catch {}
+let externalTexture15 = device1.importExternalTexture({source: videoFrame12});
+try {
+computePassEncoder67.setBindGroup(2, bindGroup60);
+} catch {}
+try {
+computePassEncoder8.setBindGroup(0, bindGroup28, new Uint32Array(900), 100, 0);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup59, new Uint32Array(161), 30, 0);
+} catch {}
+try {
+renderPassEncoder12.beginOcclusionQuery(697);
+} catch {}
+try {
+renderPassEncoder12.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer46, 'uint32', 52, 136);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(3, buffer13, 8, 27);
+} catch {}
+let buffer49 = device0.createBuffer({size: 8553, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder99 = device0.createCommandEncoder();
+let texture112 = device0.createTexture({
+  label: '\u2384\u02db\u0ec7\u028f\u{1feab}\u0fa1\u0922\u4ac1\u0628\u0062\u6a45',
+  size: [65, 1, 1],
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder73 = commandEncoder99.beginComputePass({});
+let sampler69 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 79.78,
+  compare: 'less-equal',
+});
+try {
+computePassEncoder73.setBindGroup(2, bindGroup58);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([renderBundle9]);
+} catch {}
+let promise11 = device0.queue.onSubmittedWorkDone();
+let texture113 = device1.createTexture({size: {width: 192}, dimension: '1d', format: 'rgba16float', usage: GPUTextureUsage.STORAGE_BINDING});
+try {
+computePassEncoder51.setBindGroup(1, bindGroup49);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup31, new Uint32Array(2693), 444, 0);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer9, 'uint16', 548, 4_595);
+} catch {}
+let textureView106 = texture105.createView({mipLevelCount: 1, baseArrayLayer: 0});
+try {
+renderPassEncoder8.setScissorRect(145, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer39, 'uint16', 0, 2);
+} catch {}
+offscreenCanvas0.height = 549;
+let buffer50 = device0.createBuffer({
+  size: 7467,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder48.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(2, buffer8, 360, 722);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+  await promise11;
+} catch {}
+document.body.prepend(img0);
+let texture114 = device0.createTexture({
+  size: [765, 60, 1],
+  mipLevelCount: 3,
+  format: 'astc-5x5-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(0, buffer50, 352, 5_053);
+} catch {}
+document.body.append(img0);
+let videoFrame14 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'bt470m', transfer: 'hlg'} });
+let buffer51 = device1.createBuffer({
+  size: 7052,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let textureView107 = texture70.createView({baseMipLevel: 0});
+try {
+computePassEncoder8.setBindGroup(1, bindGroup35);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer9, 'uint32', 8_888, 4_910);
+} catch {}
+try {
+device1.lost.then(({reason, message}) => { console.log('device1 lost!'); console.log(message, reason); });
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 270, height: 5, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder100 = device1.createCommandEncoder({});
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(2, bindGroup8, new Uint32Array(1922), 60, 0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(5, buffer13, 184, 64);
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let imageData10 = new ImageData(32, 52);
+let bindGroup63 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [{binding: 93, resource: {buffer: buffer42, offset: 0, size: 1900}}],
+});
+let commandEncoder101 = device0.createCommandEncoder({});
+let texture115 = device0.createTexture({
+  size: {width: 65},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView108 = texture26.createView({});
+let renderPassEncoder27 = commandEncoder101.beginRenderPass({
+  colorAttachments: [{
+  view: textureView87,
+  clearValue: { r: -324.9, g: 615.1, b: -355.1, a: 281.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+offscreenCanvas0.width = 2854;
+let veryExplicitBindGroupLayout15 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 13,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32uint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 17,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d-array' },
+    },
+    {
+      binding: 41,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 48,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 63,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {binding: 91, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+    {
+      binding: 122,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 169,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 191,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '3d' },
+    },
+    {binding: 196, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }},
+    {
+      binding: 216,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d-array' },
+    },
+    {
+      binding: 339,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 456,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let buffer52 = device1.createBuffer({
+  size: 5417,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView109 = texture53.createView({dimension: '2d', mipLevelCount: 1});
+let computePassEncoder74 = commandEncoder100.beginComputePass({});
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup55, new Uint32Array(2191), 413, 0);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(3, buffer36, 1_388, 12_527);
+} catch {}
+let texture116 = device1.createTexture({
+  size: [864, 6, 21],
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup55);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle4, renderBundle4, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer9, 'uint16', 638, 5_044);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+  await promise10;
+} catch {}
+try {
+globalThis.someLabel = externalTexture4.label;
+} catch {}
+let sampler70 = device0.createSampler({});
+let sampler71 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'repeat', mipmapFilter: 'nearest', lodMaxClamp: 84.34});
+try {
+renderPassEncoder26.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(1, buffer16, 0, 583);
+} catch {}
+let videoFrame15 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'bt709', transfer: 'gamma22curve'} });
+let buffer53 = device0.createBuffer({size: 14193, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+let commandEncoder102 = device0.createCommandEncoder({});
+let computePassEncoder75 = commandEncoder102.beginComputePass({});
+try {
+renderPassEncoder27.setIndexBuffer(buffer1, 'uint16', 10, 364);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(2, buffer16, 0, 1_291);
+} catch {}
+try {
+computePassEncoder18.setBindGroup(1, bindGroup45);
+} catch {}
+try {
+computePassEncoder65.setBindGroup(1, bindGroup37, new Uint32Array(2393), 257, 0);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(4, buffer5);
+} catch {}
+let bindGroup64 = device1.createBindGroup({
+  label: '\u{1fd0c}\ub837\u471a\u80fd',
+  layout: veryExplicitBindGroupLayout9,
+  entries: [{binding: 205, resource: textureView16}],
+});
+let commandEncoder103 = device1.createCommandEncoder({});
+let computePassEncoder76 = commandEncoder103.beginComputePass({});
+try {
+computePassEncoder27.setBindGroup(2, bindGroup16, new Uint32Array(359), 42, 0);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle4, renderBundle4, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(5, buffer48, 0);
+} catch {}
+let shaderModule0 = device0.createShaderModule({
+  label: '\u{1fb9f}\u0fbd\u0e23\u6294\ufc69\u151f\u0c18\u{1fbad}\u8e5a',
+  code: `
+requires readonly_and_readwrite_storage_textures;
+
+enable f16;
+
+diagnostic(info, xyz);
+
+var<workgroup> vw1: atomic<i32>;
+
+@id(29193) override override1: i32 = 178;
+
+var<workgroup> vw0: atomic<u32>;
+
+override override0 = true;
+
+struct T2 {
+  @size(4672) f0: array<T0>,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<workgroup> vw4: T1;
+
+struct S0 {
+  @builtin(instance_index) f0: u32,
+  @location(4) f1: vec2u,
+  @location(7) @interpolate(flat) f2: i32,
+  @location(6) @interpolate(flat) f3: vec4f,
+  @location(11) f4: i32,
+  @location(13) f5: i32,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@group(0) @binding(40) var tex0: texture_2d<f32>;
+
+struct T1 {
+  f0: atomic<i32>,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw3: T1;
+
+var<workgroup> vw2: array<atomic<u32>, 1>;
+
+struct FragmentOutput0 {
+  @location(0) @interpolate(flat) f0: vec2u,
+  @builtin(sample_mask) f1: u32,
+  @location(1) @interpolate(flat) f2: vec4u,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@group(0) @binding(85) var tex1: texture_2d<f32>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct T0 {
+  f0: array<vec2u, 1>,
+}
+
+/* used global variables: tex0, tex1 */
+@vertex
+fn vertex0(a0: S0, @location(5) @interpolate(flat, centroid) a1: vec2h) -> @builtin(position) vec4f {
+  var out: vec4f;
+  let vf0: f16 = a1[unconst_u32(164)];
+  out *= vec4f(f32(override0));
+  out = vec4f(f32(vf0));
+  var vf1: u32 = textureNumLevels(tex0);
+  let vf2: u32 = textureNumLevels(tex1);
+  var vf3: bool = (unconst_bool(true) && unconst_bool(false));
+  let vf4: i32 = a0.f4;
+  var vf5: i32 = a0.f2;
+  vf3 = bool(unpack4xU8(bitcast<u32>(a0.f4)).g);
+  var vf6: u32 = a0.f0;
+  let ptr0: ptr<function, u32> = &vf6;
+  var vf7: vec4f = a0.f3;
+  vf5 = bitcast<i32>(a0.f3[unconst_u32(151)]);
+  let vf8: vec2u = textureDimensions(tex1, unconst_i32(109));
+  let vf9: vec2u = a0.f1;
+  let ptr1: ptr<function, u32> = &(*ptr0);
+  for (var it0=a0.f1.g; it0<u32(vf4); it0++) {
+  var vf10: vec2f = fma(vec2f(unconst_f32(0.1067), unconst_f32(0.1072)), vec2f(unconst_f32(0.03686), unconst_f32(0.08148)), bitcast<vec2f>(unpack4xU8(unconst_u32(253)).xx));
+  let vf11: vec4h = reflect(vec4h(unconst_f16(12759.2), unconst_f16(17463.0), unconst_f16(9977.3), unconst_f16(26406.2)), vec4h(unconst_f16(13665.9), unconst_f16(4080.4), unconst_f16(9383.7), unconst_f16(3025.3)));
+  break;
+}
+  vf6 = u32(exp2(unconst_f16(1441.6)));
+  return out;
+  _ = override0;
+  _ = tex0;
+  _ = tex1;
+}
+
+/* used global variables: tex0 */
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  out.f0 |= vec2u(textureNumLevels(tex0));
+  let vf12: vec2f = ceil(transpose(mat2x4f(unconst_f32(0.1263), unconst_f32(-0.2781), unconst_f32(0.1007), unconst_f32(0.1034), unconst_f32(0.1017), unconst_f32(0.03822), unconst_f32(0.02620), unconst_f32(0.01720)))[unconst_i32(1)]);
+  let vf13: bool = override0;
+  let vf14: u32 = pack4x8snorm(vec4f(unconst_f32(0.1046), unconst_f32(0.05281), unconst_f32(0.3023), unconst_f32(0.2773)));
+  var vf15: vec3h = atanh(vec3h(unconst_f16(8864.8), unconst_f16(1047.9), unconst_f16(3348.3)));
+  return out;
+  _ = override0;
+  _ = tex0;
+}
+
+/* zero global variables used */
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+  let vf16: vec2u = countTrailingZeros(vec2u(atomicExchange(&vw2[0], unconst_u32(29))));
+  atomicSub(&vw4.f0, unconst_i32(17));
+  atomicAdd(&vw3.f0, unconst_i32(530));
+  atomicSub(&vw3.f0, unconst_i32(269));
+  let ptr2: ptr<workgroup, atomic<u32>> = &(*&vw2)[unconst_u32(147)];
+  let ptr3: ptr<workgroup, T1> = &vw4;
+  atomicSub(&vw2[unconst_u32(109)], unconst_u32(356));
+  var vf17: vec3<bool> = (vec3u(unconst_u32(48), unconst_u32(0), unconst_u32(577)) <= vec3u(atomicLoad(&(*&vw2)[0])));
+  atomicStore(&vw3.f0, unconst_i32(8));
+  let ptr4: ptr<workgroup, atomic<u32>> = &(*&vw2)[0];
+  var vf18: vec3h = refract(vec3h(unconst_f16(12805.0), unconst_f16(4035.6), unconst_f16(14037.3)), vec3h(unconst_f16(3219.2), unconst_f16(2476.9), unconst_f16(6532.2)), unconst_f16(5825.0));
+  textureBarrier();
+  var vf19: vec3h = atan2(vec3h(unconst_f16(25119.7), unconst_f16(7463.7), unconst_f16(15831.8)), vec3h(unconst_f16(-5397.7), unconst_f16(28342.2), unconst_f16(697.9)));
+  let ptr5: ptr<workgroup, atomic<i32>> = &vw4.f0;
+  vf18 += vec3h(f16(atomicExchange(&vw0, unconst_u32(30))));
+  vf18 = vec3h(f16(atomicLoad(&(*&vw1))));
+  atomicXor(&vw0, unconst_u32(479));
+}`,
+});
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup0, new Uint32Array(1436), 146, 0);
+} catch {}
+try {
+renderPassEncoder26.beginOcclusionQuery(2);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(1, undefined, 423_762_306);
+} catch {}
+let img1 = await imageWithData(12, 57, '#10101010', '#20202020');
+let commandEncoder104 = device0.createCommandEncoder({});
+let textureView110 = texture26.createView({});
+let computePassEncoder77 = commandEncoder104.beginComputePass();
+try {
+renderPassEncoder26.setIndexBuffer(buffer8, 'uint32', 676, 167);
+} catch {}
+let commandEncoder105 = device1.createCommandEncoder({});
+let texture117 = device1.createTexture({
+  size: [216, 1, 24],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder78 = commandEncoder105.beginComputePass({});
+try {
+renderPassEncoder15.setVertexBuffer(1, buffer52, 0, 2_240);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let videoFrame16 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'unspecified', transfer: 'smpte170m'} });
+let texture118 = device1.createTexture({
+  size: [1728],
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView111 = texture80.createView({dimension: '2d-array'});
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup46);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup28, new Uint32Array(3), 0, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer38, 'uint16', 4_464, 4_662);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let bindGroup65 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 154, resource: {buffer: buffer43, offset: 512, size: 2448}}],
+});
+let externalTexture16 = device1.importExternalTexture({source: videoFrame0});
+try {
+computePassEncoder5.setBindGroup(1, bindGroup55, new Uint32Array(394), 4, 0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup35, new Uint32Array(2144), 6, 0);
+} catch {}
+try {
+renderPassEncoder12.beginOcclusionQuery(649);
+} catch {}
+let bindGroup66 = device0.createBindGroup({layout: veryExplicitBindGroupLayout6, entries: [{binding: 539, resource: textureView43}]});
+let texture119 = device0.createTexture({
+  size: [65, 1, 1],
+  format: 'rg32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder56.setBindGroup(1, bindGroup5, new Uint32Array(6191), 1_336, 0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup50, new Uint32Array(553), 122, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 2380, new DataView(new ArrayBuffer(17564)), 71, 776);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 64, height: 64, depthOrArrayLayers: 21}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 124, y: 48 },
+  flipY: false,
+}, {
+  texture: texture77,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 10},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup67 = device1.createBindGroup({layout: veryExplicitBindGroupLayout9, entries: [{binding: 205, resource: textureView9}]});
+let buffer54 = device1.createBuffer({
+  size: 33725,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder106 = device1.createCommandEncoder({});
+let renderPassEncoder28 = commandEncoder106.beginRenderPass({
+  colorAttachments: [{
+  view: textureView24,
+  depthSlice: 269,
+  clearValue: { r: 622.3, g: -776.0, b: -869.2, a: -482.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder74.setBindGroup(0, bindGroup30, new Uint32Array(483), 51, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup55, new Uint32Array(647), 78, 0);
+} catch {}
+try {
+renderPassEncoder17.end();
+} catch {}
+try {
+commandEncoder74.resolveQuerySet(querySet7, 50, 2, buffer13, 0);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 432, height: 3, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame11,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 110, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer55 = device1.createBuffer({size: 29256, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+try {
+renderPassEncoder8.beginOcclusionQuery(1039);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+document.body.prepend(img0);
+let veryExplicitBindGroupLayout16 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 47,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'bgra8unorm', access: 'read-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let bindGroup68 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 93, resource: {buffer: buffer12, offset: 3584, size: 10969}}],
+});
+let pipelineLayout11 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout11]});
+let buffer56 = device0.createBuffer({
+  size: 5038,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder107 = device0.createCommandEncoder({});
+let textureView112 = texture92.createView({format: 'rgba8unorm', baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 5, arrayLayerCount: 12});
+let computePassEncoder79 = commandEncoder107.beginComputePass();
+try {
+computePassEncoder7.setBindGroup(1, bindGroup24);
+} catch {}
+try {
+computePassEncoder10.setBindGroup(0, bindGroup66, new Uint32Array(249), 202, 0);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle12]);
+} catch {}
+try {
+renderPassEncoder21.setStencilReference(236);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer5, 'uint32', 96, 769);
+} catch {}
+try {
+computePassEncoder40.insertDebugMarker('\uc61e');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer17, 536, new DataView(new ArrayBuffer(6531)), 2775, 816);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 120, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(12).fill(39), /* required buffer size: 12 */
+{offset: 12}, {width: 10, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let texture120 = device0.createTexture({
+  size: {width: 525, height: 1, depthOrArrayLayers: 2},
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture121 = device0.createTexture({
+  size: {width: 131, height: 1, depthOrArrayLayers: 8},
+  mipLevelCount: 1,
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let sampler72 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  lodMaxClamp: 86.74,
+});
+try {
+renderPassEncoder26.setBindGroup(3, bindGroup10, new Uint32Array(2274), 701, 0);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder24.setViewport(328.1056738602971, 0.5248472753511497, 164.29029330631954, 0.025153717506782032, 0.05184696750552642, 0.1553333205873318);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer1, 'uint16', 110, 537);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(7, buffer16, 0, 365);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer23, 2692, new Int16Array(3306), 80, 24);
+} catch {}
+let bindGroup69 = device0.createBindGroup({layout: veryExplicitBindGroupLayout10, entries: [{binding: 68, resource: textureView48}]});
+let texture122 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 21},
+  format: 'rg32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder26.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer42, 'uint16', 1_004, 1_303);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(7, buffer56, 0);
+} catch {}
+try {
+globalThis.someLabel = buffer39.label;
+} catch {}
+let bindGroup70 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [{binding: 87, resource: sampler47}, {binding: 57, resource: textureView14}],
+});
+let commandEncoder108 = device1.createCommandEncoder({});
+let computePassEncoder80 = commandEncoder108.beginComputePass();
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let veryExplicitBindGroupLayout17 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 278,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder109 = device1.createCommandEncoder();
+let texture123 = device1.createTexture({
+  size: [192, 1, 1],
+  dimension: '2d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView113 = texture52.createView({baseMipLevel: 0});
+let computePassEncoder81 = commandEncoder109.beginComputePass({});
+let sampler73 = device1.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'mirror-repeat', magFilter: 'linear', lodMaxClamp: 92.74});
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup60);
+} catch {}
+try {
+renderPassEncoder12.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.setViewport(52.38462491891888, 1.5198051480689105, 28.170628006453185, 0.47391902330744123, 0.5131591422875983, 0.7685767481638441);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(3, buffer47, 0, 3);
+} catch {}
+try {
+buffer9.unmap();
+} catch {}
+let bindGroup71 = device0.createBindGroup({layout: veryExplicitBindGroupLayout11, entries: [{binding: 68, resource: textureView87}]});
+let textureView114 = texture119.createView({dimension: '2d-array'});
+let sampler74 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat'});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup36, new Uint32Array(2591), 29, 0);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer1, 'uint32', 124, 403);
+} catch {}
+let veryExplicitBindGroupLayout18 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 284,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '1d' },
+    },
+  ],
+});
+let pipelineLayout12 = device1.createPipelineLayout({label: '\u07df\u0a01\u3c3c\u02f2\u0eed', bindGroupLayouts: [veryExplicitBindGroupLayout17]});
+try {
+computePassEncoder69.setBindGroup(3, bindGroup70);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle4, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(3, buffer47, 48);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandBuffer3 = commandEncoder74.finish();
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup52, []);
+} catch {}
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer39, 'uint16', 0, 6);
+} catch {}
+try {
+texture5.destroy();
+} catch {}
+try {
+device1.queue.writeBuffer(buffer55, 3124, new Int16Array(1335), 222, 252);
+} catch {}
+await gc();
+let commandEncoder110 = device0.createCommandEncoder({});
+let texture124 = device0.createTexture({
+  size: {width: 131, height: 1, depthOrArrayLayers: 1},
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler75 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 80.43});
+try {
+renderPassEncoder20.setVertexBuffer(6, buffer23, 1_088, 171);
+} catch {}
+try {
+buffer37.unmap();
+} catch {}
+let videoFrame17 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'film', transfer: 'smpteSt4281'} });
+let texture125 = device0.createTexture({
+  size: {width: 65, height: 1, depthOrArrayLayers: 122},
+  sampleCount: 1,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder82 = commandEncoder110.beginComputePass({});
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({colorFormats: ['rg8uint'], depthReadOnly: true});
+let sampler76 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 57.56});
+try {
+computePassEncoder31.setBindGroup(3, bindGroup12);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(4, buffer41, 0, 546);
+} catch {}
+let textureView115 = texture93.createView({dimension: '1d'});
+try {
+renderPassEncoder8.beginOcclusionQuery(1860);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer26, 1064, new BigUint64Array(12624), 2309, 88);
+} catch {}
+await gc();
+let imageData11 = new ImageData(24, 36);
+let buffer57 = device0.createBuffer({size: 1245, usage: GPUBufferUsage.MAP_READ});
+let texture126 = device0.createTexture({
+  label: '\u0989\u81b1\u0edf\u{1f68d}\u0f31\u4bf7\u{1fe94}\u8b74',
+  size: {width: 64, height: 64, depthOrArrayLayers: 21},
+  mipLevelCount: 2,
+  format: 'rg8uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8uint'],
+});
+try {
+renderPassEncoder5.executeBundles([renderBundle12, renderBundle12]);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(0, bindGroup18);
+} catch {}
+let commandEncoder111 = device1.createCommandEncoder({});
+let texture127 = device1.createTexture({
+  size: [1728],
+  dimension: '1d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder83 = commandEncoder111.beginComputePass({});
+try {
+computePassEncoder39.setBindGroup(2, bindGroup46);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer36, 1564, new Int16Array(2166), 216, 272);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let videoFrame18 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'bt709', transfer: 'gamma22curve'} });
+let textureView116 = texture50.createView({dimension: '2d', format: 'bgra8unorm', baseArrayLayer: 1});
+let texture128 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 21},
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler77 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'linear',
+  lodMinClamp: 32.25,
+  lodMaxClamp: 39.23,
+});
+try {
+computePassEncoder65.setBindGroup(3, bindGroup53);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup68);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer16, 'uint16', 3_806, 526);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer53, 'uint16', 6_682, 1_470);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(5, buffer41);
+} catch {}
+try {
+textureView38.label = '\uddb7\u{1fc12}\u08b3\u{1f868}\u0a25';
+} catch {}
+let texture129 = device1.createTexture({
+  size: [96, 1, 14],
+  mipLevelCount: 2,
+  format: 'r32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView117 = texture46.createView({format: 'r32sint'});
+try {
+computePassEncoder83.setBindGroup(3, bindGroup56);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup46, new Uint32Array(3499), 47, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+document.body.prepend(canvas0);
+let buffer58 = device0.createBuffer({size: 11950, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture130 = device0.createTexture({
+  size: {width: 262, height: 1, depthOrArrayLayers: 26},
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle17 = renderBundleEncoder17.finish({});
+let sampler78 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', mipmapFilter: 'nearest', lodMaxClamp: 93.52});
+try {
+computePassEncoder37.setBindGroup(2, bindGroup33);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(2, bindGroup66, new Uint32Array(1384), 488, 0);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let texture131 = device0.createTexture({
+  size: {width: 65, height: 1, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture132 = device0.createTexture({
+  size: [131, 1, 183],
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb'],
+});
+let externalTexture17 = device0.importExternalTexture({source: videoFrame8, colorSpace: 'srgb'});
+try {
+computePassEncoder18.setBindGroup(3, bindGroup37);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 131, height: 1, depthOrArrayLayers: 613}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 29},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup72 = device0.createBindGroup({layout: veryExplicitBindGroupLayout3, entries: [{binding: 10, resource: textureView12}]});
+let commandEncoder112 = device0.createCommandEncoder();
+let texture133 = device0.createTexture({
+  size: [525, 1, 1],
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView118 = texture126.createView({dimension: 'cube-array', mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 6});
+let sampler79 = device0.createSampler({addressModeU: 'mirror-repeat', magFilter: 'nearest', lodMinClamp: 93.96, lodMaxClamp: 97.50});
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup45, new Uint32Array(218), 5, 0);
+} catch {}
+try {
+renderPassEncoder20.setScissorRect(42, 0, 15, 0);
+} catch {}
+try {
+commandEncoder112.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 3296 */
+  offset: 3296,
+  bytesPerRow: 47616,
+  buffer: buffer7,
+}, {
+  texture: texture29,
+  mipLevel: 1,
+  origin: {x: 240, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 15, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let bindGroup73 = device0.createBindGroup({layout: veryExplicitBindGroupLayout6, entries: [{binding: 539, resource: textureView21}]});
+let buffer59 = device0.createBuffer({size: 4916, usage: GPUBufferUsage.MAP_READ});
+let textureView119 = texture131.createView({dimension: '2d-array'});
+try {
+computePassEncoder38.setBindGroup(2, bindGroup54, new Uint32Array(726), 12, 0);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup38);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([renderBundle9, renderBundle13]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture115,
+  mipLevel: 0,
+  origin: {x: 38, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(27).fill(32), /* required buffer size: 27 */
+{offset: 27}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer60 = device1.createBuffer({
+  size: 24071,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture134 = device1.createTexture({
+  size: {width: 1728, height: 12, depthOrArrayLayers: 196},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup59);
+} catch {}
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.setViewport(103.14294225836376, 1.377370532454491, 5.265202553430138, 0.03759855187630033, 0.7385700706407836, 0.9554407975977323);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(5, buffer20, 396);
+} catch {}
+let commandEncoder113 = device1.createCommandEncoder({});
+let texture135 = device1.createTexture({
+  size: [1728, 12, 1],
+  format: 'eac-rg11snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder84 = commandEncoder113.beginComputePass();
+try {
+computePassEncoder41.setBindGroup(0, bindGroup52);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(4, buffer48);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture67,
+  mipLevel: 1,
+  origin: {x: 8, y: 0, z: 12},
+  aspect: 'all',
+}, new Uint8Array(201_305).fill(80), /* required buffer size: 201_305 */
+{offset: 65, bytesPerRow: 780, rowsPerImage: 86}, {width: 97, height: 0, depthOrArrayLayers: 4});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 216, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img0,
+  origin: { x: 0, y: 6 },
+  flipY: true,
+}, {
+  texture: texture13,
+  mipLevel: 1,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup52, []);
+} catch {}
+let renderPassEncoder29 = commandEncoder112.beginRenderPass({
+  colorAttachments: [{
+  view: textureView87,
+  clearValue: { r: -624.5, g: -689.8, b: -378.0, a: 209.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 9656205,
+});
+try {
+computePassEncoder1.setBindGroup(2, bindGroup21);
+} catch {}
+try {
+renderPassEncoder20.setStencilReference(580);
+} catch {}
+let bindGroup74 = device0.createBindGroup({layout: veryExplicitBindGroupLayout6, entries: [{binding: 539, resource: textureView21}]});
+let buffer61 = device0.createBuffer({size: 1589, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder114 = device0.createCommandEncoder({});
+let querySet14 = device0.createQuerySet({type: 'occlusion', count: 95});
+let computePassEncoder85 = commandEncoder114.beginComputePass({});
+try {
+computePassEncoder43.setBindGroup(1, bindGroup43, new Uint32Array(1087), 158, 0);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(2, bindGroup5, new Uint32Array(1162), 138, 0);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(4, buffer8, 932);
+} catch {}
+let bindGroup75 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [{binding: 93, resource: {buffer: buffer2, offset: 768, size: 1073}}],
+});
+let renderBundleEncoder18 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint'], depthReadOnly: true});
+let renderBundle18 = renderBundleEncoder18.finish({});
+let sampler80 = device0.createSampler({lodMaxClamp: 77.71});
+try {
+computePassEncoder58.setBindGroup(0, bindGroup68, []);
+} catch {}
+try {
+computePassEncoder35.setBindGroup(0, bindGroup73, new Uint32Array(10000), 878, 0);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer1, 'uint16', 260, 1_170);
+} catch {}
+let videoFrame19 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'smpte170m', transfer: 'iec6196624'} });
+let texture136 = device1.createTexture({
+  size: [1728, 12, 1],
+  dimension: '2d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup31, new Uint32Array(4252), 41, 0);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(1, bindGroup46, new Uint32Array(2780), 303, 0);
+} catch {}
+document.body.prepend(canvas1);
+let bindGroup76 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [{binding: 93, resource: {buffer: buffer2, offset: 4608, size: 195}}],
+});
+let commandEncoder115 = device0.createCommandEncoder({});
+let texture137 = gpuCanvasContext0.getCurrentTexture();
+let textureView120 = texture29.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder86 = commandEncoder115.beginComputePass();
+try {
+computePassEncoder63.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup63);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer16, 'uint16', 2_492, 80);
+} catch {}
+document.body.prepend(img0);
+let textureView121 = texture134.createView({aspect: 'all', baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 0});
+let textureView122 = texture129.createView({format: 'r32float', mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 4});
+try {
+computePassEncoder16.setBindGroup(1, bindGroup49, []);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup59);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer43, 0);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let texture138 = gpuCanvasContext1.getCurrentTexture();
+let sampler81 = device0.createSampler({addressModeV: 'mirror-repeat'});
+try {
+computePassEncoder31.setBindGroup(2, bindGroup25);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer16, 'uint16', 1_726, 1_337);
+} catch {}
+let commandEncoder116 = device0.createCommandEncoder();
+let texture139 = device0.createTexture({
+  size: [131, 1, 12],
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let sampler82 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 64.22, maxAnisotropy: 1});
+try {
+computePassEncoder61.setBindGroup(1, bindGroup25, new Uint32Array(2560), 317, 0);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(3, buffer11, 0, 5_071);
+} catch {}
+try {
+commandEncoder116.copyBufferToBuffer(buffer15, 1972, buffer2, 536, 68);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture77,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(1_569).fill(255), /* required buffer size: 1_569 */
+{offset: 867, bytesPerRow: 22, rowsPerImage: 9}, {width: 5, height: 5, depthOrArrayLayers: 4});
+} catch {}
+let promise12 = device0.queue.onSubmittedWorkDone();
+let textureView123 = texture50.createView({dimension: 'cube', baseArrayLayer: 4});
+let computePassEncoder87 = commandEncoder116.beginComputePass({});
+try {
+computePassEncoder86.setBindGroup(1, bindGroup13, new Uint32Array(1352), 117, 0);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(1, bindGroup40, []);
+} catch {}
+let bindGroup77 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout13,
+  entries: [
+    {binding: 307, resource: {buffer: buffer20, offset: 768, size: 444}},
+    {binding: 117, resource: {buffer: buffer47, offset: 0, size: 136}},
+  ],
+});
+let buffer62 = device1.createBuffer({
+  size: 18649,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder1.setIndexBuffer(buffer46, 'uint32', 792, 82);
+} catch {}
+try {
+device1.pushErrorScope('internal');
+} catch {}
+let promise13 = device1.queue.onSubmittedWorkDone();
+document.body.append(img0);
+let textureView124 = texture80.createView({dimension: '2d-array', aspect: 'all'});
+let textureView125 = texture75.createView({dimension: '1d', aspect: 'all'});
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup28, new Uint32Array(1100), 59, 0);
+} catch {}
+let texture140 = device1.createTexture({size: [270, 5, 1], format: 'r16uint', usage: GPUTextureUsage.COPY_SRC});
+let sampler83 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.59,
+  compare: 'always',
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder23.setBindGroup(0, bindGroup57);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup51, new Uint32Array(2092), 68, 0);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7, undefined);
+} catch {}
+try {
+computePassEncoder75.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+computePassEncoder20.setBindGroup(0, bindGroup24, new Uint32Array(121), 35, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture133,
+  mipLevel: 0,
+  origin: {x: 34, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(111).fill(207), /* required buffer size: 111 */
+{offset: 111}, {width: 224, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline0 = device0.createRenderPipeline({
+  label: '\ub97e\u82b6\uc439\u0bd5\u{1fa7b}\u{1ff19}\u{1ffa2}\u095f\u{1f976}',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule0,
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 36,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32', offset: 16, shaderLocation: 4},
+          {format: 'sint32x3', offset: 0, shaderLocation: 7},
+          {format: 'sint32x3', offset: 0, shaderLocation: 13},
+          {format: 'float32x4', offset: 0, shaderLocation: 5},
+          {format: 'sint32x2', offset: 0, shaderLocation: 11},
+          {format: 'unorm8x2', offset: 10, shaderLocation: 6},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'cw'},
+});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+computePassEncoder52.label = '\u3465\u{1f9ed}\ufa99\u0f82\u0162\u80ad\u{1fff3}\ud811';
+} catch {}
+let bindGroup78 = device1.createBindGroup({layout: veryExplicitBindGroupLayout5, entries: [{binding: 205, resource: textureView16}]});
+let commandEncoder117 = device1.createCommandEncoder({});
+let textureView126 = texture127.createView({aspect: 'all', format: 'rgba16float', baseArrayLayer: 0});
+let sampler84 = device1.createSampler({addressModeU: 'mirror-repeat'});
+try {
+buffer46.unmap();
+} catch {}
+try {
+commandEncoder117.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 675 */
+  offset: 675,
+  bytesPerRow: 7424,
+  rowsPerImage: 85,
+  buffer: buffer52,
+}, {
+  texture: texture27,
+  mipLevel: 2,
+  origin: {x: 4, y: 0, z: 2},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let buffer63 = device0.createBuffer({size: 1308, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let commandEncoder118 = device0.createCommandEncoder({});
+let textureView127 = texture92.createView({mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 2});
+let texture141 = device0.createTexture({size: [131, 1, 1], format: 'rg8uint', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let computePassEncoder88 = commandEncoder118.beginComputePass({});
+try {
+renderPassEncoder24.setBindGroup(1, bindGroup24, []);
+} catch {}
+try {
+computePassEncoder11.pushDebugGroup('\u5913');
+} catch {}
+let pipeline1 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {module: shaderModule0, constants: {override0: 1}, targets: [{format: 'rg8uint', writeMask: 0}]},
+  vertex: {
+    module: shaderModule0,
+    buffers: [
+      {
+        arrayStride: 268,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x4', offset: 0, shaderLocation: 13},
+          {format: 'float32x4', offset: 4, shaderLocation: 5},
+          {format: 'float32x4', offset: 12, shaderLocation: 6},
+          {format: 'uint16x2', offset: 20, shaderLocation: 4},
+          {format: 'sint8x2', offset: 16, shaderLocation: 7},
+          {format: 'sint32', offset: 4, shaderLocation: 11},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', frontFace: 'ccw'},
+});
+let commandEncoder119 = device1.createCommandEncoder({});
+let renderPassEncoder30 = commandEncoder119.beginRenderPass({
+  colorAttachments: [{
+  view: textureView24,
+  depthSlice: 435,
+  clearValue: { r: -875.0, g: -346.4, b: 789.6, a: 969.1, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder11.setIndexBuffer(buffer39, 'uint16', 4, 15);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(3, buffer20, 2_104);
+} catch {}
+try {
+commandEncoder117.clearBuffer(buffer3);
+} catch {}
+let imageBitmap4 = await createImageBitmap(videoFrame10);
+let computePassEncoder89 = commandEncoder117.beginComputePass({});
+try {
+computePassEncoder33.setBindGroup(3, bindGroup51);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup60);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1728, height: 12, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture136,
+  mipLevel: 0,
+  origin: {x: 171, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup79 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout15,
+  entries: [
+    {binding: 196, resource: sampler33},
+    {binding: 339, resource: {buffer: buffer45, offset: 768}},
+    {binding: 63, resource: textureView16},
+    {binding: 91, resource: sampler57},
+    {binding: 13, resource: textureView67},
+    {binding: 48, resource: textureView54},
+    {binding: 456, resource: textureView31},
+    {binding: 41, resource: textureView80},
+    {binding: 122, resource: {buffer: buffer47, offset: 0, size: 272}},
+    {binding: 169, resource: textureView57},
+    {binding: 191, resource: textureView117},
+    {binding: 216, resource: textureView55},
+    {binding: 17, resource: textureView59},
+  ],
+});
+let sampler85 = device1.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 89.25,
+  compare: 'never',
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder68.setBindGroup(2, bindGroup35, []);
+} catch {}
+let promise14 = device1.queue.onSubmittedWorkDone();
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.append(canvas0);
+let videoFrame20 = new VideoFrame(videoFrame1, {timestamp: 0});
+let veryExplicitBindGroupLayout19 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 117,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 307,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder120 = device1.createCommandEncoder();
+let texture142 = device1.createTexture({
+  size: [216, 1, 24],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder90 = commandEncoder120.beginComputePass({});
+try {
+renderPassEncoder16.setIndexBuffer(buffer46, 'uint16', 462, 59);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(0, buffer36, 0);
+} catch {}
+let bindGroup80 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [{binding: 93, resource: {buffer: buffer1, offset: 1024, size: 243}}],
+});
+let commandEncoder121 = device0.createCommandEncoder();
+let textureView128 = texture17.createView({dimension: '1d'});
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 144, new DataView(new ArrayBuffer(9819)), 2723);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let querySet15 = device1.createQuerySet({type: 'occlusion', count: 408});
+let textureView129 = texture48.createView({dimension: '2d-array', format: 'rgba16float', mipLevelCount: 1});
+try {
+renderPassEncoder22.setBindGroup(1, bindGroup49, []);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(5, buffer45, 1_732, 1_216);
+} catch {}
+let autogeneratedBindGroupLayout0 = pipeline0.getBindGroupLayout(0);
+let texture143 = device0.createTexture({
+  size: [131, 1, 95],
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler86 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'mirror-repeat', lodMaxClamp: 98.91});
+try {
+renderPassEncoder29.setVertexBuffer(4, buffer11, 728, 4_711);
+} catch {}
+try {
+commandEncoder121.copyTextureToBuffer({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 360 widthInBlocks: 90 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2312 */
+  offset: 2312,
+  bytesPerRow: 27392,
+  buffer: buffer33,
+}, {width: 90, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 131, height: 1, depthOrArrayLayers: 613}
+*/
+{
+  source: imageData0,
+  origin: { x: 4, y: 3 },
+  flipY: true,
+}, {
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 6},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer64 = device1.createBuffer({size: 2888, usage: GPUBufferUsage.COPY_DST});
+let commandEncoder122 = device1.createCommandEncoder({});
+let texture144 = device1.createTexture({
+  size: {width: 432, height: 3, depthOrArrayLayers: 1},
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture145 = device1.createTexture({
+  size: {width: 48, height: 1, depthOrArrayLayers: 19},
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView130 = texture48.createView({dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 0});
+let renderPassEncoder31 = commandEncoder122.beginRenderPass({colorAttachments: [{view: textureView22, loadOp: 'load', storeOp: 'discard'}]});
+try {
+renderPassEncoder23.setVertexBuffer(4, buffer0, 4_208, 545);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+let bindGroup81 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout15,
+  entries: [
+    {binding: 91, resource: sampler48},
+    {binding: 216, resource: textureView59},
+    {binding: 63, resource: textureView9},
+    {binding: 48, resource: textureView54},
+    {binding: 191, resource: textureView117},
+    {binding: 196, resource: sampler63},
+    {binding: 122, resource: {buffer: buffer46, offset: 0, size: 372}},
+    {binding: 41, resource: textureView28},
+    {binding: 456, resource: textureView39},
+    {binding: 13, resource: textureView67},
+    {binding: 17, resource: textureView55},
+    {binding: 169, resource: textureView57},
+    {binding: 339, resource: {buffer: buffer19, offset: 512, size: 9540}},
+  ],
+});
+let buffer65 = device1.createBuffer({
+  label: '\u88cd\ua55a',
+  size: 14103,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let textureView131 = texture63.createView({mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 1});
+let texture146 = device1.createTexture({
+  size: {width: 128, height: 128, depthOrArrayLayers: 127},
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView132 = texture123.createView({});
+try {
+computePassEncoder27.setBindGroup(2, bindGroup48, new Uint32Array(1544), 57, 0);
+} catch {}
+let bindGroup82 = device0.createBindGroup({layout: veryExplicitBindGroupLayout16, entries: [{binding: 47, resource: textureView25}]});
+let texture147 = device0.createTexture({
+  size: [131, 1, 1],
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView133 = texture124.createView({dimension: '2d-array', format: 'rgba8sint'});
+let computePassEncoder91 = commandEncoder121.beginComputePass({});
+try {
+computePassEncoder11.setBindGroup(1, bindGroup71, new Uint32Array(955), 80, 0);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer17, 'uint16', 1_680, 128);
+} catch {}
+try {
+buffer41.unmap();
+} catch {}
+try {
+  await promise14;
+} catch {}
+let textureView134 = texture99.createView({baseArrayLayer: 0});
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({colorFormats: ['rgba8unorm'], depthReadOnly: false, stencilReadOnly: true});
+let renderBundle19 = renderBundleEncoder19.finish({});
+try {
+computePassEncoder63.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer5, 'uint16', 48, 80);
+} catch {}
+let promise15 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise12;
+} catch {}
+try {
+computePassEncoder8.setBindGroup(3, bindGroup52, new Uint32Array(324), 116, 0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup49);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(0, buffer20, 4_464);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+computePassEncoder41.setBindGroup(1, bindGroup8, new Uint32Array(983), 241, 0);
+} catch {}
+try {
+renderPassEncoder11.setBlendConstant({ r: 260.7, g: 255.6, b: 429.3, a: -471.7, });
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer16, 'uint16', 74, 308);
+} catch {}
+let bindGroup83 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [{binding: 57, resource: textureView54}, {binding: 87, resource: sampler33}],
+});
+let buffer66 = device1.createBuffer({
+  size: 21823,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder123 = device1.createCommandEncoder({});
+try {
+computePassEncoder67.setBindGroup(1, bindGroup28);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup46, new Uint32Array(757), 118, 0);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 6, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(493).fill(218), /* required buffer size: 493 */
+{offset: 493}, {width: 142, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet16 = device1.createQuerySet({type: 'occlusion', count: 206});
+let textureView135 = texture45.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 0});
+try {
+computePassEncoder9.setBindGroup(0, bindGroup51);
+} catch {}
+try {
+computePassEncoder69.setBindGroup(3, bindGroup57, new Uint32Array(1236), 216, 0);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer26, 'uint16', 102, 867);
+} catch {}
+let bindGroup84 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 93, resource: {buffer: buffer42, offset: 1024, size: 706}}],
+});
+let texture148 = device0.createTexture({
+  size: {width: 131, height: 1, depthOrArrayLayers: 69},
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+document.body.append(img0);
+let imageData12 = new ImageData(12, 28);
+let commandEncoder124 = device0.createCommandEncoder({label: '\u{1f7b9}\u0046\u3bec\u03cf\u{1fb75}\u0876\u{1ff1a}\u092d\ud62f'});
+try {
+renderPassEncoder21.executeBundles([renderBundle9, renderBundle19, renderBundle13]);
+} catch {}
+let offscreenCanvas1 = new OffscreenCanvas(512, 106);
+let querySet17 = device1.createQuerySet({type: 'occlusion', count: 80});
+let texture149 = device1.createTexture({
+  size: {width: 432, height: 3, depthOrArrayLayers: 1},
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder32 = commandEncoder123.beginRenderPass({colorAttachments: [{view: textureView22, loadOp: 'clear', storeOp: 'discard'}]});
+try {
+computePassEncoder67.setBindGroup(3, bindGroup39);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup60);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup55, new Uint32Array(113), 3, 0);
+} catch {}
+try {
+renderPassEncoder12.beginOcclusionQuery(84);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer38, 'uint16', 1_032, 14);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(2, buffer47, 68);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let querySet18 = device0.createQuerySet({type: 'occlusion', count: 830});
+let texture150 = device0.createTexture({
+  size: {width: 131, height: 1, depthOrArrayLayers: 71},
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture151 = device0.createTexture({
+  size: {width: 65, height: 1, depthOrArrayLayers: 107},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder11.popDebugGroup();
+} catch {}
+await gc();
+let commandEncoder125 = device1.createCommandEncoder({});
+let texture152 = device1.createTexture({
+  size: [135, 2, 1],
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder92 = commandEncoder125.beginComputePass({});
+let sampler87 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 51.76,
+});
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup31, new Uint32Array(759), 6, 0);
+} catch {}
+try {
+renderPassEncoder12.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer39, 'uint16', 2, 6);
+} catch {}
+try {
+gpuCanvasContext1.configure({device: device1, format: 'rgba8unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+} catch {}
+let veryExplicitBindGroupLayout20 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 29,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: true },
+    },
+    {
+      binding: 50,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 73,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'sint', multisampled: false },
+    },
+    {binding: 95, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform', hasDynamicOffset: false }},
+    {
+      binding: 103,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 109,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8uint', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 122,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d' },
+    },
+    {
+      binding: 321,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let bindGroup85 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout14,
+  entries: [{binding: 453, resource: {buffer: buffer18, offset: 1024, size: 8488}}],
+});
+let buffer67 = device0.createBuffer({
+  size: 4191,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let commandEncoder126 = device0.createCommandEncoder({});
+try {
+computePassEncoder60.setBindGroup(3, bindGroup12, new Uint32Array(4300), 290, 0);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer42, 'uint16', 1_528, 972);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup86 = device0.createBindGroup({layout: veryExplicitBindGroupLayout6, entries: [{binding: 539, resource: textureView43}]});
+let textureView136 = texture50.createView({dimension: 'cube', baseArrayLayer: 5});
+let textureView137 = texture54.createView({baseArrayLayer: 0});
+let computePassEncoder93 = commandEncoder126.beginComputePass({});
+let renderPassEncoder33 = commandEncoder124.beginRenderPass({
+  colorAttachments: [{view: textureView87, loadOp: 'clear', storeOp: 'discard'}],
+  maxDrawCount: 84030585,
+});
+let sampler88 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'not-equal',
+});
+try {
+computePassEncoder28.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+computePassEncoder91.setBindGroup(2, bindGroup71, new Uint32Array(8453), 327, 0);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([renderBundle13]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 0, new DataView(new ArrayBuffer(1321)), 181, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(126_358).fill(87), /* required buffer size: 126_358 */
+{offset: 134, bytesPerRow: 784, rowsPerImage: 23}, {width: 92, height: 0, depthOrArrayLayers: 8});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 131, height: 1, depthOrArrayLayers: 613}
+*/
+{
+  source: imageData2,
+  origin: { x: 1, y: 0 },
+  flipY: false,
+}, {
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder127 = device0.createCommandEncoder({});
+let texture153 = device0.createTexture({
+  size: {width: 65, height: 1, depthOrArrayLayers: 79},
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture154 = device0.createTexture({
+  size: [262, 1, 37],
+  mipLevelCount: 2,
+  format: 'rg8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView138 = texture111.createView({dimension: '2d-array'});
+let externalTexture18 = device0.importExternalTexture({label: '\u0b57\u{1f6e1}\u049c', source: videoFrame9});
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup15, new Uint32Array(1869), 880, 0);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(2, buffer63, 0, 86);
+} catch {}
+try {
+commandEncoder127.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 656 */
+  offset: 656,
+  bytesPerRow: 18432,
+  buffer: buffer8,
+}, {
+  texture: texture29,
+  mipLevel: 1,
+  origin: {x: 80, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 20, height: 10, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder128 = device0.createCommandEncoder({});
+let computePassEncoder94 = commandEncoder127.beginComputePass({});
+let sampler89 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  lodMaxClamp: 99.33,
+  compare: 'equal',
+});
+try {
+renderPassEncoder21.setIndexBuffer(buffer41, 'uint16', 194, 195);
+} catch {}
+document.body.prepend(img1);
+let commandEncoder129 = device1.createCommandEncoder({});
+let texture155 = gpuCanvasContext1.getCurrentTexture();
+let computePassEncoder95 = commandEncoder129.beginComputePass({});
+let sampler90 = device1.createSampler({addressModeW: 'mirror-repeat'});
+try {
+computePassEncoder51.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup56);
+} catch {}
+try {
+device1.pushErrorScope('out-of-memory');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let texture156 = device1.createTexture({
+  size: [48, 1, 1],
+  sampleCount: 1,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView139 = texture80.createView({dimension: '2d-array', aspect: 'all'});
+let renderBundleEncoder20 = device1.createRenderBundleEncoder({colorFormats: ['r32float']});
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup8, new Uint32Array(2061), 6, 0);
+} catch {}
+try {
+renderPassEncoder28.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder30.setScissorRect(4, 0, 36, 0);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer38, 'uint16', 424, 1_736);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(1, bindGroup60, new Uint32Array(2143), 153, 0);
+} catch {}
+let bindGroup87 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout17,
+  entries: [{binding: 278, resource: {buffer: buffer19, offset: 0, size: 816}}],
+});
+let buffer68 = device1.createBuffer({
+  size: 3710,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder130 = device1.createCommandEncoder();
+let textureView140 = texture52.createView({baseMipLevel: 0});
+let renderBundle20 = renderBundleEncoder20.finish({});
+try {
+computePassEncoder72.setBindGroup(3, bindGroup48, new Uint32Array(1082), 88, 0);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup35, new Uint32Array(2332), 188, 0);
+} catch {}
+document.body.append(canvas0);
+let textureView141 = texture42.createView({dimension: '1d', mipLevelCount: 1});
+let computePassEncoder96 = commandEncoder128.beginComputePass({});
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup85);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+document.body.prepend(canvas0);
+let buffer69 = device0.createBuffer({
+  size: 12675,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture157 = gpuCanvasContext0.getCurrentTexture();
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup33);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer10, 'uint32', 5_912, 4_397);
+} catch {}
+let buffer70 = device0.createBuffer({size: 7285, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView142 = texture2.createView({dimension: '2d', baseArrayLayer: 5});
+let texture158 = device0.createTexture({
+  size: [65, 1, 1],
+  mipLevelCount: 2,
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView143 = texture103.createView({});
+try {
+computePassEncoder86.setBindGroup(2, bindGroup14, new Uint32Array(595), 59, 0);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(5, buffer8, 484, 672);
+} catch {}
+try {
+  await promise15;
+} catch {}
+let bindGroup88 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout8,
+  entries: [
+    {binding: 117, resource: {buffer: buffer20, offset: 0, size: 502}},
+    {binding: 307, resource: {buffer: buffer68, offset: 256, size: 388}},
+  ],
+});
+let pipelineLayout13 = device1.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout5]});
+let buffer71 = device1.createBuffer({
+  size: 11918,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder131 = device1.createCommandEncoder({});
+let texture159 = device1.createTexture({
+  size: [1080, 20, 1],
+  mipLevelCount: 2,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder97 = commandEncoder130.beginComputePass({});
+try {
+computePassEncoder95.setBindGroup(3, bindGroup81, new Uint32Array(456), 50, 0);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(5, buffer43, 1_400, 38);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 67, height: 1, depthOrArrayLayers: 9}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 4, y: 6 },
+  flipY: true,
+}, {
+  texture: texture27,
+  mipLevel: 1,
+  origin: {x: 8, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 17, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder132 = device0.createCommandEncoder({});
+let sampler91 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'repeat', lodMaxClamp: 73.60});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup68, new Uint32Array(161), 84, 0);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(1, bindGroup76, new Uint32Array(168), 31, 0);
+} catch {}
+try {
+renderPassEncoder26.beginOcclusionQuery(7);
+} catch {}
+try {
+renderPassEncoder27.setViewport(437.2966607998429, 0.090403307496282, 72.22107487336824, 0.6009430826497983, 0.5901093498462313, 0.6768363633745537);
+} catch {}
+try {
+commandEncoder132.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 19316 */
+  offset: 884,
+  bytesPerRow: 2304,
+  buffer: buffer10,
+}, {
+  texture: texture38,
+  mipLevel: 1,
+  origin: {x: 0, y: 17, z: 6},
+  aspect: 'all',
+}, {width: 0, height: 9, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext2 = offscreenCanvas1.getContext('webgpu');
+try {
+  await promise13;
+} catch {}
+let veryExplicitBindGroupLayout21 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 47,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'bgra8unorm', access: 'read-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let commandEncoder133 = device0.createCommandEncoder();
+try {
+computePassEncoder21.setBindGroup(2, bindGroup74);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(3, bindGroup25, new Uint32Array(400), 43, 0);
+} catch {}
+let promise16 = device0.queue.onSubmittedWorkDone();
+let texture160 = device0.createTexture({size: [262, 1, 9], format: 'rg8uint', usage: GPUTextureUsage.TEXTURE_BINDING, viewFormats: []});
+try {
+renderPassEncoder25.executeBundles([renderBundle13, renderBundle19, renderBundle13, renderBundle19, renderBundle19]);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer42, 'uint32', 80, 167);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(71).fill(128), /* required buffer size: 71 */
+{offset: 71}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas0);
+let bindGroup89 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout14,
+  entries: [{binding: 453, resource: {buffer: buffer18, offset: 7424, size: 8260}}],
+});
+let commandEncoder134 = device0.createCommandEncoder({});
+let textureView144 = texture132.createView({});
+let renderPassEncoder34 = commandEncoder132.beginRenderPass({
+  colorAttachments: [{
+  view: textureView83,
+  clearValue: { r: -975.8, g: -300.2, b: -634.9, a: 126.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 24084378,
+});
+let sampler92 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 55.25,
+  maxAnisotropy: 8,
+});
+try {
+renderPassEncoder25.setIndexBuffer(buffer67, 'uint16', 748, 804);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let videoFrame21 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'unspecified', transfer: 'bt1361ExtendedColourGamut'} });
+let bindGroup90 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout20,
+  entries: [
+    {binding: 50, resource: textureView90},
+    {binding: 122, resource: textureView76},
+    {binding: 103, resource: textureView29},
+    {binding: 29, resource: {buffer: buffer33, offset: 512, size: 872}},
+    {binding: 321, resource: textureView87},
+    {binding: 95, resource: {buffer: buffer34, offset: 256}},
+    {binding: 73, resource: textureView81},
+    {binding: 109, resource: textureView79},
+  ],
+});
+let texture161 = device0.createTexture({
+  label: '\ua730\u1bea\u7e40\u2e35\u322a',
+  size: [131, 1, 52],
+  mipLevelCount: 3,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder98 = commandEncoder133.beginComputePass();
+let sampler93 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder85.setBindGroup(3, bindGroup86, new Uint32Array(24), 0, 0);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(2, bindGroup11, new Uint32Array(2879), 828, 0);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let promise17 = device0.queue.onSubmittedWorkDone();
+let autogeneratedBindGroupLayout1 = pipeline0.getBindGroupLayout(0);
+let pipelineLayout14 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout12, autogeneratedBindGroupLayout0]});
+let computePassEncoder99 = commandEncoder134.beginComputePass({});
+try {
+buffer56.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer50, 464, new Float32Array(940), 174, 88);
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(406, 90);
+let imageData13 = new ImageData(16, 56);
+let videoFrame22 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'smpte432', transfer: 'gamma22curve'} });
+let veryExplicitBindGroupLayout22 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 17,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 270,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '1d' },
+    },
+  ],
+});
+let commandEncoder135 = device1.createCommandEncoder({});
+let computePassEncoder100 = commandEncoder135.beginComputePass({});
+try {
+computePassEncoder34.setBindGroup(3, bindGroup23, new Uint32Array(5577), 13, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup22, new Uint32Array(754), 8, 0);
+} catch {}
+let bindGroup91 = device0.createBindGroup({layout: veryExplicitBindGroupLayout7, entries: [{binding: 47, resource: textureView86}]});
+let commandEncoder136 = device0.createCommandEncoder();
+try {
+computePassEncoder22.setBindGroup(1, bindGroup36);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(2, bindGroup45, new Uint32Array(1704), 130, 0);
+} catch {}
+try {
+renderPassEncoder26.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer16, 'uint32', 1_572, 1_202);
+} catch {}
+try {
+commandEncoder136.copyBufferToTexture({
+  /* bytesInLastRow: 372 widthInBlocks: 93 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1352 */
+  offset: 1352,
+  bytesPerRow: 7424,
+  buffer: buffer56,
+}, {
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 93, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer31, 708, new BigUint64Array(1345), 286, 28);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer72 = device0.createBuffer({
+  size: 4156,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder137 = device0.createCommandEncoder({});
+try {
+renderPassEncoder29.setBindGroup(1, bindGroup89, []);
+} catch {}
+try {
+  await promise17;
+} catch {}
+let computePassEncoder101 = commandEncoder131.beginComputePass();
+try {
+computePassEncoder52.setBindGroup(0, bindGroup39, new Uint32Array(6912), 505, 0);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(0, bindGroup88, new Uint32Array(1338), 129, 0);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer60, 2412, new Int16Array(10310), 3096, 304);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture123,
+  mipLevel: 0,
+  origin: {x: 40, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(328).fill(182), /* required buffer size: 328 */
+{offset: 328}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder138 = device0.createCommandEncoder();
+let externalTexture19 = device0.importExternalTexture({source: videoFrame19, colorSpace: 'srgb'});
+try {
+computePassEncoder7.setBindGroup(3, bindGroup45, new Uint32Array(1697), 72, 0);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup10, new Uint32Array(1050), 33, 0);
+} catch {}
+try {
+buffer56.unmap();
+} catch {}
+try {
+commandEncoder136.copyTextureToTexture({
+  texture: texture150,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 15},
+  aspect: 'all',
+},
+{
+  texture: texture90,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 70, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture124,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(47).fill(107), /* required buffer size: 47 */
+{offset: 47, bytesPerRow: 47}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 131, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData4,
+  origin: { x: 1, y: 33 },
+  flipY: false,
+}, {
+  texture: texture111,
+  mipLevel: 0,
+  origin: {x: 63, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let autogeneratedBindGroupLayout2 = pipeline0.getBindGroupLayout(0);
+let buffer73 = device0.createBuffer({
+  size: 495,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture162 = device0.createTexture({
+  size: {width: 65, height: 1, depthOrArrayLayers: 44},
+  dimension: '3d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder102 = commandEncoder136.beginComputePass({});
+let sampler94 = device0.createSampler({magFilter: 'linear', minFilter: 'linear', mipmapFilter: 'linear', lodMaxClamp: 74.69, maxAnisotropy: 11});
+try {
+renderPassEncoder18.beginOcclusionQuery(104);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer31, 'uint16', 950, 1_700);
+} catch {}
+try {
+commandEncoder137.copyBufferToBuffer(buffer23, 1048, buffer40, 48, 900);
+} catch {}
+try {
+commandEncoder138.copyBufferToTexture({
+  /* bytesInLastRow: 180 widthInBlocks: 45 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 520 */
+  offset: 520,
+  bytesPerRow: 25856,
+  buffer: buffer23,
+}, {
+  texture: texture133,
+  mipLevel: 0,
+  origin: {x: 54, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 45, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.RENDER_ATTACHMENT, alphaMode: 'opaque'});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 131, height: 1, depthOrArrayLayers: 613}
+*/
+{
+  source: videoFrame6,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 17},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder139 = device1.createCommandEncoder({});
+let textureView145 = texture41.createView({aspect: 'all'});
+try {
+computePassEncoder33.setBindGroup(0, bindGroup49, []);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup28, new Uint32Array(218), 81, 0);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle20, renderBundle20]);
+} catch {}
+try {
+renderPassEncoder7.setScissorRect(15, 0, 60, 0);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer38, 'uint16', 5_526, 22);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(3, buffer60, 4_184);
+} catch {}
+let bindGroup92 = device0.createBindGroup({layout: veryExplicitBindGroupLayout6, entries: [{binding: 539, resource: textureView43}]});
+let computePassEncoder103 = commandEncoder137.beginComputePass();
+let sampler95 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 17,
+});
+try {
+buffer5.unmap();
+} catch {}
+let buffer74 = device1.createBuffer({size: 52691, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+let texture163 = gpuCanvasContext0.getCurrentTexture();
+try {
+computePassEncoder42.setBindGroup(3, bindGroup77, new Uint32Array(1168), 645, 0);
+} catch {}
+try {
+commandEncoder139.copyTextureToBuffer({
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 644 */
+  offset: 644,
+  bytesPerRow: 9728,
+  buffer: buffer45,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer64, 892, new BigUint64Array(7060), 3216, 16);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1728, height: 12, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData0,
+  origin: { x: 2, y: 7 },
+  flipY: false,
+}, {
+  texture: texture136,
+  mipLevel: 0,
+  origin: {x: 106, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let img2 = await imageWithData(11, 2, '#10101010', '#20202020');
+try {
+adapter0.label = '\u402e\u{1fd76}';
+} catch {}
+let querySet19 = device1.createQuerySet({type: 'occlusion', count: 495});
+let renderPassEncoder35 = commandEncoder139.beginRenderPass({
+  colorAttachments: [{view: textureView109, loadOp: 'load', storeOp: 'discard'}],
+  maxDrawCount: 533382733,
+});
+try {
+renderPassEncoder12.end();
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle20]);
+} catch {}
+try {
+commandEncoder62.copyBufferToBuffer(buffer13, 140, buffer43, 124, 0);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+  await promise16;
+} catch {}
+let commandEncoder140 = device0.createCommandEncoder({});
+let computePassEncoder104 = commandEncoder138.beginComputePass();
+try {
+renderPassEncoder21.setBindGroup(1, bindGroup11, new Uint32Array(4909), 976, 0);
+} catch {}
+try {
+renderPassEncoder18.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer5, 'uint32', 292, 133);
+} catch {}
+try {
+commandEncoder140.copyBufferToTexture({
+  /* bytesInLastRow: 10 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 3810 */
+  offset: 3810,
+  bytesPerRow: 35584,
+  buffer: buffer72,
+}, {
+  texture: texture158,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext3 = offscreenCanvas2.getContext('webgpu');
+let commandEncoder141 = device1.createCommandEncoder();
+let textureView146 = texture144.createView({dimension: '2d-array', format: 'r32float', baseMipLevel: 0});
+let computePassEncoder105 = commandEncoder141.beginComputePass({});
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup46);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer68, 'uint16', 1_620, 24);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(3, buffer39, 12, 2);
+} catch {}
+try {
+commandEncoder62.copyBufferToTexture({
+  /* bytesInLastRow: 1864 widthInBlocks: 233 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 6224 */
+  offset: 6224,
+  rowsPerImage: 34,
+  buffer: buffer51,
+}, {
+  texture: texture136,
+  mipLevel: 0,
+  origin: {x: 79, y: 5, z: 0},
+  aspect: 'all',
+}, {width: 233, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder62.copyTextureToBuffer({
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 190, y: 4, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 996 widthInBlocks: 249 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2064 */
+  offset: 2064,
+  bytesPerRow: 13824,
+  buffer: buffer43,
+}, {width: 249, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let promise18 = device1.queue.onSubmittedWorkDone();
+let commandEncoder142 = device0.createCommandEncoder({});
+let textureView147 = texture44.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 10});
+try {
+computePassEncoder98.setBindGroup(3, bindGroup5, new Uint32Array(853), 281, 0);
+} catch {}
+let bindGroup93 = device0.createBindGroup({
+  label: '\u06a4\u9470',
+  layout: veryExplicitBindGroupLayout20,
+  entries: [
+    {binding: 321, resource: textureView87},
+    {binding: 122, resource: textureView76},
+    {binding: 109, resource: textureView79},
+    {binding: 50, resource: textureView137},
+    {binding: 29, resource: {buffer: buffer18, offset: 512, size: 2224}},
+    {binding: 95, resource: {buffer: buffer34, offset: 0}},
+    {binding: 73, resource: textureView81},
+    {binding: 103, resource: textureView33},
+  ],
+});
+let buffer75 = device0.createBuffer({size: 22508, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let commandEncoder143 = device0.createCommandEncoder({});
+let renderPassEncoder36 = commandEncoder142.beginRenderPass({colorAttachments: [{view: textureView29, loadOp: 'load', storeOp: 'discard'}]});
+try {
+renderPassEncoder18.setBindGroup(1, bindGroup75, new Uint32Array(428), 6, 0);
+} catch {}
+let buffer76 = device0.createBuffer({
+  size: 12849,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: false,
+});
+let commandEncoder144 = device0.createCommandEncoder({});
+let texture164 = device0.createTexture({
+  size: [525, 1, 1],
+  mipLevelCount: 4,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder37 = commandEncoder144.beginRenderPass({
+  label: '\uc0c6\uad1e\u49b8\u{1f86d}\u{1f90b}\ube0e\ud974\ucfc9\u{1fac1}\u6aa6\ub89c',
+  colorAttachments: [{view: textureView138, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet0,
+});
+let sampler96 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', addressModeW: 'repeat', lodMinClamp: 0.2612});
+try {
+computePassEncoder93.setBindGroup(3, bindGroup53);
+} catch {}
+try {
+computePassEncoder99.setBindGroup(2, bindGroup40, new Uint32Array(3008), 2_175, 0);
+} catch {}
+try {
+computePassEncoder31.end();
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(6, buffer11, 0, 2_360);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 131, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData9,
+  origin: { x: 21, y: 2 },
+  flipY: false,
+}, {
+  texture: texture111,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline2 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule0,
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule0,
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm8x2', offset: 330, shaderLocation: 6},
+          {format: 'sint32x2', offset: 32, shaderLocation: 13},
+          {format: 'sint16x2', offset: 436, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 736,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'snorm16x2', offset: 52, shaderLocation: 5},
+          {format: 'uint32x3', offset: 152, shaderLocation: 4},
+          {format: 'sint32x3', offset: 52, shaderLocation: 11},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', frontFace: 'cw', cullMode: 'back'},
+});
+let veryExplicitBindGroupLayout23 = device1.createBindGroupLayout({
+  label: '\u179c\uc1da\u7d20',
+  entries: [
+    {
+      binding: 205,
+      visibility: 0,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let commandEncoder145 = device1.createCommandEncoder({label: '\u0744\u0895\u8b9b\u0cb9'});
+let renderBundleEncoder21 = device1.createRenderBundleEncoder({colorFormats: ['r16uint', 'rgba16float'], sampleCount: 1, stencilReadOnly: true});
+try {
+computePassEncoder42.setBindGroup(0, bindGroup81, []);
+} catch {}
+try {
+computePassEncoder69.setBindGroup(3, bindGroup2, new Uint32Array(2651), 164, 0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup77);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup16, new Uint32Array(1348), 200, 0);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle20]);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(2, buffer39);
+} catch {}
+try {
+commandEncoder145.copyBufferToTexture({
+  /* bytesInLastRow: 6936 widthInBlocks: 867 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 552 */
+  offset: 552,
+  bytesPerRow: 26368,
+  buffer: buffer48,
+}, {
+  texture: texture136,
+  mipLevel: 0,
+  origin: {x: 131, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 867, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter0.label = '\u3825\ube9a\u0655\u58c7\u{1fc70}\u1067\uff0c\u2ef4\ueef1\u{1fb17}\u{1ffb1}';
+} catch {}
+let autogeneratedBindGroupLayout3 = pipeline2.getBindGroupLayout(0);
+let bindGroup94 = device0.createBindGroup({layout: veryExplicitBindGroupLayout21, entries: [{binding: 47, resource: textureView78}]});
+let commandEncoder146 = device0.createCommandEncoder({});
+let texture165 = device0.createTexture({
+  size: {width: 525, height: 1, depthOrArrayLayers: 280},
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+document.body.append(canvas0);
+let pipelineLayout15 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout16]});
+try {
+renderPassEncoder29.executeBundles([renderBundle9]);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder143.copyBufferToTexture({
+  /* bytesInLastRow: 168 widthInBlocks: 42 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 6780 */
+  offset: 6780,
+  buffer: buffer53,
+}, {
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 140, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 42, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+await gc();
+let buffer77 = device1.createBuffer({
+  size: 17582,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let texture166 = device1.createTexture({
+  size: [540, 10, 1],
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView148 = texture63.createView({dimension: '2d'});
+try {
+computePassEncoder90.setBindGroup(1, bindGroup59);
+} catch {}
+try {
+computePassEncoder67.setBindGroup(3, bindGroup56, new Uint32Array(181), 180, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(1, bindGroup88);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer66, 1320, new Float32Array(3388), 650, 260);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 270, height: 5, depthOrArrayLayers: 354}
+*/
+{
+  source: imageData9,
+  origin: { x: 1, y: 2 },
+  flipY: false,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 90, y: 0, z: 30},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder58.setBindGroup(3, bindGroup68, []);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+commandEncoder140.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3468 */
+  offset: 3468,
+  buffer: buffer7,
+}, {
+  texture: texture111,
+  mipLevel: 0,
+  origin: {x: 29, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise19 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 64, height: 64, depthOrArrayLayers: 21}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 111, y: 44 },
+  flipY: false,
+}, {
+  texture: texture77,
+  mipLevel: 0,
+  origin: {x: 8, y: 5, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 5, height: 11, depthOrArrayLayers: 0});
+} catch {}
+let pipeline3 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {module: shaderModule0, constants: {}, targets: [{format: 'rg8uint'}]},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 180,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 44, shaderLocation: 6},
+          {format: 'uint16x2', offset: 8, shaderLocation: 4},
+          {format: 'sint16x4', offset: 76, shaderLocation: 13},
+          {format: 'sint32x4', offset: 8, shaderLocation: 7},
+          {format: 'sint32x4', offset: 32, shaderLocation: 11},
+        ],
+      },
+      {arrayStride: 720, attributes: [{format: 'unorm16x2', offset: 32, shaderLocation: 5}]},
+    ],
+  },
+  primitive: {topology: 'triangle-strip', frontFace: 'cw', cullMode: 'front'},
+});
+document.body.append(canvas0);
+let texture167 = gpuCanvasContext2.getCurrentTexture();
+let computePassEncoder106 = commandEncoder62.beginComputePass({});
+try {
+renderPassEncoder35.setIndexBuffer(buffer52, 'uint32', 2_620, 511);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { console.log('device1.uncapturederror'); console.log(e); e.label = device1.label; });
+} catch {}
+try {
+commandEncoder145.clearBuffer(buffer77, 972, 2648);
+} catch {}
+try {
+commandEncoder145.resolveQuerySet(querySet19, 229, 16, buffer77, 1024);
+} catch {}
+let imageData14 = new ImageData(8, 44);
+let autogeneratedBindGroupLayout4 = pipeline0.getBindGroupLayout(0);
+let commandEncoder147 = device0.createCommandEncoder({});
+try {
+computePassEncoder15.setBindGroup(1, bindGroup94, new Uint32Array(1463), 50, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder148 = device0.createCommandEncoder({});
+let texture168 = device0.createTexture({
+  size: {width: 525, height: 1, depthOrArrayLayers: 73},
+  mipLevelCount: 3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView149 = texture110.createView({dimension: '2d-array', arrayLayerCount: 1});
+let renderPassEncoder38 = commandEncoder146.beginRenderPass({
+  colorAttachments: [{
+  view: textureView138,
+  clearValue: { r: -557.8, g: 995.9, b: 306.6, a: -960.4, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet0,
+});
+try {
+computePassEncoder22.setBindGroup(3, bindGroup5, new Uint32Array(1076), 17, 0);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(3, bindGroup47, new Uint32Array(2090), 310, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer69, 1764, new DataView(new ArrayBuffer(10748)), 951, 1288);
+} catch {}
+let commandEncoder149 = device0.createCommandEncoder({});
+let commandBuffer4 = commandEncoder40.finish();
+let texture169 = device0.createTexture({
+  size: [64, 64, 21],
+  mipLevelCount: 1,
+  dimension: '2d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder107 = commandEncoder148.beginComputePass({});
+let renderPassEncoder39 = commandEncoder149.beginRenderPass({
+  colorAttachments: [{
+  view: textureView33,
+  clearValue: { r: -148.7, g: 803.1, b: -507.0, a: -206.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder43.setBindGroup(0, bindGroup63, new Uint32Array(1631), 181, 0);
+} catch {}
+try {
+commandEncoder143.copyBufferToBuffer(buffer32, 8, buffer50, 108, 252);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+try {
+  await promise19;
+} catch {}
+let videoFrame23 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'smpteSt4281', transfer: 'smpte170m'} });
+try {
+adapter1.label = '\u6d2d\u1576\u{1fa3e}\u{1f767}\u{1fa21}\u0399\u573e\u957d\u0c73';
+} catch {}
+try {
+globalThis.someLabel = device1.queue.label;
+} catch {}
+let bindGroup95 = device1.createBindGroup({layout: veryExplicitBindGroupLayout23, entries: [{binding: 205, resource: textureView9}]});
+let texture170 = device1.createTexture({
+  size: [135, 2, 1],
+  mipLevelCount: 1,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundle21 = renderBundleEncoder21.finish({label: '\u93c7\uca65\u0328\u4a38\u102f\u3f40\uc32a\u1ec8\ubfab\u{1ff27}'});
+let sampler97 = device1.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', minFilter: 'linear'});
+try {
+computePassEncoder45.setBindGroup(3, bindGroup87);
+} catch {}
+try {
+  await promise18;
+} catch {}
+let buffer78 = device1.createBuffer({size: 13247, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let texture171 = device1.createTexture({
+  size: {width: 135, height: 2, depthOrArrayLayers: 1},
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder40 = commandEncoder145.beginRenderPass({
+  colorAttachments: [{
+  view: textureView18,
+  clearValue: { r: -350.7, g: -964.3, b: -33.84, a: -513.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder67.setBindGroup(1, bindGroup81);
+} catch {}
+try {
+computePassEncoder44.setBindGroup(3, bindGroup59, new Uint32Array(3), 0, 0);
+} catch {}
+try {
+computePassEncoder27.end();
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(3, bindGroup55, new Uint32Array(271), 54, 0);
+} catch {}
+try {
+renderPassEncoder8.beginOcclusionQuery(228);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(6, buffer43, 836, 24);
+} catch {}
+let veryExplicitBindGroupLayout24 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 17,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 270,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '1d' },
+    },
+  ],
+});
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup57);
+} catch {}
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder36.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 5986 */
+  offset: 5986,
+  bytesPerRow: 3328,
+  rowsPerImage: 538,
+  buffer: buffer22,
+}, {
+  texture: texture27,
+  mipLevel: 1,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder36.copyTextureToBuffer({
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 192 widthInBlocks: 48 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 52 */
+  offset: 52,
+  bytesPerRow: 14848,
+  buffer: buffer26,
+}, {width: 48, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup61);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup66, new Uint32Array(654), 13, 0);
+} catch {}
+try {
+renderPassEncoder26.beginOcclusionQuery(17);
+} catch {}
+try {
+renderPassEncoder26.endOcclusionQuery();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 525, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame23,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture133,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView150 = texture45.createView({dimension: '2d', baseMipLevel: 0});
+let computePassEncoder108 = commandEncoder36.beginComputePass({});
+try {
+computePassEncoder68.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+computePassEncoder68.setBindGroup(3, bindGroup8, new Uint32Array(4884), 266, 0);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(1, bindGroup20, new Uint32Array(528), 68, 0);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 33, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(125).fill(47), /* required buffer size: 125 */
+{offset: 125}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas2 = document.createElement('canvas');
+let videoFrame24 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'unspecified', primaries: 'smpte240m', transfer: 'iec6196624'} });
+let buffer79 = device0.createBuffer({size: 12166, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let commandEncoder150 = device0.createCommandEncoder({});
+let texture172 = device0.createTexture({
+  size: {width: 65, height: 1, depthOrArrayLayers: 1},
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder109 = commandEncoder143.beginComputePass({});
+try {
+computePassEncoder50.setBindGroup(1, bindGroup84, new Uint32Array(2006), 33, 0);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, new Uint8Array(53_361).fill(255), /* required buffer size: 53_361 */
+{offset: 0, bytesPerRow: 539, rowsPerImage: 33}, {width: 525, height: 0, depthOrArrayLayers: 4});
+} catch {}
+let buffer80 = device0.createBuffer({
+  size: 5107,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let sampler98 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', mipmapFilter: 'nearest', lodMaxClamp: 76.94});
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 13, y: 2, z: 3},
+  aspect: 'all',
+}, new Uint8Array(8_123).fill(148), /* required buffer size: 8_123 */
+{offset: 23, bytesPerRow: 210, rowsPerImage: 27}, {width: 15, height: 12, depthOrArrayLayers: 2});
+} catch {}
+document.body.prepend(canvas1);
+let texture173 = device1.createTexture({
+  size: {width: 540, height: 10, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView151 = texture12.createView({});
+let sampler99 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 82.13,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder26.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderPassEncoder35.executeBundles([renderBundle20, renderBundle20, renderBundle20]);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer9, 'uint16', 14_978, 5_439);
+} catch {}
+try {
+buffer20.unmap();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let imageData15 = new ImageData(12, 4);
+let querySet20 = device1.createQuerySet({type: 'occlusion', count: 589});
+try {
+computePassEncoder34.setBindGroup(0, bindGroup39, new Uint32Array(218), 10, 0);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(2, bindGroup64, new Uint32Array(2778), 422, 0);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(0, buffer66, 2_260);
+} catch {}
+let computePassEncoder110 = commandEncoder150.beginComputePass();
+try {
+renderPassEncoder34.executeBundles([renderBundle9, renderBundle19, renderBundle19, renderBundle13]);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer42, 'uint32', 28, 1_092);
+} catch {}
+let promise20 = device0.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let bindGroup96 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout19,
+  entries: [
+    {binding: 117, resource: {buffer: buffer0, offset: 1024, size: 631}},
+    {binding: 307, resource: {buffer: buffer22, offset: 1280}},
+  ],
+});
+let commandEncoder151 = device1.createCommandEncoder();
+let texture174 = device1.createTexture({
+  size: [540, 10, 1],
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView152 = texture71.createView({baseArrayLayer: 1, arrayLayerCount: 2});
+let computePassEncoder111 = commandEncoder151.beginComputePass({});
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup70);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle20, renderBundle20, renderBundle20]);
+} catch {}
+try {
+buffer22.unmap();
+} catch {}
+let imageData16 = new ImageData(56, 28);
+let commandEncoder152 = device1.createCommandEncoder({});
+let computePassEncoder112 = commandEncoder152.beginComputePass({});
+try {
+renderPassEncoder28.setBindGroup(0, bindGroup56);
+} catch {}
+let videoFrame25 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'smpte170m', transfer: 'gamma22curve'} });
+let videoFrame26 = videoFrame10.clone();
+let commandEncoder153 = device1.createCommandEncoder({});
+let textureView153 = texture71.createView({dimension: '2d', baseArrayLayer: 4});
+let computePassEncoder113 = commandEncoder153.beginComputePass();
+try {
+computePassEncoder111.setBindGroup(2, bindGroup22, new Uint32Array(1472), 236, 0);
+} catch {}
+try {
+renderPassEncoder8.beginOcclusionQuery(221);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle20, renderBundle20]);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer9, 'uint16', 5_636, 14_073);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(4, buffer77);
+} catch {}
+try {
+buffer71.unmap();
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await promise20;
+} catch {}
+let bindGroup97 = device1.createBindGroup({layout: veryExplicitBindGroupLayout18, entries: [{binding: 284, resource: textureView115}]});
+let textureView154 = texture152.createView({aspect: 'all'});
+let textureView155 = texture8.createView({dimension: '2d-array', format: 'astc-6x6-unorm-srgb'});
+try {
+computePassEncoder74.setBindGroup(3, bindGroup59);
+} catch {}
+try {
+computePassEncoder69.setBindGroup(1, bindGroup88, new Uint32Array(1181), 6, 0);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(3, bindGroup78, new Uint32Array(3695), 38, 0);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer22, 'uint32', 3_864, 2_497);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1728, height: 12, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame17,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture136,
+  mipLevel: 0,
+  origin: {x: 306, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup98 = device0.createBindGroup({layout: veryExplicitBindGroupLayout3, entries: [{binding: 10, resource: textureView6}]});
+let buffer81 = device0.createBuffer({
+  size: 7063,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder154 = device0.createCommandEncoder({});
+let sampler100 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 65.30, maxAnisotropy: 1});
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let textureView156 = texture63.createView({baseMipLevel: 0, arrayLayerCount: 1});
+let textureView157 = texture118.createView({});
+try {
+computePassEncoder57.setBindGroup(2, bindGroup31, new Uint32Array(3962), 290, 0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+});
+} catch {}
+let buffer82 = device1.createBuffer({
+  size: 14325,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder155 = device1.createCommandEncoder({});
+let computePassEncoder114 = commandEncoder155.beginComputePass({});
+let sampler101 = device1.createSampler({addressModeV: 'mirror-repeat', lodMaxClamp: 96.57});
+try {
+computePassEncoder95.setBindGroup(1, bindGroup78);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture135,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(221).fill(218), /* required buffer size: 221 */
+{offset: 221}, {width: 24, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let buffer83 = device0.createBuffer({
+  size: 1779,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let renderPassEncoder41 = commandEncoder154.beginRenderPass({
+  colorAttachments: [{view: textureView92, depthSlice: 96, loadOp: 'load', storeOp: 'discard'}],
+  occlusionQuerySet: querySet11,
+});
+try {
+renderPassEncoder36.setVertexBuffer(0, buffer69, 3_560, 438);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 28, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(72).fill(233), /* required buffer size: 72 */
+{offset: 72, rowsPerImage: 41}, {width: 43, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let img3 = await imageWithData(35, 86, '#10101010', '#20202020');
+let buffer84 = device1.createBuffer({
+  size: 11635,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let texture175 = device1.createTexture({
+  size: [135, 2, 1],
+  sampleCount: 4,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder46.setBindGroup(2, bindGroup32);
+} catch {}
+try {
+computePassEncoder67.setBindGroup(1, bindGroup30, new Uint32Array(3810), 130, 0);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(2, bindGroup39, new Uint32Array(1112), 147, 0);
+} catch {}
+document.body.append(img3);
+try {
+canvas2.getContext('webgpu');
+} catch {}
+let bindGroup99 = device0.createBindGroup({layout: veryExplicitBindGroupLayout16, entries: [{binding: 47, resource: textureView86}]});
+let sampler102 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 15,
+});
+try {
+commandEncoder147.copyBufferToTexture({
+  /* bytesInLastRow: 232 widthInBlocks: 58 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3008 */
+  offset: 3008,
+  rowsPerImage: 285,
+  buffer: buffer17,
+}, {
+  texture: texture147,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 58, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 131, height: 1, depthOrArrayLayers: 613}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 151},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas3 = document.createElement('canvas');
+let renderBundleEncoder22 = device1.createRenderBundleEncoder({colorFormats: ['r32float'], depthReadOnly: true});
+let sampler103 = device1.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 90.19,
+  compare: 'less',
+  maxAnisotropy: 2,
+});
+try {
+renderPassEncoder22.setIndexBuffer(buffer52, 'uint32', 916, 129);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer9, 'uint32', 2_888, 17_889);
+} catch {}
+try {
+device1.lost.then(({reason, message}) => { console.log('device1 lost!'); console.log(message, reason); });
+} catch {}
+let computePassEncoder115 = commandEncoder140.beginComputePass({});
+try {
+computePassEncoder94.setBindGroup(0, bindGroup94);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer69, 'uint32', 4_864, 395);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(0, buffer8);
+} catch {}
+try {
+buffer72.unmap();
+} catch {}
+let gpuCanvasContext4 = canvas3.getContext('webgpu');
+document.body.append(img2);
+let commandEncoder156 = device0.createCommandEncoder({});
+let commandBuffer5 = commandEncoder156.finish({});
+let computePassEncoder116 = commandEncoder147.beginComputePass({});
+try {
+computePassEncoder19.setBindGroup(1, bindGroup58, new Uint32Array(824), 1, 0);
+} catch {}
+try {
+renderPassEncoder39.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder20.setScissorRect(69, 0, 4, 0);
+} catch {}
+let commandEncoder157 = device0.createCommandEncoder({});
+let computePassEncoder117 = commandEncoder157.beginComputePass({});
+try {
+computePassEncoder91.setBindGroup(3, bindGroup25, new Uint32Array(615), 10, 0);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(0, bindGroup75, new Uint32Array(1472), 551, 0);
+} catch {}
+try {
+renderPassEncoder39.setScissorRect(7, 14, 1, 2);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer16, 'uint16', 1_722, 1_679);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(6, buffer41, 0);
+} catch {}
+try {
+buffer75.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer5, commandBuffer4]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer70, 868, new Int16Array(53203), 888, 104);
+} catch {}
+let videoFrame27 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'jedecP22Phosphors', transfer: 'hlg'} });
+let bindGroup100 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout19,
+  entries: [
+    {binding: 117, resource: {buffer: buffer54, offset: 4864, size: 4103}},
+    {binding: 307, resource: {buffer: buffer20, offset: 256, size: 1124}},
+  ],
+});
+let querySet21 = device1.createQuerySet({type: 'occlusion', count: 1558});
+let sampler104 = device1.createSampler({addressModeU: 'repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 94.69, maxAnisotropy: 1});
+try {
+renderBundleEncoder22.setVertexBuffer(2, buffer36, 6_244, 459);
+} catch {}
+let querySet22 = device1.createQuerySet({type: 'occlusion', count: 252});
+let texture176 = device1.createTexture({
+  size: {width: 48, height: 1, depthOrArrayLayers: 28},
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView158 = texture152.createView({dimension: '2d-array', aspect: 'all'});
+let renderBundleEncoder23 = device1.createRenderBundleEncoder({colorFormats: ['r32float'], depthReadOnly: true});
+try {
+computePassEncoder90.setBindGroup(3, bindGroup48);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(3, bindGroup35, new Uint32Array(220), 21, 0);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture123,
+  mipLevel: 0,
+  origin: {x: 43, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(84).fill(77), /* required buffer size: 84 */
+{offset: 84}, {width: 18, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup101 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout4,
+  entries: [{binding: 40, resource: textureView116}, {binding: 85, resource: textureView74}],
+});
+let commandEncoder158 = device0.createCommandEncoder({});
+let texture177 = device0.createTexture({
+  size: [262, 1, 58],
+  mipLevelCount: 3,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder118 = commandEncoder158.beginComputePass({});
+try {
+renderPassEncoder5.executeBundles([renderBundle18, renderBundle2]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder29.setBindGroup(2, bindGroup86);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(1, bindGroup14, new Uint32Array(153), 1, 0);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer5, 'uint32', 96, 496);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture115,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(348).fill(189), /* required buffer size: 348 */
+{offset: 348}, {width: 22, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup102 = device0.createBindGroup({layout: veryExplicitBindGroupLayout16, entries: [{binding: 47, resource: textureView86}]});
+try {
+computePassEncoder87.setBindGroup(1, bindGroup43);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer16, 'uint32', 700, 258);
+} catch {}
+let commandEncoder159 = device1.createCommandEncoder({label: '\u0b78\uc549\u805a\uf7a4'});
+let texture178 = device1.createTexture({
+  size: [216, 1, 24],
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32float'],
+});
+let renderPassEncoder42 = commandEncoder159.beginRenderPass({
+  colorAttachments: [{
+  view: textureView41,
+  depthSlice: 251,
+  clearValue: { r: -450.3, g: -285.3, b: 698.9, a: 324.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let sampler105 = device1.createSampler({addressModeW: 'mirror-repeat', lodMaxClamp: 99.07});
+try {
+computePassEncoder112.setBindGroup(1, bindGroup100, []);
+} catch {}
+try {
+renderPassEncoder22.setViewport(75.08536756190345, 1.1750701476716359, 12.022345457598814, 0.0832451508269939, 0.6795687104541419, 0.9938740240859713);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer84, 'uint16', 4_544, 196);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(0, buffer48, 0);
+} catch {}
+try {
+device1.lost.then(r => { console.log('device1 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1728, height: 12, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame7,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture136,
+  mipLevel: 0,
+  origin: {x: 79, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame28 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'bt470bg', transfer: 'iec61966-2-1'} });
+let commandEncoder160 = device1.createCommandEncoder({});
+let computePassEncoder119 = commandEncoder160.beginComputePass({});
+try {
+renderPassEncoder9.setIndexBuffer(buffer26, 'uint16', 240, 256);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(6, buffer0);
+} catch {}
+try {
+buffer43.unmap();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 432, height: 3, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame24,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 126, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame29 = new VideoFrame(videoFrame22, {timestamp: 0});
+let commandEncoder161 = device0.createCommandEncoder();
+let computePassEncoder120 = commandEncoder161.beginComputePass({});
+try {
+renderPassEncoder36.setViewport(32.54255910210649, 39.208966211118735, 26.656422794985165, 12.384938426558412, 0.8863836548552334, 0.9879332755430857);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(1, buffer17, 0);
+} catch {}
+try {
+buffer58.unmap();
+} catch {}
+try {
+texture103.label = '\uc1ef\u{1fb7a}\ua5e5\u{1fd31}\u{1ff1d}\u0a5f\u5faf\u0ac5';
+} catch {}
+let buffer85 = device0.createBuffer({
+  size: 6792,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder5.setIndexBuffer(buffer5, 'uint32', 80, 74);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let texture179 = device1.createTexture({
+  size: {width: 192},
+  dimension: '1d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder8.setBindGroup(3, bindGroup48);
+} catch {}
+try {
+computePassEncoder92.setBindGroup(3, bindGroup97, new Uint32Array(584), 76, 0);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(3, bindGroup70, new Uint32Array(4), 0, 0);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer9, 'uint32', 6_204, 13_310);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(0, bindGroup87, new Uint32Array(1108), 280, 0);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(7, buffer3, 0, 31);
+} catch {}
+try {
+device1.queue.submit([]);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture173,
+  mipLevel: 0,
+  origin: {x: 151, y: 4, z: 0},
+  aspect: 'all',
+}, new Uint8Array(291).fill(53), /* required buffer size: 291 */
+{offset: 291, bytesPerRow: 110}, {width: 20, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup103 = device0.createBindGroup({layout: veryExplicitBindGroupLayout12, entries: [{binding: 68, resource: textureView87}]});
+let texture180 = device0.createTexture({
+  size: [262, 1, 95],
+  dimension: '3d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler106 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 90.43});
+try {
+renderPassEncoder18.executeBundles([renderBundle3, renderBundle12]);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(7, buffer80, 252);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer31, 152, new Float32Array(60759), 13588, 56);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture177,
+  mipLevel: 2,
+  origin: {x: 17, y: 0, z: 10},
+  aspect: 'all',
+}, new Uint8Array(3_094).fill(32), /* required buffer size: 3_094 */
+{offset: 454, bytesPerRow: 44, rowsPerImage: 5}, {width: 11, height: 0, depthOrArrayLayers: 13});
+} catch {}
+let bindGroup104 = device0.createBindGroup({layout: veryExplicitBindGroupLayout16, entries: [{binding: 47, resource: textureView86}]});
+let texture181 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 21},
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView159 = texture97.createView({arrayLayerCount: 1});
+try {
+computePassEncoder21.setBindGroup(2, bindGroup58, new Uint32Array(1027), 269, 0);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(1, bindGroup72);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer31, 292, new DataView(new ArrayBuffer(5825)), 1276, 296);
+} catch {}
+let videoFrame30 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'film', transfer: 'unspecified'} });
+let commandEncoder162 = device1.createCommandEncoder();
+let renderBundle22 = renderBundleEncoder22.finish({});
+let sampler107 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 78.10,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder68.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+computePassEncoder45.setBindGroup(2, bindGroup3, new Uint32Array(223), 13, 0);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(5, buffer36, 10_028);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(1, bindGroup77, []);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(2, bindGroup32, new Uint32Array(100), 8, 0);
+} catch {}
+try {
+renderBundleEncoder23.setIndexBuffer(buffer38, 'uint16', 3_768, 452);
+} catch {}
+let texture182 = device0.createTexture({
+  size: {width: 525, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView160 = texture111.createView({baseMipLevel: 0});
+try {
+renderPassEncoder20.setBindGroup(2, bindGroup98);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(3, bindGroup19, new Uint32Array(2061), 941, 0);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer73, 'uint32', 100, 6);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(1, buffer50, 0, 956);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let commandEncoder163 = device1.createCommandEncoder({});
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup64, new Uint32Array(2274), 155, 0);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle22, renderBundle20, renderBundle20]);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer26, 'uint16', 3_640, 870);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(0, bindGroup100);
+} catch {}
+try {
+renderBundleEncoder23.setIndexBuffer(buffer46, 'uint32', 1_000, 31);
+} catch {}
+let veryExplicitBindGroupLayout25 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 28,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 33,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 60, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }},
+  ],
+});
+let commandEncoder164 = device0.createCommandEncoder();
+let computePassEncoder121 = commandEncoder164.beginComputePass({});
+try {
+renderPassEncoder36.setStencilReference(335);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer81, 'uint32', 60, 482);
+} catch {}
+let pipeline4 = device0.createRenderPipeline({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule0,
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule0,
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x4', offset: 620, shaderLocation: 13},
+          {format: 'float16x4', offset: 72, shaderLocation: 5},
+          {format: 'uint16x4', offset: 584, shaderLocation: 4},
+          {format: 'float32x2', offset: 212, shaderLocation: 6},
+          {format: 'sint32', offset: 196, shaderLocation: 11},
+        ],
+      },
+      {arrayStride: 32, attributes: [{format: 'sint8x2', offset: 4, shaderLocation: 7}]},
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'cw'},
+});
+canvas0.height = 964;
+let buffer86 = device0.createBuffer({
+  size: 7161,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder165 = device0.createCommandEncoder({});
+let textureView161 = texture88.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 3});
+let computePassEncoder122 = commandEncoder165.beginComputePass({});
+let sampler108 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 85.04});
+try {
+computePassEncoder38.setBindGroup(3, bindGroup18, new Uint32Array(1276), 378, 0);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer86, 'uint32', 260, 722);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(4, buffer11, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 525, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData13,
+  origin: { x: 3, y: 12 },
+  flipY: true,
+}, {
+  texture: texture133,
+  mipLevel: 0,
+  origin: {x: 31, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup105 = device1.createBindGroup({
+  label: '\u31bf\u0de4\u5c5d\u1297',
+  layout: veryExplicitBindGroupLayout18,
+  entries: [{binding: 284, resource: textureView115}],
+});
+let commandEncoder166 = device1.createCommandEncoder({});
+let textureView162 = texture89.createView({baseArrayLayer: 0});
+let computePassEncoder123 = commandEncoder163.beginComputePass({});
+let renderBundleEncoder24 = device1.createRenderBundleEncoder({colorFormats: ['r16uint', 'rgba16float'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup60, new Uint32Array(275), 111, 0);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer39, 'uint32', 4, 11);
+} catch {}
+let pipelineLayout16 = device1.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout9]});
+let texture183 = device1.createTexture({size: [864, 6, 1], format: 'r32float', usage: GPUTextureUsage.TEXTURE_BINDING});
+let texture184 = gpuCanvasContext3.getCurrentTexture();
+let renderPassEncoder43 = commandEncoder166.beginRenderPass({
+  colorAttachments: [{view: textureView8, depthSlice: 513, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet16,
+});
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup78);
+} catch {}
+let img4 = await imageWithData(103, 2, '#10101010', '#20202020');
+let pipelineLayout17 = device1.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout5]});
+let commandEncoder167 = device1.createCommandEncoder({});
+let texture185 = device1.createTexture({
+  size: [128, 128, 58],
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder124 = commandEncoder167.beginComputePass({});
+try {
+computePassEncoder8.setBindGroup(2, bindGroup51);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(1, bindGroup55, new Uint32Array(845), 22, 0);
+} catch {}
+document.body.append(canvas3);
+let commandEncoder168 = device1.createCommandEncoder();
+let externalTexture20 = device1.importExternalTexture({source: videoFrame30, colorSpace: 'display-p3'});
+try {
+computePassEncoder92.setBindGroup(3, bindGroup83, new Uint32Array(1024), 351, 0);
+} catch {}
+try {
+commandEncoder162.copyTextureToBuffer({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 112 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 720 */
+  offset: 720,
+  buffer: buffer82,
+}, {width: 42, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(28).fill(175), /* required buffer size: 28 */
+{offset: 28, bytesPerRow: 99, rowsPerImage: 60}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let autogeneratedBindGroupLayout5 = pipeline0.getBindGroupLayout(0);
+let bindGroup106 = device0.createBindGroup({layout: veryExplicitBindGroupLayout21, entries: [{binding: 47, resource: textureView86}]});
+let buffer87 = device0.createBuffer({size: 1561, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder169 = device0.createCommandEncoder({});
+let texture186 = device0.createTexture({size: [64, 64, 66], dimension: '3d', format: 'rg8uint', usage: GPUTextureUsage.COPY_SRC});
+try {
+renderPassEncoder41.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(2, bindGroup45, new Uint32Array(2722), 1_571, 0);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer5, 'uint32', 936, 125);
+} catch {}
+try {
+buffer42.unmap();
+} catch {}
+try {
+commandEncoder169.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 388 */
+  offset: 388,
+  bytesPerRow: 41216,
+  buffer: buffer79,
+}, {
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder169.copyTextureToTexture({
+  texture: texture161,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet23 = device0.createQuerySet({type: 'occlusion', count: 176});
+let renderPassEncoder44 = commandEncoder169.beginRenderPass({
+  colorAttachments: [{
+  view: textureView87,
+  clearValue: { r: -678.4, g: -653.4, b: 876.7, a: 538.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 114686535,
+});
+let sampler109 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 74.84,
+});
+try {
+computePassEncoder21.setBindGroup(1, bindGroup50);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(1, bindGroup21, new Uint32Array(1839), 1_201, 0);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle19, renderBundle13, renderBundle19, renderBundle9]);
+} catch {}
+await gc();
+let texture187 = device0.createTexture({
+  size: [65],
+  dimension: '1d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture188 = device0.createTexture({
+  size: {width: 110, height: 4985, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'astc-10x5-unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+document.body.append(img3);
+let bindGroup107 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout5,
+  entries: [{binding: 85, resource: textureView74}, {binding: 40, resource: textureView48}],
+});
+let buffer88 = device0.createBuffer({size: 13073, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView163 = texture151.createView({mipLevelCount: 1});
+try {
+renderPassEncoder44.setBindGroup(1, bindGroup69, new Uint32Array(550), 34, 0);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer41, 'uint16', 574, 1_485);
+} catch {}
+try {
+renderPassEncoder44.setVertexBuffer(1, buffer85, 304, 571);
+} catch {}
+let commandEncoder170 = device1.createCommandEncoder();
+let textureView164 = texture93.createView({aspect: 'all', format: 'r32uint'});
+let computePassEncoder125 = commandEncoder168.beginComputePass();
+let renderPassEncoder45 = commandEncoder170.beginRenderPass({
+  colorAttachments: [{
+  view: textureView28,
+  clearValue: { r: -565.3, g: -741.2, b: 561.7, a: -981.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 9024080,
+});
+let sampler110 = device1.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 86.51,
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder78.setBindGroup(1, bindGroup59);
+} catch {}
+try {
+commandEncoder162.copyTextureToTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 52},
+  aspect: 'all',
+},
+{
+  texture: texture149,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder171 = device0.createCommandEncoder();
+let texture189 = device0.createTexture({
+  size: [525],
+  dimension: '1d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder126 = commandEncoder171.beginComputePass({});
+let sampler111 = device0.createSampler({addressModeU: 'mirror-repeat', mipmapFilter: 'nearest', lodMaxClamp: 67.34});
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup62);
+} catch {}
+try {
+renderPassEncoder38.beginOcclusionQuery(70);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer67, 'uint16', 3_114, 701);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(3, buffer75, 0, 3_255);
+} catch {}
+try {
+buffer72.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(canvas2);
+let textureView165 = texture189.createView({dimension: '1d'});
+let texture190 = device0.createTexture({
+  size: [65],
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture191 = device1.createTexture({
+  size: {width: 48, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder127 = commandEncoder162.beginComputePass({});
+let renderBundle23 = renderBundleEncoder24.finish({});
+try {
+computePassEncoder105.setBindGroup(0, bindGroup51);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(4, buffer39, 4, 8);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let bindGroup108 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout0,
+  entries: [{binding: 40, resource: textureView48}, {binding: 85, resource: textureView87}],
+});
+let buffer89 = device0.createBuffer({
+  size: 6589,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder172 = device0.createCommandEncoder({});
+let computePassEncoder128 = commandEncoder172.beginComputePass({});
+let renderBundleEncoder25 = device0.createRenderBundleEncoder({colorFormats: ['rg8uint']});
+try {
+renderPassEncoder33.setBindGroup(1, bindGroup26);
+} catch {}
+try {
+renderBundleEncoder25.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder25.insertDebugMarker('\u054a');
+} catch {}
+let sampler112 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 99.75});
+try {
+computePassEncoder94.setBindGroup(2, bindGroup0, new Uint32Array(651), 195, 0);
+} catch {}
+try {
+renderPassEncoder38.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(5, buffer75, 2_460);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 32, new Float32Array(8242), 4664, 60);
+} catch {}
+let promise21 = device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {module: shaderModule0, targets: [{format: 'rg8uint', writeMask: GPUColorWrite.GREEN}]},
+  vertex: {
+    module: shaderModule0,
+    buffers: [
+      {
+        arrayStride: 32,
+        attributes: [
+          {format: 'float32x2', offset: 0, shaderLocation: 6},
+          {format: 'sint32x3', offset: 8, shaderLocation: 13},
+          {format: 'sint32', offset: 0, shaderLocation: 11},
+          {format: 'sint8x4', offset: 4, shaderLocation: 7},
+          {format: 'float32x3', offset: 8, shaderLocation: 5},
+        ],
+      },
+      {arrayStride: 152, attributes: [{format: 'uint16x2', offset: 0, shaderLocation: 4}]},
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'front'},
+});
+let veryExplicitBindGroupLayout26 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 57,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 87,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let bindGroup109 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout24,
+  entries: [{binding: 270, resource: textureView51}, {binding: 17, resource: textureView73}],
+});
+let buffer90 = device1.createBuffer({
+  size: 5813,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView166 = texture45.createView({arrayLayerCount: 1});
+try {
+computePassEncoder74.setBindGroup(3, bindGroup97);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder23.setIndexBuffer(buffer84, 'uint16', 228, 1_277);
+} catch {}
+await gc();
+let veryExplicitBindGroupLayout27 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 205,
+      visibility: 0,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let buffer91 = device1.createBuffer({
+  size: 20354,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let commandEncoder173 = device1.createCommandEncoder({});
+let renderBundle24 = renderBundleEncoder23.finish({});
+let sampler113 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  lodMaxClamp: 72.41,
+});
+try {
+computePassEncoder101.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle20, renderBundle20, renderBundle20, renderBundle22, renderBundle22, renderBundle20]);
+} catch {}
+try {
+computePassEncoder71.insertDebugMarker('\u01be');
+} catch {}
+try {
+device1.queue.submit([]);
+} catch {}
+try {
+renderPassEncoder27.setViewport(118.75480041359599, 0.3096215793510321, 167.3553086490717, 0.22313733624101073, 0.8820969000447856, 0.9624808872153372);
+} catch {}
+try {
+buffer59.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer14, 4216, new DataView(new ArrayBuffer(23)), 1, 4);
+} catch {}
+let sampler114 = device1.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', mipmapFilter: 'linear', lodMaxClamp: 90.01});
+try {
+computePassEncoder106.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(3, buffer48, 1_384, 3_711);
+} catch {}
+try {
+commandEncoder173.copyBufferToTexture({
+  /* bytesInLastRow: 160 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1552 */
+  offset: 1552,
+  bytesPerRow: 38144,
+  buffer: buffer51,
+}, {
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder173.resolveQuerySet(querySet5, 168, 63, buffer65, 0);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(134).fill(81), /* required buffer size: 134 */
+{offset: 134}, {width: 58, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img4);
+let commandEncoder174 = device1.createCommandEncoder({});
+let computePassEncoder129 = commandEncoder173.beginComputePass({label: '\u6738\ucf7d\u84ca\u{1fb66}'});
+try {
+computePassEncoder16.setBindGroup(2, bindGroup81);
+} catch {}
+try {
+computePassEncoder113.setBindGroup(3, bindGroup8, new Uint32Array(651), 29, 0);
+} catch {}
+try {
+renderPassEncoder45.setBindGroup(0, bindGroup52);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup52, new Uint32Array(2331), 501, 0);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer46, 'uint32', 160, 73);
+} catch {}
+document.body.prepend(img3);
+let texture192 = device0.createTexture({
+  size: {width: 65, height: 1, depthOrArrayLayers: 5},
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+renderPassEncoder21.setBindGroup(1, bindGroup50, new Uint32Array(431), 0, 0);
+} catch {}
+try {
+renderPassEncoder5.setViewport(8.073715491428537, 24.471171918654527, 2.996954300293587, 37.07224867170124, 0.8828622834013843, 0.9255901871823009);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer86, 'uint32', 692, 361);
+} catch {}
+try {
+renderBundleEncoder25.setPipeline(pipeline4);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+let pipeline5 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {module: shaderModule0, targets: [{format: 'rg8uint'}]},
+  vertex: {
+    module: shaderModule0,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 832,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint32x2', offset: 312, shaderLocation: 4},
+          {format: 'unorm8x2', offset: 584, shaderLocation: 6},
+          {format: 'sint32x4', offset: 28, shaderLocation: 11},
+          {format: 'sint32x4', offset: 196, shaderLocation: 7},
+          {format: 'sint32', offset: 52, shaderLocation: 13},
+          {format: 'float32', offset: 456, shaderLocation: 5},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw'},
+});
+let commandEncoder175 = device0.createCommandEncoder({});
+let texture193 = device0.createTexture({size: {width: 64}, dimension: '1d', format: 'rgba8unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+let computePassEncoder130 = commandEncoder175.beginComputePass();
+try {
+renderPassEncoder33.setBindGroup(0, bindGroup26, new Uint32Array(183), 9, 0);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer53, 'uint16', 4_726, 4_560);
+} catch {}
+let pipeline6 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule0,
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule0,
+    buffers: [
+      {
+        arrayStride: 52,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x4', offset: 0, shaderLocation: 11},
+          {format: 'sint32x2', offset: 20, shaderLocation: 7},
+          {format: 'uint32x3', offset: 0, shaderLocation: 4},
+          {format: 'float16x2', offset: 8, shaderLocation: 6},
+          {format: 'sint32x3', offset: 16, shaderLocation: 13},
+          {format: 'float16x4', offset: 12, shaderLocation: 5},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', frontFace: 'cw'},
+});
+let canvas4 = document.createElement('canvas');
+let bindGroup110 = device1.createBindGroup({layout: veryExplicitBindGroupLayout9, entries: [{binding: 205, resource: textureView154}]});
+try {
+computePassEncoder81.setBindGroup(0, bindGroup56);
+} catch {}
+try {
+renderPassEncoder30.executeBundles([renderBundle22, renderBundle22, renderBundle22]);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer51, 'uint32', 2_020, 148);
+} catch {}
+try {
+commandEncoder174.copyBufferToTexture({
+  /* bytesInLastRow: 444 widthInBlocks: 111 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1332 */
+  offset: 1332,
+  bytesPerRow: 16896,
+  rowsPerImage: 27,
+  buffer: buffer25,
+}, {
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 95, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 111, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1728, height: 12, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData7,
+  origin: { x: 4, y: 0 },
+  flipY: true,
+}, {
+  texture: texture136,
+  mipLevel: 0,
+  origin: {x: 18, y: 11, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let buffer92 = device0.createBuffer({
+  size: 3523,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let textureView167 = texture77.createView({dimension: '2d'});
+try {
+renderPassEncoder29.setBindGroup(2, bindGroup43, new Uint32Array(7800), 1_770, 0);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(3, bindGroup40, new Uint32Array(2927), 140, 0);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(6, buffer5, 72, 269);
+} catch {}
+try {
+buffer37.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(132).fill(108), /* required buffer size: 132 */
+{offset: 132, rowsPerImage: 42}, {width: 42, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+canvas4.getContext('webgpu');
+} catch {}
+let bindGroup111 = device0.createBindGroup({layout: veryExplicitBindGroupLayout3, entries: [{binding: 10, resource: textureView6}]});
+let textureView168 = texture99.createView({});
+let renderBundleEncoder26 = device0.createRenderBundleEncoder({
+  label: '\u16f7\uf833\u{1ff8f}\u2f20\u97a5\u{1fe20}\ucc1b\u5518\u8ad6',
+  colorFormats: ['rgba16uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder121.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+computePassEncoder64.setBindGroup(2, bindGroup47, new Uint32Array(1064), 143, 0);
+} catch {}
+try {
+renderPassEncoder19.setBlendConstant({ r: 118.1, g: -972.4, b: -938.7, a: 424.4, });
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let imageData17 = new ImageData(36, 20);
+let commandEncoder176 = device1.createCommandEncoder();
+let texture194 = gpuCanvasContext2.getCurrentTexture();
+try {
+computePassEncoder45.setBindGroup(1, bindGroup95);
+} catch {}
+try {
+commandEncoder174.copyTextureToTexture({
+  texture: texture144,
+  mipLevel: 0,
+  origin: {x: 37, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 105},
+  aspect: 'all',
+},
+{width: 22, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderBundleEncoder27 = device1.createRenderBundleEncoder({colorFormats: ['rg32float'], stencilReadOnly: true});
+try {
+computePassEncoder81.setBindGroup(0, bindGroup2, new Uint32Array(1844), 700, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup88);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup28, new Uint32Array(1698), 208, 0);
+} catch {}
+try {
+renderPassEncoder42.setVertexBuffer(4, buffer36, 0);
+} catch {}
+try {
+commandEncoder174.copyTextureToBuffer({
+  texture: texture174,
+  mipLevel: 0,
+  origin: {x: 178, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 40 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1664 */
+  offset: 1664,
+  bytesPerRow: 17664,
+  buffer: buffer55,
+}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 432, height: 3, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData13,
+  origin: { x: 2, y: 1 },
+  flipY: false,
+}, {
+  texture: texture144,
+  mipLevel: 0,
+  origin: {x: 85, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let buffer93 = device0.createBuffer({
+  size: 2712,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder177 = device0.createCommandEncoder({});
+let textureView169 = texture68.createView({dimension: '2d', baseArrayLayer: 1});
+let computePassEncoder131 = commandEncoder177.beginComputePass({});
+try {
+renderPassEncoder44.setIndexBuffer(buffer86, 'uint16', 970, 165);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(3, undefined);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(3, bindGroup93, [2048]);
+} catch {}
+let promise22 = device0.queue.onSubmittedWorkDone();
+let commandEncoder178 = device0.createCommandEncoder({});
+let computePassEncoder132 = commandEncoder178.beginComputePass({});
+let renderBundle25 = renderBundleEncoder25.finish({});
+try {
+computePassEncoder130.setBindGroup(0, bindGroup45);
+} catch {}
+try {
+computePassEncoder91.setBindGroup(2, bindGroup14, new Uint32Array(505), 258, 0);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(3, bindGroup44);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(1, bindGroup94, new Uint32Array(3076), 270, 0);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(buffer73, 'uint32', 72, 2);
+} catch {}
+let promise23 = device0.queue.onSubmittedWorkDone();
+let pipeline7 = device0.createRenderPipeline({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule0,
+    buffers: [
+      {
+        arrayStride: 348,
+        attributes: [
+          {format: 'float32', offset: 180, shaderLocation: 5},
+          {format: 'snorm16x4', offset: 60, shaderLocation: 6},
+          {format: 'sint8x4', offset: 100, shaderLocation: 7},
+          {format: 'sint16x4', offset: 44, shaderLocation: 13},
+          {format: 'uint32', offset: 28, shaderLocation: 4},
+          {format: 'sint32', offset: 68, shaderLocation: 11},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', frontFace: 'cw', cullMode: 'front'},
+});
+let autogeneratedBindGroupLayout6 = pipeline3.getBindGroupLayout(0);
+let commandEncoder179 = device0.createCommandEncoder({});
+let textureView170 = texture69.createView({dimension: '1d', mipLevelCount: 1, arrayLayerCount: 1});
+try {
+renderPassEncoder39.setIndexBuffer(buffer10, 'uint32', 22_080, 778);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(2, buffer93);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(buffer31, 'uint16', 2_364, 110);
+} catch {}
+try {
+  await promise22;
+} catch {}
+let bindGroup112 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout15,
+  entries: [
+    {binding: 17, resource: textureView59},
+    {binding: 196, resource: sampler90},
+    {binding: 191, resource: textureView53},
+    {binding: 91, resource: sampler103},
+    {binding: 13, resource: textureView45},
+    {binding: 63, resource: textureView16},
+    {binding: 169, resource: textureView166},
+    {binding: 339, resource: {buffer: buffer82, offset: 0, size: 12160}},
+    {binding: 48, resource: textureView80},
+    {binding: 216, resource: textureView59},
+    {binding: 456, resource: textureView31},
+    {binding: 41, resource: textureView28},
+    {binding: 122, resource: {buffer: buffer20, offset: 2560, size: 1765}},
+  ],
+});
+let sampler115 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 96.56,
+  maxAnisotropy: 15,
+});
+let externalTexture21 = device1.importExternalTexture({source: videoFrame17, colorSpace: 'srgb'});
+try {
+computePassEncoder106.setBindGroup(2, bindGroup60);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer68, 'uint32', 532, 49);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(2, buffer47);
+} catch {}
+try {
+commandEncoder174.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 9248 */
+  offset: 9248,
+  bytesPerRow: 5376,
+  buffer: buffer19,
+}, {
+  texture: texture75,
+  mipLevel: 0,
+  origin: {x: 33, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder174.copyTextureToBuffer({
+  texture: texture140,
+  mipLevel: 0,
+  origin: {x: 68, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1650 */
+  offset: 1650,
+  bytesPerRow: 4096,
+  buffer: buffer62,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup113 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout26,
+  entries: [{binding: 87, resource: sampler101}, {binding: 57, resource: textureView54}],
+});
+let commandEncoder180 = device1.createCommandEncoder({});
+let texture195 = device1.createTexture({
+  size: [540, 10, 1],
+  sampleCount: 4,
+  dimension: '2d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder133 = commandEncoder180.beginComputePass();
+try {
+renderPassEncoder6.setIndexBuffer(buffer38, 'uint16', 3_172, 1_782);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(6, buffer71, 3_036);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(2, bindGroup56);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(1, bindGroup105, new Uint32Array(1002), 41, 0);
+} catch {}
+let texture196 = device1.createTexture({
+  size: {width: 96, height: 1, depthOrArrayLayers: 19},
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder41.setBindGroup(2, bindGroup51, new Uint32Array(1105), 55, 0);
+} catch {}
+try {
+commandEncoder176.copyTextureToTexture({
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture185,
+  mipLevel: 0,
+  origin: {x: 14, y: 23, z: 4},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder174.resolveQuerySet(querySet16, 42, 37, buffer43, 512);
+} catch {}
+let veryExplicitBindGroupLayout28 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 17,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 270,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '1d' },
+    },
+  ],
+});
+let commandEncoder181 = device1.createCommandEncoder({});
+let textureView171 = texture61.createView({dimension: '2d-array', baseArrayLayer: 0, arrayLayerCount: 1});
+try {
+computePassEncoder9.setBindGroup(2, bindGroup22);
+} catch {}
+try {
+computePassEncoder33.setBindGroup(1, bindGroup22, new Uint32Array(1192), 168, 0);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(1, bindGroup113, new Uint32Array(123), 8, 0);
+} catch {}
+await gc();
+let autogeneratedBindGroupLayout7 = pipeline4.getBindGroupLayout(0);
+let computePassEncoder134 = commandEncoder179.beginComputePass({});
+try {
+computePassEncoder17.setBindGroup(2, bindGroup10, new Uint32Array(1660), 122, 0);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(buffer72, 'uint32', 260, 56);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(1, buffer23, 0);
+} catch {}
+let pipeline8 = device0.createComputePipeline({layout: pipelineLayout11, compute: {module: shaderModule0}});
+document.body.prepend(canvas1);
+let imageData18 = new ImageData(20, 20);
+let bindGroup114 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 154, resource: {buffer: buffer91, offset: 6656, size: 4500}}],
+});
+let pipelineLayout18 = device1.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout24]});
+let commandEncoder182 = device1.createCommandEncoder({});
+let texture197 = device1.createTexture({size: [48, 1, 1], format: 'r16uint', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC});
+let textureView172 = texture195.createView({});
+let computePassEncoder135 = commandEncoder181.beginComputePass();
+let renderPassEncoder46 = commandEncoder176.beginRenderPass({
+  colorAttachments: [{
+  view: textureView109,
+  clearValue: { r: 837.9, g: 946.8, b: -604.6, a: 610.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 172236226,
+});
+let renderBundleEncoder28 = device1.createRenderBundleEncoder({colorFormats: ['rg32float'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle26 = renderBundleEncoder27.finish();
+try {
+renderBundleEncoder28.setVertexBuffer(6, buffer0, 1_008, 62);
+} catch {}
+try {
+commandEncoder182.copyBufferToTexture({
+  /* bytesInLastRow: 140 widthInBlocks: 35 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1412 */
+  offset: 1412,
+  buffer: buffer90,
+}, {
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 33, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 35, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder174.copyTextureToTexture({
+  texture: texture93,
+  mipLevel: 0,
+  origin: {x: 72, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture118,
+  mipLevel: 0,
+  origin: {x: 173, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer62, 2256, new BigUint64Array(16023), 1836, 724);
+} catch {}
+document.body.prepend(canvas2);
+try {
+externalTexture3.label = '\u01e8\u0f79\u08a2\u{1f85a}\u0057\u{1f610}';
+} catch {}
+let buffer94 = device0.createBuffer({
+  size: 6772,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let commandEncoder183 = device0.createCommandEncoder({});
+let renderPassEncoder47 = commandEncoder183.beginRenderPass({colorAttachments: [{view: textureView33, loadOp: 'clear', storeOp: 'discard'}]});
+let sampler116 = device0.createSampler({addressModeU: 'repeat'});
+try {
+renderBundleEncoder26.setBindGroup(3, bindGroup21);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(0, buffer41, 0, 1_286);
+} catch {}
+let imageData19 = new ImageData(8, 4);
+let texture198 = device0.createTexture({
+  size: {width: 525},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder25.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup68);
+} catch {}
+try {
+renderPassEncoder41.setBlendConstant({ r: 544.9, g: -842.7, b: 910.0, a: 784.3, });
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer31, 'uint16', 308, 1_025);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(0, bindGroup101, []);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture91,
+  mipLevel: 0,
+  origin: {x: 7, y: 2, z: 7},
+  aspect: 'all',
+}, new Uint8Array(53).fill(222), /* required buffer size: 53 */
+{offset: 53, rowsPerImage: 12}, {width: 6, height: 1, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas4);
+let bindGroup115 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout3,
+  entries: [{binding: 40, resource: textureView160}, {binding: 85, resource: textureView74}],
+});
+let querySet24 = device0.createQuerySet({type: 'occlusion', count: 3456});
+let renderBundle27 = renderBundleEncoder26.finish({});
+try {
+renderPassEncoder47.setBindGroup(0, bindGroup72);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup58, new Uint32Array(2797), 65, 0);
+} catch {}
+try {
+renderPassEncoder36.executeBundles([renderBundle12, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder25.setViewport(437.1095276056366, 0.9516685797020161, 69.64359131174598, 0.0196659605884525, 0.7349077101163929, 0.9393664153761);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer81, 'uint32', 144, 571);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(6, buffer75, 0, 3_500);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+renderPassEncoder26.insertDebugMarker('\ub1d3');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture165,
+  mipLevel: 0,
+  origin: {x: 129, y: 0, z: 6},
+  aspect: 'all',
+}, new Uint8Array(7_810).fill(176), /* required buffer size: 7_810 */
+{offset: 250, bytesPerRow: 63, rowsPerImage: 10}, {width: 5, height: 0, depthOrArrayLayers: 13});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+adapter1.label = '\u0124\u{1f8eb}\u9510\u359d\u{1fce7}';
+} catch {}
+let commandEncoder184 = device1.createCommandEncoder({});
+let texture199 = device1.createTexture({
+  size: {width: 128, height: 128, depthOrArrayLayers: 13},
+  mipLevelCount: 3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder136 = commandEncoder174.beginComputePass({});
+let renderPassEncoder48 = commandEncoder184.beginRenderPass({
+  colorAttachments: [{
+  view: textureView146,
+  clearValue: { r: 223.9, g: -841.3, b: -52.78, a: -954.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder8.setBindGroup(1, bindGroup20, []);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup46);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup52, new Uint32Array(360), 60, 0);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(2, buffer71, 0);
+} catch {}
+let bindGroup116 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout3,
+  entries: [{binding: 85, resource: textureView116}, {binding: 40, resource: textureView48}],
+});
+let commandEncoder185 = device0.createCommandEncoder();
+let textureView173 = texture97.createView({});
+let computePassEncoder137 = commandEncoder185.beginComputePass({});
+try {
+computePassEncoder21.setBindGroup(3, bindGroup66);
+} catch {}
+try {
+computePassEncoder35.setBindGroup(0, bindGroup37, new Uint32Array(1184), 204, 0);
+} catch {}
+try {
+buffer28.unmap();
+} catch {}
+let pipeline9 = device0.createComputePipeline({layout: pipelineLayout0, compute: {module: shaderModule0, entryPoint: 'compute0'}});
+let commandEncoder186 = device0.createCommandEncoder({});
+try {
+computePassEncoder75.setBindGroup(1, bindGroup37, new Uint32Array(3481), 723, 0);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(1, bindGroup11, new Uint32Array(2148), 61, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture189,
+  mipLevel: 0,
+  origin: {x: 46, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(152).fill(19), /* required buffer size: 152 */
+{offset: 152}, {width: 85, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture200 = device0.createTexture({
+  size: {width: 262, height: 1, depthOrArrayLayers: 78},
+  mipLevelCount: 2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView174 = texture160.createView({format: 'rg8uint', arrayLayerCount: 3});
+try {
+computePassEncoder48.setBindGroup(0, bindGroup68);
+} catch {}
+try {
+renderPassEncoder38.setStencilReference(43);
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer31, 'uint16', 1_000, 109);
+} catch {}
+try {
+buffer24.unmap();
+} catch {}
+try {
+commandEncoder186.copyBufferToBuffer(buffer79, 1032, buffer80, 348, 956);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let bindGroup117 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [{binding: 93, resource: {buffer: buffer83, offset: 0, size: 299}}],
+});
+let texture201 = device0.createTexture({
+  size: [262, 1, 2],
+  mipLevelCount: 1,
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder138 = commandEncoder186.beginComputePass({});
+try {
+computePassEncoder118.setPipeline(pipeline8);
+} catch {}
+let buffer95 = device0.createBuffer({
+  size: 9344,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture202 = device0.createTexture({
+  size: {width: 262, height: 1, depthOrArrayLayers: 1},
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture203 = gpuCanvasContext1.getCurrentTexture();
+let externalTexture22 = device0.importExternalTexture({source: videoFrame9});
+try {
+computePassEncoder20.setBindGroup(3, bindGroup10, new Uint32Array(533), 82, 0);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup118 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout8,
+  entries: [
+    {binding: 117, resource: {buffer: buffer46, offset: 256, size: 542}},
+    {binding: 307, resource: {buffer: buffer0, offset: 0, size: 1192}},
+  ],
+});
+let computePassEncoder139 = commandEncoder182.beginComputePass({});
+try {
+computePassEncoder41.setBindGroup(3, bindGroup2, new Uint32Array(3811), 862, 0);
+} catch {}
+try {
+buffer62.unmap();
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let bindGroup119 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout3,
+  entries: [{binding: 85, resource: textureView116}, {binding: 40, resource: textureView116}],
+});
+let pipelineLayout19 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout2]});
+let buffer96 = device0.createBuffer({size: 39894, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let texture204 = device0.createTexture({size: {width: 131}, dimension: '1d', format: 'rgba8unorm', usage: GPUTextureUsage.STORAGE_BINDING});
+let sampler117 = device0.createSampler({addressModeV: 'mirror-repeat', lodMinClamp: 18.72, compare: 'always'});
+try {
+computePassEncoder62.setBindGroup(1, bindGroup19, new Uint32Array(178), 27, 0);
+} catch {}
+try {
+computePassEncoder88.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(3, bindGroup42, new Uint32Array(1219), 55, 0);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle9, renderBundle19, renderBundle13]);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(6, buffer11);
+} catch {}
+try {
+computePassEncoder110.pushDebugGroup('\u0fa3');
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+computePassEncoder9.setBindGroup(3, bindGroup87);
+} catch {}
+try {
+computePassEncoder127.setBindGroup(3, bindGroup52, new Uint32Array(1756), 66, 0);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(1, bindGroup83, new Uint32Array(129), 5, 0);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer71, 548, new Int16Array(5233), 431, 852);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(82).fill(5), /* required buffer size: 82 */
+{offset: 82}, {width: 11, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let imageData20 = new ImageData(164, 16);
+let texture205 = device0.createTexture({
+  size: {width: 462, height: 95, depthOrArrayLayers: 1},
+  format: 'astc-6x5-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder121.setBindGroup(3, bindGroup45);
+} catch {}
+try {
+computePassEncoder28.setPipeline(pipeline8);
+} catch {}
+try {
+computePassEncoder91.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(2, bindGroup63, new Uint32Array(535), 7, 0);
+} catch {}
+try {
+renderPassEncoder14.setBlendConstant({ r: -616.0, g: 666.7, b: 418.8, a: 937.2, });
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(6, undefined);
+} catch {}
+let videoFrame31 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'unspecified', transfer: 'log'} });
+let bindGroup120 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 154, resource: {buffer: buffer20, offset: 1792, size: 4848}}],
+});
+let texture206 = device1.createTexture({
+  size: {width: 216, height: 1, depthOrArrayLayers: 1},
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView175 = texture142.createView({mipLevelCount: 1, baseArrayLayer: 0});
+let renderBundle28 = renderBundleEncoder28.finish({});
+try {
+computePassEncoder80.setBindGroup(0, bindGroup67);
+} catch {}
+try {
+computePassEncoder95.setBindGroup(2, bindGroup81, new Uint32Array(1590), 1_162, 0);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(5, buffer45, 5_980, 76);
+} catch {}
+try {
+device1.pushErrorScope('validation');
+} catch {}
+document.body.prepend(canvas3);
+let bindGroup121 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout5,
+  entries: [{binding: 85, resource: textureView87}, {binding: 40, resource: textureView83}],
+});
+let buffer97 = device0.createBuffer({size: 13193, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView176 = texture133.createView({dimension: '2d-array'});
+let texture207 = device0.createTexture({
+  size: [262, 1, 16],
+  mipLevelCount: 2,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView177 = texture172.createView({dimension: '2d'});
+try {
+computePassEncoder17.setBindGroup(0, bindGroup98);
+} catch {}
+try {
+computePassEncoder93.setPipeline(pipeline9);
+} catch {}
+try {
+computePassEncoder56.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup37);
+} catch {}
+let bindGroup122 = device0.createBindGroup({layout: veryExplicitBindGroupLayout3, entries: [{binding: 10, resource: textureView69}]});
+let commandEncoder187 = device0.createCommandEncoder({});
+try {
+computePassEncoder98.setBindGroup(3, bindGroup68, new Uint32Array(1302), 447, 0);
+} catch {}
+try {
+computePassEncoder93.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(2, bindGroup122);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup115, new Uint32Array(1213), 25, 0);
+} catch {}
+let pipeline10 = device0.createRenderPipeline({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule0,
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule0,
+    buffers: [
+      {
+        arrayStride: 468,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x4', offset: 164, shaderLocation: 6},
+          {format: 'sint32x3', offset: 116, shaderLocation: 7},
+          {format: 'float32', offset: 108, shaderLocation: 5},
+          {format: 'sint8x4', offset: 0, shaderLocation: 13},
+          {format: 'uint8x4', offset: 32, shaderLocation: 4},
+          {format: 'sint16x2', offset: 52, shaderLocation: 11},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw'},
+});
+let texture208 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 21},
+  sampleCount: 1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder140 = commandEncoder187.beginComputePass({});
+let sampler118 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  compare: 'greater-equal',
+});
+try {
+computePassEncoder98.setBindGroup(3, bindGroup54, new Uint32Array(479), 210, 0);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer93, 'uint32', 400, 1_034);
+} catch {}
+let autogeneratedBindGroupLayout8 = pipeline1.getBindGroupLayout(0);
+let commandEncoder188 = device0.createCommandEncoder();
+let texture209 = device0.createTexture({
+  size: [131],
+  dimension: '1d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+  await shaderModule0.getCompilationInfo();
+} catch {}
+let bindGroup123 = device1.createBindGroup({layout: veryExplicitBindGroupLayout9, entries: [{binding: 205, resource: textureView148}]});
+let buffer98 = device1.createBuffer({size: 23237, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let sampler119 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 86.73,
+});
+try {
+computePassEncoder16.setBindGroup(3, bindGroup100);
+} catch {}
+try {
+computePassEncoder135.setBindGroup(1, bindGroup60, new Uint32Array(213), 76, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup105);
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(2, bindGroup46, new Uint32Array(1310), 198, 0);
+} catch {}
+try {
+renderPassEncoder35.executeBundles([renderBundle22]);
+} catch {}
+try {
+renderPassEncoder11.setViewport(41.67686660334708, 0.14647873011380252, 378.67965139294745, 0.36293401459857894, 0.2942759201955615, 0.6762987832362877);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer39, 'uint32', 0, 0);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(5, buffer39, 0);
+} catch {}
+let computePassEncoder141 = commandEncoder188.beginComputePass({});
+try {
+computePassEncoder65.setPipeline(pipeline8);
+} catch {}
+try {
+gpuCanvasContext1.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+} catch {}
+let commandEncoder189 = device1.createCommandEncoder({});
+let textureView178 = texture12.createView({});
+let computePassEncoder142 = commandEncoder189.beginComputePass();
+try {
+computePassEncoder59.setBindGroup(0, bindGroup31, new Uint32Array(1665), 1_001, 0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup28);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(3, bindGroup77, new Uint32Array(61), 7, 0);
+} catch {}
+try {
+renderPassEncoder3.setViewport(8.26138701582418, 1.662498703334958, 56.5013296367197, 0.2833626941418848, 0.42892765254574017, 0.6986884377546843);
+} catch {}
+let shaderModule1 = device1.createShaderModule({
+  code: `
+enable f16;
+
+requires pointer_composite_access;
+
+var<workgroup> vw5: array<atomic<i32>, 58>;
+
+struct T1 {
+  @align(32) @size(1632) f0: array<u32>,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+/* used global variables: buffer99 */
+fn fn1() -> VertexOutput0 {
+  var out: VertexOutput0;
+  let vf25: bool = (unconst_u32(244) < unconst_u32(521));
+  if bool(unpack4x8unorm(unconst_u32(101))[1]) {
+  out.f0 = f16(ceil(unconst_f32(0.03386)));
+  let vf26: u32 = atomicLoad(&buffer99.f0[unconst_u32(44)]);
+  let vf27: bool = (bool(atomicLoad(&(*&buffer99).f0[unconst_i32(-225)])) || unconst_bool(true));
+  for (var it2=u32(atomicLoad(&vw5[57])); it2<u32(atomicLoad(&vw5[57])); it2++) {
+  let vf28: i32 = atomicLoad(&vw5[57]);
+  vp0 = modf(vec3f(f32(distance(unconst_f16(17662.3), fma(vec3h(unconst_f16(12565.6), unconst_f16(22342.0), unconst_f16(240.4)), vec3h(unconst_f16(11750.4), unconst_f16(5658.0), unconst_f16(967.5)), vec3h(f16(atomicLoad(&(*&buffer99).f0[unconst_i32(-7)]))))[1]))));
+  let ptr6: ptr<workgroup, atomic<i32>> = &(*&vw5)[57];
+  var vf29: vec4<bool> = (vec4f(unconst_f32(0.5435), unconst_f32(0.1308), unconst_f32(0.07773), unconst_f32(-0.1064)) < vec4f(unconst_f32(0.01081), unconst_f32(-0.00152), unconst_f32(1.000), unconst_f32(0.09864)));
+  var vf30: bool = override4;
+  var vf31: vec4u = unpack4xU8(unconst_u32(19));
+  let vf32: f32 = acosh(bitcast<f32>(atomicLoad(&(*&buffer99).f0[unconst_u32(133)])));
+  out.f1 -= unpack4xI8(pack4xI8Clamp(vec4i(unconst_i32(177), unconst_i32(-23), unconst_i32(42), unconst_i32(326))));
+  break;
+  _ = override4;
+  _ = buffer99;
+}
+  let ptr7: ptr<private, vec3f> = &vp0.fract;
+  let ptr8: ptr<storage, array<atomic<u32>>, read_write> = &buffer99.f0;
+  var vf33: u32 = pack4xU8(vec4u(unconst_u32(915), unconst_u32(240), unconst_u32(12), unconst_u32(212)));
+  let ptr9: ptr<storage, atomic<u32>, read_write> = &buffer99.f0[unconst_i32(83)];
+  var vf34: u32 = insertBits(unconst_u32(69), unconst_u32(125), unconst_u32(81), unconst_u32(228));
+  let ptr10: ptr<storage, atomic<u32>, read_write> = &(*ptr9);
+  _ = override4;
+  _ = buffer99;
+}
+  let ptr11: ptr<storage, atomic<u32>, read_write> = &buffer99.f0[unconst_i32(379)];
+  let ptr12: ptr<workgroup, atomic<i32>> = &(*&vw5)[unconst_u32(59)];
+  var vf35: i32 = atomicExchange(&(*ptr12), unconst_i32(89));
+  let ptr13: ptr<storage, atomic<u32>, read_write> = &(*&buffer99).f0[unconst_u32(91)];
+  out.f0 = f16(dot4I8Packed(unconst_u32(243), unconst_u32(240)));
+  let vf36: vec2f = smoothstep(vec2f(unconst_f32(0.1346), unconst_f32(-0.02297)), vec2f(unconst_f32(0.2321), unconst_f32(0.1671)), vec2f(unconst_f32(0.1026), unconst_f32(0.05309)));
+  return out;
+  _ = override4;
+  _ = buffer99;
+}
+
+@id(18581) override override2: bool;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<private> vp0 = modf(vec3f(0.02215, 0.07436, 0.3084));
+
+/* zero global variables used */
+fn fn0() -> array<array<array<array<f32, 1>, 1>, 1>, 27> {
+  var out: array<array<array<array<f32, 1>, 1>, 1>, 27>;
+  for (var it1=vec3u(vp0.fract).g; it1<u32(ldexp(vec2h((vec2<bool>(unconst_bool(true), unconst_bool(false)) & vec2<bool>(unconst_bool(false), unconst_bool(true))))[1], unconst_i32(105))); it1++) {
+  vp0.whole = vec3f(sqrt(vec4h(unconst_f16(27388.1), unconst_f16(1281.4), unconst_f16(15904.0), unconst_f16(19146.3))).wzy);
+  out[unconst_u32(93)][unconst_u32(142)][vec3u(vp0.fract).y][unconst_u32(43)] *= f32(round(unconst_f16(3505.4)));
+}
+  let vf20: vec2f = unpack2x16snorm(unconst_u32(65));
+  var vf21: vec4u = unpack4xU8(unconst_u32(284));
+  var vf22: bool = any(unconst_bool(false));
+  var vf23: u32 = pack4xU8Clamp(vec4u(unconst_u32(97), unconst_u32(18), unconst_u32(352), unconst_u32(488)));
+  let vf24: vec4u = abs(bitcast<vec4u>(select(vec3f(f32(override2)), vec3f(unconst_f32(0.08291), unconst_f32(0.01720), unconst_f32(0.5677)), vec3<bool>(unconst_bool(false), unconst_bool(true), unconst_bool(true))).brrg));
+  vp0.whole = vec3f(bitcast<f32>(pack4xI8(vec4i(unconst_i32(25), unconst_i32(143), unconst_i32(570), unconst_i32(2)))));
+  return out;
+  _ = override2;
+}
+
+override override3: i32 = 46;
+
+struct T0 {
+  @size(2432) f0: array<atomic<u32>>,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@id(48238) override override4: bool;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct VertexOutput0 {
+  @location(15) f0: f16,
+  @location(13) f1: vec4i,
+  @builtin(position) f2: vec4f,
+  @location(2) @interpolate(flat, either) f3: vec4i,
+}
+
+@group(0) @binding(154) var<storage, read_write> buffer99: T0;
+
+/* zero global variables used */
+fn fn2() {
+  let vf37: vec2h = asinh(vec2h(unconst_f16(624.0), unconst_f16(2915.0)));
+  let vf38: vec2f = quantizeToF16(vec2f(unconst_f32(0.1700), unconst_f32(0.04585)));
+  for (var it3=vec2u((vec2h(unconst_f16(33818.7), unconst_f16(3019.4)) > vec2h(unconst_f16(1789.7), unconst_f16(1032.0)))).r; it3<pack4xU8(max(vec4u(unconst_u32(88), unconst_u32(231), unconst_u32(1), unconst_u32(158)), vec4u(unconst_u32(19), unconst_u32(47), unconst_u32(283), unconst_u32(147)))); it3++) {
+  let ptr14: ptr<private, vec3f> = &vp0.fract;
+  var vf39: bool = override4;
+  let ptr15 = &vp0;
+  var vf40: f32 = quantizeToF16(unconst_f32(0.2861));
+  vf39 = bool(pack4x8unorm(vec4f(unconst_f32(0.2396), unconst_f32(0.03321), unconst_f32(0.1799), unconst_f32(0.8188))));
+  vf39 = bool(vp0.fract[0]);
+  _ = override4;
+}
+  vp0.fract = vec3f(f32((bool(vf37[unconst_u32(654)]) && unconst_bool(false))));
+  if bool(vp0.whole[0]) {
+  vp0.fract *= vec3f(asin(vec3h(unconst_f16(612.0), unconst_f16(5263.0), unconst_f16(-15093.9))));
+  vp0 = modf(vec3f(faceForward(vec3h(unconst_f16(4711.6), unconst_f16(21603.0), unconst_f16(4498.3)), vec3h(unconst_f16(551.4), unconst_f16(-19831.1), unconst_f16(2326.2)), vec3h(unconst_f16(18372.7), unconst_f16(7837.2), unconst_f16(-33670.0)))));
+  vp0 = modf(vec3f(f32(override2)));
+  switch (unconst_i32(317) << unconst_u32(9)) { 
+  default {
+  vp0 = modf(vec3f(unpack4xU8(unconst_u32(34)).zwz));
+  var vf41: vec2f = unpack2x16float(unconst_u32(9));
+  vp0.fract += vec3f(transpose(mat4x2h(unconst_f16(19219.2), unconst_f16(4697.9), unconst_f16(14667.5), unconst_f16(8456.9), unconst_f16(1422.3), unconst_f16(9040.8), unconst_f16(392.3), unconst_f16(8760.2)))[unconst_i32(1)].abr);
+  let vf42: vec4u = unpack4xU8(vec4u(transpose(mat4x2h(unconst_f16(3925.5), unconst_f16(20367.5), unconst_f16(31164.6), unconst_f16(8389.5), unconst_f16(377.3), unconst_f16(17799.5), unconst_f16(874.9), unconst_f16(1039.8)))[unconst_i32(1)])[0]);
+  var vf43: vec4i = abs(vec4i(unconst_i32(11), unconst_i32(361), unconst_i32(208), unconst_i32(158)));
+}
+  }
+  var vf44: vec3f = tanh(vec3f(unconst_f32(0.5996), unconst_f32(0.07527), unconst_f32(-0.01239)));
+  let ptr16: ptr<private, vec3f> = &vp0.whole;
+  var vf45: i32 = override3;
+  _ = override3;
+  _ = override2;
+}
+  let vf46: vec2h = vf37;
+  var vf47: vec2h = vf46;
+  vf47 -= vec2h(f16(all(vec4<bool>(unconst_bool(false), unconst_bool(false), unconst_bool(false), unconst_bool(false)))));
+  vp0 = modf(vec3f(f32(vf46[unconst_u32(226)])));
+  let vf48: vec3i = firstLeadingBit(vec3i(unconst_i32(94), unconst_i32(-69), unconst_i32(227)));
+  let ptr17: ptr<function, vec2h> = &vf47;
+  vf47 *= vec2h(vf48.gg);
+  vf47 -= vec2h((vec2i(unconst_i32(108), unconst_i32(255)) + vec2i(unconst_i32(309), unconst_i32(592))));
+  let vf49: vec3h = faceForward(vec3h(unconst_f16(7009.0), unconst_f16(7174.0), unconst_f16(4938.3)), vec3h(unconst_f16(55404.7), unconst_f16(4880.1), unconst_f16(5218.0)), vec3h(unconst_f16(8649.1), unconst_f16(2185.6), unconst_f16(18267.2)));
+  var vf50: bool = all(unconst_bool(false));
+  vf50 = bool(vf47.y);
+  let vf51: vec2<bool> = (vec2h(unconst_f16(19183.5), unconst_f16(1909.6)) > vec2h(unconst_f16(19310.9), unconst_f16(90.39)));
+  _ = override4;
+  _ = override3;
+  _ = override2;
+}
+
+/* zero global variables used */
+@vertex
+fn vertex1(@location(5) @interpolate(linear) a0: vec4f, @location(2) a1: vec2f, @location(10) a2: vec4u, @location(12) @interpolate(flat) a3: i32) -> VertexOutput0 {
+  var out: VertexOutput0;
+  fn0();
+  var vf52: u32 = dot4U8Packed(u32(a3), unconst_u32(466));
+  var vf53 = fn0();
+  let ptr18: ptr<function, array<f32, 1>> = &vf53[unconst_u32(355)][vec3u(vp0.whole).x][bitcast<u32>(vf53[26][0][0][0])];
+  fn2();
+  fn2();
+  var vf54 = fn0();
+  fn2();
+  out.f0 *= f16(vf53[26][0][unconst_u32(116)][unconst_u32(84)]);
+  var vf55 = fn0();
+  fn2();
+  {
+  switch unpack4xI8(unconst_u32(30)).x { 
+  default {
+  let vf56: vec4u = (vec4u(unconst_u32(15), unconst_u32(170), unconst_u32(118), unconst_u32(333)) | vec4u(unconst_u32(158), unconst_u32(27), unconst_u32(83), unconst_u32(19)));
+  let vf57: vec4u = a2;
+  for (var it4=a2.y; it4<u32(distance(unconst_f16(1215.5), unconst_f16(18469.2))); it4++) {
+  if bool(length(vec2h(unconst_f16(5237.0), unconst_f16(7233.1)))) {
+  fn2();
+  out.f1 = vec4i(a3);
+  fn2();
+  fn2();
+  _ = override3;
+  _ = override4;
+  _ = override2;
+}
+  out.f3 &= vec4i(transpose(mat4x3h(unconst_f16(39684.7), unconst_f16(1672.9), unconst_f16(3318.8), unconst_f16(-27882.6), unconst_f16(10133.5), unconst_f16(18213.5), unconst_f16(22005.0), unconst_f16(11137.3), unconst_f16(800.1), unconst_f16(9798.6), unconst_f16(1947.3), unconst_f16(9267.8)))[unconst_i32(2)]);
+  fn2();
+  return out;
+  _ = override2;
+  _ = override3;
+  _ = override4;
+}
+  out.f0 -= vec3h(vp0.whole).b;
+  var vf58: vec4u = vf56;
+  out.f1 ^= vec4i(vp0.whole.bbbb);
+  _ = override3;
+  _ = override2;
+  _ = override4;
+}
+  }
+  var vf59: vec4i = reverseBits(vec4i(unconst_i32(14), unconst_i32(-208), unconst_i32(167), unconst_i32(83)));
+  var vf60: f32 = a1[unconst_u32(248)];
+  var vf61 = fn0();
+  fn0();
+  fn0();
+  out.f2 = vec4f(vf61[unconst_u32(178)][0][0][0]);
+  var vf62 = fn0();
+  vf62[unconst_u32(106)][unconst_u32(54)][u32(vf62[26][unconst_u32(364)][unconst_u32(196)][0])][unconst_u32(208)] += vf61[26][unconst_u32(10)][0][0];
+  vf61[26][unconst_u32(78)][unconst_u32(108)][unconst_u32(69)] = vf61[26][unconst_u32(321)][unconst_u32(102)][0];
+  fn0();
+  _ = override4;
+  _ = override3;
+  _ = override2;
+}
+  out = VertexOutput0(f16(vf53[26][0][0][0]), vec4i(i32(vf53[26][0][0][0])), vec4f(vf53[26][0][0][0]), vec4i(bitcast<i32>(vf53[26][0][0][0])));
+  fn2();
+  let ptr19: ptr<function, array<array<f32, 1>, 1>> = &vf54[unconst_u32(53)][0];
+  let vf63: i32 = override3;
+  switch i32(vf53[unconst_u32(101)][0][0][0]) { 
+  default {
+  fn0();
+  out = VertexOutput0(vec2h( !vec2<bool>(unconst_bool(false), unconst_bool(false)))[1], vec4i( !vec2<bool>(unconst_bool(false), unconst_bool(false)).grgg), vec4f( !vec2<bool>(unconst_bool(false), unconst_bool(false)).ggrr), vec4i( !vec2<bool>(unconst_bool(false), unconst_bool(false)).gggg));
+  let ptr20 = &vp0;
+  let vf64: vec3i = countOneBits(vec3i(unconst_i32(359), unconst_i32(51), unconst_i32(1)));
+  out.f3 ^= bitcast<vec4i>(unpack4xU8(unconst_u32(244)));
+  vp0 = modf(bitcast<vec3f>(select(vec4i(unconst_i32(329), unconst_i32(305), unconst_i32(74), unconst_i32(4)), vec4i(unconst_i32(32), unconst_i32(190), unconst_i32(29), unconst_i32(163)), unconst_bool(true)).gga));
+  {
+  let vf65: bool = override4;
+  break;
+  _ = override4;
+}
+  break;
+  _ = override2;
+  _ = override4;
+}
+  }
+  return out;
+  _ = override3;
+  _ = override2;
+  _ = override4;
+}
+
+/* used global variables: buffer99 */
+@compute @workgroup_size(2, 1, 1)
+fn compute1() {
+  fn1();
+  for (var it5=pack4xU8Clamp(vec4u(reverseBits(vec4i(unconst_i32(19), unconst_i32(48), unconst_i32(310), unconst_i32(305))))); it5<vec3u(vp0.fract).b; it5++) {
+  atomicMin(&buffer99.f0[unconst_u32(44)], unconst_u32(29));
+  var vf66: vec2f = unpack2x16unorm(unconst_u32(249));
+  var vf67 = fn1();
+  var vf68: u32 = atomicLoad(&(*&buffer99).f0[unconst_u32(593)]);
+  let vf69: i32 = atomicExchange(&vw5[unconst_u32(32)], unconst_i32(-262));
+  break;
+  _ = override4;
+  _ = buffer99;
+}
+  let vf70: vec4h = atan(vec4h(unconst_f16(7913.1), unconst_f16(7716.2), unconst_f16(26601.5), unconst_f16(16229.4)));
+  atomicAnd(&vw5[unconst_u32(179)], unconst_i32(34));
+  loop {
+  let ptr21: ptr<workgroup, atomic<i32>> = &vw5[unconst_u32(232)];
+  fn1();
+  let ptr22: ptr<private, vec3f> = &vp0.whole;
+  vp0 = modf(vec3f(bitcast<f32>(atomicExchange(&(*&buffer99).f0[unconst_u32(71)], unconst_u32(68)))));
+  atomicOr(&vw5[unconst_u32(19)], unconst_i32(34));
+  atomicOr(&vw5[unconst_u32(70)], unconst_i32(-65));
+  let ptr23: ptr<private, vec3f> = &(*ptr22);
+  switch bitcast<i32>(atomicLoad(&(*&buffer99).f0[arrayLength(&(*&buffer99).f0)])) { 
+  default {
+  let ptr24: ptr<workgroup, atomic<i32>> = &(*&vw5)[unconst_u32(103)];
+  fn2();
+  _ = override4;
+  _ = override3;
+  _ = override2;
+}
+  }
+  fn1();
+  vp0.fract = vec3f(f32(override3));
+  loop {
+  fn2();
+  var vf71: u32 = atomicExchange(&(*&buffer99).f0[arrayLength(&(*&buffer99).f0)], unconst_u32(124));
+  vf71 -= arrayLength(&buffer99.f0);
+  atomicOr(&buffer99.f0[unconst_u32(316)], unconst_u32(13));
+  if bool(atomicLoad(&buffer99.f0[arrayLength(&buffer99.f0)])) {
+  let vf72: vec4<bool> = (unpack4xU8(atomicLoad(&(*&buffer99).f0[arrayLength(&(*&buffer99).f0)])) <= vec4u(unconst_u32(462), unconst_u32(196), unconst_u32(71), unconst_u32(85)));
+  {
+  storageBarrier();
+  vp0 = modf(vec3f(f32(arrayLength(&buffer99.f0))));
+  _ = buffer99;
+}
+  let ptr25: ptr<workgroup, atomic<i32>> = &vw5[unconst_u32(98)];
+  atomicCompareExchangeWeak(&vw5[unconst_u32(215)], unconst_i32(-409), unconst_i32(-48));
+  return;
+  _ = buffer99;
+}
+  vp0.whole = vec3f(f32(override2));
+  vf71 *= bitcast<u32>(atomicLoad(&(*&vw5)[unconst_u32(47)]));
+  break;
+  _ = override4;
+  _ = override3;
+  _ = override2;
+  _ = buffer99;
+}
+  break;
+  _ = override4;
+  _ = override3;
+  _ = override2;
+  _ = buffer99;
+}
+  _ = override3;
+  _ = override2;
+  _ = override4;
+  _ = buffer99;
+}`,
+});
+let texture210 = device1.createTexture({
+  size: {width: 864, height: 6, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler120 = device1.createSampler({
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 90.88,
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder114.setBindGroup(0, bindGroup78);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup105, new Uint32Array(3342), 403, 0);
+} catch {}
+let shaderModule2 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+var<workgroup> vw15: FragmentOutput1;
+
+struct T3 {
+  @align(16) @size(608) f0: array<atomic<u32>>,
+}
+
+var<workgroup> vw8: array<array<atomic<u32>, 1>, 1>;
+
+var<workgroup> vw18: array<vec4h, 1>;
+
+struct T2 {
+  @size(20) f0: array<atomic<i32>>,
+}
+
+struct T0 {
+  @size(20) f0: array<array<atomic<i32>, 2>>,
+}
+
+var<workgroup> vw16: array<mat3x4h, 1>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw17: atomic<i32>;
+
+@group(0) @binding(13) var st1: texture_storage_1d<r32uint, read_write>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<workgroup> vw14: array<array<atomic<i32>, 1>, 14>;
+
+/* used global variables: tex3 */
+fn fn0() -> mat3x3h {
+  var out: mat3x3h;
+  var vf73: u32 = pack2x16snorm(vec2f(unconst_f32(0.3477), unconst_f32(0.2205)));
+  out = mat3x3h(f16(log2(unconst_f32(0.6565))), f16(log2(unconst_f32(0.6565))), f16(log2(unconst_f32(0.6565))), f16(log2(unconst_f32(0.6565))), f16(log2(unconst_f32(0.6565))), f16(log2(unconst_f32(0.6565))), f16(log2(unconst_f32(0.6565))), f16(log2(unconst_f32(0.6565))), f16(log2(unconst_f32(0.6565))));
+  out = mat3x3h(vec3h(faceForward(vec3f(unconst_f32(-0.5226), unconst_f32(0.09510), unconst_f32(0.09482)), vec3f(unconst_f32(0.00424), unconst_f32(0.1882), unconst_f32(0.7463)), vec3f(unconst_f32(0.2473), unconst_f32(0.06395), unconst_f32(0.1703)))), vec3h(faceForward(vec3f(unconst_f32(-0.5226), unconst_f32(0.09510), unconst_f32(0.09482)), vec3f(unconst_f32(0.00424), unconst_f32(0.1882), unconst_f32(0.7463)), vec3f(unconst_f32(0.2473), unconst_f32(0.06395), unconst_f32(0.1703)))), vec3h(faceForward(vec3f(unconst_f32(-0.5226), unconst_f32(0.09510), unconst_f32(0.09482)), vec3f(unconst_f32(0.00424), unconst_f32(0.1882), unconst_f32(0.7463)), vec3f(unconst_f32(0.2473), unconst_f32(0.06395), unconst_f32(0.1703)))));
+  while bool(ldexp(vec2f(unconst_f32(0.1158), unconst_f32(0.02630)), vec2i(unconst_i32(69), unconst_i32(102))).g) {
+  var vf74: vec3u = insertBits(bitcast<vec3u>(fma(vec3f(unconst_f32(0.02341), unconst_f32(0.04319), unconst_f32(-0.03671)), vec3f(unconst_f32(0.1691), unconst_f32(0.02933), unconst_f32(1.000)), vec3f(unconst_f32(0.00693), unconst_f32(0.1171), unconst_f32(0.1839)))), vec3u(unconst_u32(280), unconst_u32(390), unconst_u32(353)), unconst_u32(9), unconst_u32(290));
+  var vf75: u32 = textureNumLevels(tex3);
+  out -= mat3x3h(atan(unconst_f16(2315.9)), atan(unconst_f16(2315.9)), atan(unconst_f16(2315.9)), atan(unconst_f16(2315.9)), atan(unconst_f16(2315.9)), atan(unconst_f16(2315.9)), atan(unconst_f16(2315.9)), atan(unconst_f16(2315.9)), atan(unconst_f16(2315.9)));
+  out += mat3x3h(vec3h(textureDimensions(tex3).ggr), vec3h(textureDimensions(tex3).ggr), vec3h(textureDimensions(tex3).xyx));
+  vf75 = bitcast<u32>(select(vec2i(unconst_i32(139), unconst_i32(427)), vec2i(unconst_i32(222), unconst_i32(144)), vec2<bool>(unconst_bool(false), unconst_bool(false))).r);
+  vf74 *= vec3u(inverseSqrt(vec3f(unconst_f32(-0.04115), unconst_f32(0.1478), unconst_f32(-0.1233))));
+  vf75 &= u32(sinh(unconst_f16(9770.8)));
+  var vf76: vec3f = sign(vec3f(bitcast<f32>(textureNumLevels(tex3))));
+  let vf77: vec3u = insertBits(vec3u(u32(countLeadingZeros(unconst_i32(193)))), vec3u(unconst_u32(663), unconst_u32(0), unconst_u32(186)), unconst_u32(96), unconst_u32(354));
+  _ = tex3;
+}
+  return out;
+  _ = tex3;
+}
+
+var<workgroup> vw13: i32;
+
+var<workgroup> vw19: FragmentOutput1;
+
+var<workgroup> vw20: atomic<u32>;
+
+struct T1 {
+  @size(128) f0: vec4f,
+  @size(2816) f1: array<array<array<vec4h, 1>, 1>>,
+}
+
+struct T4 {
+  @size(128) f0: array<atomic<u32>, 16>,
+  @align(64) @size(256) f1: array<mat4x4f>,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<workgroup> vw12: atomic<u32>;
+
+/* used global variables: st1, tex2, tex3 */
+fn fn1() -> vec4f {
+  var out: vec4f;
+  let vf78: vec4h = refract(vec4h(unconst_f16(22065.3), unconst_f16(9288.6), unconst_f16(16881.9), unconst_f16(3054.7)), vec4h(unconst_f16(12234.2), unconst_f16(1155.9), unconst_f16(3104.3), unconst_f16(575.4)), unconst_f16(23192.3));
+  out = vec4f(f32(textureNumLevels(tex3)));
+  out = min(vec2f(unconst_f32(0.2019), unconst_f32(-0.3587)), vec2f(unconst_f32(0.08798), unconst_f32(-0.1966))).yyxy;
+  textureStore(st1, unconst_i32(21), vec4u(vec4u(unconst_u32(31), unconst_u32(119), unconst_u32(99), unconst_u32(196))));
+  let vf79: vec4f = textureLoad(tex3, vec2i(unconst_i32(317), unconst_i32(34)), unconst_i32(15));
+  textureStore(st1, unconst_i32(332), vec4u(vec4u(unconst_u32(201), unconst_u32(195), unconst_u32(96), unconst_u32(262))));
+  out += vec4f(log(vec4h(unconst_f16(29926.2), unconst_f16(10321.7), unconst_f16(113.4), unconst_f16(-824.1))));
+  let vf80: vec4i = extractBits(vec4i(unconst_i32(513), unconst_i32(129), unconst_i32(275), unconst_i32(627)), unconst_u32(190), pack4xU8(vec4u(textureLoad(tex2, vec2i(unconst_i32(126), unconst_i32(191)), unconst_i32(127)))));
+  if bool(vf78[1]) {
+  var vf81: f32 = tan(unconst_f32(-0.1799));
+  var vf82: vec4u = textureLoad(st1, unconst_i32(59));
+  fn0();
+  var vf83: u32 = pack2x16float(vec2f(unconst_f32(1.000), unconst_f32(0.4909)));
+  _ = st1;
+  _ = tex3;
+}
+  return out;
+  _ = st1;
+  _ = tex2;
+  _ = tex3;
+}
+
+var<workgroup> vw9: array<vec2<bool>, 1>;
+
+var<workgroup> vw6: atomic<u32>;
+
+alias vec3b = vec3<bool>;
+
+var<workgroup> vw11: vec4h;
+
+@group(0) @binding(85) var tex3: texture_2d<f32>;
+
+var<workgroup> vw7: vec2i;
+
+var<workgroup> vw10: FragmentOutput1;
+
+@group(0) @binding(40) var tex2: texture_2d<f32>;
+
+struct FragmentOutput1 {
+  @location(0) f0: vec4u,
+  @builtin(sample_mask) f1: u32,
+  @location(2) @interpolate(flat, sample) f2: vec4i,
+}
+
+/* used global variables: tex3 */
+@vertex
+fn vertex2() -> @builtin(position) vec4f {
+  var out: vec4f;
+  fn0();
+  var vf84: f32 = smoothstep(unconst_f32(0.4045), vec4f(unpack4xI8(unconst_u32(131))).a, unconst_f32(0.2429));
+  vf84 *= f32(any(vec4<bool>(unconst_bool(false), unconst_bool(false), unconst_bool(true), unconst_bool(false))));
+  fn0();
+  var vf85: vec3i = countOneBits(vec3i(unconst_i32(250), unconst_i32(134), unconst_i32(1)));
+  var vf86: bool = any(vec4<bool>(unconst_bool(true), unconst_bool(true), unconst_bool(true), unconst_bool(true)));
+  vf84 = f32((bool(quantizeToF16(vec2f(unconst_f32(0.08122), unconst_f32(0.1426)))[1]) && unconst_bool(false)));
+  var vf87 = fn0();
+  out += bitcast<vec4f>(select(vec2i(unconst_i32(65), unconst_i32(964)), vec2i(unconst_i32(113), unconst_i32(132)), bool(textureNumLevels(tex3))).rrgr);
+  return out;
+  _ = tex3;
+}
+
+/* used global variables: st1, tex2, tex3 */
+@fragment
+fn fragment1() -> FragmentOutput1 {
+  var out: FragmentOutput1;
+  var vf88 = fn1();
+  vf88 += vec4f(f32(textureNumLevels(tex3)));
+  out.f0 >>= vec4u((vec3u(unconst_u32(51), unconst_u32(229), unconst_u32(109)) == vec3u(unconst_u32(29), unconst_u32(312), unconst_u32(145))).zyyz);
+  var vf89 = fn0();
+  out = FragmentOutput1(vec4u(insertBits(vec4i(unconst_i32(132), unconst_i32(92), unconst_i32(15), unconst_i32(162)), vec4i(i32(pack4xU8(vec4u(unconst_u32(7), unconst_u32(66), unconst_u32(342), unconst_u32(979))))), unconst_u32(119), unconst_u32(202))), pack4xU8Clamp(vec4u(insertBits(vec4i(unconst_i32(132), unconst_i32(92), unconst_i32(15), unconst_i32(162)), vec4i(i32(pack4xU8(vec4u(unconst_u32(7), unconst_u32(66), unconst_u32(342), unconst_u32(979))))), unconst_u32(119), unconst_u32(202)))), insertBits(vec4i(unconst_i32(132), unconst_i32(92), unconst_i32(15), unconst_i32(162)), vec4i(i32(pack4xU8(vec4u(unconst_u32(7), unconst_u32(66), unconst_u32(342), unconst_u32(979))))), unconst_u32(119), unconst_u32(202)));
+  vf89 += mat3x3h(vec3h(reflect(vec4f(unconst_f32(0.00113), unconst_f32(0.3295), unconst_f32(0.3554), unconst_f32(0.3386)), vec4f(unconst_f32(0.1832), unconst_f32(0.09860), unconst_f32(0.2285), unconst_f32(0.3313))).rga), vec3h(reflect(vec4f(unconst_f32(0.00113), unconst_f32(0.3295), unconst_f32(0.3554), unconst_f32(0.3386)), vec4f(unconst_f32(0.1832), unconst_f32(0.09860), unconst_f32(0.2285), unconst_f32(0.3313))).bgr), vec3h(reflect(vec4f(unconst_f32(0.00113), unconst_f32(0.3295), unconst_f32(0.3554), unconst_f32(0.3386)), vec4f(unconst_f32(0.1832), unconst_f32(0.09860), unconst_f32(0.2285), unconst_f32(0.3313))).rgr));
+  let vf90: vec2u = textureDimensions(tex2, i32(all((vec3u(unconst_u32(56), unconst_u32(101), unconst_u32(163)) == vec3u(unconst_u32(546), unconst_u32(30), unconst_u32(243))))));
+  let vf91: f32 = radians(acosh(f32(all((vec3u(unconst_u32(252), unconst_u32(66), unconst_u32(197)) == textureDimensions(tex3).yyy)))));
+  var vf92 = fn1();
+  vf89 = mat3x3h(f16(pack4xI8Clamp(vec4i(textureDimensions(tex3).xxyx))), f16(pack4xI8Clamp(vec4i(textureDimensions(tex3).xxyx))), f16(pack4xI8Clamp(vec4i(textureDimensions(tex3).xxyx))), f16(pack4xI8Clamp(vec4i(textureDimensions(tex3).xxyx))), f16(pack4xI8Clamp(vec4i(textureDimensions(tex3).xxyx))), f16(pack4xI8Clamp(vec4i(textureDimensions(tex3).xxyx))), f16(pack4xI8Clamp(vec4i(textureDimensions(tex3).xxyx))), f16(pack4xI8Clamp(vec4i(textureDimensions(tex3).xxyx))), f16(pack4xI8Clamp(vec4i(textureDimensions(tex3).xxyx))));
+  let vf93: vec2h = tanh(vec2h(unconst_f16(1412.0), unconst_f16(2674.9)));
+  var vf94: vec4u = (vec4u(unconst_u32(24), unconst_u32(201), unconst_u32(202), unconst_u32(410)) >> vec4u(unconst_u32(29), unconst_u32(456), unconst_u32(59), unconst_u32(596)));
+  var vf95 = fn0();
+  fn0();
+  {
+  var vf96 = fn0();
+  {
+  textureStore(st1, unconst_i32(878), vec4u(vec4u(unconst_u32(250), unconst_u32(291), unconst_u32(382), unconst_u32(38))));
+  var vf97: i32 = dot4I8Packed(unconst_u32(62), unconst_u32(29));
+  var vf98 = fn1();
+  for (var it6=bitcast<u32>((vec2h(unconst_f16(12664.9), unconst_f16(60000.0)) * mat2x2h(f16(trunc(unconst_f32(0.1121))), f16(trunc(unconst_f32(0.1121))), f16(trunc(unconst_f32(0.1121))), f16(trunc(unconst_f32(0.1121)))))); it6<textureLoad(st1, unconst_i32(426)).a; it6++) {
+  var vf99 = fn1();
+  {
+  var vf100: vec3<bool> = (vec3<bool>(unconst_bool(false), unconst_bool(false), unconst_bool(true)) & vec3<bool>(unconst_bool(false), unconst_bool(false), unconst_bool(false)));
+  fn0();
+  fn0();
+  _ = tex3;
+}
+  out.f1 *= vec2u(fma(vec2f(unconst_f32(0.3538), unconst_f32(0.2264)), vec2f(unconst_f32(0.02736), unconst_f32(0.3798)), vec2f(unconst_f32(0.06858), unconst_f32(0.00330))))[1];
+  out.f1 &= vec3u(fract(vec3f((mat4x2h() * mat3x4h(unconst_f16(3293.3), unconst_f16(3103.1), unconst_f16(15459.2), unconst_f16(18478.4), unconst_f16(28023.1), unconst_f16(9777.5), unconst_f16(7690.1), unconst_f16(3779.0), unconst_f16(5853.5), unconst_f16(7153.9), unconst_f16(8837.6), unconst_f16(12077.0)))[unconst_i32(2)].rrr))).x;
+  _ = tex3;
+  _ = tex2;
+  _ = st1;
+}
+  var vf101 = fn1();
+  var vf102: vec2h = tanh(vec2h(unconst_f16(41878.6), unconst_f16(7004.6)));
+  for (var it7=pack2x16float(vec2f(unconst_f32(0.4334), unconst_f32(0.1478))); it7<u32(vf97); it7++) {
+  var vf103: vec2h = inverseSqrt(vec2h(unconst_f16(5741.6), unconst_f16(2820.0)));
+  out.f2 ^= unpack4xI8(textureNumLevels(tex2));
+  _ = tex2;
+}
+  _ = st1;
+  _ = tex3;
+  _ = tex2;
+}
+  out.f2 = vec4i(i32(textureNumLevels(tex3)));
+  var vf104: vec2u = textureDimensions(tex2, unconst_i32(235));
+  var vf105 = fn0();
+  out.f2 = vec4i(exp(vec2h(unconst_f16(24767.8), unconst_f16(1195.4))).xxyx);
+  _ = st1;
+  _ = tex2;
+  _ = tex3;
+}
+  return out;
+  _ = tex3;
+  _ = st1;
+  _ = tex2;
+}
+
+/* zero global variables used */
+@compute @workgroup_size(1, 1, 1)
+fn compute2() {
+  var vf106: u32 = atomicExchange(&vw8[unconst_u32(40)][0], unconst_u32(584));
+  vw16[u32(vw16[0][unconst_u32(389)].w)] = mat3x4h(f16(atomicExchange(&(*&vw8)[0][unconst_u32(4)], unconst_u32(138))), f16(atomicExchange(&(*&vw8)[0][unconst_u32(4)], unconst_u32(138))), f16(atomicExchange(&(*&vw8)[0][unconst_u32(4)], unconst_u32(138))), f16(atomicExchange(&(*&vw8)[0][unconst_u32(4)], unconst_u32(138))), f16(atomicExchange(&(*&vw8)[0][unconst_u32(4)], unconst_u32(138))), f16(atomicExchange(&(*&vw8)[0][unconst_u32(4)], unconst_u32(138))), f16(atomicExchange(&(*&vw8)[0][unconst_u32(4)], unconst_u32(138))), f16(atomicExchange(&(*&vw8)[0][unconst_u32(4)], unconst_u32(138))), f16(atomicExchange(&(*&vw8)[0][unconst_u32(4)], unconst_u32(138))), f16(atomicExchange(&(*&vw8)[0][unconst_u32(4)], unconst_u32(138))), f16(atomicExchange(&(*&vw8)[0][unconst_u32(4)], unconst_u32(138))), f16(atomicExchange(&(*&vw8)[0][unconst_u32(4)], unconst_u32(138))));
+}
+
+/* used global variables: tex3 */
+@compute @workgroup_size(1, 1, 1)
+fn compute3(@builtin(local_invocation_index) a0: u32) {
+  vw11 *= vec4h(f16(atomicLoad(&(*&vw14)[unconst_u32(83)][0])));
+  var vf107 = fn0();
+  let ptr26: ptr<workgroup, atomic<u32>> = &vw8[unconst_u32(7)][0];
+  fn0();
+  vw7 = vec2i(atomicLoad(&(*&vw14)[unconst_u32(722)][0]));
+  fn0();
+  for (var it8=atomicLoad(&(*&vw8)[0][0]); it8<u32(vw18[0].y); it8++) {
+  vw9[unconst_u32(374)] = vec2<bool>(workgroupUniformLoad(&vw18)[0].rr);
+  let ptr27: ptr<workgroup, vec2<bool>> = &(*&vw9)[unconst_u32(534)];
+  let ptr28: ptr<workgroup, array<array<atomic<i32>, 1>, 14>> = &(*&vw14);
+  let ptr29: ptr<workgroup, atomic<i32>> = &(*ptr28)[13][unconst_u32(19)];
+  fn0();
+  vw13 ^= vec2i(vw9[0])[0];
+  _ = tex3;
+}
+  {
+  vw19 = FragmentOutput1(vec4u(atomicExchange(&(*&vw8)[0][unconst_u32(15)], (*&vw15).f0[3])), atomicExchange(&(*&vw8)[0][unconst_u32(15)], (*&vw15).f0[3]), vec4i(i32(atomicExchange(&(*&vw8)[0][unconst_u32(15)], (*&vw15).f0[3]))));
+  let vf108: bool = vw9[unconst_u32(9)][unconst_u32(32)];
+  vw9[unconst_u32(82)] = vw9[unconst_u32(953)];
+}
+  vw10 = FragmentOutput1(bitcast<vec4u>((*&vw7).xyxy), bitcast<vec2u>((*&vw7)).g, (*&vw7).xxxy);
+  var vf109 = fn0();
+  var vf110 = fn0();
+  atomicCompareExchangeWeak(&vw6, unconst_u32(431), unconst_u32(159));
+  var vf111: vec3f = cross(vec3f(unconst_f32(0.4968), unconst_f32(0.4994), unconst_f32(0.04989)), vec3f(unconst_f32(0.2115), unconst_f32(0.01136), unconst_f32(0.04296)));
+  var vf112: u32 = atomicLoad(&(*&vw20));
+  var vf113 = fn0();
+  atomicXor(&vw20, unconst_u32(39));
+  atomicSub(&vw6, unconst_u32(108));
+  var vf114 = fn0();
+  vf113 += mat3x3h(vec3h(vw15.f2.agr), vec3h(vw15.f2.zxz), vec3h(vw15.f2.xxy));
+  _ = tex3;
+}`,
+});
+let sampler121 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'clamp-to-edge', lodMaxClamp: 68.11, compare: 'always'});
+try {
+computePassEncoder14.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(2, bindGroup0, new Uint32Array(849), 85, 0);
+} catch {}
+try {
+renderPassEncoder37.executeBundles([renderBundle13]);
+} catch {}
+try {
+renderPassEncoder47.setIndexBuffer(buffer8, 'uint32', 1_032, 688);
+} catch {}
+let pipeline11 = device0.createComputePipeline({layout: pipelineLayout14, compute: {module: shaderModule0, constants: {}}});
+let commandEncoder190 = device1.createCommandEncoder();
+let texture211 = device1.createTexture({
+  size: {width: 384},
+  dimension: '1d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder9.executeBundles([renderBundle20]);
+} catch {}
+try {
+renderPassEncoder35.setViewport(133.45961816277438, 0.962498778428402, 1.3575839013080533, 0.46718935402034184, 0.8823998357046403, 0.9752911163142823);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer39, 'uint16', 2, 13);
+} catch {}
+try {
+renderPassEncoder48.setVertexBuffer(5, buffer66, 11_908, 2_014);
+} catch {}
+document.body.prepend(canvas2);
+let commandEncoder191 = device0.createCommandEncoder({});
+let texture212 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 21},
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder143 = commandEncoder191.beginComputePass({});
+try {
+computePassEncoder130.setBindGroup(1, bindGroup106);
+} catch {}
+try {
+computePassEncoder141.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(6, buffer73, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer88, 1220, new Float32Array(13322), 2417, 176);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture44,
+  mipLevel: 1,
+  origin: {x: 3, y: 8, z: 5},
+  aspect: 'all',
+}, new Uint8Array(10_206).fill(240), /* required buffer size: 10_206 */
+{offset: 602, bytesPerRow: 49, rowsPerImage: 49}, {width: 3, height: 0, depthOrArrayLayers: 5});
+} catch {}
+let offscreenCanvas3 = new OffscreenCanvas(5, 376);
+let veryExplicitBindGroupLayout29 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 205,
+      visibility: 0,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let buffer100 = device1.createBuffer({
+  size: 274,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let renderPassEncoder49 = commandEncoder190.beginRenderPass({
+  colorAttachments: [{
+  view: textureView28,
+  clearValue: { r: -594.1, g: -291.1, b: -701.1, a: 223.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let sampler122 = device1.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 16.12,
+  lodMaxClamp: 59.33,
+});
+try {
+renderPassEncoder46.setBindGroup(0, bindGroup32);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(5, buffer13, 48, 4);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let imageData21 = new ImageData(4, 4);
+try {
+offscreenCanvas3.getContext('webgl2');
+} catch {}
+let buffer101 = device0.createBuffer({
+  size: 11046,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView179 = texture180.createView({});
+let sampler123 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 81.33,
+  compare: 'greater-equal',
+});
+let externalTexture23 = device0.importExternalTexture({source: videoFrame26});
+try {
+computePassEncoder47.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(7, buffer85, 948, 2_282);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 690, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(129).fill(30), /* required buffer size: 129 */
+{offset: 129, bytesPerRow: 562}, {width: 290, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup124 = device0.createBindGroup({layout: veryExplicitBindGroupLayout21, entries: [{binding: 47, resource: textureView25}]});
+let sampler124 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 2,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder14); computePassEncoder14.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer1, 'uint16', 218, 117);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(6, buffer85, 0, 1_235);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 13, z: 15},
+  aspect: 'all',
+}, new Uint8Array(5_188).fill(183), /* required buffer size: 5_188 */
+{offset: 14, bytesPerRow: 41, rowsPerImage: 51}, {width: 1, height: 25, depthOrArrayLayers: 3});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 131, height: 1, depthOrArrayLayers: 78}
+*/
+{
+  source: videoFrame30,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture200,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 8},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline12 = await device0.createRenderPipelineAsync({
+  label: '\u{1fbd5}\ufd5a\u0b8e\u03f9\ucce9\u{1f918}\ucea4\u0b34\u29e4\uffda',
+  layout: 'auto',
+  multisample: {},
+  fragment: {module: shaderModule2, targets: [{format: 'rg8uint', writeMask: GPUColorWrite.GREEN}]},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 208,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 36, shaderLocation: 4},
+          {format: 'sint32x2', offset: 16, shaderLocation: 13},
+          {format: 'sint8x4', offset: 36, shaderLocation: 11},
+          {format: 'snorm16x4', offset: 56, shaderLocation: 6},
+          {format: 'float16x4', offset: 24, shaderLocation: 5},
+          {format: 'sint8x2', offset: 16, shaderLocation: 7},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'cw'},
+});
+try {
+  await promise23;
+} catch {}
+let sampler125 = device0.createSampler({
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 85.69,
+  maxAnisotropy: 13,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder14); computePassEncoder14.dispatchWorkgroupsIndirect(buffer33, 12); };
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(3, bindGroup61, new Uint32Array(732), 55, 0);
+} catch {}
+document.body.prepend(canvas0);
+let veryExplicitBindGroupLayout30 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 1,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {binding: 85, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 148,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup125 = device0.createBindGroup({layout: veryExplicitBindGroupLayout16, entries: [{binding: 47, resource: textureView86}]});
+let texture213 = device0.createTexture({
+  size: [131, 1, 1],
+  mipLevelCount: 6,
+  sampleCount: 1,
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler126 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 65.63,
+});
+try {
+computePassEncoder56.setBindGroup(3, bindGroup71);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder14); computePassEncoder14.dispatchWorkgroups(1); };
+} catch {}
+let pipeline13 = device0.createRenderPipeline({
+  layout: 'auto',
+  multisample: {mask: 0x14a251b2},
+  fragment: {
+  module: shaderModule2,
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {module: shaderModule2, constants: {}, buffers: []},
+  primitive: {frontFace: 'cw', cullMode: 'front'},
+});
+try {
+computePassEncoder139.setBindGroup(2, bindGroup30, new Uint32Array(1305), 4, 0);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle22, renderBundle22]);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { console.log('device1.uncapturederror'); console.log(e); e.label = device1.label; });
+} catch {}
+let shaderModule3 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+var<workgroup> vw25: array<vec2i, 1>;
+
+struct FragmentOutput2 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: vec4u,
+}
+
+var<workgroup> vw21: FragmentOutput2;
+
+struct S1 {
+  @location(13) @interpolate(flat) f0: i32,
+  @location(8) f1: vec4i,
+  @location(0) @interpolate(flat, centroid) f2: vec4h,
+  @location(10) f3: vec4i,
+  @location(4) @interpolate(flat) f4: i32,
+  @location(1) f5: u32,
+  @location(2) @interpolate(flat, center) f6: vec4i,
+  @location(14) f7: f16,
+  @location(15) f8: vec2h,
+  @location(3) f9: vec2i,
+}
+
+var<workgroup> vw22: atomic<u32>;
+
+struct T0 {
+  @align(8) @size(8) f0: vec2h,
+}
+
+override override5: f16 = 2162.6;
+
+override override10 = false;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<workgroup> vw26: atomic<u32>;
+
+@id(11530) override override9: f32;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct T2 {
+  @align(16) @size(80) f0: array<mat4x4h>,
+}
+
+@group(0) @binding(40) var tex4: texture_2d<f32>;
+
+struct T1 {
+  @size(16) f0: T0,
+}
+
+var<workgroup> vw24: array<mat2x2h, 1>;
+
+@group(0) @binding(13) var st2: texture_storage_1d<r32uint, read_write>;
+
+@id(12958) override override7: i32 = 28;
+
+@id(50939) override override11: f32;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<workgroup> vw23: FragmentOutput2;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@id(51201) override override8: u32 = 592;
+
+override override6 = false;
+
+override override12 = true;
+
+struct VertexOutput1 {
+  @location(12) @interpolate(flat, sample) f4: f16,
+  @builtin(position) f5: vec4f,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(85) var tex5: texture_2d<f32>;
+
+/* used global variables: tex4 */
+@vertex
+fn vertex3(a0: S1, @location(9) a1: i32) -> VertexOutput1 {
+  var out: VertexOutput1;
+  out.f4 -= f16(a0.f4);
+  var vf115: vec3f = reflect(vec3f(unconst_f32(0.8972), unconst_f32(0.02567), unconst_f32(0.2089)), vec3f(exp2(vec4h(unconst_f16(-21897.2), unconst_f16(-6929.8), unconst_f16(567.6), unconst_f16(4471.8))).rag));
+  var vf116: vec4i = a0.f6;
+  out.f4 = f16((unconst_u32(61) != unconst_u32(85)));
+  var vf117: vec4i = a0.f1;
+  let ptr30: ptr<function, vec4i> = &vf117;
+  out.f5 *= vec4f((vec3i(unconst_i32(25), unconst_i32(124), unconst_i32(161)) / vec3i(unconst_i32(144), unconst_i32(227), unconst_i32(356))).grgb);
+  let vf118: vec4i = a0.f6;
+  var vf119: vec4h = a0.f2;
+  vf119 = vec4h(vf118);
+  let ptr31: ptr<function, vec4i> = &vf116;
+  let vf120: i32 = vf118[unconst_u32(319)];
+  let vf121: vec4i = vf118;
+  var vf122: vec2u = textureDimensions(tex4);
+  var vf123: vec2h = a0.f8;
+  var vf124: vec2u = reverseBits(vec2u(unconst_u32(23), unconst_u32(66)));
+  var vf125: f16 = length(vec3h(unconst_f16(2517.3), unconst_f16(825.9), unconst_f16(-13409.6)));
+  let vf126: vec3f = sin(vec3f(f32(a0.f4)));
+  return out;
+  _ = tex4;
+}
+
+/* used global variables: st2, tex4, tex5 */
+@fragment
+fn fragment2(@location(12) a0: f16) -> FragmentOutput2 {
+  var out: FragmentOutput2;
+  out.f0 ^= u32(length(unconst_f16(9679.7)));
+  let vf127: f32 = acos(unconst_f32(0.2036));
+  var vf128: f32 = acos(unconst_f32(0.00473));
+  textureStore(st2, unconst_i32(6), vec4u(vec4u(unconst_u32(142), unconst_u32(72), unconst_u32(17), unconst_u32(50))));
+  let vf129: vec4h =  -vec4h(unconst_f16(2425.1), unconst_f16(16415.7), unconst_f16(5430.7), unconst_f16(21229.2));
+  let vf130: u32 = dot4U8Packed(unconst_u32(141), unconst_u32(391));
+  let vf131: vec2u = textureDimensions(tex4);
+  let vf132: bool = override10;
+  var vf133: vec4u = textureLoad(st2, unconst_i32(125));
+  var vf134: vec4u = textureLoad(st2, unconst_i32(352));
+  let vf135: f32 = acos(unconst_f32(0.1038));
+  let vf136: bool = (unconst_bool(false) || unconst_bool(false));
+  out.f1 <<= vec4u(u32((bool(textureDimensions(tex4)[0]) || all((vec3i(unconst_i32(87), unconst_i32(330), unconst_i32(-45)) < vec3i(faceForward(vec2f(unconst_f32(0.1649), unconst_f32(0.2846)), vec2f(unconst_f32(-0.09286), unconst_f32(0.1640)), vec2f(unconst_f32(-0.1674), unconst_f32(0.09735))).grg))))));
+  textureStore(st2, unconst_i32(29), vec4u(vec4u(unconst_u32(38), unconst_u32(149), unconst_u32(36), unconst_u32(205))));
+  var vf137: vec2h = saturate(vec2h(unconst_f16(4772.7), unconst_f16(3290.5)));
+  var vf138: vec2u = firstTrailingBit(vec2u(unconst_u32(7), unconst_u32(93)));
+  var vf139: vec4f = textureLoad(tex5, vec2i(unconst_i32(185), unconst_i32(-241)), unconst_i32(-112));
+  var vf140: u32 = vf131[unconst_u32(294)];
+  return out;
+  _ = override10;
+  _ = tex5;
+  _ = tex4;
+  _ = st2;
+}
+
+/* zero global variables used */
+@compute @workgroup_size(1, 1, 1)
+fn compute4() {
+  vw25[unconst_u32(436)] -= vec2i(override7);
+  var vf141: vec2h = atanh(vw24[0][unconst_i32(0)]);
+  for (var it9=bitcast<u32>((*&vw24)[0][unconst_i32(1)]); it9<(*&vw23).f0; it9++) {
+  let ptr32: ptr<workgroup, atomic<u32>> = &(*&vw26);
+  while bool((*&vw24)[0][unconst_i32(1)].g) {
+  let ptr33: ptr<workgroup, vec2i> = &(*&vw25)[0];
+  storageBarrier();
+  break;
+}
+  let vf142: vec3i = sign(vec3i(unconst_i32(405), unconst_i32(-305), unconst_i32(113)));
+  vw23.f0 = bitcast<u32>(vw24[0][unconst_i32(1)]);
+  var vf143: i32 = (*&vw25)[0][atomicLoad(&(*&vw22))];
+  vf143 += bitcast<i32>(vw24[unconst_u32(240)][unconst_i32(1)]);
+  var vf144: u32 = atomicExchange(&vw26, unconst_u32(96));
+}
+  _ = override7;
+}`,
+});
+let bindGroup126 = device0.createBindGroup({layout: veryExplicitBindGroupLayout12, entries: [{binding: 68, resource: textureView116}]});
+let buffer102 = device0.createBuffer({size: 3134, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let sampler127 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 47.33,
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder115.setBindGroup(0, bindGroup82);
+} catch {}
+try {
+computePassEncoder14.end();
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(0, bindGroup72, new Uint32Array(2930), 24, 0);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer1, 'uint16', 242, 84);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(5, buffer31, 0, 64);
+} catch {}
+try {
+commandEncoder19.copyBufferToBuffer(buffer83, 24, buffer8, 1604, 1212);
+} catch {}
+let commandEncoder192 = device0.createCommandEncoder({});
+let textureView180 = texture213.createView({mipLevelCount: 2});
+let computePassEncoder144 = commandEncoder192.beginComputePass({});
+let externalTexture24 = device0.importExternalTexture({source: videoFrame1});
+try {
+commandEncoder19.copyBufferToTexture({
+  /* bytesInLastRow: 672 widthInBlocks: 42 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 2416 */
+  offset: 2416,
+  bytesPerRow: 1792,
+  buffer: buffer17,
+}, {
+  texture: texture114,
+  mipLevel: 0,
+  origin: {x: 55, y: 10, z: 0},
+  aspect: 'all',
+}, {width: 210, height: 15, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder19.resolveQuerySet(querySet18, 122, 201, buffer92, 0);
+} catch {}
+try {
+computePassEncoder110.popDebugGroup();
+} catch {}
+let buffer103 = device1.createBuffer({size: 31795, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT});
+let commandEncoder193 = device1.createCommandEncoder({});
+let texture214 = device1.createTexture({
+  size: {width: 270, height: 5, depthOrArrayLayers: 15},
+  dimension: '3d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderPassEncoder50 = commandEncoder193.beginRenderPass({
+  colorAttachments: [{
+  view: textureView109,
+  clearValue: { r: 757.5, g: -844.9, b: -89.51, a: -779.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet17,
+  maxDrawCount: 145412096,
+});
+let externalTexture25 = device1.importExternalTexture({source: videoFrame23});
+try {
+computePassEncoder135.setBindGroup(1, bindGroup87);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(2, bindGroup113);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(7, buffer66, 0, 19_940);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 432, height: 3, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame26,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture144,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture215 = device1.createTexture({
+  size: [216, 1, 80],
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup67, new Uint32Array(4365), 384, 0);
+} catch {}
+try {
+renderPassEncoder43.beginOcclusionQuery(9);
+} catch {}
+try {
+buffer78.unmap();
+} catch {}
+let veryExplicitBindGroupLayout31 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 10,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'write-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let commandEncoder194 = device0.createCommandEncoder({});
+let computePassEncoder145 = commandEncoder194.beginComputePass({});
+let renderPassEncoder51 = commandEncoder19.beginRenderPass({
+  colorAttachments: [{
+  view: textureView159,
+  depthSlice: 280,
+  clearValue: { r: 655.9, g: 472.4, b: -444.3, a: -954.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet14,
+});
+try {
+computePassEncoder75.setBindGroup(2, bindGroup6, new Uint32Array(748), 35, 0);
+} catch {}
+try {
+computePassEncoder75.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder44.setIndexBuffer(buffer1, 'uint16', 110, 86);
+} catch {}
+let buffer104 = device1.createBuffer({
+  size: 1255,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let renderBundleEncoder29 = device1.createRenderBundleEncoder({colorFormats: ['r16uint', 'rgba16float']});
+let sampler128 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 89.14,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder78.setBindGroup(0, bindGroup46);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(3, bindGroup51);
+} catch {}
+try {
+renderPassEncoder10.setViewport(280.6411316719601, 2.631940689097641, 107.18605877371765, 0.1725983144158329, 0.8551335498165183, 0.8614221571273464);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(0, undefined);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture185,
+  mipLevel: 0,
+  origin: {x: 1, y: 10, z: 19},
+  aspect: 'all',
+}, new Uint8Array(1_507).fill(204), /* required buffer size: 1_507 */
+{offset: 169, bytesPerRow: 78}, {width: 6, height: 18, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder195 = device0.createCommandEncoder({});
+let renderPassEncoder52 = commandEncoder195.beginRenderPass({colorAttachments: [{view: textureView179, depthSlice: 67, loadOp: 'clear', storeOp: 'store'}]});
+try {
+computePassEncoder115.setBindGroup(0, bindGroup94);
+} catch {}
+try {
+computePassEncoder4.setBindGroup(0, bindGroup50, new Uint32Array(2191), 510, 0);
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(0, bindGroup117, new Uint32Array(6427), 189, 0);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([renderBundle13]);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(0, buffer50, 0, 1_536);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture165,
+  mipLevel: 0,
+  origin: {x: 48, y: 0, z: 74},
+  aspect: 'all',
+}, new Uint8Array(3_602_293).fill(212), /* required buffer size: 3_602_293 */
+{offset: 79, bytesPerRow: 414, rowsPerImage: 113}, {width: 99, height: 0, depthOrArrayLayers: 78});
+} catch {}
+let commandEncoder196 = device1.createCommandEncoder({});
+let textureView181 = texture14.createView({dimension: '2d', baseArrayLayer: 4, arrayLayerCount: 1});
+let renderBundle29 = renderBundleEncoder29.finish({});
+let sampler129 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  lodMaxClamp: 89.53,
+  compare: 'never',
+});
+try {
+computePassEncoder89.setBindGroup(2, bindGroup95, new Uint32Array(1240), 410, 0);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(5, undefined, 498_024_005);
+} catch {}
+try {
+commandEncoder196.copyBufferToBuffer(buffer13, 184, buffer60, 360, 48);
+} catch {}
+let veryExplicitBindGroupLayout32 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 13,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32uint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 17,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d-array' },
+    },
+    {
+      binding: 41,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 48,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 63,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {binding: 91, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+    {
+      binding: 122,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 169,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 191,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '3d' },
+    },
+    {binding: 196, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }},
+    {
+      binding: 216,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d-array' },
+    },
+    {
+      binding: 339,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 456,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let bindGroup127 = device1.createBindGroup({layout: veryExplicitBindGroupLayout29, entries: [{binding: 205, resource: textureView150}]});
+let buffer105 = device1.createBuffer({
+  size: 27105,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView182 = texture16.createView({format: 'r16uint', mipLevelCount: 1});
+try {
+renderPassEncoder43.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder30.executeBundles([renderBundle22, renderBundle22]);
+} catch {}
+let buffer106 = device1.createBuffer({
+  size: 59126,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder197 = device1.createCommandEncoder({});
+let texture216 = device1.createTexture({
+  size: [128, 128, 13],
+  dimension: '2d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder146 = commandEncoder197.beginComputePass({});
+let renderPassEncoder53 = commandEncoder196.beginRenderPass({
+  colorAttachments: [{
+  view: textureView22,
+  clearValue: { r: 65.17, g: 84.00, b: 429.3, a: 82.84, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet17,
+});
+try {
+computePassEncoder51.setBindGroup(3, bindGroup127);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(4, buffer77);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let videoFrame32 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'smpteRp431', transfer: 'bt2020_10bit'} });
+let commandEncoder198 = device0.createCommandEncoder({});
+let renderPassEncoder54 = commandEncoder198.beginRenderPass({
+  colorAttachments: [{
+  view: textureView179,
+  depthSlice: 29,
+  clearValue: { r: -413.8, g: 360.4, b: -886.0, a: -721.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder58.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder41.beginOcclusionQuery(100);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(4, buffer86, 2_124, 332);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 131, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame31,
+  origin: { x: 0, y: 1 },
+  flipY: false,
+}, {
+  texture: texture111,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer107 = device1.createBuffer({size: 1604, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+let texture217 = device1.createTexture({
+  size: {width: 192, height: 1, depthOrArrayLayers: 21},
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder95.setBindGroup(3, bindGroup48, new Uint32Array(1003), 2, 0);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 135, height: 2, depthOrArrayLayers: 18}
+*/
+{
+  source: videoFrame8,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup128 = device0.createBindGroup({
+  label: '\u6c3d\u5d9b\u1c22',
+  layout: veryExplicitBindGroupLayout30,
+  entries: [
+    {binding: 1, resource: textureView48},
+    {binding: 148, resource: {buffer: buffer89, offset: 0, size: 112}},
+    {binding: 85, resource: externalTexture8},
+  ],
+});
+let buffer108 = device0.createBuffer({size: 49856, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+let texture218 = device0.createTexture({
+  size: [262, 1, 109],
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView183 = texture128.createView({dimension: 'cube', baseArrayLayer: 8});
+try {
+computePassEncoder130.setPipeline(pipeline8);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+await gc();
+let buffer109 = device1.createBuffer({size: 1696, usage: GPUBufferUsage.MAP_WRITE});
+let commandEncoder199 = device1.createCommandEncoder();
+let sampler130 = device1.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 96.26,
+  maxAnisotropy: 12,
+});
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup30);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(0, bindGroup55, new Uint32Array(499), 78, 0);
+} catch {}
+try {
+renderPassEncoder45.setVertexBuffer(0, buffer78, 1_364, 3_044);
+} catch {}
+try {
+commandEncoder199.clearBuffer(buffer3, 8);
+} catch {}
+try {
+commandEncoder199.resolveQuerySet(querySet19, 8, 30, buffer91, 512);
+} catch {}
+try {
+adapter1.label = '\ucc63\u0dc2\uab23\u0312\ucb12\u{1ff41}\ueff4\u{1fb51}';
+} catch {}
+let buffer110 = device1.createBuffer({size: 814, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let commandEncoder200 = device1.createCommandEncoder({});
+try {
+computePassEncoder69.setBindGroup(1, bindGroup113);
+} catch {}
+try {
+computePassEncoder76.setBindGroup(2, bindGroup3, new Uint32Array(1767), 149, 0);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(2, bindGroup97);
+} catch {}
+try {
+renderPassEncoder35.executeBundles([renderBundle22, renderBundle20]);
+} catch {}
+let adapter2 = await navigator.gpu.requestAdapter({});
+let buffer111 = device1.createBuffer({
+  size: 19718,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder201 = device1.createCommandEncoder({});
+let computePassEncoder147 = commandEncoder201.beginComputePass({});
+try {
+computePassEncoder135.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder49.setBindGroup(3, bindGroup20);
+} catch {}
+try {
+renderPassEncoder31.end();
+} catch {}
+try {
+renderPassEncoder48.setStencilReference(464);
+} catch {}
+try {
+commandEncoder122.clearBuffer(buffer103, 6336, 14216);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 270, height: 5, depthOrArrayLayers: 354}
+*/
+{
+  source: img1,
+  origin: { x: 0, y: 32 },
+  flipY: true,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 207},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture219 = device0.createTexture({size: [525, 1, 1], mipLevelCount: 4, format: 'rgba16uint', usage: GPUTextureUsage.COPY_DST});
+try {
+computePassEncoder25.setBindGroup(0, bindGroup126);
+} catch {}
+try {
+computePassEncoder10.setBindGroup(2, bindGroup92, new Uint32Array(882), 191, 0);
+} catch {}
+try {
+renderPassEncoder47.setBindGroup(1, bindGroup45, new Uint32Array(1533), 504, 0);
+} catch {}
+let querySet25 = device0.createQuerySet({type: 'occlusion', count: 250});
+let sampler131 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 96.64});
+let externalTexture26 = device0.importExternalTexture({source: videoFrame1});
+try {
+{ clearResourceUsages(device0, computePassEncoder25); computePassEncoder25.dispatchWorkgroupsIndirect(buffer53, 548); };
+} catch {}
+try {
+computePassEncoder25.end();
+} catch {}
+try {
+computePassEncoder38.setPipeline(pipeline11);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+renderPassEncoder52.insertDebugMarker('\u1a61');
+} catch {}
+let imageData22 = new ImageData(120, 164);
+let texture220 = device0.createTexture({
+  size: {width: 131},
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView184 = texture50.createView({mipLevelCount: 1, baseArrayLayer: 4, arrayLayerCount: 1});
+let renderPassEncoder55 = commandEncoder35.beginRenderPass({
+  colorAttachments: [{view: textureView177, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet2,
+  maxDrawCount: 263126251,
+});
+let renderBundleEncoder30 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint'], depthReadOnly: true});
+let renderBundle30 = renderBundleEncoder30.finish();
+try {
+computePassEncoder115.setBindGroup(3, bindGroup12);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder130); computePassEncoder130.dispatchWorkgroupsIndirect(buffer7, 15_656); };
+} catch {}
+try {
+computePassEncoder49.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder52.executeBundles([renderBundle10, renderBundle17]);
+} catch {}
+try {
+renderPassEncoder37.setViewport(123.02773330355599, 0.9190311462314699, 0.24851513240840079, 0.041171162253912694, 0.04140566856022254, 0.6975581996537403);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer101, 'uint32', 352, 1_822);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 64, height: 64, depthOrArrayLayers: 21}
+*/
+{
+  source: imageData16,
+  origin: { x: 14, y: 1 },
+  flipY: true,
+}, {
+  texture: texture181,
+  mipLevel: 0,
+  origin: {x: 2, y: 10, z: 5},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 9, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder202 = device1.createCommandEncoder({});
+let texture221 = device1.createTexture({
+  size: {width: 540, height: 10, depthOrArrayLayers: 1},
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder45.setBindGroup(2, bindGroup55);
+} catch {}
+try {
+renderPassEncoder30.executeBundles([renderBundle22, renderBundle22]);
+} catch {}
+try {
+renderPassEncoder50.setVertexBuffer(1, undefined, 916_123_296, 1_284_157_903);
+} catch {}
+try {
+commandEncoder202.resolveQuerySet(querySet15, 28, 12, buffer91, 1536);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1728, height: 12, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 40, y: 1 },
+  flipY: true,
+}, {
+  texture: texture136,
+  mipLevel: 0,
+  origin: {x: 182, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 367, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup129 = device1.createBindGroup({layout: veryExplicitBindGroupLayout29, entries: [{binding: 205, resource: textureView135}]});
+let commandEncoder203 = device1.createCommandEncoder({});
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup20, new Uint32Array(99), 42, 0);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(5, buffer77);
+} catch {}
+try {
+buffer110.unmap();
+} catch {}
+try {
+device1.queue.writeBuffer(buffer111, 488, new BigUint64Array(4510), 855, 504);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture211,
+  mipLevel: 0,
+  origin: {x: 89, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(315).fill(126), /* required buffer size: 315 */
+{offset: 315}, {width: 25, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let buffer112 = device0.createBuffer({
+  size: 6184,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let textureView185 = texture95.createView({});
+try {
+{ clearResourceUsages(device0, computePassEncoder130); computePassEncoder130.dispatchWorkgroupsIndirect(buffer31, 620); };
+} catch {}
+try {
+renderPassEncoder41.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle27]);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(0, buffer8, 0, 566);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture207,
+  mipLevel: 0,
+  origin: {x: 50, y: 0, z: 2},
+  aspect: 'all',
+}, new Uint8Array(43).fill(44), /* required buffer size: 43 */
+{offset: 43}, {width: 50, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let buffer113 = device1.createBuffer({
+  size: 7310,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder204 = device1.createCommandEncoder();
+let textureView186 = texture75.createView({baseArrayLayer: 0, arrayLayerCount: 1});
+let renderPassEncoder56 = commandEncoder204.beginRenderPass({
+  colorAttachments: [{
+  view: textureView109,
+  clearValue: { r: 543.7, g: 422.6, b: 621.9, a: -933.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet7,
+});
+try {
+computePassEncoder41.setBindGroup(3, bindGroup35);
+} catch {}
+try {
+commandEncoder200.copyBufferToTexture({
+  /* bytesInLastRow: 1152 widthInBlocks: 288 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 204 */
+  offset: 204,
+  bytesPerRow: 1792,
+  buffer: buffer6,
+}, {
+  texture: texture116,
+  mipLevel: 0,
+  origin: {x: 110, y: 2, z: 10},
+  aspect: 'all',
+}, {width: 288, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let buffer114 = device1.createBuffer({
+  size: 2081,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+});
+let commandEncoder205 = device1.createCommandEncoder();
+let textureView187 = texture46.createView({mipLevelCount: 1});
+let computePassEncoder148 = commandEncoder200.beginComputePass({});
+document.body.append(canvas4);
+let commandEncoder206 = device0.createCommandEncoder({});
+let texture222 = device0.createTexture({
+  size: {width: 262, height: 1, depthOrArrayLayers: 33},
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let computePassEncoder149 = commandEncoder206.beginComputePass({});
+try {
+computePassEncoder4.setBindGroup(2, bindGroup24, new Uint32Array(1681), 132, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder130); computePassEncoder130.dispatchWorkgroupsIndirect(buffer53, 3_064); };
+} catch {}
+try {
+computePassEncoder130.end();
+} catch {}
+try {
+computePassEncoder29.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(7, buffer5, 52, 143);
+} catch {}
+try {
+buffer61.unmap();
+} catch {}
+try {
+computePassEncoder26.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+computePassEncoder127.setBindGroup(2, bindGroup55, new Uint32Array(8047), 1_354, 0);
+} catch {}
+try {
+commandEncoder203.copyBufferToBuffer(buffer39, 8, buffer55, 6368, 32);
+} catch {}
+try {
+commandEncoder203.copyBufferToTexture({
+  /* bytesInLastRow: 336 widthInBlocks: 42 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1088 */
+  offset: 1088,
+  bytesPerRow: 44288,
+  buffer: buffer111,
+}, {
+  texture: texture149,
+  mipLevel: 0,
+  origin: {x: 57, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 42, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 198, y: 10, z: 0},
+  aspect: 'all',
+}, new Uint8Array(125).fill(100), /* required buffer size: 125 */
+{offset: 125}, {width: 10, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout20 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout5]});
+let commandEncoder207 = device0.createCommandEncoder({});
+let renderPassEncoder57 = commandEncoder175.beginRenderPass({
+  colorAttachments: [{
+  view: textureView179,
+  depthSlice: 51,
+  clearValue: { r: -622.0, g: -958.1, b: -632.0, a: -684.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder63.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+commandEncoder207.copyTextureToBuffer({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 2, y: 14, z: 9},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 24 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 56 */
+  offset: 56,
+  bytesPerRow: 24064,
+  buffer: buffer14,
+}, {width: 6, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder207.copyTextureToTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 9, y: 4, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture198,
+  mipLevel: 0,
+  origin: {x: 46, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup130 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout17,
+  entries: [{binding: 278, resource: {buffer: buffer47, offset: 0, size: 152}}],
+});
+let computePassEncoder150 = commandEncoder203.beginComputePass();
+try {
+renderPassEncoder3.setIndexBuffer(buffer84, 'uint32', 1_676, 242);
+} catch {}
+try {
+renderPassEncoder42.setVertexBuffer(7, buffer45, 1_536, 5_516);
+} catch {}
+try {
+device1.pushErrorScope('validation');
+} catch {}
+let veryExplicitBindGroupLayout33 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 264,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let pipelineLayout21 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout10]});
+let texture223 = device0.createTexture({size: [131, 1, 1], format: 'rg8uint', usage: GPUTextureUsage.TEXTURE_BINDING, viewFormats: []});
+let textureView188 = texture180.createView({});
+let computePassEncoder151 = commandEncoder207.beginComputePass({});
+try {
+computePassEncoder13.setBindGroup(1, bindGroup106, new Uint32Array(1762), 1_594, 0);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer31, 'uint16', 1_466, 30);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(5, buffer80, 1_900, 711);
+} catch {}
+let pipeline14 = device0.createComputePipeline({layout: pipelineLayout21, compute: {module: shaderModule3, constants: {}}});
+let buffer115 = device0.createBuffer({size: 17798, usage: GPUBufferUsage.MAP_READ});
+let commandEncoder208 = device0.createCommandEncoder();
+let renderPassEncoder58 = commandEncoder208.beginRenderPass({
+  colorAttachments: [{
+  view: textureView179,
+  depthSlice: 84,
+  clearValue: { r: -657.6, g: 843.0, b: -171.1, a: 37.80, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 85016469,
+});
+try {
+computePassEncoder143.setBindGroup(2, bindGroup19);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder29); computePassEncoder29.dispatchWorkgroups(2); };
+} catch {}
+try {
+computePassEncoder134.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(3, bindGroup37);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(3, bindGroup11, new Uint32Array(170), 5, 0);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(7, buffer73, 36, 16);
+} catch {}
+let buffer116 = device0.createBuffer({size: 3670, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture224 = device0.createTexture({
+  size: [525, 1, 38],
+  mipLevelCount: 2,
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let texture225 = gpuCanvasContext3.getCurrentTexture();
+try {
+computePassEncoder102.setBindGroup(3, bindGroup40, new Uint32Array(677), 397, 0);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(2, bindGroup74);
+} catch {}
+try {
+renderPassEncoder14.setBlendConstant({ r: -905.2, g: -155.3, b: -571.2, a: 347.0, });
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer81, 'uint32', 72, 236);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+});
+} catch {}
+let offscreenCanvas4 = new OffscreenCanvas(213, 804);
+let commandEncoder209 = device0.createCommandEncoder({});
+let computePassEncoder152 = commandEncoder209.beginComputePass({});
+try {
+computePassEncoder126.setBindGroup(1, bindGroup53, new Uint32Array(1913), 1_034, 0);
+} catch {}
+try {
+computePassEncoder121.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder58.setBindGroup(3, bindGroup74);
+} catch {}
+try {
+renderPassEncoder52.setPipeline(pipeline6);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+try {
+globalThis.someLabel = externalTexture2.label;
+} catch {}
+try {
+computePassEncoder29.end();
+} catch {}
+try {
+computePassEncoder13.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder58.setBindGroup(0, bindGroup84, new Uint32Array(389), 89, 0);
+} catch {}
+try {
+renderPassEncoder37.beginOcclusionQuery(77);
+} catch {}
+try {
+renderPassEncoder37.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder57.setPipeline(pipeline3);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let buffer117 = device1.createBuffer({size: 4291, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let commandEncoder210 = device1.createCommandEncoder({});
+let commandBuffer6 = commandEncoder122.finish();
+let texture226 = gpuCanvasContext1.getCurrentTexture();
+let textureView189 = texture140.createView({});
+let sampler132 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 91.14,
+});
+try {
+renderPassEncoder35.setScissorRect(35, 0, 4, 0);
+} catch {}
+try {
+buffer77.unmap();
+} catch {}
+try {
+commandEncoder205.copyTextureToBuffer({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 109, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 904 widthInBlocks: 226 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2060 */
+  offset: 2060,
+  bytesPerRow: 1536,
+  buffer: buffer74,
+}, {width: 226, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let videoFrame33 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'fcc', primaries: 'bt470bg', transfer: 'logSqrt'} });
+let buffer118 = device1.createBuffer({size: 1972, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let computePassEncoder153 = commandEncoder210.beginComputePass({});
+try {
+computePassEncoder100.setBindGroup(1, bindGroup51);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(0, bindGroup109);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer39, 'uint32', 24, 1);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(7, buffer71, 0, 903);
+} catch {}
+try {
+commandEncoder202.copyTextureToBuffer({
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 164, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 112 */
+  offset: 112,
+  bytesPerRow: 512,
+  buffer: buffer36,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8unorm'],
+});
+} catch {}
+try {
+device1.queue.submit([commandBuffer6]);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+try {
+computePassEncoder19.setBindGroup(0, bindGroup89);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(2, bindGroup11, new Uint32Array(1149), 121, 0);
+} catch {}
+try {
+renderPassEncoder54.setViewport(139.99228668098064, 0.323069022547688, 93.76704241952332, 0.46454642467273993, 0.8296635551417378, 0.9944074289210963);
+} catch {}
+try {
+  await buffer97.mapAsync(GPUMapMode.WRITE, 1368, 1888);
+} catch {}
+try {
+commandEncoder39.copyBufferToBuffer(buffer87, 44, buffer8, 6316, 136);
+} catch {}
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame22.close();
+videoFrame23.close();
+videoFrame25.close();
+videoFrame26.close();
+videoFrame27.close();
+videoFrame28.close();
+videoFrame29.close();
+videoFrame30.close();
+videoFrame31.close();
+videoFrame32.close();
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>


### PR DESCRIPTION
#### 0fcfda2cd76d01cc4b5494cb75345b951bc1a64d
<pre>
[WebGPU] out of bounds access to shaderStage array in Device::createBindGroup
<a href="https://bugs.webkit.org/show_bug.cgi?id=284335">https://bugs.webkit.org/show_bug.cgi?id=284335</a>
<a href="https://rdar.apple.com/141184676">rdar://141184676</a>

Reviewed by Dan Glastonbury.

Not a security issue but placing visibility = 0 on a bind group entry
resulted in a crash since EnumeratedArray release asserts on out of
bounds access.

* LayoutTests/fast/webgpu/nocrash/fuzz-284335-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-284335.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::Device::createBindGroup):
Only necessary if the shader stage != Undefined.

Canonical link: <a href="https://commits.webkit.org/287687@main">https://commits.webkit.org/287687@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6737b3cc206151eb14dbddcd04f4ce22b895d9e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80450 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59457 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34111 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84971 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31432 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68518 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7759 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62860 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20668 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83519 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52952 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73245 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43163 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50260 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27402 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29891 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71401 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27921 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86405 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7676 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5421 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71151 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7851 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69083 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70443 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17548 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14393 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13338 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7638 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7477 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10996 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9282 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->