### PR TITLE
Guard some buffer accesses to fix non-unified build

### DIFF
--- a/Source/JavaScriptCore/assembler/AssemblerBuffer.h
+++ b/Source/JavaScriptCore/assembler/AssemblerBuffer.h
@@ -439,9 +439,11 @@ namespace JSC {
             template<typename IntegralType>
             void putIntegralUnchecked(IntegralType value)
             {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
                 ASSERT(m_index + sizeof(IntegralType) <= m_buffer.m_storage.capacity());
                 WTF::unalignedStore<IntegralType>(m_storageBuffer + m_index, value);
                 m_index += sizeof(IntegralType);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
             }
             AssemblerBuffer& m_buffer;
             char* m_storageBuffer;
@@ -474,6 +476,7 @@ namespace JSC {
         template<typename IntegralType>
         void putIntegralUnchecked(IntegralType value)
         {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #if CPU(ARM64)
             static_assert(sizeof(value) == 4);
 #if ENABLE(JIT_SIGN_ASSEMBLER_BUFFER)
@@ -484,6 +487,7 @@ namespace JSC {
             ASSERT(isAvailable(sizeof(IntegralType)));
             WTF::unalignedStore<IntegralType>(m_storage.buffer() + m_index, value);
             m_index += sizeof(IntegralType);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         }
 
     private:

--- a/Source/JavaScriptCore/heap/IncrementalSweeper.cpp
+++ b/Source/JavaScriptCore/heap/IncrementalSweeper.cpp
@@ -34,10 +34,12 @@
 #if !USE(SYSTEM_MALLOC)
 #include <bmalloc/BPlatform.h>
 #if BUSE(LIBPAS)
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include <bmalloc/pas_debug_spectrum.h>
 #include <bmalloc/pas_fd_stream.h>
 #include <bmalloc/pas_heap_lock.h>
 #include <bmalloc/pas_thread_local_cache.h>
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 #endif
 #endif
 

--- a/Source/JavaScriptCore/runtime/JSStringInlines.h
+++ b/Source/JavaScriptCore/runtime/JSStringInlines.h
@@ -219,6 +219,7 @@ inline void JSRopeString::convertToNonRope(String&& string) const
 template<typename CharacterType>
 void JSRopeString::resolveToBufferSlow(JSString* fiber0, JSString* fiber1, JSString* fiber2, std::span<CharacterType> buffer, uint8_t*)
 {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     // Keep in mind that resolveToBufferSlow signature must be the same to resolveToBuffer to encourage tail-calls by clang, that's the reason why
     // it takes the last stackLimit parameter still while it is not used here.
 
@@ -258,6 +259,7 @@ void JSRopeString::resolveToBufferSlow(JSString* fiber0, JSString* fiber1, JSStr
     } while (!workQueue.isEmpty());
 
     ASSERT(buffer.data() == position);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 template<typename CharacterType>

--- a/Source/JavaScriptCore/runtime/RegExp.h
+++ b/Source/JavaScriptCore/runtime/RegExp.h
@@ -118,6 +118,7 @@ public:
         return m_rareData->m_captureGroupNames[i];
     }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     template <typename Offsets>
     unsigned subpatternIdForGroupName(StringView groupName, const Offsets ovector) const
     {
@@ -131,6 +132,7 @@ public:
 
         return ovector[offsetVectorBaseForNamedCaptures() + it->value[0] - 1];
     }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     bool hasCode()
     {

--- a/Source/JavaScriptCore/runtime/SmallStrings.h
+++ b/Source/JavaScriptCore/runtime/SmallStrings.h
@@ -67,7 +67,9 @@ public:
 
     JSString* singleCharacterString(unsigned char character)
     {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         return m_singleCharacterStrings[character];
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 
     JS_EXPORT_PRIVATE Ref<AtomStringImpl> singleCharacterStringRep(unsigned char character);

--- a/Source/WTF/wtf/CagedUniquePtr.h
+++ b/Source/WTF/wtf/CagedUniquePtr.h
@@ -58,12 +58,14 @@ public:
     template<typename... Arguments>
     static CagedUniquePtr tryCreate(size_t length, Arguments&&... arguments)
     {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         T* result = static_cast<T*>(Gigacage::tryMalloc(kind, sizeof(T) * length));
         if (!result)
             return { };
         while (length--)
             new (result + length) T(arguments...);
         return CagedUniquePtr(result);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 
     CagedUniquePtr& operator=(CagedUniquePtr&& ptr)


### PR DESCRIPTION
#### 7f449c1289dc58fa1b0d93ab630045b46bc9612f
<pre>
Guard some buffer accesses to fix non-unified build
<a href="https://bugs.webkit.org/show_bug.cgi?id=284369">https://bugs.webkit.org/show_bug.cgi?id=284369</a>

Reviewed by Justin Michaud.

Building with clang and non-unified sources shows that
there are some unsafe buffer usages that are not currently
guarded with WTF_ALLOW_UNSAFE_BUFFER_USAGE as they should be.

These seem not to be detected with unified sources, presumably
due to their uses being guarded somehow in unified compile units.
Guarding them, both to fix non-unified builds and also to
make sure they don&apos;t go unnoticed, as they should probably be fixed
eventually.

* Source/JavaScriptCore/assembler/AssemblerBuffer.h:
(JSC::AssemblerBuffer::LocalWriter::putIntegralUnchecked):
(JSC::AssemblerBuffer::putIntegralUnchecked):
* Source/JavaScriptCore/heap/IncrementalSweeper.cpp:
* Source/JavaScriptCore/runtime/JSStringInlines.h:
(JSC::JSRopeString::resolveToBufferSlow):
* Source/JavaScriptCore/runtime/RegExp.h:
* Source/JavaScriptCore/runtime/SmallStrings.h:
(JSC::SmallStrings::singleCharacterString):
* Source/WTF/wtf/CagedUniquePtr.h:
(WTF::CagedUniquePtr::tryCreate):

Canonical link: <a href="https://commits.webkit.org/287625@main">https://commits.webkit.org/287625@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aff81ad7b0fe0525fe125a8f99b6fc53a539848a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80268 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59270 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33682 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84785 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31244 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68331 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7570 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62766 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20565 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83337 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52808 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73103 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43072 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27259 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29705 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/73244 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71266 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27772 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86218 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/79325 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7488 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5297 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71048 "Found 1 new test failure: media/modern-media-controls/css/transformed-media-crash.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7663 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68943 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70283 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17504 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14264 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13212 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/101733 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7452 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/24794 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7291 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10811 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9096 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->