### PR TITLE
Fix http/tests/security/aboutBlank/security-context-window-open.html with site isolation enabled

### DIFF
--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -242,7 +242,6 @@ http/tests/referrer-policy-anchor/unsafe-url/cross-origin-http.https.html [ Skip
 http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-top-frame-redirect-collusion.html [ Skip ]
 http/tests/resourceLoadStatistics/third-party-cookie-blocking-on-sites-without-user-interaction.html [ Skip ]
 http/tests/resourceLoadStatistics/third-party-cookie-blocking.html [ Skip ]
-http/tests/security/aboutBlank/security-context-window-open.html [ Skip ]
 http/tests/security/beforeload-iframe-server-redirect.html [ Skip ]
 http/tests/security/block-top-level-navigations-by-third-party-iframes.html [ Skip ]
 http/tests/security/contentSecurityPolicy/1.1/form-action-src-allowed.html [ Skip ]


### PR DESCRIPTION
#### 40dcc54d8f8a587b9b8d5f6eeeeaed12ce9a22b5
<pre>
Fix http/tests/security/aboutBlank/security-context-window-open.html with site isolation enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=284343">https://bugs.webkit.org/show_bug.cgi?id=284343</a>
<a href="https://rdar.apple.com/141188809">rdar://141188809</a>

Reviewed by NOBODY (OOPS!).

In Document::initSecurityContext we are setting the cookie URL based on the owner frame.
Before this PR we were assuming the owner frame was always a LocalFrame, and it is with
site isolation off.  With site isolation on, though, we need to not return early if there&apos;s
a RemoteFrame and use the Page&apos;s main frame URL instead, which is updated in all processes.
There&apos;s still more work to do in this area, but this makes the test pass instead of crashing.

* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::initSecurityContext):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40dcc54d8f8a587b9b8d5f6eeeeaed12ce9a22b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59205 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33616 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84720 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31179 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82314 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68266 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7504 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62698 "Found 34 new test failures: fast/cookies/cookie-averse-document.html http/tests/cookies/same-site/fetch-in-about-blank-popup.html http/tests/cookies/same-site/fetch-in-cross-origin-iframe.html http/tests/cookies/third-party-cookie-relaxing.html http/tests/storageAccess/aggregate-sorted-data-with-storage-access.https.html http/tests/storageAccess/grant-storage-access-under-opener-at-popup-user-gesture-ephemeral.https.html http/tests/storageAccess/grant-storage-access-under-opener-at-popup-user-gesture.https.html http/tests/storageAccess/grant-with-prompt-under-general-third-party-cookie-blocking.https.html http/tests/storageAccess/has-storage-access-true-if-third-party-has-cookies.https.html http/tests/storageAccess/has-storage-access-under-general-third-party-cookie-blocking-with-cookie.https.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20505 "Found 22 new test failures: http/tests/cookies/third-party-cookie-relaxing.html http/tests/resourceLoadStatistics/blocking-in-web-worker-script-import.https.html http/tests/resourceLoadStatistics/no-third-party-cookie-blocking-when-itp-is-off.html http/tests/security/aboutBlank/security-context-grandchildren-lexical.html http/tests/security/aboutBlank/security-context-grandchildren-write-lexical.html http/tests/security/aboutBlank/security-context-grandchildren-writeln-lexical.html http/tests/security/aboutBlank/security-context-grandchildren.html http/tests/security/aboutBlank/security-context-window-open.html http/tests/security/cookies/base-about-blank.html http/tests/security/cookies/base-tag.html ... (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83272 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52764 "Found 29 new test failures: fast/cookies/cookie-averse-document.html http/tests/cookies/same-site/fetch-after-navigating-iframe-in-cross-origin-page.html http/tests/cookies/same-site/fetch-in-about-blank-popup.html http/tests/cookies/same-site/fetch-in-cross-origin-iframe.html http/tests/cookies/third-party-cookie-relaxing.html http/tests/resourceLoadStatistics/add-blocking-to-redirect.html http/tests/resourceLoadStatistics/blocking-in-web-worker-script-import.https.html http/tests/resourceLoadStatistics/cookie-deletion.html http/tests/resourceLoadStatistics/cookies-with-and-without-user-interaction.html http/tests/resourceLoadStatistics/do-not-remove-blocking-in-redirect.https.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73041 "Found 1 new API test failure: TestWebKitAPI.SOAuthorizationSubFrame.InterceptionSucceedWithCookie (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43006 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50094 "Found 16 new test failures: imported/w3c/web-platform-tests/cookies/attributes/expires.html imported/w3c/web-platform-tests/cookies/attributes/invalid.html imported/w3c/web-platform-tests/cookies/attributes/max-age.html imported/w3c/web-platform-tests/cookies/attributes/path-redirect.html imported/w3c/web-platform-tests/cookies/attributes/path.html imported/w3c/web-platform-tests/cookies/attributes/secure-non-secure.html imported/w3c/web-platform-tests/cookies/attributes/secure.https.html imported/w3c/web-platform-tests/cookies/name/name-ctl.html imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.tentative.https.html imported/w3c/web-platform-tests/cookies/path/default.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27195 "Found 28 new test failures: fast/cookies/cookie-averse-document.html http/tests/cookies/same-site/fetch-after-navigating-iframe-in-cross-origin-page.html http/tests/cookies/same-site/fetch-in-about-blank-popup.html http/tests/cookies/same-site/fetch-in-cross-origin-iframe.html http/tests/cookies/third-party-cookie-relaxing.html http/tests/security/aboutBlank/security-context-grandchildren-lexical.html http/tests/security/aboutBlank/security-context-grandchildren-write-lexical.html http/tests/security/aboutBlank/security-context-grandchildren-writeln-lexical.html http/tests/security/aboutBlank/security-context-grandchildren.html http/tests/security/aboutBlank/security-context-window-open.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29640 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71223 "Found 1 new API test failure: TestWebKitAPI.SOAuthorizationSubFrame.InterceptionSucceedWithCookie (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27705 "Found 60 new test failures: css3/color-filters/color-filter-current-color.html fast/cookies/cookie-averse-document.html fast/css/tagname-and-namespace-case-sensitivity-xml-in-xhtml.xhtml fast/editing/recursive-reapply-edit-command-crash.html fast/selectors/selection-gap-background-color.html fast/table/multiple-captions-crash5.html fast/text/emoji-gender-2-6.html http/tests/cookies/same-site/fetch-after-navigating-iframe-in-cross-origin-page.html http/tests/cookies/same-site/fetch-in-about-blank-popup.html http/tests/cookies/same-site/fetch-in-cross-origin-iframe.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86152 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7423 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5252 "Found 60 new test failures: fast/cookies/cookie-averse-document.html fast/selectors/text-field-selection-stroke-color.html fast/text/emoji-gender-2-9.html fast/writing-mode/english-rl-text-with-spelling-marker.html gamepad/gamepad-event-handlers.html http/tests/cookies/same-site/fetch-in-about-blank-popup.html http/tests/cookies/same-site/fetch-in-cross-origin-iframe.html http/tests/cookies/third-party-cookie-relaxing.html http/tests/misc/repeat-open-cancel.html http/tests/resourceLoadStatistics/add-blocking-to-redirect.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70968 "Found 47 new test failures: fast/cookies/cookie-averse-document.html http/tests/cookies/same-site/fetch-in-about-blank-popup.html http/tests/cookies/same-site/fetch-in-cross-origin-iframe.html http/tests/cookies/third-party-cookie-relaxing.html http/tests/security/aboutBlank/security-context-grandchildren-lexical.html http/tests/security/aboutBlank/security-context-grandchildren-write-lexical.html http/tests/security/aboutBlank/security-context-grandchildren-writeln-lexical.html http/tests/security/aboutBlank/security-context-grandchildren.html http/tests/security/aboutBlank/security-context-window-open.html http/tests/security/cookies/base-about-blank.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7598 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68881 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70209 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14200 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13153 "Found 60 new test failures: css3/masking/reference-clip-path-animate-transform-repaint.html fast/attachment/attachment-title-with-rtl.html fast/cookies/cookie-averse-document.html http/tests/cookies/same-site/fetch-after-navigating-iframe-in-cross-origin-page.html http/tests/cookies/same-site/fetch-in-about-blank-popup.html http/tests/cookies/same-site/fetch-in-cross-origin-iframe.html http/tests/cookies/third-party-cookie-relaxing.html http/tests/resourceLoadStatistics/add-blocking-to-redirect.html http/tests/resourceLoadStatistics/blocking-in-web-worker-script-import.https.html http/tests/resourceLoadStatistics/cookie-deletion.html ... (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7387 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12904 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7226 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10746 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9031 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->