### PR TITLE
WebKit returns 300x150 for naturalHeight/naturalWidth for SVG-as-an-image with unspecified, percent-valued, or 0 size

### DIFF
--- a/Source/WebCore/svg/graphics/SVGImage.cpp
+++ b/Source/WebCore/svg/graphics/SVGImage.cpp
@@ -176,10 +176,10 @@ IntSize SVGImage::containerSize() const
         currentSize = rootElement->currentViewBoxRect().size();
 
     // Use the default CSS intrinsic size if the above failed.
-    if (currentSize.isEmpty())
-        return IntSize(300, 150);
+    if (!currentSize.isEmpty())
+        return IntSize(currentSize);
 
-    return IntSize(currentSize);
+    return IntSize();
 }
 
 ImageDrawResult SVGImage::drawForContainer(GraphicsContext& context, const FloatSize containerSize, float containerZoom, const URL& initialFragmentURL, const FloatRect& dstRect, const FloatRect& srcRect, ImagePaintingOptions options)


### PR DESCRIPTION
#### 3454a108b9d5db07ba8efd383280d64442286e4e
<pre>
WebKit returns 300x150 for naturalHeight/naturalWidth for SVG-as-an-image with unspecified, percent-valued, or 0 size
<a href="https://bugs.webkit.org/show_bug.cgi?id=284341">https://bugs.webkit.org/show_bug.cgi?id=284341</a>
<a href="https://rdar.apple.com/141196049">rdar://141196049</a>

Reviewed by NOBODY (OOPS!).

WIP: This is for now to test a patch.

The three browsers have different results:
Firefox: 0x0
Chrome:  0x150
Safari:  300x150

This should be harmonized.
It has been discussed also on
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1935269">https://bugzilla.mozilla.org/show_bug.cgi?id=1935269</a>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1607081#c4">https://bugzilla.mozilla.org/show_bug.cgi?id=1607081#c4</a>

* Source/WebCore/svg/graphics/SVGImage.cpp:
(WebCore::SVGImage::containerSize const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3454a108b9d5db07ba8efd383280d64442286e4e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80399 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59405 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34006 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84920 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31381 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82510 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68467 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7708 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62830 "Found 113 new test failures: fast/borders/border-image-fill-no-intrinsic-size.html fast/gradients/background-image-repeat-space.html fast/hidpi/image-srcset-relative-svg-canvas-2x.html fast/hidpi/image-srcset-relative-svg-canvas.html fast/shapes/shape-outside-floats/shape-outside-image-fit-001.html fast/shapes/shape-outside-floats/shape-outside-image-fit-002.html fast/shapes/shape-outside-floats/shape-outside-polygon-zero-vertex.html fast/shapes/shape-outside-floats/shape-outside-relative-size-svg.html imported/blink/svg/as-image/svg-as-image-object-fit-cover.html imported/blink/svg/custom/image-reinsert.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20642 "Found 7 new test failures: css3/images/cross-fade-svg-with-opacity.html fast/gradients/background-image-repeat-space.html http/tests/css/css-masking/mask-external-svg-fragment.html http/tests/css/css-masking/mask-external-svg-mask.html http/tests/security/cross-origin-cached-images-with-memory-pressure.html imported/w3c/web-platform-tests/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.zerosource.image.html storage/indexeddb/modern/blob-svg-image.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83468 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52915 "Found 39 new test failures: css3/images/cross-fade-svg-with-opacity.html fast/borders/border-image-fill-no-intrinsic-size.html fast/gradients/background-image-repeat-space.html fast/hidpi/image-srcset-relative-svg-canvas-2x.html fast/images/pagewide-play-pause-offscreen-animations.html fast/shapes/shape-outside-floats/shape-outside-image-fit-001.html fast/shapes/shape-outside-floats/shape-outside-image-fit-002.html fast/shapes/shape-outside-floats/shape-outside-polygon-zero-vertex.html fast/shapes/shape-outside-floats/shape-outside-relative-size-svg.html http/tests/css/css-masking/mask-external-svg-fragment.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73214 "Found 2 new API test failures: TestWebKitAPI.WKWebExtensionController.WebAccessibleResourcesV2, TestWebKitAPI.WKWebExtensionController.WebAccessibleResources (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43134 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50227 "Found 60 new test failures: imported/w3c/web-platform-tests/css/compositing/mix-blend-mode/mix-blend-mode-paragraph-background-image.html imported/w3c/web-platform-tests/css/css-backgrounds/background-image-007.html imported/w3c/web-platform-tests/css/css-backgrounds/background-size/background-size-contain-svg-view.html imported/w3c/web-platform-tests/css/css-backgrounds/background-size/vector/background-size-vector-022.html imported/w3c/web-platform-tests/css/css-backgrounds/background-size/vector/background-size-vector-024.html imported/w3c/web-platform-tests/css/css-backgrounds/background-size/vector/background-size-vector-026.html imported/w3c/web-platform-tests/css/css-backgrounds/background-size/vector/background-size-vector-028.html imported/w3c/web-platform-tests/css/css-backgrounds/background-size/vector/diagonal-percentage-vector-background.html imported/w3c/web-platform-tests/css/css-backgrounds/background-size/vector/tall--auto--omitted-width-percent-height.html imported/w3c/web-platform-tests/css/css-backgrounds/background-size/vector/tall--auto--percent-width-nonpercent-height.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27368 "Found 60 new test failures: css3/images/cross-fade-svg-with-opacity.html fast/borders/border-image-fill-no-intrinsic-size.html fast/frames/frame-append-body-child-crash.html fast/gradients/background-image-repeat-space.html fast/hidpi/image-srcset-relative-svg-canvas-2x.html fast/shapes/shape-outside-floats/shape-outside-image-fit-001.html fast/shapes/shape-outside-floats/shape-outside-image-fit-002.html fast/shapes/shape-outside-floats/shape-outside-polygon-zero-vertex.html fast/shapes/shape-outside-floats/shape-outside-relative-size-svg.html fonts/font-weight-invalid-crash.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29840 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71367 "Found 2 new API test failures: TestWebKitAPI.WKWebExtensionController.WebAccessibleResourcesV2, TestWebKitAPI.WKWebExtensionController.WebAccessibleResources (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27889 "Found 60 new test failures: css3/color-filters/color-filter-current-color.html css3/images/cross-fade-svg-with-opacity.html fast/borders/border-image-fill-no-intrinsic-size.html fast/gradients/background-image-repeat-space.html fast/hidpi/image-srcset-relative-svg-canvas-2x.html fast/selectors/text-field-selection-window-inactive-stroke-color.html fast/shapes/shape-outside-floats/shape-outside-image-fit-001.html fast/shapes/shape-outside-floats/shape-outside-image-fit-002.html fast/shapes/shape-outside-floats/shape-outside-polygon-zero-vertex.html fast/shapes/shape-outside-floats/shape-outside-relative-size-svg.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86354 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7624 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5390 "Found 60 new test failures: css3/images/cross-fade-svg-with-opacity.html editing/execCommand/apply-inline-style-to-element-with-no-renderer-crash.html fast/borders/border-image-fill-no-intrinsic-size.html fast/gradients/background-image-repeat-space.html fast/hidpi/image-srcset-relative-svg-canvas-2x.html fast/hidpi/image-srcset-relative-svg-canvas.html fast/images/pagewide-play-pause-offscreen-animations.html fast/shapes/shape-outside-floats/shape-outside-image-fit-001.html fast/shapes/shape-outside-floats/shape-outside-image-fit-002.html fast/shapes/shape-outside-floats/shape-outside-polygon-zero-vertex.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71115 "Found 118 new test failures: css3/images/cross-fade-svg-with-opacity.html fast/borders/border-image-fill-no-intrinsic-size.html fast/gradients/background-image-repeat-space.html fast/hidpi/image-srcset-relative-svg-canvas-2x.html fast/hidpi/image-srcset-relative-svg-canvas.html fast/shapes/shape-outside-floats/shape-outside-image-fit-001.html fast/shapes/shape-outside-floats/shape-outside-image-fit-002.html fast/shapes/shape-outside-floats/shape-outside-polygon-zero-vertex.html fast/shapes/shape-outside-floats/shape-outside-relative-size-svg.html http/tests/security/cross-origin-cached-images-with-memory-pressure.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7799 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69051 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70356 "Passed tests") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14355 "Found 1 new test failure: interaction-region/content-hint.html (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13309 "Found 60 new test failures: css3/images/cross-fade-svg-with-opacity.html fast/borders/border-image-fill-no-intrinsic-size.html fast/gradients/background-image-repeat-space.html fast/hidpi/image-srcset-relative-svg-canvas-2x.html fast/shapes/shape-outside-floats/shape-outside-image-fit-001.html fast/shapes/shape-outside-floats/shape-outside-image-fit-002.html fast/shapes/shape-outside-floats/shape-outside-polygon-zero-vertex.html fast/shapes/shape-outside-floats/shape-outside-relative-size-svg.html http/tests/css/css-masking/mask-external-svg-fragment.html http/tests/css/css-masking/mask-external-svg-mask.html ... (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7586 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13106 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7425 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10945 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9231 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->