### PR TITLE
AudioDecoderCocoa should trim start of decoded samples in accordance with preSkip information

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/AudioDecoderCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioDecoderCocoa.cpp
@@ -35,6 +35,7 @@
 #include "MediaUtilities.h"
 #include "PlatformRawAudioData.h"
 #include "SharedBuffer.h"
+#include "WebMAudioUtilitiesCocoa.h"
 #include <CoreAudio/CoreAudioTypes.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -248,9 +249,10 @@ String InternalAudioDecoderCocoa::initialize(const String& codecName, const Audi
     if (!result)
         return result.error();
 
+    unsigned preSkip = 0;
     auto [codec, format] = *result;
     if (!format) {
-        if (codec == kAudioFormatOpus && config.numberOfChannels >= 2)
+        if (codec == kAudioFormatOpus && config.numberOfChannels > 2)
             return "Opus with more than 2 channels isn't supported"_s;
 
         if (codec == kAudioFormatFLAC && config.description.empty())
@@ -268,6 +270,11 @@ String InternalAudioDecoderCocoa::initialize(const String& codecName, const Audi
         if (config.description.size()) {
             UInt32 size = sizeof(absd);
             succeeded = PAL::AudioFormatGetProperty(kAudioFormatProperty_FormatInfo, config.description.size(), config.description.data(), &size, &absd) == noErr;
+            if (codec == kAudioFormatOpus) {
+                OpusCookieContents cookie;
+                if (parseOpusPrivateData(config.description, { }, cookie))
+                    preSkip = cookie.preSkip;
+            }
         }
         if (!succeeded) {
             absd.mSampleRate = double(config.sampleRate);
@@ -286,7 +293,8 @@ String InternalAudioDecoderCocoa::initialize(const String& codecName, const Audi
     AudioSampleBufferConverter::Options options = {
         .format = kAudioFormatLinearPCM,
         .description = m_outputDescription->streamDescription(),
-        .generateTimestamp = false
+        .generateTimestamp = false,
+        .preSkip = preSkip
     };
 
     m_converter = AudioSampleBufferConverter::create(decompressedAudioOutputBufferCallback, this, options);

--- a/Source/WebCore/platform/audio/cocoa/AudioSampleBufferConverter.h
+++ b/Source/WebCore/platform/audio/cocoa/AudioSampleBufferConverter.h
@@ -46,6 +46,7 @@ public:
         std::optional<AudioStreamBasicDescription> description { };
         std::optional<unsigned> outputBitRate { };
         bool generateTimestamp { true };
+        std::optional<unsigned> preSkip { 0 };
     };
     static RefPtr<AudioSampleBufferConverter> create(CMBufferQueueTriggerCallback, void* callbackObject, const Options&);
     ~AudioSampleBufferConverter();
@@ -68,7 +69,7 @@ private:
     static OSStatus audioConverterComplexInputDataProc(AudioConverterRef, UInt32*, AudioBufferList*, AudioStreamPacketDescription**, void*);
 
     void processSampleBuffer(CMSampleBufferRef);
-    bool initAudioConverterForSourceFormatDescription(CMFormatDescriptionRef, AudioFormatID);
+    OSStatus initAudioConverterForSourceFormatDescription(CMFormatDescriptionRef, AudioFormatID);
     void attachPrimingTrimsIfNeeded(CMSampleBufferRef);
     RetainPtr<NSNumber> gradualDecoderRefreshCount();
     Expected<RetainPtr<CMSampleBufferRef>, OSStatus> sampleBuffer(const WebAudioBufferList&, uint32_t numSamples);
@@ -106,8 +107,8 @@ private:
     Vector<AudioStreamPacketDescription> m_packetDescriptions WTF_GUARDED_BY_CAPABILITY(queue().get());
     OSStatus m_lastError WTF_GUARDED_BY_CAPABILITY(queue().get()) { 0 };
     const AudioFormatID m_outputCodecType;
-    const std::optional<unsigned> m_outputBitRate;
-    const bool m_generateTimestamp { true };
+    const Options m_options;
+    std::atomic<unsigned> m_defaultBitRate { 0 };
 };
 
 }

--- a/Source/WebCore/platform/audio/cocoa/AudioSampleBufferConverter.mm
+++ b/Source/WebCore/platform/audio/cocoa/AudioSampleBufferConverter.mm
@@ -66,8 +66,7 @@ AudioSampleBufferConverter::AudioSampleBufferConverter(const Options& options)
     , m_currentOutputPresentationTimeStamp(PAL::kCMTimeInvalid)
     , m_remainingPrimeDuration(PAL::kCMTimeInvalid)
     , m_outputCodecType(options.format)
-    , m_outputBitRate(options.outputBitRate)
-    , m_generateTimestamp(options.generateTimestamp)
+    , m_options(options)
 {
 }
 
@@ -161,7 +160,7 @@ UInt32 AudioSampleBufferConverter::defaultOutputBitRate(const AudioStreamBasicDe
     return 64000;
 }
 
-bool AudioSampleBufferConverter::initAudioConverterForSourceFormatDescription(CMFormatDescriptionRef formatDescription, AudioFormatID outputFormatID)
+OSStatus AudioSampleBufferConverter::initAudioConverterForSourceFormatDescription(CMFormatDescriptionRef formatDescription, AudioFormatID outputFormatID)
 {
     assertIsCurrent(queue().get());
 
@@ -179,18 +178,18 @@ bool AudioSampleBufferConverter::initAudioConverterForSourceFormatDescription(CM
     UInt32 size = sizeof(m_destinationFormat);
     if (auto error = PAL::AudioFormatGetProperty(kAudioFormatProperty_FormatInfo, 0, NULL, &size, &m_destinationFormat)) {
         RELEASE_LOG_ERROR(MediaStream, "AudioSampleBufferConverter AudioFormatGetProperty failed with %d", static_cast<int>(error));
-        return false;
+        return error;
     }
 
     AudioConverterRef converter;
     auto error = PAL::AudioConverterNew(&m_sourceFormat, &m_destinationFormat, &converter);
-    if (error == 'fmt?' && outputFormatID != kAudioFormatOpus) {
-        m_destinationFormat.mSampleRate = 44100;
+    if (error == kAudioConverterErr_FormatNotSupported) {
+        m_destinationFormat.mSampleRate = 48000;
         error = PAL::AudioConverterNew(&m_sourceFormat, &m_destinationFormat, &converter);
     }
     if (error) {
         RELEASE_LOG_ERROR(MediaStream, "AudioSampleBufferConverter AudioConverterNew failed with %d", static_cast<int>(error));
-        return false;
+        return error;
     }
     m_converter = converter;
 
@@ -206,26 +205,26 @@ bool AudioSampleBufferConverter::initAudioConverterForSourceFormatDescription(CM
     if (cookieSize) {
         if (auto error = PAL::AudioConverterSetProperty(m_converter, kAudioConverterDecompressionMagicCookie, (UInt32)cookieSize, cookie)) {
             RELEASE_LOG_ERROR(MediaStream, "AudioSampleBufferConverter setting kAudioConverterDecompressionMagicCookie failed with %d", static_cast<int>(error));
-            return false;
+            return error;
         }
     }
 
     size = sizeof(m_sourceFormat);
     if (auto error = PAL::AudioConverterGetProperty(m_converter, kAudioConverterCurrentInputStreamDescription, &size, &m_sourceFormat)) {
         RELEASE_LOG_ERROR(MediaStream, "AudioSampleBufferConverter getting kAudioConverterCurrentInputStreamDescription failed with %d", static_cast<int>(error));
-        return false;
+        return error;
     }
 
     size = sizeof(m_destinationFormat);
     if (auto error = PAL::AudioConverterGetProperty(m_converter, kAudioConverterCurrentOutputStreamDescription, &size, &m_destinationFormat)) {
         RELEASE_LOG_ERROR(MediaStream, "AudioSampleBufferConverter getting kAudioConverterCurrentOutputStreamDescription failed with %d", static_cast<int>(error));
-        return false;
+        return error;
     }
 
     if (!isPCM()) {
         bool shouldSetDefaultOutputBitRate = true;
-        if (m_outputBitRate) {
-            if (auto error = PAL::AudioConverterSetProperty(m_converter, kAudioConverterEncodeBitRate, sizeof(*m_outputBitRate), &m_outputBitRate.value()))
+        if (m_options.outputBitRate) {
+            if (auto error = PAL::AudioConverterSetProperty(m_converter, kAudioConverterEncodeBitRate, sizeof(*m_options.outputBitRate), &m_options.outputBitRate.value()))
                 RELEASE_LOG_ERROR_IF(error, MediaStream, "AudioSampleBufferConverter setting kAudioConverterEncodeBitRate failed with %d", static_cast<int>(error));
             else
                 shouldSetDefaultOutputBitRate = false;
@@ -235,7 +234,23 @@ bool AudioSampleBufferConverter::initAudioConverterForSourceFormatDescription(CM
             size = sizeof(outputBitRate);
             if (auto error = PAL::AudioConverterSetProperty(m_converter, kAudioConverterEncodeBitRate, size, &outputBitRate))
                 RELEASE_LOG_ERROR(MediaStream, "AudioSampleBufferConverter setting default kAudioConverterEncodeBitRate failed with %d", static_cast<int>(error));
+            else
+                m_defaultBitRate = outputBitRate;
         }
+    }
+
+    if (isPCM() && m_options.preSkip) {
+        AudioConverterPrimeInfo primeInfo = { static_cast<UInt32>(*m_options.preSkip), 0 };
+        if (auto error = PAL::AudioConverterSetProperty(converter, kAudioConverterPrimeInfo, sizeof(primeInfo), &primeInfo))
+            RELEASE_LOG_ERROR(MediaStream, "AudioSampleBufferConverter setting default kAudioConverterPrimeInfo failed with %d", static_cast<int>(error));
+    }
+
+    if (!isPCM()) {
+        AudioConverterPrimeInfo primeInfo { 0, 0 };
+        UInt32 size = sizeof(primeInfo);
+        if (auto error = PAL::AudioConverterGetProperty(m_converter, kAudioConverterPrimeInfo, &size, &primeInfo))
+            RELEASE_LOG_ERROR(MediaStream, "AudioSampleBufferConverter getting kAudioConverterPrimeInfo failed with %d", static_cast<int>(error));
+        m_remainingPrimeDuration = PAL::CMTimeMake(primeInfo.leadingFrames, m_destinationFormat.mSampleRate);
     }
 
     if (!m_destinationFormat.mBytesPerPacket) {
@@ -244,7 +259,7 @@ bool AudioSampleBufferConverter::initAudioConverterForSourceFormatDescription(CM
 
         if (auto error = PAL::AudioConverterGetProperty(m_converter, kAudioConverterPropertyMaximumOutputPacketSize, &size, &m_maxOutputPacketSize)) {
             RELEASE_LOG_ERROR(MediaStream, "AudioSampleBufferConverter getting kAudioConverterPropertyMaximumOutputPacketSize failed with %d", static_cast<int>(error));
-            return false;
+            return error;
         }
     } else
         m_maxOutputPacketSize = m_destinationFormat.mBytesPerPacket;
@@ -256,7 +271,7 @@ bool AudioSampleBufferConverter::initAudioConverterForSourceFormatDescription(CM
         m_destinationBuffer.grow(sizeNeededForDestination);
 
     m_destinationPacketDescriptions.reserveInitialCapacity(m_destinationBuffer.capacity() / m_maxOutputPacketSize);
-    return true;
+    return noErr;
 }
 
 void AudioSampleBufferConverter::attachPrimingTrimsIfNeeded(CMSampleBufferRef buffer)
@@ -265,17 +280,7 @@ void AudioSampleBufferConverter::attachPrimingTrimsIfNeeded(CMSampleBufferRef bu
 
     using namespace PAL;
 
-    if (CMTIME_IS_INVALID(m_remainingPrimeDuration)) {
-        AudioConverterPrimeInfo primeInfo { 0, 0 };
-        UInt32 size = sizeof(primeInfo);
-
-        if (auto error = AudioConverterGetProperty(m_converter, kAudioConverterPrimeInfo, &size, &primeInfo)) {
-            RELEASE_LOG_ERROR(MediaStream, "AudioSampleBufferConverter getting kAudioConverterPrimeInfo failed with %d", static_cast<int>(error));
-            return;
-        }
-
-        m_remainingPrimeDuration = CMTimeMake(primeInfo.leadingFrames, m_destinationFormat.mSampleRate);
-    }
+    ASSERT(CMTIME_IS_VALID(m_remainingPrimeDuration));
 
     if (CMTIME_COMPARE_INLINE(kCMTimeZero, <, m_remainingPrimeDuration)) {
         CMTime sampleDuration = CMSampleBufferGetDuration(buffer);
@@ -394,7 +399,7 @@ OSStatus AudioSampleBufferConverter::provideSourceDataNumOutputPackets(UInt32* n
     if (audioBufferList->mNumberBuffers != list->mNumberBuffers)
         return kAudioConverterErr_BadPropertySizeError;
 
-    if (!m_generateTimestamp)
+    if (!m_options.generateTimestamp)
         setTimeFromSample(sampleBuffer.get());
 
     for (size_t index = 0; index < list->mNumberBuffers; index++)
@@ -437,12 +442,12 @@ void AudioSampleBufferConverter::processSampleBuffers()
         RetainPtr buffer = (CMSampleBufferRef)(const_cast<void*>(CMBufferQueueGetHead(m_inputBufferQueue.get())));
         ASSERT(buffer);
 
-        if (m_generateTimestamp)
+        if (m_options.generateTimestamp)
             setTimeFromSample(buffer.get());
 
         RetainPtr formatDescription = PAL::CMSampleBufferGetFormatDescription(buffer.get());
-        if (!initAudioConverterForSourceFormatDescription(formatDescription.get(), m_outputCodecType)) {
-            // FIXME: Maybe we should error the media recorder if we are not able to get a correct converter.
+        if (auto error = initAudioConverterForSourceFormatDescription(formatDescription.get(), m_outputCodecType)) {
+            m_lastError = error;
             return;
         }
     }
@@ -499,18 +504,18 @@ void AudioSampleBufferConverter::processSampleBuffers()
         }
         RetainPtr buffer = WTFMove(*sampleOrError);
 
-        attachPrimingTrimsIfNeeded(buffer.get());
+        // FIXME: "Test encoding Opus with additional parameters: Opus with frameDuration" will fail otherwise, it is more correct to set the priming trims at all time.
+        if (!isPCM() && m_options.generateTimestamp)
+            attachPrimingTrimsIfNeeded(buffer.get());
 
-        if (m_generateTimestamp) {
-            if (auto error = CMSampleBufferSetOutputPresentationTimeStamp(buffer.get(), m_currentOutputPresentationTimeStamp))
-                RELEASE_LOG_ERROR(MediaStream, "AudioSampleBufferConverter CMSampleBufferSetOutputPresentationTimeStamp failed with %d", static_cast<int>(error)); // not a fatal error. Is this even possible?
+        if (auto error = CMSampleBufferSetOutputPresentationTimeStamp(buffer.get(), m_currentOutputPresentationTimeStamp))
+            RELEASE_LOG_ERROR(MediaStream, "AudioSampleBufferConverter CMSampleBufferSetOutputPresentationTimeStamp failed with %d", static_cast<int>(error)); // not a fatal error. Is this even possible?
 
-            CMTime nativeDuration = CMSampleBufferGetDuration(buffer.get());
-            m_currentNativePresentationTimeStamp = PAL::CMTimeAdd(m_currentNativePresentationTimeStamp, nativeDuration);
+        CMTime nativeDuration = CMSampleBufferGetDuration(buffer.get());
+        m_currentNativePresentationTimeStamp = PAL::CMTimeAdd(m_currentNativePresentationTimeStamp, nativeDuration);
 
-            CMTime outputDuration = CMSampleBufferGetOutputDuration(buffer.get());
-            m_currentOutputPresentationTimeStamp = PAL::CMTimeAdd(m_currentOutputPresentationTimeStamp, outputDuration);
-        }
+        CMTime outputDuration = CMSampleBufferGetOutputDuration(buffer.get());
+        m_currentOutputPresentationTimeStamp = PAL::CMTimeAdd(m_currentOutputPresentationTimeStamp, outputDuration);
 
         if (auto error = CMBufferQueueEnqueue(m_outputBufferQueue.get(), buffer.get())) {
             RELEASE_LOG_ERROR(MediaStream, "AudioSampleBufferConverter CMBufferQueueEnqueue failed with %d", static_cast<int>(error));
@@ -561,7 +566,7 @@ RetainPtr<CMSampleBufferRef> AudioSampleBufferConverter::takeOutputSampleBuffer(
 
 unsigned AudioSampleBufferConverter::bitRate() const
 {
-    return m_outputBitRate.value_or(0);
+    return m_options.outputBitRate.value_or(m_defaultBitRate.load());
 }
 
 bool AudioSampleBufferConverter::isEmpty() const

--- a/Source/WebCore/platform/graphics/cocoa/CMUtilities.h
+++ b/Source/WebCore/platform/graphics/cocoa/CMUtilities.h
@@ -61,7 +61,7 @@ public:
     ~PacketDurationParser();
 
     bool isValid() const { return m_isValid; }
-    size_t framesInPacket(SharedBuffer&);
+    size_t framesInPacket(std::span<const uint8_t>);
     void reset();
 
 private:

--- a/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
+++ b/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
@@ -367,7 +367,7 @@ PacketDurationParser::PacketDurationParser(const AudioInfo& info)
     m_isValid = true;
 }
 
-size_t PacketDurationParser::framesInPacket(SharedBuffer& packet)
+size_t PacketDurationParser::framesInPacket(std::span<const uint8_t> packet)
 {
 #if !HAVE(AUDIOFORMATPROPERTY_VARIABLEPACKET_SUPPORTED)
     UNUSED_PARAM(packet);
@@ -376,7 +376,7 @@ size_t PacketDurationParser::framesInPacket(SharedBuffer& packet)
     if (m_constantFramesPerPacket)
         return m_constantFramesPerPacket;
 
-    if (packet.isEmpty())
+    if (packet.empty())
         return 0;
 
     switch (m_audioFormatID) {

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
@@ -1213,7 +1213,7 @@ WebMParser::ConsumeFrameDataResult WebMParser::AudioTrackData::consumeFrameData(
                 return Skip(&reader, bytesRemaining);
             }
             OpusCookieContents cookieContents;
-            if (!parseOpusPrivateData(std::span { privateData }, *contiguousBuffer, cookieContents)) {
+            if (!parseOpusPrivateData(std::span { privateData }, contiguousBuffer->span(), cookieContents)) {
                 PARSER_LOG_ERROR_IF_POSSIBLE("Failed to parse Opus private data");
                 return Skip(&reader, bytesRemaining);
             }
@@ -1252,7 +1252,7 @@ WebMParser::ConsumeFrameDataResult WebMParser::AudioTrackData::consumeFrameData(
             PARSER_LOG_ERROR_IF_POSSIBLE("AudioTrackData::consumeFrameData: unable to create contiguous data block");
             return Skip(&reader, bytesRemaining);
         }
-        if (!parseOpusPrivateData(std::span { privateData }, *contiguousBuffer, cookieContents)
+        if (!parseOpusPrivateData(std::span { privateData }, contiguousBuffer->span(), cookieContents)
             || cookieContents.framesPerPacket != m_framesPerPacket
             || cookieContents.frameDuration != m_frameDuration) {
             PARSER_LOG_ERROR_IF_POSSIBLE("Opus frames-per-packet changed within a track; error");
@@ -1276,7 +1276,7 @@ WebMParser::ConsumeFrameDataResult WebMParser::AudioTrackData::consumeFrameData(
         parser().formatDescriptionChangedForTrackData(*this);
     }
 
-    MediaTime packetDuration = MediaTime(m_packetDurationParser->framesInPacket(*contiguousBuffer), downcast<AudioInfo>(formatDescription())->rate);
+    MediaTime packetDuration = MediaTime(m_packetDurationParser->framesInPacket(contiguousBuffer->span()), downcast<AudioInfo>(formatDescription())->rate);
     auto trimDuration = MediaTime::zeroTime();
     MediaTime localPresentationTime = presentationTime;
     if (m_remainingTrimDuration.isFinite() && m_remainingTrimDuration > MediaTime::zeroTime()) {

--- a/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.h
@@ -64,10 +64,10 @@ WEBCORE_EXPORT bool isOpusDecoderAvailable();
 WEBCORE_EXPORT bool registerOpusDecoderIfNeeded();
 static constexpr size_t kOpusHeaderSize = 19;
 static constexpr size_t kOpusMinimumFrameDataSize = 2;
-bool parseOpusPrivateData(std::span<const uint8_t> privateData, SharedBuffer& frameData, OpusCookieContents&);
-bool parseOpusTOCData(const SharedBuffer& frameData, OpusCookieContents&);
+bool parseOpusPrivateData(std::span<const uint8_t> privateData, std::span<const uint8_t> frameData, OpusCookieContents&);
+bool parseOpusTOCData(std::span<const uint8_t> frameData, OpusCookieContents&);
 RefPtr<AudioInfo> createOpusAudioInfo(const OpusCookieContents&);
-Vector<uint8_t> createOpusPrivateData(const AudioStreamBasicDescription&);
+Vector<uint8_t> createOpusPrivateData(const AudioStreamBasicDescription&, uint16_t preSkip = 0);
 
 }
 


### PR DESCRIPTION
#### e51ae074f0641885b3a4301ec5c3736dd8dbd563
<pre>
AudioDecoderCocoa should trim start of decoded samples in accordance with preSkip information
<a href="https://bugs.webkit.org/show_bug.cgi?id=284354">https://bugs.webkit.org/show_bug.cgi?id=284354</a>
<a href="https://rdar.apple.com/141202697">rdar://141202697</a>

Reviewed by NOBODY (OOPS!).

Opus provides out of band information related to the encoder delay (a.k.a preSkip)
available in the AudioConfig&apos;s description.
Other codecs do no, so we could have assumed as AudioToolbox does, default preSkip
values (2112 for AAC, 536 for Lame MP4, 0 for Flac and an entire packet for vorbis).
However doing so, while technically more accurate, would cause WPT&apos;s test failures
as some existing mp3 and aac frames make strong assumptions on how many decoded frames
we return.

We use the preSkip, when available and set the AudioSampleBufferConverter to trim those frames.

- We also store the AudioSampleBufferConverter&apos;s Config object rather than individual values
as this configuration object will need to be extensively amended to support the future AudioEncoder object.
- Fly by: Return error if we failed to create and configure the AudioConverter.

Following this changes, we provide more accurate Opus decoding. There&apos;s no change in the result
of existing AudioDecoder&apos;s tests, but incoming AudioEncoder ones do rely on the files to be correctly
trimmed.

* Source/WebCore/platform/audio/cocoa/AudioDecoderCocoa.cpp:
(WebCore::InternalAudioDecoderCocoa::initialize): Fly-by: Do not incorrectly reject Opus stereo content.
* Source/WebCore/platform/audio/cocoa/AudioSampleBufferConverter.h:
(WebCore::AudioSampleBufferConverter::preSkip const):
* Source/WebCore/platform/audio/cocoa/AudioSampleBufferConverter.mm:
(WebCore::m_options):
(WebCore::AudioSampleBufferConverter::initAudioConverterForSourceFormatDescription):
(WebCore::AudioSampleBufferConverter::attachPrimingTrimsIfNeeded):
(WebCore::AudioSampleBufferConverter::provideSourceDataNumOutputPackets):
(WebCore::AudioSampleBufferConverter::processSampleBuffers):
(WebCore::AudioSampleBufferConverter::bitRate const):
(WebCore::m_generateTimestamp): Deleted.
* Source/WebCore/platform/graphics/cocoa/CMUtilities.h:
* Source/WebCore/platform/graphics/cocoa/CMUtilities.mm:
(WebCore::PacketDurationParser::framesInPacket):
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp:
(WebCore::WebMParser::AudioTrackData::consumeFrameData):
* Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.h:
* Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm:
(WebCore::parseOpusTOCData):
(WebCore::parseOpusPrivateData):
(WebCore::createOpusPrivateData):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e51ae074f0641885b3a4301ec5c3736dd8dbd563

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80235 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59237 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33648 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84752 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31211 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82346 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68298 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7536 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62718 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20532 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83304 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52783 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73066 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43026 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50112 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27221 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29672 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71242 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27734 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86185 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7455 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71001 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7630 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68906 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70237 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14230 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13175 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7419 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12936 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7258 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10778 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9063 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->