### PR TITLE
Typo in AudioDecoderCocoa and MediaRecorderPrivateEncoder

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/AudioDecoderCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioDecoderCocoa.cpp
@@ -261,21 +261,21 @@ String InternalAudioDecoderCocoa::initialize(const String& codecName, const Audi
 
         mIsAAC = codec == kAudioFormatMPEG4AAC || codec == kAudioFormatMPEG4AAC_HE || codec == kAudioFormatMPEG4AAC_LD || codec == kAudioFormatMPEG4AAC_HE_V2 || codec == kAudioFormatMPEG4AAC_ELD;
 
-        AudioStreamBasicDescription absd { };
-        absd.mFormatID = codec;
+        AudioStreamBasicDescription asbd { };
+        asbd.mFormatID = codec;
         // Attempt to create description with provided cookie.
         bool succeeded = false;
         if (config.description.size()) {
-            UInt32 size = sizeof(absd);
-            succeeded = PAL::AudioFormatGetProperty(kAudioFormatProperty_FormatInfo, config.description.size(), config.description.data(), &size, &absd) == noErr;
+            UInt32 size = sizeof(asbd);
+            succeeded = PAL::AudioFormatGetProperty(kAudioFormatProperty_FormatInfo, config.description.size(), config.description.data(), &size, &asbd) == noErr;
         }
         if (!succeeded) {
-            absd.mSampleRate = double(config.sampleRate);
-            absd.mChannelsPerFrame = uint32_t(config.numberOfChannels);
+            asbd.mSampleRate = double(config.sampleRate);
+            asbd.mChannelsPerFrame = uint32_t(config.numberOfChannels);
         } else
             m_codecDescription = config.description;
 
-        m_inputDescription = absd;
+        m_inputDescription = asbd;
     } else
         m_inputDescription = CAAudioStreamDescription { double(config.sampleRate), uint32_t(config.numberOfChannels), *format, CAAudioStreamDescription::IsInterleaved::Yes };
 

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp
@@ -377,15 +377,15 @@ void MediaRecorderPrivateEncoder::audioSamplesAvailable(const MediaTime& time, s
     if (m_hadError)
         return;
 
-    auto* absd = PAL::CMAudioFormatDescriptionGetStreamBasicDescription(m_audioFormatDescription.get());
-    ASSERT(absd);
-    if (!absd) {
+    auto* asbd = PAL::CMAudioFormatDescriptionGetStreamBasicDescription(m_audioFormatDescription.get());
+    ASSERT(asbd);
+    if (!asbd) {
         RELEASE_LOG_ERROR(MediaStream, "MediaRecorderPrivateEncoder::audioSamplesAvailable: inconsistent running state");
         m_hadError = true;
         return;
     }
 
-    auto result = WebAudioBufferList::createWebAudioBufferListWithBlockBuffer(*absd, sampleCount);
+    auto result = WebAudioBufferList::createWebAudioBufferListWithBlockBuffer(*asbd, sampleCount);
     if (!result) {
         RELEASE_LOG_ERROR(MediaStream, "MediaRecorderPrivateEncoder::audioSamplesAvailable: failed to create block buffer");
         m_hadError = true;


### PR DESCRIPTION
#### 8e48a6eb7967168427a05faeb60a5830f9081662
<pre>
Typo in AudioDecoderCocoa and MediaRecorderPrivateEncoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=284358">https://bugs.webkit.org/show_bug.cgi?id=284358</a>
<a href="https://rdar.apple.com/141205262">rdar://141205262</a>

Reviewed by Youenn Fablet.

No change in behaviours.

* Source/WebCore/platform/audio/cocoa/AudioDecoderCocoa.cpp:
(WebCore::InternalAudioDecoderCocoa::initialize):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp:
(WebCore::MediaRecorderPrivateEncoder::audioSamplesAvailable):

Canonical link: <a href="https://commits.webkit.org/287597@main">https://commits.webkit.org/287597@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e021b3870d3f5971e07358e6b9bec5a63280399c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80239 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59241 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33652 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84756 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31215 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82350 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68302 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7540 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62722 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20535 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83308 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/52786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73068 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43030 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/50115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27223 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29676 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71245 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27736 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86189 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7459 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70997 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7634 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68908 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70239 "Found 8 new API test failures: /TestWebKit:WebKit.FirstMeaningfulPaint, /TestWebKit:WebKit.FrameMIMETypePNG, /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginShouldNotBeDispatchedForAlreadyFocusedField, /TestWebKit:WebKit.FrameMIMETypeHTML, /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginAndEndEditingEvents, /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidEndShouldBeDispatchedForRemovedFocusField, /TestWebKit:WebKit.LoadAlternateHTMLStringWithNonDirectoryURL, /TestWebKit:WebKit.GeolocationBasic (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17483 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14233 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13177 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7423 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7262 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10782 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9067 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->