### PR TITLE
AX: scroll views shouldn't be ignored when they have a remote frame child

### DIFF
--- a/LayoutTests/http/tests/site-isolation/accessibility/hit-test-resolving-remote-frame.html
+++ b/LayoutTests/http/tests/site-isolation/accessibility/hit-test-resolving-remote-frame.html
@@ -20,7 +20,7 @@ function runTest() {
         output += `iframe rect: ${iframeRect.x}, ${iframeRect.y}\n`;
 
         setTimeout(async function() {
-            var axElement = accessibilityController.rootElement.elementAtPointResolvingRemoteFrameForTesting(iframeRect.x + 50, iframeRect.y + 50, function (result) {
+            var axElement = accessibilityController.rootElement.elementAtPointResolvingRemoteFrame(iframeRect.x + 50, iframeRect.y + 50, function (result) {
                 output += `Element at (${iframeRect.x + 50}, ${iframeRect.y + 50}): ${result}\n`;
 
                 debug(output);

--- a/LayoutTests/http/tests/site-isolation/accessibility/hit-test-returns-remote-frame.html
+++ b/LayoutTests/http/tests/site-isolation/accessibility/hit-test-returns-remote-frame.html
@@ -23,9 +23,9 @@ function runTest() {
         output += `iframe rect: ${iframeRect.x}, ${iframeRect.y}\n`;
 
         setTimeout(async function() {
-            var headingHitTest = accessibilityController.rootElement.elementAtPointWithRemoteElementForTesting(headingRect.x + 10, headingRect.y + 10);
+            var headingHitTest = accessibilityController.rootElement.elementAtPointWithRemoteElement(headingRect.x + 10, headingRect.y + 10);
             output += `Hit test at "heading" returns a remote element? ${headingHitTest.isRemoteFrame ? "YES" : "NO"}\n`;
-            var iframeHitTest = accessibilityController.rootElement.elementAtPointWithRemoteElementForTesting(iframeRect.x + 50, iframeRect.y + 50);
+            var iframeHitTest = accessibilityController.rootElement.elementAtPointWithRemoteElement(iframeRect.x + 50, iframeRect.y + 50);
             output += `Hit test at "iframe" returns a remote element? ${iframeHitTest.isRemoteFrame ? "YES" : "NO"}\n`;
 
             debug(output);

--- a/LayoutTests/http/tests/site-isolation/accessibility/remote-element-returned-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/accessibility/remote-element-returned-expected.txt
@@ -1,0 +1,8 @@
+This test ensures that a remote element is present in the AX tree.
+
+Remote frame exists
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/accessibility/remote-element-returned.html
+++ b/LayoutTests/http/tests/site-isolation/accessibility/remote-element-returned.html
@@ -1,0 +1,32 @@
+<html><!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/js-test-resources/accessibility-helper.js"></script>
+<style>
+</style>
+</head>
+<body id="body">
+
+<iframe id="iframe" onload="runTest()" src="http://localhost:8000/site-isolation/resources/iframe.html"></iframe>
+
+<script>
+var output = "This test ensures that a remote element is present in the AX tree.\n\n";
+
+function runTest() {
+    if (window.accessibilityController) {
+        window.jsTestIsAsync = true;
+
+        setTimeout(async function() {
+            // Traverse ScrollView -> WebArea -> ScrollView (of iframe) -> Remote Frame
+            await waitFor(() => accessibilityController.rootElement.childAtIndex(0).childAtIndex(0).childAtIndexWithRemoteElement(0).isRemoteFrame);
+            output += `Remote frame exists\n`;
+            
+            debug(output);
+            finishJSTest();
+        }, 0);
+    }
+}
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -214,6 +214,10 @@ void AccessibilityScrollView::clearChildren()
 
 bool AccessibilityScrollView::computeIsIgnored() const
 {
+    // Scroll view's that host remote frames won't have web area objects, but shouldn't be ignored so that they are also available in the isolated tree.
+    if (m_remoteFrame)
+        return false;
+
     AccessibilityObject* webArea = webAreaObject();
     if (!webArea)
         return true;

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.h
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.h
@@ -123,7 +123,7 @@ RetainPtr<NSAttributedString> attributedStringCreate(Node&, StringView, const Si
 
 extern WebCore::AccessibilitySearchCriteria accessibilitySearchCriteriaForSearchPredicate(WebCore::AXCoreObject&, const NSDictionary *);
 
-extern NSArray *makeNSArray(const WebCore::AXCoreObject::AccessibilityChildrenVector&);
+extern NSArray *makeNSArray(const WebCore::AXCoreObject::AccessibilityChildrenVector&, BOOL returnPlatformElements = YES);
 extern NSRange makeNSRange(std::optional<WebCore::SimpleRange>);
 extern std::optional<WebCore::SimpleRange> makeDOMRange(WebCore::Document*, NSRange);
 

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
@@ -262,16 +262,16 @@ static NSArray *convertMathPairsToNSArray(const AccessibilityObject::Accessibili
     }).autorelease();
 }
 
-NSArray *makeNSArray(const WebCore::AXCoreObject::AccessibilityChildrenVector& children)
+NSArray *makeNSArray(const WebCore::AXCoreObject::AccessibilityChildrenVector& children, BOOL returnPlatformElements)
 {
-    return createNSArray(children, [] (const auto& child) -> id {
+    return createNSArray(children, [returnPlatformElements] (const auto& child) -> id {
         auto wrapper = child->wrapper();
         // We want to return the attachment view instead of the object representing the attachment,
         // otherwise, we get palindrome errors in the AX hierarchy.
         if (child->isAttachment()) {
             if (id attachmentView = wrapper.attachmentView)
                 return attachmentView;
-        } else if (child->isRemoteFrame())
+        } else if (child->isRemoteFrame() && returnPlatformElements)
             return child->remoteFramePlatformElement().get();
 
         return wrapper;

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.h
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.h
@@ -139,6 +139,7 @@ extern "C" AXUIElementRef NSAccessibilityCreateAXUIElementRef(id element);
 - (id)_associatedPluginParent;
 // For testing use only.
 - (void)_accessibilityHitTestResolvingRemoteFrame:(NSPoint)point callback:(void(^)(NSString *))callback;
+- (NSArray *)_accessibilityChildrenFromIndex:(NSUInteger)index maxCount:(NSUInteger)maxCount returnPlatformElements:(BOOL)returnPlatformElements;
 
 @end
 

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp
@@ -134,9 +134,10 @@ unsigned AccessibilityUIElement::numberOfCharacters() const { return 0; }
 JSValueRef AccessibilityUIElement::columns(JSContextRef) { return { }; }
 JSRetainPtr<JSStringRef> AccessibilityUIElement::dateValue() { return nullptr; }
 RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::textMarkerRangeForLine(long) { return nullptr; }
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::elementAtPointWithRemoteElementForTesting(int x, int y) { return nullptr; }
-void AccessibilityUIElement::elementAtPointResolvingRemoteFrameForTesting(JSContextRef context, int x, int y, JSValueRef jsCallback) { }
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::elementAtPointWithRemoteElement(int x, int y) { return nullptr; }
+void AccessibilityUIElement::elementAtPointResolvingRemoteFrame(JSContextRef context, int x, int y, JSValueRef jsCallback) { }
 bool AccessibilityUIElement::isRemoteFrame() const { return false; }
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::childAtIndexWithRemoteElement(unsigned) { return nullptr; }
 #endif // !PLATFORM(MAC)
 
 #if !PLATFORM(COCOA)

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
@@ -89,11 +89,12 @@ public:
     JSRetainPtr<JSStringRef> domIdentifier() const;
 
     RefPtr<AccessibilityUIElement> elementAtPoint(int x, int y);
-    RefPtr<AccessibilityUIElement> elementAtPointWithRemoteElementForTesting(int x, int y);
-    void elementAtPointResolvingRemoteFrameForTesting(JSContextRef, int x, int y, JSValueRef callback);
+    RefPtr<AccessibilityUIElement> elementAtPointWithRemoteElement(int x, int y);
+    void elementAtPointResolvingRemoteFrame(JSContextRef, int x, int y, JSValueRef callback);
 
     JSValueRef children(JSContextRef);
     RefPtr<AccessibilityUIElement> childAtIndex(unsigned);
+    RefPtr<AccessibilityUIElement> childAtIndexWithRemoteElement(unsigned);
     unsigned indexOfChild(AccessibilityUIElement*);
     unsigned childrenCount();
     RefPtr<AccessibilityUIElement> titleUIElement();

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl
@@ -29,9 +29,10 @@ interface AccessibilityUIElement {
 
     // Element access.
     AccessibilityUIElement elementAtPoint(long x, long y);
-    AccessibilityUIElement elementAtPointWithRemoteElementForTesting(long x, long y);
-    undefined elementAtPointResolvingRemoteFrameForTesting(long x, long y, object callbackFunction);
+    AccessibilityUIElement elementAtPointWithRemoteElement(long x, long y);
+    undefined elementAtPointResolvingRemoteFrame(long x, long y, object callbackFunction);
     AccessibilityUIElement childAtIndex(unsigned long index);
+    AccessibilityUIElement childAtIndexWithRemoteElement(unsigned long index);
     unsigned long indexOfChild(AccessibilityUIElement child);
     AccessibilityUIElement linkedUIElementAtIndex(unsigned long index);
     readonly attribute AccessibilityUIElement activeElement;


### PR DESCRIPTION
#### 03436a4ea53a9e093c3b626fb60fac615edf40c4
<pre>
AX: scroll views shouldn&apos;t be ignored when they have a remote frame child
<a href="https://bugs.webkit.org/show_bug.cgi?id=284379">https://bugs.webkit.org/show_bug.cgi?id=284379</a>
<a href="https://rdar.apple.com/problem/141228277">rdar://problem/141228277</a>

Reviewed by Tyler Wilcock.

We can&apos;t ignore scroll view&apos;s when they have remote children—this leads to missing content
on the isolated tree, since this scroll view is being requested.

A new testing method was added to AccessibilityUIElement, childAtIndexWithRemoteElement,
for validating the existence of a remote frame.

* LayoutTests/http/tests/site-isolation/accessibility/hit-test-resolving-remote-frame.html:
* LayoutTests/http/tests/site-isolation/accessibility/hit-test-returns-remote-frame.html:
* LayoutTests/http/tests/site-isolation/accessibility/remote-element-returned-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/accessibility/remote-element-returned.html: Added.
* Source/WebCore/accessibility/AccessibilityScrollView.cpp:
(WebCore::AccessibilityScrollView::computeIsIgnored const):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm:
(makeNSArray):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper accessibilityArrayAttributeValues:index:maxCount:]):
(-[WebAccessibilityObjectWrapper _accessibilityChildrenFromIndex:maxCount:returnPlatformElements:]):
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp:
(WTR::AccessibilityUIElement::elementAtPointWithRemoteElement):
(WTR::AccessibilityUIElement::elementAtPointResolvingRemoteFrame):
(WTR::AccessibilityUIElement::childAtIndexWithRemoteElement):
(WTR::AccessibilityUIElement::elementAtPointWithRemoteElementForTesting): Deleted.
(WTR::AccessibilityUIElement::elementAtPointResolvingRemoteFrameForTesting): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl:
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
(WTR::AccessibilityUIElement::childAtIndexWithRemoteElement):
(WTR::AccessibilityUIElement::elementAtPointWithRemoteElement):
(WTR::AccessibilityUIElement::elementAtPointResolvingRemoteFrame):
(WTR::AccessibilityUIElement::elementAtPointWithRemoteElementForTesting): Deleted.
(WTR::AccessibilityUIElement::elementAtPointResolvingRemoteFrameForTesting): Deleted.

Canonical link: <a href="https://commits.webkit.org/287701@main">https://commits.webkit.org/287701@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92e5a446847ff09c59cf7d93d9108af06316050c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80524 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59531 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34305 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85045 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31506 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82635 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68592 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7836 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62912 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20718 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83593 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/53020 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73310 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43215 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50322 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27468 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29965 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71467 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27991 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86479 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7750 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5475 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71204 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7925 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69147 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70444 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17559 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14458 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13403 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7712 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/13231 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7551 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11070 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9356 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->