### PR TITLE
UnifiedPDF: Compositing spends time copying bitmaps to GPUP

### DIFF
--- a/LayoutTests/pdf/pdf-in-iframe-with-text-annotation.html
+++ b/LayoutTests/pdf/pdf-in-iframe-with-text-annotation.html
@@ -1,7 +1,7 @@
 <html><!-- webkit-test-runner [ UnifiedPDFEnabled=true PDFPluginHUDEnabled=false ] -->
 <head>
 <script src="../resources/ui-helper.js"></script>
-<meta name="fuzzy" content="maxDifference=0-15;totalPixels=0-50" />
+<meta name="fuzzy" content="maxDifference=0-15;totalPixels=0-304" />
 </head>
 <body>
 <iframe style="height: 50%"; src="annotations/text-annotation.pdf"></iframe>


### PR DESCRIPTION
#### 37bb67537f13e0298596bbd34a07470c9bf0cff2
<pre>
UnifiedPDF: Compositing spends time copying bitmaps to GPUP
<a href="https://bugs.webkit.org/show_bug.cgi?id=284366">https://bugs.webkit.org/show_bug.cgi?id=284366</a>
<a href="https://rdar.apple.com/141214825">rdar://141214825</a>

Reviewed by Simon Fraser and Abrar Rahman Protyasha.

Store the PDF bitmap tiles as NativeImages. ImageBuffers are mutable
draw targets, something that are drawn to. NativeImages immutable images
that are drawn from.

This allows then data to be sent to GPUP only once, avoiding numerous
full-tile copies per tile draw.

For incremental PDF tile renders, render the tile in the PDF paint queue.
Previously, the rendered region was blit to the real tile in the
main thread.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm:
(WebKit::AsyncPDFRenderer::renderInfoIsValidForTile const):
(WebKit::AsyncPDFRenderer::willRepaintTile):
(WebKit::AsyncPDFRenderer::enqueueTileRenderForTileGridRepaint):
(WebKit::AsyncPDFRenderer::didRevalidateTiles):
(WebKit::AsyncPDFRenderer::enqueueTileRenderIfNecessary):
(WebKit::AsyncPDFRenderer::renderInfoForFullTile const):
(WebKit::AsyncPDFRenderer::renderInfoForTile const):
(WebKit::renderPDFTile):
(WebKit::AsyncPDFRenderer::serviceRequestQueue):
(WebKit::AsyncPDFRenderer::didCompleteTileRender):
(WebKit::AsyncPDFRenderer::paintTilesForPage):
(WebKit::AsyncPDFRenderer::pdfContentChangedInRect):
(WebKit::operator&lt;&lt;):

(WebKit::AsyncPDFRenderer::enqueueTilePaintForTileGridRepaint): Deleted.
(WebKit::AsyncPDFRenderer::enqueueTilePaintIfNecessary): Deleted.

Standardize on term &quot;render&quot; instead of &quot;render&quot; and &quot;paint&quot; for the
operation which updates the PDF tiles.

(WebKit::AsyncPDFRenderer::enqueuePaintWithClip): Deleted.
(WebKit::AsyncPDFRenderer::paintTileOnWorkQueue): Deleted.
(WebKit::AsyncPDFRenderer::paintPDFIntoBuffer): Deleted.
(WebKit::AsyncPDFRenderer::transferBufferToMainThread): Deleted.

Remove redundant member functions that were run in the paint queue
and only called once.

Canonical link: <a href="https://commits.webkit.org/287666@main">https://commits.webkit.org/287666@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06865fa53aa4f7eabd25298095c7f3bd7538e54a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80458 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59465 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34124 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84979 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31440 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68526 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7768 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62866 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20674 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83527 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52961 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73252 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43169 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50267 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27411 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29899 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71409 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27929 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86413 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7684 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5428 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71156 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7859 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69090 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70395 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17533 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14400 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13345 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7646 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/13165 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7485 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11004 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9290 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->