### PR TITLE
[TexMap] Incorrect damage information produced for animations with blur

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
@@ -168,6 +168,7 @@ private:
         Region& nonOverlapRegion;
     };
     void computeOverlapRegions(ComputeOverlapRegionData&, const TransformationMatrix&, bool includesReplica = true);
+    Vector<IntRect, 1> computeConsolidatedOverlapRegionRects(TextureMapperPaintOptions&);
 
     void paintRecursive(TextureMapperPaintOptions&);
     void paintFlattened(TextureMapperPaintOptions&);
@@ -188,7 +189,10 @@ private:
 #if ENABLE(DAMAGE_TRACKING)
     bool canInferDamage() const { return m_damagePropagation && !m_damage.isInvalid(); }
     void collectDamageRecursive(TextureMapperPaintOptions&, Damage&);
+    void collectDamageSelfAndChildren(TextureMapperPaintOptions&, Damage&);
     void collectDamageSelf(TextureMapperPaintOptions&, Damage&);
+    void collectDamageSelfChildrenReplicaFilterAndMask(TextureMapperPaintOptions&, Damage&);
+    void collectDamageSelfChildrenFilterAndMask(TextureMapperPaintOptions&, Damage&);
     void damageWholeLayerDueToTransformChange(const TransformationMatrix& beforeChange, const TransformationMatrix& afterChange);
     FloatRect transformRectForDamage(const FloatRect&, const TransformationMatrix&, const TextureMapperPaintOptions&);
 #endif
@@ -284,6 +288,7 @@ private:
 #if ENABLE(DAMAGE_TRACKING)
     bool m_damagePropagation { false };
     Damage m_damage;
+    FloatRect m_accumulatedOverlapRegionDamage;
 #endif
 
     struct {

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -537,10 +537,8 @@ void CoordinatedPlatformLayer::setDirtyRegion(Vector<IntRect, 1>&& dirtyRegion)
 void CoordinatedPlatformLayer::setDamage(Damage&& damage)
 {
     ASSERT(m_lock.isHeld());
-    if (m_damage == damage)
-        return;
-
-    m_damage = WTFMove(damage);
+    if (m_damage != damage)
+        m_damage = WTFMove(damage);
     m_pendingChanges.add(Change::Damage);
 }
 #endif
@@ -874,14 +872,6 @@ void CoordinatedPlatformLayer::flushCompositingState(TextureMapper& textureMappe
             layer.setDamage({ });
         } else
             layer.setDamage(m_damage);
-    }
-
-    if (m_damagePropagation && m_pendingChanges.isEmpty()) {
-        // If there are no changes to the layer and yet m_backingStoreProxy || m_contentsBuffer
-        // we must damage the whole layer for now to handle cases such as e.g. scrollbars.
-        Damage fullLayerDamage;
-        fullLayerDamage.add(layer.effectiveLayerRect());
-        layer.setDamage(fullLayerDamage);
     }
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedGraphicsScene.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedGraphicsScene.cpp
@@ -59,19 +59,14 @@ void CoordinatedGraphicsScene::paintToCurrentGLContext(const TransformationMatri
     currentRootLayer.prepareForPainting(*m_textureMapper);
     if (m_client && m_damagePropagation != Damage::Propagation::None) {
         Damage frameDamage;
-        if (sceneHasRunningAnimations) {
-            // When running animations for now we need to damage the whole frame.
-            frameDamage.add(clipRect);
-        } else {
-            WTFBeginSignpost(this, CollectDamage);
-            currentRootLayer.collectDamage(*m_textureMapper, frameDamage);
-            WTFEndSignpost(this, CollectDamage);
+        WTFBeginSignpost(this, CollectDamage);
+        currentRootLayer.collectDamage(*m_textureMapper, frameDamage);
+        WTFEndSignpost(this, CollectDamage);
 
-            if (m_damagePropagation == Damage::Propagation::Unified) {
-                Damage boundsDamage;
-                boundsDamage.add(frameDamage.bounds());
-                frameDamage = WTFMove(boundsDamage);
-            }
+        if (m_damagePropagation == Damage::Propagation::Unified) {
+            Damage boundsDamage;
+            boundsDamage.add(frameDamage.bounds());
+            frameDamage = WTFMove(boundsDamage);
         }
 
         const auto& damageSinceLastSurfaceUse = m_client->addSurfaceDamage(!frameDamage.isInvalid() && !frameDamage.isEmpty() ? frameDamage : Damage::invalid());


### PR DESCRIPTION
#### ab86837116be8c4fced269c90d9cea2ff3e3204e
<pre>
[TexMap] Incorrect damage information produced for animations with blur
<a href="https://bugs.webkit.org/show_bug.cgi?id=277484">https://bugs.webkit.org/show_bug.cgi?id=277484</a>

Reviewed by Nikolas Zimmermann.

This change:
- adds a mechanism to collect damage from replica/filter/mask&apos;s
  overlap regions
- makes the damage being propagated always when dirty region changes
- removes two workarounds invalidating whole layer in some cases
so that damage from ongoing animations is colleced correctly now.

* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
(WebCore::TextureMapperLayer::collectDamageRecursive):
(WebCore::TextureMapperLayer::collectDamageSelfAndChildren):
(WebCore::TextureMapperLayer::collectDamageSelfChildrenReplicaFilterAndMask):
(WebCore::TextureMapperLayer::collectDamageSelfChildrenFilterAndMask):
(WebCore::TextureMapperLayer::computeConsolidatedOverlapRegionRects):
(WebCore::TextureMapperLayer::paintSelfChildrenFilterAndMask):
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::setDamage):
(WebCore::CoordinatedPlatformLayer::flushCompositingState):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedGraphicsScene.cpp:
(WebKit::CoordinatedGraphicsScene::paintToCurrentGLContext):

Canonical link: <a href="https://commits.webkit.org/289158@main">https://commits.webkit.org/289158@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46d51329d8642320937966fa1f01741651447988

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85510 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5216 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39917 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90610 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36524 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87570 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5397 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13196 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66458 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24272 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88530 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4136 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77642 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46740 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4012 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31904 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35593 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74699 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32754 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92225 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12836 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9410 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75146 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13057 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73475 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74277 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18352 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18542 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16977 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4929 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12848 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18242 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12655 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16094 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14429 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->