### PR TITLE
Implement Observable#toArray

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-toArray.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-toArray.any-expected.txt
@@ -1,8 +1,10 @@
+CONSOLE MESSAGE: Error: custom error
+CONSOLE MESSAGE: Error: custom error
 
-FAIL toArray(): basic next/complete promise_test: Unhandled rejection with value: object "TypeError: observable.toArray is not a function. (In 'observable.toArray()', 'observable.toArray' is undefined)"
-FAIL toArray(): first error() rejects promise; subsequent error()s report the exceptions assert_equals: expected object "Error: custom error" but got object "TypeError: observable.toArray is not a function. (In 'observable.toArray()', 'observable.toArray' is undefined)"
-FAIL toArray(): complete() resolves promise; subsequent error()s report the exceptions promise_test: Unhandled rejection with value: object "TypeError: observable.toArray is not a function. (In 'observable.toArray()', 'observable.toArray' is undefined)"
-FAIL toArray(): Subscribing with an aborted signal returns an immediately rejected promise promise_test: Unhandled rejection with value: object "TypeError: observable.toArray is not a function. (In 'observable.toArray({signal: AbortSignal.abort()})', 'observable.toArray' is undefined)"
-FAIL toArray(): Aborting the passed-in signal rejects the returned promise promise_test: Unhandled rejection with value: object "TypeError: observable.toArray is not a function. (In 'observable.toArray({signal: controller.signal})', 'observable.toArray' is undefined)"
-FAIL Operator Promise abort ordering promise_test: Unhandled rejection with value: object "TypeError: observable.toArray is not a function. (In 'observable.toArray({signal: controller.signal})', 'observable.toArray' is undefined)"
+PASS toArray(): basic next/complete
+PASS toArray(): first error() rejects promise; subsequent error()s report the exceptions
+PASS toArray(): complete() resolves promise; subsequent error()s report the exceptions
+PASS toArray(): Subscribing with an aborted signal returns an immediately rejected promise
+PASS toArray(): Aborting the passed-in signal rejects the returned promise
+PASS Operator Promise abort ordering
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-toArray.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-toArray.any.worker-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL toArray(): basic next/complete promise_test: Unhandled rejection with value: object "TypeError: observable.toArray is not a function. (In 'observable.toArray()', 'observable.toArray' is undefined)"
-FAIL toArray(): first error() rejects promise; subsequent error()s report the exceptions assert_equals: expected object "Error: custom error" but got object "TypeError: observable.toArray is not a function. (In 'observable.toArray()', 'observable.toArray' is undefined)"
-FAIL toArray(): complete() resolves promise; subsequent error()s report the exceptions promise_test: Unhandled rejection with value: object "TypeError: observable.toArray is not a function. (In 'observable.toArray()', 'observable.toArray' is undefined)"
-FAIL toArray(): Subscribing with an aborted signal returns an immediately rejected promise promise_test: Unhandled rejection with value: object "TypeError: observable.toArray is not a function. (In 'observable.toArray({signal: AbortSignal.abort()})', 'observable.toArray' is undefined)"
-FAIL toArray(): Aborting the passed-in signal rejects the returned promise promise_test: Unhandled rejection with value: object "TypeError: observable.toArray is not a function. (In 'observable.toArray({signal: controller.signal})', 'observable.toArray' is undefined)"
-FAIL Operator Promise abort ordering promise_test: Unhandled rejection with value: object "TypeError: observable.toArray is not a function. (In 'observable.toArray({signal: controller.signal})', 'observable.toArray' is undefined)"
+PASS toArray(): basic next/complete
+PASS toArray(): first error() rejects promise; subsequent error()s report the exceptions
+PASS toArray(): complete() resolves promise; subsequent error()s report the exceptions
+PASS toArray(): Subscribing with an aborted signal returns an immediately rejected promise
+PASS toArray(): Aborting the passed-in signal rejects the returned promise
+PASS Operator Promise abort ordering
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1283,6 +1283,7 @@ dom/InternalObserverDrop.cpp
 dom/InternalObserverEvery.cpp
 dom/InternalObserverFilter.cpp
 dom/InternalObserverFind.cpp
+dom/InternalObserverToArray.cpp
 dom/InternalObserverFirst.cpp
 dom/InternalObserverForEach.cpp
 dom/InternalObserverFromScript.cpp

--- a/Source/WebCore/dom/InternalObserver.h
+++ b/Source/WebCore/dom/InternalObserver.h
@@ -26,11 +26,14 @@
 #pragma once
 
 #include "ActiveDOMObject.h"
+#include "ScriptExecutionContext.h"
+#include <JavaScriptCore/JSGlobalObject.h>
 #include <wtf/RefCounted.h>
 
 namespace JSC {
 class AbstractSlotVisitor;
 class JSValue;
+class VM;
 } // namespace JSC
 
 namespace WebCore {
@@ -53,16 +56,23 @@ public:
     virtual void visitAdditionalChildren(JSC::AbstractSlotVisitor&) const = 0;
 
 protected:
-    bool m_active { true };
+    JSC::VM& globalVM() const
+    {
+        auto* globalObject = protectedScriptExecutionContext()->globalObject();
+        ASSERT(globalObject);
+        return globalObject->vm();
+    }
+
+    // ActiveDOMObject
+    void stop() override { }
+    bool virtualHasPendingActivity() const override { return m_active; }
 
     InternalObserver(ScriptExecutionContext& context)
         : ActiveDOMObject(&context)
     {
     }
 
-    // ActiveDOMObject
-    void stop() override { }
-    bool virtualHasPendingActivity() const override { return m_active; }
+    bool m_active { true };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/InternalObserverToArray.cpp
+++ b/Source/WebCore/dom/InternalObserverToArray.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2025 Marais Rossouw <me@marais.co>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "InternalObserverToArray.h"
+
+#include "InternalObserver.h"
+#include "JSDOMPromiseDeferred.h"
+#include "JSValueInWrappedObject.h"
+#include "Observable.h"
+#include "ScriptExecutionContext.h"
+#include "SubscribeOptions.h"
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+class InternalObserverToArray final : public InternalObserver {
+public:
+    static Ref<InternalObserverToArray> create(ScriptExecutionContext& context, Ref<DeferredPromise>&& promise)
+    {
+        Ref internalObserver = adoptRef(*new InternalObserverToArray(context, WTFMove(promise)));
+        internalObserver->suspendIfNeeded();
+        return internalObserver;
+    }
+
+private:
+    void next(JSC::JSValue value) final
+    {
+        m_list.append({ globalVM(), value });
+    }
+
+    void error(JSC::JSValue value) final
+    {
+        m_promise->reject<IDLAny>(value);
+    }
+
+    void complete() final
+    {
+        InternalObserver::complete();
+
+        m_promise->resolve<IDLSequence<IDLAny>>(m_list);
+    }
+
+    void visitAdditionalChildren(JSC::AbstractSlotVisitor&) const final
+    {
+    }
+
+    InternalObserverToArray(ScriptExecutionContext& context, Ref<DeferredPromise>&& promise)
+        : InternalObserver(context)
+        , m_promise(WTFMove(promise))
+    {
+    }
+
+    Vector<JSC::Strong<JSC::Unknown>> m_list;
+    const Ref<DeferredPromise> m_promise;
+};
+
+void createInternalObserverOperatorToArray(ScriptExecutionContext& context, Observable& observable, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)
+{
+    if (RefPtr signal = options.signal) {
+        if (signal->aborted())
+            return promise->reject<IDLAny>(signal->reason().getValue());
+
+        signal->addAlgorithm([promise](JSC::JSValue reason) {
+            promise->reject<IDLAny>(reason);
+        });
+    }
+
+    Ref observer = InternalObserverToArray::create(context, WTFMove(promise));
+    observable.subscribeInternal(context, WTFMove(observer), options);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/dom/InternalObserverToArray.h
+++ b/Source/WebCore/dom/InternalObserverToArray.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2025 Marais Rossouw <me@marais.co>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+class DeferredPromise;
+class Observable;
+class ScriptExecutionContext;
+struct SubscribeOptions;
+
+void createInternalObserverOperatorToArray(ScriptExecutionContext&, Observable&, const SubscribeOptions&, Ref<DeferredPromise>&&);
+
+} // namespace WebCore

--- a/Source/WebCore/dom/Observable.cpp
+++ b/Source/WebCore/dom/Observable.cpp
@@ -43,6 +43,7 @@
 #include "InternalObserverReduce.h"
 #include "InternalObserverSome.h"
 #include "InternalObserverTake.h"
+#include "InternalObserverToArray.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSSubscriptionObserverCallback.h"
 #include "MapperCallback.h"
@@ -139,6 +140,11 @@ Ref<Observable> Observable::inspect(ScriptExecutionContext& context, std::option
             return create(createSubscriberCallbackInspect(context, *this, WTFMove(inspector)));
         }
     );
+}
+
+void Observable::toArray(ScriptExecutionContext& context, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)
+{
+    return createInternalObserverOperatorToArray(context, *this, options, WTFMove(promise));
 }
 
 void Observable::first(ScriptExecutionContext& context, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)

--- a/Source/WebCore/dom/Observable.h
+++ b/Source/WebCore/dom/Observable.h
@@ -66,6 +66,7 @@ public:
 
     // Promise-returning operators.
 
+    void toArray(ScriptExecutionContext&, const SubscribeOptions&, Ref<DeferredPromise>&&);
     void first(ScriptExecutionContext&, const SubscribeOptions&, Ref<DeferredPromise>&&);
     void forEach(ScriptExecutionContext&, Ref<VisitorCallback>&&, const SubscribeOptions&, Ref<DeferredPromise>&&);
     void last(ScriptExecutionContext&, const SubscribeOptions&, Ref<DeferredPromise>&&);

--- a/Source/WebCore/dom/Observable.idl
+++ b/Source/WebCore/dom/Observable.idl
@@ -45,6 +45,7 @@ interface Observable {
 
   // Promise-returning operators.
 
+  [CallWith=CurrentScriptExecutionContext] Promise<sequence<any>> toArray(optional SubscribeOptions options = {});
   [CallWith=CurrentScriptExecutionContext] Promise<any> first(optional SubscribeOptions options = {});
   [CallWith=CurrentScriptExecutionContext] Promise<undefined> forEach(VisitorCallback callback, optional SubscribeOptions options = {});
   [CallWith=CurrentScriptExecutionContext] Promise<any> last(optional SubscribeOptions options = {});


### PR DESCRIPTION
#### 59e8dc1704c4ed34fb6397f471553913aaca3c4d
<pre>
Implement Observable#toArray
<a href="https://bugs.webkit.org/show_bug.cgi?id=277514">https://bugs.webkit.org/show_bug.cgi?id=277514</a>

Reviewed by NOBODY (OOPS!).

This change introduces the `.toArray` promise-returning operator
for Observables, using the InternalObserver and subscribing immediately.

Spec: &lt;<a href="https://wicg.github.io/observable/#dom-observable-toarray">https://wicg.github.io/observable/#dom-observable-toarray</a>&gt;

* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-toArray.any-expected.txt: Rebaseline.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-toArray.any.worker-expected.txt: Rebaseline.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/InternalObserver.h:
(WebCore::InternalObserver::globalVM const): Added helper function, as
used often.
(WebCore::InternalObserver::InternalObserver):
* Source/WebCore/dom/InternalObserverToArray.cpp: Added.
(WebCore::createInternalObserverOperatorToArray):
* Source/WebCore/dom/InternalObserverToArray.h: Added.
* Source/WebCore/dom/Observable.cpp:
(WebCore::Observable::toArray):
* Source/WebCore/dom/Observable.h:
* Source/WebCore/dom/Observable.idl:
Exposes `Promise&lt;sequence&lt;any&gt;&gt; toArray(options)` as a promise-returning operator.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59e8dc1704c4ed34fb6397f471553913aaca3c4d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32395 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118862 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63145 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114625 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33047 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40958 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85739 "Found 1 new test failure: imported/w3c/web-platform-tests/dom/observable/tentative/observable-toArray.any.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36373 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115610 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26368 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101349 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66047 "Found 144 new API test failures: /WPE/TestLoaderClient:/webkit/WebKitWebView/loading-status, /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification, /WPE/TestWebKitFindController:/webkit/WebKitFindController/options, /WPE/TestLoaderClient:/webkit/WebKitWebView/reload, /WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/script-message-received, /WPE/TestWebKitWebView:/webkit/WebKitWebView/run-javascript, /WPE/TestWebKitWebView:/webkit/WebKitWebView/disable-web-security, /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification-initial-permission-allowed, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme, /WPE/TestSSL:/webkit/WebKitWebView/tls-subresource ... (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25665 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19485 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62621 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95755 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19560 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122083 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39737 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29608 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94608 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40120 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97586 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94350 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39465 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17275 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35828 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39625 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45113 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39264 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42597 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41003 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->