### PR TITLE
Replaced elements inside grid item with aspect ratio and padding grows indefinitely when resizing window.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-elements-inside-grid-item-percent-height-and-padding-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-elements-inside-grid-item-percent-height-and-padding-expected.txt
@@ -1,0 +1,6 @@
+
+
+PASS replaced-elements-inside-grid-item-percent-height-and-padding
+PASS replaced-elements-inside-grid-item-percent-height-and-padding 1
+PASS replaced-elements-inside-grid-item-percent-height-and-padding 2
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-elements-inside-grid-item-percent-height-and-padding.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-elements-inside-grid-item-percent-height-and-padding.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio">
+<meta name="assert" content="Replaced elements' with no intrinsic size but aspect ratio width should remain same">
+<style>
+  grid {
+    display: grid;
+    width: 100px;
+  }
+  .aspect-ratio-and-padding {
+    padding: 10px;
+    aspect-ratio: 1
+  }
+  .percent-height {
+    height: 100%;
+  }
+  .aspect-ratio {
+    aspect-ratio: 1;
+  }
+</style>
+</head>
+<body>
+  <grid>
+    <div class="aspect-ratio-and-padding">
+      <div class="percent-height">
+        <svg class="percent-height" viewBox="0 0 1 1"></svg>
+        <img class="percent-height aspect-ratio">
+        <canvas class="percent-height aspect-ratio"></canvas>
+      </div>
+    </div>
+  </grid>
+</body>
+<script>
+document.body.offsetHeight;
+let svg = document.querySelector("svg");
+let initialSVGWidth = window.getComputedStyle(svg)["width"];
+
+let canvas = document.querySelector("canvas");
+let initialCanvasWidth = window.getComputedStyle(canvas)["width"];
+
+let img = document.querySelector("img");
+let initialImgWidth = window.getComputedStyle(img)["width"];
+
+document.body.style.width = "90%";
+document.body.offsetHeight;
+
+test(() => {
+  assert_equals(initialSVGWidth, window.getComputedStyle(svg)["width"]);
+});
+
+test(() => {
+  assert_equals(initialImgWidth, window.getComputedStyle(img)["width"]);
+});
+
+test(() => {
+  assert_equals(initialCanvasWidth, window.getComputedStyle(canvas)["width"]);
+});
+</script>
+

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -3194,7 +3194,14 @@ std::optional<LayoutUnit> RenderBlock::availableLogicalHeightForPercentageComput
             // Only grid is expected to be in a state where it is calculating pref width and having unknown logical width.
             if (isRenderGrid() && preferredLogicalWidthsDirty() && !style.logicalWidth().isSpecified())
                 return { };
-            return blockSizeFromAspectRatio(horizontalBorderAndPaddingExtent(), verticalBorderAndPaddingExtent(), LayoutUnit { style.logicalAspectRatio() }, style.boxSizingForAspectRatio(), logicalWidth(), style.aspectRatioType(), isRenderReplaced());
+
+            auto logicalWidth = [&] {
+                if (auto overridingContainingBlockLogicalWidth = overridingContainingBlockContentLogicalWidth(); overridingContainingBlockLogicalWidth && *overridingContainingBlockLogicalWidth && isGridItem())
+                    return computeLogicalWidthInFragmentUsing(SizeType::MainOrPreferredSize, style.logicalWidth(), *overridingContainingBlockLogicalWidth.value(), *containingBlock(), nullptr);
+                return this->logicalWidth();
+            }();
+
+            return blockSizeFromAspectRatio(horizontalBorderAndPaddingExtent(), verticalBorderAndPaddingExtent(), LayoutUnit { style.logicalAspectRatio() }, style.boxSizingForAspectRatio(), logicalWidth, style.aspectRatioType(), isRenderReplaced());
         }
 
         // A positioned element that specified both top/bottom or that specifies


### PR DESCRIPTION
#### 473a7b965be537d3f2ad67d2615e5746f3f95963
<pre>
Replaced elements inside grid item with aspect ratio and padding grows indefinitely when resizing window.
<a href="https://bugs.webkit.org/show_bug.cgi?id=283194">https://bugs.webkit.org/show_bug.cgi?id=283194</a>
<a href="https://rdar.apple.com/136048569">rdar://136048569</a>

Reviewed by NOBODY (OOPS!).

Certain types of grid content with a replaced descendant that has
percent height and aspect ratio can trigger an unstable layout
in which the size of the content grows unexpectedly whenever the
inline constraints change. The following is a small snippet in
which this type of pathological behavior can occur:

&lt;grid&gt;
  &lt;div class=&quot;aspect-ratio-and-padding&quot;&gt;
    &lt;div class=&quot;percent-height&quot;&gt;
      &lt;svg class=&quot;percent-height&quot;&gt;&lt;/svg&gt;
    &lt;/div&gt;
  &lt;/div&gt;
&lt;/grid&gt;

Replacing the SVG with any sort of replaced element that does not have
an intrinsic size but does have an aspect ratio causes the same bug to
occur.

During track sizing, grid will query the grid item for its preferred
logical width. The preferred logical width of a replaced element without an
intrinsic logical width but with an intrinsic ratio and a non-auto value for its
logical height is computed from the ratio and logical height.

The replaced element has a percent-based height, so we will attempt to resolve its
value based off the height of the containing block. The containing block
of the replaced element is also percent-based, so we will do the same thing.
Its containing block is a grid item with an aspect ratio.

This lands us in availableLogicalHeightForPercentageComputation for the grid item
in which &quot;shouldComputeLogicalHeightFromAspectRatio,&quot; returns true since the
width and height are both auto. We then try to compute the logical
height using the logical width off the renderer, which is a stale and
incorrect value for this context. Instead, let&apos;s just try to compute
the width of the grid item based on the constraints that are supposed to
be set by the grid via computeLogicalWidthInFragmentUsing.

* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-elements-inside-grid-item-percent-height-and-padding-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-elements-inside-grid-item-percent-height-and-padding.html: Added.
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::availableLogicalHeightForPercentageComputation const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/473a7b965be537d3f2ad67d2615e5746f3f95963

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80535 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34369 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85056 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31517 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82646 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68603 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7847 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62919 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20731 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83604 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/53028 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73322 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43222 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50330 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27480 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29976 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71475 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28003 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86490 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7761 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5485 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71211 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7936 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69159 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70451 "Found 4 new API test failures: /TestWebKit:WebKit2UserMessageRoundTripTest.WKString, /TestWebKit:WebKit.LoadAlternateHTMLStringWithEmptyBaseURL, /TestWebKit:WebKit.DocumentStartUserScriptAlertCrashTest, /TestWebKit:WebKit.WillSendSubmitEvent (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14462 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13411 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7723 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13242 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7562 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11081 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9367 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->