### PR TITLE
[GStreamer][MediaStream] Reduce memory allocations in MediaStreamAudioSource

### DIFF
--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioSource.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioSource.cpp
@@ -37,6 +37,10 @@ MediaStreamAudioSource::MediaStreamAudioSource(float sampleRate)
     : RealtimeMediaSource(CaptureDevice { { }, CaptureDevice::DeviceType::Microphone, "MediaStreamAudioDestinationNode"_s })
 {
     m_currentSettings.setSampleRate(sampleRate);
+
+#if USE(GSTREAMER)
+    gst_audio_info_init(&m_info);
+#endif
 }
 
 MediaStreamAudioSource::~MediaStreamAudioSource() = default;

--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioSource.h
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioSource.h
@@ -32,6 +32,10 @@
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
+#if USE(GSTREAMER)
+#include "GStreamerCommon.h"
+#endif
+
 namespace WebCore {
 
 class AudioBus;
@@ -63,6 +67,10 @@ private:
     std::unique_ptr<PlatformAudioData> m_audioBuffer;
 #if USE(AVFOUNDATION) || USE(GSTREAMER)
     size_t m_numberOfFrames { 0 };
+#endif
+#if USE(GSTREAMER)
+    GstAudioInfo m_info;
+    GRefPtr<GstCaps> m_caps;
 #endif
 };
 

--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceGStreamer.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceGStreamer.cpp
@@ -58,22 +58,24 @@ void MediaStreamAudioSource::consumeAudio(AudioBus& bus, size_t numberOfFrames)
     MediaTime mediaTime((m_numberOfFrames * G_USEC_PER_SEC) / m_currentSettings.sampleRate(), G_USEC_PER_SEC);
     m_numberOfFrames += numberOfFrames;
 
-    GstAudioInfo info;
-    gst_audio_info_set_format(&info, GST_AUDIO_FORMAT_F32LE, m_currentSettings.sampleRate(), bus.numberOfChannels(), nullptr);
-    GST_AUDIO_INFO_LAYOUT(&info) = GST_AUDIO_LAYOUT_NON_INTERLEAVED;
-    size_t size = GST_AUDIO_INFO_BPS(&info) * bus.numberOfChannels() * numberOfFrames;
+    // Lazily initialize caps, the settings don't change so this is OK.
+    if (!m_caps || GST_AUDIO_INFO_CHANNELS(&m_info) != static_cast<int>(bus.numberOfChannels())) {
+        gst_audio_info_set_format(&m_info, GST_AUDIO_FORMAT_F32LE, m_currentSettings.sampleRate(), bus.numberOfChannels(), nullptr);
+        GST_AUDIO_INFO_LAYOUT(&m_info) = GST_AUDIO_LAYOUT_NON_INTERLEAVED;
+        m_caps = adoptGRef(gst_audio_info_to_caps(&m_info));
+    }
 
-    auto caps = adoptGRef(gst_audio_info_to_caps(&info));
+    size_t size = GST_AUDIO_INFO_BPS(&m_info) * bus.numberOfChannels() * numberOfFrames;
     auto buffer = adoptGRef(gst_buffer_new_allocate(nullptr, size, nullptr));
 
     GST_BUFFER_PTS(buffer.get()) = toGstClockTime(mediaTime);
     GST_BUFFER_FLAG_SET(buffer.get(), GST_BUFFER_FLAG_LIVE);
 
     copyBusData(bus, buffer.get(), muted());
-    gst_buffer_add_audio_meta(buffer.get(), &info, numberOfFrames, nullptr);
-    auto sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
-    GStreamerAudioData audioBuffer(WTFMove(sample), info);
-    GStreamerAudioStreamDescription description(&info);
+    gst_buffer_add_audio_meta(buffer.get(), &m_info, numberOfFrames, nullptr);
+    auto sample = adoptGRef(gst_sample_new(buffer.get(), m_caps.get(), nullptr, nullptr));
+    GStreamerAudioData audioBuffer(WTFMove(sample), m_info);
+    GStreamerAudioStreamDescription description(&m_info);
     audioSamplesAvailable(mediaTime, audioBuffer, description, numberOfFrames);
 }
 


### PR DESCRIPTION
#### 3a8aaf9dc79df5d62f4f25e7948d35aa0e85126b
<pre>
[GStreamer][MediaStream] Reduce memory allocations in MediaStreamAudioSource
<a href="https://bugs.webkit.org/show_bug.cgi?id=284364">https://bugs.webkit.org/show_bug.cgi?id=284364</a>

Reviewed by Xabier Rodriguez-Calvar.

Keep track of the GstAudioInfo and corresponding caps instead of allocating them at each iteration.

* Source/WebCore/Modules/webaudio/MediaStreamAudioSource.h:
* Source/WebCore/Modules/webaudio/MediaStreamAudioSourceGStreamer.cpp:
(WebCore::MediaStreamAudioSource::consumeAudio):

Canonical link: <a href="https://commits.webkit.org/287660@main">https://commits.webkit.org/287660@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d10c72ac7478984c48b35bf3005c67b0ad48cf7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80275 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59277 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33689 "Failed to checkout and rebase branch from PR 37701") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84792 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31251 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82386 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68338 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7577 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62758 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20568 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83344 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52814 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/33689 "Failed to checkout and rebase branch from PR 37701") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43063 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50138 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/33689 "Failed to checkout and rebase branch from PR 37701") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29712 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71271 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/33689 "Failed to checkout and rebase branch from PR 37701") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86225 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7495 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5312 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71030 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-transforms/animation/translate-percent-with-width-and-height-separate.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7670 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/33689 "Failed to checkout and rebase branch from PR 37701") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70273 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17530 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14269 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/33689 "Failed to checkout and rebase branch from PR 37701") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7459 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12976 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7298 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10818 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9103 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->