### PR TITLE
[GTK][WPE] Fix the flakiness of API test /webkit/WebKitPolicyClient/new-window-policy.

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitPolicyClient.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitPolicyClient.cpp
@@ -285,7 +285,7 @@ static void testNewWindowPolicy(PolicyClientTest* test, gconstpointer)
     g_signal_connect(test->m_webView, "create", G_CALLBACK(createCallback), &data);
     test->m_policyDecisionResponse = PolicyClientTest::Use;
     test->loadHtml(windowOpeningHTML, "http://webkitgtk.org/");
-    test->wait(1);
+    test->waitUntilLoadFinished();
     g_assert_true(data.triedToOpenWindow);
 
     WebKitNavigationPolicyDecision* decision = WEBKIT_NAVIGATION_POLICY_DECISION(test->m_previousPolicyDecision.get());

--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -373,9 +373,6 @@
             "/webkit/WebKitPolicyClient/autoplay-policy": {
                 "expected": {"gtk": {"status": ["TIMEOUT", "PASS"], "bug": "webkit.org/b/222091"},
                              "wpe": {"status": ["PASS", "FAIL"], "bug": "webkit.org/b/281986"}}
-            },
-            "/webkit/WebKitPolicyClient/new-window-policy": {
-                "expected": {"wpe": {"status": ["FAIL", "PASS"], "bug": "webkit.org/b/281812"}}
             }
         }
     },


### PR DESCRIPTION
#### 228e91c7abb27238b203cde55f8989e059d7df0f
<pre>
[GTK][WPE] Fix the flakiness of API test /webkit/WebKitPolicyClient/new-window-policy.
<a href="https://bugs.webkit.org/show_bug.cgi?id=281812">https://bugs.webkit.org/show_bug.cgi?id=281812</a>

Reviewed by NOBODY (OOPS!).

Call waitUntilLoadFinished() function rather than setting
a hard-coded value for waiting time.

* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitPolicyClient.cpp:
(testNewWindowPolicy):
* Tools/TestWebKitAPI/glib/TestExpectations.json:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/228e91c7abb27238b203cde55f8989e059d7df0f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80274 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59276 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33688 "Failed to checkout and rebase branch from PR 37705") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84791 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31250 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82385 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68337 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7576 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62756 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20566 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83343 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52811 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/33688 "Failed to checkout and rebase branch from PR 37705") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43061 "Found 1 new API test failure: /WPE/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/33688 "Failed to checkout and rebase branch from PR 37705") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29711 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71269 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/33688 "Failed to checkout and rebase branch from PR 37705") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86224 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7494 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5310 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-invoke-pause-networkState.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71028 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7669 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/33688 "Failed to checkout and rebase branch from PR 37705") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70270 "Found 1 new API test failure: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14268 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/33688 "Failed to checkout and rebase branch from PR 37705") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7458 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7297 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10817 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9102 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->