### PR TITLE
bindings/scripts/preprocessor.pm reports "Use of uninitialized value $defines" after 287517@main

### DIFF
--- a/Source/WebCore/bindings/scripts/preprocessor.pm
+++ b/Source/WebCore/bindings/scripts/preprocessor.pm
@@ -63,12 +63,15 @@ sub applyPreprocessor
         push(@args, "-isysroot", $ENV{SDKROOT}) if $ENV{SDKROOT};
     }
 
-    # Remove double quotations from $defines and extract macros.
-    # For example, if $defines is ' "A=1" "B=1" C=1 ""    D  ',
-    # then it is converted into four macros -DA=1, -DB=1, -DC=1 and -DD.
-    $defines =~ s/\"//g;
-    my @macros = grep { $_ } split(/\s+/, $defines); # grep skips empty macros.
-    @macros = map { "-D$_" } @macros;
+    my @macros;
+    if ($defines) {
+        # Remove double quotations from $defines and extract macros.
+        # For example, if $defines is ' "A=1" "B=1" C=1 ""    D  ',
+        # then it is converted into four macros -DA=1, -DB=1, -DC=1 and -DD.
+        $defines =~ s/\"//g;
+        @macros = grep { $_ } split(/\s+/, $defines); # grep skips empty macros.
+        @macros = map { "-D$_" } @macros;
+    }
 
     my $pid = 0;
     if ($Config{osname} eq "cygwin") {


### PR DESCRIPTION
#### 317066649cb974825180c7e250193c3b0cf8635b
<pre>
bindings/scripts/preprocessor.pm reports &quot;Use of uninitialized value $defines&quot; after 287517@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=284345">https://bugs.webkit.org/show_bug.cgi?id=284345</a>

Reviewed by Chris Dumez.

&lt;<a href="https://commits.webkit.org/287517@main">https://commits.webkit.org/287517@main</a>&gt; added a CMake rule to
generate bindings for WebExtensions. It don&apos;t use --defines switch.
preprocessor.pm reported &quot;Use of uninitialized value $defines&quot;.

Added an UNDEF check for $defines.

* Source/WebCore/bindings/scripts/preprocessor.pm:
(applyPreprocessor):

Canonical link: <a href="https://commits.webkit.org/287583@main">https://commits.webkit.org/287583@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be2eb3536121ca3a92d611e882784181418054e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80205 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59207 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33618 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84722 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31181 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82316 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68268 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7506 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62694 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/20510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83274 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/52765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73042 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43002 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/50095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27196 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29642 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/71224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27706 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86154 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7425 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/70969 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7600 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68882 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70210 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14204 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/13154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12403 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7389 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/7228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/10748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9033 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->