### PR TITLE
Improve the Bugzilla Submit Bug button

### DIFF
--- a/Websites/bugs.webkit.org/js/field.js
+++ b/Websites/bugs.webkit.org/js/field.js
@@ -25,6 +25,9 @@ function validateEnterBug(theform) {
     var description = theform.comment;
     var attach_data = theform.data;
     var attach_desc = theform.description;
+    var submitbug = document.getElementById('submitbug');
+    
+    submitbug.disabled = true;
 
     var current_errors = YAHOO.util.Dom.getElementsByClassName(
         'validation_error_text', null, theform);
@@ -70,6 +73,7 @@ function validateEnterBug(theform) {
 
     if (focus_me) {
         focus_me.focus();
+        submitbug.disabled = false;
         return false;
     }
 

--- a/Websites/bugs.webkit.org/skins/custom/global.css
+++ b/Websites/bugs.webkit.org/skins/custom/global.css
@@ -408,6 +408,15 @@ input[type=submit]:active {
     background-color: var(--link-color);
 }
 
+.button-primary[disabled],
+.bz_query_remember input[type=submit][disabled],
+.bz_query_buttons input[type=submit][disabled],
+#submitbug[disabled] {
+    opacity: 0.8;
+    background-color: var(--submit-background-active-color);
+}
+
+
 a.button.small {
     padding: 0.3rem 1rem;
     font-size: var(--font-size-small);

--- a/Websites/bugs.webkit.org/template/en/custom/bug/create/create.html.tmpl
+++ b/Websites/bugs.webkit.org/template/en/custom/bug/create/create.html.tmpl
@@ -155,6 +155,8 @@ TUI_hide_default('attachment_text_field');
     [% END %]
     
     <p><em>Note: If you are reporting an intermittent issue that WebKit developers may not be able to easily reproduce, please also file a <a href="https://feedbackassistant.apple.com">Feedback Assistant</a> report to <a href="https://developer.apple.com/bug-reporting/profiles-and-logs/?name=sysdiagnose">include a sysdiagnose</a>.</em></p>
+
+    <p><input type="submit" id="submitbug" value="Submit [% terms.Bug %]"></p>
 </section>
 
 <aside id="bug_details">
@@ -416,8 +418,6 @@ TUI_hide_default('attachment_text_field');
     
 
 </aside>
-
-    <p><input type="submit" id="submitbug" value="Submit [% terms.Bug %]"></p>
 
 </form>
 


### PR DESCRIPTION
#### d0c18a2204efdb15032dd38fb6d3f90542306615
<pre>
Improve the Bugzilla Submit Bug button
<a href="https://bugs.webkit.org/show_bug.cgi?id=284376">https://bugs.webkit.org/show_bug.cgi?id=284376</a>

Reviewed by Wenson Hsieh.

Moved the Submit Bug positioning below the comment area so that it
does not get pushed below the scroll when showing advanced fields
in the sidebar, and ensure that it is disabled when submitting a bug
but re-activated if there are any validation issues.

Canonical link: <a href="https://commits.webkit.org/287626@main">https://commits.webkit.org/287626@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3009bd2694a6a7be71561a1ef941d947a3ddd612

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80307 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59313 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33729 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84828 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31289 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68375 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7613 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62785 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20588 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83376 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52847 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73129 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43088 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50170 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29748 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71307 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27799 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86262 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7532 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5332 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/71073 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7707 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68966 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/70313 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14291 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13239 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12424 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7494 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7333 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10853 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9139 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->