### PR TITLE
Reduce use of memset()

### DIFF
--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -931,6 +931,17 @@ void memsetSpan(std::span<T, Extent> destination, uint8_t byte)
     memset(destination.data(), byte, destination.size_bytes());
 }
 
+template<typename T, std::size_t Extent>
+void secureMemsetSpan(std::span<T, Extent> destination, uint8_t byte)
+{
+    static_assert(std::is_trivially_copyable_v<T>);
+#ifdef __STDC_LIB_EXT1__
+    memset_s(destination.data(), byte, destination.size_bytes());
+#else
+    memset(destination.data(), byte, destination.size_bytes());
+#endif
+}
+
 template<typename T> concept ByteType = sizeof(T) == 1 && ((std::is_integral_v<T> && !std::same_as<T, bool>) || std::same_as<T, std::byte>) && !std::is_const_v<T>;
 
 template<typename> struct ByteCastTraits;
@@ -1203,6 +1214,7 @@ using WTF::roundUpToMultipleOf;
 using WTF::roundUpToMultipleOfNonPowerOfTwo;
 using WTF::roundDownToMultipleOf;
 using WTF::safeCast;
+using WTF::secureMemsetSpan;
 using WTF::singleElementSpan;
 using WTF::spanConstCast;
 using WTF::spanReinterpretCast;

--- a/Source/WTF/wtf/text/CString.cpp
+++ b/Source/WTF/wtf/text/CString.cpp
@@ -83,6 +83,14 @@ char* CString::mutableData()
     return m_buffer->mutableData();
 }
 
+std::span<char> CString::mutableSpan()
+{
+    copyBufferIfNeeded();
+    if (!m_buffer)
+        return { };
+    return m_buffer->mutableSpan();
+}
+
 CString CString::newUninitialized(size_t length, std::span<char>& characterBuffer)
 {
     CString result;

--- a/Source/WTF/wtf/text/CString.h
+++ b/Source/WTF/wtf/text/CString.h
@@ -85,6 +85,7 @@ public:
     std::span<const char> spanIncludingNullTerminator() const;
 
     WTF_EXPORT_PRIVATE char* mutableData();
+    WTF_EXPORT_PRIVATE std::span<char> mutableSpan();
     size_t length() const;
 
     bool isNull() const { return !m_buffer; }

--- a/Source/WebCore/Modules/compression/CompressionStream.cpp
+++ b/Source/WebCore/Modules/compression/CompressionStream.cpp
@@ -25,12 +25,14 @@
 #include "config.h"
 #include "CompressionStream.h"
 
+#include <wtf/StdLibExtras.h>
+
 namespace WebCore {
 
 CompressionStream::CompressionStream()
 {
 #if PLATFORM(COCOA)
-    std::memset(&m_stream, 0, sizeof(m_stream));
+    memsetSpan(asMutableByteSpan(m_stream), 0);
 #endif
 }
 

--- a/Source/WebCore/Modules/compression/ZStream.cpp
+++ b/Source/WebCore/Modules/compression/ZStream.cpp
@@ -25,6 +25,8 @@
 #include "config.h"
 #include "ZStream.h"
 
+#include <wtf/StdLibExtras.h>
+
 namespace WebCore {
 
 bool ZStream::initializeIfNecessary(Algorithm algorithm, Operation operation)
@@ -72,7 +74,7 @@ bool ZStream::initializeIfNecessary(Algorithm algorithm, Operation operation)
 
 ZStream::ZStream()
 {
-    std::memset(&m_stream, 0, sizeof(m_stream));
+    memsetSpan(asMutableByteSpan(m_stream), 0);
 }
 
 ZStream::~ZStream()

--- a/Source/WebCore/Modules/webaudio/AudioScheduledSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioScheduledSourceNode.cpp
@@ -37,6 +37,7 @@
 #include <algorithm>
 #include <wtf/MathExtras.h>
 #include <wtf/Scope.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(IOS_FAMILY)
@@ -117,7 +118,7 @@ void AudioScheduledSourceNode::updateSchedulingInfo(size_t quantumFrameSize, Aud
     // Zero any initial frames representing silence leading up to a rendering start time in the middle of the quantum.
     if (quantumFrameOffset) {
         for (unsigned i = 0; i < outputBus.numberOfChannels(); ++i)
-            memset(outputBus.channel(i)->mutableData(), 0, sizeof(float) * quantumFrameOffset);
+            memsetSpan(outputBus.channel(i)->mutableSpan().first(quantumFrameOffset), 0);
     }
 
     // Handle silence after we're done playing.
@@ -139,7 +140,7 @@ void AudioScheduledSourceNode::updateSchedulingInfo(size_t quantumFrameSize, Aud
                 nonSilentFramesToProcess -= framesToZero;
 
             for (unsigned i = 0; i < outputBus.numberOfChannels(); ++i)
-                memset(outputBus.channel(i)->mutableData() + zeroStartFrame, 0, sizeof(float) * framesToZero);
+                memsetSpan(outputBus.channel(i)->mutableSpan().subspan(zeroStartFrame, framesToZero), 0);
         }
 
         finish();

--- a/Source/WebCore/Modules/webaudio/PeriodicWave.cpp
+++ b/Source/WebCore/Modules/webaudio/PeriodicWave.cpp
@@ -37,6 +37,7 @@
 #include "FFTFrame.h"
 #include "VectorMath.h"
 #include <algorithm>
+#include <wtf/StdLibExtras.h>
 
 // The number of bands per octave. Each octave will have this many entries in the wave tables.
 constexpr unsigned NumberOfOctaveBands = 3;
@@ -218,9 +219,9 @@ void PeriodicWave::createBandLimitedTables(const float* realData, const float* i
         // pitch range.
         unsigned clampedNumberOfComponents = std::min(numberOfComponents, numberOfPartials + 1);
         if (clampedNumberOfComponents < halfSize) {
-            size_t numBytes = (halfSize - clampedNumberOfComponents) * sizeof(float);
-            memset(&realP[clampedNumberOfComponents], 0, numBytes);
-            memset(&imagP[clampedNumberOfComponents], 0, numBytes);
+            size_t numValues = halfSize - clampedNumberOfComponents;
+            memsetSpan(realP.span().subspan(clampedNumberOfComponents, numValues), 0);
+            memsetSpan(imagP.span().subspan(clampedNumberOfComponents, numValues), 0);
         }
 
         // Clear packed-nyquist and any DC-offset.

--- a/Source/WebCore/Modules/webauthn/fido/FidoHidPacket.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/FidoHidPacket.cpp
@@ -33,6 +33,7 @@
 #if ENABLE(WEB_AUTHN)
 
 #include <algorithm>
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -106,7 +107,7 @@ Vector<uint8_t> FidoHidInitPacket::getSerializedData() const
     serialized.appendVector(m_data);
     auto offset = serialized.size();
     serialized.grow(kHidPacketSize);
-    memset(serialized.data() + offset, 0, kHidPacketSize - offset);
+    memsetSpan(serialized.mutableSpan().subspan(offset, kHidPacketSize - offset), 0);
 
     return serialized;
 }
@@ -154,7 +155,7 @@ Vector<uint8_t> FidoHidContinuationPacket::getSerializedData() const
     serialized.appendVector(m_data);
     auto offset = serialized.size();
     serialized.grow(kHidPacketSize);
-    memset(serialized.data() + offset, 0, kHidPacketSize - offset);
+    memsetSpan(serialized.mutableSpan().subspan(offset, kHidPacketSize - offset), 0);
 
     return serialized;
 }

--- a/Source/WebCore/Modules/websockets/WebSocketDeflater.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketDeflater.cpp
@@ -52,7 +52,7 @@ WebSocketDeflater::WebSocketDeflater(int windowBits, ContextTakeOverMode context
     ASSERT(m_windowBits >= 8);
     ASSERT(m_windowBits <= 15);
     m_stream = makeUniqueWithoutFastMallocCheck<z_stream>();
-    memset(m_stream.get(), 0, sizeof(z_stream));
+    memsetSpan(asMutableByteSpan(*m_stream), 0);
 }
 
 bool WebSocketDeflater::initialize()
@@ -138,7 +138,7 @@ WebSocketInflater::WebSocketInflater(int windowBits)
     : m_windowBits(windowBits)
     , m_stream(makeUniqueWithoutFastMallocCheck<z_stream>())
 {
-    memset(m_stream.get(), 0, sizeof(z_stream));
+    memsetSpan(asMutableByteSpan(*m_stream), 0);
 }
 
 bool WebSocketInflater::initialize()

--- a/Source/WebCore/PAL/pal/text/TextCodecUTF8.h
+++ b/Source/WebCore/PAL/pal/text/TextCodecUTF8.h
@@ -51,7 +51,7 @@ private:
     void consumePartialSequenceByte();
 
     int m_partialSequenceSize { 0 };
-    uint8_t m_partialSequence[U8_MAX_LENGTH];
+    std::array<uint8_t, U8_MAX_LENGTH> m_partialSequence;
     bool m_shouldStripByteOrderMark { false };
 };
 

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -54,7 +54,7 @@ TextMarkerData::TextMarkerData(AXObjectCache& cache, const VisiblePosition& visi
 {
     ASSERT(isMainThread());
 
-    memset(static_cast<void*>(this), 0, sizeof(*this));
+    memsetSpan(asMutableByteSpan(*this), 0);
     treeID = cache.treeID().toUInt64();
     auto position = visiblePosition.deepEquivalent();
     auto optionalObjectID = nodeID(cache, position.anchorNode());
@@ -71,7 +71,7 @@ TextMarkerData::TextMarkerData(AXObjectCache& cache, const CharacterOffset& char
 {
     ASSERT(isMainThread());
 
-    memset(static_cast<void*>(this), 0, sizeof(*this));
+    memsetSpan(asMutableByteSpan(*this), 0);
     treeID = cache.treeID().toUInt64();
     auto optionalObjectID = nodeID(cache, characterOffsetParam.node.get());
     objectID = optionalObjectID ? optionalObjectID->toUInt64() : 0;

--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include "AccessibilityObject.h"
+#include <wtf/StdLibExtras.h>
 
 namespace WebCore {
 
@@ -80,7 +81,7 @@ struct TextMarkerData {
     // For an example of such byte-comparison, see the TestRunner WTR::AccessibilityTextMarker::isEqual.
     TextMarkerData()
     {
-        memset(static_cast<void*>(this), 0, sizeof(*this));
+        memsetSpan(asMutableByteSpan(*this), 0);
     }
 
     TextMarkerData(std::optional<AXID> axTreeID, std::optional<AXID> axObjectID,
@@ -89,7 +90,7 @@ struct TextMarkerData {
         Affinity affinityParam = Affinity::Downstream,
         unsigned charStart = 0, unsigned charOffset = 0, bool ignoredParam = false)
     {
-        memset(static_cast<void*>(this), 0, sizeof(*this));
+        memsetSpan(asMutableByteSpan(*this), 0);
         treeID = axTreeID ? axTreeID->toUInt64() : 0;
         objectID = axObjectID ? axObjectID->toUInt64() : 0;
         offset = offsetParam;

--- a/Source/WebCore/contentextensions/DFABytecodeCompiler.cpp
+++ b/Source/WebCore/contentextensions/DFABytecodeCompiler.cpp
@@ -31,6 +31,7 @@
 #include "ContentExtensionRule.h"
 #include "DFA.h"
 #include "DFANode.h"
+#include <wtf/StdLibExtras.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -311,9 +312,9 @@ auto DFABytecodeCompiler::transitions(const DFANode& node) -> Transitions
 {
     Transitions transitions;
 
-    uint32_t destinations[128];
-    memset(destinations, 0xff, sizeof(destinations));
-    const uint32_t noDestination = std::numeric_limits<uint32_t>::max();
+    constexpr uint32_t noDestination = std::numeric_limits<uint32_t>::max();
+    std::array<uint32_t, 128> destinations;
+    destinations.fill(noDestination);
 
     transitions.useFallbackTransition = node.canUseFallbackTransition(m_dfa);
     if (transitions.useFallbackTransition)

--- a/Source/WebCore/contentextensions/DFAMinimizer.cpp
+++ b/Source/WebCore/contentextensions/DFAMinimizer.cpp
@@ -258,7 +258,7 @@ public:
 
         // Count the number of incoming transitions per node.
         m_flattenedTransitionsStartOffsetPerNode.resize(dfa.nodes.size());
-        memset(m_flattenedTransitionsStartOffsetPerNode.data(), 0, m_flattenedTransitionsStartOffsetPerNode.size() * sizeof(unsigned));
+        m_flattenedTransitionsStartOffsetPerNode.fill(0);
 
         auto singularTransitionsFirsts = WTF::map<0, ContentExtensionsOverflowHandler>(singularTransitions, [&](auto& transition) {
             return transition.first;
@@ -292,8 +292,7 @@ public:
             counter = 0;
         m_flattenedTransitions.resize(flattenedTransitionsSize);
 
-        Vector<uint32_t> transitionPerRangeOffset(m_transitionPartition.size());
-        memset(transitionPerRangeOffset.data(), 0, transitionPerRangeOffset.size() * sizeof(uint32_t));
+        Vector<uint32_t> transitionPerRangeOffset(m_transitionPartition.size(), 0);
 
         for (unsigned i = 0; i < dfa.nodes.size(); ++i) {
             const DFANode& node = dfa.nodes[i];

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSAMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSAMac.cpp
@@ -93,7 +93,7 @@ static ExceptionOr<Vector<uint8_t>> signECDSA(CryptoAlgorithmIdentifier hash, co
     size_t bytesToCopy = keyLengthInBytes;
     if (signature[offset] < keyLengthInBytes) {
         newSignature.grow(keyLengthInBytes - signature[offset]);
-        memset(newSignature.data(), InitialOctet, keyLengthInBytes - signature[offset]);
+        memsetSpan(newSignature.mutableSpan().first(keyLengthInBytes - signature[offset]), InitialOctet);
         bytesToCopy = signature[offset];
     } else if (signature[offset] > keyLengthInBytes) // Otherwise skip the leading 0s of r.
         offset += signature[offset] - keyLengthInBytes;

--- a/Source/WebCore/loader/FTPDirectoryParser.h
+++ b/Source/WebCore/loader/FTPDirectoryParser.h
@@ -70,6 +70,7 @@
 
 #pragma once
 
+#include <wtf/StdLibExtras.h>
 #include <wtf/text/WTFString.h>
 
 #include <time.h>
@@ -97,7 +98,7 @@ struct ListState {
         , carryBufferLength(0)
         , numLines(0)
     { 
-        memset(&nowFTPTime, 0, sizeof(FTPTime));
+        memsetSpan(asMutableByteSpan(nowFTPTime), 0);
     }
     
     double      now;               /* needed for year determination */
@@ -134,7 +135,7 @@ struct ListResult
         linknameLength = 0;
         fileSize = { };
         caseSensitive = false;
-        memset(&modifiedTime, 0, sizeof(FTPTime));
+        memsetSpan(asMutableByteSpan(modifiedTime), 0);
     }
 
     std::span<const char> filenameSpan() const { return { filename, filenameLength }; }

--- a/Source/WebCore/platform/audio/AudioArray.h
+++ b/Source/WebCore/platform/audio/AudioArray.h
@@ -32,6 +32,7 @@
 #include <span>
 #include <string.h>
 #include <wtf/CheckedArithmetic.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -101,11 +102,7 @@ public:
     T& operator[](size_t i) { return at(i); }
     const T& operator[](size_t i) const { return at(i); }
 
-    void zero()
-    {
-        // This multiplication is made safe by the check in resize().
-        memset(this->data(), 0, sizeof(T) * this->size());
-    }
+    void zero() { memsetSpan(this->span(), 0); }
 
     void zeroRange(unsigned start, unsigned end)
     {
@@ -116,7 +113,7 @@ public:
 
         // This expression cannot overflow because end - start cannot be
         // greater than m_size, which is safe due to the check in resize().
-        memset(this->data() + start, 0, sizeof(T) * (end - start));
+        memsetSpan(this->span().subspan(start, end - start), 0);
     }
 
     void copyToRange(const T* sourceData, unsigned start, unsigned end)

--- a/Source/WebCore/platform/audio/AudioChannel.cpp
+++ b/Source/WebCore/platform/audio/AudioChannel.cpp
@@ -81,16 +81,16 @@ void AudioChannel::copyFromRange(const AudioChannel* sourceChannel, unsigned sta
     if (!isRangeLengthSafe)
         return;
 
-    const float* source = sourceChannel->data();
-    float* destination = mutableData();
+    auto source = sourceChannel->span();
+    auto destination = mutableSpan();
 
     if (sourceChannel->isSilent()) {
         if (rangeLength == length())
             zero();
         else
-            memset(destination, 0, sizeof(float) * rangeLength);
+            memsetSpan(destination.first(rangeLength), 0);
     } else
-        memcpy(destination, source + startFrame, sizeof(float) * rangeLength);
+        memcpySpan(destination, source.subspan(startFrame, rangeLength));
 }
 
 void AudioChannel::sumFrom(const AudioChannel* sourceChannel)

--- a/Source/WebCore/platform/audio/AudioChannel.h
+++ b/Source/WebCore/platform/audio/AudioChannel.h
@@ -33,6 +33,7 @@
 #include <memory>
 #include <span>
 #include <wtf/Noncopyable.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMalloc.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -104,11 +105,10 @@ public:
             return;
 
         m_silent = true;
-
-        if (m_memBuffer.get())
+        if (m_memBuffer)
             m_memBuffer->zero();
         else
-            memset(m_rawPointer, 0, sizeof(float) * m_length);
+            memsetSpan(mutableSpan(), 0);
     }
 
     // Clears the silent flag.

--- a/Source/WebCore/platform/audio/DenormalDisabler.h
+++ b/Source/WebCore/platform/audio/DenormalDisabler.h
@@ -27,6 +27,7 @@
 
 #include <cinttypes>
 #include <wtf/MathExtras.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -103,7 +104,7 @@ private:
         } __attribute__ ((aligned (16)));
 
         fxsaveResult registerData;
-        memset(&registerData, 0, sizeof(fxsaveResult));
+        memsetSpan(asMutableByteSpan(registerData), 0);
         asm volatile("fxsave %0" : "=m" (registerData));
         s_isSupported = registerData.CSRMask & 0x0040;
         s_isInited = true;

--- a/Source/WebCore/platform/audio/ReverbAccumulationBuffer.h
+++ b/Source/WebCore/platform/audio/ReverbAccumulationBuffer.h
@@ -43,7 +43,7 @@ public:
     explicit ReverbAccumulationBuffer(size_t length);
 
     // This will read from, then clear-out numberOfFrames
-    void readAndClear(float* destination, size_t numberOfFrames);
+    void readAndClear(std::span<float> destination, size_t numberOfFrames);
 
     // Each ReverbConvolverStage will accumulate its output at the appropriate delay from the read position.
     // We need to pass in and update readIndex here, since each ReverbConvolverStage may be running in

--- a/Source/WebCore/platform/audio/ReverbConvolver.cpp
+++ b/Source/WebCore/platform/audio/ReverbConvolver.cpp
@@ -178,8 +178,8 @@ void ReverbConvolver::process(const AudioChannel* sourceChannel, AudioChannel* d
         return;
         
     const float* source = sourceChannel->data();
-    float* destination = destinationChannel->mutableData();
-    bool isDataSafe = source && destination;
+    auto destination = destinationChannel->mutableSpan();
+    bool isDataSafe = source && destination.data();
     ASSERT(isDataSafe);
     if (!isDataSafe)
         return;

--- a/Source/WebCore/platform/audio/cocoa/WebAudioBufferList.cpp
+++ b/Source/WebCore/platform/audio/cocoa/WebAudioBufferList.cpp
@@ -28,6 +28,7 @@
 
 #include "CAAudioStreamDescription.h"
 #include <wtf/CheckedArithmetic.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
 #include <pal/cf/CoreMediaSoftLink.h>
@@ -151,7 +152,7 @@ RetainPtr<CMBlockBufferRef> WebAudioBufferList::setSampleCountWithBlockBuffer(si
 
 void WebAudioBufferList::initializeList(std::span<uint8_t> buffer, size_t channelLength)
 {
-    memset(buffer.data(), 0, buffer.size());
+    memsetSpan(buffer, 0);
 
     for (uint32_t index = 0; index < m_canonicalList->mNumberBuffers; ++index) {
         m_canonicalList->mBuffers[index].mData = buffer.data() + channelLength * index;
@@ -201,7 +202,7 @@ AudioBuffer* WebAudioBufferList::buffer(uint32_t index) const
 
 void WebAudioBufferList::zeroFlatBuffer()
 {
-    memset(m_flatBuffer.data(), 0, m_flatBuffer.size());
+    m_flatBuffer.fill(0);
 }
 
 }

--- a/Source/WebCore/platform/graphics/PixelBuffer.cpp
+++ b/Source/WebCore/platform/graphics/PixelBuffer.cpp
@@ -27,6 +27,7 @@
 #include "PixelBuffer.h"
 
 #include <JavaScriptCore/TypedArrayInlines.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/text/TextStream.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -117,7 +118,7 @@ bool PixelBuffer::zeroRange(size_t byteOffset, size_t rangeByteLength)
     if (!isSumSmallerThanOrEqual(byteOffset, rangeByteLength, m_bytes.size()))
         return false;
 
-    memset(m_bytes.data() + byteOffset, 0, rangeByteLength);
+    memsetSpan(m_bytes.subspan(byteOffset, rangeByteLength), 0);
     return true;
 }
 

--- a/Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp
+++ b/Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp
@@ -36,6 +36,7 @@
 #include <float.h>
 #include <wtf/Assertions.h>
 #include <wtf/MathExtras.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
@@ -1781,7 +1782,7 @@ void TransformationMatrix::blend(const TransformationMatrix& from, double progre
 bool TransformationMatrix::decompose2(Decomposed2Type& decomp) const
 {
     if (isIdentity()) {
-        memset(&decomp, 0, sizeof(decomp));
+        memsetSpan(asMutableByteSpan(decomp), 0);
         decomp.scaleX = 1;
         decomp.scaleY = 1;
         decomp.m11 = 1;
@@ -1795,7 +1796,7 @@ bool TransformationMatrix::decompose2(Decomposed2Type& decomp) const
 bool TransformationMatrix::decompose4(Decomposed4Type& decomp) const
 {
     if (isIdentity()) {
-        memset(&decomp, 0, sizeof(decomp));
+        memsetSpan(asMutableByteSpan(decomp), 0);
         decomp.perspectiveW = 1;
         decomp.scaleX = 1;
         decomp.scaleY = 1;

--- a/Source/WebCore/platform/image-decoders/bmp/BMPImageReader.cpp
+++ b/Source/WebCore/platform/image-decoders/bmp/BMPImageReader.cpp
@@ -30,6 +30,8 @@
 
 #include "config.h"
 #include "BMPImageReader.h"
+
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -52,7 +54,7 @@ BMPImageReader::BMPImageReader(ScalableImageDecoder* parent, size_t decodedAndHe
     , m_andMaskState(usesAndMask ? NotYetDecoded : None)
 {
     // Clue-in decodeBMP() that we need to detect the correct info header size.
-    memset(&m_infoHeader, 0, sizeof(m_infoHeader));
+    memsetSpan(asMutableByteSpan(m_infoHeader), 0);
 }
 
 bool BMPImageReader::decodeBMP(bool onlySize)

--- a/Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.cpp
@@ -40,11 +40,12 @@
 #include "config.h"
 #include "JPEGImageDecoder.h"
 
+#include <wtf/TZoneMallocInlines.h>
+#include <wtf/StdLibExtras.h>
+
 #if USE(LCMS)
 #include "LCMSUniquePtr.h"
 #endif
-
-#include <wtf/TZoneMallocInlines.h>
 
 extern "C" {
 #include <setjmp.h>
@@ -259,7 +260,7 @@ public:
         , m_state(JPEG_HEADER)
         , m_samples(0)
     {
-        memset(&m_info, 0, sizeof(jpeg_decompress_struct));
+        memsetSpan(asMutableByteSpan(m_info), 0);
 
         // We set up the normal JPEG error routines, then override error_exit.
         m_info.err = jpeg_std_error(&m_err.pub);

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCDav1dDecoder.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCDav1dDecoder.cpp
@@ -31,6 +31,7 @@
 #include "LibWebRTCMacros.h"
 #include "Logging.h"
 #include <algorithm>
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/UniqueRef.h>
 
@@ -173,7 +174,7 @@ int32_t Dav1dDecoder::Decode(const webrtc::EncodedImage& encodedImage, bool /*mi
 
     ScopedDav1dData scopedDav1dData;
     Dav1dData& dav1dData = scopedDav1dData.Data();
-    memset(&dav1dData, 0, sizeof(Dav1dData));
+    memsetSpan(asMutableByteSpan(dav1dData), 0);
     auto* data = encodedImage.data();
     auto size = encodedImage.size();
     if (!data || !size) {
@@ -189,7 +190,7 @@ int32_t Dav1dDecoder::Decode(const webrtc::EncodedImage& encodedImage, bool /*mi
 
     ScopedDav1dPicture scopedDav1dPicture;
     Dav1dPicture& dav1dPicture = scopedDav1dPicture.Picture();
-    memset(&dav1dPicture, 0, sizeof(Dav1dPicture));
+    memsetSpan(asMutableByteSpan(dav1dPicture), 0);
 
     if (int res = dav1d_get_picture(m_context, &dav1dPicture)) {
         RELEASE_LOG_ERROR(WebRTC, "Dav1dDecoder::Decode getting picture failed with error code %d", res);

--- a/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm
+++ b/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm
@@ -43,10 +43,11 @@
 #import <AVFoundation/AVAudioBuffer.h>
 #import <AudioToolbox/AudioConverter.h>
 #import <CoreAudio/CoreAudioTypes.h>
-#include <wtf/RunLoop.h>
-#include <wtf/TZoneMallocInlines.h>
-#include <wtf/Vector.h>
-#include <wtf/WorkQueue.h>
+#import <wtf/RunLoop.h>
+#import <wtf/StdLibExtras.h>
+#import <wtf/TZoneMallocInlines.h>
+#import <wtf/Vector.h>
+#import <wtf/WorkQueue.h>
 
 #import <pal/cf/AudioToolboxSoftLink.h>
 #import <pal/cf/CoreMediaSoftLink.h>
@@ -327,7 +328,7 @@ void MockAudioSharedInternalUnit::emitSampleBuffers(uint32_t frameCount)
     AudioUnitRenderActionFlags ioActionFlags = 0;
     
     AudioTimeStamp timeStamp;
-    memset(&timeStamp, 0, sizeof(AudioTimeStamp));
+    memsetSpan(asMutableByteSpan(timeStamp), 0);
     timeStamp.mSampleTime = sampleTime;
     timeStamp.mHostTime = static_cast<UInt64>(sampleTime);
 

--- a/Source/WebCore/svg/SVGToOTFFontConversion.cpp
+++ b/Source/WebCore/svg/SVGToOTFFontConversion.cpp
@@ -538,7 +538,7 @@ void SVGToOTFFontConverter::appendOS2Table()
         }
     }
     if (numPanoseBytes != panoseSize)
-        memset(panoseBytes.data(), 0, panoseSize);
+        panoseBytes.fill(0);
     m_result.append(std::span<char> { panoseBytes });
 
     for (int i = 0; i < 4; ++i)

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -69,6 +69,7 @@
 #include "XMLDocumentParserScope.h"
 #include <libxml/parser.h>
 #include <libxml/parserInternals.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/unicode/CharacterNames.h>
@@ -1286,7 +1287,7 @@ static void ignorableWhitespaceHandler(void*, const xmlChar*, int)
 void XMLDocumentParser::initializeParserContext(const CString& chunk)
 {
     xmlSAXHandler sax;
-    memset(&sax, 0, sizeof(sax));
+    memsetSpan(asMutableByteSpan(sax), 0);
 
     sax.error = normalErrorHandler;
     sax.fatalError = fatalErrorHandler;
@@ -1501,7 +1502,7 @@ std::optional<HashMap<String, String>> parseAttributes(CachedResourceLoader& cac
     AttributeParseState attributes;
 
     xmlSAXHandler sax;
-    memset(&sax, 0, sizeof(sax));
+    memsetSpan(asMutableByteSpan(sax), 0);
     sax.startElementNs = attributesStartElementNsHandler;
     sax.initialized = XML_SAX2_MAGIC;
 

--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -746,8 +746,7 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, std::span<uint
         auto checkedNewBytesPerImageTimesMaxZ = checkedProduct<uint32_t>(newBytesPerImage, maxZ);
         if (checkedNewBytesPerImageTimesMaxZ.hasOverflowed())
             return;
-        newData.resize(checkedNewBytesPerImageTimesMaxZ.value());
-        memset(&newData[0], 0, newData.size());
+        newData = Vector<uint8_t>(checkedNewBytesPerImageTimesMaxZ.value(), 0);
         dataLayoutOffset = 0;
 
         auto verticalOffset = checkedProduct<uint64_t>(maxY ? (maxY - 1) : 0, bytesPerRow);

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp
@@ -39,6 +39,7 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/Scope.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/WorkQueue.h>
 
@@ -228,7 +229,7 @@ static bool connectToRemoteAddress(int socket, bool useIPv4)
     const int publicPort = 53;
 
     sockaddr_storage remoteAddressStorage;
-    memset(&remoteAddressStorage, 0, sizeof(sockaddr_storage));
+    memsetSpan(asMutableByteSpan(remoteAddressStorage), 0);
     size_t remoteAddressStorageLength = 0;
     if (useIPv4) {
         auto& remoteAddress = *reinterpret_cast<sockaddr_in*>(&remoteAddressStorage);
@@ -266,7 +267,7 @@ static bool connectToRemoteAddress(int socket, bool useIPv4)
 static std::optional<RTCNetwork::IPAddress> getSocketLocalAddress(int socket, bool useIPv4)
 {
     sockaddr_storage localAddressStorage;
-    memset(&localAddressStorage, 0, sizeof(sockaddr_storage));
+    memsetSpan(asMutableByteSpan(localAddressStorage), 0);
     socklen_t localAddressStorageLength = sizeof(sockaddr_storage);
     if (::getsockname(socket, reinterpret_cast<sockaddr*>(&localAddressStorage), &localAddressStorageLength) < 0) {
         RELEASE_LOG_ERROR(WebRTC, "getDefaultIPAddress getsockname failed, useIPv4=%d", useIPv4);

--- a/Source/WebKit/Platform/IPC/darwin/IPCEventDarwin.cpp
+++ b/Source/WebKit/Platform/IPC/darwin/IPCEventDarwin.cpp
@@ -31,6 +31,7 @@
 #include <mach/mach_init.h>
 #include <mach/mach_port.h>
 #include <mach/message.h>
+#include <wtf/StdLibExtras.h>
 
 namespace IPC {
 
@@ -62,7 +63,7 @@ static void clearNoSenderNotifications(mach_port_t port)
 void Signal::signal()
 {
     mach_msg_header_t message;
-    memset(&message, 0, sizeof(message));
+    memsetSpan(asMutableByteSpan(message), 0);
     message.msgh_remote_port = m_sendRight.sendRight();
     message.msgh_local_port = MACH_PORT_NULL;
     message.msgh_bits = MACH_MSGH_BITS(MACH_MSG_TYPE_COPY_SEND, 0);
@@ -110,7 +111,7 @@ typedef struct {
 bool Event::wait()
 {
     ReceiveMessage receiveMessage;
-    memset(&receiveMessage, 0, sizeof(receiveMessage));
+    memsetSpan(asMutableByteSpan(receiveMessage), 0);
     mach_msg_return_t ret = mach_msg(&receiveMessage.header, MACH_RCV_MSG, 0, sizeof(receiveMessage), m_receiveRight, MACH_MSG_TIMEOUT_NONE, MACH_PORT_NULL);
     if (ret != MACH_MSG_SUCCESS)
         return false;
@@ -122,7 +123,7 @@ bool Event::wait()
 bool Event::waitFor(Timeout timeout)
 {
     ReceiveMessage receiveMessage;
-    memset(&receiveMessage, 0, sizeof(receiveMessage));
+    memsetSpan(asMutableByteSpan(receiveMessage), 0);
     mach_msg_return_t ret = mach_msg(&receiveMessage.header, MACH_RCV_MSG | MACH_RCV_TIMEOUT, 0, sizeof(receiveMessage), m_receiveRight, timeout.secondsUntilDeadline().milliseconds(), MACH_PORT_NULL);
     if (ret != MACH_MSG_SUCCESS)
         return false;

--- a/Source/WebKit/Shared/API/APIClient.h
+++ b/Source/WebKit/Shared/API/APIClient.h
@@ -29,6 +29,7 @@
 #include <algorithm>
 #include <array>
 #include <tuple>
+#include <wtf/StdLibExtras.h>
 
 namespace API {
 
@@ -66,7 +67,7 @@ public:
             return;
         }
 
-        memset(&m_client, 0, sizeof(m_client));
+        memsetSpan(asMutableByteSpan(m_client), 0);
 
         if (client && client->version < latestClientVersion) {
             auto interfaceSizes = InterfaceSizes<ClientVersions>::sizes();

--- a/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
+++ b/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
@@ -366,7 +366,7 @@ static Expected<MappedData, std::error_code> compiledToFile(WTF::String&& json, 
     }
     
     std::array<uint8_t, CurrentVersionFileHeaderSize> invalidHeader;
-    memset(invalidHeader.data(), 0xFF, invalidHeader.size());
+    invalidHeader.fill(0xFF);
     // This header will be rewritten in CompilationClient::finalize.
     if (writeToFile(temporaryFileHandle, invalidHeader) == -1) {
         WTFLogAlways("Content Rule List compiling failed: Writing header to file failed.");

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm
@@ -61,6 +61,7 @@
 #import <wtf/BlockPtr.h>
 #import <wtf/CheckedPtr.h>
 #import <wtf/NeverDestroyed.h>
+#import <wtf/StdLibExtras.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/cf/CFURLExtras.h>
 #import <wtf/cocoa/SpanCocoa.h>
@@ -438,7 +439,7 @@ static void setUpPageLoaderClient(WKBrowsingContextController *browsingContext, 
 ALLOW_DEPRECATED_DECLARATIONS_END
 {
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    memsetSpan(asMutableByteSpan(loaderClient), 0);
 
     loaderClient.base.version = 0;
     loaderClient.base.clientInfo = (__bridge void*)browsingContext;
@@ -477,7 +478,7 @@ static void setUpPagePolicyClient(WKBrowsingContextController *browsingContext, 
 ALLOW_DEPRECATED_DECLARATIONS_END
 {
     WKPagePolicyClientInternal policyClient;
-    memset(&policyClient, 0, sizeof(policyClient));
+    memsetSpan(asMutableByteSpan(policyClient), 0);
 
     policyClient.base.version = 2;
     policyClient.base.clientInfo = (__bridge void*)browsingContext;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessGroup.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessGroup.mm
@@ -39,6 +39,7 @@
 #import "WebFrameProxy.h"
 #import "WebProcessPool.h"
 #import <wtf/RetainPtr.h>
+#import <wtf/StdLibExtras.h>
 #import <wtf/WeakObjCPtr.h>
 
 #if PLATFORM(IOS_FAMILY)
@@ -62,7 +63,7 @@ static void setUpInjectedBundleClient(WKProcessGroup *processGroup, WKContextRef
 ALLOW_DEPRECATED_DECLARATIONS_END
 {
     WKContextInjectedBundleClientV1 injectedBundleClient;
-    memset(&injectedBundleClient, 0, sizeof(injectedBundleClient));
+    memsetSpan(asMutableByteSpan(injectedBundleClient), 0);
 
     injectedBundleClient.base.version = 1;
     injectedBundleClient.base.clientInfo = (__bridge void*)processGroup;
@@ -131,7 +132,7 @@ static void setUpHistoryClient(WKProcessGroup *processGroup, WKContextRef contex
 ALLOW_DEPRECATED_DECLARATIONS_END
 {
     WKContextHistoryClientV0 historyClient;
-    memset(&historyClient, 0, sizeof(historyClient));
+    memsetSpan(asMutableByteSpan(historyClient), 0);
 
     historyClient.base.version = 0;
     historyClient.base.clientInfo = (__bridge CFTypeRef)processGroup;

--- a/Source/WebKit/UIProcess/ios/WKPDFView.mm
+++ b/Source/WebKit/UIProcess/ios/WKPDFView.mm
@@ -47,6 +47,7 @@
 #import <wtf/BlockPtr.h>
 #import <wtf/MainThread.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/StdLibExtras.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/cocoa/Entitlements.h>
 #import <wtf/cocoa/NSURLExtras.h>
@@ -177,7 +178,7 @@ static void* kvoContext = &kvoContext;
     [[_hostViewController view] removeFromSuperview];
     [_pageNumberIndicator removeFromSuperview];
     [_keyboardScrollingAnimator invalidate];
-    std::memset(_passwordForPrinting.mutableData(), 0, _passwordForPrinting.length());
+    secureMemsetSpan(_passwordForPrinting.mutableSpan(), 0);
 #if HAVE(UIFINDINTERACTION)
     _searchAggregator = nil;
     _searchString = nil;

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugIn.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugIn.mm
@@ -34,6 +34,7 @@
 #import "WKWebProcessPlugInBrowserContextControllerInternal.h"
 #import <WebCore/WebCoreObjCExtras.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/StdLibExtras.h>
 
 @interface WKWebProcessPlugInController () {
     API::ObjectStorage<WebKit::InjectedBundle> _bundle;
@@ -74,7 +75,7 @@ static void willDestroyPage(WKBundleRef bundle, WKBundlePageRef page, const void
 static void setUpBundleClient(WKWebProcessPlugInController *plugInController, WebKit::InjectedBundle& bundle)
 {
     WKBundleClientV1 bundleClient;
-    memset(&bundleClient, 0, sizeof(bundleClient));
+    memsetSpan(asMutableByteSpan(bundleClient), 0);
 
     bundleClient.base.version = 1;
     bundleClient.base.clientInfo = (__bridge void*)plugInController;

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
@@ -64,6 +64,7 @@
 #import <WebCore/HTMLInputElement.h>
 #import <WebCore/LocalFrame.h>
 #import <WebCore/WebCoreObjCExtras.h>
+#import <wtf/StdLibExtras.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/cocoa/VectorCocoa.h>
@@ -254,7 +255,7 @@ static void didHandleOnloadEventsForFrame(WKBundlePageRef page, WKBundleFrameRef
 static void setUpPageLoaderClient(WKWebProcessPlugInBrowserContextController *contextController, WebKit::WebPage& page)
 {
     WKBundlePageLoaderClientV11 client;
-    memset(&client, 0, sizeof(client));
+    memsetSpan(asMutableByteSpan(client), 0);
 
     client.base.version = 11;
     client.base.clientInfo = (__bridge void*)contextController;
@@ -351,7 +352,7 @@ static void didFailLoadForResource(WKBundlePageRef, WKBundleFrameRef frame, uint
 static void setUpResourceLoadClient(WKWebProcessPlugInBrowserContextController *contextController, WebKit::WebPage& page)
 {
     WKBundlePageResourceLoadClientV1 client;
-    memset(&client, 0, sizeof(client));
+    memsetSpan(asMutableByteSpan(client), 0);
 
     client.base.version = 1;
     client.base.clientInfo = (__bridge void*) contextController;

--- a/Tools/TestWebKitAPI/Tests/WebKit/DownloadDecideDestinationCrash.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/DownloadDecideDestinationCrash.cpp
@@ -30,6 +30,7 @@
 #include "PlatformUtilities.h"
 #include "PlatformWebView.h"
 #include <WebKit/WKDownloadRef.h>
+#include <wtf/StdLibExtras.h>
 
 namespace TestWebKitAPI {
 
@@ -50,7 +51,7 @@ static WKStringRef decideDestinationWithSuggestedFilename(WKDownloadRef download
 static void navigationResponseDidBecomeDownload(WKPageRef page, WKNavigationResponseRef navigationResponse, WKDownloadRef download, const void* clientInfo)
 {
     WKDownloadClientV0 client;
-    memset(&client, 0, sizeof(client));
+    memsetSpan(asMutableByteSpan(client), 0);
     client.base.version = 0;
     client.decideDestinationWithResponse = decideDestinationWithSuggestedFilename;
     WKDownloadSetClient(download, &client.base);

--- a/Tools/TestWebKitAPI/Tests/WebKit/NetworkProcessCrashWithPendingConnection.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/NetworkProcessCrashWithPendingConnection.mm
@@ -35,6 +35,7 @@
 #import <WebKit/WKWebsiteDataStorePrivate.h>
 #import <WebKit/WebKit.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/StdLibExtras.h>
 
 static bool loadedOrCrashed = false;
 static bool loaded = false;
@@ -69,7 +70,7 @@ TEST(WebKit, NetworkProcessCrashWithPendingConnection)
 
     // FIXME: Adopt the new API once it's added in webkit.org/b/174061.
     WKContextClientV0 client;
-    memset(&client, 0, sizeof(client));
+    memsetSpan(asMutableByteSpan(client), 0);
     client.networkProcessDidCrash = [](WKContextRef context, const void* clientInfo) {
         networkProcessCrashed = true;
     };
@@ -136,7 +137,7 @@ TEST(WebKit, NetworkProcessRelaunchOnLaunchFailure)
     networkProcessCrashed = false;
 
     WKContextClientV0 client;
-    memset(&client, 0, sizeof(client));
+    memsetSpan(asMutableByteSpan(client), 0);
     client.networkProcessDidCrash = [](WKContextRef context, const void* clientInfo) {
         networkProcessCrashed = true;
     };

--- a/Tools/TestWebKitAPI/Tests/WebKit/mac/ContextMenuDownload.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/mac/ContextMenuDownload.mm
@@ -35,6 +35,7 @@
 #import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKRetainPtr.h>
 #import <WebKit/_WKDownload.h>
+#import <wtf/StdLibExtras.h>
 
 namespace TestWebKitAPI {
 
@@ -80,7 +81,7 @@ static WKStringRef decideDestinationWithSuggestedFilename(WKDownloadRef download
 static void contextMenuDidCreateDownload(WKPageRef page, WKDownloadRef download, const void* clientInfo)
 {
     WKDownloadClientV0 client;
-    memset(&client, 0, sizeof(client));
+    memsetSpan(asMutableByteSpan(client), 0);
     client.base.version = 0;
     client.decideDestinationWithResponse = decideDestinationWithSuggestedFilename;
     WKDownloadSetClient(download, &client.base);
@@ -132,7 +133,7 @@ static WKStringRef decideDestinationWithSuggestedFilenameContainingSlashes(WKDow
 static void contextMenuDidCreateDownloadWithSuggestedFilenameContainingSlashes(WKPageRef page, WKDownloadRef download, const void* clientInfo)
 {
     WKDownloadClientV0 client;
-    memset(&client, 0, sizeof(client));
+    memsetSpan(asMutableByteSpan(client), 0);
     client.base.version = 0;
     client.decideDestinationWithResponse = decideDestinationWithSuggestedFilenameContainingSlashes;
     WKDownloadSetClient(download, &client.base);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/BasicProposedCredentialPlugIn.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/BasicProposedCredentialPlugIn.mm
@@ -29,6 +29,7 @@
 #import <WebKit/WKBundlePageResourceLoadClient.h>
 #import <WebKit/WKWebProcessPlugIn.h>
 #import <WebKit/WKWebProcessPlugInBrowserContextControllerPrivate.h>
+#import <wtf/StdLibExtras.h>
 
 @interface BasicProposedCredentialPlugIn : NSObject<WKWebProcessPlugIn>
 @end
@@ -38,7 +39,7 @@
 - (void)webProcessPlugIn:(WKWebProcessPlugInController *)plugInController didCreateBrowserContextController:(WKWebProcessPlugInBrowserContextController *)browserContextController
 {
     WKBundlePageResourceLoadClientV1 client;
-    memset(&client, 0, sizeof(client));
+    memsetSpan(asMutableByteSpan(client), 0);
     client.base.version = 1;
     client.shouldUseCredentialStorage = [](auto...) {
         static size_t queries { 0 };

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/BundlePageConsoleMessage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/BundlePageConsoleMessage.mm
@@ -32,6 +32,7 @@
 #import <WebKit/WKRetainPtr.h>
 #import <WebKit/WKWebProcessPlugIn.h>
 #import <WebKit/WKWebProcessPlugInBrowserContextControllerPrivate.h>
+#import <wtf/StdLibExtras.h>
 
 void willAddMessageToConsoleCallback(WKBundlePageRef page, WKStringRef message, uint32_t lineNumber, const void *)
 {
@@ -47,7 +48,7 @@ void willAddMessageToConsoleCallback(WKBundlePageRef page, WKStringRef message, 
 - (void)webProcessPlugIn:(WKWebProcessPlugInController *)plugInController didCreateBrowserContextController:(WKWebProcessPlugInBrowserContextController *)browserContextController
 {
     WKBundlePageUIClientV4 client;
-    memset(&client, 0, sizeof(client));
+    memsetSpan(asMutableByteSpan(client), 0);
     client.base.version = 4;
     client.willAddMessageToConsole = willAddMessageToConsoleCallback;
     WKBundlePageSetUIClient([browserContextController _bundlePageRef], &client.base);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/BundlePageConsoleMessageWithDetails.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/BundlePageConsoleMessageWithDetails.mm
@@ -34,6 +34,7 @@
 #import <WebKit/WKStringCF.h>
 #import <WebKit/WKWebProcessPlugIn.h>
 #import <WebKit/WKWebProcessPlugInBrowserContextControllerPrivate.h>
+#import <wtf/StdLibExtras.h>
 
 static NSArray<NSString *> *stringsArrayFromWKArrayRef(WKArrayRef wkArray)
 {
@@ -69,7 +70,7 @@ static void willAddMessageWithDetailsToConsoleCallback(WKBundlePageRef page, WKS
 - (void)webProcessPlugIn:(WKWebProcessPlugInController *)plugInController didCreateBrowserContextController:(WKWebProcessPlugInBrowserContextController *)browserContextController
 {
     WKBundlePageUIClientV5 client;
-    memset(&client, 0, sizeof(client));
+    memsetSpan(asMutableByteSpan(client), 0);
     client.base.version = 5;
     client.willAddMessageWithDetailsToConsole = willAddMessageWithDetailsToConsoleCallback;
     WKBundlePageSetUIClient([browserContextController _bundlePageRef], &client.base);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ClickAutoFillButton.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ClickAutoFillButton.mm
@@ -37,6 +37,7 @@
 #import <WebKit/WKWebProcessPlugInFrame.h>
 #import <WebKit/WKWebProcessPlugInNodeHandlePrivate.h>
 #import <WebKit/WKWebProcessPlugInScriptWorld.h>
+#import <wtf/StdLibExtras.h>
 
 void didClickAutoFillButton(WKBundlePageRef, WKBundleNodeHandleRef, WKTypeRef* userData, const void *)
 {
@@ -51,7 +52,7 @@ void didClickAutoFillButton(WKBundlePageRef, WKBundleNodeHandleRef, WKTypeRef* u
 - (void)webProcessPlugIn:(WKWebProcessPlugInController *)plugInController didCreateBrowserContextController:(WKWebProcessPlugInBrowserContextController *)browserContextController
 {
     WKBundlePageUIClientV3 client;
-    memset(&client, 0, sizeof(client));
+    memsetSpan(asMutableByteSpan(client), 0);
     client.base.version = 3;
     client.didClickAutoFillButton = didClickAutoFillButton;
     WKBundlePageSetUIClient([browserContextController _bundlePageRef], &client.base);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/DidResignInputElementStrongPasswordAppearance.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/DidResignInputElementStrongPasswordAppearance.mm
@@ -37,6 +37,7 @@
 #import <WebKit/WKWebProcessPlugInFrame.h>
 #import <WebKit/WKWebProcessPlugInNodeHandlePrivate.h>
 #import <WebKit/WKWebProcessPlugInScriptWorld.h>
+#import <wtf/StdLibExtras.h>
 
 void didResignInputElementStrongPasswordAppearance(WKBundlePageRef, WKBundleNodeHandleRef, WKTypeRef* userData, const void *)
 {
@@ -51,7 +52,7 @@ void didResignInputElementStrongPasswordAppearance(WKBundlePageRef, WKBundleNode
 - (void)webProcessPlugIn:(WKWebProcessPlugInController *)plugInController didCreateBrowserContextController:(WKWebProcessPlugInBrowserContextController *)browserContextController
 {
     WKBundlePageUIClientV4 client;
-    memset(&client, 0, sizeof(client));
+    memsetSpan(asMutableByteSpan(client), 0);
     client.base.version = 4;
     client.didResignInputElementStrongPasswordAppearance = didResignInputElementStrongPasswordAppearance;
     WKBundlePageSetUIClient([browserContextController _bundlePageRef], &client.base);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FrameHandleSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FrameHandleSerialization.mm
@@ -29,6 +29,7 @@
 #import <WebKit/WKBundlePageUIClient.h>
 #import <WebKit/WKWebProcessPlugIn.h>
 #import <WebKit/WKWebProcessPlugInBrowserContextControllerPrivate.h>
+#import <wtf/StdLibExtras.h>
 
 void mouseDidMoveOverElement(WKBundlePageRef page, WKBundleHitTestResultRef hitTestResult, WKEventModifiers modifiers, WKTypeRef* userData, const void* clientInfo)
 {
@@ -43,7 +44,7 @@ void mouseDidMoveOverElement(WKBundlePageRef page, WKBundleHitTestResultRef hitT
 - (void)webProcessPlugIn:(WKWebProcessPlugInController *)plugInController didCreateBrowserContextController:(WKWebProcessPlugInBrowserContextController *)browserContextController
 {
     WKBundlePageUIClientV0 client;
-    memset(&client, 0, sizeof(client));
+    memsetSpan(asMutableByteSpan(client), 0);
     client.mouseDidMoveOverElement = mouseDidMoveOverElement;
     WKBundlePageSetUIClient([browserContextController _bundlePageRef], &client.base);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitObjC/CustomProtocolsTest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitObjC/CustomProtocolsTest.mm
@@ -37,6 +37,7 @@
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/WKWebsiteDataStoreRef.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/StdLibExtras.h>
 
 static bool testFinished;
 
@@ -85,7 +86,7 @@ static RetainPtr<WKWebView> wkView;
 {
     dispatch_async(dispatch_get_main_queue(), ^ {
         WKContextClientV0 client;
-        memset(&client, 0, sizeof(client));
+        memsetSpan(asMutableByteSpan(client), 0);
         client.base.clientInfo = self;
         client.networkProcessDidCrash = [](WKContextRef context, const void* clientInfo) {
             auto protocol = (CloseWhileStartingProtocol *)clientInfo;


### PR DESCRIPTION
#### f2ef13045f0d5fc83a49ff015667ed78fdaeda69
<pre>
Reduce use of memset()
<a href="https://bugs.webkit.org/show_bug.cgi?id=284352">https://bugs.webkit.org/show_bug.cgi?id=284352</a>

Reviewed by Geoffrey Garen.

Reduce use of memset(), in favor of safer variants.

* Source/WTF/wtf/StdLibExtras.h:
(WTF::safeMemsetSpan):
* Source/WTF/wtf/text/CString.cpp:
(WTF::CString::mutableSpan):
* Source/WTF/wtf/text/CString.h:
* Source/WebCore/Modules/compression/CompressionStream.cpp:
(WebCore::CompressionStream::CompressionStream):
* Source/WebCore/Modules/compression/ZStream.cpp:
(WebCore::ZStream::ZStream):
* Source/WebCore/Modules/webaudio/AudioScheduledSourceNode.cpp:
(WebCore::AudioScheduledSourceNode::updateSchedulingInfo):
* Source/WebCore/Modules/webaudio/PeriodicWave.cpp:
(WebCore::PeriodicWave::createBandLimitedTables):
* Source/WebCore/Modules/webauthn/fido/FidoHidPacket.cpp:
(fido::FidoHidInitPacket::getSerializedData const):
(fido::FidoHidContinuationPacket::getSerializedData const):
* Source/WebCore/Modules/websockets/WebSocketDeflater.cpp:
(WebCore::WebSocketDeflater::WebSocketDeflater):
(WebCore::WebSocketInflater::WebSocketInflater):
* Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp:
(PAL::TextCodecUTF8::consumePartialSequenceByte):
(PAL::TextCodecUTF8::handlePartialSequence):
(PAL::TextCodecUTF8::decode):
* Source/WebCore/PAL/pal/text/TextCodecUTF8.h:
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::TextMarkerData::TextMarkerData):
* Source/WebCore/accessibility/AXTextMarker.h:
(WebCore::TextMarkerData::TextMarkerData):
* Source/WebCore/contentextensions/DFABytecodeCompiler.cpp:
(WebCore::ContentExtensions::DFABytecodeCompiler::transitions):
* Source/WebCore/contentextensions/DFAMinimizer.cpp:
* Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSAMac.cpp:
(WebCore::signECDSA):
* Source/WebCore/loader/FTPDirectoryParser.h:
(WebCore::ListState::ListState):
(WebCore::ListResult::clear):
* Source/WebCore/platform/audio/AudioArray.h:
(WebCore::AudioArray::zero):
(WebCore::AudioArray::zeroRange):
* Source/WebCore/platform/audio/AudioBus.cpp:
(WebCore::AudioBus::copyWithGainFrom):
* Source/WebCore/platform/audio/AudioChannel.cpp:
(WebCore::AudioChannel::copyFromRange):
* Source/WebCore/platform/audio/AudioChannel.h:
* Source/WebCore/platform/audio/DenormalDisabler.h:
* Source/WebCore/platform/audio/PushPullFIFO.cpp:
(WebCore::PushPullFIFO::pull):
* Source/WebCore/platform/audio/ReverbAccumulationBuffer.cpp:
(WebCore::ReverbAccumulationBuffer::readAndClear):
* Source/WebCore/platform/audio/cocoa/WebAudioBufferList.cpp:
(WebCore::WebAudioBufferList::initializeList):
(WebCore::WebAudioBufferList::zeroFlatBuffer):
* Source/WebCore/platform/graphics/PixelBuffer.cpp:
(WebCore::PixelBuffer::zeroRange):
* Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp:
(WebCore::TransformationMatrix::decompose2 const):
(WebCore::TransformationMatrix::decompose4 const):
* Source/WebCore/platform/image-decoders/bmp/BMPImageReader.cpp:
(WebCore::BMPImageReader::BMPImageReader):
* Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.cpp:
(WebCore::JPEGImageReader::JPEGImageReader):
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCDav1dDecoder.cpp:
(WebCore::Dav1dDecoder::Decode):
* Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm:
(WebCore::MockAudioSharedInternalUnit::emitSampleBuffers):
* Source/WebCore/svg/SVGToOTFFontConversion.cpp:
(WebCore::SVGToOTFFontConverter::appendOS2Table):
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::XMLDocumentParser::initializeParserContext):
(WebCore::parseAttributes):
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::writeTexture):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp:
(WebKit::connectToRemoteAddress):
(WebKit::getSocketLocalAddress):
* Source/WebKit/Platform/IPC/darwin/IPCEventDarwin.cpp:
(IPC::Signal::signal):
(IPC::Event::wait):
(IPC::Event::waitFor):
* Source/WebKit/Shared/API/APIClient.h:
(API::Client::initialize):
* Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp:
(API::compiledToFile):
* Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKProcessGroup.mm:
* Source/WebKit/UIProcess/ios/WKPDFView.mm:
(-[WKPDFView dealloc]):
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugIn.mm:
(setUpBundleClient):
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm:
(setUpPageLoaderClient):
(setUpResourceLoadClient):
* Tools/TestWebKitAPI/Tests/WebKit/DownloadDecideDestinationCrash.cpp:
(TestWebKitAPI::navigationResponseDidBecomeDownload):
* Tools/TestWebKitAPI/Tests/WebKit/NetworkProcessCrashWithPendingConnection.mm:
(TestWebKitAPI::TEST(WebKit, NetworkProcessCrashWithPendingConnection)):
(TestWebKitAPI::TEST(WebKit, NetworkProcessRelaunchOnLaunchFailure)):
* Tools/TestWebKitAPI/Tests/WebKit/mac/ContextMenuDownload.mm:
(TestWebKitAPI::contextMenuDidCreateDownload):
(TestWebKitAPI::contextMenuDidCreateDownloadWithSuggestedFilenameContainingSlashes):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/BasicProposedCredentialPlugIn.mm:
(-[BasicProposedCredentialPlugIn webProcessPlugIn:didCreateBrowserContextController:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/BundlePageConsoleMessage.mm:
(-[BundlePageConsoleMessage webProcessPlugIn:didCreateBrowserContextController:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/BundlePageConsoleMessageWithDetails.mm:
(-[BundlePageConsoleMessageWithDetails webProcessPlugIn:didCreateBrowserContextController:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ClickAutoFillButton.mm:
(-[ClickAutoFillButton webProcessPlugIn:didCreateBrowserContextController:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DidResignInputElementStrongPasswordAppearance.mm:
(-[DidResignInputElementStrongPasswordAppearance webProcessPlugIn:didCreateBrowserContextController:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FrameHandleSerialization.mm:
(-[FrameHandleSerialization webProcessPlugIn:didCreateBrowserContextController:]):
* Tools/TestWebKitAPI/Tests/WebKitObjC/CustomProtocolsTest.mm:
(-[CloseWhileStartingProtocol startLoading]):

Canonical link: <a href="https://commits.webkit.org/287670@main">https://commits.webkit.org/287670@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16ff75a86c075e13c17a47062174adb8b84f4980

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80424 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59430 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34079 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84945 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31406 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82535 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68492 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7733 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62848 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20655 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83493 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52932 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73225 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43152 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50241 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27380 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29865 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/73404 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71381 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27901 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86379 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/79483 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7649 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5403 "Found 1 new test failure: imported/w3c/web-platform-tests/dom/observable/tentative/observable-filter.any.worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71133 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7824 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69063 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70373 "Found 4 new API test failures: /TestWebKit:WebKit.PageLoadTwiceAndReload, /TestWebKit:WebKit.PageLoadState, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/dom-input-element-is-user-edited, /TestWebKit:WebKit.HitTestResultNodeHandle (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14374 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13319 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/101890 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12447 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7611 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13131 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/24825 "Found 2 new JSC stress test failures: wasm.yaml/wasm/stress/struct-new_default-small-members.js.wasm-no-cjit, wasm.yaml/wasm/stress/struct-new_default-small-members.js.wasm-slow-memory (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7450 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10970 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9256 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->