### PR TITLE
REGRESSION(281090@main): Sluggish animations on some shopify stores

### DIFF
--- a/PerformanceTests/Layout/nested-grids-single-item-content-change.html
+++ b/PerformanceTests/Layout/nested-grids-single-item-content-change.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../resources/runner.js"></script>
+<script>
+function startTest() {
+  document.body.offsetHeight;
+
+  var index = 0;
+  PerfTestRunner.measureRunsPerSecond({run: function() {
+    document.getElementById("item").style.height = ++index % 2 ?  "10px" : "50px";
+    document.body.offsetHeight;
+  }});
+}
+</script>
+</head>
+<body onload="startTest()">
+  <div style="display: grid; grid-template-columns: auto auto; grid-template-rows: auto;">
+    <div id="item" style="width: 50px; height: 50px; background-color: blue;"></div>
+    <div style="display: grid; grid-column: 2;">
+      <div style="display: grid;">
+        <div style="display: grid;">
+          <div style="display: grid;">
+            <div style="display: grid;">
+              <div style="display: grid;"></div>
+              <div style="display: grid;">
+                <div style="display: grid;">
+                  <div style="display: grid;">
+                    <div style="display: grid;">
+                      <div style="display: grid;">
+                        <div style="display: grid;">
+                          <div style="display: grid;">
+                            <div style="display: grid;">
+                              <div style="display: grid;">
+                                <div style="display: grid;"></div>
+                                <div style="display: grid;">
+                                  <div style="display: grid;">
+                                    <div style="display: grid;">
+                                      <div style="display: grid;">
+                                        <div style="display: grid;">
+                                          <div style="width: 100px; height: 800px; background-color: green;"></div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -1037,6 +1037,13 @@ void GridTrackSizingAlgorithm::computeGridContainerIntrinsicSizes()
 LayoutUnit GridTrackSizingAlgorithmStrategy::logicalHeightForGridItem(RenderBox& gridItem, GridLayoutState& gridLayoutState) const
 {
     GridTrackSizingDirection gridItemBlockDirection = GridLayoutFunctions::flowAwareDirectionForGridItem(*renderGrid(), gridItem, GridTrackSizingDirection::ForRows);
+
+    auto& intrinsicLogicalHeightsForRowSizingFirstPass = renderGrid()->intrinsicLogicalHeightsForRowSizingFirstPass();
+    if (intrinsicLogicalHeightsForRowSizingFirstPass && !gridItem.needsLayout() && sizingState() == GridTrackSizingAlgorithm::SizingState::RowSizingFirstIteration) {
+        if (auto cachedLogicalHeight = intrinsicLogicalHeightsForRowSizingFirstPass->sizeForItem(gridItem))
+            return *cachedLogicalHeight;
+    }
+
     // If |gridItem| has a relative logical height, we shouldn't let it override its intrinsic height, which is
     // what we are interested in here. Thus we need to set the block-axis override size to nullopt (no possible resolution).
     auto hasOverridingContainingBlockContentSizeForGridItem = [&] {
@@ -1057,7 +1064,12 @@ LayoutUnit GridTrackSizingAlgorithmStrategy::logicalHeightForGridItem(RenderBox&
         gridItem.clearOverridingContentSize();
 
     gridItem.layoutIfNeeded();
-    return gridItem.logicalHeight() + GridLayoutFunctions::marginLogicalSizeForGridItem(*renderGrid(), gridItemBlockDirection, gridItem) + m_algorithm.baselineOffsetForGridItem(gridItem, gridAxisForDirection(direction()));
+
+    auto gridItemLogicalHeight = gridItem.logicalHeight() + GridLayoutFunctions::marginLogicalSizeForGridItem(*renderGrid(), gridItemBlockDirection, gridItem) + m_algorithm.baselineOffsetForGridItem(gridItem, gridAxisForDirection(direction()));
+    if (intrinsicLogicalHeightsForRowSizingFirstPass && sizingState() == GridTrackSizingAlgorithm::SizingState::RowSizingFirstIteration)
+        intrinsicLogicalHeightsForRowSizingFirstPass->setSizeForGridItem(gridItem, gridItemLogicalHeight);
+
+    return gridItemLogicalHeight;
 }
 
 LayoutUnit GridTrackSizingAlgorithmStrategy::minContentContributionForGridItem(RenderBox& gridItem, GridLayoutState& gridLayoutState) const
@@ -1103,6 +1115,10 @@ LayoutUnit GridTrackSizingAlgorithmStrategy::minContentContributionForGridItem(R
 
     if (updateOverridingContainingBlockContentSizeForGridItem(gridItem, gridItemInlineDirection)) {
         gridItem.setNeedsLayout(MarkOnlyThis);
+
+        if (auto& intrinsicLogicalHeightsForRowSizingFirstPass = renderGrid()->intrinsicLogicalHeightsForRowSizingFirstPass())
+            intrinsicLogicalHeightsForRowSizingFirstPass->invalidateSizeForItem(gridItem);
+
         // For a grid item with relative width constraints to the grid area, such as percentaged paddings, we reset the overridingContainingBlockContentSizeForGridItem value for columns when we are executing a definite strategy
         // for columns. Since we have updated the overridingContainingBlockContentSizeForGridItem inline-axis/width value here, we might need to recompute the grid item's relative width. For some cases, we probably will not
         // be able to do it during the RenderGrid::layoutGridItems() function as the grid area does't change there any more. Also, as we are doing a layout inside GridTrackSizingAlgorithmStrategy::logicalHeightForGridItem()
@@ -1126,8 +1142,11 @@ LayoutUnit GridTrackSizingAlgorithmStrategy::maxContentContributionForGridItem(R
         return gridItem.maxPreferredLogicalWidth() + GridLayoutFunctions::marginLogicalSizeForGridItem(*renderGrid(), gridItemInlineDirection, gridItem) + m_algorithm.baselineOffsetForGridItem(gridItem, gridAxisForDirection(direction()));
     }
 
-    if (updateOverridingContainingBlockContentSizeForGridItem(gridItem, gridItemInlineDirection))
+    if (updateOverridingContainingBlockContentSizeForGridItem(gridItem, gridItemInlineDirection)) {
+        if (auto& intrinsicLogicalHeightsForRowSizingFirstPass = renderGrid()->intrinsicLogicalHeightsForRowSizingFirstPass())
+            intrinsicLogicalHeightsForRowSizingFirstPass->invalidateSizeForItem(gridItem);
         gridItem.setNeedsLayout(MarkOnlyThis);
+    }
     return logicalHeightForGridItem(gridItem, gridLayoutState);
 }
 

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -46,6 +46,16 @@ struct ContentAlignmentData {
 
 enum class GridAxisPosition : uint8_t { GridAxisStart, GridAxisEnd, GridAxisCenter };
 
+class GridItemSizeCache {
+public:
+    void setSizeForGridItem(const RenderBox& gridItem, LayoutUnit size);
+    std::optional<LayoutUnit> sizeForItem(const RenderBox& gridItem) const;
+    void invalidateSizeForItem(const RenderBox& gridItem);
+
+private:
+    SingleThreadWeakHashMap<const RenderBox, std::optional<LayoutUnit>> m_sizes;
+};
+
 class RenderGrid final : public RenderBlock {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(RenderGrid);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderGrid);
@@ -94,6 +104,7 @@ public:
     // of a descendant subgrid.
     GridSpan gridSpanForGridItem(const RenderBox&, GridTrackSizingDirection) const;
 
+    bool isSubgrid() const;
     bool isSubgrid(GridTrackSizingDirection) const;
     bool isSubgridRows() const
     {
@@ -128,6 +139,9 @@ public:
 
     LayoutUnit masonryContentSize() const;
     Vector<LayoutRect> gridItemsLayoutRects();
+
+    void updateIntrinsicLogicalHeightsForRowSizingFirstPassCacheAvailability();
+    std::optional<GridItemSizeCache>& intrinsicLogicalHeightsForRowSizingFirstPass() const;
 
     bool shouldCheckExplicitIntrinsicInnerLogicalSize(GridTrackSizingDirection) const;
 
@@ -265,6 +279,8 @@ private:
     AutoRepeatType autoRepeatColumnsType() const;
     AutoRepeatType autoRepeatRowsType() const;
 
+    bool canCreateIntrinsicLogicalHeightsForRowSizingFirstPassCache() const;
+
     class GridWrapper {
         Grid m_layoutGrid;
     public:
@@ -291,6 +307,8 @@ private:
     bool m_hasAspectRatioBlockSizeDependentItem { false };
     bool m_baselineItemsCached {false};
     bool m_hasAnyBaselineAlignmentItem { false };
+
+    mutable std::optional<GridItemSizeCache> m_intrinsicLogicalHeightsForRowSizingFirstPass;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 6efee9d4dde03e60eb8a23ff8c28708d7e8bd370
<pre>
REGRESSION(281090@main): Sluggish animations on some shopify stores
<a href="https://bugs.webkit.org/show_bug.cgi?id=279492">https://bugs.webkit.org/show_bug.cgi?id=279492</a>
<a href="https://rdar.apple.com/135791322">rdar://135791322</a>

Reviewed by Brandon Stewart.

In 281090@main, we added an extra bit of information for the grid to keep track of on its
grid items. In particular, we expanded the grid&apos;s capabilities to keep track of whether or
not any of its grid items needed to perform stretch alignment. This included some extra
invalidation inside of GridTrackSizingAlgorithm::logicalHeightForGridItem, as performing
layout on a grid item would clear its stretched size.

However, this seems to expose an issue in which we experience thrashing when rerunning the
grid layout. This can become an issue because of 2 main aspects of grid layout currently:

1.) We rerun the full grid track sizing algorithm each time (i.e. little partial layout)
2.) Grid track sizing may need to query the intrinsic sizes of an item. If an item was
previously stretched, we will clear that size, compute the intrinsic sizes for track
sizing, and then stretch the item again.

These 2 issues unfortunately get compounded in the presence of nested grid content.

This patch aims to address 2 by caching the intrinsic logical height of a grid item
to try to avoid the adverse effects of recomputing it. This cache will specifically be
used to cache the intrinsic logical heights of grid items that are computed during the
first pass of row sizing. That means the values that it contains are only valid for that
portion of the track sizing algorithm code, and the track sizing algorithm should only
populate it with sizes during that step.

Availability -
The cache will live on RenderGrid, which will determine whether or not
it will be available to use by the rest of the code. This availability is dependent on the
type of the current grid content. The cache is available to use if none
of the following are true:

1.) The grid is a subgrid

2.) Any of the items are a subgrid

3.) The grid is a masonry grid

4.) Any of the items are being baseline aligned (due to the  intrinsic size implications
of baseline-aligned grid items in the spec).

5.) The grid is contained in a fragmented flow.

Invalidation -
If we have an existing cache that is still valid to use during another
pass of layout (i.e. it is still available), then we may need to
invalidate the items.

1.) Before we run grid layout, we will check to see if any of the grid
item renderers have been dirtied. If so, we will then invalidate that
item if it is in the cache and recompute the intrinsic size during the
track sizing algorithm.

2.) If the grid experiences any sort of style mutation, we just
invalidate the entire cache.

3.) During track sizing, we may end up changing the inline constraints
that were used to compute the logical height in a previous pass. If this
is the case, then we need to invalidate the item in the cache as a
different set of constraints may result in a different logical height.

API -
This cache is exposed by RenderGrid via intrinsicLogicalHeightsForRowSizingFirstPass()
so that callers can either query, invalidate, or populate it. Callers should only expect
to be able to use the cache if it is made available by RenderGrid.

Inside logicalHeightForGridItem, we will check to see if this cache exists and if it
contains a value we previously computed for the item. If we do not have a value for this
item, we will just compute it and add it to the cache afterwards.

nested-grids-single-item-content-change.html was added as a performance
test to demonstrate the effectiveness of this change. On my M1 Pro MBP,
running this test went from ~950 runs/s to ~1900 runs/s.

* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithmStrategy::logicalHeightForGridItem const):
(WebCore::GridTrackSizingAlgorithmStrategy::minContentContributionForGridItem const):
(WebCore::GridTrackSizingAlgorithmStrategy::maxContentContributionForGridItem const):
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::styleDidChange):
(WebCore::RenderGrid::layoutGrid):
(WebCore::RenderGrid::isSubgrid const):
(WebCore::RenderGrid::updateIntrinsicLogicalHeightsForRowSizingFirstPassCacheAvailability):
(WebCore::RenderGrid::intrinsicLogicalHeightsForRowSizingFirstPass const):
(WebCore::RenderGrid::canCreateIntrinsicLogicalHeightsForRowSizingFirstPassCache const):
(WebCore::GridItemSizeCache::setSizeForGridItem):
(WebCore::GridItemSizeCache::sizeForItem const):
(WebCore::GridItemSizeCache::invalidateSizeForItem):
* Source/WebCore/rendering/RenderGrid.h:

Canonical link: <a href="https://commits.webkit.org/287890@main">https://commits.webkit.org/287890@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c303daf71e60760c0af2364ea783af5c5ea6c93

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80306 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59312 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33728 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84827 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31288 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82417 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68374 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7612 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62783 "Found 1 new test failure: fast/events/domactivate-sets-underlying-click-event-as-handled.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20591 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83375 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52843 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73128 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43086 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50167 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27284 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29747 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71303 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27798 "Found 1 new test failure: imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-postMessage-workers.https.window.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86261 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7531 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5329 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71068 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7706 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68965 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70308 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17666 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14293 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13238 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7493 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13872 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7332 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10852 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9138 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->