### PR TITLE
[scroll-animations] scroll timelines should account for the source's writing mode when computing the current time

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7354,7 +7354,6 @@ imported/w3c/web-platform-tests/scroll-animations/css/animation-range-visual-tes
 imported/w3c/web-platform-tests/scroll-animations/css/printing/animation-timeline-none-with-progress-print.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/scroll-animations/css/printing/scroll-timeline-default-iframe-print.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/scroll-animations/css/printing/scroll-timeline-default-print.tentative.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-default-writing-mode-rl.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-with-transform.html [ Pass ImageOnlyFailure ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/layout-changes-on-percentage-based-timeline.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/two-animations-attach-to-same-scroll-timeline-cancel-one.html [ Pass ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative-expected.txt
@@ -7,9 +7,9 @@ FAIL Change in scroll-timeline-name to match animation timeline updates animatio
 FAIL Change in scroll-timeline-name to no longer match animation timeline updates animation. assert_equals: Failed to remove timeline expected null but got object "[object ScrollTimeline]"
 FAIL Timeline lookup updates candidate when closer match available. assert_equals: Timeline not updated expected "B" but got "A"
 PASS Timeline lookup updates candidate when match becomes available.
-FAIL scroll-timeline-axis is block assert_equals: expected "50" but got "0"
-FAIL scroll-timeline-axis is inline assert_equals: expected "50" but got "0"
+PASS scroll-timeline-axis is block
+PASS scroll-timeline-axis is inline
 PASS scroll-timeline-axis is x
-FAIL scroll-timeline-axis is y assert_equals: expected "50" but got "0"
+PASS scroll-timeline-axis is y
 FAIL scroll-timeline-axis is mutated assert_equals: expected "75" but got "25"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-scroll-functional-notation.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-scroll-functional-notation.tentative-expected.txt
@@ -5,5 +5,5 @@ PASS animation-timeline: scroll(self)
 PASS animation-timeline: scroll(self), on non-scroller
 PASS animation-timeline: scroll(inline)
 PASS animation-timeline: scroll(x)
-FAIL animation-timeline: scroll(y) assert_equals: expected "100px" but got "none"
+PASS animation-timeline: scroll(y)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-view-functional-notation.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-view-functional-notation.tentative-expected.txt
@@ -4,7 +4,7 @@ PASS animation-timeline: view(50px) without timeline range name
 FAIL animation-timeline: view(auto 50px) without timeline range name assert_equals: At 0% expected "0" but got "0.416667"
 PASS animation-timeline: view(inline) without timeline range name
 PASS animation-timeline: view(x) without timeline range name
-FAIL animation-timeline: view(y) without timeline range name assert_approx_equals: At 66.7% expected 0.33333 +/- 0.00001 but got 0.350877
+PASS animation-timeline: view(y) without timeline range name
 PASS animation-timeline: view(x 50px) without timeline range name
 PASS animation-timeline: view(50px), view(inline 50px) without timeline range name
 PASS animation-timeline: view(inline) changes to view(inline 50px), withouttimeline range name

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-axis-writing-mode-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-axis-writing-mode-expected.txt
@@ -1,9 +1,9 @@
 
 PASS Initial axis
-FAIL Vertical axis assert_equals: expected "175px" but got "100px"
+PASS Vertical axis
 PASS Horizontal axis
 PASS Block axis in horizontal writing-mode
 PASS Inline axis in horizontal writing-mode
-FAIL Block axis in vertical writing-mode assert_equals: expected "125px" but got "100px"
-FAIL Inline axis in vertical writing-mode assert_equals: expected "175px" but got "100px"
+PASS Block axis in vertical writing-mode
+PASS Inline axis in vertical writing-mode
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-animation-expected.txt
@@ -1,5 +1,5 @@
 
 FAIL Default view-timeline assert_equals: expected "-1" but got "100"
 FAIL Horizontal view-timeline assert_equals: expected "-1" but got "100"
-FAIL Multiple view-timelines on the same element assert_equals: expected "0" but got "-1"
+FAIL Multiple view-timelines on the same element assert_equals: expected "-1" but got "100"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/current-time-writing-modes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/current-time-writing-modes-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL currentTime handles direction: rtl correctly assert_approx_equals: values do not match for "Unscrolled inline timeline" expected 0 +/- 0.125 but got 100
-FAIL currentTime handles writing-mode: vertical-rl correctly assert_approx_equals: values do not match for "Unscrolled inline timeline" expected 0 +/- 0.125 but got 100
-FAIL currentTime handles writing-mode: sideways-rl correctly assert_approx_equals: values do not match for "Unscrolled inline timeline" expected 0 +/- 0.125 but got 100
-FAIL currentTime handles writing-mode: vertical-lr correctly assert_approx_equals: values do not match for "Scrolled block timeline" expected 20 +/- 0.125 but got 10
-FAIL currentTime handles writing-mode: sideways-lr correctly assert_approx_equals: values do not match for "Unscrolled block timeline" expected 0 +/- 0.125 but got 100
+PASS currentTime handles direction: rtl correctly
+PASS currentTime handles writing-mode: vertical-rl correctly
+PASS currentTime handles writing-mode: sideways-rl correctly
+PASS currentTime handles writing-mode: vertical-lr correctly
+PASS currentTime handles writing-mode: sideways-lr correctly
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/block-view-timeline-current-time-vertical-rl.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/block-view-timeline-current-time-vertical-rl.tentative-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL View timeline with container having vertical-rl layout assert_approx_equals: values do not match for "Timeline's currentTime at container start boundary" expected -150 +/- 0.125 but got 64.91228485107422
+FAIL View timeline with container having vertical-rl layout assert_equals: Opacity with fill none at effect end time expected "1" but got "0.7"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/inline-view-timeline-current-time.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/inline-view-timeline-current-time.tentative-expected.txt
@@ -2,5 +2,5 @@
 FAIL View timeline with start and end scroll offsets that do not align with the scroll boundaries assert_approx_equals: values do not match for "Timeline's currentTime at container start boundary" expected -150 +/- 0.125 but got -152.5
 FAIL View timeline does not clamp starting scroll offset at 0 assert_approx_equals: values do not match for "Timeline's currentTime at container start boundary" expected 50 +/- 0.125 but got 47.5
 FAIL View timeline does not clamp end scroll offset at max scroll assert_approx_equals: values do not match for "Timeline's currentTime at container start boundary" expected -150 +/- 0.125 but got -152.5
-FAIL View timeline with container having RTL layout assert_approx_equals: values do not match for "Timeline's currentTime at container start boundary" expected -150 +/- 0.125 but got 247.49998474121094
+FAIL View timeline with container having RTL layout assert_approx_equals: values do not match for "Timeline's currentTime at container start boundary" expected -150 +/- 0.125 but got -147.5
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-subject-size-changes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-subject-size-changes-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL View timeline with subject size change after the creation of the animation assert_equals: Effect at the start of the active phase expected "0.3" but got "0.7"
+FAIL View timeline with subject size change after the creation of the animation assert_equals: Effect at the midpoint of the active range expected "0.5" but got "0.46"
 

--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -87,6 +87,12 @@ protected:
 
     static ScrollableArea* scrollableAreaForSourceRenderer(const RenderElement*, Document&);
 
+    struct ResolvedScrollDirection {
+        bool isVertical;
+        bool isReversed;
+    };
+    std::optional<ResolvedScrollDirection> resolvedScrollDirection() const;
+
 private:
     enum class Scroller : uint8_t { Nearest, Root, Self };
 

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -228,11 +228,14 @@ void ViewTimeline::cacheCurrentTime()
         auto* sourceScrollableArea = scrollableAreaForSourceRenderer(sourceScrollerRenderer(), m_subject->document());
         if (!sourceScrollableArea)
             return { };
+        auto scrollDirection = resolvedScrollDirection();
+        if (!scrollDirection)
+            return { };
 
-        float scrollOffset = axis() == ScrollAxis::Block ? sourceScrollableArea->scrollOffset().y() : sourceScrollableArea->scrollOffset().x();
-        float scrollContainerSize = axis() == ScrollAxis::Block ? sourceScrollableArea->visibleHeight() : sourceScrollableArea->visibleWidth();
+        float scrollOffset = scrollDirection->isVertical ? sourceScrollableArea->scrollOffset().y() : sourceScrollableArea->scrollOffset().x();
+        float scrollContainerSize = scrollDirection->isVertical ? sourceScrollableArea->visibleHeight() : sourceScrollableArea->visibleWidth();
         auto subjectOffsetFromSource = subjectRenderer->localToContainerPoint(pointForLocalToContainer(*sourceScrollableArea), sourceScrollerRenderer());
-        float subjectOffset = axis() == ScrollAxis::Block ? subjectOffsetFromSource.y() : subjectOffsetFromSource.x();
+        float subjectOffset = scrollDirection->isVertical ? subjectOffsetFromSource.y() : subjectOffsetFromSource.x();
         auto subjectBounds = [&] -> FloatSize {
             if (CheckedPtr subjectRenderBox = dynamicDowncast<RenderBox>(subjectRenderer.get()))
                 return subjectRenderBox->contentBoxRect().size();
@@ -245,7 +248,7 @@ void ViewTimeline::cacheCurrentTime()
             return { };
         }();
 
-        auto subjectSize = axis() == ScrollAxis::Block ? subjectBounds.height() : subjectBounds.width();
+        auto subjectSize = scrollDirection->isVertical ? subjectBounds.height() : subjectBounds.width();
 
         auto insetStartLength = m_insets.start.value_or(Length());
         auto insetEndLength = m_insets.start.value_or(insetStartLength);


### PR DESCRIPTION
#### 8ddc6659d2b26ee20a772dc838a3e5c37ae94ab5
<pre>
[scroll-animations] scroll timelines should account for the source&apos;s writing mode when computing the current time
<a href="https://bugs.webkit.org/show_bug.cgi?id=284372">https://bugs.webkit.org/show_bug.cgi?id=284372</a>
<a href="https://rdar.apple.com/141220539">rdar://141220539</a>

Reviewed by Tim Nguyen and Anne van Kesteren.

Account for the scroll container&apos;s `writing-mode` to determine whether we are scrolling horizontally or
vertically and whether the scrolling direction is reversed.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-scroll-functional-notation.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-view-functional-notation.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-axis-writing-mode-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-animation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/current-time-writing-modes-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/block-view-timeline-current-time-vertical-rl.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/inline-view-timeline-current-time.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-subject-size-changes-expected.txt:
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::resolvedScrollDirection const):
(WebCore::ScrollTimeline::cacheCurrentTime):
(WebCore::ScrollTimeline::currentTime):
* Source/WebCore/animation/ScrollTimeline.h:
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::cacheCurrentTime):

Canonical link: <a href="https://commits.webkit.org/287662@main">https://commits.webkit.org/287662@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fe8d845972ff6ceee65a8f8f5c5d70cc9c6fab0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80448 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34109 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84969 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31430 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82559 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68516 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7757 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62859 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20667 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83517 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52951 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73243 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43162 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50259 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27400 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29889 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71400 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27919 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86403 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7673 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71150 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7848 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69081 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70390 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14389 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13336 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12442 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7635 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/13155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7474 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10994 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9280 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->