### PR TITLE
AudioDecoderCocoa should trim start of decoded samples in accordance with preSkip information

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/AudioSampleBufferConverter.h
+++ b/Source/WebCore/platform/audio/cocoa/AudioSampleBufferConverter.h
@@ -46,6 +46,7 @@ public:
         std::optional<AudioStreamBasicDescription> description { };
         std::optional<unsigned> outputBitRate { };
         bool generateTimestamp { true };
+        std::optional<unsigned> preSkip { }; // If not set, let AudioConverter use the default.
     };
     static RefPtr<AudioSampleBufferConverter> create(CMBufferQueueTriggerCallback, void* callbackObject, const Options&);
     ~AudioSampleBufferConverter();
@@ -68,7 +69,7 @@ private:
     static OSStatus audioConverterComplexInputDataProc(AudioConverterRef, UInt32*, AudioBufferList*, AudioStreamPacketDescription**, void*);
 
     void processSampleBuffer(CMSampleBufferRef);
-    bool initAudioConverterForSourceFormatDescription(CMFormatDescriptionRef, AudioFormatID);
+    OSStatus initAudioConverterForSourceFormatDescription(CMFormatDescriptionRef, AudioFormatID);
     void attachPrimingTrimsIfNeeded(CMSampleBufferRef);
     RetainPtr<NSNumber> gradualDecoderRefreshCount();
     Expected<RetainPtr<CMSampleBufferRef>, OSStatus> sampleBuffer(const WebAudioBufferList&, uint32_t numSamples);
@@ -106,8 +107,8 @@ private:
     Vector<AudioStreamPacketDescription> m_packetDescriptions WTF_GUARDED_BY_CAPABILITY(queue().get());
     OSStatus m_lastError WTF_GUARDED_BY_CAPABILITY(queue().get()) { 0 };
     const AudioFormatID m_outputCodecType;
-    const std::optional<unsigned> m_outputBitRate;
-    const bool m_generateTimestamp { true };
+    const Options m_options;
+    std::atomic<unsigned> m_defaultBitRate { 0 };
 };
 
 }

--- a/Source/WebCore/platform/graphics/cocoa/CMUtilities.h
+++ b/Source/WebCore/platform/graphics/cocoa/CMUtilities.h
@@ -60,7 +60,7 @@ public:
     ~PacketDurationParser();
 
     bool isValid() const { return m_isValid; }
-    size_t framesInPacket(SharedBuffer&);
+    size_t framesInPacket(std::span<const uint8_t>);
     void reset();
 
 private:

--- a/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
+++ b/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
@@ -367,7 +367,7 @@ PacketDurationParser::PacketDurationParser(const AudioInfo& info)
     m_isValid = true;
 }
 
-size_t PacketDurationParser::framesInPacket(SharedBuffer& packet)
+size_t PacketDurationParser::framesInPacket(std::span<const uint8_t> packet)
 {
 #if !HAVE(AUDIOFORMATPROPERTY_VARIABLEPACKET_SUPPORTED)
     UNUSED_PARAM(packet);
@@ -376,7 +376,7 @@ size_t PacketDurationParser::framesInPacket(SharedBuffer& packet)
     if (m_constantFramesPerPacket)
         return m_constantFramesPerPacket;
 
-    if (packet.isEmpty())
+    if (packet.empty())
         return 0;
 
     switch (m_audioFormatID) {

--- a/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.h
@@ -64,10 +64,10 @@ WEBCORE_EXPORT bool isOpusDecoderAvailable();
 WEBCORE_EXPORT bool registerOpusDecoderIfNeeded();
 static constexpr size_t kOpusHeaderSize = 19;
 static constexpr size_t kOpusMinimumFrameDataSize = 2;
-bool parseOpusPrivateData(std::span<const uint8_t> privateData, SharedBuffer& frameData, OpusCookieContents&);
-bool parseOpusTOCData(const SharedBuffer& frameData, OpusCookieContents&);
+std::optional<OpusCookieContents> parseOpusPrivateData(std::span<const uint8_t> privateData, std::span<const uint8_t> frameData);
+bool parseOpusTOCData(std::span<const uint8_t> frameData, OpusCookieContents&);
 RefPtr<AudioInfo> createOpusAudioInfo(const OpusCookieContents&);
-Vector<uint8_t> createOpusPrivateData(const AudioStreamBasicDescription&);
+Vector<uint8_t> createOpusPrivateData(const AudioStreamBasicDescription&, uint16_t preSkip = 0);
 
 }
 


### PR DESCRIPTION
#### 2b04af10a098c18c19cc2bc578ec6539c0087f26
<pre>
AudioDecoderCocoa should trim start of decoded samples in accordance with preSkip information
<a href="https://bugs.webkit.org/show_bug.cgi?id=284354">https://bugs.webkit.org/show_bug.cgi?id=284354</a>
<a href="https://rdar.apple.com/141202697">rdar://141202697</a>

Reviewed by Youenn Fablet.

Opus provides out of band information related to the encoder delay (a.k.a preSkip)
available in the AudioConfig&apos;s description.
Other codecs do no, so we could have assumed as AudioToolbox does, default preSkip
values (2112 for AAC, 536 for Lame MP4, 0 for Flac and an entire packet for vorbis).
However doing so, while technically more accurate, would cause WPT&apos;s test failures
as some existing mp3 and aac frames make strong assumptions on how many decoded frames
we return.

We use the preSkip, when available and set the AudioSampleBufferConverter to trim those frames.

- We also store the AudioSampleBufferConverter&apos;s Config object rather than individual values
as this configuration object will need to be extensively amended to support the future AudioEncoder object.
- Fly by: Return error if we failed to create and configure the AudioConverter.

Following this changes, we provide more accurate Opus decoding. There&apos;s no change in the result
of existing AudioDecoder&apos;s tests, but incoming AudioEncoder ones do rely on the files to be correctly
trimmed.

* Source/WebCore/platform/audio/cocoa/AudioDecoderCocoa.cpp:
(WebCore::InternalAudioDecoderCocoa::initialize): Fly-by: Do not incorrectly reject Opus stereo content.
* Source/WebCore/platform/audio/cocoa/AudioSampleBufferConverter.h:
(WebCore::AudioSampleBufferConverter::preSkip const):
* Source/WebCore/platform/audio/cocoa/AudioSampleBufferConverter.mm:
(WebCore::m_options):
(WebCore::AudioSampleBufferConverter::initAudioConverterForSourceFormatDescription): Return error code when failing.
Change fallback rate from 44.1kHz to 48kHz. 48kHz is a more logical choice, it&apos;s supported by all hardware and is the default
for a codec (44.1kHz would have required to upsample to 48kHz first).
(WebCore::AudioSampleBufferConverter::attachPrimingTrimsIfNeeded):
(WebCore::AudioSampleBufferConverter::provideSourceDataNumOutputPackets):
(WebCore::AudioSampleBufferConverter::processSampleBuffers):
(WebCore::AudioSampleBufferConverter::bitRate const):
(WebCore::m_generateTimestamp): Deleted.
* Source/WebCore/platform/graphics/cocoa/CMUtilities.h:
* Source/WebCore/platform/graphics/cocoa/CMUtilities.mm:
(WebCore::PacketDurationParser::framesInPacket):
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp:
(WebCore::WebMParser::AudioTrackData::consumeFrameData):
* Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.h: Have parseOpusPrivateData take a span instead of a SharedBuffer
and return optional&lt;OpusCookieContent&gt; instead of using an out parameter.
* Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm:
(WebCore::parseOpusTOCData):
(WebCore::parseOpusPrivateData):
(WebCore::createOpusPrivateData):

Canonical link: <a href="https://commits.webkit.org/287708@main">https://commits.webkit.org/287708@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2637d4184871bd01511eb8c15fd4ca47540923f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80570 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59577 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34503 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85091 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31552 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82681 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68638 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7882 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62941 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20748 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83639 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/53055 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73343 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43246 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50350 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27501 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30011 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71496 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28024 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86525 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7796 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71234 "Found 12 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/iframe-old-has-scrollbar.html imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-offscreen-old.html imported/w3c/web-platform-tests/css/css-view-transitions/names-are-tree-scoped.html imported/w3c/web-platform-tests/css/css-view-transitions/navigation/root-and-nested-element-transition.html imported/w3c/web-platform-tests/css/css-view-transitions/old-content-intrinsic-aspect-ratio.html imported/w3c/web-platform-tests/css/css-view-transitions/old-content-root-scrollbar-with-fixed-background.html imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-empty-iframe.html webanimations/accelerated-animation-opacity-animation-begin-time-after-scale-animation-ends.html webanimations/accelerated-transform-animation-to-scale-zero-with-implicit-from-keyframe.html webanimations/accelerated-transition-by-removing-property.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7971 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69180 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70475 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17565 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14481 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13424 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7758 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/13277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7597 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/11116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9402 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->