### PR TITLE
Allocate megapages from different page provider than large allocations in libpas

### DIFF
--- a/LayoutTests/crypto/crypto-random-values-oom.html
+++ b/LayoutTests/crypto/crypto-random-values-oom.html
@@ -11,16 +11,6 @@ description("Test crypto.getRandomValues behavior in oom situation.")
 let exceptionString = undefined;
 
 function useAllMemory() {
-    const a = [];
-    a.length = 2**30;
-    a.__proto__ = {};
-    Object.defineProperty(a, 0, {get: foo});
-
-    function foo() {
-        new Uint8Array(a);
-    }
-
-    new Promise(foo);
     try {
         for (let i = 0; i < 1000; i++) {
           new ArrayBuffer(2**20);

--- a/LayoutTests/storage/indexeddb/IDBKey-create-array-buffer-view-oom.html
+++ b/LayoutTests/storage/indexeddb/IDBKey-create-array-buffer-view-oom.html
@@ -11,18 +11,6 @@ description("Test IndexedDB IDBKeyRange when we are Out of Memory.");
 // Since we are low on memory, it is difficult to use the exception test helpers.
 let exceptionString = undefined;
 
-const a = [];
-a.length = 2**30;
-a.__proto__ = {};
-Object.defineProperty(a, 0, { get: foo });
-function foo() {
-    new Uint8Array(a);
-}
-
-try {
-    foo();
-} catch { }
-
 try {
     for (let timeoutCount = 1000; timeoutCount--;)
         new ArrayBuffer(2**20);

--- a/Source/bmalloc/CMakeLists.txt
+++ b/Source/bmalloc/CMakeLists.txt
@@ -186,6 +186,8 @@ set(bmalloc_C_SOURCES
     libpas/src/libpas/pas_simple_free_heap_helpers.c
     libpas/src/libpas/pas_simple_large_free_heap.c
     libpas/src/libpas/pas_simple_type.c
+    libpas/src/libpas/pas_small_medium_bootstrap_free_heap.c
+    libpas/src/libpas/pas_small_medium_bootstrap_heap_page_provider.c
     libpas/src/libpas/pas_status_reporter.c
     libpas/src/libpas/pas_stream.c
     libpas/src/libpas/pas_string_stream.c
@@ -556,6 +558,7 @@ set(bmalloc_PUBLIC_HEADERS
     libpas/src/libpas/pas_page_base.h
     libpas/src/libpas/pas_page_base_inlines.h
     libpas/src/libpas/pas_page_config_kind.h
+    libpas/src/libpas/pas_page_config_size_category.h
     libpas/src/libpas/pas_page_granule_use_count.h
     libpas/src/libpas/pas_page_header_placement_mode.h
     libpas/src/libpas/pas_page_header_table.h
@@ -645,6 +648,8 @@ set(bmalloc_PUBLIC_HEADERS
     libpas/src/libpas/pas_slow_path_mode.h
     libpas/src/libpas/pas_slow_path_mode_prefix.h
     libpas/src/libpas/pas_small_large_map_entry.h
+    libpas/src/libpas/pas_small_medium_bootstrap_free_heap.h
+    libpas/src/libpas/pas_small_medium_bootstrap_heap_page_provider.h
     libpas/src/libpas/pas_snprintf.h
     libpas/src/libpas/pas_status_reporter.h
     libpas/src/libpas/pas_stream.h

--- a/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 55;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -145,6 +145,11 @@
 		6599C5CC1EC3F15900A2F7BB /* AvailableMemory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6599C5CA1EC3F15900A2F7BB /* AvailableMemory.cpp */; };
 		6599C5CD1EC3F15900A2F7BB /* AvailableMemory.h in Headers */ = {isa = PBXBuildFile; fileRef = 6599C5CB1EC3F15900A2F7BB /* AvailableMemory.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		65FE739D2B79E09800C5CDAF /* TZoneHeapManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 65072AE62B6195B90065065C /* TZoneHeapManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		7234F6B62D01112E000B645D /* pas_small_medium_bootstrap_heap_page_provider.h in Headers */ = {isa = PBXBuildFile; fileRef = 7234F6B42D01112E000B645D /* pas_small_medium_bootstrap_heap_page_provider.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		7234F6B72D01112E000B645D /* pas_small_medium_bootstrap_free_heap.h in Headers */ = {isa = PBXBuildFile; fileRef = 7234F6B22D01112E000B645D /* pas_small_medium_bootstrap_free_heap.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		7234F6B82D01112E000B645D /* pas_small_medium_bootstrap_free_heap.c in Sources */ = {isa = PBXBuildFile; fileRef = 7234F6B32D01112E000B645D /* pas_small_medium_bootstrap_free_heap.c */; };
+		7234F6B92D01112E000B645D /* pas_small_medium_bootstrap_heap_page_provider.c in Sources */ = {isa = PBXBuildFile; fileRef = 7234F6B52D01112E000B645D /* pas_small_medium_bootstrap_heap_page_provider.c */; };
+		7234F6C42D011152000B645D /* pas_page_config_size_category.h in Headers */ = {isa = PBXBuildFile; fileRef = 7234F6C22D011152000B645D /* pas_page_config_size_category.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7939885B2076EEB60074A2E7 /* BulkDecommit.h in Headers */ = {isa = PBXBuildFile; fileRef = 7939885A2076EEB50074A2E7 /* BulkDecommit.h */; };
 		795AB3C7206E0D340074FE76 /* PhysicalPageMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 795AB3C6206E0D250074FE76 /* PhysicalPageMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		AD0934331FCF406D00E85EB5 /* BCompiler.h in Headers */ = {isa = PBXBuildFile; fileRef = AD0934321FCF405000E85EB5 /* BCompiler.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1368,6 +1373,11 @@
 		652E16962C4869D000C377D7 /* TZoneLog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TZoneLog.cpp; path = bmalloc/TZoneLog.cpp; sourceTree = "<group>"; };
 		6599C5CA1EC3F15900A2F7BB /* AvailableMemory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = AvailableMemory.cpp; path = bmalloc/AvailableMemory.cpp; sourceTree = "<group>"; };
 		6599C5CB1EC3F15900A2F7BB /* AvailableMemory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AvailableMemory.h; path = bmalloc/AvailableMemory.h; sourceTree = "<group>"; };
+		7234F6B22D01112E000B645D /* pas_small_medium_bootstrap_free_heap.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; name = pas_small_medium_bootstrap_free_heap.h; path = libpas/src/libpas/pas_small_medium_bootstrap_free_heap.h; sourceTree = "<group>"; };
+		7234F6B32D01112E000B645D /* pas_small_medium_bootstrap_free_heap.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pas_small_medium_bootstrap_free_heap.c; path = libpas/src/libpas/pas_small_medium_bootstrap_free_heap.c; sourceTree = "<group>"; };
+		7234F6B42D01112E000B645D /* pas_small_medium_bootstrap_heap_page_provider.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; name = pas_small_medium_bootstrap_heap_page_provider.h; path = libpas/src/libpas/pas_small_medium_bootstrap_heap_page_provider.h; sourceTree = "<group>"; };
+		7234F6B52D01112E000B645D /* pas_small_medium_bootstrap_heap_page_provider.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pas_small_medium_bootstrap_heap_page_provider.c; path = libpas/src/libpas/pas_small_medium_bootstrap_heap_page_provider.c; sourceTree = "<group>"; };
+		7234F6C22D011152000B645D /* pas_page_config_size_category.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = pas_page_config_size_category.h; path = libpas/src/libpas/pas_page_config_size_category.h; sourceTree = "<group>"; };
 		7939885A2076EEB50074A2E7 /* BulkDecommit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BulkDecommit.h; path = bmalloc/BulkDecommit.h; sourceTree = "<group>"; };
 		795AB3C6206E0D250074FE76 /* PhysicalPageMap.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = PhysicalPageMap.h; path = bmalloc/PhysicalPageMap.h; sourceTree = "<group>"; };
 		AD0934321FCF405000E85EB5 /* BCompiler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BCompiler.h; path = bmalloc/BCompiler.h; sourceTree = "<group>"; };
@@ -1858,6 +1868,7 @@
 				0F87005625AF8A1A000E1ABF /* pas_page_base_config_utils_inlines.h */,
 				0F87005025AF8A1A000E1ABF /* pas_page_base_inlines.h */,
 				0F87004A25AF8A19000E1ABF /* pas_page_config_kind.h */,
+				7234F6C22D011152000B645D /* pas_page_config_size_category.h */,
 				0F87006225AF8A1B000E1ABF /* pas_page_granule_use_count.h */,
 				0F87004925AF8A19000E1ABF /* pas_page_header_placement_mode.h */,
 				0F87006125AF8A1B000E1ABF /* pas_page_header_table.c */,
@@ -1980,6 +1991,10 @@
 				0FC40A922451498D00876DA0 /* pas_slow_path_mode.h */,
 				0FC40A612451498900876DA0 /* pas_slow_path_mode_prefix.h */,
 				0FC40AD52451499100876DA0 /* pas_small_large_map_entry.h */,
+				7234F6B32D01112E000B645D /* pas_small_medium_bootstrap_free_heap.c */,
+				7234F6B22D01112E000B645D /* pas_small_medium_bootstrap_free_heap.h */,
+				7234F6B52D01112E000B645D /* pas_small_medium_bootstrap_heap_page_provider.c */,
+				7234F6B42D01112E000B645D /* pas_small_medium_bootstrap_heap_page_provider.h */,
 				0FC40AEB2451499300876DA0 /* pas_snprintf.h */,
 				0FC40A1E2451498400876DA0 /* pas_status_reporter.c */,
 				0FC40A1B2451498400876DA0 /* pas_status_reporter.h */,
@@ -2582,6 +2597,7 @@
 				DD4BEE0D29CBA49700398E35 /* pas_page_base_config_utils_inlines.h in Headers */,
 				DD4BED4A29CBA49700398E35 /* pas_page_base_inlines.h in Headers */,
 				DD4BEC7729CBA49700398E35 /* pas_page_config_kind.h in Headers */,
+				7234F6C42D011152000B645D /* pas_page_config_size_category.h in Headers */,
 				DD4BED6A29CBA49700398E35 /* pas_page_granule_use_count.h in Headers */,
 				DD4BED3429CBA49700398E35 /* pas_page_header_placement_mode.h in Headers */,
 				DD4BECE729CBA49700398E35 /* pas_page_header_table.h in Headers */,
@@ -2670,6 +2686,8 @@
 				DD4BECE129CBA49700398E35 /* pas_slow_path_mode.h in Headers */,
 				DD4BEC9029CBA49700398E35 /* pas_slow_path_mode_prefix.h in Headers */,
 				DD4BEDEF29CBA49700398E35 /* pas_small_large_map_entry.h in Headers */,
+				7234F6B72D01112E000B645D /* pas_small_medium_bootstrap_free_heap.h in Headers */,
+				7234F6B62D01112E000B645D /* pas_small_medium_bootstrap_heap_page_provider.h in Headers */,
 				DD4BECCB29CBA49700398E35 /* pas_snprintf.h in Headers */,
 				DD4BEDE429CBA49700398E35 /* pas_status_reporter.h in Headers */,
 				DD4BED7029CBA49700398E35 /* pas_stream.h in Headers */,
@@ -3020,6 +3038,9 @@
 				DD4BED3229CBA49700398E35 /* pas_simple_free_heap_helpers.c in Sources */,
 				DD4BEC9929CBA49700398E35 /* pas_simple_large_free_heap.c in Sources */,
 				DD4BEDC529CBA49700398E35 /* pas_simple_type.c in Sources */,
+				7234F6B82D01112E000B645D /* pas_small_medium_bootstrap_free_heap.c in Sources */,
+				7234F6C72D011EF3000B645D /* pas_small_medium_bootstrap_free_heap.h in Sources */,
+				7234F6B92D01112E000B645D /* pas_small_medium_bootstrap_heap_page_provider.c in Sources */,
 				DD4BEC7A29CBA49700398E35 /* pas_status_reporter.c in Sources */,
 				DD4BED2329CBA49700398E35 /* pas_stream.c in Sources */,
 				DD4BEE0729CBA49700398E35 /* pas_string_stream.c in Sources */,

--- a/Source/bmalloc/libpas/src/libpas/jit_heap_config.h
+++ b/Source/bmalloc/libpas/src/libpas/jit_heap_config.h
@@ -133,6 +133,7 @@ PAS_HEAP_CONFIG_SPECIALIZATION_DECLARATIONS(jit_heap_config);
             .heap_config_ptr = &jit_heap_config, \
             .page_config_ptr = &jit_heap_config.variant_lowercase ## _bitfit_config.base, \
             .page_config_kind = pas_page_config_kind_bitfit, \
+            .page_config_size_category = pas_page_config_size_category_ ## variant_lowercase, \
             .min_align_shift = JIT_ ## variant_uppercase ## _BITFIT_MIN_ALIGN_SHIFT, \
             .page_size = JIT_ ## variant_uppercase ## _PAGE_SIZE, \
             .granule_size = JIT_ ## variant_uppercase ## _GRANULE_SIZE, \
@@ -166,6 +167,7 @@ PAS_HEAP_CONFIG_SPECIALIZATION_DECLARATIONS(jit_heap_config);
                 .heap_config_ptr = &jit_heap_config, \
                 .page_config_ptr = &jit_heap_config.small_segregated_config.base, \
                 .page_config_kind = pas_page_config_kind_segregated, \
+                .page_config_size_category = pas_page_config_size_category_small, \
                 .min_align_shift = JIT_SMALL_SEGREGATED_MIN_ALIGN_SHIFT, \
                 .page_size = JIT_SMALL_PAGE_SIZE, \
                 .granule_size = JIT_SMALL_GRANULE_SIZE, \

--- a/Source/bmalloc/libpas/src/libpas/pas_basic_heap_page_caches.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_basic_heap_page_caches.h
@@ -37,6 +37,7 @@ struct pas_basic_heap_page_caches;
 typedef struct pas_basic_heap_page_caches pas_basic_heap_page_caches;
 
 struct pas_basic_heap_page_caches {
+    pas_large_heap_physical_page_sharing_cache megapage_large_heap_cache;
     pas_large_heap_physical_page_sharing_cache large_heap_cache;
     pas_megapage_cache small_exclusive_segregated_megapage_cache;
     pas_shared_page_directory_by_size small_shared_page_directories;
@@ -51,6 +52,7 @@ struct pas_basic_heap_page_caches {
 
 #define PAS_BASIC_HEAP_PAGE_CACHES_INITIALIZER(small_log_shift, medium_log_shift) \
     ((pas_basic_heap_page_caches){ \
+        .megapage_large_heap_cache = PAS_MEGAPAGE_LARGE_FREE_HEAP_PHYSICAL_PAGE_SHARING_CACHE_INITIALIZER, \
         .large_heap_cache = PAS_LARGE_FREE_HEAP_PHYSICAL_PAGE_SHARING_CACHE_INITIALIZER, \
         .small_exclusive_segregated_megapage_cache = PAS_MEGAPAGE_CACHE_INITIALIZER, \
         .small_shared_page_directories = PAS_SHARED_PAGE_DIRECTORY_BY_SIZE_INITIALIZER( \

--- a/Source/bmalloc/libpas/src/libpas/pas_compact_heap_reservation.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_compact_heap_reservation.c
@@ -71,7 +71,7 @@ pas_aligned_allocation_result pas_compact_heap_reservation_try_allocate(size_t s
         PAS_ASSERT(page_result.result);
 #else
         page_result = pas_page_malloc_try_allocate_without_deallocating_padding(
-            pas_compact_heap_reservation_size, pas_alignment_create_trivial());
+            pas_compact_heap_reservation_size, pas_alignment_create_trivial(), false);
         PAS_ASSERT(!page_result.left_padding_size);
         PAS_ASSERT(!page_result.right_padding_size);
         PAS_ASSERT(page_result.result);

--- a/Source/bmalloc/libpas/src/libpas/pas_enumerable_page_malloc.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_enumerable_page_malloc.c
@@ -35,11 +35,11 @@ pas_enumerable_range_list pas_enumerable_page_malloc_page_list;
 
 pas_aligned_allocation_result
 pas_enumerable_page_malloc_try_allocate_without_deallocating_padding(
-    size_t size, pas_alignment alignment)
+    size_t size, pas_alignment alignment, bool may_contain_small_or_medium)
 {
     pas_aligned_allocation_result result;
 
-    result = pas_page_malloc_try_allocate_without_deallocating_padding(size, alignment);
+    result = pas_page_malloc_try_allocate_without_deallocating_padding(size, alignment, may_contain_small_or_medium);
 
     if (result.result) {
         pas_enumerable_range_list_append(

--- a/Source/bmalloc/libpas/src/libpas/pas_enumerator_region.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_enumerator_region.c
@@ -52,7 +52,7 @@ void* pas_enumerator_region_allocate(pas_enumerator_region** region_ptr,
         PAS_ASSERT_WITH_DETAIL(pas_is_aligned(allocation_size, PAS_INTERNAL_MIN_ALIGN));
 
         allocation_result = pas_page_malloc_try_allocate_without_deallocating_padding(
-            allocation_size, pas_alignment_create_trivial());
+            allocation_size, pas_alignment_create_trivial(), false);
 
         PAS_ASSERT_WITH_DETAIL(allocation_result.result);
         PAS_ASSERT_WITH_DETAIL(allocation_result.result == allocation_result.left_padding);

--- a/Source/bmalloc/libpas/src/libpas/pas_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap.c
@@ -72,7 +72,8 @@ pas_heap* pas_heap_create(pas_heap_ref* heap_ref,
     heap->type = heap_ref->type;
     pas_segregated_heap_construct(
         &heap->segregated_heap, heap, config, runtime_config);
-    pas_large_heap_construct(&heap->large_heap);
+    pas_large_heap_construct(&heap->megapage_large_heap, true);
+    pas_large_heap_construct(&heap->large_heap, false);
     heap->heap_ref = heap_ref;
     heap->heap_ref_kind = heap_ref_kind;
     heap->config_kind = config->kind;

--- a/Source/bmalloc/libpas/src/libpas/pas_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap.h
@@ -44,6 +44,7 @@ typedef struct pas_segregated_page pas_segregated_page;
 
 struct pas_heap {
     pas_segregated_heap segregated_heap;
+    pas_large_heap megapage_large_heap;
     pas_large_heap large_heap;
     const pas_heap_type* type;
     pas_heap_ref* heap_ref;
@@ -61,11 +62,14 @@ PAS_API pas_heap* pas_heap_create(pas_heap_ref* heap_ref,
 PAS_API size_t pas_heap_get_type_size(pas_heap* heap);
 PAS_API size_t pas_heap_get_type_alignment(pas_heap* heap);
 
-/* The large heap belongs to the heap in such a way that given a large heap, we can find the
+/* All large heaps belong to the heap in such a way that given a large heap, we can find the
    heap. */
 static inline pas_heap* pas_heap_for_large_heap(pas_large_heap* large_heap)
 {
-    return (pas_heap*)((uintptr_t)large_heap - PAS_OFFSETOF(pas_heap, large_heap));
+    size_t offset = large_heap->is_megapage_heap
+        ? PAS_OFFSETOF(pas_heap, megapage_large_heap)
+        : PAS_OFFSETOF(pas_heap, large_heap);
+    return (pas_heap*)((uintptr_t)large_heap - offset);
 }
 
 /* FIXME: It would be so much simpler if every segregated_heap belong to a heap, or if they were just

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.c
@@ -119,7 +119,10 @@ pas_heap_config_utils_allocate_aligned(
 
     runtime_config = (pas_basic_heap_runtime_config*)
         pas_heap_for_large_heap(large_heap)->segregated_heap.runtime_config;
-    cache = &runtime_config->page_caches->large_heap_cache;
+    if (large_heap->is_megapage_heap)
+        cache = &runtime_config->page_caches->megapage_large_heap_cache;
+    else
+        cache = &runtime_config->page_caches->large_heap_cache;
     
     allocation_result =
         pas_large_heap_physical_page_sharing_cache_try_allocate_with_alignment(

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.h
@@ -104,6 +104,7 @@ typedef struct {
             .heap_config_ptr = &name ## _heap_config, \
             .page_config_ptr = &name ## _heap_config.small_segregated_config.base, \
             .page_config_kind = pas_page_config_kind_segregated, \
+            .page_config_size_category = pas_page_config_size_category_small, \
             .min_align_shift = \
                 ((pas_basic_heap_config_arguments){__VA_ARGS__}).small_segregated_min_align_shift, \
             .page_size = \
@@ -170,6 +171,7 @@ typedef struct {
             .heap_config_ptr = &name ## _heap_config, \
             .page_config_ptr = &name ## _heap_config.medium_segregated_config.base, \
             .page_config_kind = pas_page_config_kind_segregated, \
+            .page_config_size_category = pas_page_config_size_category_medium, \
             .min_align_shift = \
                 ((pas_basic_heap_config_arguments){__VA_ARGS__}).medium_segregated_min_align_shift, \
             .page_size = \
@@ -222,6 +224,7 @@ typedef struct {
             .heap_config_ptr = &name ## _heap_config, \
             .page_config_ptr = &name ## _heap_config.small_bitfit_config.base, \
             .page_config_kind = pas_page_config_kind_bitfit, \
+            .page_config_size_category = pas_page_config_size_category_small, \
             .min_align_shift = \
                 ((pas_basic_heap_config_arguments){__VA_ARGS__}).small_bitfit_min_align_shift, \
             .page_size = \
@@ -263,6 +266,7 @@ typedef struct {
             .heap_config_ptr = &name ## _heap_config, \
             .page_config_ptr = &name ## _heap_config.medium_bitfit_config.base, \
             .page_config_kind = pas_page_config_kind_bitfit, \
+            .page_config_size_category = pas_page_config_size_category_medium, \
             .min_align_shift = \
                 ((pas_basic_heap_config_arguments){__VA_ARGS__}).medium_bitfit_min_align_shift, \
             .page_size = \
@@ -293,6 +297,7 @@ typedef struct {
             .heap_config_ptr = &name ## _heap_config, \
             .page_config_ptr = &name ## _heap_config.marge_bitfit_config.base, \
             .page_config_kind = pas_page_config_kind_bitfit, \
+            .page_config_size_category = pas_page_config_size_category_marge, \
             .min_align_shift = \
                 ((pas_basic_heap_config_arguments){__VA_ARGS__}).marge_bitfit_min_align_shift, \
             .page_size = \

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_kind.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_kind.h
@@ -34,6 +34,7 @@ PAS_BEGIN_EXTERN_C;
    part of that. */
 enum pas_heap_kind {
     pas_bootstrap_free_heap_kind,
+    pas_small_medium_bootstrap_free_heap_kind,
     pas_compact_bootstrap_free_heap_kind,
     pas_large_utility_free_heap_kind,
     pas_immortal_heap_kind,
@@ -44,13 +45,15 @@ enum pas_heap_kind {
 
 typedef enum pas_heap_kind pas_heap_kind;
 
-#define PAS_NUM_HEAP_KINDS 7
+#define PAS_NUM_HEAP_KINDS 8
 
 static inline const char* pas_heap_kind_get_string(pas_heap_kind kind)
 {
     switch (kind) {
     case pas_bootstrap_free_heap_kind:
         return "bootstrap_free_heap";
+    case pas_small_medium_bootstrap_free_heap_kind:
+        return "small_medium_bootstrap_free_heap";
     case pas_compact_bootstrap_free_heap_kind:
         return "compact_bootstrap_free_heap";
     case pas_large_utility_free_heap_kind:

--- a/Source/bmalloc/libpas/src/libpas/pas_large_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_heap.c
@@ -41,7 +41,7 @@
 #include "pas_probabilistic_guard_malloc_allocator.h"
 #include <stdio.h>
 
-void pas_large_heap_construct(pas_large_heap* heap)
+void pas_large_heap_construct(pas_large_heap* heap, bool is_megapage_heap)
 {
     /* Warning: anything you do here must be duplicated in
        pas_try_allocate_intrinsic.h. */
@@ -49,6 +49,7 @@ void pas_large_heap_construct(pas_large_heap* heap)
     pas_fast_large_free_heap_construct(&heap->free_heap);
     heap->table_state = pas_heap_table_state_uninitialized;
     heap->index = 0;
+    heap->is_megapage_heap = is_megapage_heap;
 }
 
 typedef struct {

--- a/Source/bmalloc/libpas/src/libpas/pas_large_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_heap.h
@@ -44,12 +44,13 @@ struct pas_large_heap {
     pas_fast_large_free_heap free_heap;
     uint16_t index;
     pas_heap_table_state table_state : 8;
+    bool is_megapage_heap;
 };
 
 /* Note that all of these functions have to be called with the heap lock held. */
 
 /* NOTE: it's only valid to construct a large heap that is a member of a pas_heap. */
-PAS_API void pas_large_heap_construct(pas_large_heap* heap);
+PAS_API void pas_large_heap_construct(pas_large_heap* heap, bool is_megapage_heap);
 
 PAS_API pas_allocation_result
 pas_large_heap_try_allocate_and_forget(pas_large_heap* heap,

--- a/Source/bmalloc/libpas/src/libpas/pas_large_heap_physical_page_sharing_cache.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_heap_physical_page_sharing_cache.h
@@ -44,6 +44,13 @@ struct pas_large_heap_physical_page_sharing_cache {
     void* provider_arg;
 };
 
+#define PAS_MEGAPAGE_LARGE_FREE_HEAP_PHYSICAL_PAGE_SHARING_CACHE_INITIALIZER \
+    ((pas_large_heap_physical_page_sharing_cache){ \
+         .free_heap = PAS_SIMPLE_LARGE_FREE_HEAP_INITIALIZER, \
+         .provider = pas_small_medium_bootstrap_heap_page_provider, \
+         .provider_arg = NULL \
+     })
+
 #define PAS_LARGE_FREE_HEAP_PHYSICAL_PAGE_SHARING_CACHE_INITIALIZER \
     ((pas_large_heap_physical_page_sharing_cache){ \
          .free_heap = PAS_SIMPLE_LARGE_FREE_HEAP_INITIALIZER, \

--- a/Source/bmalloc/libpas/src/libpas/pas_local_allocator.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_local_allocator.h
@@ -55,6 +55,7 @@ struct pas_local_allocator {
     uint8_t alignment_shift;
     pas_local_allocator_config_kind config_kind : 8;
     bool current_word_is_valid; /* This is just used by enumeration. */
+    bool is_small_bumpable; /* Marks that the bumpable region in this local allocator is part of a small page. */
 
     /* This has to have a pointer to our index within the view. We can get to the view using
        page_ish. Maybe worth reconsidering that, but then again maybe it's good enough. 

--- a/Source/bmalloc/libpas/src/libpas/pas_megapage_cache.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_megapage_cache.h
@@ -28,6 +28,7 @@
 
 #include "pas_bootstrap_heap_page_provider.h"
 #include "pas_simple_large_free_heap.h"
+#include "pas_small_medium_bootstrap_heap_page_provider.h"
 #include "pas_utils.h"
 
 PAS_BEGIN_EXTERN_C;
@@ -59,7 +60,7 @@ struct pas_megapage_cache_config {
 
 #define PAS_MEGAPAGE_CACHE_INITIALIZER { \
         .free_heap = PAS_SIMPLE_LARGE_FREE_HEAP_INITIALIZER, \
-        .provider = pas_bootstrap_heap_page_provider, \
+        .provider = pas_small_medium_bootstrap_heap_page_provider, \
         .provider_arg = NULL \
     }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_page_base_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_base_config.h
@@ -28,6 +28,7 @@
 
 #include "pas_lock.h"
 #include "pas_page_config_kind.h"
+#include "pas_page_config_size_category.h"
 #include "pas_page_kind.h"
 #include "pas_page_granule_use_count.h"
 #include "pas_utils.h"
@@ -73,6 +74,9 @@ struct pas_page_base_config {
     /* What page_kind to put in pages allocated by this config. This happens to tell if the config
        is a segregated or a bitfit config. */
     pas_page_config_kind page_config_kind;
+
+    /* The broad object size of pages allocated by this config, as in small or medium or large. */
+    pas_page_config_size_category page_config_size_category;
 
     /* Smallest small object size and the minimum alignment. */
     uint8_t min_align_shift;

--- a/Source/bmalloc/libpas/src/libpas/pas_page_config_size_category.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_config_size_category.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Apple Inc. All rights reserved.
+ * Copyright (c) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -20,27 +20,42 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef PAS_ENUMERABLE_PAGE_MALLOC_H
-#define PAS_ENUMERABLE_PAGE_MALLOC_H
+#ifndef PAS_PAGE_CONFIG_SIZE_CATEGORY_H
+#define PAS_PAGE_CONFIG_SIZE_CATEGORY_H
 
-#include "pas_aligned_allocation_result.h"
-#include "pas_alignment.h"
-#include "pas_enumerable_range_list.h"
+#include "pas_utils.h"
 
 PAS_BEGIN_EXTERN_C;
 
-PAS_API extern pas_enumerable_range_list pas_enumerable_page_malloc_page_list;
+enum pas_page_config_size_category {
+    pas_page_config_size_category_small,
+    pas_page_config_size_category_medium,
+    pas_page_config_size_category_marge,
+    pas_page_config_size_category_large,
+};
 
-/* It's assumed that whatever is returned from this is never deallocated, but may be decommitted. */
-PAS_API pas_aligned_allocation_result
-pas_enumerable_page_malloc_try_allocate_without_deallocating_padding(
-    size_t size, pas_alignment alignment, bool may_contain_small_or_medium);
+typedef enum pas_page_config_size_category pas_page_config_size_category;
+
+static inline const char* pas_page_config_size_category_get_string(pas_page_config_size_category page_config_size_category)
+{
+    switch (page_config_size_category) {
+    case pas_page_config_size_category_small:
+        return "small";
+    case pas_page_config_size_category_medium:
+        return "medium";
+    case pas_page_config_size_category_marge:
+        return "marge";
+    case pas_page_config_size_category_large:
+        return "large";
+    }
+    PAS_ASSERT(!"Should not be reached");
+    return NULL;
+}
 
 PAS_END_EXTERN_C;
 
-#endif /* PAS_ENUMERABLE_PAGE_MALLOC_H */
-
+#endif /* PAS_PAGE_CONFIG_SIZE_CATEGORY_H */
 

--- a/Source/bmalloc/libpas/src/libpas/pas_page_malloc.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_malloc.c
@@ -86,11 +86,11 @@ PAS_NEVER_INLINE size_t pas_page_malloc_alignment_shift_slow(void)
 }
 
 static void*
-pas_page_malloc_try_map_pages(size_t size)
+pas_page_malloc_try_map_pages(size_t size, bool may_contain_small_or_medium)
 {
     void* mmap_result = NULL;
 
-    PAS_PROFILE(PAGE_ALLOCATION, size, PAS_VM_TAG);
+    PAS_PROFILE(PAGE_ALLOCATION, size, may_contain_small_or_medium, PAS_VM_TAG);
 
     mmap_result = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON | PAS_NORESERVE, PAS_VM_TAG, 0);
     if (mmap_result == MAP_FAILED) {
@@ -106,7 +106,7 @@ pas_page_malloc_try_map_pages(size_t size)
 
 pas_aligned_allocation_result
 pas_page_malloc_try_allocate_without_deallocating_padding(
-    size_t size, pas_alignment alignment)
+    size_t size, pas_alignment alignment, bool may_contain_small_or_medium)
 {
     static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
     
@@ -141,7 +141,7 @@ pas_page_malloc_try_allocate_without_deallocating_padding(
             return result;
     }
 
-    mmap_result = pas_page_malloc_try_map_pages(mapped_size);
+    mmap_result = pas_page_malloc_try_map_pages(mapped_size, may_contain_small_or_medium);
     if (!mmap_result)
         return result;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_page_malloc.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_malloc.h
@@ -60,7 +60,7 @@ static inline size_t pas_page_malloc_alignment_shift(void)
 
 PAS_API pas_aligned_allocation_result
 pas_page_malloc_try_allocate_without_deallocating_padding(
-    size_t size, pas_alignment alignment);
+    size_t size, pas_alignment alignment, bool may_contain_small_or_medium);
 
 PAS_API void pas_page_malloc_deallocate(void* base, size_t size);
 

--- a/Source/bmalloc/libpas/src/libpas/pas_small_medium_bootstrap_free_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_small_medium_bootstrap_free_heap.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 Apple Inc. All rights reserved.
+ * Copyright (c) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -20,19 +20,19 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include "pas_config.h"
 
 #if LIBPAS_ENABLED
 
-#include "pas_bootstrap_free_heap.h"
+#include "pas_small_medium_bootstrap_free_heap.h"
 
 #include "pas_config.h"
+#include "pas_enumerable_page_malloc.h"
 #include "pas_heap_lock.h"
 #include "pas_large_free_heap_config.h"
-#include "pas_enumerable_page_malloc.h"
 #include "pas_simple_free_heap_helpers.h"
 
 static pas_aligned_allocation_result bootstrap_source_allocate_aligned(size_t size,
@@ -43,12 +43,12 @@ static pas_aligned_allocation_result bootstrap_source_allocate_aligned(size_t si
     static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_BOOTSTRAP_HEAPS);
 
     if (verbose)
-        pas_log("bootstrap heap allocating %zu\n", size);
+        pas_log("small/medium bootstrap heap allocating %zu\n", size);
 
-    pas_aligned_allocation_result retval = pas_enumerable_page_malloc_try_allocate_without_deallocating_padding(size, alignment, false);
+    pas_aligned_allocation_result retval = pas_enumerable_page_malloc_try_allocate_without_deallocating_padding(size, alignment, true);
 
     if (verbose)
-        pas_log("bootstrap heap done allocating, returning %p.\n", retval.result);
+        pas_log("small/medium bootstrap heap done allocating, returning %p.\n", retval.result);
 
     return retval;
 }
@@ -63,8 +63,8 @@ static void initialize_config(pas_large_free_heap_config* config)
     config->deallocator_arg = NULL;
 }
 
-#define PAS_SIMPLE_FREE_HEAP_NAME pas_bootstrap_free_heap
-#define PAS_SIMPLE_FREE_HEAP_ID(suffix) pas_bootstrap_free_heap ## suffix
+#define PAS_SIMPLE_FREE_HEAP_NAME pas_small_medium_bootstrap_free_heap
+#define PAS_SIMPLE_FREE_HEAP_ID(suffix) pas_small_medium_bootstrap_free_heap ## suffix
 #include "pas_simple_free_heap_definitions.def"
 #undef PAS_SIMPLE_FREE_HEAP_NAME
 #undef PAS_SIMPLE_FREE_HEAP_ID

--- a/Source/bmalloc/libpas/src/libpas/pas_small_medium_bootstrap_free_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_small_medium_bootstrap_free_heap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Apple Inc. All rights reserved.
+ * Copyright (c) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -20,27 +20,27 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef PAS_ENUMERABLE_PAGE_MALLOC_H
-#define PAS_ENUMERABLE_PAGE_MALLOC_H
+#ifndef PAS_SMALL_MEDIUM_BOOTSTRAP_FREE_HEAP_H
+#define PAS_SMALL_MEDIUM_BOOTSTRAP_FREE_HEAP_H
 
-#include "pas_aligned_allocation_result.h"
-#include "pas_alignment.h"
-#include "pas_enumerable_range_list.h"
+#include "pas_allocation_config.h"
+#include "pas_allocation_kind.h"
+#include "pas_lock.h"
+#include "pas_simple_large_free_heap.h"
 
 PAS_BEGIN_EXTERN_C;
 
-PAS_API extern pas_enumerable_range_list pas_enumerable_page_malloc_page_list;
+#define PAS_BOOTSTRAP_FOR_SMALL_FREE_LIST_MINIMUM_SIZE 4u
 
-/* It's assumed that whatever is returned from this is never deallocated, but may be decommitted. */
-PAS_API pas_aligned_allocation_result
-pas_enumerable_page_malloc_try_allocate_without_deallocating_padding(
-    size_t size, pas_alignment alignment, bool may_contain_small_or_medium);
+#define PAS_SIMPLE_FREE_HEAP_NAME pas_small_medium_bootstrap_free_heap
+#define PAS_SIMPLE_FREE_HEAP_ID(suffix) pas_small_medium_bootstrap_free_heap ## suffix
+#include "pas_simple_free_heap_declarations.def"
+#undef PAS_SIMPLE_FREE_HEAP_NAME
+#undef PAS_SIMPLE_FREE_HEAP_ID
 
 PAS_END_EXTERN_C;
 
-#endif /* PAS_ENUMERABLE_PAGE_MALLOC_H */
-
-
+#endif /* PAS_SMALL_MEDIUM_BOOTSTRAP_FREE_HEAP_H */

--- a/Source/bmalloc/libpas/src/libpas/pas_small_medium_bootstrap_heap_page_provider.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_small_medium_bootstrap_heap_page_provider.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Apple Inc. All rights reserved.
+ * Copyright (c) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -20,27 +20,40 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef PAS_ENUMERABLE_PAGE_MALLOC_H
-#define PAS_ENUMERABLE_PAGE_MALLOC_H
+#include "pas_config.h"
 
-#include "pas_aligned_allocation_result.h"
-#include "pas_alignment.h"
-#include "pas_enumerable_range_list.h"
+#if LIBPAS_ENABLED
 
-PAS_BEGIN_EXTERN_C;
+#include "pas_small_medium_bootstrap_heap_page_provider.h"
 
-PAS_API extern pas_enumerable_range_list pas_enumerable_page_malloc_page_list;
+#include "pas_small_medium_bootstrap_free_heap.h"
 
-/* It's assumed that whatever is returned from this is never deallocated, but may be decommitted. */
-PAS_API pas_aligned_allocation_result
-pas_enumerable_page_malloc_try_allocate_without_deallocating_padding(
-    size_t size, pas_alignment alignment, bool may_contain_small_or_medium);
+pas_allocation_result pas_small_medium_bootstrap_heap_page_provider(
+    size_t size,
+    pas_alignment alignment,
+    const char* name,
+    pas_heap* heap,
+    pas_physical_memory_transaction* transaction,
+    void *arg)
+{
+    PAS_UNUSED_PARAM(arg);
+    PAS_UNUSED_PARAM(heap);
+    PAS_UNUSED_PARAM(transaction);
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_BOOTSTRAP_HEAPS);
 
-PAS_END_EXTERN_C;
+    if (verbose)
+        pas_log("small/medium bootstrap heap page-provider allocating %zu for %s\n", size, name);
 
-#endif /* PAS_ENUMERABLE_PAGE_MALLOC_H */
+    pas_allocation_result retval = pas_small_medium_bootstrap_free_heap_try_allocate_with_alignment(
+        size, alignment, name, pas_delegate_allocation);
 
+    if (verbose)
+        pas_log("small/medium bootstrap heap page-provider done allocating\n");
 
+    return retval;
+}
+
+#endif /* LIBPAS_ENABLED */

--- a/Source/bmalloc/libpas/src/libpas/pas_small_medium_bootstrap_heap_page_provider.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_small_medium_bootstrap_heap_page_provider.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Apple Inc. All rights reserved.
+ * Copyright (c) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -20,27 +20,25 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef PAS_ENUMERABLE_PAGE_MALLOC_H
-#define PAS_ENUMERABLE_PAGE_MALLOC_H
+#ifndef PAS_SMALL_MEDIUM_BOOTSTRAP_HEAP_PAGE_PROVIDER_H
+#define PAS_SMALL_MEDIUM_BOOTSTRAP_HEAP_PAGE_PROVIDER_H
 
-#include "pas_aligned_allocation_result.h"
-#include "pas_alignment.h"
-#include "pas_enumerable_range_list.h"
+#include "pas_heap_page_provider.h"
 
 PAS_BEGIN_EXTERN_C;
 
-PAS_API extern pas_enumerable_range_list pas_enumerable_page_malloc_page_list;
-
-/* It's assumed that whatever is returned from this is never deallocated, but may be decommitted. */
-PAS_API pas_aligned_allocation_result
-pas_enumerable_page_malloc_try_allocate_without_deallocating_padding(
-    size_t size, pas_alignment alignment, bool may_contain_small_or_medium);
+PAS_API pas_allocation_result pas_small_medium_bootstrap_heap_page_provider(
+    size_t size,
+    pas_alignment alignment,
+    const char* name,
+    pas_heap* heap,
+    pas_physical_memory_transaction* transaction,
+    void *arg);
 
 PAS_END_EXTERN_C;
 
-#endif /* PAS_ENUMERABLE_PAGE_MALLOC_H */
-
+#endif /* PAS_SMALL_MEDIUM_BOOTSTRAP_HEAP_PAGE_PROVIDER_H */
 

--- a/Source/bmalloc/libpas/src/libpas/pas_try_allocate_intrinsic.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_allocate_intrinsic.h
@@ -62,10 +62,17 @@ PAS_BEGIN_EXTERN_C;
 
 #define PAS_INTRINSIC_HEAP_INITIALIZER(heap_ptr, primitive_type, intrinsic_support, passed_config, runtime_config) { \
         PAS_INTRINSIC_HEAP_SEGREGATED_HEAP_FIELDS(heap_ptr, intrinsic_support, runtime_config) \
+        .megapage_large_heap = { \
+            .free_heap = PAS_FAST_LARGE_FREE_HEAP_INITIALIZER, \
+            .index = 0, \
+            .table_state = pas_heap_table_state_uninitialized, \
+            .is_megapage_heap = true, \
+        }, \
         .large_heap = { \
             .free_heap = PAS_FAST_LARGE_FREE_HEAP_INITIALIZER, \
             .index = 0, \
             .table_state = pas_heap_table_state_uninitialized, \
+            .is_megapage_heap = false, \
         }, \
         .type = (const pas_heap_type*)(primitive_type), \
         .heap_ref = NULL, \

--- a/Source/bmalloc/libpas/src/libpas/pas_utility_heap_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_utility_heap_config.h
@@ -96,6 +96,7 @@ PAS_API void pas_utility_heap_config_dump_shared_page_directory_arg(
                 .heap_config_ptr = &pas_utility_heap_config, \
                 .page_config_ptr = &pas_utility_heap_config.small_segregated_config.base, \
                 .page_config_kind = pas_page_config_kind_segregated, \
+                .page_config_size_category = pas_page_config_size_category_small, \
                 .min_align_shift = PAS_INTERNAL_MIN_ALIGN_SHIFT, \
                 .page_size = PAS_SMALL_PAGE_DEFAULT_SIZE, \
                 .granule_size = PAS_SMALL_PAGE_DEFAULT_SIZE, \


### PR DESCRIPTION
#### 968212ccdd07944a158b38d628827e06f2f1fa89
<pre>
Allocate megapages from different page provider than large allocations in libpas
<a href="https://bugs.webkit.org/show_bug.cgi?id=284338">https://bugs.webkit.org/show_bug.cgi?id=284338</a>
<a href="https://rdar.apple.com/138070544">rdar://138070544</a>

Reviewed by Yusuke Suzuki.

This patch separates out the way megapages are allocated from other
large allocations in libpas. First, we create a distinct bootstrap heap
and page provider for small/medium allocations. Next, we create a new
large free heap whose page provider is this new bootstrap heap. Next,
for each pas_heap, we create a new megapage_large_heap alongside the
existing large heap, a pas_large_heap backed by the new bootstrap heap.
Finally, we change the way megapage caches are constructed, to use this
new large heap as the allocator for megapages instead of self-hosting
using the existing large heap. Altogether, this means megapages, and the
small/medium objects within them, are no longer allocated out of the same
page source as marge/large objects. This patch also adds some new fields
to page configs and local allocators to make it clear whether a page or
allocator belongs to a megapage or not.

This patch also decreases the memory pressure in two OOM layout tests.
These tests are relying too strongly on the absence of an OOM error in
subsequent code, and with this patch perturbing the heap, it seems they
consistently but spuriously crash with an OOM error. Removing some
allocations in these tests reduces the chance we get an OOM after the
critical section of the test is over, preventing spurious failures.

* Source/bmalloc/CMakeLists.txt:
* Source/bmalloc/bmalloc.xcodeproj/project.pbxproj:
* Source/bmalloc/libpas/src/libpas/jit_heap_config.h:
* Source/bmalloc/libpas/src/libpas/pas_basic_heap_page_caches.h:
* Source/bmalloc/libpas/src/libpas/pas_bootstrap_free_heap.c:
(bootstrap_source_allocate_aligned):
* Source/bmalloc/libpas/src/libpas/pas_compact_heap_reservation.c:
(pas_compact_heap_reservation_try_allocate):
* Source/bmalloc/libpas/src/libpas/pas_create_basic_heap_page_caches_with_reserved_memory.c:
(allocate_from_megapages):
(pas_create_basic_heap_page_caches_with_reserved_memory):
* Source/bmalloc/libpas/src/libpas/pas_enumerable_page_malloc.c:
(pas_enumerable_page_malloc_try_allocate_without_deallocating_padding):
* Source/bmalloc/libpas/src/libpas/pas_enumerable_page_malloc.h:
* Source/bmalloc/libpas/src/libpas/pas_enumerator_region.c:
(pas_enumerator_region_allocate):
* Source/bmalloc/libpas/src/libpas/pas_heap.c:
(pas_heap_create):
* Source/bmalloc/libpas/src/libpas/pas_heap.h:
(pas_heap_for_large_heap):
* Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.c:
(pas_heap_config_utils_allocate_aligned):
* Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.h:
* Source/bmalloc/libpas/src/libpas/pas_heap_kind.h:
(pas_heap_kind_get_string):
* Source/bmalloc/libpas/src/libpas/pas_large_heap.c:
(pas_large_heap_construct):
* Source/bmalloc/libpas/src/libpas/pas_large_heap.h:
* Source/bmalloc/libpas/src/libpas/pas_large_heap_physical_page_sharing_cache.h:
* Source/bmalloc/libpas/src/libpas/pas_local_allocator.h:
* Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h:
(pas_local_allocator_set_up_bump):
(pas_local_allocator_make_bump):
(pas_local_allocator_set_up_primordial_bump):
(pas_local_allocator_try_allocate_inline_cases):
* Source/bmalloc/libpas/src/libpas/pas_megapage_cache.h:
* Source/bmalloc/libpas/src/libpas/pas_page_base_config.h:
* Source/bmalloc/libpas/src/libpas/pas_page_config_size.h: Copied from Source/bmalloc/libpas/src/libpas/pas_enumerable_page_malloc.h.
(pas_page_config_size_get_string):
* Source/bmalloc/libpas/src/libpas/pas_page_malloc.c:
(pas_page_malloc_try_map_pages):
(pas_page_malloc_try_allocate_without_deallocating_padding):
* Source/bmalloc/libpas/src/libpas/pas_page_malloc.h:
* Source/bmalloc/libpas/src/libpas/pas_segregated_page_config_kind.h:
(pas_segregated_page_config_kind_is_small):
* Source/bmalloc/libpas/src/libpas/pas_small_medium_bootstrap_free_heap.c: Copied from Source/bmalloc/libpas/src/libpas/pas_bootstrap_free_heap.c.
(bootstrap_source_allocate_aligned):
(initialize_config):
* Source/bmalloc/libpas/src/libpas/pas_small_medium_bootstrap_free_heap.h: Copied from Source/bmalloc/libpas/src/libpas/pas_enumerable_page_malloc.h.
* Source/bmalloc/libpas/src/libpas/pas_small_medium_bootstrap_heap_page_provider.c: Copied from Source/bmalloc/libpas/src/libpas/pas_enumerable_page_malloc.c.
(pas_small_medium_bootstrap_heap_page_provider):
* Source/bmalloc/libpas/src/libpas/pas_small_medium_bootstrap_heap_page_provider.h: Copied from Source/bmalloc/libpas/src/libpas/pas_enumerable_page_malloc.h.
* Source/bmalloc/libpas/src/libpas/pas_try_allocate_intrinsic.h:
* Source/bmalloc/libpas/src/libpas/pas_utility_heap_config.h:

Canonical link: <a href="https://commits.webkit.org/288057@main">https://commits.webkit.org/288057@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2f3a581bb99dd1b399523849f3896cb4b7a5ece

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81752 "47 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1278 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35706 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86297 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32748 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1311 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9098 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63777 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21500 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84822 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/952 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74404 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44063 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/852 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28579 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31201 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/74732 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29182 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87735 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/80806 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8992 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6388 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72113 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9177 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70224 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71343 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17776 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15441 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14358 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/103218 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8943 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25062 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8784 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12307 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10592 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->