### PR TITLE
[iOS] Software keyboard sometimes dismisses immediately when focusing elements in the Pearson TestNav app

### DIFF
--- a/LayoutTests/fast/events/touch/ios/focus-textarea-on-touchstart-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/focus-textarea-on-touchstart-expected.txt
@@ -1,0 +1,11 @@
+Verifies that the keyboard does not immediately dismiss after tapping on an editable element that is focused during `touchstart`. This test requires WebKitTestRunner.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS willHideCountBeforeTapping is willHideCountAfterTapping
+PASS Dismissed keyboard
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/events/touch/ios/focus-textarea-on-touchstart.html
+++ b/LayoutTests/fast/events/touch/ios/focus-textarea-on-touchstart.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+<script src="../../../../resources/js-test.js" type="text/javascript"></script>
+<script src="../../../../resources/ui-helper.js" type="text/javascript"></script>
+<style>
+body, html {
+    margin: 0;
+    width: 100%;
+    height: 5000px;
+}
+
+textarea {
+    width: 100%;
+    height: 100px;
+    position: absolute;
+    top: calc(100% - 100px);
+    left: 0;
+    display: block;
+    font-size: 20px;
+    border: 1px solid tomato;
+    border-radius: 4px;
+    outline: none;
+    box-sizing: border-box;
+    padding: 6px;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Verifies that the keyboard does not immediately dismiss after tapping on an editable element that is focused during `touchstart`. This test requires WebKitTestRunner.");
+
+    const textarea = document.querySelector("textarea");
+    textarea.addEventListener("touchstart", () => {
+        textarea.focus();
+    });
+
+    let target = UIHelper.midPointOfRect(textarea.getBoundingClientRect());
+
+    document.body.addEventListener("click", () => {
+        // Empty click event handler to trigger a potential synthetic click over the body.
+    });
+
+    await UIHelper.setHardwareKeyboardAttached(false);
+
+    willHideCountBeforeTapping = await UIHelper.keyboardWillHideCount();
+    await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+        .begin(target.x, target.y)
+        .wait(0.2)
+        .end()
+        .takeResult());
+
+    await UIHelper.waitForKeyboardToShow();
+
+    // Also wait for the keyboard to begin dismissing, in the case where the bug reproduces.
+    await UIHelper.delayFor(200);
+
+    willHideCountAfterTapping = await UIHelper.keyboardWillHideCount();
+
+    shouldBe("willHideCountBeforeTapping", "willHideCountAfterTapping");
+
+    document.activeElement.blur();
+    await UIHelper.waitForKeyboardToHide();
+    testPassed("Dismissed keyboard");
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <textarea>Tap here (slowly)</textarea>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -4399,12 +4399,12 @@ void WebPageProxy::handlePreventableTouchEvent(NativeWebTouchEvent& event)
     sendPreventableTouchEvent(m_mainFrame->frameID(), event);
 }
 
-void WebPageProxy::didBeginTouchPoint()
+void WebPageProxy::didBeginTouchPoint(FloatPoint locationInRootView)
 {
     if (!hasRunningProcess())
         return;
 
-    send(Messages::WebPage::DidBeginTouchPoint());
+    send(Messages::WebPage::DidBeginTouchPoint(locationInRootView));
 }
 
 void WebPageProxy::sendUnpreventableTouchEvent(WebCore::FrameIdentifier frameID, const NativeWebTouchEvent& event)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1289,7 +1289,7 @@ public:
 #endif
 
 #if ENABLE(IOS_TOUCH_EVENTS)
-    void didBeginTouchPoint();
+    void didBeginTouchPoint(WebCore::FloatPoint locationInRootView);
     void handlePreventableTouchEvent(NativeWebTouchEvent&);
     void handleUnpreventableTouchEvent(const NativeWebTouchEvent&);
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -2154,7 +2154,7 @@ typedef NS_ENUM(NSInteger, EndEditingReason) {
         _layerTreeTransactionIdAtLastInteractionStart = downcast<WebKit::RemoteLayerTreeDrawingAreaProxy>(*_page->drawingArea()).lastCommittedMainFrameLayerTreeTransactionID();
 
 #if ENABLE(TOUCH_EVENTS)
-        _page->didBeginTouchPoint();
+        _page->didBeginTouchPoint(lastTouchEvent.locationInRootViewCoordinates);
 #endif
 
         WebKit::InteractionInformationRequest positionInformationRequest { WebCore::IntPoint(_lastInteractionLocation) };

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -3830,10 +3830,11 @@ HandleUserInputEventResult WebPage::dispatchTouchEvent(FrameIdentifier frameID, 
     return handleTouchEventResult;
 }
 
-void WebPage::didBeginTouchPoint()
+void WebPage::didBeginTouchPoint(FloatPoint locationInRootView)
 {
     m_hasAnyActiveTouchPoints = true;
     m_potentialTapSecurityOrigin = nullptr;
+    m_lastTouchLocationBeforeTap = locationInRootView;
 }
 
 void WebPage::updatePotentialTapSecurityOrigin(const WebTouchEvent& touchEvent, bool wasHandled)
@@ -7734,6 +7735,7 @@ void WebPage::didCommitLoad(WebFrame* frame)
     WebProcess::singleton().eventDispatcher().takeQueuedTouchEventsForPage(*this, queuedEvents);
     cancelAsynchronousTouchEvents(WTFMove(queuedEvents));
 #endif
+    m_lastTouchLocationBeforeTap = { };
     m_hasAnyActiveTouchPoints = false;
     m_activeTextInteractionSources = { };
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2065,7 +2065,7 @@ private:
 
 #if ENABLE(IOS_TOUCH_EVENTS)
     void touchEventSync(const WebTouchEvent&, CompletionHandler<void(bool)>&&);
-    void didBeginTouchPoint();
+    void didBeginTouchPoint(WebCore::FloatPoint locationInRootView);
     void updatePotentialTapSecurityOrigin(const WebTouchEvent&, bool wasHandled);
 #elif ENABLE(TOUCH_EVENTS)
     void touchEvent(const WebTouchEvent&, CompletionHandler<void(std::optional<WebEventType>, bool)>&&);
@@ -2807,6 +2807,7 @@ private:
     bool m_isMobileDoctype { false };
     bool m_hasAnyActiveTouchPoints { false };
     OptionSet<TextInteractionSource> m_activeTextInteractionSources;
+    std::optional<WebCore::FloatPoint> m_lastTouchLocationBeforeTap;
 #endif // PLATFORM(IOS_FAMILY)
 
     WebCore::Timer m_layerVolatilityTimer;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -158,7 +158,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
 #endif
 
 #if ENABLE(IOS_TOUCH_EVENTS)
-    DidBeginTouchPoint()
+    DidBeginTouchPoint(WebCore::FloatPoint locationInRootView)
 #endif
 #if !ENABLE(IOS_TOUCH_EVENTS) && ENABLE(TOUCH_EVENTS)
     TouchEvent(WebKit::WebTouchEvent event) -> (std::optional<WebKit::WebEventType> eventType, bool handled)


### PR DESCRIPTION
#### 72124d79b53ff977057a41424093ef90017db5d9
<pre>
[iOS] Software keyboard sometimes dismisses immediately when focusing elements in the Pearson TestNav app
<a href="https://bugs.webkit.org/show_bug.cgi?id=284346">https://bugs.webkit.org/show_bug.cgi?id=284346</a>
<a href="https://rdar.apple.com/134957760">rdar://134957760</a>

Reviewed by Abrar Rahman Protyasha.

Avoid treating a tap as a synthetic click in the following scenario:

-   The page adds a `touchstart` event listener which triggers main frame scrolling (either directly
    or indirectly, by focusing an editable element).

-   The user taps the element with the above `touchstart` listener, and the web view scrolls.

-   When the tap gesture ends, the synthetic tap gesture fires, triggering a synthetic click over
    the new content underneath the user&apos;s finger (after scrolling).

In the context of TestNav, this causes the keyboard to (sometimes) immediately dismiss when tapping,
as the `textarea` immediately focuses itself underneath `touchstart`, which may induce scrolling to
reveal the focused element.

To mitigate this, we add a heuristic to detect when the potential tap location differs significantly
from the location of the initial location of the user&apos;s touch, relative to root view coordinates; if
so (and the new hit-tested potential tap node differs from the node at the prior touch start
location), we simply ignore the potential tap and avoid treating it as a synthetic click.

* LayoutTests/fast/events/touch/ios/focus-textarea-on-touchstart-expected.txt: Added.
* LayoutTests/fast/events/touch/ios/focus-textarea-on-touchstart.html: Added.

Add a layout test to exercise this scenario.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didBeginTouchPoint):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _touchEventsRecognized]):

Send the touch start location to the webpage alongside this IPC message.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::didBeginTouchPoint):

Keep track of the last touch start location in `m_lastTouchLocationBeforeTap`. The lifecycle of this
member variable is (unfortunately) a bit finnicky, but it&apos;s guaranteed to be up to date (as its name
suggests) before the next potential tap, where it&apos;s reset. The reason this can&apos;t always be cleared
underneath `didReleaseAllTouchPoints()` is that the tap gesture is recognized after the user ends
all touches, so `m_lastTouchLocationBeforeTap` would already be reset by the time we need to consult
it in `potentialTapAtPosition`.

(WebKit::WebPage::didCommitLoad):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::potentialTapAtPosition):

Add a simple heuristic to reject tap gestures as synthetic clicks (see description above for more
details).

Canonical link: <a href="https://commits.webkit.org/287608@main">https://commits.webkit.org/287608@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b2fff0966d6873b2bba33ccff63ef69613839a5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80282 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59284 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33696 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84799 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31258 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68345 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7584 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62764 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/20574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83351 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52823 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73107 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43070 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/50153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27263 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29719 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/71289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27776 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86232 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7502 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/71037 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7677 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68947 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70281 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17492 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14275 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13216 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7466 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7305 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10825 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9110 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->