### PR TITLE
[WebGPU] Dynamic offsets algorithm requires indices to be sorted

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-284390-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-284390-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-284390.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-284390.html
@@ -1,0 +1,17768 @@
+<!-- webkit-test-runner [ enableMetalShaderValidation=true ] -->
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = console.log;
+
+async function gc() {
+  await 0;
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUComputePassEncoder} computePassEncoder
+ */
+function clearResourceUsages(device, computePassEncoder) {
+  let code = `@compute @workgroup_size(1) fn c() {}`;
+  let module = device.createShaderModule({code});
+  computePassEncoder.setPipeline(device.createComputePipeline(
+    {
+      layout: 'auto',
+      compute: {module},
+    }));
+  computePassEncoder.dispatchWorkgroups(1);
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+const videoUrls = [
+
+];
+
+/**
+ * @param {number} index
+ * @returns {Promise<HTMLVideoElement>}
+ */
+function videoWithData(index) {
+  let video = document.createElement('video');
+  video.src = videoUrls[index % videoUrls.length];
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+/**
+ * @param {string} payload
+ * @returns {string}
+ */
+function toBlobUrl(payload) {
+  let blob = new Blob([payload], {type: 'text/javascript'});
+  return URL.createObjectURL(blob);
+}
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+let adapter0 = await navigator.gpu.requestAdapter({});
+let device0 = await adapter0.requestDevice({
+  label: '\ueb84\uf533\ua15f\u6348',
+  defaultQueue: {},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxBindingsPerBindGroup: 1000,
+    maxUniformBufferBindingSize: 95452709,
+    maxStorageBufferBindingSize: 187154747,
+    maxSampledTexturesPerShaderStage: 16,
+  },
+});
+try {
+device0.queue.label = '\u{1fcd2}\u9555\u{1f824}\u05bd\u9ab8\u9bcd\ub33a';
+} catch {}
+let commandEncoder0 = device0.createCommandEncoder({label: '\u{1ffa4}\u{1fdb4}\u{1fc4d}\u02d4\u{1f6f4}\ub7a1'});
+let computePassEncoder0 = commandEncoder0.beginComputePass({});
+let sampler0 = device0.createSampler({
+  label: '\u1c30\u{1f9a7}\u{1fca3}\u85fe\u75ee\ubd6d\u658f',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 66.00,
+  lodMaxClamp: 91.10,
+});
+let commandEncoder1 = device0.createCommandEncoder();
+let computePassEncoder1 = commandEncoder1.beginComputePass({label: '\u820b\u0f2c'});
+let offscreenCanvas0 = new OffscreenCanvas(54, 141);
+let commandEncoder2 = device0.createCommandEncoder();
+let querySet0 = device0.createQuerySet({type: 'occlusion', count: 944});
+let sampler1 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 80.60,
+});
+try {
+commandEncoder2.pushDebugGroup('\u3747');
+} catch {}
+let commandEncoder3 = device0.createCommandEncoder();
+let texture0 = device0.createTexture({
+  size: {width: 40, height: 39, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+commandEncoder2.popDebugGroup();
+} catch {}
+let commandEncoder4 = device0.createCommandEncoder({label: '\ube53\u{1fb23}\uf48c\u089b\u9b43\u5205\u85c8\u{1f93a}\u0265\u17eb'});
+let querySet1 = device0.createQuerySet({type: 'occlusion', count: 1881});
+let texture1 = device0.createTexture({size: [120, 48, 49], dimension: '2d', format: 'rgb10a2uint', usage: GPUTextureUsage.COPY_SRC});
+let textureView0 = texture0.createView({dimension: '2d-array'});
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 11, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(160).fill(167), /* required buffer size: 160 */
+{offset: 160, bytesPerRow: 81}, {width: 4, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext0 = offscreenCanvas0.getContext('webgpu');
+let videoFrame0 = new VideoFrame(offscreenCanvas0, {timestamp: 0});
+let sampler2 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 81.00,
+  lodMaxClamp: 97.20,
+  maxAnisotropy: 6,
+});
+let videoFrame1 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'bt470m', transfer: 'gamma28curve'} });
+let textureView1 = texture1.createView({format: 'rgb10a2uint', arrayLayerCount: 14});
+let sampler3 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 31.49,
+  lodMaxClamp: 33.14,
+});
+let externalTexture0 = device0.importExternalTexture({source: videoFrame1, colorSpace: 'display-p3'});
+let texture2 = device0.createTexture({
+  size: [15, 6, 21],
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder2 = commandEncoder3.beginComputePass({label: '\u0677\u0988\u7b2d\u0d1e\ub85f\ud318\u{1fa64}\u29fc'});
+let buffer0 = device0.createBuffer({size: 18239, usage: GPUBufferUsage.UNIFORM});
+let commandEncoder5 = device0.createCommandEncoder({});
+let textureView2 = texture1.createView({dimension: '2d', baseArrayLayer: 3});
+try {
+commandEncoder5.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 4, y: 14, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 9, y: 2, z: 3},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer1 = device0.createBuffer({size: 9790, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let commandEncoder6 = device0.createCommandEncoder({});
+let computePassEncoder3 = commandEncoder6.beginComputePass({});
+try {
+adapter0.label = '\u5606\u61bc';
+} catch {}
+let buffer2 = device0.createBuffer({
+  label: '\u{1fa0c}\u{1f632}\u0037',
+  size: 22718,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let textureView3 = texture0.createView({dimension: '2d-array'});
+let computePassEncoder4 = commandEncoder2.beginComputePass({label: '\u6771\u22b1\u2175\u0398\ue13a\u8e20\u633c\u2335'});
+let textureView4 = texture1.createView({dimension: '2d', baseArrayLayer: 9});
+let sampler4 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 63.16,
+  lodMaxClamp: 90.02,
+  maxAnisotropy: 6,
+});
+let computePassEncoder5 = commandEncoder4.beginComputePass({label: '\uabf2\u{1f8d9}'});
+try {
+commandEncoder5.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 5, y: 7, z: 18},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 3},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 11});
+} catch {}
+try {
+computePassEncoder4.insertDebugMarker('\u2ae1');
+} catch {}
+let textureView5 = texture1.createView({aspect: 'all', baseArrayLayer: 0, arrayLayerCount: 3});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView6 = texture0.createView({mipLevelCount: 1});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], depthReadOnly: true});
+try {
+device0.queue.submit([]);
+} catch {}
+let buffer3 = device0.createBuffer({
+  size: 9346,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder7 = device0.createCommandEncoder({label: '\u4b1a\u0e40\u178a\u298f\u{1fdad}\u8754'});
+let renderBundle0 = renderBundleEncoder0.finish({});
+let commandBuffer0 = commandEncoder5.finish();
+let texture3 = device0.createTexture({
+  size: {width: 10},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let computePassEncoder6 = commandEncoder7.beginComputePass({});
+let externalTexture1 = device0.importExternalTexture({source: videoFrame0});
+let offscreenCanvas1 = new OffscreenCanvas(63, 93);
+let bindGroupLayout0 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 35,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 60,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let texture4 = device0.createTexture({
+  size: [10, 9, 1],
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView7 = texture4.createView({});
+try {
+device0.queue.writeBuffer(buffer3, 1696, new Float32Array(24685), 2440, 124);
+} catch {}
+try {
+adapter0.label = '\u1ed0\uf989\u{1fe90}\u0a52';
+} catch {}
+let promise0 = device0.queue.onSubmittedWorkDone();
+let bindGroupLayout1 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 16,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 3,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 925,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 139,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 426,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {binding: 25, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {
+      binding: 779,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: true },
+    },
+    {
+      binding: 142,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 88,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: true },
+    },
+    {
+      binding: 96,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16sint', access: 'write-only', viewDimension: '2d' },
+    },
+    {
+      binding: 32,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '1d' },
+    },
+  ],
+});
+let texture5 = device0.createTexture({
+  size: {width: 80},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture6 = device0.createTexture({
+  size: [120, 48, 1],
+  format: 'astc-8x8-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView8 = texture5.createView({});
+let sampler5 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 65.85,
+  lodMaxClamp: 87.92,
+});
+let gpuCanvasContext1 = offscreenCanvas1.getContext('webgpu');
+offscreenCanvas1.height = 165;
+let texture7 = device0.createTexture({
+  size: [1330, 1, 1],
+  mipLevelCount: 2,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler6 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 66.37,
+  lodMaxClamp: 71.13,
+});
+let querySet2 = device0.createQuerySet({type: 'occlusion', count: 1544});
+let textureView9 = texture7.createView({mipLevelCount: 1, arrayLayerCount: 1});
+let externalTexture2 = device0.importExternalTexture({source: videoFrame0});
+try {
+device0.queue.submit([commandBuffer0]);
+} catch {}
+try {
+  await promise0;
+} catch {}
+let bindGroup0 = device0.createBindGroup({
+  label: '\uf419\u77f3\u{1f77f}\u4234\u416c\u{1fd13}\u407c\u8e13',
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 60, resource: textureView7},
+    {binding: 35, resource: {buffer: buffer1, offset: 0, size: 152}},
+  ],
+});
+let texture8 = device0.createTexture({
+  size: [1330, 1, 1],
+  sampleCount: 1,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let bindGroupLayout2 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 83,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 232,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let pipelineLayout0 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout1, bindGroupLayout0]});
+let texture9 = device0.createTexture({
+  size: [16, 16, 13],
+  format: 'r8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], sampleCount: 1});
+try {
+renderBundleEncoder1.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+let buffer4 = device0.createBuffer({
+  size: 4119,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView10 = texture9.createView({dimension: '2d'});
+let sampler7 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 32.62,
+  lodMaxClamp: 91.02,
+});
+try {
+computePassEncoder4.setBindGroup(3, bindGroup0);
+} catch {}
+let commandEncoder8 = device0.createCommandEncoder({});
+let textureView11 = texture7.createView({format: 'rg32sint', mipLevelCount: 1});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+computePassEncoder2.setBindGroup(2, bindGroup0, new Uint32Array(1844), 143, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipelineLayout1 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer5 = device0.createBuffer({size: 16579, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder9 = device0.createCommandEncoder({});
+let textureView12 = texture8.createView({});
+let computePassEncoder7 = commandEncoder9.beginComputePass({});
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+commandEncoder8.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 80 */
+  offset: 80,
+  buffer: buffer3,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 8, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout2 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder10 = device0.createCommandEncoder({});
+let texture10 = device0.createTexture({
+  size: {width: 10},
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView13 = texture1.createView({baseArrayLayer: 5, arrayLayerCount: 11});
+let computePassEncoder8 = commandEncoder8.beginComputePass({});
+let sampler8 = device0.createSampler({
+  label: '\u0c79\ua51c\u0c44',
+  addressModeV: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 9.871,
+});
+try {
+commandEncoder10.copyBufferToTexture({
+  /* bytesInLastRow: 616 widthInBlocks: 77 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 232 */
+  offset: 232,
+  buffer: buffer4,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 34, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 77, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup1 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 83, resource: {buffer: buffer4, offset: 256, size: 120}},
+    {binding: 232, resource: {buffer: buffer4, offset: 1024, size: 272}},
+  ],
+});
+let computePassEncoder9 = commandEncoder10.beginComputePass({});
+try {
+renderBundleEncoder1.setBindGroup(0, bindGroup0, new Uint32Array(3110), 1_486, 0);
+} catch {}
+let commandEncoder11 = device0.createCommandEncoder({});
+let textureView14 = texture3.createView({label: '\ue224\uad83\u0358\u7f5b\u99fc\u2cc4\u08ca\u{1f9f5}\u0f48\u022a', aspect: 'all'});
+let computePassEncoder10 = commandEncoder11.beginComputePass({});
+let renderBundle1 = renderBundleEncoder1.finish();
+let commandEncoder12 = device0.createCommandEncoder();
+let computePassEncoder11 = commandEncoder12.beginComputePass({});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup0);
+} catch {}
+let buffer6 = device0.createBuffer({
+  size: 14172,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let commandEncoder13 = device0.createCommandEncoder({});
+let sampler9 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 26.21,
+  lodMaxClamp: 54.48,
+});
+try {
+computePassEncoder10.setBindGroup(3, bindGroup0, new Uint32Array(1458), 127, 0);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let bindGroupLayout3 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 13,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 283,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 41,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 50,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: true },
+    },
+    {
+      binding: 49,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 294,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 39,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 452,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8snorm', access: 'write-only', viewDimension: '2d' },
+    },
+    {
+      binding: 26,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 66, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'uniform', hasDynamicOffset: true }},
+    {
+      binding: 125,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let texture11 = device0.createTexture({size: [20, 19, 1], format: 'r8unorm', usage: GPUTextureUsage.TEXTURE_BINDING, viewFormats: []});
+try {
+computePassEncoder7.pushDebugGroup('\u{1f924}');
+} catch {}
+try {
+computePassEncoder7.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let bindGroup2 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 60, resource: textureView7},
+    {binding: 35, resource: {buffer: buffer3, offset: 768, size: 1760}},
+  ],
+});
+let texture12 = device0.createTexture({
+  size: [15, 6, 46],
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup0, new Uint32Array(3226), 536, 0);
+} catch {}
+try {
+commandEncoder13.copyBufferToBuffer(buffer6, 320, buffer5, 60, 4488);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let promise1 = device0.queue.onSubmittedWorkDone();
+let videoFrame2 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'smpte170m', transfer: 'iec61966-2-1'} });
+let texture13 = device0.createTexture({
+  size: {width: 80, height: 78, depthOrArrayLayers: 1},
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder12 = commandEncoder13.beginComputePass({label: '\u{1f87e}\u41f7\uc604\u0037\u0bc2'});
+let bindGroup3 = device0.createBindGroup({
+  label: '\u66fd\ub931\u{1fa5e}\u00f3',
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 96, resource: textureView12},
+    {binding: 142, resource: textureView11},
+    {binding: 16, resource: {buffer: buffer1, offset: 512, size: 7284}},
+    {binding: 925, resource: textureView9},
+    {binding: 88, resource: {buffer: buffer4, offset: 512, size: 164}},
+    {binding: 779, resource: {buffer: buffer0, offset: 0, size: 5538}},
+    {binding: 139, resource: textureView10},
+    {binding: 426, resource: {buffer: buffer3, offset: 0, size: 7280}},
+    {binding: 3, resource: sampler1},
+    {binding: 25, resource: {buffer: buffer1, offset: 4608, size: 4228}},
+    {binding: 32, resource: textureView8},
+  ],
+});
+let texture14 = device0.createTexture({
+  size: {width: 166, height: 1, depthOrArrayLayers: 1},
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView15 = texture2.createView({format: 'rgb10a2uint'});
+let bindGroup4 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 16, resource: {buffer: buffer3, offset: 256, size: 7096}},
+    {binding: 426, resource: {buffer: buffer3, offset: 2048, size: 1240}},
+    {binding: 779, resource: {buffer: buffer4, offset: 256, size: 1467}},
+    {binding: 139, resource: textureView10},
+    {binding: 3, resource: sampler5},
+    {binding: 925, resource: textureView9},
+    {binding: 142, resource: textureView11},
+    {binding: 25, resource: {buffer: buffer1, offset: 768, size: 4544}},
+    {binding: 88, resource: {buffer: buffer4, offset: 768, size: 64}},
+    {binding: 96, resource: textureView12},
+    {binding: 32, resource: textureView8},
+  ],
+});
+let buffer7 = device0.createBuffer({size: 35105, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE});
+let commandEncoder14 = device0.createCommandEncoder({});
+let texture15 = device0.createTexture({
+  size: [1330, 1, 1],
+  sampleCount: 4,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture16 = device0.createTexture({
+  size: {width: 20, height: 19, depthOrArrayLayers: 38},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView16 = texture7.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder13 = commandEncoder14.beginComputePass({});
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 2932, new BigUint64Array(9058), 802, 276);
+} catch {}
+let imageBitmap0 = await createImageBitmap(videoFrame1);
+let commandEncoder15 = device0.createCommandEncoder();
+let texture17 = device0.createTexture({
+  size: {width: 1330, height: 1, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView17 = texture15.createView({format: 'rg16uint'});
+let computePassEncoder14 = commandEncoder15.beginComputePass({});
+try {
+computePassEncoder8.setBindGroup(1, bindGroup1, new Uint32Array(355), 44, 0);
+} catch {}
+let textureView18 = texture14.createView({});
+let textureView19 = texture10.createView({label: '\u{1fb0b}\uc164\u564b'});
+try {
+computePassEncoder8.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+computePassEncoder5.setBindGroup(1, bindGroup2, new Uint32Array(275), 88, 0);
+} catch {}
+let promise2 = device0.queue.onSubmittedWorkDone();
+let textureView20 = texture7.createView({baseMipLevel: 0, mipLevelCount: 1});
+let sampler10 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 61.85,
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder7.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+buffer0.destroy();
+} catch {}
+let buffer8 = device0.createBuffer({
+  size: 37953,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], stencilReadOnly: true});
+try {
+renderBundleEncoder2.setBindGroup(2, bindGroup2, new Uint32Array(26), 0, 0);
+} catch {}
+try {
+renderBundleEncoder2.setIndexBuffer(buffer6, 'uint16', 1_018, 1_736);
+} catch {}
+let commandEncoder16 = device0.createCommandEncoder({});
+let renderBundle2 = renderBundleEncoder2.finish();
+try {
+computePassEncoder8.setBindGroup(0, bindGroup2, new Uint32Array(196), 64, 0);
+} catch {}
+try {
+commandEncoder16.copyBufferToBuffer(buffer3, 2216, buffer5, 1348, 736);
+} catch {}
+try {
+commandEncoder16.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 564 */
+  offset: 564,
+  buffer: buffer2,
+}, {
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder16.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 0, y: 10, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout4 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 194,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 87,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba8unorm', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 267,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 362,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let commandEncoder17 = device0.createCommandEncoder({});
+let texture18 = device0.createTexture({
+  size: [120],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+buffer1.unmap();
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let textureView21 = texture18.createView({});
+try {
+computePassEncoder2.setBindGroup(3, bindGroup0, new Uint32Array(3003), 165, 0);
+} catch {}
+let bindGroup5 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 16, resource: {buffer: buffer3, offset: 256, size: 7044}},
+    {binding: 426, resource: {buffer: buffer3, offset: 768, size: 2720}},
+    {binding: 96, resource: textureView12},
+    {binding: 925, resource: textureView20},
+    {binding: 779, resource: {buffer: buffer8, offset: 6400, size: 18527}},
+    {binding: 88, resource: {buffer: buffer4, offset: 512, size: 812}},
+    {binding: 32, resource: textureView19},
+    {binding: 139, resource: textureView10},
+    {binding: 142, resource: textureView11},
+    {binding: 25, resource: {buffer: buffer4, offset: 0, size: 4116}},
+    {binding: 3, resource: sampler7},
+  ],
+});
+let buffer9 = device0.createBuffer({size: 9126, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder18 = device0.createCommandEncoder({});
+let textureView22 = texture5.createView({label: '\u9e50\u08a6\u0876\u4c8e\udf12\u7eb9\u09d7\u{1fd71}\u0bc1\u0b9e\u3f82'});
+let textureView23 = texture13.createView({dimension: '2d-array'});
+try {
+computePassEncoder14.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+commandEncoder17.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 21},
+  aspect: 'all',
+},
+{
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+externalTexture1.label = '\u9d90\u04b1\u6f93\u8e1d\ua1fa\u{1fdc3}\u28a5\ub328';
+} catch {}
+let commandEncoder19 = device0.createCommandEncoder({});
+let textureView24 = texture9.createView({arrayLayerCount: 1});
+let texture19 = gpuCanvasContext0.getCurrentTexture();
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let commandEncoder20 = device0.createCommandEncoder({});
+let textureView25 = texture19.createView({});
+let computePassEncoder15 = commandEncoder17.beginComputePass({});
+try {
+buffer6.unmap();
+} catch {}
+try {
+  await buffer2.mapAsync(GPUMapMode.WRITE, 0, 2556);
+} catch {}
+let texture20 = device0.createTexture({
+  size: {width: 30},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+buffer7.unmap();
+} catch {}
+try {
+commandEncoder16.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 72 */
+  offset: 72,
+  bytesPerRow: 8192,
+  rowsPerImage: 422,
+  buffer: buffer8,
+}, {
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 11, y: 4, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 14, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder21 = device0.createCommandEncoder({});
+try {
+commandEncoder21.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 912 */
+  offset: 912,
+  bytesPerRow: 13824,
+  rowsPerImage: 435,
+  buffer: buffer6,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 8, z: 0},
+  aspect: 'all',
+}, {width: 16, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let bindGroup6 = device0.createBindGroup({
+  label: '\u649c\u41a3\u{1f814}\ud9a8\u{1fb1d}\u0bf7\u0446\u0339\u1e3b\u{1ffbb}',
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 283, resource: {buffer: buffer4, offset: 512, size: 1052}},
+    {binding: 39, resource: textureView9},
+    {binding: 50, resource: {buffer: buffer1, offset: 768, size: 1164}},
+    {binding: 125, resource: textureView19},
+    {binding: 41, resource: textureView25},
+    {binding: 294, resource: textureView17},
+    {binding: 26, resource: {buffer: buffer1, offset: 768, size: 1016}},
+    {binding: 66, resource: {buffer: buffer3, offset: 3584, size: 988}},
+    {binding: 452, resource: textureView18},
+    {binding: 49, resource: textureView25},
+    {binding: 13, resource: {buffer: buffer3, offset: 256, size: 1576}},
+  ],
+});
+let buffer10 = device0.createBuffer({size: 603, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX, mappedAtCreation: false});
+let computePassEncoder16 = commandEncoder20.beginComputePass({});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup5, [1536, 1536]);
+} catch {}
+try {
+computePassEncoder0.setBindGroup(0, bindGroup2, new Uint32Array(996), 231, 0);
+} catch {}
+try {
+commandEncoder18.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1716 */
+  offset: 1716,
+  rowsPerImage: 2191,
+  buffer: buffer4,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.COPY_DST});
+} catch {}
+let buffer11 = device0.createBuffer({size: 216, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let texture21 = device0.createTexture({
+  size: {width: 40, height: 39, depthOrArrayLayers: 435},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+try {
+computePassEncoder4.setBindGroup(3, bindGroup5, [0, 2304]);
+} catch {}
+try {
+commandEncoder21.copyBufferToBuffer(buffer4, 520, buffer10, 36, 4);
+} catch {}
+let bindGroup7 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 83, resource: {buffer: buffer4, offset: 0, size: 560}},
+    {binding: 232, resource: {buffer: buffer7, offset: 11776, size: 6232}},
+  ],
+});
+let buffer12 = device0.createBuffer({size: 3586, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let sampler11 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 70.80,
+  lodMaxClamp: 76.22,
+  maxAnisotropy: 1,
+});
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder19.copyTextureToBuffer({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 1, y: 21, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 328 widthInBlocks: 41 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1440 */
+  offset: 1440,
+  bytesPerRow: 28416,
+  buffer: buffer3,
+}, {width: 41, height: 5, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let videoFrame3 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'smpte432', transfer: 'logSqrt'} });
+let commandEncoder22 = device0.createCommandEncoder({});
+try {
+computePassEncoder5.setBindGroup(2, bindGroup5, [6912, 768]);
+} catch {}
+try {
+computePassEncoder11.setBindGroup(3, bindGroup4, new Uint32Array(69), 7, 2);
+} catch {}
+try {
+commandEncoder19.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5040 */
+  offset: 5040,
+  buffer: buffer6,
+}, {
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder5.insertDebugMarker('\uc36b');
+} catch {}
+let commandEncoder23 = device0.createCommandEncoder({});
+let textureView26 = texture2.createView({});
+let sampler12 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 3.831,
+  lodMaxClamp: 31.07,
+  compare: 'never',
+  maxAnisotropy: 8,
+});
+let externalTexture3 = device0.importExternalTexture({label: '\u462d\u{1f8d7}\u{1fa98}\u0486\ucf8c', source: videoFrame0});
+let arrayBuffer0 = buffer2.getMappedRange(0, 272);
+try {
+commandEncoder23.copyTextureToBuffer({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 5, y: 79, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 56 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 4128 */
+  offset: 4128,
+  bytesPerRow: 26112,
+  buffer: buffer9,
+}, {width: 7, height: 38, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_DST, alphaMode: 'opaque'});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+globalThis.someLabel = computePassEncoder4.label;
+} catch {}
+try {
+computePassEncoder7.setBindGroup(1, bindGroup5, [7936, 512]);
+} catch {}
+try {
+computePassEncoder1.setBindGroup(3, bindGroup7, new Uint32Array(1285), 42, 0);
+} catch {}
+let promise3 = device0.queue.onSubmittedWorkDone();
+let textureView27 = texture7.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder17 = commandEncoder23.beginComputePass({label: '\u06f7\u06b7\ud09b\u0e55\u{1f895}\u66f5\u635b'});
+try {
+computePassEncoder4.setBindGroup(1, bindGroup5, new Uint32Array(1303), 130, 2);
+} catch {}
+try {
+  await promise3;
+} catch {}
+let textureView28 = texture11.createView({label: '\u6a4c\uf8f5\uf40d\ufec7\uebde\u9a86', aspect: 'all'});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup6, [1792, 256]);
+} catch {}
+try {
+commandEncoder19.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 11, y: 9, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(97).fill(116), /* required buffer size: 97 */
+{offset: 97}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup8 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 50, resource: {buffer: buffer7, offset: 9472, size: 2552}},
+    {binding: 39, resource: textureView9},
+    {binding: 294, resource: textureView17},
+    {binding: 125, resource: textureView8},
+    {binding: 26, resource: {buffer: buffer4, offset: 0, size: 1312}},
+    {binding: 41, resource: textureView25},
+    {binding: 283, resource: {buffer: buffer4, offset: 0, size: 934}},
+    {binding: 13, resource: {buffer: buffer7, offset: 3072, size: 2920}},
+    {binding: 452, resource: textureView18},
+    {binding: 49, resource: textureView18},
+    {binding: 66, resource: {buffer: buffer11, offset: 0, size: 4}},
+  ],
+});
+let commandEncoder24 = device0.createCommandEncoder();
+let texture22 = device0.createTexture({
+  label: '\ue8c2\ub762\u070d\u601f\u071f\u0624\u1249\u{1f827}\u0f27\u06c3\u{1fc6b}',
+  size: {width: 120, height: 48, depthOrArrayLayers: 1},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView29 = texture8.createView({});
+try {
+commandEncoder22.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder25 = device0.createCommandEncoder({label: '\u0049\u3a9b\u{1ffd4}\u557d'});
+let texture23 = device0.createTexture({size: [80], mipLevelCount: 1, dimension: '1d', format: 'rgb10a2uint', usage: GPUTextureUsage.COPY_DST});
+try {
+buffer6.unmap();
+} catch {}
+try {
+commandEncoder25.insertDebugMarker('\u073e');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 54, height: 141, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 1, y: 7 },
+  flipY: false,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 14, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer13 = device0.createBuffer({
+  size: 31748,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let textureView30 = texture6.createView({label: '\ufa7c\u{1ff6a}\u02ea\u2cb7\u151f\u0a42\u{1fe59}'});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({
+  label: '\ubd21\u5d6f\u0477\u001e\u54f5\u0f4a\u587c\u{1f7dd}',
+  colorFormats: ['rgb10a2uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle3 = renderBundleEncoder3.finish();
+let sampler13 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 68.92,
+});
+try {
+computePassEncoder9.setBindGroup(3, bindGroup6, [512, 0]);
+} catch {}
+let arrayBuffer1 = buffer2.getMappedRange(272, 44);
+try {
+  await promise1;
+} catch {}
+let bindGroup9 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 25, resource: {buffer: buffer1, offset: 256, size: 4316}},
+    {binding: 16, resource: {buffer: buffer7, offset: 2048, size: 12108}},
+    {binding: 3, resource: sampler9},
+    {binding: 139, resource: textureView10},
+    {binding: 142, resource: textureView9},
+    {binding: 925, resource: textureView11},
+    {binding: 88, resource: {buffer: buffer4, offset: 256, size: 400}},
+    {binding: 426, resource: {buffer: buffer1, offset: 256, size: 1220}},
+    {binding: 779, resource: {buffer: buffer3, offset: 1024, size: 1839}},
+    {binding: 32, resource: textureView8},
+    {binding: 96, resource: textureView29},
+  ],
+});
+let texture24 = device0.createTexture({
+  label: '\u034b\u3aa4\u058e',
+  size: [332, 1, 310],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder18 = commandEncoder24.beginComputePass({});
+let commandEncoder26 = device0.createCommandEncoder({label: '\u0d14\u119f\u0c64'});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], stencilReadOnly: false});
+try {
+computePassEncoder15.setBindGroup(1, bindGroup5, new Uint32Array(1298), 35, 2);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup9, [0, 3072]);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(3, bindGroup0, new Uint32Array(3881), 3, 0);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer10, 'uint32', 108, 46);
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+try {
+commandEncoder18.copyBufferToBuffer(buffer6, 400, buffer9, 1088, 672);
+} catch {}
+try {
+commandEncoder22.pushDebugGroup('\u098d');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 8},
+  aspect: 'all',
+}, new Uint8Array(310).fill(209), /* required buffer size: 310 */
+{offset: 44, bytesPerRow: 19, rowsPerImage: 7}, {width: 1, height: 0, depthOrArrayLayers: 3});
+} catch {}
+let videoFrame4 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'bt470m', transfer: 'gamma22curve'} });
+let shaderModule0 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(3) var sam0: sampler;
+
+@group(0) @binding(25) var<storage, read_write> buffer14: array<array<vec4f, 37>, 6>;
+
+@group(0) @binding(32) var st0: texture_storage_1d<r32sint, read_write>;
+
+@group(0) @binding(88) var<storage, read_write> buffer15: array<array<array<array<f16, 1>, 1>, 2>>;
+
+@group(0) @binding(96) var st1: texture_storage_2d<rgba16sint, write>;
+
+@group(0) @binding(139) var tex0: texture_2d<u32>;
+
+@group(0) @binding(142) var tex1: texture_2d<i32>;
+
+@group(0) @binding(426) var<storage, read_write> buffer16: array<array<f16, 4>, 17>;
+
+@group(0) @binding(779) var<uniform> buffer17: vec2i;
+
+@group(0) @binding(925) var tex2: texture_2d<i32>;
+
+@group(1) @binding(35) var<storage, read_write> buffer18: atomic<u32>;
+
+@group(1) @binding(60) var tex3: texture_2d<f32>;
+
+struct T0 {
+  @size(8) f0: vec2h,
+  f1: mat4x3h,
+  @size(544) f2: mat2x3h,
+}
+
+struct T1 {
+  @align(8) @size(136) f0: array<u32>,
+}
+
+struct VertexOutput0 {
+  @location(13) @interpolate(flat, center) f0: u32,
+  @invariant @builtin(position) f1: vec4f,
+  @location(4) @interpolate(flat) f2: vec2i,
+}
+
+alias vec3b = vec3<bool>;
+
+fn fn0() -> array<array<array<i32, 1>, 30>, 1> {
+  var out: array<array<array<i32, 1>, 30>, 1>;
+  atomicMin(&buffer18, u32(unconst_u32(314)));
+  let ptr0: ptr<storage, f16, read_write> = &(*&buffer15)[u32(unconst_u32(21))][u32(unconst_u32(68))][0][0];
+  vp0[u32(atan2(f32(unconst_f32(0.1930)), f32(textureDimensions(tex1, i32(unconst_i32(15))).r)))] = modf(vec4h((*&buffer15)[u32(unconst_u32(305))][1][0][0]));
+  let ptr1: ptr<storage, array<array<f16, 4>, 17>, read_write> = &(*&buffer16);
+  vp0[u32(unconst_u32(113))].fract = vec4h(buffer15[arrayLength(&buffer15)][u32(unconst_u32(730))][0][0]);
+  let ptr2: ptr<storage, array<f16, 4>, read_write> = &(*ptr1)[16];
+  let ptr3: ptr<storage, f16, read_write> = &buffer15[arrayLength(&buffer15)][u32(unconst_u32(115))][u32(unconst_u32(202))][u32(unconst_u32(12))];
+  buffer15[u32((*ptr2)[3])][u32(unconst_u32(132))][u32(unconst_u32(32))][u32(unconst_u32(24))] *= (*&buffer16)[u32(unconst_u32(42))][3];
+  vp0[u32((*&buffer15)[i32(unconst_i32(21))][1][0][0])] = modf(vec4h(buffer15[arrayLength(&buffer15)][u32(unconst_u32(619))][0][0]));
+  let ptr4: ptr<storage, f16, read_write> = &buffer15[arrayLength(&buffer15)][1][u32(unconst_u32(42))][u32(unconst_u32(926))];
+  let ptr5: ptr<storage, f16, read_write> = &(*&buffer16)[u32(unconst_u32(8))][u32(unconst_u32(97))];
+  out[u32(unconst_u32(258))][u32(unconst_u32(1))][u32(unconst_u32(94))] ^= i32((*&buffer15)[arrayLength(&(*&buffer15))][u32(unconst_u32(55))][0][0]);
+  let ptr6: ptr<storage, array<f16, 1>, read_write> = &buffer15[arrayLength(&buffer15)][u32(unconst_u32(14))][u32(unconst_u32(23))];
+  return out;
+}
+
+fn fn1() -> VertexOutput0 {
+  var out: VertexOutput0;
+  let ptr7 = &vp0[u32(unconst_u32(98))];
+  let ptr8: ptr<uniform, vec2i> = &(*&buffer17);
+  let vf0: i32 = (*&buffer17)[u32(unconst_u32(116))];
+  out.f2 *= vec2i(transpose(mat3x4h())[unconst_i32(1)].bb);
+  return out;
+}
+
+var<workgroup> vw0: atomic<i32>;
+
+var<workgroup> vw1: VertexOutput0;
+
+var<workgroup> vw2: array<VertexOutput0, 1>;
+
+var<workgroup> vw3: atomic<u32>;
+
+var<workgroup> vw4: VertexOutput0;
+
+var<workgroup> vw5: atomic<i32>;
+
+var<workgroup> vw6: array<vec2h, 6>;
+
+var<workgroup> vw7: atomic<i32>;
+
+var<private> vp0 = array(modf(vec4h(-11658.1, -7868.8, 10520.6, -8006.0)));
+
+@vertex
+fn vertex0(@location(10) @interpolate(flat, sample) a0: i32, @location(8) @interpolate(flat) a1: vec2u, @location(4) a2: i32) -> VertexOutput0 {
+  var out: VertexOutput0;
+  let ptr9 = &vp0[u32(unconst_u32(62))];
+  var vf1 = fn1();
+  out = VertexOutput0(u32(vp0[0].whole.g), vec4f(vp0[0].whole), bitcast<vec2i>(vp0[0].whole));
+  var vf2: vec4i = textureLoad(tex1, vec2i(unconst_i32(146), unconst_i32(132)), i32(unconst_i32(100)));
+  var vf3: f32 = dot(vec4f(unconst_f32(0.7057), unconst_f32(0.1274), unconst_f32(-0.4011), unconst_f32(0.01250)), vec4f(vf1.f2.rgrr));
+  vf2 = unpack4xI8(pack4x8unorm(vec4f(unconst_f32(0.1284), unconst_f32(0.03378), unconst_f32(0.05825), unconst_f32(0.00189))));
+  let vf4: vec4i = textureLoad(tex1, vec2i(i32(sin(f16(unconst_f16(70.08))))), i32(unconst_i32(-244)));
+  out.f2 ^= vf2.zx;
+  return out;
+}
+
+@vertex
+fn vertex1(@location(2) @interpolate(linear) a0: vec2f) -> @builtin(position) vec4f {
+  var out: vec4f;
+  var vf5 = fn1();
+  fn1();
+  vf5.f2 |= bitcast<vec2i>(textureGather(15 % 4, tex0, sam0, vec2f(unconst_f32(0.2315), unconst_f32(-0.1317)), clamp(vec2i(100, 202), vec2i(-8), vec2i(7))).zz);
+  fn1();
+  out = vec4f(textureDimensions(tex3).gggg);
+  out = vec4f(vp0[0].whole);
+  return out;
+}
+
+@fragment
+fn fragment0() -> @location(200) vec4u {
+  var out: vec4u;
+  vp0[0] = modf(bitcast<vec4h>(textureDimensions(tex1, i32(unconst_i32(265)))));
+  out <<= unpack4xU8(u32(buffer15[arrayLength(&buffer15)][u32(unconst_u32(8))][u32(unconst_u32(81))][0]));
+  let vf6: vec2h = mix(vec2h(unconst_f16(3816.1), unconst_f16(12479.6)), vec2h(unconst_f16(10714.2), unconst_f16(18382.5)), vec2h(unconst_f16(2052.0), unconst_f16(4025.5)));
+  atomicCompareExchangeWeak(&buffer18, unconst_u32(191), unconst_u32(111));
+  let ptr10: ptr<storage, f16, read_write> = &buffer15[u32(unconst_u32(107))][1][u32(unconst_u32(11))][u32(unconst_u32(251))];
+  atomicCompareExchangeWeak(&buffer18, unconst_u32(22), unconst_u32(20));
+  buffer16[u32(unconst_u32(201))][u32(unconst_u32(403))] *= buffer15[arrayLength(&buffer15)][u32((*&buffer15)[arrayLength(&(*&buffer15))][1][0][0])][0][u32(unconst_u32(38))];
+  let ptr11: ptr<storage, array<array<f16, 1>, 1>, read_write> = &buffer15[arrayLength(&buffer15)][u32(unconst_u32(50))];
+  var vf7 = fn0();
+  var vf8 = fn1();
+  let ptr12: ptr<storage, f16, read_write> = &buffer15[u32(unconst_u32(281))][1][u32(unconst_u32(39))][0];
+  var vf9 = fn0();
+  buffer15[u32(vf7[u32(unconst_u32(23))][29][0])][u32(unconst_u32(32))][u32(unconst_u32(428))][u32(unconst_u32(253))] = buffer15[u32(unconst_u32(472))][1][0][u32(unconst_u32(22))];
+  fn0();
+  var vf10: i32 = extractBits(i32(unconst_i32(38)), u32(unconst_u32(17)), u32(unconst_u32(182)));
+  atomicCompareExchangeWeak(&buffer18, unconst_u32(58), unconst_u32(125));
+  var vf11 = fn0();
+  let ptr13: ptr<storage, array<f16, 1>, read_write> = &(*ptr11)[u32(unconst_u32(10))];
+  discard;
+  fn1();
+  vp0[0].fract = vec4h((*&buffer15)[u32(unconst_u32(99))][u32(unconst_u32(430))][0][u32(unconst_u32(146))]);
+  let ptr14: ptr<storage, array<f16, 1>, read_write> = &(*&buffer15)[arrayLength(&(*&buffer15))][u32(unconst_u32(3))][0];
+  vf9[u32(unconst_u32(51))][u32(unconst_u32(199))][u32((*ptr14)[0])] = i32((*&buffer15)[arrayLength(&(*&buffer15))][1][u32(unconst_u32(96))][bitcast<u32>(vf7[u32(unconst_u32(135))][u32(unconst_u32(30))][u32(unconst_u32(26))])]);
+  let ptr15: ptr<storage, f16, read_write> = &buffer15[arrayLength(&buffer15)][1][u32(unconst_u32(14))][u32(unconst_u32(75))];
+  fn1();
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+  let ptr16: ptr<storage, array<f16, 1>, read_write> = &(*&buffer15)[u32(unconst_u32(256))][1][0];
+  let ptr17: ptr<storage, f16, read_write> = &buffer15[arrayLength(&buffer15)][1][pack4x8unorm(vw4.f1)][u32(unconst_u32(483))];
+  fn1();
+  vw4 = VertexOutput0((*&vw1).f0, unpack4x8snorm((*&vw1).f0), vec2i(bitcast<i32>((*&vw1).f0)));
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder27 = device0.createCommandEncoder({});
+let texture25 = device0.createTexture({
+  size: [30, 12, 28],
+  mipLevelCount: 2,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder19 = commandEncoder21.beginComputePass({});
+try {
+computePassEncoder3.setBindGroup(2, bindGroup9, [0, 3840]);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(0, bindGroup9, new Uint32Array(177), 10, 2);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(0, buffer8, 0, 2_943);
+} catch {}
+try {
+commandEncoder16.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 372 */
+  offset: 372,
+  buffer: buffer6,
+}, {
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData0 = new ImageData(40, 8);
+let commandEncoder28 = device0.createCommandEncoder({});
+let textureView31 = texture14.createView({label: '\ua5e1\u{1f974}\ud41b\u0de0\u9810\u{1f72a}\u2e99', dimension: '2d-array'});
+let texture26 = gpuCanvasContext0.getCurrentTexture();
+try {
+computePassEncoder11.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+computePassEncoder17.setBindGroup(3, bindGroup2, new Uint32Array(676), 19, 0);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(0, bindGroup0, new Uint32Array(1356), 248, 0);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer10, 'uint16', 144, 0);
+} catch {}
+let imageData1 = new ImageData(8, 84);
+try {
+adapter0.label = '\ua319\u0e90\ud3a4\u0410\ub926\u135c\u9f36\ua40e\uba34\u573f\u{1fcf3}';
+} catch {}
+let commandEncoder29 = device0.createCommandEncoder();
+let computePassEncoder20 = commandEncoder26.beginComputePass({label: '\u2578\u95cd'});
+let renderBundle4 = renderBundleEncoder4.finish();
+let sampler14 = device0.createSampler({
+  label: '\u492d\u967a\u0ca5\u46ef\u83a6\ubd3f\u0752\u7a3d\u0558\u5203',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 21.94,
+  lodMaxClamp: 77.37,
+  maxAnisotropy: 1,
+});
+let arrayBuffer2 = buffer2.getMappedRange(360, 300);
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise2;
+} catch {}
+let buffer19 = device0.createBuffer({size: 9682, usage: GPUBufferUsage.STORAGE});
+let computePassEncoder21 = commandEncoder28.beginComputePass();
+let arrayBuffer3 = buffer2.getMappedRange(320, 0);
+try {
+device0.queue.writeBuffer(buffer9, 2356, new BigUint64Array(38767), 1624, 52);
+} catch {}
+let videoFrame5 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'fcc', primaries: 'film', transfer: 'smpte240m'} });
+let bindGroup10 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 35, resource: {buffer: buffer1, offset: 768, size: 2964}},
+    {binding: 60, resource: textureView18},
+  ],
+});
+let computePassEncoder22 = commandEncoder29.beginComputePass({});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], depthReadOnly: false, stencilReadOnly: true});
+let renderBundle5 = renderBundleEncoder5.finish();
+let sampler15 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 64.04,
+  lodMaxClamp: 68.86,
+});
+try {
+commandEncoder19.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2472 */
+  offset: 2472,
+  bytesPerRow: 16128,
+  buffer: buffer3,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+adapter0.label = '\ua10d\u3826\u1e91\u057a\u7f61\u21cd\u0b7e';
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+let bindGroup11 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 50, resource: {buffer: buffer7, offset: 9728, size: 2164}},
+    {binding: 452, resource: textureView18},
+    {binding: 294, resource: textureView17},
+    {binding: 39, resource: textureView9},
+    {binding: 49, resource: textureView28},
+    {binding: 66, resource: {buffer: buffer4, offset: 0, size: 1426}},
+    {binding: 125, resource: textureView22},
+    {binding: 26, resource: {buffer: buffer19, offset: 768, size: 5288}},
+    {binding: 283, resource: {buffer: buffer4, offset: 0, size: 1374}},
+    {binding: 41, resource: textureView18},
+    {binding: 13, resource: {buffer: buffer7, offset: 256, size: 168}},
+  ],
+});
+let buffer20 = device0.createBuffer({
+  size: 8375,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let texture27 = device0.createTexture({
+  label: '\u{1fcb5}\u073d\u92e2\u{1f816}\ufea2\ud616\u500f',
+  size: {width: 80, height: 78, depthOrArrayLayers: 51},
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder23 = commandEncoder22.beginComputePass({});
+let sampler16 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.59,
+  maxAnisotropy: 8,
+});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup8, new Uint32Array(411), 23, 2);
+} catch {}
+let arrayBuffer4 = buffer2.getMappedRange(328, 4);
+let bindGroup12 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 96, resource: textureView29},
+    {binding: 3, resource: sampler15},
+    {binding: 142, resource: textureView11},
+    {binding: 139, resource: textureView10},
+    {binding: 25, resource: {buffer: buffer7, offset: 2048, size: 4284}},
+    {binding: 426, resource: {buffer: buffer7, offset: 5120, size: 9200}},
+    {binding: 779, resource: {buffer: buffer4, offset: 0, size: 613}},
+    {binding: 925, resource: textureView11},
+    {binding: 32, resource: textureView22},
+    {binding: 88, resource: {buffer: buffer7, offset: 768, size: 2836}},
+    {binding: 16, resource: {buffer: buffer19, offset: 256, size: 7732}},
+  ],
+});
+let buffer21 = device0.createBuffer({
+  size: 33477,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder30 = device0.createCommandEncoder({});
+let textureView32 = texture18.createView({dimension: '1d', aspect: 'all', format: 'rgba8unorm', baseMipLevel: 0});
+let computePassEncoder24 = commandEncoder16.beginComputePass({});
+try {
+commandEncoder18.clearBuffer(buffer5, 2436, 1992);
+} catch {}
+let texture28 = device0.createTexture({
+  size: {width: 665, height: 1, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder25 = commandEncoder27.beginComputePass({});
+try {
+computePassEncoder21.setBindGroup(1, bindGroup11, new Uint32Array(2541), 165, 2);
+} catch {}
+let videoFrame6 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte240m', primaries: 'smpte432', transfer: 'gamma28curve'} });
+let texture29 = device0.createTexture({size: [20], dimension: '1d', format: 'rgb10a2uint', usage: GPUTextureUsage.COPY_DST});
+try {
+computePassEncoder7.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+commandEncoder19.clearBuffer(buffer9, 348, 1144);
+} catch {}
+let buffer22 = device0.createBuffer({size: 2724, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder31 = device0.createCommandEncoder();
+let textureView33 = texture8.createView({label: '\uebb9\u33c3\u{1fb47}\u025c\u0eb8\u0e8c\u407e\ud02c', dimension: '2d', aspect: 'all'});
+let texture30 = device0.createTexture({
+  size: {width: 60},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let sampler17 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 55.25,
+  lodMaxClamp: 86.69,
+});
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+let commandEncoder32 = device0.createCommandEncoder({});
+let sampler18 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 91.55,
+  lodMaxClamp: 93.07,
+  compare: 'less-equal',
+});
+let textureView34 = texture18.createView({});
+let computePassEncoder26 = commandEncoder31.beginComputePass();
+try {
+buffer9.unmap();
+} catch {}
+try {
+commandEncoder30.copyBufferToBuffer(buffer3, 3348, buffer13, 3764, 2476);
+} catch {}
+try {
+commandEncoder18.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 580 */
+  offset: 580,
+  bytesPerRow: 26624,
+  buffer: buffer4,
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 0, y: 9, z: 0},
+  aspect: 'all',
+}, new Uint8Array(28).fill(174), /* required buffer size: 28 */
+{offset: 28, bytesPerRow: 202}, {width: 40, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let buffer23 = device0.createBuffer({
+  size: 13829,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder33 = device0.createCommandEncoder({});
+let sampler19 = device0.createSampler({
+  label: '\u1ea5\u036a',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 99.15,
+});
+let buffer24 = device0.createBuffer({
+  label: '\u062c\u9edb\u7b65\u{1fc5f}\u0cf0\uf61b',
+  size: 7315,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let querySet3 = device0.createQuerySet({type: 'occlusion', count: 1590});
+try {
+commandEncoder18.copyBufferToBuffer(buffer23, 4252, buffer24, 568, 560);
+} catch {}
+let buffer25 = device0.createBuffer({size: 13846, usage: GPUBufferUsage.UNIFORM});
+let texture31 = device0.createTexture({
+  size: [16, 16, 13],
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView35 = texture11.createView({dimension: '2d-array'});
+let computePassEncoder27 = commandEncoder33.beginComputePass({});
+offscreenCanvas1.width = 14;
+let computePassEncoder28 = commandEncoder19.beginComputePass({});
+try {
+computePassEncoder26.setBindGroup(1, bindGroup4, [0, 512]);
+} catch {}
+try {
+computePassEncoder8.setBindGroup(1, bindGroup9, new Uint32Array(2893), 243, 2);
+} catch {}
+try {
+commandEncoder30.copyBufferToBuffer(buffer21, 8072, buffer12, 24, 36);
+} catch {}
+offscreenCanvas0.height = 1642;
+let commandEncoder34 = device0.createCommandEncoder({label: '\u8634\u1363\u49d3\u{1fc01}\u{1fc33}\udce5\ud852\udb88\ud24b\u{1fa4d}'});
+let textureView36 = texture31.createView({arrayLayerCount: 5});
+let computePassEncoder29 = commandEncoder18.beginComputePass({});
+let arrayBuffer5 = buffer2.getMappedRange(336, 0);
+let texture32 = gpuCanvasContext1.getCurrentTexture();
+let computePassEncoder30 = commandEncoder32.beginComputePass({label: '\u0e28\u065f\u49ce\ue033\uac84'});
+let videoFrame7 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'smpte432', transfer: 'bt2020_10bit'} });
+let commandEncoder35 = device0.createCommandEncoder({label: '\ub1a7\u2fe8\u0d26\u07e1'});
+let texture33 = device0.createTexture({
+  size: [20],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder31 = commandEncoder30.beginComputePass({label: '\u0102\u02cf\u22c2\u{1f8e2}\u82d3\ue1c4\ue290'});
+try {
+computePassEncoder4.setBindGroup(2, bindGroup8, new Uint32Array(417), 104, 2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer11, 168, new Float32Array(1362), 129, 0);
+} catch {}
+let computePassEncoder32 = commandEncoder25.beginComputePass({});
+try {
+commandEncoder35.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 7404 */
+  offset: 7404,
+  bytesPerRow: 4864,
+  buffer: buffer21,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder35.copyTextureToBuffer({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 88 widthInBlocks: 22 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3524 */
+  offset: 3524,
+  buffer: buffer5,
+}, {width: 22, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 3172, new DataView(new ArrayBuffer(7351)), 405, 1792);
+} catch {}
+let bindGroup13 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 232, resource: {buffer: buffer3, offset: 256, size: 3184}},
+    {binding: 83, resource: {buffer: buffer19, offset: 256, size: 492}},
+  ],
+});
+let querySet4 = device0.createQuerySet({label: '\u0f68\u{1fe2e}\ud525\u{1f9ca}', type: 'occlusion', count: 358});
+let texture34 = gpuCanvasContext0.getCurrentTexture();
+let pipeline0 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule0,
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex1',
+    buffers: [{arrayStride: 536, attributes: [{format: 'float32', offset: 128, shaderLocation: 2}]}],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+let bindGroup14 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 35, resource: {buffer: buffer13, offset: 2560}}, {binding: 60, resource: textureView7}],
+});
+let querySet5 = device0.createQuerySet({label: '\u082a\u0868\u{1fb96}', type: 'occlusion', count: 41});
+let computePassEncoder33 = commandEncoder35.beginComputePass();
+try {
+computePassEncoder30.setBindGroup(2, bindGroup7, []);
+} catch {}
+let arrayBuffer6 = buffer2.getMappedRange(344, 0);
+let promise4 = device0.queue.onSubmittedWorkDone();
+let commandEncoder36 = device0.createCommandEncoder();
+let texture35 = device0.createTexture({
+  size: [16, 16, 13],
+  mipLevelCount: 3,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture36 = gpuCanvasContext0.getCurrentTexture();
+try {
+  await promise4;
+} catch {}
+let sampler20 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 55.58,
+  lodMaxClamp: 90.55,
+  maxAnisotropy: 14,
+});
+try {
+commandEncoder36.copyTextureToBuffer({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'depth-only',
+}, {
+  /* bytesInLastRow: 40 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 268 */
+  offset: 268,
+  bytesPerRow: 55808,
+  rowsPerImage: 330,
+  buffer: buffer5,
+}, {width: 10, height: 9, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder26.pushDebugGroup('\u5453');
+} catch {}
+try {
+computePassEncoder26.popDebugGroup();
+} catch {}
+let bindGroup15 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 88, resource: {buffer: buffer21, offset: 18432, size: 3064}},
+    {binding: 142, resource: textureView11},
+    {binding: 25, resource: {buffer: buffer4, offset: 0, size: 3556}},
+    {binding: 3, resource: sampler5},
+    {binding: 139, resource: textureView10},
+    {binding: 779, resource: {buffer: buffer23, offset: 0, size: 4489}},
+    {binding: 426, resource: {buffer: buffer7, offset: 2048, size: 2768}},
+    {binding: 16, resource: {buffer: buffer24, offset: 0, size: 7060}},
+    {binding: 925, resource: textureView11},
+    {binding: 32, resource: textureView22},
+    {binding: 96, resource: textureView33},
+  ],
+});
+let texture37 = device0.createTexture({
+  size: [80, 78, 1],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder34 = commandEncoder34.beginComputePass({});
+try {
+commandEncoder36.copyBufferToBuffer(buffer23, 1992, buffer11, 28, 28);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 54, height: 141, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 6, y: 6, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let imageData2 = new ImageData(8, 12);
+let buffer26 = device0.createBuffer({
+  size: 16905,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView37 = texture18.createView({dimension: '1d'});
+let computePassEncoder35 = commandEncoder36.beginComputePass({});
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 54, height: 141, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 6, y: 418 },
+  flipY: false,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 1, y: 36, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let texture38 = device0.createTexture({
+  size: [20, 19, 53],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView38 = texture37.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 54, height: 141, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData2,
+  origin: { x: 0, y: 4 },
+  flipY: false,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 9, y: 66, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter0.label = '\u1941\ue657\u00df\ua320\u0180';
+} catch {}
+let bindGroup16 = device0.createBindGroup({
+  label: '\u710d\uff50\u8e34\u2667\u65ce\u{1ff98}\ub8ff',
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 125, resource: textureView19},
+    {binding: 41, resource: textureView28},
+    {binding: 39, resource: textureView11},
+    {binding: 26, resource: {buffer: buffer19, offset: 2048, size: 1928}},
+    {binding: 50, resource: {buffer: buffer4, offset: 768, size: 296}},
+    {binding: 294, resource: textureView17},
+    {binding: 13, resource: {buffer: buffer3, offset: 768, size: 432}},
+    {binding: 49, resource: textureView28},
+    {binding: 283, resource: {buffer: buffer25, offset: 1792, size: 1483}},
+    {binding: 66, resource: {buffer: buffer8, offset: 15360, size: 1448}},
+    {binding: 452, resource: textureView18},
+  ],
+});
+let texture39 = device0.createTexture({
+  label: '\u04c6\u060a\u657f\uea80\u0665\uc346',
+  size: {width: 166, height: 1, depthOrArrayLayers: 9},
+  mipLevelCount: 2,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let sampler21 = device0.createSampler({
+  label: '\u5df1\u{1f89f}\u{1f7b7}\u{1f7d2}\u0543\u2568\u5ed3\ub61c\u838b\u360b\u{1fdf6}',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 55.18,
+  maxAnisotropy: 9,
+});
+let buffer27 = device0.createBuffer({
+  size: 4512,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder37 = device0.createCommandEncoder();
+let texture40 = device0.createTexture({size: {width: 60}, dimension: '1d', format: 'rgb10a2uint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let computePassEncoder36 = commandEncoder37.beginComputePass({});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup16, [0, 1024]);
+} catch {}
+try {
+computePassEncoder31.setBindGroup(0, bindGroup7, new Uint32Array(1463), 73, 0);
+} catch {}
+let shaderModule1 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires pointer_composite_access;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(16) var<storage, read_write> buffer28: array<array<array<f32, 32>, 55>>;
+
+@group(0) @binding(32) var st2: texture_storage_1d<r32sint, read_write>;
+
+@group(0) @binding(88) var<storage, read_write> buffer29: atomic<u32>;
+
+@group(0) @binding(96) var st3: texture_storage_2d<rgba16sint, write>;
+
+@group(0) @binding(139) var tex4: texture_2d<u32>;
+
+@group(0) @binding(142) var tex5: texture_2d<i32>;
+
+@group(0) @binding(426) var<storage, read_write> buffer30: array<array<array<array<array<array<f16, 1>, 1>, 1>, 17>, 4>>;
+
+@group(0) @binding(779) var<uniform> buffer31: vec2f;
+
+@group(0) @binding(925) var tex6: texture_2d<i32>;
+
+@group(1) @binding(35) var<storage, read_write> buffer32: atomic<i32>;
+
+@group(1) @binding(60) var tex7: texture_2d<f32>;
+
+struct T0 {
+  @align(8) @size(584) f0: vec2h,
+}
+
+struct VertexOutput1 {
+  @location(9) f3: vec2h,
+  @builtin(position) f4: vec4f,
+  @location(12) @interpolate(perspective, centroid) f5: f16,
+}
+
+alias vec3b = vec3<bool>;
+
+override override0: f16 = -6026.8;
+
+@vertex
+fn vertex2(@location(9) @interpolate(perspective, center) a0: vec4f, @location(11) a1: vec4u, @location(1) @interpolate(flat, center) a2: i32, @builtin(instance_index) a3: u32) -> VertexOutput1 {
+  var out: VertexOutput1;
+  out.f5 = f16(textureNumLevels(tex5));
+  return out;
+}
+
+@fragment
+fn fragment1() -> @location(200) @interpolate(linear, centroid) vec4u {
+  var out: vec4u;
+  textureStore(st3, vec2i(unconst_i32(57), unconst_i32(130)), vec4i(vec4i(unconst_i32(144), unconst_i32(2), unconst_i32(178), unconst_i32(308))));
+  let ptr18: ptr<storage, array<f16, 1>, read_write> = &(*&buffer30)[arrayLength(&(*&buffer30))][u32(unconst_u32(44))][u32((*&buffer30)[arrayLength(&(*&buffer30))][3][16][0][0][0])][0][u32(unconst_u32(508))];
+  out ^= unpack4xU8(u32((*&buffer30)[arrayLength(&(*&buffer30))][3][16][0][0][u32(unconst_u32(5))]));
+  buffer28[u32(unconst_u32(136))][u32(unconst_u32(276))][u32(unconst_u32(210))] -= f32(atomicLoad(&(*&buffer32)));
+  let ptr19: ptr<storage, f16, read_write> = &(*&buffer30)[arrayLength(&(*&buffer30))][u32(unconst_u32(69))][u32(unconst_u32(128))][0][u32(unconst_u32(257))][0];
+  let ptr20: ptr<storage, f16, read_write> = &(*&buffer30)[arrayLength(&(*&buffer30))][u32(unconst_u32(175))][16][u32(unconst_u32(14))][0][u32(unconst_u32(353))];
+  let ptr21: ptr<storage, f16, read_write> = &buffer30[u32(unconst_u32(111))][u32(unconst_u32(82))][16][0][u32(unconst_u32(82))][0];
+  let ptr22: ptr<storage, array<array<f16, 1>, 1>, read_write> = &buffer30[arrayLength(&buffer30)][3][u32(unconst_u32(221))][0];
+  textureStore(st2, i32(unconst_i32(728)), vec4i(vec4i(unconst_i32(141), unconst_i32(189), unconst_i32(347), unconst_i32(603))));
+  atomicAnd(&buffer29, u32(unconst_u32(159)));
+  buffer30[u32(unconst_u32(14))][u32(unconst_u32(225))][u32(unconst_u32(295))][u32(unconst_u32(275))][bitcast<u32>(atomicLoad(&buffer32))][u32(unconst_u32(5))] = (*&buffer30)[arrayLength(&(*&buffer30))][3][u32(unconst_u32(24))][u32(unconst_u32(110))][0][0];
+  atomicAdd(&buffer29, u32(unconst_u32(82)));
+  buffer30[u32(unconst_u32(496))][u32(unconst_u32(79))][u32(unconst_u32(58))][u32(unconst_u32(33))][u32(unconst_u32(78))][u32(unconst_u32(71))] = buffer30[arrayLength(&buffer30)][u32(unconst_u32(29))][16][0][0][u32(unconst_u32(313))];
+  let ptr23: ptr<storage, array<array<array<array<f16, 1>, 1>, 1>, 17>, read_write> = &(*&buffer30)[arrayLength(&(*&buffer30))][3];
+  let ptr24: ptr<storage, array<array<f16, 1>, 1>, read_write> = &(*&buffer30)[arrayLength(&(*&buffer30))][u32(unconst_u32(446))][16][u32(unconst_u32(218))];
+  buffer28[u32(unconst_u32(690))][u32(unconst_u32(111))][u32(unconst_u32(67))] = f32((*&buffer30)[arrayLength(&(*&buffer30))][u32(unconst_u32(30))][16][0][u32((*&buffer30)[u32(unconst_u32(26))][3][16][u32(unconst_u32(64))][0][0])][0]);
+  let ptr25: ptr<storage, f16, read_write> = &buffer30[arrayLength(&buffer30)][u32(unconst_u32(448))][16][0][0][u32(unconst_u32(416))];
+  out = vec4u(u32(buffer30[u32(unconst_u32(142))][u32(unconst_u32(263))][16][u32(unconst_u32(94))][0][0]));
+  buffer28[u32(unconst_u32(39))][u32(unconst_u32(253))][u32((*&buffer30)[u32(unconst_u32(96))][3][16][0][0][0])] = ldexp(f32(unconst_f32(-0.2248)), i32(unconst_i32(95)));
+  atomicOr(&buffer29, u32(unconst_u32(5)));
+  buffer30[u32(unconst_u32(234))][u32(unconst_u32(107))][16][u32(unconst_u32(325))][u32(unconst_u32(220))][u32(unconst_u32(37))] += (*&buffer30)[arrayLength(&(*&buffer30))][u32(unconst_u32(237))][u32(unconst_u32(51))][0][0][u32(unconst_u32(48))];
+  let ptr26: ptr<storage, array<f16, 1>, read_write> = &buffer30[u32(unconst_u32(109))][u32(unconst_u32(124))][u32(unconst_u32(248))][u32(unconst_u32(272))][u32(unconst_u32(68))];
+  let ptr27: ptr<storage, f16, read_write> = &buffer30[u32(unconst_u32(111))][u32(unconst_u32(182))][u32(unconst_u32(13))][u32(unconst_u32(39))][0][0];
+  let ptr28: ptr<storage, f16, read_write> = &buffer30[u32(unconst_u32(57))][u32(unconst_u32(270))][16][u32(unconst_u32(174))][0][0];
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute1(@builtin(local_invocation_id) a0: vec3u) {
+  let ptr29: ptr<storage, f32, read_write> = &buffer28[u32(unconst_u32(3))][u32(unconst_u32(432))][31];
+  let vf12: i32 = atomicLoad(&(*&buffer32));
+  let ptr30: ptr<storage, f32, read_write> = &buffer28[u32(unconst_u32(92))][54][u32(unconst_u32(34))];
+}`,
+  sourceMap: {},
+});
+let bindGroup17 = device0.createBindGroup({
+  label: '\u099e\uf2ae\u{1f7cb}\u6681',
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 13, resource: {buffer: buffer21, offset: 1792, size: 5484}},
+    {binding: 49, resource: textureView25},
+    {binding: 66, resource: {buffer: buffer24, offset: 0, size: 81}},
+    {binding: 26, resource: {buffer: buffer20, offset: 4864, size: 1388}},
+    {binding: 39, resource: textureView20},
+    {binding: 41, resource: textureView28},
+    {binding: 125, resource: textureView19},
+    {binding: 294, resource: textureView17},
+    {binding: 452, resource: textureView18},
+    {binding: 50, resource: {buffer: buffer3, offset: 1280, size: 620}},
+    {binding: 283, resource: {buffer: buffer25, offset: 5632, size: 1318}},
+  ],
+});
+let buffer33 = device0.createBuffer({size: 39107, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT});
+let texture41 = device0.createTexture({
+  label: '\u55f7\uf528\u57cf\u0365\u8f3b\u0481',
+  size: [20, 19, 1],
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder35.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+let buffer34 = device0.createBuffer({
+  size: 12779,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let texture42 = device0.createTexture({
+  size: [80, 78, 1],
+  sampleCount: 4,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 54, height: 141, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData1,
+  origin: { x: 1, y: 9 },
+  flipY: false,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 1, y: 14, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 13, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder38 = device0.createCommandEncoder({});
+let querySet6 = device0.createQuerySet({type: 'occlusion', count: 2052});
+let textureView39 = texture37.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder37 = commandEncoder38.beginComputePass({});
+try {
+computePassEncoder5.setBindGroup(2, bindGroup15, [768, 2304]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(27).fill(55), /* required buffer size: 27 */
+{offset: 27}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 54, height: 141, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData2,
+  origin: { x: 1, y: 2 },
+  flipY: false,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 11, y: 22, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder39 = device0.createCommandEncoder();
+let texture43 = device0.createTexture({size: [332], dimension: '1d', format: 'rgb10a2uint', usage: GPUTextureUsage.COPY_SRC});
+let texture44 = gpuCanvasContext1.getCurrentTexture();
+try {
+computePassEncoder1.setBindGroup(0, bindGroup0, new Uint32Array(312), 66, 0);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let bindGroup18 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 283, resource: {buffer: buffer4, offset: 0, size: 714}},
+    {binding: 13, resource: {buffer: buffer1, offset: 256, size: 7140}},
+    {binding: 49, resource: textureView28},
+    {binding: 41, resource: textureView18},
+    {binding: 125, resource: textureView22},
+    {binding: 39, resource: textureView20},
+    {binding: 26, resource: {buffer: buffer13, offset: 5888}},
+    {binding: 50, resource: {buffer: buffer27, offset: 0}},
+    {binding: 294, resource: textureView17},
+    {binding: 452, resource: textureView18},
+    {binding: 66, resource: {buffer: buffer11, offset: 0}},
+  ],
+});
+let buffer35 = device0.createBuffer({size: 8167, usage: GPUBufferUsage.MAP_WRITE});
+let commandEncoder40 = device0.createCommandEncoder({});
+let commandEncoder41 = device0.createCommandEncoder({});
+let computePassEncoder38 = commandEncoder41.beginComputePass();
+let promise5 = device0.queue.onSubmittedWorkDone();
+let shaderModule2 = device0.createShaderModule({
+  code: `
+enable f16;
+
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+requires unrestricted_pointer_parameters;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(3) var sam1: sampler;
+
+@group(0) @binding(25) var<storage, read_write> buffer36: array<array<array<f16, 37>, 1>, 48>;
+
+@group(0) @binding(32) var st4: texture_storage_1d<r32sint, read_write>;
+
+@group(0) @binding(88) var<storage, read_write> buffer37: atomic<i32>;
+
+@group(0) @binding(96) var st5: texture_storage_2d<rgba16sint, write>;
+
+@group(0) @binding(139) var tex8: texture_2d<u32>;
+
+@group(0) @binding(142) var tex9: texture_2d<i32>;
+
+@group(0) @binding(426) var<storage, read_write> buffer38: array<array<f16, 1>, 68>;
+
+@group(0) @binding(779) var<uniform> buffer39: mat3x4h;
+
+@group(1) @binding(35) var<storage, read_write> buffer40: array<atomic<u32>>;
+
+@group(1) @binding(60) var tex10: texture_2d<f32>;
+
+struct T0 {
+  @align(4) @size(584) f0: f16,
+}
+
+struct T1 {
+  @align(8) @size(584) f0: array<atomic<u32>>,
+}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4u,
+}
+
+alias vec3b = vec3<bool>;
+
+fn fn0() -> array<array<array<array<i32, 4>, 2>, 1>, 1> {
+  var out: array<array<array<array<i32, 4>, 2>, 1>, 1>;
+  let ptr31: ptr<workgroup, array<atomic<i32>, 1>> = &(*&vw8)[0][26];
+  atomicCompareExchangeWeak(&vw8[u32(workgroupUniformLoad(&vw12)[0][0][5])][u32(unconst_u32(68))][u32(unconst_u32(74))], unconst_i32(284), unconst_i32(139));
+  let ptr32: ptr<workgroup, i32> = &vw12[u32(unconst_u32(1))][0][5];
+  vw9[u32(unconst_u32(7))] -= f16(atomicExchange(&(*ptr31)[0], i32(unconst_i32(-28))));
+  let ptr33: ptr<storage, atomic<u32>, read_write> = &buffer40[u32(unconst_u32(128))];
+  vp2.f0 |= vec4u(vp1[0][u32(unconst_u32(20))].fract.gggr);
+  vw13.f0 *= vec4u(u32(atomicLoad(&(*ptr31)[u32(unconst_u32(203))])));
+  let ptr34: ptr<workgroup, array<i32, 6>> = &(*&vw12)[0][0];
+  atomicExchange(&vw14, i32(unconst_i32(20)));
+  textureStore(st4, i32(unconst_i32(-22)), vec4i(vec4i(unconst_i32(39), unconst_i32(743), unconst_i32(81), unconst_i32(350))));
+  atomicAdd(&buffer37, i32(unconst_i32(229)));
+  let ptr35: ptr<workgroup, atomic<i32>> = &(*&vw8)[u32(unconst_u32(57))][u32(unconst_u32(125))][0];
+  atomicOr(&buffer37, i32(unconst_i32(196)));
+  atomicCompareExchangeWeak(&vw11[u32(unconst_u32(146))], unconst_u32(95), unconst_u32(206));
+  var vf13: array<f16, 1> = workgroupUniformLoad(&vw9);
+  let ptr36: ptr<function, f16> = &vf13[u32(unconst_u32(42))];
+  let ptr37 = &vp1[0][u32(unconst_u32(26))];
+  atomicCompareExchangeWeak(&vw11[0], unconst_u32(38), unconst_u32(107));
+  return out;
+}
+
+fn fn1() -> vec4u {
+  var out: vec4u;
+  let vf14: vec4f = unpack4x8unorm(u32(unconst_u32(154)));
+  vp3 = FragmentOutput0(textureDimensions(tex10).ggrg);
+  let vf15: vec3f = log(vec3f(unconst_f32(0.02946), unconst_f32(0.1462), unconst_f32(0.1628)));
+  let ptr38 = &vp1[u32(unconst_u32(67))];
+  let ptr39: ptr<private, vec4u> = &vp3.f0;
+  let ptr40 = &vp1[u32(unconst_u32(153))][u32(unconst_u32(57))];
+  vp1[u32(unconst_u32(138))][u32(unconst_u32(22))].fract = vp1[u32(unconst_u32(160))][0].whole;
+  vp2 = FragmentOutput0(vec4u(buffer39[u32((*&buffer39)[unconst_i32(2)].y)]));
+  let ptr41: ptr<private, vec4u> = &vp3.f0;
+  let ptr42 = &vp1[0];
+  let ptr43 = &vp1[u32(unconst_u32(611))];
+  vp1[0][u32(unconst_u32(23))].whole -= bitcast<vec2h>(pack2x16snorm(vec2f(unconst_f32(0.2765), unconst_f32(0.03909))));
+  let ptr44 = &vp1[0];
+  vp1[u32(unconst_u32(159))][u32(unconst_u32(31))].fract = vec2h(textureGather(89 % 4, tex9, sam1, vec2f(unconst_f32(0.04408), unconst_f32(0.05757))).xz);
+  vp3.f0 &= vec4u(u32(length(vec2h(unconst_f16(-39502.4), unconst_f16(11119.7)))));
+  let ptr45: ptr<private, vec2h> = &(*ptr44)[0].whole;
+  let vf16: vec4u = textureGather(5 % 4, tex8, sam1, vec2f(unconst_f32(0.4753), unconst_f32(0.1324)), clamp(vec2i(164, 313), vec2i(-8), vec2i(7)));
+  return out;
+}
+
+var<workgroup> vw8: array<array<array<atomic<i32>, 1>, 27>, 1>;
+
+var<workgroup> vw9: array<f16, 1>;
+
+var<workgroup> vw10: atomic<u32>;
+
+var<workgroup> vw11: array<atomic<u32>, 1>;
+
+var<workgroup> vw12: array<array<array<i32, 6>, 1>, 1>;
+
+var<workgroup> vw13: FragmentOutput0;
+
+var<workgroup> vw14: atomic<i32>;
+
+var<workgroup> vw15: array<FragmentOutput0, 1>;
+
+var<private> vp1 = array(array(modf(vec2h(6737.1, 575.3))));
+
+var<private> vp2: FragmentOutput0 = FragmentOutput0();
+
+var<private> vp3: FragmentOutput0 = FragmentOutput0(vec4u(110, 182, 57, 82));
+
+@fragment
+fn fragment2() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  var vf17: u32 = textureNumLevels(tex9);
+  var vf18: u32 = vp3.f0[u32(unconst_u32(7))];
+  out.f0 = vec4u(vp1[0][dot4U8Packed(u32(unconst_u32(95)), u32(unconst_u32(157)))].whole.yxxy);
+  let ptr46: ptr<storage, f16, read_write> = &(*&buffer38)[u32(unconst_u32(111))][0];
+  textureStore(st4, i32(unconst_i32(347)), vec4i(vec4i(unconst_i32(6), unconst_i32(170), unconst_i32(2), unconst_i32(313))));
+  let ptr47: ptr<storage, array<f16, 1>, read_write> = &(*&buffer38)[u32(unconst_u32(78))];
+  vp3.f0 >>= vec4u((*&buffer39)[u32(unconst_u32(15))]);
+  textureStore(st5, vec2i(unconst_i32(38), unconst_i32(237)), vec4i(vec4i(unconst_i32(-325), unconst_i32(142), unconst_i32(102), unconst_i32(6))));
+  textureStore(st5, vec2i(unconst_i32(4), unconst_i32(306)), vec4i(vec4i(unconst_i32(332), unconst_i32(52), unconst_i32(83), unconst_i32(257))));
+  let ptr48: ptr<storage, f16, read_write> = &(*ptr47)[u32(unconst_u32(143))];
+  let ptr49: ptr<storage, array<f16, 1>, read_write> = &(*&buffer38)[67];
+  var vf19: u32 = atomicLoad(&(*&buffer40)[u32(unconst_u32(57))]);
+  let ptr50: ptr<storage, atomic<u32>, read_write> = &buffer40[u32(unconst_u32(229))];
+  atomicAdd(&buffer37, i32((*ptr46)));
+  let ptr51: ptr<storage, atomic<u32>, read_write> = &(*ptr50);
+  let ptr52: ptr<storage, f16, read_write> = &(*&buffer38)[67][u32(unconst_u32(166))];
+  vp1[vf17][u32(unconst_u32(51))] = modf(bitcast<vec2h>(textureDimensions(st4)));
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute2() {
+  buffer36[u32(unconst_u32(376))][bitcast<u32>(vw12[0][0][5])][u32(unconst_u32(272))] = f16(pack4xI8(vec4i(unconst_i32(110), unconst_i32(176), unconst_i32(593), unconst_i32(224))));
+  fn0();
+  var vf20 = fn0();
+  atomicCompareExchangeWeak(&buffer40[u32(atomicExchange(&vw8[0][26][u32(unconst_u32(332))], i32(unconst_i32(39))))], unconst_u32(7), unconst_u32(48));
+  let ptr53: ptr<function, i32> = &vf20[0][bitcast<u32>((*&vw12)[u32(unconst_u32(133))][bitcast<u32>(vf20[0][u32(unconst_u32(162))][u32(unconst_u32(139))][u32(unconst_u32(13))])][u32(unconst_u32(216))])][1][u32(unconst_u32(155))];
+  textureStore(st5, vec2i(unconst_i32(-136), unconst_i32(-2)), vec4i(vec4i(unconst_i32(9), unconst_i32(-58), unconst_i32(35), unconst_i32(-325))));
+  atomicCompareExchangeWeak(&buffer40[u32(unconst_u32(387))], unconst_u32(149), unconst_u32(42));
+  atomicXor(&vw14, i32(unconst_i32(6)));
+  textureStore(st4, i32(unconst_i32(-51)), vec4i(vec4i(unconst_i32(100), unconst_i32(698), unconst_i32(89), unconst_i32(57))));
+  atomicSub(&vw11[u32(unconst_u32(20))], u32(unconst_u32(239)));
+  vp3 = FragmentOutput0(vec4u(u32(buffer36[47][u32(unconst_u32(193))][u32(unconst_u32(505))])));
+  atomicOr(&buffer40[u32(unconst_u32(331))], u32(unconst_u32(134)));
+  let vf21: i32 = atomicExchange(&(*&vw8)[0][bitcast<u32>(atomicLoad(&(*&vw14)))][u32(unconst_u32(126))], atomicExchange(&vw14, i32(unconst_i32(2))));
+  vw15[u32(unconst_u32(66))] = FragmentOutput0(unpack4xU8(u32(vf20[u32(unconst_u32(111))][0][u32(unconst_u32(50))][3])));
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup19 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 362, resource: textureView36},
+    {binding: 267, resource: textureView23},
+    {binding: 87, resource: textureView34},
+    {binding: 194, resource: textureView18},
+  ],
+});
+let commandEncoder42 = device0.createCommandEncoder({});
+let texture45 = device0.createTexture({
+  size: {width: 120, height: 48, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView40 = texture15.createView({baseMipLevel: 0});
+let computePassEncoder39 = commandEncoder40.beginComputePass({});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], depthReadOnly: true});
+try {
+renderBundleEncoder6.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer34, 'uint16', 2_032, 2_872);
+} catch {}
+let arrayBuffer7 = buffer2.getMappedRange(352, 0);
+try {
+commandEncoder42.copyTextureToTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 0, y: 7, z: 12},
+  aspect: 'all',
+},
+{
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer23, 700, new Float32Array(16091), 1961, 256);
+} catch {}
+let commandEncoder43 = device0.createCommandEncoder();
+try {
+computePassEncoder33.setBindGroup(3, bindGroup16, [1792, 6400]);
+} catch {}
+try {
+renderBundleEncoder6.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder39.copyBufferToTexture({
+  /* bytesInLastRow: 96 widthInBlocks: 12 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 872 */
+  offset: 872,
+  bytesPerRow: 13824,
+  buffer: buffer34,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 8, y: 11, z: 0},
+  aspect: 'all',
+}, {width: 12, height: 21, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout5 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 65,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let textureView41 = texture35.createView({dimension: '2d', baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 3});
+let computePassEncoder40 = commandEncoder42.beginComputePass({});
+try {
+commandEncoder39.resolveQuerySet(querySet3, 27, 227, buffer9, 256);
+} catch {}
+let textureView42 = texture7.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder27.setBindGroup(3, bindGroup0, new Uint32Array(1816), 61, 0);
+} catch {}
+try {
+renderBundleEncoder6.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder39.resolveQuerySet(querySet6, 432, 227, buffer27, 256);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup20 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 267, resource: textureView23},
+    {binding: 87, resource: textureView37},
+    {binding: 362, resource: textureView36},
+    {binding: 194, resource: textureView28},
+  ],
+});
+let renderBundle6 = renderBundleEncoder6.finish({});
+try {
+computePassEncoder7.setBindGroup(0, bindGroup16, new Uint32Array(855), 5, 2);
+} catch {}
+try {
+computePassEncoder3.end();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer24, 228, new BigUint64Array(4741), 1015, 188);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let buffer41 = device0.createBuffer({
+  size: 6090,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView43 = texture13.createView({});
+let textureView44 = texture8.createView({dimension: '2d', baseMipLevel: 0, mipLevelCount: 1});
+let commandBuffer1 = commandEncoder6.finish();
+let texture46 = device0.createTexture({
+  label: '\u{1ff58}\u0c03\u9266\u0b38',
+  size: {width: 120, height: 48, depthOrArrayLayers: 1},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder41 = commandEncoder43.beginComputePass({});
+try {
+computePassEncoder19.setBindGroup(1, bindGroup15, [0, 512]);
+} catch {}
+let arrayBuffer8 = buffer2.getMappedRange(1488, 112);
+try {
+commandEncoder39.copyBufferToTexture({
+  /* bytesInLastRow: 24 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1120 */
+  offset: 1120,
+  buffer: buffer3,
+}, {
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer1]);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+try {
+computePassEncoder1.setBindGroup(0, bindGroup9, [1024, 0]);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+commandEncoder39.copyBufferToBuffer(buffer2, 2152, buffer41, 792, 236);
+} catch {}
+try {
+commandEncoder39.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1436 */
+  offset: 1436,
+  bytesPerRow: 3584,
+  buffer: buffer20,
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(736).fill(59), /* required buffer size: 736 */
+{offset: 736, rowsPerImage: 94}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 54, height: 141, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame8 = new VideoFrame(offscreenCanvas0, {timestamp: 0});
+try {
+texture41.label = '\u06c4\u088c\u{1fe21}\u{1faa0}\u0f5d\ue310';
+} catch {}
+let buffer42 = device0.createBuffer({
+  size: 1531,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture47 = device0.createTexture({
+  size: {width: 80, height: 78, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  sampleCount: 1,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+device0.queue.writeBuffer(buffer5, 72, new BigUint64Array(10545), 2088, 84);
+} catch {}
+let commandEncoder44 = device0.createCommandEncoder({});
+let texture48 = device0.createTexture({
+  label: '\u{1f740}\u07e3\u0081\u9b7e\ub400\u{1ffe7}\u{1f9f2}\u{1f85b}\u0584',
+  size: [80, 78, 39],
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+commandEncoder44.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let bindGroup21 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 49, resource: textureView28},
+    {binding: 26, resource: {buffer: buffer41, offset: 0, size: 1692}},
+    {binding: 41, resource: textureView18},
+    {binding: 13, resource: {buffer: buffer7, offset: 18432, size: 396}},
+    {binding: 66, resource: {buffer: buffer8, offset: 1536, size: 666}},
+    {binding: 283, resource: {buffer: buffer3, offset: 0, size: 4907}},
+    {binding: 294, resource: textureView40},
+    {binding: 125, resource: textureView19},
+    {binding: 39, resource: textureView20},
+    {binding: 452, resource: textureView18},
+    {binding: 50, resource: {buffer: buffer27, offset: 256, size: 428}},
+  ],
+});
+let commandEncoder45 = device0.createCommandEncoder({label: '\u{1f756}\u07eb\ua5ff\u8a03'});
+let texture49 = device0.createTexture({
+  size: {width: 20},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2uint'],
+});
+let computePassEncoder42 = commandEncoder45.beginComputePass({});
+let sampler22 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 20.66,
+  lodMaxClamp: 67.52,
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder22.setBindGroup(0, bindGroup6, [512, 512]);
+} catch {}
+try {
+computePassEncoder6.setBindGroup(2, bindGroup20, new Uint32Array(2339), 1_240, 0);
+} catch {}
+let arrayBuffer9 = buffer2.getMappedRange(1680, 244);
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 54, height: 141, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 1, y: 24 },
+  flipY: true,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 1, y: 43, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 3, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let imageData3 = new ImageData(68, 32);
+let texture50 = device0.createTexture({
+  size: [332, 1, 17],
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder43 = commandEncoder44.beginComputePass({});
+try {
+commandEncoder39.copyBufferToTexture({
+  /* bytesInLastRow: 28 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 940 */
+  offset: 940,
+  bytesPerRow: 60160,
+  buffer: buffer21,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(235).fill(97), /* required buffer size: 235 */
+{offset: 235, bytesPerRow: 29}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 54, height: 141, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 5, y: 18 },
+  flipY: false,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 45, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder46 = device0.createCommandEncoder({});
+let textureView45 = texture25.createView({
+  label: '\u{1fe9f}\u9961\u{1fcb0}\u0aca\u0d22\u{1fbe2}\ue4f5\u049c\u2e71',
+  dimension: '2d',
+  mipLevelCount: 1,
+  baseArrayLayer: 6,
+});
+let computePassEncoder44 = commandEncoder39.beginComputePass({});
+try {
+device0.queue.writeTexture({
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 4, y: 9, z: 0},
+  aspect: 'all',
+}, new Uint8Array(57).fill(125), /* required buffer size: 57 */
+{offset: 57, bytesPerRow: 11}, {width: 2, height: 42, depthOrArrayLayers: 0});
+} catch {}
+offscreenCanvas0.height = 1055;
+await gc();
+let offscreenCanvas2 = new OffscreenCanvas(95, 631);
+try {
+globalThis.someLabel = externalTexture0.label;
+} catch {}
+let bindGroupLayout6 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 302,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let buffer43 = device0.createBuffer({size: 13245, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+try {
+commandEncoder46.copyTextureToBuffer({
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 3, y: 5, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1128 */
+  offset: 1128,
+  bytesPerRow: 7936,
+  rowsPerImage: 299,
+  buffer: buffer5,
+}, {width: 5, height: 7, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder44.pushDebugGroup('\udbc1');
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+let buffer44 = device0.createBuffer({
+  size: 3990,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView46 = texture3.createView({dimension: '1d'});
+let sampler23 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 1.475,
+  lodMaxClamp: 62.55,
+});
+let computePassEncoder45 = commandEncoder46.beginComputePass({});
+try {
+computePassEncoder14.setBindGroup(3, bindGroup16, new Uint32Array(3025), 1_199, 2);
+} catch {}
+try {
+computePassEncoder44.popDebugGroup();
+} catch {}
+try {
+  await promise5;
+} catch {}
+let texture51 = device0.createTexture({size: [20, 19, 1], format: 'rgb10a2uint', usage: GPUTextureUsage.COPY_SRC});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint']});
+let sampler24 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 77.46,
+});
+try {
+renderBundleEncoder7.setPipeline(pipeline0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout7 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 236,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+try {
+renderBundleEncoder7.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(5, buffer26, 452);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+await gc();
+try {
+globalThis.someLabel = externalTexture0.label;
+} catch {}
+let textureView47 = texture40.createView({label: '\u2526\uc143\u{1f8ed}\u34b9\ub9c3\u0c71\u0d4d'});
+let sampler25 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 15.65,
+});
+try {
+computePassEncoder44.setBindGroup(3, bindGroup6, new Uint32Array(545), 114, 2);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(1, bindGroup10, new Uint32Array(2233), 75, 0);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(3, buffer11);
+} catch {}
+let shaderModule3 = device0.createShaderModule({
+  code: `
+enable f16;
+
+enable f16;
+
+enable f16;
+
+requires pointer_composite_access;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(3) var sam2: sampler;
+
+@group(0) @binding(16) var<storage, read_write> buffer45: array<array<array<array<array<array<array<array<f16, 1>, 1>, 11>, 1>, 1>, 8>, 40>>;
+
+@group(0) @binding(25) var<storage, read_write> buffer46: array<array<array<array<f16, 37>, 1>, 2>, 24>;
+
+@group(0) @binding(32) var st6: texture_storage_1d<r32sint, read_write>;
+
+@group(0) @binding(96) var st7: texture_storage_2d<rgba16sint, write>;
+
+@group(0) @binding(139) var tex11: texture_2d<u32>;
+
+@group(0) @binding(142) var tex12: texture_2d<i32>;
+
+@group(0) @binding(779) var<uniform> buffer49: mat3x3h;
+
+@group(1) @binding(60) var tex14: texture_2d<f32>;
+
+struct T0 {
+  f0: vec4f,
+  @size(568) f1: array<array<mat2x4h, 1>, 1>,
+}
+
+struct VertexOutput2 {
+  @builtin(position) f6: vec4f,
+}
+
+override override1: f16 = 4042.3;
+
+fn fn0() -> VertexOutput2 {
+  var out: VertexOutput2;
+  let ptr54: ptr<storage, f16, read_write> = &buffer45[arrayLength(&buffer45)][39][u32(unconst_u32(26))][u32(unconst_u32(196))][0][10][0][u32(unconst_u32(303))];
+  let ptr55: ptr<storage, f16, read_write> = &(*&buffer45)[u32(unconst_u32(1000))][u32(unconst_u32(3))][u32(unconst_u32(635))][u32(unconst_u32(70))][u32(buffer45[u32((*&buffer45)[arrayLength(&(*&buffer45))][39][u32(unconst_u32(40))][0][0][10][0][0])][u32((*&buffer45)[u32(unconst_u32(192))][39][u32(unconst_u32(161))][0][0][10][0][u32(buffer45[u32(unconst_u32(163))][u32(unconst_u32(203))][u32(buffer45[u32(unconst_u32(44))][39][7][0][u32(unconst_u32(183))][10][u32(unconst_u32(143))][0])][0][u32(unconst_u32(155))][10][u32(unconst_u32(16))][0])])][7][0][0][u32(unconst_u32(234))][0][u32(unconst_u32(165))])][10][0][u32(unconst_u32(54))];
+  let ptr56: ptr<storage, f16, read_write> = &(*&buffer45)[arrayLength(&(*&buffer45))][39][7][u32(unconst_u32(48))][0][u32(unconst_u32(40))][0][u32(unconst_u32(346))];
+  let ptr57: ptr<storage, array<array<f16, 1>, 1>, read_write> = &buffer45[u32(unconst_u32(76))][39][7][u32(unconst_u32(44))][u32(unconst_u32(272))][u32(unconst_u32(17))];
+  let ptr58: ptr<storage, array<array<f16, 1>, 1>, read_write> = &buffer45[u32(unconst_u32(3))][39][7][u32(unconst_u32(95))][u32((*&buffer45)[u32(unconst_u32(184))][u32((*&buffer45)[u32(unconst_u32(280))][u32(unconst_u32(249))][u32(unconst_u32(523))][u32(unconst_u32(291))][u32(unconst_u32(159))][10][0][0])][u32(unconst_u32(132))][u32(unconst_u32(1))][0][u32(unconst_u32(382))][u32(unconst_u32(204))][u32(unconst_u32(184))])][u32(unconst_u32(137))];
+  buffer45[u32(unconst_u32(1))][u32(unconst_u32(17))][u32(unconst_u32(148))][u32(unconst_u32(312))][u32(buffer45[u32(unconst_u32(215))][u32(unconst_u32(716))][7][0][0][10][0][u32(unconst_u32(213))])][u32(unconst_u32(72))][u32((*&buffer45)[arrayLength(&(*&buffer45))][u32((*&buffer45)[arrayLength(&(*&buffer45))][39][7][u32(unconst_u32(71))][u32(unconst_u32(99))][u32(unconst_u32(121))][u32(unconst_u32(134))][0])][7][u32(unconst_u32(4))][u32(unconst_u32(100))][10][0][u32(unconst_u32(80))])][u32(unconst_u32(180))] = buffer45[u32(unconst_u32(115))][39][7][0][u32(unconst_u32(110))][10][u32(unconst_u32(432))][u32(unconst_u32(248))];
+  let ptr59: ptr<storage, array<f16, 1>, read_write> = &(*&buffer45)[arrayLength(&(*&buffer45))][u32(unconst_u32(131))][u32((*ptr57)[u32(unconst_u32(36))][0])][0][u32(buffer45[arrayLength(&buffer45)][u32(unconst_u32(33))][7][0][0][10][0][0])][10][0];
+  out.f6 += vec4f(f32((*&buffer45)[u32(unconst_u32(311))][39][7][u32(unconst_u32(607))][u32(unconst_u32(128))][u32(unconst_u32(30))][0][0]));
+  buffer45[u32(unconst_u32(387))][u32(unconst_u32(242))][u32(unconst_u32(392))][u32(unconst_u32(106))][u32(unconst_u32(173))][u32(unconst_u32(163))][0][u32(unconst_u32(83))] = (*&buffer45)[u32(unconst_u32(555))][u32(unconst_u32(92))][7][u32(unconst_u32(63))][u32(unconst_u32(124))][10][0][0];
+  let ptr60: ptr<storage, array<array<f16, 1>, 1>, read_write> = &(*&buffer45)[arrayLength(&(*&buffer45))][39][u32(unconst_u32(197))][u32(unconst_u32(198))][u32(unconst_u32(45))][10];
+  let ptr61: ptr<storage, f16, read_write> = &(*&buffer45)[arrayLength(&(*&buffer45))][39][u32(unconst_u32(19))][u32(unconst_u32(6))][0][u32(unconst_u32(17))][u32(unconst_u32(10))][u32(unconst_u32(496))];
+  let ptr62: ptr<storage, f16, read_write> = &(*&buffer45)[u32(unconst_u32(239))][39][7][u32(unconst_u32(5))][0][10][0][0];
+  textureStore(st7, vec2i(unconst_i32(197), unconst_i32(101)), vec4i(vec4i(unconst_i32(100), unconst_i32(-247), unconst_i32(42), unconst_i32(218))));
+  let ptr63: ptr<storage, f16, read_write> = &(*&buffer45)[arrayLength(&(*&buffer45))][39][7][u32(unconst_u32(4))][0][u32(unconst_u32(217))][u32(unconst_u32(21))][0];
+  return out;
+}
+
+fn fn1() -> array<array<VertexOutput2, 5>, 1> {
+  var out: array<array<VertexOutput2, 5>, 1>;
+  let ptr64: ptr<storage, f16, read_write> = &(*&buffer45)[arrayLength(&(*&buffer45))][u32(unconst_u32(2))][7][u32(unconst_u32(27))][u32(unconst_u32(84))][10][u32(unconst_u32(28))][0];
+  var vf22 = fn0();
+  vf22 = VertexOutput2(vec4f(f32(buffer45[arrayLength(&buffer45)][u32(unconst_u32(242))][u32(unconst_u32(300))][0][u32(unconst_u32(122))][10][0][0])));
+  fn0();
+  atomicStore(&vw18[0][u32(unconst_u32(24))], u32(unconst_u32(271)));
+  vf22 = VertexOutput2(vec4f(f32((*&buffer46)[u32(unconst_u32(482))][1][0][36])));
+  let ptr65: ptr<storage, f16, read_write> = &(*&buffer45)[u32(unconst_u32(180))][39][7][u32(unconst_u32(66))][u32(unconst_u32(149))][u32(unconst_u32(56))][0][0];
+  vp4 = modf(f32((*&buffer45)[u32(unconst_u32(122))][u32(unconst_u32(58))][7][u32(unconst_u32(175))][0][10][0][0]));
+  buffer46[u32(unconst_u32(160))][u32(unconst_u32(138))][u32(unconst_u32(64))][u32(unconst_u32(58))] = buffer45[arrayLength(&buffer45)][39][u32(unconst_u32(7))][u32(unconst_u32(113))][0][10][0][u32(unconst_u32(375))];
+  textureStore(st6, i32(unconst_i32(-100)), vec4i(vec4i(unconst_i32(175), unconst_i32(192), unconst_i32(140), unconst_i32(152))));
+  var vf23 = fn0();
+  atomicMax(&vw18[u32(buffer45[arrayLength(&buffer45)][39][7][u32(unconst_u32(15))][0][10][0][0])][u32(unconst_u32(65))], u32(unconst_u32(16)));
+  var vf24 = fn0();
+  var vf25 = fn0();
+  return out;
+}
+
+var<workgroup> vw16: VertexOutput2;
+
+var<workgroup> vw17: VertexOutput2;
+
+var<workgroup> vw18: array<array<atomic<u32>, 14>, 1>;
+
+var<private> vp4 = modf(f32(0.07645));
+
+@vertex
+fn vertex3() -> VertexOutput2 {
+  var out: VertexOutput2;
+  out = VertexOutput2(cross(vec3f(unconst_f32(0.1026), unconst_f32(0.01853), unconst_f32(0.4498)), vec3f(unconst_f32(0.02201), unconst_f32(0.2930), unconst_f32(0.08203))).rgbr);
+  return out;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder47 = device0.createCommandEncoder({});
+let textureView48 = texture10.createView({aspect: 'all', arrayLayerCount: 1});
+let computePassEncoder46 = commandEncoder47.beginComputePass();
+let externalTexture4 = device0.importExternalTexture({source: videoFrame4});
+try {
+computePassEncoder20.setBindGroup(2, bindGroup1, new Uint32Array(1859), 186, 0);
+} catch {}
+let bindGroupLayout8 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 59,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+let textureView49 = texture10.createView({});
+let renderBundle7 = renderBundleEncoder7.finish({});
+let externalTexture5 = device0.importExternalTexture({source: videoFrame3, colorSpace: 'display-p3'});
+try {
+offscreenCanvas2.getContext('webgl2');
+} catch {}
+let commandEncoder48 = device0.createCommandEncoder({});
+let computePassEncoder47 = commandEncoder48.beginComputePass();
+try {
+computePassEncoder0.setBindGroup(0, bindGroup15, [256, 1280]);
+} catch {}
+try {
+computePassEncoder19.setBindGroup(2, bindGroup2, new Uint32Array(273), 163, 0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder49 = device0.createCommandEncoder({});
+let texture52 = device0.createTexture({
+  size: [15, 6, 6],
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder48 = commandEncoder49.beginComputePass({});
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 54, height: 141, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 20, y: 4, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout9 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 37,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder50 = device0.createCommandEncoder({});
+let texture53 = gpuCanvasContext0.getCurrentTexture();
+let computePassEncoder49 = commandEncoder50.beginComputePass({});
+let sampler26 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 82.65,
+  lodMaxClamp: 97.54,
+});
+try {
+computePassEncoder39.setBindGroup(1, bindGroup19, new Uint32Array(8001), 4_174, 0);
+} catch {}
+await gc();
+let canvas0 = document.createElement('canvas');
+try {
+computePassEncoder12.setBindGroup(0, bindGroup4, new Uint32Array(624), 290, 2);
+} catch {}
+try {
+buffer20.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 54, height: 141, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 30, y: 25, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext2 = canvas0.getContext('webgpu');
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+document.body.append(canvas0);
+let texture54 = device0.createTexture({
+  size: {width: 40, height: 39, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView50 = texture15.createView({aspect: 'all', baseArrayLayer: 0});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({colorFormats: ['r16uint'], depthStencilFormat: 'depth16unorm', depthReadOnly: false});
+let buffer51 = device0.createBuffer({size: 8508, usage: GPUBufferUsage.UNIFORM});
+let commandEncoder51 = device0.createCommandEncoder({label: '\u078a\u1945\u{1fc9e}\u7182\u0bc1\u{1f7fc}\u09f3\u2d8c\u0186\uafe6\u{1fefe}'});
+let textureView51 = texture21.createView({label: '\u2ba8\ub3bd\u0d01\ua11a\u{1fb0e}\ue9cd\u{1f61b}\u0aac\u0e14', mipLevelCount: 1});
+let renderBundle8 = renderBundleEncoder8.finish({});
+try {
+computePassEncoder48.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+computePassEncoder1.setBindGroup(1, bindGroup4, new Uint32Array(1842), 128, 2);
+} catch {}
+offscreenCanvas2.width = 228;
+let bindGroup22 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 59, resource: sampler18}]});
+let computePassEncoder50 = commandEncoder51.beginComputePass({});
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 54, height: 141, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData0,
+  origin: { x: 0, y: 1 },
+  flipY: false,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 6, y: 8, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 24, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout10 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 187,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 82,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer52 = device0.createBuffer({
+  size: 3280,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder52 = device0.createCommandEncoder({});
+let textureView52 = texture20.createView({});
+let texture55 = device0.createTexture({
+  size: {width: 332, height: 1, depthOrArrayLayers: 59},
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView53 = texture49.createView({aspect: 'all'});
+let computePassEncoder51 = commandEncoder52.beginComputePass();
+try {
+computePassEncoder10.setBindGroup(3, bindGroup17, new Uint32Array(8), 0, 2);
+} catch {}
+let buffer53 = device0.createBuffer({size: 4652, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture56 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 13},
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder19.setBindGroup(2, bindGroup20);
+} catch {}
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], depthReadOnly: true});
+let renderBundle9 = renderBundleEncoder9.finish({});
+try {
+computePassEncoder45.setBindGroup(2, bindGroup6, new Uint32Array(594), 190, 2);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 988, new Float32Array(5315), 170, 212);
+} catch {}
+let buffer54 = device0.createBuffer({
+  size: 9015,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let sampler27 = device0.createSampler({
+  label: '\u07b4\u{1f6ab}\ud92c',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 3.957,
+  lodMaxClamp: 76.80,
+  maxAnisotropy: 2,
+});
+let externalTexture6 = device0.importExternalTexture({source: videoFrame3});
+try {
+device0.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+}, new Uint8Array(25_152).fill(226), /* required buffer size: 25_152 */
+{offset: 72, bytesPerRow: 88, rowsPerImage: 95}, {width: 16, height: 0, depthOrArrayLayers: 4});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let texture57 = device0.createTexture({
+  label: '\ue69d\u0c9f\u0429\u15cd\u634e\u0207\ub45c\u{1fbe8}\uac24',
+  size: [332, 1, 8],
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let externalTexture7 = device0.importExternalTexture({source: videoFrame3});
+try {
+computePassEncoder15.setBindGroup(3, bindGroup22, new Uint32Array(586), 52, 0);
+} catch {}
+let commandEncoder53 = device0.createCommandEncoder({});
+let computePassEncoder52 = commandEncoder53.beginComputePass({});
+let sampler28 = device0.createSampler({
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 27.07,
+  lodMaxClamp: 68.83,
+  compare: 'equal',
+  maxAnisotropy: 7,
+});
+let externalTexture8 = device0.importExternalTexture({source: videoFrame4, colorSpace: 'display-p3'});
+try {
+computePassEncoder21.setBindGroup(1, bindGroup1, new Uint32Array(14), 0, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise6 = device0.queue.onSubmittedWorkDone();
+let texture58 = device0.createTexture({
+  label: '\u0038\u{1f9dc}\u1ddf\u079f\u043a\u{1f85c}',
+  size: [120, 48, 24],
+  mipLevelCount: 2,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let bindGroup23 = device0.createBindGroup({layout: bindGroupLayout5, entries: [{binding: 65, resource: textureView9}]});
+let pipelineLayout3 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout2]});
+let buffer55 = device0.createBuffer({
+  size: 3315,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder54 = device0.createCommandEncoder({});
+let querySet7 = device0.createQuerySet({type: 'occlusion', count: 369});
+let computePassEncoder53 = commandEncoder54.beginComputePass();
+try {
+computePassEncoder30.setBindGroup(0, bindGroup11, [4096, 0]);
+} catch {}
+let imageData4 = new ImageData(20, 88);
+let videoFrame9 = new VideoFrame(videoFrame5, {timestamp: 0});
+let buffer56 = device0.createBuffer({
+  size: 10444,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture59 = device0.createTexture({
+  label: '\uf06c\u61da\u{1fb27}\u8619\uf7a2\u4394\u2865\u8c59\u{1f714}\u3cde\u{1f90f}',
+  size: [332, 1, 67],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+computePassEncoder8.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+computePassEncoder43.setBindGroup(0, bindGroup5, new Uint32Array(2003), 937, 2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer56, 156, new DataView(new ArrayBuffer(3501)), 343, 828);
+} catch {}
+let textureView54 = texture12.createView({dimension: '2d', baseArrayLayer: 5});
+let textureView55 = texture55.createView({dimension: '2d', baseMipLevel: 0, mipLevelCount: 1, arrayLayerCount: 1});
+try {
+computePassEncoder14.setBindGroup(0, bindGroup6, new Uint32Array(4202), 50, 2);
+} catch {}
+let texture60 = device0.createTexture({
+  size: [30, 12, 23],
+  dimension: '2d',
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 54, height: 141, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData3,
+  origin: { x: 5, y: 0 },
+  flipY: true,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 11, y: 13, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 7, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer12, 892, new Float32Array(34953), 11474, 188);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder55 = device0.createCommandEncoder();
+let texture61 = device0.createTexture({
+  size: {width: 120, height: 48, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder54 = commandEncoder55.beginComputePass();
+let sampler29 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 30.85,
+});
+try {
+computePassEncoder50.setBindGroup(3, bindGroup6, new Uint32Array(1309), 131, 2);
+} catch {}
+let bindGroup24 = device0.createBindGroup({
+  layout: bindGroupLayout10,
+  entries: [
+    {binding: 187, resource: textureView45},
+    {binding: 82, resource: {buffer: buffer23, offset: 9728, size: 3808}},
+  ],
+});
+let buffer57 = device0.createBuffer({size: 38048, usage: GPUBufferUsage.UNIFORM});
+let texture62 = device0.createTexture({size: [60], dimension: '1d', format: 'r16uint', usage: GPUTextureUsage.COPY_SRC, viewFormats: []});
+let sampler30 = device0.createSampler({addressModeW: 'mirror-repeat', mipmapFilter: 'linear', lodMinClamp: 24.91});
+try {
+computePassEncoder22.setBindGroup(2, bindGroup11, [1024, 0]);
+} catch {}
+try {
+  await shaderModule1.getCompilationInfo();
+} catch {}
+try {
+buffer9.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let commandEncoder56 = device0.createCommandEncoder({});
+let texture63 = device0.createTexture({size: [665, 1, 1], sampleCount: 1, format: 'depth16unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+try {
+computePassEncoder9.setBindGroup(3, bindGroup11, [2816, 1024]);
+} catch {}
+let pipelineLayout4 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder57 = device0.createCommandEncoder();
+let texture64 = device0.createTexture({
+  size: {width: 332, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  dimension: '2d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView56 = texture61.createView({dimension: '2d-array', aspect: 'depth-only', mipLevelCount: 1});
+try {
+computePassEncoder4.setBindGroup(3, bindGroup17, [4608, 512]);
+} catch {}
+try {
+computePassEncoder29.setBindGroup(1, bindGroup24, new Uint32Array(3159), 159, 0);
+} catch {}
+try {
+commandEncoder56.copyTextureToTexture({
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 6, y: 33, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup25 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 35, resource: {buffer: buffer43, offset: 2816, size: 1572}},
+    {binding: 60, resource: textureView45},
+  ],
+});
+let commandEncoder58 = device0.createCommandEncoder();
+let computePassEncoder55 = commandEncoder56.beginComputePass({label: '\u03ac\u{1ffd4}\u0462\u{1fa2f}\u05da\u9fa7'});
+let sampler31 = device0.createSampler({
+  label: '\u360e\u0fec\u09d4\u9306\u43ce\ue370\u7c59\u{1fe6a}\u0903\u9e59',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 30.53,
+  lodMaxClamp: 77.65,
+});
+try {
+computePassEncoder52.setBindGroup(0, bindGroup19);
+} catch {}
+try {
+commandEncoder58.copyBufferToBuffer(buffer20, 992, buffer9, 1324, 376);
+} catch {}
+let bindGroup26 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 35, resource: {buffer: buffer3, offset: 512, size: 4792}},
+    {binding: 60, resource: textureView28},
+  ],
+});
+let computePassEncoder56 = commandEncoder57.beginComputePass({});
+try {
+computePassEncoder40.setBindGroup(0, bindGroup19, new Uint32Array(996), 270, 0);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let shaderModule4 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires pointer_composite_access;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(232) var<storage, read> buffer58: u32;
+
+struct T0 {
+  @align(16) @size(80) f0: array<u32>,
+}
+
+struct T1 {
+  @align(16) @size(80) f0: array<array<atomic<u32>, 3>>,
+}
+
+struct VertexOutput3 {
+  @location(5) @interpolate(flat, sample) f7: u32,
+  @location(0) f8: vec2h,
+  @invariant @builtin(position) f9: vec4f,
+  @location(1) @interpolate(flat, sample) f10: f16,
+  @location(4) f11: vec2i,
+}
+
+struct FragmentOutput1 {
+  @location(0) f0: vec2u,
+  @location(4) @interpolate(perspective, centroid) f1: f32,
+}
+
+fn fn0() -> mat2x3f {
+  var out: mat2x3f;
+  let ptr66: ptr<private, f32> = &vp6.fract;
+  var vf26: vec4i = extractBits(vec4i(unconst_i32(133), unconst_i32(672), unconst_i32(-226), unconst_i32(180)), u32(unconst_u32(9)), u32(unconst_u32(69)));
+  var vf27: vec2f = unpack2x16snorm(u32(unconst_u32(71)));
+  vf27 = tan(vec4f(unconst_f32(0.00441), unconst_f32(0.01969), unconst_f32(0.01880), unconst_f32(0.03303))).zw;
+  out = mat2x3f(vec3f(vp5.fract), vec3f(vp5.fract));
+  let vf28: vec4h = atan(vec4h(unconst_f16(16922.1), unconst_f16(-4553.6), unconst_f16(338.8), unconst_f16(4059.0)));
+  vf26 ^= vec4i(atan(vec4h(unconst_f16(8620.0), unconst_f16(37322.2), unconst_f16(28715.7), unconst_f16(141.4))));
+  var vf29: vec4i = extractBits(vec4i(unconst_i32(114), unconst_i32(177), unconst_i32(745), unconst_i32(388)), u32(unconst_u32(179)), u32(unconst_u32(104)));
+  let ptr67 = &vp6;
+  vf26 = vec4i(bitcast<i32>(vp6.fract));
+  let ptr68: ptr<private, f32> = &vp6.whole;
+  var vf30: i32 = vf26[u32(unconst_u32(51))];
+  let vf31: i32 = vf29[u32(unconst_u32(127))];
+  let ptr69: ptr<storage, u32, read> = &(*&buffer58);
+  let ptr70 = &(*ptr67);
+  let ptr71: ptr<private, f32> = &(*ptr70).fract;
+  vf27 *= vec2f(vp6.whole);
+  let ptr72: ptr<storage, u32, read> = &buffer58;
+  let ptr73: ptr<storage, u32, read> = &(*ptr69);
+  vf30 -= bitcast<i32>(vp6.whole);
+  let ptr74: ptr<function, vec2f> = &vf27;
+  vf29 |= vec4i(vf28);
+  vf27 += vec2f(bitcast<f32>((*&buffer58)));
+  vf27 *= bitcast<vec2f>(vf28);
+  return out;
+}
+
+fn fn1() -> VertexOutput3 {
+  var out: VertexOutput3;
+  let ptr75: ptr<private, vec3h> = &vp5.fract;
+  let vf32: vec4f = log2(vec4f(unconst_f32(0.05985), unconst_f32(0.05512), unconst_f32(0.4481), unconst_f32(0.06873)));
+  let ptr76: ptr<private, vec3h> = &(*ptr75);
+  let vf33: vec4u = firstLeadingBit(vec4u(unconst_u32(110), unconst_u32(278), unconst_u32(214), unconst_u32(188)));
+  let vf34: f16 = (*ptr76)[u32(unconst_u32(266))];
+  out.f8 = bitcast<vec2h>(vf33[u32(unconst_u32(50))]);
+  return out;
+}
+
+var<workgroup> vw19: VertexOutput3;
+
+var<private> vp5 = modf(vec3h(835.7, 21864.6, 205.9));
+
+var<private> vp6 = modf(f32(0.09570));
+
+@vertex
+fn vertex4(@location(1) a0: u32) -> VertexOutput3 {
+  var out: VertexOutput3;
+  out.f11 ^= vec2i(bitcast<i32>(vp6.whole));
+  var vf35 = fn0();
+  var vf36 = fn0();
+  out.f11 *= vec2i(i32((*&buffer58)));
+  var vf37 = fn0();
+  out.f8 = vec2h(unpack2x16unorm(u32(unconst_u32(204))));
+  vf36 = mat2x3f(f32(distance(vec4h(unconst_f16(6240.2), unconst_f16(14996.4), unconst_f16(15534.4), unconst_f16(4871.7)), vec4h(unconst_f16(13347.5), unconst_f16(9277.8), unconst_f16(-14452.8), unconst_f16(9973.0)))), f32(distance(vec4h(unconst_f16(6240.2), unconst_f16(14996.4), unconst_f16(15534.4), unconst_f16(4871.7)), vec4h(unconst_f16(13347.5), unconst_f16(9277.8), unconst_f16(-14452.8), unconst_f16(9973.0)))), f32(distance(vec4h(unconst_f16(6240.2), unconst_f16(14996.4), unconst_f16(15534.4), unconst_f16(4871.7)), vec4h(unconst_f16(13347.5), unconst_f16(9277.8), unconst_f16(-14452.8), unconst_f16(9973.0)))), f32(distance(vec4h(unconst_f16(6240.2), unconst_f16(14996.4), unconst_f16(15534.4), unconst_f16(4871.7)), vec4h(unconst_f16(13347.5), unconst_f16(9277.8), unconst_f16(-14452.8), unconst_f16(9973.0)))), f32(distance(vec4h(unconst_f16(6240.2), unconst_f16(14996.4), unconst_f16(15534.4), unconst_f16(4871.7)), vec4h(unconst_f16(13347.5), unconst_f16(9277.8), unconst_f16(-14452.8), unconst_f16(9973.0)))), f32(distance(vec4h(unconst_f16(6240.2), unconst_f16(14996.4), unconst_f16(15534.4), unconst_f16(4871.7)), vec4h(unconst_f16(13347.5), unconst_f16(9277.8), unconst_f16(-14452.8), unconst_f16(9973.0)))));
+  let vf38: vec3f = vf35[u32(unconst_u32(219))];
+  return out;
+}
+
+@fragment
+fn fragment3() -> FragmentOutput1 {
+  var out: FragmentOutput1;
+  var vf39 = fn1();
+  var vf40 = fn1();
+  let vf41: u32 = pack4xI8Clamp(vec4i(unconst_i32(10), unconst_i32(-16), unconst_i32(230), unconst_i32(96)));
+  vp5.fract = vec3h(f16(pack4x8unorm(vec4f(unconst_f32(0.6039), unconst_f32(0.09183), unconst_f32(0.1738), unconst_f32(0.09341)))));
+  vp6 = modf(normalize(vec2f(unconst_f32(0.4338), unconst_f32(0.2493))).r);
+  let vf42: u32 = vf41;
+  out.f1 = bitcast<f32>(vf40.f7);
+  var vf43: i32 = vf40.f11[u32(unconst_u32(89))];
+  vf39.f8 *= vec2h(min(vec2u(bitcast<u32>(cosh(f32(unconst_f32(0.4937))))), vec2u(unconst_u32(29), unconst_u32(9))));
+  out.f0 >>= vec2u(bitcast<u32>(vf39.f9[u32(unconst_u32(304))]));
+  out.f1 = bitcast<vec2f>(vf40.f11)[0];
+  var vf44 = fn1();
+  var vf45 = fn1();
+  fn1();
+  var vf46 = fn1();
+  vf44.f8 += vec2h(unpack2x16unorm(u32(unconst_u32(18))));
+  let ptr77: ptr<function, u32> = &vf46.f7;
+  let ptr78: ptr<function, vec2i> = &vf44.f11;
+  return out;
+}
+
+@compute @workgroup_size(2, 1, 1)
+fn compute3() {
+  vp6.whole += (*&vw19).f9[3];
+  vp6 = modf(vw19.f9.w);
+  vp5.fract = vp5.fract;
+  let ptr79: ptr<workgroup, vec2h> = &(*&vw19).f8;
+  fn1();
+  fn1();
+  let vf47: f16 = (*&vw19).f8[u32(unconst_u32(193))];
+  vp5 = modf(vw19.f8.xyx);
+  fn0();
+  var vf48 = fn0();
+  fn1();
+  fn0();
+  vp5 = modf(vec3h(cos(f16(unconst_f16(7166.9)))));
+  vf48 = mat2x3f(workgroupUniformLoad(&vw19).f9.www, workgroupUniformLoad(&vw19).f9.bbr);
+  vp6.whole -= f32(vw19.f7);
+  fn0();
+  let ptr80: ptr<workgroup, u32> = &vw19.f7;
+  vp6 = modf(f32(vp5.whole.b));
+}`,
+  hints: {},
+});
+let texture65 = gpuCanvasContext2.getCurrentTexture();
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+let bindGroup27 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 236, resource: sampler29}]});
+let texture66 = device0.createTexture({
+  size: {width: 20, height: 19, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let computePassEncoder57 = commandEncoder58.beginComputePass();
+let sampler32 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 40.73,
+  lodMaxClamp: 60.06,
+  compare: 'greater-equal',
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder34.setBindGroup(0, bindGroup25, new Uint32Array(1280), 18, 0);
+} catch {}
+let buffer59 = device0.createBuffer({size: 1663, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let commandEncoder59 = device0.createCommandEncoder({});
+let texture67 = device0.createTexture({
+  size: [332, 1, 14],
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder58 = commandEncoder59.beginComputePass({});
+try {
+computePassEncoder47.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 54, height: 141, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 3, y: 31 },
+  flipY: true,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 16, y: 40, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 36, depthOrArrayLayers: 0});
+} catch {}
+let buffer60 = device0.createBuffer({size: 1551, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture68 = device0.createTexture({
+  label: '\u091b\u{1f678}\uc475\u{1fbe6}\u281a\u0731\u11fc\u{1fbbd}\u80d9\u801b\u{1f741}',
+  size: {width: 15},
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView57 = texture20.createView({format: 'rgb10a2uint'});
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let buffer61 = device0.createBuffer({
+  size: 26413,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let texture69 = device0.createTexture({
+  size: {width: 20, height: 19, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let shaderModule5 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(83) var<storage, read_write> buffer62: array<array<array<array<array<array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>, 1>, 10>, 1>, 4>>;
+
+@group(0) @binding(232) var<storage, read> buffer63: array<u32>;
+
+struct T0 {
+  @align(16) @size(80) f0: mat2x4h,
+}
+
+struct T1 {
+  @align(4) @size(4) f0: array<array<f16, 1>, 1>,
+}
+
+struct VertexOutput4 {
+  @builtin(position) f12: vec4f,
+}
+
+struct VertexOutput5 {
+  @location(15) @interpolate(flat) f13: vec2u,
+  @builtin(position) f14: vec4f,
+  @location(7) @interpolate(linear) f15: vec2h,
+  @location(13) @interpolate(flat, centroid) f16: vec2f,
+}
+
+alias vec3b = vec3<bool>;
+
+@id(49258) override override2: u32;
+
+fn fn0() -> T1 {
+  var out: T1;
+  let ptr81: ptr<workgroup, VertexOutput4> = &(*&vw22);
+  let ptr82: ptr<private, vec4f> = &vp9.f12;
+  let ptr83: ptr<workgroup, vec4f> = &vw22.f12;
+  vw22.f12 = vec4f(f32(vp7[44].fract));
+  let ptr84: ptr<private, vec2h> = &vp10[pack4x8snorm((*&vw22).f12)].whole;
+  let ptr85: ptr<private, f16> = &vp11.f0[u32(unconst_u32(55))][0];
+  vp15 = mat2x3h(f16((*ptr81).f12[u32(unconst_u32(107))]), f16((*ptr81).f12[u32(unconst_u32(107))]), f16((*ptr81).f12[u32(unconst_u32(107))]), f16((*ptr81).f12[u32(unconst_u32(107))]), f16((*ptr81).f12[u32(unconst_u32(107))]), f16((*ptr81).f12[u32(unconst_u32(107))]));
+  let vf49: u32 = vp8.f13[u32(unconst_u32(54))];
+  vp9 = VertexOutput4(vec4f(bitcast<f32>(buffer63[arrayLength(&buffer63) - 1])));
+  return out;
+}
+
+fn fn1() -> T1 {
+  var out: T1;
+  let ptr86 = &vp7[44];
+  vp7[u32(unconst_u32(36))].whole += f16(vp8.f14[u32(unconst_u32(44))]);
+  let ptr87: ptr<private, vec2h> = &vp8.f15;
+  out.f0[u32(unconst_u32(444))][u32(unconst_u32(159))] += f16(dot4U8Packed(u32(unconst_u32(38)), u32(unconst_u32(59))));
+  vp15 = mat2x3h(vp12.f0[u32(unconst_u32(3))].zzx, vp12.f0[u32(unconst_u32(3))].wyy);
+  vp11 = T1(array<array<f16, 1>, 1>(array<f16, 1>(vp10[0].fract[0])));
+  vp11 = T1(array<array<f16, 1>, 1>(array<f16, 1>(f16(vp13[0].whole.y))));
+  let ptr88: ptr<private, f16> = &vp7[u32(unconst_u32(109))].whole;
+  let ptr89: ptr<private, vec2f> = &vp13[u32(unconst_u32(64))].whole;
+  let ptr90 = &vp7[u32(unconst_u32(162))];
+  let ptr91: ptr<private, f16> = &vp7[44].whole;
+  vp9.f12 = vec4f(f32(override2));
+  vp13[u32(unconst_u32(51))].whole += vec2f(f32(vp11.f0[0][0]));
+  let vf50: u32 = pack4xU8Clamp(bitcast<vec4u>(vp9.f12));
+  let ptr92: ptr<private, mat2x3h> = &vp15;
+  let ptr93: ptr<private, array<f16, 1>> = &vp11.f0[u32(unconst_u32(129))];
+  return out;
+  _ = override2;
+}
+
+fn fn2() -> vec2i {
+  var out: vec2i;
+  vp9 = VertexOutput4(vec4f(f32(vp11.f0[u32(unconst_u32(57))][0])));
+  vp8 = VertexOutput5(bitcast<vec2u>(vp8.f14.yz), vp8.f14, vec2h(vp8.f14.gb), vp8.f14.wx);
+  let ptr94: ptr<private, vec2h> = &vp8.f15;
+  vp9 = VertexOutput4(vec4f(f32(vp7[44].fract)));
+  vp12.f0 += mat2x4h(vp11.f0[u32(unconst_u32(84))][0], vp11.f0[u32(unconst_u32(84))][0], vp11.f0[u32(unconst_u32(84))][0], vp11.f0[u32(unconst_u32(84))][0], vp11.f0[u32(unconst_u32(84))][0], vp11.f0[u32(unconst_u32(84))][0], vp11.f0[u32(unconst_u32(84))][0], vp11.f0[u32(unconst_u32(84))][0]);
+  vp10[u32(unconst_u32(65))] = modf(vec2h(vp8.f16));
+  var vf51 = fn1();
+  let ptr95: ptr<private, vec2f> = &vp13[u32(unconst_u32(171))].whole;
+  var vf52 = fn1();
+  vp15 -= mat2x3h(vp10[0].whole.xyy, vp10[0].whole.yxy);
+  out += vec2i(i32(vp11.f0[0][0]));
+  vp9 = VertexOutput4(vec4f(f32(vp15[u32(unconst_u32(130))][u32(unconst_u32(108))])));
+  var vf53: vec3h = sqrt(vec3h(unconst_f16(11846.2), unconst_f16(6279.2), unconst_f16(4419.4)));
+  var vf54 = fn1();
+  fn1();
+  vp8 = VertexOutput5(vec2u(u32(vp11.f0[0][0])), vec4f(f32(vp11.f0[0][0])), vec2h(vp11.f0[0][0]), vec2f(f32(vp11.f0[0][0])));
+  var vf55 = fn1();
+  vp10[u32(unconst_u32(239))].whole += vec2h(vp11.f0[0][0]);
+  let ptr96: ptr<function, f16> = &vf54.f0[u32(unconst_u32(24))][0];
+  return out;
+  _ = override2;
+}
+
+var<workgroup> vw20: mat4x2f;
+
+var<workgroup> vw21: atomic<i32>;
+
+var<workgroup> vw22: VertexOutput4;
+
+var<workgroup> vw23: i32;
+
+var<workgroup> vw24: atomic<i32>;
+
+var<private> vp7 = array(modf(f16(24708.9)), modf(f16(-11709.2)), modf(f16(5759.3)), modf(f16(31074.6)), modf(f16(-22176.2)), modf(f16(13046.4)), modf(f16(9054.1)), modf(f16(290.5)), modf(f16(-5594.7)), modf(f16(5809.9)), modf(f16(23213.0)), modf(f16(2222.4)), modf(f16(7801.9)), modf(f16(-3271.2)), modf(f16(29326.1)), modf(f16(-4752.1)), modf(f16(9519.8)), modf(f16(4340.5)), modf(f16(1637.2)), modf(f16(3954.0)), modf(f16(-672.2)), modf(f16(13612.8)), modf(f16(30544.9)), modf(f16(12773.5)), modf(f16(15991.0)), modf(f16(164.1)), modf(f16(8837.3)), modf(f16(2196.9)), modf(f16(19688.7)), modf(f16(-11552.0)), modf(f16(4044.5)), modf(f16(15718.7)), modf(f16(7661.7)), modf(f16(153.4)), modf(f16(9080.5)), modf(f16(36646.9)), modf(f16(16528.7)), modf(f16(33981.7)), modf(f16(840.8)), modf(f16(22285.5)), modf(f16(13257.5)), modf(f16(-4242.3)), modf(f16(9034.7)), modf(f16(34052.1)), modf(f16(4671.9)));
+
+var<private> vp8: VertexOutput5 = VertexOutput5(vec2u(278, 95), vec4f(0.5129, 0.06453, 0.2412, 0.04871), vec2h(12101.6, 6125.4), vec2f(0.01617, 0.1810));
+
+var<private> vp9: VertexOutput4 = VertexOutput4();
+
+var<private> vp10 = array(modf(vec2h(9782.7, -41.73)));
+
+var<private> vp11: T1 = T1(array(array<f16, 1>()));
+
+var<private> vp12: T0 = T0();
+
+var<private> vp13 = array(modf(vec2f(0.3928, -0.05255)));
+
+var<private> vp14 = modf(f16(1345.5));
+
+var<private> vp15: mat2x3h = mat2x3h(17171.7, 25075.0, 26274.4, 2998.0, 34971.2, 2224.9);
+
+@vertex
+fn vertex5(@location(7) a0: i32) -> VertexOutput4 {
+  var out: VertexOutput4;
+  out.f12 = vp8.f14;
+  let ptr97: ptr<storage, u32, read> = &(*&buffer63)[arrayLength(&(*&buffer63))];
+  fn2();
+  vp11 = T1(array<array<f16, 1>, 1>(array<f16, 1>(vp11.f0[0][0])));
+  let vf56: f16 = fma(f16(unconst_f16(3067.2)), f16(unconst_f16(9372.8)), f16(unconst_f16(357.3)));
+  fn2();
+  var vf57 = fn1();
+  var vf58 = fn1();
+  vp10[u32(vp7[44].fract)].fract *= vp10[0].whole;
+  vp15 = mat2x3h(vf58.f0[0][0], vf58.f0[0][0], vf58.f0[0][0], vf58.f0[0][0], vf58.f0[0][0], vf58.f0[0][0]);
+  let ptr98: ptr<storage, u32, read> = &(*&buffer63)[u32(unconst_u32(446))];
+  fn2();
+  vf57 = T1(array<array<f16, 1>, 1>(array<f16, 1>(vf58.f0[0][0])));
+  let ptr99: ptr<function, array<f16, 1>> = &vf57.f0[u32(unconst_u32(154))];
+  return out;
+  _ = override2;
+}
+
+@vertex
+fn vertex6(@location(0) @interpolate(flat) a0: vec2f, @location(5) @interpolate(perspective, centroid) a1: vec2h, @location(7) @interpolate(flat, center) a2: vec2i) -> VertexOutput5 {
+  var out: VertexOutput5;
+  let ptr100: ptr<private, vec2h> = &vp10[0].fract;
+  let ptr101: ptr<private, f16> = &vp11.f0[0][0];
+  var vf59: f32 = vp8.f14[u32(unconst_u32(68))];
+  fn1();
+  var vf60 = fn1();
+  return out;
+  _ = override2;
+}
+
+@fragment
+fn fragment4() -> @location(200) vec4f {
+  var out: vec4f;
+  let ptr102: ptr<storage, array<array<f16, 1>, 1>, read_write> = &(*&buffer62)[arrayLength(&(*&buffer62))][u32(unconst_u32(302))][u32(unconst_u32(174))][u32(unconst_u32(165))][0][u32(unconst_u32(369))][u32(unconst_u32(98))][0];
+  var vf61 = fn1();
+  vp10[u32(unconst_u32(148))].fract = vec2h((*&buffer62)[u32(unconst_u32(21))][3][u32(unconst_u32(209))][9][0][0][u32(unconst_u32(25))][u32(unconst_u32(127))][0][0]);
+  vp10[u32(unconst_u32(208))] = modf(vec2h(buffer62[arrayLength(&buffer62)][3][u32(unconst_u32(23))][9][0][u32(unconst_u32(192))][0][0][u32(unconst_u32(90))][0]));
+  out = vec4f(f32((*&buffer62)[arrayLength(&(*&buffer62))][u32(unconst_u32(298))][0][9][u32(unconst_u32(2))][u32(unconst_u32(81))][u32(unconst_u32(294))][0][u32(unconst_u32(319))][0]));
+  var vf62 = fn1();
+  discard;
+  let ptr103: ptr<storage, array<f16, 1>, read_write> = &buffer62[arrayLength(&buffer62)][u32(unconst_u32(192))][u32(unconst_u32(81))][9][0][0][0][u32(unconst_u32(22))][u32(unconst_u32(656))];
+  var vf63 = fn1();
+  var vf64 = fn2();
+  fn2();
+  vf63.f0[u32(unconst_u32(84))][u32(unconst_u32(83))] -= buffer62[arrayLength(&buffer62)][3][u32(unconst_u32(271))][u32(unconst_u32(658))][0][u32(unconst_u32(771))][0][u32((*&buffer62)[u32(unconst_u32(267))][u32(buffer62[u32(unconst_u32(249))][3][u32((*&buffer62)[u32(unconst_u32(255))][3][u32(unconst_u32(1))][9][u32(unconst_u32(253))][u32(unconst_u32(95))][0][u32(unconst_u32(115))][0][0])][u32(unconst_u32(146))][u32(buffer62[arrayLength(&buffer62)][u32(unconst_u32(246))][0][9][u32(unconst_u32(204))][u32(unconst_u32(170))][0][u32(unconst_u32(78))][0][0])][u32(unconst_u32(567))][u32(buffer62[arrayLength(&buffer62)][3][0][9][0][0][0][u32(unconst_u32(112))][u32(unconst_u32(98))][0])][u32(unconst_u32(378))][0][u32(unconst_u32(525))])][0][9][u32(unconst_u32(8))][0][u32(unconst_u32(242))][0][0][u32(unconst_u32(67))])][u32(buffer62[u32(unconst_u32(304))][3][u32(unconst_u32(86))][u32(unconst_u32(60))][0][0][u32(unconst_u32(347))][0][0][0])][0];
+  fn1();
+  var vf65 = fn2();
+  buffer62[u32(unconst_u32(248))][u32(unconst_u32(69))][u32(unconst_u32(336))][u32(unconst_u32(341))][0][u32(unconst_u32(130))][u32((*&buffer62)[u32(unconst_u32(23))][u32(unconst_u32(605))][0][9][0][u32(unconst_u32(75))][0][0][0][0])][u32(unconst_u32(182))][u32(unconst_u32(168))][u32((*&buffer62)[u32(unconst_u32(15))][3][u32(unconst_u32(56))][9][0][0][0][0][0][0])] *= buffer62[u32(unconst_u32(34))][u32((*&buffer62)[u32(unconst_u32(140))][3][0][9][0][u32(unconst_u32(67))][u32(unconst_u32(28))][0][u32(unconst_u32(95))][0])][u32(buffer62[arrayLength(&buffer62)][u32(unconst_u32(317))][0][u32(unconst_u32(2))][0][0][0][u32(unconst_u32(130))][0][0])][9][u32(unconst_u32(245))][u32(unconst_u32(19))][u32(unconst_u32(1000))][u32(unconst_u32(34))][0][0];
+  vp7[u32(unconst_u32(756))].fract += (*&buffer62)[u32(unconst_u32(193))][3][0][9][u32(unconst_u32(133))][0][0][u32(buffer62[arrayLength(&buffer62)][u32(unconst_u32(242))][0][9][u32(unconst_u32(135))][0][u32(unconst_u32(219))][u32((*&buffer62)[u32(unconst_u32(171))][3][0][u32(unconst_u32(100))][0][0][u32(unconst_u32(160))][u32(unconst_u32(24))][0][0])][u32(unconst_u32(255))][0])][0][0];
+  let ptr104: ptr<storage, array<array<array<f16, 1>, 1>, 1>, read_write> = &(*&buffer62)[u32(unconst_u32(652))][3][u32(unconst_u32(25))][u32(unconst_u32(168))][u32(unconst_u32(69))][u32(unconst_u32(173))][0];
+  vp8 = VertexOutput5(vec2u(u32(buffer62[u32(unconst_u32(188))][3][0][9][0][0][0][u32(unconst_u32(406))][0][0])), vec4f(f32(buffer62[u32(unconst_u32(188))][3][0][9][0][0][0][u32(unconst_u32(406))][0][0])), vec2h(buffer62[u32(unconst_u32(188))][3][0][9][0][0][0][u32(unconst_u32(406))][0][0]), vec2f(f32(buffer62[u32(unconst_u32(188))][3][0][9][0][0][0][u32(unconst_u32(406))][0][0])));
+  fn1();
+  fn2();
+  fn1();
+  var vf66 = fn1();
+  fn2();
+  vp12 = T0(mat2x4h((*&buffer62)[u32(buffer62[u32(unconst_u32(250))][3][u32(unconst_u32(245))][u32(unconst_u32(208))][u32(unconst_u32(88))][u32(unconst_u32(305))][u32(unconst_u32(115))][u32(unconst_u32(34))][u32(unconst_u32(100))][0])][u32(unconst_u32(155))][u32(unconst_u32(11))][9][u32(unconst_u32(129))][u32(unconst_u32(69))][u32(unconst_u32(19))][0][0][0], (*&buffer62)[u32(buffer62[u32(unconst_u32(250))][3][u32(unconst_u32(245))][u32(unconst_u32(208))][u32(unconst_u32(88))][u32(unconst_u32(305))][u32(unconst_u32(115))][u32(unconst_u32(34))][u32(unconst_u32(100))][0])][u32(unconst_u32(155))][u32(unconst_u32(11))][9][u32(unconst_u32(129))][u32(unconst_u32(69))][u32(unconst_u32(19))][0][0][0], (*&buffer62)[u32(buffer62[u32(unconst_u32(250))][3][u32(unconst_u32(245))][u32(unconst_u32(208))][u32(unconst_u32(88))][u32(unconst_u32(305))][u32(unconst_u32(115))][u32(unconst_u32(34))][u32(unconst_u32(100))][0])][u32(unconst_u32(155))][u32(unconst_u32(11))][9][u32(unconst_u32(129))][u32(unconst_u32(69))][u32(unconst_u32(19))][0][0][0], (*&buffer62)[u32(buffer62[u32(unconst_u32(250))][3][u32(unconst_u32(245))][u32(unconst_u32(208))][u32(unconst_u32(88))][u32(unconst_u32(305))][u32(unconst_u32(115))][u32(unconst_u32(34))][u32(unconst_u32(100))][0])][u32(unconst_u32(155))][u32(unconst_u32(11))][9][u32(unconst_u32(129))][u32(unconst_u32(69))][u32(unconst_u32(19))][0][0][0], (*&buffer62)[u32(buffer62[u32(unconst_u32(250))][3][u32(unconst_u32(245))][u32(unconst_u32(208))][u32(unconst_u32(88))][u32(unconst_u32(305))][u32(unconst_u32(115))][u32(unconst_u32(34))][u32(unconst_u32(100))][0])][u32(unconst_u32(155))][u32(unconst_u32(11))][9][u32(unconst_u32(129))][u32(unconst_u32(69))][u32(unconst_u32(19))][0][0][0], (*&buffer62)[u32(buffer62[u32(unconst_u32(250))][3][u32(unconst_u32(245))][u32(unconst_u32(208))][u32(unconst_u32(88))][u32(unconst_u32(305))][u32(unconst_u32(115))][u32(unconst_u32(34))][u32(unconst_u32(100))][0])][u32(unconst_u32(155))][u32(unconst_u32(11))][9][u32(unconst_u32(129))][u32(unconst_u32(69))][u32(unconst_u32(19))][0][0][0], (*&buffer62)[u32(buffer62[u32(unconst_u32(250))][3][u32(unconst_u32(245))][u32(unconst_u32(208))][u32(unconst_u32(88))][u32(unconst_u32(305))][u32(unconst_u32(115))][u32(unconst_u32(34))][u32(unconst_u32(100))][0])][u32(unconst_u32(155))][u32(unconst_u32(11))][9][u32(unconst_u32(129))][u32(unconst_u32(69))][u32(unconst_u32(19))][0][0][0], (*&buffer62)[u32(buffer62[u32(unconst_u32(250))][3][u32(unconst_u32(245))][u32(unconst_u32(208))][u32(unconst_u32(88))][u32(unconst_u32(305))][u32(unconst_u32(115))][u32(unconst_u32(34))][u32(unconst_u32(100))][0])][u32(unconst_u32(155))][u32(unconst_u32(11))][9][u32(unconst_u32(129))][u32(unconst_u32(69))][u32(unconst_u32(19))][0][0][0]));
+  return out;
+  _ = override2;
+}
+
+@compute @workgroup_size(2, 1, 1)
+fn compute4() {
+  vp7[u32(unconst_u32(30))] = modf(vec2h(reverseBits(vec2i(unconst_i32(506), unconst_i32(155))))[1]);
+  fn0();
+  vw23 = bitcast<i32>(vp10[0].fract);
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let texture70 = device0.createTexture({
+  size: {width: 20, height: 19, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView58 = texture59.createView({mipLevelCount: 1});
+let sampler33 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 40.58,
+  lodMaxClamp: 51.20,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder40.setBindGroup(2, bindGroup13, new Uint32Array(1324), 558, 0);
+} catch {}
+let arrayBuffer10 = buffer2.getMappedRange(1616, 28);
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 54, height: 141, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 2, y: 100, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup28 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 59, resource: sampler12}]});
+let commandEncoder60 = device0.createCommandEncoder({});
+let texture71 = device0.createTexture({
+  size: [665, 1, 29],
+  mipLevelCount: 4,
+  dimension: '2d',
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder59 = commandEncoder60.beginComputePass();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 54, height: 141, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas0,
+  origin: { x: 4, y: 1 },
+  flipY: true,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 11, y: 10, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 8, height: 11, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup29 = device0.createBindGroup({layout: bindGroupLayout5, entries: [{binding: 65, resource: textureView20}]});
+let textureView59 = texture49.createView({});
+let sampler34 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 11.93,
+  lodMaxClamp: 40.01,
+  compare: 'greater',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder18.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(63).fill(170), /* required buffer size: 63 */
+{offset: 63, rowsPerImage: 6}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas0);
+let commandEncoder61 = device0.createCommandEncoder({});
+let promise7 = shaderModule3.getCompilationInfo();
+try {
+commandEncoder61.resolveQuerySet(querySet7, 132, 6, buffer27, 256);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 268, new Int16Array(1824), 67, 12);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(108).fill(137), /* required buffer size: 108 */
+{offset: 108, rowsPerImage: 139}, {width: 40, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let textureView60 = texture61.createView({aspect: 'depth-only', mipLevelCount: 1});
+let computePassEncoder60 = commandEncoder61.beginComputePass({});
+let buffer64 = device0.createBuffer({
+  size: 6799,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder23.setBindGroup(2, bindGroup7, new Uint32Array(3806), 0, 0);
+} catch {}
+let videoFrame10 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'fcc', primaries: 'smpte240m', transfer: 'bt1361ExtendedColourGamut'} });
+let bindGroup30 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 362, resource: textureView24},
+    {binding: 87, resource: textureView21},
+    {binding: 194, resource: textureView60},
+    {binding: 267, resource: textureView35},
+  ],
+});
+let buffer65 = device0.createBuffer({size: 3141, usage: GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder62 = device0.createCommandEncoder({});
+let textureView61 = texture0.createView({dimension: '2d-array'});
+try {
+commandEncoder62.copyBufferToTexture({
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 108 */
+  offset: 108,
+  bytesPerRow: 32512,
+  buffer: buffer52,
+}, {
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 0, y: 6, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 39, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 54, height: 141, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 1, y: 26, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+try {
+globalThis.someLabel = buffer43.label;
+} catch {}
+let buffer66 = device0.createBuffer({size: 5471, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let commandEncoder63 = device0.createCommandEncoder();
+let externalTexture9 = device0.importExternalTexture({source: videoFrame10});
+try {
+computePassEncoder49.setBindGroup(1, bindGroup21, new Uint32Array(3314), 195, 2);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let pipeline1 = device0.createRenderPipeline({
+  layout: pipelineLayout3,
+  fragment: {module: shaderModule4, constants: {}, targets: [{format: 'r16uint'}]},
+  depthStencil: {
+    format: 'depth16unorm',
+    depthWriteEnabled: true,
+    depthCompare: 'greater-equal',
+    stencilReadMask: 318951094,
+    stencilWriteMask: 1195547528,
+    depthBiasClamp: 345.77400082160875,
+  },
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex5',
+    constants: {49_258: 0},
+    buffers: [{arrayStride: 40, attributes: [{format: 'sint32', offset: 0, shaderLocation: 7}]}],
+  },
+  primitive: {topology: 'point-list', cullMode: 'front', unclippedDepth: true},
+});
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+try {
+  await promise7;
+} catch {}
+let commandEncoder64 = device0.createCommandEncoder({});
+let computePassEncoder61 = commandEncoder62.beginComputePass({});
+try {
+device0.queue.writeBuffer(buffer56, 84, new BigUint64Array(2085), 784, 556);
+} catch {}
+let renderPassEncoder0 = commandEncoder63.beginRenderPass({colorAttachments: [{view: textureView58, depthSlice: 12, loadOp: 'clear', storeOp: 'discard'}]});
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup27);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer21, 'uint16', 1_496, 2_389);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(5, buffer64, 0, 27);
+} catch {}
+let sampler35 = device0.createSampler({
+  label: '\ue999\u23dd\uac6b\u{1fef9}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 93.21,
+  lodMaxClamp: 97.62,
+  maxAnisotropy: 8,
+});
+try {
+computePassEncoder22.setBindGroup(2, bindGroup8, [7424, 0]);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 4, y: 7, z: 7},
+  aspect: 'all',
+}, new Uint8Array(1_269).fill(67), /* required buffer size: 1_269 */
+{offset: 53, bytesPerRow: 16, rowsPerImage: 38}, {width: 4, height: 0, depthOrArrayLayers: 3});
+} catch {}
+let pipeline2 = device0.createComputePipeline({layout: pipelineLayout3, compute: {module: shaderModule4, constants: {}}});
+document.body.append(canvas0);
+let commandEncoder65 = device0.createCommandEncoder({});
+let computePassEncoder62 = commandEncoder64.beginComputePass({});
+try {
+computePassEncoder19.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup2, new Uint32Array(2867), 1_293, 0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle2, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer21, 'uint16', 18_714, 1_222);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(6, buffer26, 0);
+} catch {}
+let promise8 = device0.createComputePipelineAsync({layout: pipelineLayout0, compute: {module: shaderModule1, constants: {}}});
+try {
+computePassEncoder62.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+computePassEncoder56.setBindGroup(0, bindGroup2, new Uint32Array(825), 113, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup10, new Uint32Array(4236), 60, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer55, 'uint16', 42, 148);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(1, buffer42);
+} catch {}
+let buffer67 = device0.createBuffer({
+  size: 13577,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView62 = texture6.createView({dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 0});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], sampleCount: 1, depthReadOnly: true});
+let renderBundle10 = renderBundleEncoder10.finish();
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup26);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup7, new Uint32Array(90), 5, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(4, buffer24, 1_324);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 54, height: 141, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData1,
+  origin: { x: 0, y: 2 },
+  flipY: true,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 1, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 26, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder66 = device0.createCommandEncoder({});
+let computePassEncoder63 = commandEncoder66.beginComputePass();
+try {
+computePassEncoder57.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(5, buffer26, 2_964, 2_889);
+} catch {}
+try {
+commandEncoder65.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1256 */
+  offset: 1256,
+  bytesPerRow: 12800,
+  buffer: buffer52,
+}, {
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame11 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'smpte170m', transfer: 'bt2020_12bit'} });
+let commandEncoder67 = device0.createCommandEncoder({});
+let textureView63 = texture58.createView({mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 5});
+try {
+renderPassEncoder0.executeBundles([renderBundle2, renderBundle1]);
+} catch {}
+let pipeline3 = await promise8;
+try {
+  await promise6;
+} catch {}
+let buffer68 = device0.createBuffer({
+  size: 27929,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let commandEncoder68 = device0.createCommandEncoder({});
+let commandBuffer2 = commandEncoder65.finish();
+let texture72 = device0.createTexture({
+  label: '\u1c9a\ufa82\uec52\u{1fd0d}\u84d2\u0fbe\u998a\u{1fa50}\u0081',
+  size: {width: 1330, height: 1, depthOrArrayLayers: 40},
+  mipLevelCount: 5,
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView64 = texture24.createView({dimension: '3d', format: 'rgb10a2uint', mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder64 = commandEncoder67.beginComputePass({});
+try {
+computePassEncoder24.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder68.copyBufferToTexture({
+  /* bytesInLastRow: 184 widthInBlocks: 23 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1488 */
+  offset: 1488,
+  bytesPerRow: 2048,
+  buffer: buffer6,
+}, {
+  texture: texture72,
+  mipLevel: 4,
+  origin: {x: 1, y: 0, z: 2},
+  aspect: 'all',
+}, {width: 23, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup31 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 362, resource: textureView36},
+    {binding: 267, resource: textureView63},
+    {binding: 87, resource: textureView32},
+    {binding: 194, resource: textureView7},
+  ],
+});
+let querySet8 = device0.createQuerySet({type: 'occlusion', count: 393});
+let sampler36 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 77.88,
+  lodMaxClamp: 94.72,
+});
+try {
+computePassEncoder25.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer26, 'uint16', 2_494, 565);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder68.copyBufferToBuffer(buffer33, 1684, buffer52, 760, 648);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer41, 1088, new Float32Array(2542), 1320, 96);
+} catch {}
+let bindGroup32 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 362, resource: textureView36},
+    {binding: 267, resource: textureView23},
+    {binding: 87, resource: textureView32},
+    {binding: 194, resource: textureView7},
+  ],
+});
+try {
+computePassEncoder26.setBindGroup(3, bindGroup5, [1792, 256]);
+} catch {}
+try {
+computePassEncoder53.setBindGroup(1, bindGroup9, new Uint32Array(338), 18, 2);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer6, 'uint16', 1_230, 2_136);
+} catch {}
+let texture73 = device0.createTexture({
+  label: '\u4a81\u0ca6\u08dc\uc219\u0c35\u1eb8\ucb2e\ud359',
+  size: [80, 78, 1],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView65 = texture13.createView({dimension: '2d-array', baseMipLevel: 0, baseArrayLayer: 0});
+let computePassEncoder65 = commandEncoder68.beginComputePass({});
+try {
+computePassEncoder43.setBindGroup(0, bindGroup23, new Uint32Array(447), 43, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup5, [6144, 0]);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup31, new Uint32Array(1359), 161, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer67, 'uint32', 180, 2_312);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(1, buffer61, 5_748, 48);
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 665, height: 1, depthOrArrayLayers: 40}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 1, y: 0 },
+  flipY: false,
+}, {
+  texture: texture72,
+  mipLevel: 1,
+  origin: {x: 50, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+try {
+computePassEncoder34.setBindGroup(3, bindGroup30, new Uint32Array(603), 331, 0);
+} catch {}
+try {
+computePassEncoder31.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer54, 'uint32', 88, 958);
+} catch {}
+try {
+device0.queue.submit([commandBuffer2]);
+} catch {}
+let pipeline4 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout0,
+  multisample: {mask: 0x2f4b426},
+  fragment: {module: shaderModule1, entryPoint: 'fragment1', targets: [{format: 'rgb10a2uint'}]},
+  vertex: {
+    module: shaderModule1,
+    buffers: [
+      {
+        arrayStride: 28,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 4, shaderLocation: 9},
+          {format: 'uint32', offset: 0, shaderLocation: 11},
+          {format: 'sint16x4', offset: 0, shaderLocation: 1},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'back', unclippedDepth: true},
+});
+let commandEncoder69 = device0.createCommandEncoder({label: '\u0823\u0071\u0436\ud191\u0dfb'});
+let texture74 = device0.createTexture({
+  size: {width: 60, height: 24, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let computePassEncoder66 = commandEncoder69.beginComputePass({});
+try {
+computePassEncoder27.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup24);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup19, new Uint32Array(845), 363, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(5, undefined, 0);
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+let texture75 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 13},
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder11.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer43, 'uint32', 580, 1_154);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(5, buffer42, 236, 99);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 54, height: 141, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData4,
+  origin: { x: 2, y: 6 },
+  flipY: true,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 2, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 5, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup33 = device0.createBindGroup({
+  layout: bindGroupLayout9,
+  entries: [{binding: 37, resource: {buffer: buffer7, offset: 8192, size: 2268}}],
+});
+let buffer69 = device0.createBuffer({
+  size: 3971,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup2, []);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline0);
+} catch {}
+let pipeline5 = device0.createRenderPipeline({
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule1,
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule1,
+    buffers: [
+      {
+        arrayStride: 632,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 60, shaderLocation: 11},
+          {format: 'sint32', offset: 76, shaderLocation: 1},
+          {format: 'snorm16x2', offset: 76, shaderLocation: 9},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'back', unclippedDepth: false},
+});
+let pipelineLayout5 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout8]});
+let texture76 = device0.createTexture({
+  size: {width: 166, height: 1, depthOrArrayLayers: 42},
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture77 = device0.createTexture({
+  size: {width: 30, height: 12, depthOrArrayLayers: 41},
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder51.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder60.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup20, new Uint32Array(494), 9, 0);
+} catch {}
+offscreenCanvas1.width = 392;
+let bindGroup34 = device0.createBindGroup({
+  label: '\u0994\u8c05\u0c7e\u30b7\u{1fb20}\u{1fa7c}\uaacd\u{1f878}',
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 779, resource: {buffer: buffer8, offset: 15104, size: 6251}},
+    {binding: 16, resource: {buffer: buffer23, offset: 0, size: 7212}},
+    {binding: 32, resource: textureView49},
+    {binding: 96, resource: textureView33},
+    {binding: 3, resource: sampler23},
+    {binding: 25, resource: {buffer: buffer1, offset: 0, size: 5840}},
+    {binding: 88, resource: {buffer: buffer54, offset: 0, size: 1248}},
+    {binding: 139, resource: textureView41},
+    {binding: 925, resource: textureView9},
+    {binding: 142, resource: textureView11},
+    {binding: 426, resource: {buffer: buffer56, offset: 1024, size: 2932}},
+  ],
+});
+let commandEncoder70 = device0.createCommandEncoder({});
+try {
+computePassEncoder64.setBindGroup(3, bindGroup26);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup23, new Uint32Array(34), 10, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer67, 'uint16', 5_014, 254);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 116, new Int16Array(10696), 105, 0);
+} catch {}
+try {
+computePassEncoder66.setBindGroup(2, bindGroup6, new Uint32Array(146), 40, 2);
+} catch {}
+try {
+computePassEncoder42.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer20, 'uint32', 312, 845);
+} catch {}
+try {
+commandEncoder70.copyTextureToBuffer({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 32, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 80 widthInBlocks: 20 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3448 */
+  offset: 3448,
+  bytesPerRow: 3584,
+  buffer: buffer41,
+}, {width: 20, height: 7, depthOrArrayLayers: 0});
+} catch {}
+let buffer70 = device0.createBuffer({
+  size: 12358,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let textureView66 = texture16.createView({mipLevelCount: 1, baseArrayLayer: 0, arrayLayerCount: 1});
+let computePassEncoder67 = commandEncoder70.beginComputePass();
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup19, new Uint32Array(2196), 275, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer24, 'uint32', 112, 4_596);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let buffer71 = device0.createBuffer({
+  label: '\u8466\u4ca1\ue8df',
+  size: 15474,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: false,
+});
+let commandEncoder71 = device0.createCommandEncoder({});
+let textureView67 = texture7.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder68 = commandEncoder71.beginComputePass();
+let sampler37 = device0.createSampler({
+  addressModeU: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 64.24,
+  lodMaxClamp: 86.67,
+  compare: 'equal',
+});
+try {
+computePassEncoder51.setBindGroup(3, bindGroup31, new Uint32Array(1148), 53, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder31); computePassEncoder31.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder31.end();
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup19, new Uint32Array(3827), 331, 0);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline4);
+} catch {}
+let img0 = await imageWithData(17, 38, '#10101010', '#20202020');
+let texture78 = device0.createTexture({
+  size: {width: 60, height: 24, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  sampleCount: 1,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder67.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer70, 'uint32', 9_828, 901);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+try {
+commandEncoder30.copyBufferToTexture({
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 328 */
+  offset: 328,
+  bytesPerRow: 256,
+  buffer: buffer4,
+}, {
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder62.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup24);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(38);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer54, 'uint16', 846, 2_088);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(5, buffer54, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 54, height: 141, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 38, y: 4 },
+  flipY: true,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 6, y: 8, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 3, height: 43, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer3 = commandEncoder30.finish();
+try {
+computePassEncoder15.setBindGroup(1, bindGroup34, new Uint32Array(8928), 85, 2);
+} catch {}
+try {
+computePassEncoder49.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(736);
+} catch {}
+try {
+  await shaderModule1.getCompilationInfo();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 54, height: 141, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData0,
+  origin: { x: 3, y: 0 },
+  flipY: false,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 0, y: 39, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55); };
+} catch {}
+try {
+computePassEncoder21.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+computePassEncoder29.setBindGroup(1, bindGroup8, new Uint32Array(8297), 69, 2);
+} catch {}
+try {
+computePassEncoder4.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup27);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer43, 'uint16', 256, 493);
+} catch {}
+try {
+device0.queue.submit([commandBuffer3]);
+} catch {}
+let buffer72 = device0.createBuffer({
+  size: 2461,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView68 = texture67.createView({label: '\u{1f7e5}\u70e2\u7fc6\u{1faa3}\u5ceb\u{1fcf3}\u004f\u04d2\u{1fd44}\u06bf', mipLevelCount: 1});
+try {
+computePassEncoder33.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline5);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame12 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'film', transfer: 'bt709'} });
+let buffer73 = device0.createBuffer({size: 49768, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let textureView69 = texture61.createView({
+  label: '\u{1f97c}\u05aa\u{1f742}\udac1\u5e95\u01e1\u7b01',
+  aspect: 'all',
+  baseMipLevel: 0,
+  mipLevelCount: 1,
+});
+let sampler38 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 98.42,
+  lodMaxClamp: 100.00,
+  compare: 'never',
+});
+try {
+computePassEncoder21.setBindGroup(2, bindGroup22);
+} catch {}
+try {
+computePassEncoder29.setBindGroup(2, bindGroup26, new Uint32Array(366), 110, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder62); computePassEncoder62.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder60.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer64, 'uint16', 1_032, 2_384);
+} catch {}
+let pipeline6 = await device0.createComputePipelineAsync({layout: pipelineLayout3, compute: {module: shaderModule4}});
+let commandEncoder72 = device0.createCommandEncoder();
+let texture79 = device0.createTexture({
+  label: '\u0689\ud583\u8220\u0fe9\u98cb',
+  size: {width: 15, height: 6, depthOrArrayLayers: 1},
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder69 = commandEncoder72.beginComputePass({});
+try {
+computePassEncoder51.setBindGroup(2, bindGroup25);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer24, 'uint32', 440, 527);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let bindGroup35 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 283, resource: {buffer: buffer51, offset: 1024}},
+    {binding: 50, resource: {buffer: buffer4, offset: 768, size: 412}},
+    {binding: 26, resource: {buffer: buffer13, offset: 12032}},
+    {binding: 39, resource: textureView9},
+    {binding: 294, resource: textureView40},
+    {binding: 41, resource: textureView43},
+    {binding: 13, resource: {buffer: buffer69, offset: 768, size: 1368}},
+    {binding: 66, resource: {buffer: buffer69, offset: 0, size: 269}},
+    {binding: 49, resource: textureView28},
+    {binding: 125, resource: textureView48},
+    {binding: 452, resource: textureView54},
+  ],
+});
+let pipelineLayout6 = device0.createPipelineLayout({bindGroupLayouts: []});
+let texture80 = device0.createTexture({
+  size: [665, 1, 49],
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler39 = device0.createSampler({
+  label: '\u09ff\u1645\ufb25\u0b49\u{1fc34}\u3fd0\uc675\u{1fd06}\u02a0',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 78.49,
+  lodMaxClamp: 90.78,
+});
+try {
+renderPassEncoder0.setIndexBuffer(buffer70, 'uint16', 880, 229);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(0, buffer55);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer61, 3964, new Float32Array(38683), 365, 428);
+} catch {}
+let promise9 = device0.createRenderPipelineAsync({
+  layout: pipelineLayout0,
+  fragment: {module: shaderModule2, constants: {}, targets: [{format: 'rgb10a2uint'}]},
+  vertex: {module: shaderModule3, buffers: []},
+});
+try {
+adapter0.label = '\u{1f75a}\u03b3';
+} catch {}
+let bindGroupLayout11 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 39,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 22,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 221,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 4, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {
+      binding: 107,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '3d' },
+    },
+    {
+      binding: 101,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 110,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 68,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 242,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 9, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {
+      binding: 252,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+    {binding: 174, visibility: GPUShaderStage.VERTEX, sampler: { type: 'filtering' }},
+    {
+      binding: 848,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 176,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 187,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 57,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 431,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let texture81 = device0.createTexture({
+  label: '\uc2fc\ud5d0\u{1fcc8}\u{1fdee}\u84d9\u{1f700}\u{1fc2f}',
+  size: {width: 16, height: 16, depthOrArrayLayers: 100},
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder54.setBindGroup(1, bindGroup25, []);
+} catch {}
+try {
+computePassEncoder22.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder61.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder0.draw(14, 0, 2_116_520_107, 2);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(4, 0, 15, 944_101_511, 1);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer72, 240);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer59, 44);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(5, buffer54, 0, 1_501);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture64,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(111).fill(64), /* required buffer size: 111 */
+{offset: 111}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture82 = device0.createTexture({
+  size: [80, 78, 120],
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView70 = texture79.createView({arrayLayerCount: 1});
+try {
+computePassEncoder49.setBindGroup(2, bindGroup19, new Uint32Array(1543), 214, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup20, new Uint32Array(832), 76, 0);
+} catch {}
+try {
+renderPassEncoder0.draw(436, 1, 1_765_439_420);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(88, 0, 0, 366_153_000);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer24, 1_284);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer59, 140);
+} catch {}
+try {
+buffer24.unmap();
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroupLayout12 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 148,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let texture83 = device0.createTexture({
+  label: '\uccdc\u083e\u9634\u9644\ud7d8\u{1fb88}\u07be\u2e70\u0f16\udcaf',
+  size: {width: 80, height: 78, depthOrArrayLayers: 284},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder25.setBindGroup(3, bindGroup21, [1536, 0]);
+} catch {}
+try {
+computePassEncoder23.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder0.draw(373, 0, 305_524_102);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer24, 'uint16', 2_360, 111);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let texture84 = device0.createTexture({
+  size: [120, 48, 175],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder14.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup22, new Uint32Array(625), 64, 0);
+} catch {}
+try {
+renderPassEncoder0.setViewport(131.22612199508484, 0.715395529296514, 144.18329953776464, 0.10129293986009887, 0.3125179345885982, 0.3257205552400668);
+} catch {}
+try {
+renderPassEncoder0.draw(140, 1, 241_149_999);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(14, 1, 16, 459_613_126, 1);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer69, 4);
+} catch {}
+try {
+buffer55.unmap();
+} catch {}
+let bindGroup36 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 88, resource: {buffer: buffer23, offset: 1536, size: 1204}},
+    {binding: 16, resource: {buffer: buffer24, offset: 0, size: 7044}},
+    {binding: 96, resource: textureView44},
+    {binding: 925, resource: textureView11},
+    {binding: 3, resource: sampler26},
+    {binding: 32, resource: textureView8},
+    {binding: 25, resource: {buffer: buffer69, offset: 0, size: 3624}},
+    {binding: 779, resource: {buffer: buffer41, offset: 3584, size: 866}},
+    {binding: 139, resource: textureView41},
+    {binding: 142, resource: textureView20},
+    {binding: 426, resource: {buffer: buffer41, offset: 1024, size: 432}},
+  ],
+});
+let texture85 = device0.createTexture({
+  size: [16, 16, 13],
+  format: 'astc-8x8-unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView71 = texture76.createView({});
+try {
+computePassEncoder14.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder62); computePassEncoder62.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup5, [4096, 512]);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup26, new Uint32Array(420), 64, 0);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer20, 1_076);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer26, 0);
+} catch {}
+try {
+buffer71.unmap();
+} catch {}
+let commandEncoder73 = device0.createCommandEncoder({});
+let textureView72 = texture82.createView({format: 'r32sint'});
+let texture86 = device0.createTexture({size: [30, 12, 45], format: 'r8unorm', usage: GPUTextureUsage.COPY_SRC});
+let textureView73 = texture43.createView({baseMipLevel: 0});
+try {
+computePassEncoder15.setBindGroup(1, bindGroup24);
+} catch {}
+try {
+computePassEncoder20.setBindGroup(0, bindGroup7, new Uint32Array(1297), 154, 0);
+} catch {}
+try {
+computePassEncoder41.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder0.draw(320, 0, 746_846_842);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(29, 2, 3, 9_099_870);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(6, buffer52, 652);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+} catch {}
+let texture87 = device0.createTexture({
+  size: {width: 166, height: 1, depthOrArrayLayers: 820},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture88 = device0.createTexture({
+  size: [120, 48, 1],
+  mipLevelCount: 3,
+  format: 'r16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder70 = commandEncoder73.beginComputePass();
+let sampler40 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 24.91,
+  lodMaxClamp: 41.63,
+  compare: 'never',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder39.setBindGroup(0, bindGroup33, new Uint32Array(332), 55, 0);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer68, 3_940);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer70, 692);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let commandEncoder74 = device0.createCommandEncoder({});
+let textureView74 = texture84.createView({mipLevelCount: 1});
+let sampler41 = device0.createSampler({addressModeU: 'clamp-to-edge', addressModeW: 'repeat', mipmapFilter: 'nearest', lodMaxClamp: 70.81});
+try {
+computePassEncoder15.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(7, 1, 3, 608_732_321);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer68, 11_932);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer21, 'uint32', 2_992, 4_413);
+} catch {}
+try {
+commandEncoder74.copyBufferToTexture({
+  /* bytesInLastRow: 80 widthInBlocks: 40 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 684 */
+  offset: 684,
+  bytesPerRow: 3072,
+  buffer: buffer26,
+}, {
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 40, height: 39, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder74.resolveQuerySet(querySet8, 3, 80, buffer4, 256);
+} catch {}
+let imageData5 = new ImageData(52, 40);
+let bindGroup37 = device0.createBindGroup({
+  layout: bindGroupLayout9,
+  entries: [{binding: 37, resource: {buffer: buffer44, offset: 512, size: 1560}}],
+});
+let buffer74 = device0.createBuffer({size: 9011, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let querySet9 = device0.createQuerySet({type: 'occlusion', count: 609});
+let textureView75 = texture82.createView({mipLevelCount: 1});
+let textureView76 = texture12.createView({dimension: '2d', format: 'rgba8snorm', mipLevelCount: 1, baseArrayLayer: 7});
+let renderPassEncoder1 = commandEncoder74.beginRenderPass({
+  colorAttachments: [{
+  view: textureView58,
+  depthSlice: 43,
+  clearValue: { r: -338.8, g: 764.4, b: -190.6, a: -138.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder67.setBindGroup(1, bindGroup7, new Uint32Array(155), 71, 0);
+} catch {}
+try {
+computePassEncoder44.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle5]);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer21, 5_268);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer34, 220);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(0, buffer44, 1_204, 882);
+} catch {}
+let buffer75 = device0.createBuffer({
+  size: 13781,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder75 = device0.createCommandEncoder({});
+let texture89 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 13},
+  mipLevelCount: 2,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture90 = device0.createTexture({
+  size: {width: 60, height: 24, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder71 = commandEncoder75.beginComputePass({});
+let sampler42 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 64.89,
+  lodMaxClamp: 65.75,
+});
+try {
+computePassEncoder58.setBindGroup(1, bindGroup30);
+} catch {}
+try {
+computePassEncoder1.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(131);
+} catch {}
+try {
+renderPassEncoder0.draw(28, 0, 151_671_588);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(47, 0, 33, 1_182_596_037);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(5, buffer52, 460, 237);
+} catch {}
+let commandEncoder76 = device0.createCommandEncoder({label: '\u068b\u0f9a'});
+let textureView77 = texture85.createView({dimension: 'cube', format: 'astc-8x8-unorm-srgb'});
+let computePassEncoder72 = commandEncoder76.beginComputePass();
+try {
+computePassEncoder66.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup31);
+} catch {}
+try {
+renderPassEncoder0.end();
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline5);
+} catch {}
+let shaderModule6 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(59) var sam3: sampler_comparison;
+
+struct T0 {
+  @size(96) f0: array<u32>,
+}
+
+struct VertexOutput6 {
+  @builtin(position) f17: vec4f,
+}
+
+struct FragmentOutput2 {
+  @location(0) @interpolate(flat) f0: vec4u,
+  @builtin(sample_mask) f1: u32,
+}
+
+fn fn0() -> VertexOutput6 {
+  var out: VertexOutput6;
+  var vf67: i32 = dot(vec2i(unconst_i32(383), unconst_i32(16)), vec2i(unconst_i32(-191), unconst_i32(132)));
+  let vf68: u32 = pack2x16float(vec2f(unconst_f32(0.1954), unconst_f32(0.1784)));
+  out.f17 = unpack4x8unorm(u32(unconst_u32(846)));
+  var vf69: vec4f = unpack4x8unorm(u32(unconst_u32(186)));
+  var vf70: vec2h = inverseSqrt(vec2h(unconst_f16(4731.4), unconst_f16(370.8)));
+  out.f17 = vec4f(inverseSqrt(vec2h(unconst_f16(5645.7), unconst_f16(45.66))).xxyy);
+  let ptr105: ptr<private, vec2h> = &vp16;
+  var vf71: f32 = vf69[u32(unconst_u32(16))];
+  let ptr106: ptr<private, vec2h> = &vp16;
+  let vf72: vec4f = unpack4x8unorm(u32(unconst_u32(53)));
+  return out;
+}
+
+fn fn1() -> vec2<bool> {
+  var out: vec2<bool>;
+  let ptr107: ptr<private, vec2h> = &vp16;
+  fn0();
+  let vf73: f16 = (*ptr107)[bitcast<u32>(vp16)];
+  out = vec2<bool>(bool(step(f16(unconst_f16(19812.8)), f16(unconst_f16(3754.6)))));
+  out = vec2<bool>(unpack4xU8(u32(unconst_u32(66))).yy);
+  let vf74: f16 = vf73;
+  var vf75 = fn0();
+  fn0();
+  let vf76: u32 = pack4x8snorm(vec4f(unconst_f32(0.09584), unconst_f32(0.01279), unconst_f32(0.2459), unconst_f32(0.2086)));
+  var vf77 = fn0();
+  var vf78 = fn0();
+  fn0();
+  var vf79 = fn0();
+  vp16 = bitcast<vec2h>(vf78.f17[vf76]);
+  vf78.f17 = vec4f((*ptr107).gggr);
+  let vf80: u32 = pack4x8snorm(vec4f(unconst_f32(0.1381), unconst_f32(0.1373), unconst_f32(-0.2004), unconst_f32(0.04951)));
+  fn0();
+  let ptr108: ptr<function, VertexOutput6> = &vf77;
+  var vf81 = fn0();
+  var vf82 = fn0();
+  return out;
+}
+
+var<workgroup> vw25: atomic<u32>;
+
+var<workgroup> vw26: atomic<i32>;
+
+var<private> vp16: vec2h = vec2h(10689.1, 19236.0);
+
+@vertex
+fn vertex7() -> VertexOutput6 {
+  var out: VertexOutput6;
+  let vf83: vec2f = round(vec2f(f32(vp16[u32(unconst_u32(18))])));
+  let vf84: vec4u = unpack4xU8(u32(unconst_u32(72)));
+  out.f17 -= vf83.yxyy;
+  let vf85: vec4i = countOneBits(vec4i(unconst_i32(-165), unconst_i32(91), unconst_i32(397), unconst_i32(-225)));
+  var vf86: i32 = vf85[u32(unconst_u32(474))];
+  out.f17 -= round(vec2f(unconst_f32(0.3596), unconst_f32(0.01214))).rggg;
+  vf86 -= bitcast<i32>(vp16);
+  let vf87: vec4i = vf85;
+  let vf88: vec2f = round(vec2f(unconst_f32(0.00460), unconst_f32(0.7350)));
+  let vf89: vec4i = vf85;
+  out.f17 = vec4f(f32(all(bool(unconst_bool(true)))));
+  var vf90: f32 = vf83[u32(unconst_u32(14))];
+  vp16 = vec2h(countOneBits(vec4i(unconst_i32(-44), unconst_i32(16), unconst_i32(113), unconst_i32(130))).wy);
+  var vf91: bool = all(bool(unconst_bool(false)));
+  vf86 = vf89.w;
+  out = VertexOutput6(vec4f(vf85));
+  var vf92: vec2f = vf83;
+  vf90 = bitcast<f32>(sign(i32(unconst_i32(130))));
+  let ptr109: ptr<private, vec2h> = &vp16;
+  vf91 = bool(vf85[u32(unconst_u32(2))]);
+  let vf93: f32 = vf92[u32(unconst_u32(222))];
+  var vf94: i32 = sign(i32(unconst_i32(75)));
+  let ptr110: ptr<private, vec2h> = &vp16;
+  let vf95: i32 = sign(i32(unconst_i32(17)));
+  return out;
+}
+
+@fragment
+fn fragment5() -> FragmentOutput2 {
+  var out: FragmentOutput2;
+  out.f1 = vec3u(saturate(vec3h(unconst_f16(1901.1), unconst_f16(-2568.6), unconst_f16(2449.4)))).g;
+  out.f0 |= vec4u(acosh(vec2f(unconst_f32(0.04253), unconst_f32(0.01603))).xxxx);
+  vp16 = vec2h(firstLeadingBit(vec3i(unconst_i32(160), unconst_i32(-77), unconst_i32(232))).gr);
+  out.f1 *= bitcast<u32>(vp16);
+  out.f0 |= unpack4xU8(u32(vp16[u32(unconst_u32(2))]));
+  out.f0 >>= vec4u(floor(vec2h(unconst_f16(608.8), unconst_f16(2701.8))).ggrr);
+  fn0();
+  fn1();
+  out = FragmentOutput2(unpack4xU8(u32(vp16[u32(unconst_u32(453))])), u32(vp16[u32(unconst_u32(453))]));
+  out.f0 >>= vec4u(fma(vec4h(unconst_f16(1424.8), unconst_f16(3702.0), unconst_f16(615.9), unconst_f16(-19824.6)), vec4h(unconst_f16(7744.6), unconst_f16(512.9), unconst_f16(2457.1), unconst_f16(1410.7)), vec4h(unconst_f16(620.1), unconst_f16(19926.4), unconst_f16(11806.8), unconst_f16(-19526.3))));
+  out = FragmentOutput2(vec4u(saturate(vec3h(firstLeadingBit(vec3i(unconst_i32(496), unconst_i32(572), unconst_i32(277))))).xxxy), u32(saturate(vec3h(firstLeadingBit(vec3i(unconst_i32(496), unconst_i32(572), unconst_i32(277))))).r));
+  return out;
+}
+
+@compute @workgroup_size(1, 3, 1)
+fn compute5() {
+  var vf96 = fn1();
+  var vf97 = fn0();
+  var vf98 = fn1();
+  atomicStore(&vw25, u32(unconst_u32(412)));
+  let vf99: f16 = dot(vec4h(unconst_f16(442.5), unconst_f16(3254.7), unconst_f16(6099.3), unconst_f16(9134.9)), vec4h(unconst_f16(9227.0), unconst_f16(10803.4), unconst_f16(2474.5), unconst_f16(10782.5)));
+  atomicOr(&vw25, u32(unconst_u32(136)));
+  let ptr111: ptr<function, vec2<bool>> = &vf96;
+  var vf100 = fn1();
+  var vf101 = fn0();
+  vf100 = vec2<bool>(bool(sinh(f32(vf100[u32(unconst_u32(37))]))));
+  atomicStore(&vw26, i32(unconst_i32(294)));
+  fn1();
+  fn1();
+  atomicMin(&vw26, i32(unconst_i32(27)));
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup38 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 49, resource: textureView18},
+    {binding: 41, resource: textureView18},
+    {binding: 283, resource: {buffer: buffer4, offset: 512, size: 898}},
+    {binding: 39, resource: textureView9},
+    {binding: 294, resource: textureView17},
+    {binding: 50, resource: {buffer: buffer21, offset: 6144, size: 7452}},
+    {binding: 125, resource: textureView19},
+    {binding: 66, resource: {buffer: buffer41, offset: 512, size: 452}},
+    {binding: 452, resource: textureView43},
+    {binding: 26, resource: {buffer: buffer41, offset: 0, size: 2100}},
+    {binding: 13, resource: {buffer: buffer70, offset: 512, size: 160}},
+  ],
+});
+let commandBuffer4 = commandEncoder63.finish();
+let texture91 = device0.createTexture({
+  size: [1128, 80, 1],
+  mipLevelCount: 4,
+  format: 'astc-12x10-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder59.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle1, renderBundle10]);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(593);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer55, 'uint16', 288, 177);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.submit([commandBuffer4]);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let bindGroup39 = device0.createBindGroup({
+  layout: bindGroupLayout9,
+  entries: [{binding: 37, resource: {buffer: buffer67, offset: 7680, size: 2388}}],
+});
+let buffer76 = device0.createBuffer({
+  size: 140,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder77 = device0.createCommandEncoder({});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({colorFormats: ['r8unorm'], depthStencilFormat: 'stencil8', sampleCount: 1, depthReadOnly: true});
+let renderBundle11 = renderBundleEncoder11.finish();
+try {
+computePassEncoder47.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer54, 'uint16', 316, 443);
+} catch {}
+try {
+commandEncoder77.copyBufferToBuffer(buffer64, 180, buffer10, 144, 72);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let imageData6 = new ImageData(8, 84);
+let commandEncoder78 = device0.createCommandEncoder();
+let computePassEncoder73 = commandEncoder78.beginComputePass({});
+let renderPassEncoder2 = commandEncoder77.beginRenderPass({
+  colorAttachments: [{
+  view: textureView58,
+  depthSlice: 4,
+  clearValue: { r: -642.4, g: 985.7, b: -184.8, a: -15.28, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder49.setBindGroup(1, bindGroup33);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+try {
+computePassEncoder68.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup23, new Uint32Array(582), 319, 0);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer10, 'uint16', 176, 285);
+} catch {}
+try {
+buffer51.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer67, 616, new DataView(new ArrayBuffer(4305)), 3210, 388);
+} catch {}
+try {
+computePassEncoder65.setBindGroup(3, bindGroup11, [1280, 256]);
+} catch {}
+try {
+computePassEncoder35.setBindGroup(1, bindGroup8, new Uint32Array(1462), 49, 2);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder62); computePassEncoder62.dispatchWorkgroupsIndirect(buffer55, 140); };
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let bindGroup40 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 59, resource: sampler18}]});
+let buffer77 = device0.createBuffer({size: 1379, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture92 = device0.createTexture({
+  size: {width: 20, height: 19, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  sampleCount: 4,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView78 = texture23.createView({baseArrayLayer: 0});
+try {
+computePassEncoder33.setBindGroup(3, bindGroup9, new Uint32Array(5981), 2_133, 2);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup19);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup32, new Uint32Array(375), 5, 0);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer20, 'uint32', 1_348, 491);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(6, buffer70, 680, 430);
+} catch {}
+let bindGroup41 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 83, resource: {buffer: buffer13, offset: 5632, size: 476}},
+    {binding: 232, resource: {buffer: buffer20, offset: 2816, size: 992}},
+  ],
+});
+let buffer78 = device0.createBuffer({
+  size: 1522,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let sampler43 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 71.05,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder5.setBindGroup(1, bindGroup2, new Uint32Array(3848), 536, 0);
+} catch {}
+try {
+computePassEncoder62.end();
+} catch {}
+try {
+computePassEncoder5.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer78, 'uint16', 352, 7);
+} catch {}
+try {
+buffer23.unmap();
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let buffer79 = device0.createBuffer({
+  label: '\u8206\u00fa\uf83e\u0090\u0f88\u9451\u5017\u87ef\uea75',
+  size: 807,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let renderPassEncoder3 = commandEncoder64.beginRenderPass({
+  colorAttachments: [{view: textureView58, depthSlice: 61, loadOp: 'load', storeOp: 'discard'}],
+  occlusionQuerySet: querySet4,
+});
+try {
+computePassEncoder6.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer78, 'uint32', 380, 202);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup42 = device0.createBindGroup({
+  label: '\u213f\u38e2\ucf92\u3893\uc721\u8792\u0cfc\uca31',
+  layout: bindGroupLayout9,
+  entries: [{binding: 37, resource: {buffer: buffer24, offset: 256, size: 348}}],
+});
+let textureView79 = texture60.createView({aspect: 'depth-only', baseMipLevel: 0, baseArrayLayer: 10, arrayLayerCount: 3});
+try {
+computePassEncoder28.setBindGroup(2, bindGroup25, new Uint32Array(154), 15, 0);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer67, 'uint32', 3_700, 1_211);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline0);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let commandEncoder79 = device0.createCommandEncoder({});
+let texture93 = device0.createTexture({
+  size: {width: 20, height: 19, depthOrArrayLayers: 190},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView80 = texture38.createView({baseArrayLayer: 0});
+let sampler44 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 1.203,
+  lodMaxClamp: 10.47,
+  compare: 'greater-equal',
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder51.setBindGroup(0, bindGroup33);
+} catch {}
+try {
+computePassEncoder9.setBindGroup(1, bindGroup33, new Uint32Array(483), 25, 0);
+} catch {}
+try {
+computePassEncoder34.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup33);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer55, 'uint32', 484, 157);
+} catch {}
+let arrayBuffer11 = buffer2.getMappedRange(1984, 20);
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 78, depthOrArrayLayers: 284}
+*/
+{
+  source: imageData2,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 2, y: 18, z: 18},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder80 = device0.createCommandEncoder();
+let texture94 = device0.createTexture({
+  size: {width: 40, height: 39, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder34.setBindGroup(2, bindGroup21, new Uint32Array(665), 474, 2);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup22);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer68, 'uint32', 292, 4_482);
+} catch {}
+let imageBitmap1 = await createImageBitmap(videoFrame3);
+try {
+computePassEncoder59.setBindGroup(0, bindGroup23);
+} catch {}
+try {
+computePassEncoder45.setBindGroup(2, bindGroup39, new Uint32Array(1172), 41, 0);
+} catch {}
+try {
+computePassEncoder56.setPipeline(pipeline3);
+} catch {}
+try {
+commandEncoder79.copyBufferToTexture({
+  /* bytesInLastRow: 60 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1088 */
+  offset: 1088,
+  bytesPerRow: 45568,
+  rowsPerImage: 212,
+  buffer: buffer54,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 8},
+  aspect: 'all',
+}, {width: 30, height: 12, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup43 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 59, resource: sampler28}]});
+let querySet10 = device0.createQuerySet({type: 'occlusion', count: 465});
+let computePassEncoder74 = commandEncoder80.beginComputePass({label: '\u{1fef3}\u{1fe13}\u6be7\ub6a9\u0454'});
+try {
+computePassEncoder74.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder79.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder81 = device0.createCommandEncoder({});
+let computePassEncoder75 = commandEncoder81.beginComputePass({});
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup17, [512, 2560]);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(189, 0, 20, 0);
+} catch {}
+let bindGroupLayout13 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 46,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let commandEncoder82 = device0.createCommandEncoder({label: '\uf11f\u{1f6ab}'});
+let renderPassEncoder4 = commandEncoder79.beginRenderPass({
+  label: '\u{1f72a}\uc065\u92c4\u3a0c\u0b0f\u0a33\u5bdb\u20b1\u0f0f\u{1faef}',
+  colorAttachments: [{
+  view: textureView58,
+  depthSlice: 4,
+  clearValue: { r: -482.6, g: 573.9, b: -721.9, a: 197.0, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup31, new Uint32Array(470), 1, 0);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer6, 'uint16', 10_862, 747);
+} catch {}
+let arrayBuffer12 = buffer2.getMappedRange(1648, 4);
+try {
+commandEncoder82.resolveQuerySet(querySet4, 9, 58, buffer26, 1536);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 3236, new Int16Array(44307), 2177, 1844);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 0, y: 21, z: 0},
+  aspect: 'all',
+}, new Uint8Array(275).fill(255), /* required buffer size: 275 */
+{offset: 275, bytesPerRow: 257, rowsPerImage: 65}, {width: 13, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup44 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 35, resource: {buffer: buffer79, offset: 0, size: 56}},
+    {binding: 60, resource: textureView18},
+  ],
+});
+let textureView81 = texture37.createView({label: '\ufc6b\u5b24\u0550\u89da\u031f', dimension: '2d', mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder76 = commandEncoder82.beginComputePass({});
+try {
+computePassEncoder36.setBindGroup(2, bindGroup12, [256, 512]);
+} catch {}
+try {
+computePassEncoder52.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(57);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline4);
+} catch {}
+let texture95 = device0.createTexture({
+  size: {width: 1330, height: 1, depthOrArrayLayers: 90},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler45 = device0.createSampler({
+  label: '\u0f35\u0db4\u0c9b\ue59c\u062c\u4916\u489c\ub3ed\ue1e6\u9eec',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 73.03,
+  lodMaxClamp: 88.14,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder43.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup24);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(5, buffer68, 0, 9_359);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 39, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture94,
+  mipLevel: 0,
+  origin: {x: 5, y: 4, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder83 = device0.createCommandEncoder({});
+let sampler46 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', minFilter: 'linear', lodMaxClamp: 92.32});
+try {
+computePassEncoder32.setBindGroup(3, bindGroup6, new Uint32Array(269), 6, 2);
+} catch {}
+try {
+computePassEncoder29.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(6, buffer24, 1_784, 69);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(13).fill(220), /* required buffer size: 13 */
+{offset: 13}, {width: 60, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup45 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 236, resource: sampler14}]});
+let pipelineLayout7 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout6]});
+try {
+computePassEncoder20.setBindGroup(2, bindGroup21, new Uint32Array(1185), 279, 2);
+} catch {}
+try {
+computePassEncoder17.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder83.copyTextureToTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 5, y: 9, z: 10},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder83.resolveQuerySet(querySet0, 87, 262, buffer66, 0);
+} catch {}
+let texture96 = device0.createTexture({
+  size: [6552, 65, 1],
+  mipLevelCount: 2,
+  format: 'astc-6x5-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder77 = commandEncoder83.beginComputePass({});
+let sampler47 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 28.04,
+  lodMaxClamp: 42.55,
+  compare: 'never',
+});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup0, new Uint32Array(6124), 652, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 665, height: 1, depthOrArrayLayers: 49}
+*/
+{
+  source: videoFrame9,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup46 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 139, resource: textureView10},
+    {binding: 142, resource: textureView11},
+    {binding: 25, resource: {buffer: buffer44, offset: 0, size: 3568}},
+    {binding: 426, resource: {buffer: buffer4, offset: 256, size: 1032}},
+    {binding: 925, resource: textureView20},
+    {binding: 32, resource: textureView22},
+    {binding: 16, resource: {buffer: buffer56, offset: 1280}},
+    {binding: 3, resource: sampler5},
+    {binding: 88, resource: {buffer: buffer19, offset: 3072, size: 1160}},
+    {binding: 96, resource: textureView44},
+    {binding: 779, resource: {buffer: buffer75, offset: 512, size: 3817}},
+  ],
+});
+let textureView82 = texture21.createView({format: 'rgb10a2uint', baseMipLevel: 0, mipLevelCount: 1, arrayLayerCount: 1});
+let sampler48 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 42.41,
+  lodMaxClamp: 76.20,
+});
+try {
+computePassEncoder30.setBindGroup(2, bindGroup1, new Uint32Array(1378), 157, 0);
+} catch {}
+try {
+computePassEncoder71.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer56, 'uint32', 1_348, 963);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(1, buffer64, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer73, 5876, new BigUint64Array(8032), 263, 1392);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+let buffer80 = device0.createBuffer({
+  size: 23395,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture97 = device0.createTexture({
+  size: [30, 12, 1],
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder14.setBindGroup(0, bindGroup27, new Uint32Array(1393), 85, 0);
+} catch {}
+try {
+renderPassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline4);
+} catch {}
+try {
+  await buffer74.mapAsync(GPUMapMode.READ, 0, 200);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture91,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(91).fill(43), /* required buffer size: 91 */
+{offset: 91}, {width: 24, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let computePassEncoder78 = commandEncoder77.beginComputePass({});
+let externalTexture10 = device0.importExternalTexture({source: videoFrame12});
+try {
+computePassEncoder24.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(4, buffer78, 0, 1_371);
+} catch {}
+let arrayBuffer13 = buffer74.getMappedRange(8, 52);
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer27, 976, new Int16Array(9968), 937, 204);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let texture98 = device0.createTexture({
+  label: '\u01fd\u764f\uc639',
+  size: {width: 10, height: 9, depthOrArrayLayers: 372},
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder63.setPipeline(pipeline3);
+} catch {}
+try {
+buffer56.unmap();
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroup47 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [
+    {binding: 107, resource: textureView72},
+    {binding: 57, resource: textureView45},
+    {binding: 22, resource: {buffer: buffer13, offset: 2560}},
+    {binding: 187, resource: textureView7},
+    {binding: 4, resource: {buffer: buffer41, offset: 256, size: 2212}},
+    {binding: 9, resource: {buffer: buffer7, offset: 2816, size: 452}},
+    {binding: 252, resource: textureView74},
+    {binding: 431, resource: sampler7},
+    {binding: 110, resource: {buffer: buffer41, offset: 768, size: 1048}},
+    {binding: 242, resource: sampler39},
+    {binding: 68, resource: {buffer: buffer54, offset: 1024, size: 380}},
+    {binding: 174, resource: sampler48},
+    {binding: 176, resource: textureView11},
+    {binding: 221, resource: textureView41},
+    {binding: 39, resource: textureView11},
+    {binding: 848, resource: textureView77},
+    {binding: 101, resource: textureView11},
+  ],
+});
+let texture99 = device0.createTexture({
+  label: '\u0ec7\u0402\uf012\ua7e8\u{1f875}\uc518\u3d7f',
+  size: [332],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView83 = texture28.createView({label: '\u{1ff7f}\u0733\u{1fcec}\u0c63\uc99e\u2611\u0443', aspect: 'all'});
+try {
+computePassEncoder5.setBindGroup(1, bindGroup16, [0, 1792]);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup24, new Uint32Array(1876), 56, 0);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant({ r: 240.1, g: 352.1, b: -3.611, a: -875.2, });
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 9, depthOrArrayLayers: 372}
+*/
+{
+  source: videoFrame12,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture98,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 71},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder84 = device0.createCommandEncoder({});
+let sampler49 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 74.29,
+  lodMaxClamp: 91.43,
+});
+try {
+computePassEncoder56.setBindGroup(3, bindGroup22);
+} catch {}
+try {
+computePassEncoder35.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder84.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 192 */
+  offset: 192,
+  buffer: buffer3,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup48 = device0.createBindGroup({
+  layout: bindGroupLayout9,
+  entries: [{binding: 37, resource: {buffer: buffer69, offset: 0, size: 1276}}],
+});
+let textureView84 = texture21.createView({mipLevelCount: 1});
+let computePassEncoder79 = commandEncoder84.beginComputePass({});
+try {
+computePassEncoder79.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(7, buffer64, 0);
+} catch {}
+let bindGroup49 = device0.createBindGroup({layout: bindGroupLayout6, entries: [{binding: 302, resource: textureView9}]});
+let buffer81 = device0.createBuffer({
+  size: 17108,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let textureView85 = texture76.createView({baseMipLevel: 0, mipLevelCount: 1});
+let textureView86 = texture80.createView({dimension: '2d', baseArrayLayer: 2});
+try {
+computePassEncoder19.setBindGroup(0, bindGroup30);
+} catch {}
+try {
+computePassEncoder55.setPipeline(pipeline3);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let commandEncoder85 = device0.createCommandEncoder({});
+let computePassEncoder80 = commandEncoder85.beginComputePass({});
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup13, new Uint32Array(3204), 502, 0);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline4);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 665, height: 1, depthOrArrayLayers: 40}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture72,
+  mipLevel: 1,
+  origin: {x: 399, y: 0, z: 14},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder86 = device0.createCommandEncoder({});
+let textureView87 = texture19.createView({});
+let computePassEncoder81 = commandEncoder86.beginComputePass({});
+try {
+computePassEncoder79.setBindGroup(0, bindGroup15, new Uint32Array(107), 0, 2);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup20, new Uint32Array(64), 3, 0);
+} catch {}
+try {
+globalThis.someLabel = externalTexture4.label;
+} catch {}
+let shaderModule7 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires pointer_composite_access;
+
+requires pointer_composite_access;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(3) var sam4: sampler;
+
+@group(0) @binding(16) var<storage, read_write> buffer82: array<array<vec2f, 16>, 55>;
+
+@group(0) @binding(25) var<storage, read_write> buffer83: array<array<vec2u, 444>>;
+
+@group(0) @binding(32) var st8: texture_storage_1d<r32sint, read_write>;
+
+@group(0) @binding(88) var<storage, read_write> buffer84: atomic<u32>;
+
+@group(0) @binding(96) var st9: texture_storage_2d<rgba16sint, write>;
+
+@group(0) @binding(139) var tex15: texture_2d<u32>;
+
+@group(0) @binding(142) var tex16: texture_2d<i32>;
+
+@group(0) @binding(779) var<uniform> buffer85: vec2i;
+
+@group(0) @binding(925) var tex17: texture_2d<i32>;
+
+@group(1) @binding(35) var<storage, read_write> buffer86: vec2h;
+
+@group(1) @binding(60) var tex18: texture_2d<f32>;
+
+struct T0 {
+  @size(64) f0: mat3x4f,
+  @size(80) f1: array<array<array<array<array<array<array<vec4i, 1>, 1>, 1>, 1>, 2>, 1>, 2>,
+  @size(448) f2: vec4i,
+}
+
+struct VertexOutput7 {
+  @location(2) @interpolate(linear, centroid) f18: vec4h,
+  @builtin(position) f19: vec4f,
+}
+
+struct FragmentOutput3 {
+  @location(0) f0: f32,
+  @location(5) @interpolate(flat, sample) f1: vec2u,
+}
+
+alias vec3b = vec3<bool>;
+
+override override3: u32;
+
+fn fn0() -> mat4x4h {
+  var out: mat4x4h;
+  var vf102: u32 = atomicExchange(&buffer84, u32(unconst_u32(251)));
+  vf102 = vec2u(buffer82[u32(unconst_u32(91))][15]).r;
+  vf102 >>= override3;
+  let vf103: f16 = (*&buffer86)[u32(unconst_u32(33))];
+  let vf104: vec4f = textureLoad(tex18, vec2i(unconst_i32(31), unconst_i32(47)), i32(unconst_i32(288)));
+  vf102 *= bitcast<u32>(buffer82[u32(unconst_u32(472))][u32(unconst_u32(5))][u32(unconst_u32(113))]);
+  vf102 -= pack2x16float(buffer82[bitcast<u32>(textureGather(279 % 4, tex18, sam4, vec2f(unconst_f32(0.08799), unconst_f32(0.7583)), clamp(vec2i(420, 503), vec2i(-8), vec2i(7))).g)][15]);
+  out += mat4x4h(f16(textureNumLevels(tex16)), f16(textureNumLevels(tex16)), f16(textureNumLevels(tex16)), f16(textureNumLevels(tex16)), f16(textureNumLevels(tex16)), f16(textureNumLevels(tex16)), f16(textureNumLevels(tex16)), f16(textureNumLevels(tex16)), f16(textureNumLevels(tex16)), f16(textureNumLevels(tex16)), f16(textureNumLevels(tex16)), f16(textureNumLevels(tex16)), f16(textureNumLevels(tex16)), f16(textureNumLevels(tex16)), f16(textureNumLevels(tex16)), f16(textureNumLevels(tex16)));
+  out = mat4x4h(bitcast<vec4h>((*&buffer82)[u32(unconst_u32(127))][u32(unconst_u32(55))]), bitcast<vec4h>((*&buffer82)[u32(unconst_u32(127))][u32(unconst_u32(55))]), bitcast<vec4h>((*&buffer82)[u32(unconst_u32(127))][u32(unconst_u32(55))]), bitcast<vec4h>((*&buffer82)[u32(unconst_u32(127))][u32(unconst_u32(55))]));
+  textureStore(st8, i32(unconst_i32(145)), vec4i(vec4i(unconst_i32(60), unconst_i32(-5), unconst_i32(192), unconst_i32(454))));
+  textureStore(st8, i32(unconst_i32(-170)), vec4i(vec4i(unconst_i32(49), unconst_i32(210), unconst_i32(445), unconst_i32(795))));
+  let ptr112: ptr<storage, vec2f, read_write> = &buffer82[54][u32(unconst_u32(394))];
+  let vf105: f32 = (*ptr112)[bitcast<vec2u>((*&buffer85)).g];
+  atomicCompareExchangeWeak(&buffer84, unconst_u32(95), unconst_u32(672));
+  let vf106: vec4f = vf104;
+  out = mat4x4h(vec4h(textureGather(84 % 4, tex18, sam4, vec2f(unconst_f32(0.1436), unconst_f32(0.1910)))), vec4h(textureGather(84 % 4, tex18, sam4, vec2f(unconst_f32(0.1436), unconst_f32(0.1910)))), vec4h(textureGather(84 % 4, tex18, sam4, vec2f(unconst_f32(0.1436), unconst_f32(0.1910)))), vec4h(textureGather(84 % 4, tex18, sam4, vec2f(unconst_f32(0.1436), unconst_f32(0.1910)))));
+  textureStore(st8, i32(unconst_i32(94)), vec4i(vec4i(unconst_i32(7), unconst_i32(70), unconst_i32(190), unconst_i32(322))));
+  var vf107: f32 = (*&buffer82)[u32(unconst_u32(376))][u32(unconst_u32(380))][bitcast<u32>((*&buffer85)[u32(unconst_u32(59))])];
+  textureStore(st8, i32(unconst_i32(234)), vec4i(vec4i(unconst_i32(121), unconst_i32(106), unconst_i32(339), unconst_i32(-146))));
+  let ptr113: ptr<storage, vec2h, read_write> = &(*&buffer86);
+  buffer86 = vec2h(buffer82[54][atomicExchange(&(*&buffer84), u32(unconst_u32(37)))]);
+  return out;
+  _ = override3;
+}
+
+@vertex
+fn vertex8() -> VertexOutput7 {
+  var out: VertexOutput7;
+  out.f18 = fma(vec3h(normalize(vec4f(unconst_f32(0.1924), unconst_f32(0.3384), unconst_f32(0.07919), unconst_f32(0.1246))).bar), vec3h(unconst_f16(6227.8), unconst_f16(14906.4), unconst_f16(6934.6)), vec3h(unconst_f16(1181.6), unconst_f16(3427.7), unconst_f16(-18844.9))).ggrr;
+  var vf108: vec4f = textureGather(82 % 4, tex18, sam4, vec2f(unconst_f32(0.2160), unconst_f32(0.09678)), clamp(vec2i(288, 27), vec2i(-8), vec2i(7)));
+  var vf109: vec4i = countTrailingZeros(vec4i(unconst_i32(245), unconst_i32(24), unconst_i32(17), unconst_i32(342)));
+  let vf110: f32 = vf108[u32(unconst_u32(200))];
+  let vf111: vec2u = textureDimensions(tex15);
+  let ptr114: ptr<uniform, vec2i> = &(*&buffer85);
+  vf108 = unpack2x16float(u32(unconst_u32(613))).grgr;
+  let ptr115: ptr<uniform, vec2i> = &(*&buffer85);
+  var vf112: i32 = dot4I8Packed(u32(unconst_u32(91)), u32(unconst_u32(8)));
+  let ptr116: ptr<uniform, vec2i> = &(*ptr114);
+  let vf113: vec4i = textureGather(5 % 4, tex16, sam4, vec2f(unconst_f32(0.1539), unconst_f32(0.2977)));
+  let vf114: f32 = determinant(mat4x4f());
+  return out;
+}
+
+@fragment
+fn fragment6() -> FragmentOutput3 {
+  var out: FragmentOutput3;
+  buffer82[u32(unconst_u32(60))][15] = buffer82[u32(unconst_u32(60))][15];
+  fn0();
+  let ptr117: ptr<storage, vec2f, read_write> = &buffer82[u32(unconst_u32(383))][15];
+  var vf115 = fn0();
+  buffer82[u32(unconst_u32(12))][u32(unconst_u32(18))] = bitcast<vec2f>((*&buffer85));
+  out.f0 = f32(vf115[u32(unconst_u32(37))][u32(unconst_u32(213))]);
+  textureStore(st9, vec2i(unconst_i32(59), unconst_i32(3)), vec4i(vec4i(unconst_i32(123), unconst_i32(108), unconst_i32(115), unconst_i32(330))));
+  discard;
+  textureStore(st8, i32(unconst_i32(2)), vec4i(vec4i(unconst_i32(116), unconst_i32(201), unconst_i32(296), unconst_i32(238))));
+  return out;
+  _ = override3;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute6() {
+  let vf116: vec4f = mix(vec4f(unconst_f32(0.00494), unconst_f32(0.02991), unconst_f32(0.7001), unconst_f32(0.04959)), vec4f(unconst_f32(0.06774), unconst_f32(0.2186), unconst_f32(0.1178), unconst_f32(0.2373)), f32(unconst_f32(0.04174)));
+  var vf117: u32 = (*&buffer83)[u32(unconst_u32(533))][u32(unconst_u32(42))][u32(unconst_u32(21))];
+  let ptr118: ptr<storage, array<vec2f, 16>, read_write> = &(*&buffer82)[u32(unconst_u32(236))];
+  vf117 *= pack2x16float(buffer82[54][15]);
+  let vf118: i32 = (*&buffer85)[u32(unconst_u32(90))];
+  let ptr119: ptr<storage, vec2f, read_write> = &(*&buffer82)[54][u32(unconst_u32(355))];
+  let ptr120: ptr<storage, array<vec2u, 444>, read_write> = &buffer83[bitcast<i32>(buffer83[arrayLength(&buffer83)][443][0])];
+  buffer86 *= bitcast<vec2h>(pack4x8unorm(vec4f(unconst_f32(0.1888), unconst_f32(0.09218), unconst_f32(0.02601), unconst_f32(0.09834))));
+  buffer83[u32(unconst_u32(143))][bitcast<vec2u>(unpack2x16unorm(u32(unconst_u32(5)))).g] |= vec2u((*&buffer85));
+  let ptr121: ptr<storage, vec2f, read_write> = &buffer82[pack2x16snorm((*&buffer82)[54][u32(unconst_u32(307))])][u32(unconst_u32(493))];
+  textureStore(st8, i32(unconst_i32(3)), vec4i(vec4i(unconst_i32(257), unconst_i32(153), unconst_i32(154), unconst_i32(48))));
+  let ptr122: ptr<storage, array<vec2f, 16>, read_write> = &(*&buffer82)[54];
+  buffer86 = vec2h(buffer83[bitcast<i32>(buffer83[arrayLength(&buffer83)][u32(unconst_u32(325))][u32(unconst_u32(162))])][443]);
+  var vf119: vec4f = mix(vec4f(unconst_f32(-0.00809), unconst_f32(0.07150), unconst_f32(0.1103), unconst_f32(0.4239)), vec4f(unconst_f32(0.04485), unconst_f32(0.3377), unconst_f32(0.05844), unconst_f32(0.01037)), f32(unconst_f32(0.03227)));
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer87 = device0.createBuffer({size: 2208, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+try {
+computePassEncoder30.setBindGroup(2, bindGroup36, [256, 0]);
+} catch {}
+try {
+computePassEncoder42.setBindGroup(3, bindGroup8, new Uint32Array(3501), 1_544, 2);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle5]);
+} catch {}
+let commandEncoder87 = device0.createCommandEncoder({label: '\ub902\uf119\u251a\ufd58\u{1f6ff}\ub949\u{1f720}\u{1f8a5}\u49be\u{1f7fc}\u0e0d'});
+let textureView88 = texture61.createView({dimension: '2d-array', aspect: 'depth-only', mipLevelCount: 1});
+let computePassEncoder82 = commandEncoder87.beginComputePass({label: '\u011a\u{1f9d5}\uc633\u3ece\u1525\u{1f996}'});
+try {
+computePassEncoder48.setBindGroup(1, bindGroup33, []);
+} catch {}
+try {
+computePassEncoder12.setBindGroup(1, bindGroup2, new Uint32Array(242), 64, 0);
+} catch {}
+try {
+computePassEncoder69.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup43);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline4);
+} catch {}
+let textureView89 = texture84.createView({format: 'rgba8unorm', mipLevelCount: 1});
+let textureView90 = texture55.createView({dimension: '2d', aspect: 'all', baseArrayLayer: 12});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({colorFormats: ['r16uint'], depthStencilFormat: 'depth16unorm', depthReadOnly: true});
+let renderBundle12 = renderBundleEncoder12.finish({label: '\uf8a4\u8ad6\u3681\u606b\ubf25\u79c0\u0c1f\u{1fcce}\u87cb'});
+try {
+computePassEncoder16.setPipeline(pipeline3);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder88 = device0.createCommandEncoder({});
+let textureView91 = texture89.createView({dimension: 'cube', baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 1});
+let computePassEncoder83 = commandEncoder88.beginComputePass({label: '\u{1fff2}\uf7eb\u{1fd5a}\u3595\u70aa\u03d5\u0044\u0c65'});
+try {
+computePassEncoder33.setBindGroup(1, bindGroup42, []);
+} catch {}
+try {
+renderPassEncoder1.setViewport(60.70360176814291, 0.7560516210724562, 120.13516089529271, 0.00022022372399938678, 0.4937188879180544, 0.6870009319317038);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer56, 'uint16', 3_570, 834);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer56, 2472, new BigUint64Array(7600), 551, 60);
+} catch {}
+let commandEncoder89 = device0.createCommandEncoder({});
+let texture100 = device0.createTexture({
+  size: {width: 665},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView92 = texture67.createView({dimension: '3d', baseMipLevel: 3, mipLevelCount: 1});
+try {
+computePassEncoder73.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(1, buffer13, 0, 5_307);
+} catch {}
+let videoFrame13 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'jedecP22Phosphors', transfer: 'smpte170m'} });
+let bindGroupLayout14 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 152, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {
+      binding: 999,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 60,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let bindGroup50 = device0.createBindGroup({layout: bindGroupLayout5, entries: [{binding: 65, resource: textureView9}]});
+let buffer88 = device0.createBuffer({size: 12339, usage: GPUBufferUsage.COPY_DST});
+let texture101 = device0.createTexture({
+  size: [20, 19, 1],
+  dimension: '2d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder84 = commandEncoder89.beginComputePass({});
+try {
+computePassEncoder57.setBindGroup(1, bindGroup26, new Uint32Array(1271), 128, 0);
+} catch {}
+try {
+computePassEncoder75.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer56, 'uint16', 1_388, 1_335);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline5);
+} catch {}
+let arrayBuffer14 = buffer74.getMappedRange(0, 0);
+try {
+device0.queue.writeTexture({
+  texture: texture71,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'depth-only',
+}, new Uint8Array(1_530_470).fill(99), /* required buffer size: 1_530_470 */
+{offset: 26, bytesPerRow: 686, rowsPerImage: 223}, {width: 332, height: 1, depthOrArrayLayers: 11});
+} catch {}
+let commandEncoder90 = device0.createCommandEncoder({});
+let texture102 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 13},
+  mipLevelCount: 2,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView93 = texture38.createView({});
+try {
+computePassEncoder18.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder3.setViewport(330.7654398607086, 0.1298409692181397, 1.0851306163577346, 0.5381372162015791, 0.7858934734031608, 0.8554763660477643);
+} catch {}
+try {
+commandEncoder90.copyBufferToTexture({
+  /* bytesInLastRow: 120 widthInBlocks: 60 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 364 */
+  offset: 364,
+  buffer: buffer33,
+}, {
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 60, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture91,
+  mipLevel: 0,
+  origin: {x: 84, y: 70, z: 0},
+  aspect: 'all',
+}, new Uint8Array(233).fill(224), /* required buffer size: 233 */
+{offset: 233}, {width: 36, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup51 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 362, resource: textureView36},
+    {binding: 267, resource: textureView63},
+    {binding: 194, resource: textureView18},
+    {binding: 87, resource: textureView37},
+  ],
+});
+let textureView94 = texture102.createView({dimension: 'cube', mipLevelCount: 1, baseArrayLayer: 1});
+try {
+computePassEncoder4.setBindGroup(3, bindGroup38, new Uint32Array(2460), 174, 2);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(3, buffer42, 0, 325);
+} catch {}
+let bindGroup52 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 362, resource: textureView36},
+    {binding: 87, resource: textureView32},
+    {binding: 267, resource: textureView56},
+    {binding: 194, resource: textureView25},
+  ],
+});
+let computePassEncoder85 = commandEncoder90.beginComputePass({label: '\u3ce6\u0bd3\u0a4f\u7b9f\u7014'});
+let sampler50 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 77.46,
+  lodMaxClamp: 81.47,
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder37.setBindGroup(3, bindGroup42);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer76, 'uint32', 32, 11);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline5);
+} catch {}
+let textureView95 = texture52.createView({dimension: '2d', baseArrayLayer: 1});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({
+  label: '\u4ece\u05ab\u{1f92c}\u1429\u0298\u{1fbe1}\u09bb\u0922\u{1fcfc}\u58f7\u{1f8bc}',
+  colorFormats: ['rgb10a2uint'],
+  sampleCount: 1,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder58.setBindGroup(3, bindGroup1, new Uint32Array(2651), 921, 0);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(1, buffer1);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture77,
+  mipLevel: 0,
+  origin: {x: 3, y: 2, z: 11},
+  aspect: 'all',
+}, new Uint8Array(625).fill(70), /* required buffer size: 625 */
+{offset: 127, bytesPerRow: 247}, {width: 2, height: 3, depthOrArrayLayers: 1});
+} catch {}
+try {
+computePassEncoder53.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(3, bindGroup26, new Uint32Array(340), 159, 0);
+} catch {}
+try {
+renderBundleEncoder13.setPipeline(pipeline5);
+} catch {}
+let arrayBuffer15 = buffer74.getMappedRange(64, 36);
+try {
+buffer74.unmap();
+} catch {}
+let commandEncoder91 = device0.createCommandEncoder({});
+let querySet11 = device0.createQuerySet({type: 'occlusion', count: 1314});
+let computePassEncoder86 = commandEncoder91.beginComputePass({});
+let renderBundle13 = renderBundleEncoder13.finish({});
+try {
+computePassEncoder51.setBindGroup(1, bindGroup50, new Uint32Array(406), 158, 0);
+} catch {}
+try {
+computePassEncoder37.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder13.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.TEXTURE_BINDING});
+} catch {}
+let videoFrame14 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'smpte240m', transfer: 'linear'} });
+let buffer89 = device0.createBuffer({
+  size: 24752,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let commandEncoder92 = device0.createCommandEncoder({});
+let computePassEncoder87 = commandEncoder92.beginComputePass({label: '\u1909\ucf67'});
+try {
+renderPassEncoder1.setVertexBuffer(5, buffer78);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+let shaderModule8 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(83) var<storage, read_write> buffer90: array<T2, 1>;
+
+@group(0) @binding(232) var<storage, read> buffer91: array<i32, 1>;
+
+struct T0 {
+  @align(8) @size(80) f0: array<atomic<u32>>,
+}
+
+struct T1 {
+  f0: atomic<u32>,
+}
+
+struct T2 {
+  @size(80) f0: array<mat2x2f, 3>,
+}
+
+struct VertexOutput8 {
+  @builtin(position) f20: vec4f,
+  @location(6) f21: f16,
+  @location(0) f22: vec2u,
+  @location(15) @interpolate(flat, centroid) f23: i32,
+}
+
+struct FragmentOutput4 {
+  @location(0) @interpolate(flat) f0: vec4u,
+}
+
+fn fn0(a0: ptr<workgroup, atomic<u32>>) -> VertexOutput8 {
+  var out: VertexOutput8;
+  out.f22 = vec2u(u32(vp17[0][0]));
+  let vf120: f32 = (*&buffer90)[0].f0[2][u32(unconst_u32(233))][u32(unconst_u32(31))];
+  out.f20 = vp21[0].f0[2][unconst_i32(0)].grrg;
+  atomicOr(&(*a0), u32(unconst_u32(28)));
+  let ptr123: ptr<private, vec4h> = &vp18;
+  atomicSub(&(*a0), bitcast<u32>(asin(vec3f(insertBits(vec3i(unconst_i32(38), unconst_i32(111), unconst_i32(88)), vec3i(unconst_i32(95), unconst_i32(484), unconst_i32(159)), bitcast<u32>(normalize(vec2h(unconst_f16(650.9), unconst_f16(2747.2)))), u32(unconst_u32(480)))))[1]));
+  let ptr124: ptr<private, mat2x2f> = &vp21[u32(unconst_u32(10))].f0[2];
+  let ptr125: ptr<private, array<bool, 1>> = &vp17[0];
+  let ptr126: ptr<storage, mat2x2f, read_write> = &(*&buffer90)[u32(unconst_u32(36))].f0[2];
+  return out;
+}
+
+var<workgroup> vw27: FragmentOutput4;
+
+var<private> vp17: array<array<bool, 1>, 1> = array(array(bool(false)));
+
+var<private> vp18: vec4h = vec4h(462.4, -17011.9, 3490.7, 2970.7);
+
+var<private> vp19: mat2x4h = mat2x4h();
+
+var<private> vp20: FragmentOutput4 = FragmentOutput4();
+
+var<private> vp21: array<T2, 1> = array<T2, 1>(T2());
+
+@vertex
+fn vertex9(@location(8) @interpolate(linear, centroid) a0: vec2f, @location(6) a1: vec4i, @location(12) @interpolate(flat) a2: vec4f) -> VertexOutput8 {
+  var out: VertexOutput8;
+  let ptr127: ptr<storage, i32, read> = &(*&buffer91)[u32(unconst_u32(600))];
+  vp18 *= bitcast<vec4h>(vp21[0].f0[2][unconst_i32(1)]);
+  let ptr128: ptr<private, mat2x2f> = &vp21[u32(unconst_u32(78))].f0[u32(unconst_u32(264))];
+  var vf121: f16 = vp19[u32(unconst_u32(82))][u32(unconst_u32(293))];
+  let ptr129: ptr<private, vec4u> = &vp20.f0;
+  return out;
+}
+
+@fragment
+fn fragment7() -> FragmentOutput4 {
+  var out: FragmentOutput4;
+  vp17[u32(unconst_u32(213))][u32(unconst_u32(180))] = bool((*&buffer90)[0].f0[u32(unconst_u32(189))][unconst_i32(0)].r);
+  buffer90[u32(unconst_u32(377))].f0[u32(unconst_u32(3))] += buffer90[u32(unconst_u32(107))].f0[2];
+  let ptr130: ptr<private, mat2x2f> = &vp21[0].f0[2];
+  out = FragmentOutput4(vec4u(insertBits(u32(unconst_u32(64)), u32(unconst_u32(149)), u32(unconst_u32(72)), u32(unconst_u32(66)))));
+  buffer90[u32(unconst_u32(194))] = T2(array<mat2x2f, 3>(vp21[0].f0[2], vp21[0].f0[2], vp21[0].f0[2]));
+  var vf122: vec2f = (*&buffer90)[bitcast<vec2u>(buffer90[u32(unconst_u32(91))].f0[2][unconst_i32(0)]).r].f0[u32(unconst_u32(362))][u32(unconst_u32(8))];
+  let ptr131: ptr<storage, mat2x2f, read_write> = &(*&buffer90)[u32(unconst_u32(128))].f0[u32(unconst_u32(375))];
+  let ptr132: ptr<private, mat2x2f> = &vp21[u32(unconst_u32(63))].f0[2];
+  out.f0 &= vec4u(bitcast<u32>((*&buffer90)[0].f0[u32(unconst_u32(165))][bitcast<u32>((*&buffer90)[0].f0[u32(unconst_u32(307))][u32(unconst_u32(59))].g)][u32(unconst_u32(55))]));
+  let ptr133: ptr<storage, mat2x2f, read_write> = &(*&buffer90)[0].f0[u32(unconst_u32(188))];
+  vp19 = mat2x4h(bitcast<vec4h>(vp21[u32(unconst_u32(87))].f0[pack2x16float(vp21[0].f0[u32(unconst_u32(115))][unconst_i32(0)])][unconst_i32(1)]), bitcast<vec4h>(vp21[u32(unconst_u32(87))].f0[pack2x16float(vp21[0].f0[u32(unconst_u32(115))][unconst_i32(0)])][unconst_i32(0)]));
+  let ptr134: ptr<storage, mat2x2f, read_write> = &(*&buffer90)[0].f0[2];
+  let ptr135: ptr<storage, mat2x2f, read_write> = &(*&buffer90)[u32(unconst_u32(303))].f0[u32(unconst_u32(31))];
+  let ptr136: ptr<storage, mat2x2f, read_write> = &(*&buffer90)[pack2x16float((*ptr135)[u32(unconst_u32(199))])].f0[2];
+  vp17[u32(unconst_u32(15))][u32(unconst_u32(28))] = bool((*ptr135)[u32(unconst_u32(225))].g);
+  vp20.f0 = bitcast<vec4u>((*&buffer90)[0].f0[2][unconst_i32(0)].rrrg);
+  let ptr137: ptr<private, T2> = &vp21[0];
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute7() {
+  let ptr138: ptr<private, FragmentOutput4> = &vp20;
+  let vf123: vec2i = countTrailingZeros(vec2i(unconst_i32(251), unconst_i32(232)));
+  let ptr139: ptr<private, mat2x2f> = &vp21[0].f0[u32(unconst_u32(4))];
+  vp19 = mat2x4h(f16(buffer91[u32(unconst_u32(115))]), f16(buffer91[u32(unconst_u32(115))]), f16(buffer91[u32(unconst_u32(115))]), f16(buffer91[u32(unconst_u32(115))]), f16(buffer91[u32(unconst_u32(115))]), f16(buffer91[u32(unconst_u32(115))]), f16(buffer91[u32(unconst_u32(115))]), f16(buffer91[u32(unconst_u32(115))]));
+  vp18 = bitcast<vec4h>(vp21[0].f0[u32(unconst_u32(54))][u32(unconst_u32(21))]);
+  let ptr140: ptr<private, bool> = &vp17[u32(unconst_u32(40))][u32(unconst_u32(30))];
+  let vf124: i32 = insertBits(i32(unconst_i32(17)), i32(unconst_i32(274)), u32(unconst_u32(252)), u32(unconst_u32(103)));
+  let ptr141: ptr<private, array<bool, 1>> = &vp17[u32(unconst_u32(135))];
+  let ptr142: ptr<private, mat2x2f> = &vp21[u32(unconst_u32(24))].f0[2];
+  let ptr143: ptr<storage, i32, read> = &buffer91[0];
+  let ptr144: ptr<private, mat2x2f> = &vp21[u32(unconst_u32(51))].f0[u32(unconst_u32(116))];
+  vp18 = vec4h(f16((*&buffer91)[u32(unconst_u32(156))]));
+  vw27 = FragmentOutput4(unpack4xU8(u32((*ptr141)[0])));
+}`,
+  hints: {},
+});
+let buffer92 = device0.createBuffer({
+  size: 21061,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder20.setPipeline(pipeline3);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let videoFrame15 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'smpteRp431', transfer: 'bt709'} });
+let bindGroup53 = device0.createBindGroup({layout: bindGroupLayout5, entries: [{binding: 65, resource: textureView11}]});
+let commandEncoder93 = device0.createCommandEncoder();
+let texture103 = device0.createTexture({
+  size: {width: 40, height: 39, depthOrArrayLayers: 22},
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture104 = device0.createTexture({
+  label: '\u0c94\u04ce\u59f2\u9730\u044b\u0927\u6743\u7dbe',
+  size: [15, 6, 23],
+  mipLevelCount: 1,
+  format: 'stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView96 = texture24.createView({format: 'rgb10a2uint', mipLevelCount: 1, baseArrayLayer: 0});
+try {
+computePassEncoder82.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle3, renderBundle10, renderBundle10, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline5);
+} catch {}
+try {
+commandEncoder93.copyBufferToBuffer(buffer79, 708, buffer73, 4880, 0);
+} catch {}
+try {
+commandEncoder93.copyTextureToTexture({
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 205, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout8 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder94 = device0.createCommandEncoder({});
+let texture105 = device0.createTexture({
+  size: [665, 1, 51],
+  sampleCount: 1,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView97 = texture86.createView({
+  label: '\u91b2\uf76c\u5b1d\u{1f96a}\u{1fb93}\u061e\u845c\u{1fed4}\u359f\u0073',
+  dimension: '2d',
+  baseArrayLayer: 10,
+});
+let computePassEncoder88 = commandEncoder94.beginComputePass({});
+let renderPassEncoder5 = commandEncoder93.beginRenderPass({
+  colorAttachments: [{
+  view: textureView58,
+  depthSlice: 37,
+  clearValue: { r: -639.6, g: 85.62, b: -863.6, a: -23.46, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let sampler51 = device0.createSampler({
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 87.78,
+  lodMaxClamp: 95.10,
+});
+try {
+computePassEncoder48.setBindGroup(1, bindGroup26, new Uint32Array(825), 11, 0);
+} catch {}
+try {
+computePassEncoder32.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(4, buffer61);
+} catch {}
+document.body.append(canvas0);
+try {
+adapter0.label = '\u7d98\ue23f\ua8b1\u3828\u04cc\uea00\u{1f6d8}\u0766\uf959\u2d9d';
+} catch {}
+let buffer93 = device0.createBuffer({size: 1, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let commandEncoder95 = device0.createCommandEncoder();
+let texture106 = device0.createTexture({
+  size: {width: 72, height: 70, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'astc-12x10-unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView98 = texture10.createView({label: '\u475f\u0fe0\u009d\ud39f\u{1fd2f}\u1885\u0b17\u9d7b\u034a\u{1fe57}'});
+let computePassEncoder89 = commandEncoder95.beginComputePass({});
+try {
+computePassEncoder51.setBindGroup(2, bindGroup8, [512, 0]);
+} catch {}
+try {
+computePassEncoder7.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(0, buffer92, 2_652, 1_598);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+computePassEncoder2.setBindGroup(0, bindGroup43);
+} catch {}
+try {
+computePassEncoder78.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup5, [3072, 2304]);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder1.insertDebugMarker('\u87bb');
+} catch {}
+let textureView99 = texture46.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder80.setBindGroup(3, bindGroup52, new Uint32Array(1534), 166, 0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup43);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 78, depthOrArrayLayers: 284}
+*/
+{
+  source: videoFrame9,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 5, y: 4, z: 34},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder96 = device0.createCommandEncoder();
+let computePassEncoder90 = commandEncoder96.beginComputePass({});
+try {
+computePassEncoder46.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup49);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup31, new Uint32Array(587), 107, 0);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle6, renderBundle7, renderBundle5]);
+} catch {}
+let videoFrame16 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'smpteSt4281', transfer: 'bt2020_10bit'} });
+let bindGroupLayout15 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 385,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup54 = device0.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 148, resource: textureView11}]});
+let buffer94 = device0.createBuffer({
+  size: 27809,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let sampler52 = device0.createSampler({addressModeU: 'clamp-to-edge', addressModeV: 'repeat', lodMaxClamp: 74.78});
+try {
+computePassEncoder64.setBindGroup(1, bindGroup52);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(2, buffer73, 16_700, 1_715);
+} catch {}
+let buffer95 = device0.createBuffer({size: 1054, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX});
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup52);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: 138.4, g: -896.3, b: -856.4, a: 837.8, });
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 665, height: 1, depthOrArrayLayers: 49}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 102, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let imageData7 = new ImageData(24, 60);
+try {
+computePassEncoder85.setBindGroup(0, bindGroup32);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let textureView100 = texture4.createView({dimension: '2d'});
+try {
+renderPassEncoder5.setVertexBuffer(7, buffer55, 2_596);
+} catch {}
+try {
+buffer27.unmap();
+} catch {}
+let commandEncoder97 = device0.createCommandEncoder({});
+let textureView101 = texture105.createView({label: '\u05bd\u0f22\uc244\u0633\u014e\u88a0\u0756\u0d53', dimension: '2d', aspect: 'all'});
+let computePassEncoder91 = commandEncoder97.beginComputePass({});
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({colorFormats: ['r8unorm'], depthStencilFormat: 'stencil8', depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder41.setBindGroup(0, bindGroup52);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup41, []);
+} catch {}
+try {
+renderPassEncoder3.setViewport(301.5609152769656, 0.4656746798596114, 1.2475866896694314, 0.2931449956931302, 0.34735159784813185, 0.6112932729469506);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(5, buffer4, 116, 283);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(2, bindGroup51);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 39, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame16,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture94,
+  mipLevel: 0,
+  origin: {x: 5, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData8 = new ImageData(104, 56);
+let bindGroup55 = device0.createBindGroup({
+  label: '\u{1faf1}\u2445\u0dbf\u1e92\ub667\u7637',
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 35, resource: {buffer: buffer79, offset: 256, size: 24}},
+    {binding: 60, resource: textureView18},
+  ],
+});
+let commandEncoder98 = device0.createCommandEncoder({label: '\ua552\u0622\ueb56\uecfc\u{1f602}\u06cb\u1149\u3a84\u{1f790}\ubc41\u691b'});
+let commandBuffer5 = commandEncoder98.finish();
+let texture107 = device0.createTexture({
+  size: [30, 12, 43],
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView102 = texture61.createView({dimension: '2d-array', aspect: 'depth-only', mipLevelCount: 1});
+let sampler53 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 50.56,
+  lodMaxClamp: 53.04,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder21.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(4, undefined);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(1, bindGroup44);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(2, bindGroup38, new Uint32Array(12), 0, 2);
+} catch {}
+let arrayBuffer16 = buffer2.getMappedRange(1600, 8);
+try {
+computePassEncoder16.setBindGroup(0, bindGroup45);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(0, buffer66, 1_388, 392);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+globalThis.someLabel = externalTexture7.label;
+} catch {}
+let renderBundle14 = renderBundleEncoder14.finish();
+let sampler54 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMinClamp: 37.88,
+  lodMaxClamp: 49.44,
+  compare: 'greater-equal',
+});
+try {
+computePassEncoder65.setBindGroup(0, bindGroup32, new Uint32Array(251), 50, 0);
+} catch {}
+try {
+computePassEncoder37.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer43, 'uint32', 604, 5_213);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline0);
+} catch {}
+let arrayBuffer17 = buffer2.getMappedRange(1656, 4);
+try {
+device0.queue.writeBuffer(buffer27, 136, new Float32Array(2033), 98, 164);
+} catch {}
+document.body.append(canvas0);
+let videoFrame17 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte240m', primaries: 'smpte432', transfer: 'iec6196624'} });
+let shaderModule9 = device0.createShaderModule({
+  label: '\u0f2d\u{1f606}\u7bda\u9248\u9de9\u16a5\u0133\uc3e9\u679a\u{1fc6f}',
+  code: `
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(83) var<storage, read_write> buffer96: T0;
+
+@group(0) @binding(232) var<storage, read> buffer97: array<u32>;
+
+struct T0 {
+  @size(80) f0: array<atomic<u32>, 1>,
+}
+
+struct VertexOutput9 {
+  @location(7) f24: vec2f,
+  @invariant @builtin(position) f25: vec4f,
+  @location(13) f26: f32,
+  @location(8) @interpolate(linear, centroid) f27: f16,
+}
+
+struct FragmentOutput5 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: vec4u,
+}
+
+fn fn0() -> VertexOutput9 {
+  var out: VertexOutput9;
+  let vf125: vec2f = unpack2x16unorm(u32(unconst_u32(367)));
+  var vf126: u32 = arrayLength(&(*&buffer97));
+  out.f27 = vec2h(clamp(vec2u(unconst_u32(9), unconst_u32(149)), vec2u(unconst_u32(7), unconst_u32(141)), vec2u(unconst_u32(56), unconst_u32(506)))).x;
+  let ptr145: ptr<storage, u32, read> = &buffer97[pack4xU8Clamp(unpack4xU8(u32(vp22[u32(unconst_u32(9))][u32(unconst_u32(114))])))];
+  out.f26 = bitcast<f32>((*&buffer97)[u32(unconst_u32(31))]);
+  vf126 &= pack4x8unorm(unpack4x8snorm(u32(unconst_u32(112))));
+  out.f25 += unpack4x8unorm(vf126);
+  let ptr146: ptr<storage, u32, read> = &buffer97[arrayLength(&buffer97)];
+  let ptr147: ptr<storage, u32, read> = &buffer97[arrayLength(&buffer97) - 1];
+  let ptr148: ptr<storage, array<u32>, read> = &buffer97;
+  var vf127: vec3h = cross(vec3h(unconst_f16(-3775.5), unconst_f16(35598.6), unconst_f16(9298.4)), vec3h(unconst_f16(2860.8), unconst_f16(5591.2), unconst_f16(2613.7)));
+  var vf128: vec4h = pow(vec4h(unconst_f16(4524.2), unconst_f16(4768.1), unconst_f16(1612.4), unconst_f16(2304.2)), vec4h(unconst_f16(4731.2), unconst_f16(5493.0), unconst_f16(11896.8), unconst_f16(17795.5)));
+  out.f24 = vec2f(f32(buffer97[u32(unconst_u32(543))]));
+  out.f25 *= vec4f(f32((*&buffer97)[arrayLength(&(*&buffer97)) - 1]));
+  let vf129: vec3u = countOneBits(vec3u(unconst_u32(26), unconst_u32(4), unconst_u32(36)));
+  let ptr149: ptr<storage, u32, read> = &(*&buffer97)[arrayLength(&(*&buffer97))];
+  var vf130: bool = any(bool(unconst_bool(true)));
+  vf130 = bool((*ptr148)[i32(unconst_i32(29))]);
+  let ptr150: ptr<function, vec4h> = &vf128;
+  vf126 &= pack2x16float(unpack2x16unorm(u32(unconst_u32(210))));
+  vf128 -= pow(vec4h(unconst_f16(5764.1), unconst_f16(-8825.7), unconst_f16(2552.4), unconst_f16(5202.7)), vec4h(unconst_f16(23573.6), unconst_f16(19246.2), unconst_f16(14032.4), unconst_f16(6102.7)));
+  return out;
+}
+
+fn fn1() -> mat4x2f {
+  var out: mat4x2f;
+  var vf131: vec2h = vp22[u32(unconst_u32(18))];
+  var vf132: vec2h = vp22[u32(unconst_u32(94))];
+  let vf133: vec2h = vp22[u32(unconst_u32(123))];
+  vf132 = vf131;
+  vf131 = vf131;
+  vp22 = mat2x2h(vf131[u32(vp22[u32(unconst_u32(68))][bitcast<u32>(vp22[unconst_i32(1)])])], vf131[u32(vp22[u32(unconst_u32(68))][bitcast<u32>(vp22[unconst_i32(1)])])], vf131[u32(vp22[u32(unconst_u32(68))][bitcast<u32>(vp22[unconst_i32(1)])])], vf131[u32(vp22[u32(unconst_u32(68))][bitcast<u32>(vp22[unconst_i32(1)])])]);
+  vf131 = vec2h(vp22[u32(unconst_u32(139))][u32(unconst_u32(43))]);
+  vf132 = vp22[unconst_i32(1)];
+  vp22 -= mat2x2h(vp22[u32(unconst_u32(359))][u32(unconst_u32(128))], vp22[u32(unconst_u32(359))][u32(unconst_u32(128))], vp22[u32(unconst_u32(359))][u32(unconst_u32(128))], vp22[u32(unconst_u32(359))][u32(unconst_u32(128))]);
+  out = mat4x2f(vec2f(vp22[u32(unconst_u32(88))]), vec2f(vp22[u32(unconst_u32(88))]), vec2f(vp22[u32(unconst_u32(88))]), vec2f(vp22[u32(unconst_u32(88))]));
+  let vf134: f16 = vf133[u32(unconst_u32(356))];
+  let vf135: u32 = pack4xI8Clamp(vec4i(unconst_i32(233), unconst_i32(411), unconst_i32(128), unconst_i32(26)));
+  return out;
+}
+
+fn fn2(a0: array<array<i32, 18>, 1>) {
+  var vf136: i32 = a0[0][u32(unconst_u32(40))];
+  var vf137: i32 = a0[u32(unconst_u32(30))][u32(unconst_u32(1))];
+  let vf138: i32 = firstLeadingBit(i32(unconst_i32(35)));
+  vf137 += a0[pack2x16snorm(vec2f(unconst_f32(0.03032), unconst_f32(0.1052)))][17];
+  vf137 += i32(saturate(f32(unconst_f32(0.01181))));
+  var vf139: vec3h = atan2(vec3h(unconst_f16(5949.8), unconst_f16(2464.3), unconst_f16(8732.1)), vec3h(unconst_f16(16202.1), unconst_f16(4541.4), unconst_f16(2789.1)));
+  vf136 = countLeadingZeros(i32(unconst_i32(32)));
+  vf139 = vec3h(f16(countLeadingZeros(countLeadingZeros(i32(unconst_i32(101))))));
+  var vf140: i32 = vf138;
+  var vf141: vec4u = unpack4xU8(u32(unconst_u32(617)));
+  vp22 -= mat2x2h(vec2h(normalize(vec2f(unconst_f32(-0.4722), unconst_f32(0.00225)))), vec2h(normalize(vec2f(unconst_f32(-0.4722), unconst_f32(0.00225)))));
+  vf139 = vec3h(vp22[u32(unconst_u32(225))][u32(unconst_u32(200))]);
+  var vf142: i32 = a0[u32(unconst_u32(197))][17];
+  var vf143: f16 = vp22[u32(unconst_u32(62))][u32(unconst_u32(6))];
+  var vf144: f16 = length(vf139.xzzx);
+  vf140 &= a0[0][17];
+  let ptr151: ptr<function, i32> = &vf137;
+  var vf145: array<array<i32, 18>, 1> = a0;
+  var vf146: i32 = a0[0][u32(unconst_u32(56))];
+  vf137 -= a0[u32(unconst_u32(349))][u32(unconst_u32(45))];
+  let ptr152: ptr<function, i32> = &vf145[0][u32(unconst_u32(39))];
+  let vf147: f16 = length(vec4h(unconst_f16(13793.4), unconst_f16(4164.8), unconst_f16(30974.4), unconst_f16(7543.0)));
+  vf137 = (*ptr151);
+  let ptr153: ptr<function, i32> = &vf146;
+  let vf148: i32 = vf138;
+}
+
+var<workgroup> vw28: mat3x3f;
+
+var<workgroup> vw29: mat3x4h;
+
+var<workgroup> vw30: mat2x4f;
+
+var<workgroup> vw31: f32;
+
+var<private> vp22: mat2x2h = mat2x2h(1905.8, 6803.3, 25672.8, 19182.6);
+
+@vertex
+fn vertex10(@builtin(instance_index) a0: u32, @builtin(vertex_index) a1: u32) -> VertexOutput9 {
+  var out: VertexOutput9;
+  out.f27 = f16(pack4x8snorm(vec4f(unconst_f32(0.03394), unconst_f32(0.05229), unconst_f32(0.01270), unconst_f32(0.7554))));
+  out.f25 -= unpack4x8unorm(pack4x8snorm(vec4f(unconst_f32(0.00459), unconst_f32(0.09707), unconst_f32(0.2814), unconst_f32(0.1673))));
+  var vf149: u32 = pack4x8snorm(vec4f(unconst_f32(0.01713), unconst_f32(0.03920), unconst_f32(0.05070), unconst_f32(0.02030)));
+  vf149 *= buffer97[arrayLength(&buffer97) - 1];
+  let ptr154: ptr<storage, u32, read> = &buffer97[u32(unconst_u32(58))];
+  let vf150: vec2h = atan2(vec2h(unconst_f16(7497.1), unconst_f16(5561.0)), vec2h(unconst_f16(755.2), unconst_f16(1223.5)));
+  fn2(array<array<i32, 18>, 1>(array<i32, 18>(bitcast<vec3i>(countLeadingZeros(vec3u(unconst_u32(313), unconst_u32(145), unconst_u32(141)))).g, i32(countLeadingZeros(vec3u(unconst_u32(313), unconst_u32(145), unconst_u32(141)))[0]), i32(countLeadingZeros(vec3u(unconst_u32(313), unconst_u32(145), unconst_u32(141)))[2]), i32(countLeadingZeros(vec3u(unconst_u32(313), unconst_u32(145), unconst_u32(141))).z), i32(countLeadingZeros(vec3u(unconst_u32(313), unconst_u32(145), unconst_u32(141)))[1]), bitcast<i32>(countLeadingZeros(vec3u(unconst_u32(313), unconst_u32(145), unconst_u32(141)))[0]), i32(countLeadingZeros(vec3u(unconst_u32(313), unconst_u32(145), unconst_u32(141)))[1]), vec3i(countLeadingZeros(vec3u(unconst_u32(313), unconst_u32(145), unconst_u32(141)))).z, bitcast<i32>(countLeadingZeros(vec3u(unconst_u32(313), unconst_u32(145), unconst_u32(141))).x), bitcast<i32>(countLeadingZeros(vec3u(unconst_u32(313), unconst_u32(145), unconst_u32(141)))[2]), i32(countLeadingZeros(vec3u(unconst_u32(313), unconst_u32(145), unconst_u32(141))).b), vec3i(countLeadingZeros(vec3u(unconst_u32(313), unconst_u32(145), unconst_u32(141)))).b, bitcast<vec3i>(countLeadingZeros(vec3u(unconst_u32(313), unconst_u32(145), unconst_u32(141)))).y, bitcast<i32>(countLeadingZeros(vec3u(unconst_u32(313), unconst_u32(145), unconst_u32(141))).b), i32(countLeadingZeros(vec3u(unconst_u32(313), unconst_u32(145), unconst_u32(141))).g), bitcast<vec3i>(countLeadingZeros(vec3u(unconst_u32(313), unconst_u32(145), unconst_u32(141)))).g, i32(countLeadingZeros(vec3u(unconst_u32(313), unconst_u32(145), unconst_u32(141)))[0]), i32(countLeadingZeros(vec3u(unconst_u32(313), unconst_u32(145), unconst_u32(141))).b))));
+  vf149 += buffer97[arrayLength(&buffer97)];
+  let vf151: vec2h = vf150;
+  vf149 >>= bitcast<u32>(atan2(vec2h(unconst_f16(6776.0), unconst_f16(544.9)), vec2h(unconst_f16(3441.1), unconst_f16(681.4))));
+  let vf152: u32 = a1;
+  var vf153: f16 = vf151[u32(unconst_u32(123))];
+  out.f25 = unpack4x8unorm((*&buffer97)[u32(unconst_u32(164))]);
+  out.f25 += unpack4x8snorm(buffer97[u32(unconst_u32(228))]);
+  var vf154: f16 = min(f16(unconst_f16(4226.1)), f16(unconst_f16(29171.5)));
+  vf149 += arrayLength(&buffer97);
+  var vf155 = fn0();
+  fn2(array<array<i32, 18>, 1>(array<i32, 18>(i32((*&buffer97)[arrayLength(&(*&buffer97))]), bitcast<i32>((*&buffer97)[arrayLength(&(*&buffer97))]), i32((*&buffer97)[arrayLength(&(*&buffer97))]), bitcast<i32>((*&buffer97)[arrayLength(&(*&buffer97))]), i32((*&buffer97)[arrayLength(&(*&buffer97))]), i32((*&buffer97)[arrayLength(&(*&buffer97))]), bitcast<i32>((*&buffer97)[arrayLength(&(*&buffer97))]), bitcast<i32>((*&buffer97)[arrayLength(&(*&buffer97))]), bitcast<i32>((*&buffer97)[arrayLength(&(*&buffer97))]), bitcast<i32>((*&buffer97)[arrayLength(&(*&buffer97))]), i32((*&buffer97)[arrayLength(&(*&buffer97))]), bitcast<i32>((*&buffer97)[arrayLength(&(*&buffer97))]), bitcast<i32>((*&buffer97)[arrayLength(&(*&buffer97))]), i32((*&buffer97)[arrayLength(&(*&buffer97))]), bitcast<i32>((*&buffer97)[arrayLength(&(*&buffer97))]), i32((*&buffer97)[arrayLength(&(*&buffer97))]), bitcast<i32>((*&buffer97)[arrayLength(&(*&buffer97))]), i32((*&buffer97)[arrayLength(&(*&buffer97))]))));
+  vp22 += mat2x2h(f16(vf155.f26), f16(vf155.f26), f16(vf155.f26), f16(vf155.f26));
+  fn2(array<array<i32, 18>, 1>(array<i32, 18>(max(vec4i(unconst_i32(169), unconst_i32(193), unconst_i32(85), unconst_i32(451)), vec4i(unconst_i32(129), unconst_i32(3), unconst_i32(313), unconst_i32(1000)))[1], max(vec4i(unconst_i32(169), unconst_i32(193), unconst_i32(85), unconst_i32(451)), vec4i(unconst_i32(129), unconst_i32(3), unconst_i32(313), unconst_i32(1000))).b, max(vec4i(unconst_i32(169), unconst_i32(193), unconst_i32(85), unconst_i32(451)), vec4i(unconst_i32(129), unconst_i32(3), unconst_i32(313), unconst_i32(1000))).a, max(vec4i(unconst_i32(169), unconst_i32(193), unconst_i32(85), unconst_i32(451)), vec4i(unconst_i32(129), unconst_i32(3), unconst_i32(313), unconst_i32(1000)))[1], max(vec4i(unconst_i32(169), unconst_i32(193), unconst_i32(85), unconst_i32(451)), vec4i(unconst_i32(129), unconst_i32(3), unconst_i32(313), unconst_i32(1000)))[3], max(vec4i(unconst_i32(169), unconst_i32(193), unconst_i32(85), unconst_i32(451)), vec4i(unconst_i32(129), unconst_i32(3), unconst_i32(313), unconst_i32(1000))).g, max(vec4i(unconst_i32(169), unconst_i32(193), unconst_i32(85), unconst_i32(451)), vec4i(unconst_i32(129), unconst_i32(3), unconst_i32(313), unconst_i32(1000))).r, max(vec4i(unconst_i32(169), unconst_i32(193), unconst_i32(85), unconst_i32(451)), vec4i(unconst_i32(129), unconst_i32(3), unconst_i32(313), unconst_i32(1000)))[1], max(vec4i(unconst_i32(169), unconst_i32(193), unconst_i32(85), unconst_i32(451)), vec4i(unconst_i32(129), unconst_i32(3), unconst_i32(313), unconst_i32(1000)))[2], max(vec4i(unconst_i32(169), unconst_i32(193), unconst_i32(85), unconst_i32(451)), vec4i(unconst_i32(129), unconst_i32(3), unconst_i32(313), unconst_i32(1000)))[1], max(vec4i(unconst_i32(169), unconst_i32(193), unconst_i32(85), unconst_i32(451)), vec4i(unconst_i32(129), unconst_i32(3), unconst_i32(313), unconst_i32(1000)))[2], max(vec4i(unconst_i32(169), unconst_i32(193), unconst_i32(85), unconst_i32(451)), vec4i(unconst_i32(129), unconst_i32(3), unconst_i32(313), unconst_i32(1000)))[0], max(vec4i(unconst_i32(169), unconst_i32(193), unconst_i32(85), unconst_i32(451)), vec4i(unconst_i32(129), unconst_i32(3), unconst_i32(313), unconst_i32(1000)))[0], max(vec4i(unconst_i32(169), unconst_i32(193), unconst_i32(85), unconst_i32(451)), vec4i(unconst_i32(129), unconst_i32(3), unconst_i32(313), unconst_i32(1000))).w, max(vec4i(unconst_i32(169), unconst_i32(193), unconst_i32(85), unconst_i32(451)), vec4i(unconst_i32(129), unconst_i32(3), unconst_i32(313), unconst_i32(1000)))[2], max(vec4i(unconst_i32(169), unconst_i32(193), unconst_i32(85), unconst_i32(451)), vec4i(unconst_i32(129), unconst_i32(3), unconst_i32(313), unconst_i32(1000)))[0], max(vec4i(unconst_i32(169), unconst_i32(193), unconst_i32(85), unconst_i32(451)), vec4i(unconst_i32(129), unconst_i32(3), unconst_i32(313), unconst_i32(1000)))[2], max(vec4i(unconst_i32(169), unconst_i32(193), unconst_i32(85), unconst_i32(451)), vec4i(unconst_i32(129), unconst_i32(3), unconst_i32(313), unconst_i32(1000)))[1])));
+  return out;
+}
+
+@fragment
+fn fragment8() -> FragmentOutput5 {
+  var out: FragmentOutput5;
+  fn2(array<array<i32, 18>, 1>(array<i32, 18>(i32(exp2(vec4h(unconst_f16(1819.4), unconst_f16(-16585.2), unconst_f16(6090.2), unconst_f16(1378.4))).w), i32(exp2(vec4h(unconst_f16(1819.4), unconst_f16(-16585.2), unconst_f16(6090.2), unconst_f16(1378.4)))[0]), i32(exp2(vec4h(unconst_f16(1819.4), unconst_f16(-16585.2), unconst_f16(6090.2), unconst_f16(1378.4)))[1]), i32(exp2(vec4h(unconst_f16(1819.4), unconst_f16(-16585.2), unconst_f16(6090.2), unconst_f16(1378.4))).r), vec4i(exp2(vec4h(unconst_f16(1819.4), unconst_f16(-16585.2), unconst_f16(6090.2), unconst_f16(1378.4))))[2], i32(exp2(vec4h(unconst_f16(1819.4), unconst_f16(-16585.2), unconst_f16(6090.2), unconst_f16(1378.4)))[3]), vec4i(exp2(vec4h(unconst_f16(1819.4), unconst_f16(-16585.2), unconst_f16(6090.2), unconst_f16(1378.4)))).y, i32(exp2(vec4h(unconst_f16(1819.4), unconst_f16(-16585.2), unconst_f16(6090.2), unconst_f16(1378.4))).b), i32(exp2(vec4h(unconst_f16(1819.4), unconst_f16(-16585.2), unconst_f16(6090.2), unconst_f16(1378.4)))[2]), vec4i(exp2(vec4h(unconst_f16(1819.4), unconst_f16(-16585.2), unconst_f16(6090.2), unconst_f16(1378.4)))).g, i32(exp2(vec4h(unconst_f16(1819.4), unconst_f16(-16585.2), unconst_f16(6090.2), unconst_f16(1378.4)))[1]), vec4i(exp2(vec4h(unconst_f16(1819.4), unconst_f16(-16585.2), unconst_f16(6090.2), unconst_f16(1378.4)))).g, vec4i(exp2(vec4h(unconst_f16(1819.4), unconst_f16(-16585.2), unconst_f16(6090.2), unconst_f16(1378.4)))).r, i32(exp2(vec4h(unconst_f16(1819.4), unconst_f16(-16585.2), unconst_f16(6090.2), unconst_f16(1378.4)))[1]), vec4i(exp2(vec4h(unconst_f16(1819.4), unconst_f16(-16585.2), unconst_f16(6090.2), unconst_f16(1378.4))))[1], i32(exp2(vec4h(unconst_f16(1819.4), unconst_f16(-16585.2), unconst_f16(6090.2), unconst_f16(1378.4))).w), vec4i(exp2(vec4h(unconst_f16(1819.4), unconst_f16(-16585.2), unconst_f16(6090.2), unconst_f16(1378.4))))[0], i32(exp2(vec4h(unconst_f16(1819.4), unconst_f16(-16585.2), unconst_f16(6090.2), unconst_f16(1378.4)))[0]))));
+  out.f0 &= bitcast<u32>(clamp(vec4i(unconst_i32(37), unconst_i32(8), unconst_i32(484), unconst_i32(372)), vec4i(unconst_i32(114), unconst_i32(56), unconst_i32(24), unconst_i32(19)), vec4i(unconst_i32(20), unconst_i32(123), unconst_i32(127), unconst_i32(73))).r);
+  var vf156: u32 = dot4U8Packed(u32(unconst_u32(219)), u32(unconst_u32(19)));
+  let ptr155: ptr<storage, array<atomic<u32>, 1>, read_write> = &(*&buffer96).f0;
+  let ptr156: ptr<storage, atomic<u32>, read_write> = &(*&buffer96).f0[u32(unconst_u32(148))];
+  atomicCompareExchangeWeak(&buffer96.f0[u32(unconst_u32(10))], unconst_u32(65), unconst_u32(21));
+  out.f1 |= vec4u(atan2(vec3h(unconst_f16(11269.0), unconst_f16(262.1), unconst_f16(6203.7)), vec3h(unconst_f16(4035.5), unconst_f16(7153.5), unconst_f16(7185.9))).rrgr);
+  vf156 &= pack4xU8(vec4u(unconst_u32(437), unconst_u32(159), unconst_u32(428), unconst_u32(1)));
+  var vf157 = fn1();
+  var vf158 = fn1();
+  vp22 = mat2x2h(vec2h(vf158[unconst_i32(3)]), vec2h(vf158[unconst_i32(2)]));
+  vf157 = mat4x2f(f32(atomicExchange(&buffer96.f0[0], u32(unconst_u32(206)))), bitcast<f32>(atomicExchange(&buffer96.f0[0], u32(unconst_u32(206)))), bitcast<f32>(atomicExchange(&buffer96.f0[0], u32(unconst_u32(206)))), f32(atomicExchange(&buffer96.f0[0], u32(unconst_u32(206)))), f32(atomicExchange(&buffer96.f0[0], u32(unconst_u32(206)))), f32(atomicExchange(&buffer96.f0[0], u32(unconst_u32(206)))), f32(atomicExchange(&buffer96.f0[0], u32(unconst_u32(206)))), f32(atomicExchange(&buffer96.f0[0], u32(unconst_u32(206)))));
+  return out;
+}
+
+@fragment
+fn fragment9(@location(7) a0: vec2f) -> @location(200) @interpolate(linear, centroid) vec2f {
+  var out: vec2f;
+  fn2(array<array<i32, 18>, 1>(array<i32, 18>(i32(cross(vec3f(vp22[u32(unconst_u32(633))].yxy), vec3f(unconst_f32(0.1939), unconst_f32(0.02809), unconst_f32(0.4515)))[0]), vec3i(cross(vec3f(vp22[u32(unconst_u32(633))].yxy), vec3f(unconst_f32(0.1939), unconst_f32(0.02809), unconst_f32(0.4515))))[1], bitcast<i32>(cross(vec3f(vp22[u32(unconst_u32(633))].yxy), vec3f(unconst_f32(0.1939), unconst_f32(0.02809), unconst_f32(0.4515))).x), bitcast<i32>(cross(vec3f(vp22[u32(unconst_u32(633))].yxy), vec3f(unconst_f32(0.1939), unconst_f32(0.02809), unconst_f32(0.4515))).r), i32(cross(vec3f(vp22[u32(unconst_u32(633))].yxy), vec3f(unconst_f32(0.1939), unconst_f32(0.02809), unconst_f32(0.4515))).y), vec3i(cross(vec3f(vp22[u32(unconst_u32(633))].yxy), vec3f(unconst_f32(0.1939), unconst_f32(0.02809), unconst_f32(0.4515))))[1], bitcast<vec3i>(cross(vec3f(vp22[u32(unconst_u32(633))].yxy), vec3f(unconst_f32(0.1939), unconst_f32(0.02809), unconst_f32(0.4515))))[2], bitcast<i32>(cross(vec3f(vp22[u32(unconst_u32(633))].yxy), vec3f(unconst_f32(0.1939), unconst_f32(0.02809), unconst_f32(0.4515)))[1]), bitcast<vec3i>(cross(vec3f(vp22[u32(unconst_u32(633))].yxy), vec3f(unconst_f32(0.1939), unconst_f32(0.02809), unconst_f32(0.4515)))).b, vec3i(cross(vec3f(vp22[u32(unconst_u32(633))].yxy), vec3f(unconst_f32(0.1939), unconst_f32(0.02809), unconst_f32(0.4515)))).b, vec3i(cross(vec3f(vp22[u32(unconst_u32(633))].yxy), vec3f(unconst_f32(0.1939), unconst_f32(0.02809), unconst_f32(0.4515))))[1], bitcast<i32>(cross(vec3f(vp22[u32(unconst_u32(633))].yxy), vec3f(unconst_f32(0.1939), unconst_f32(0.02809), unconst_f32(0.4515)))[1]), i32(cross(vec3f(vp22[u32(unconst_u32(633))].yxy), vec3f(unconst_f32(0.1939), unconst_f32(0.02809), unconst_f32(0.4515)))[0]), bitcast<vec3i>(cross(vec3f(vp22[u32(unconst_u32(633))].yxy), vec3f(unconst_f32(0.1939), unconst_f32(0.02809), unconst_f32(0.4515))))[1], i32(cross(vec3f(vp22[u32(unconst_u32(633))].yxy), vec3f(unconst_f32(0.1939), unconst_f32(0.02809), unconst_f32(0.4515))).y), vec3i(cross(vec3f(vp22[u32(unconst_u32(633))].yxy), vec3f(unconst_f32(0.1939), unconst_f32(0.02809), unconst_f32(0.4515)))).x, bitcast<i32>(cross(vec3f(vp22[u32(unconst_u32(633))].yxy), vec3f(unconst_f32(0.1939), unconst_f32(0.02809), unconst_f32(0.4515)))[0]), i32(cross(vec3f(vp22[u32(unconst_u32(633))].yxy), vec3f(unconst_f32(0.1939), unconst_f32(0.02809), unconst_f32(0.4515))).r))));
+  fn2(array<array<i32, 18>, 1>(array<i32, 18>(i32(atomicExchange(&buffer96.f0[0], u32(unconst_u32(294)))), bitcast<i32>(atomicExchange(&buffer96.f0[0], u32(unconst_u32(294)))), bitcast<i32>(atomicExchange(&buffer96.f0[0], u32(unconst_u32(294)))), i32(atomicExchange(&buffer96.f0[0], u32(unconst_u32(294)))), bitcast<i32>(atomicExchange(&buffer96.f0[0], u32(unconst_u32(294)))), bitcast<i32>(atomicExchange(&buffer96.f0[0], u32(unconst_u32(294)))), bitcast<i32>(atomicExchange(&buffer96.f0[0], u32(unconst_u32(294)))), bitcast<i32>(atomicExchange(&buffer96.f0[0], u32(unconst_u32(294)))), bitcast<i32>(atomicExchange(&buffer96.f0[0], u32(unconst_u32(294)))), i32(atomicExchange(&buffer96.f0[0], u32(unconst_u32(294)))), i32(atomicExchange(&buffer96.f0[0], u32(unconst_u32(294)))), bitcast<i32>(atomicExchange(&buffer96.f0[0], u32(unconst_u32(294)))), i32(atomicExchange(&buffer96.f0[0], u32(unconst_u32(294)))), i32(atomicExchange(&buffer96.f0[0], u32(unconst_u32(294)))), i32(atomicExchange(&buffer96.f0[0], u32(unconst_u32(294)))), i32(atomicExchange(&buffer96.f0[0], u32(unconst_u32(294)))), bitcast<i32>(atomicExchange(&buffer96.f0[0], u32(unconst_u32(294)))), bitcast<i32>(atomicExchange(&buffer96.f0[0], u32(unconst_u32(294)))))));
+  fn1();
+  var vf159: f32 = a0[u32(unconst_u32(116))];
+  var vf160: vec4h = exp2(vec4h(unconst_f16(3193.6), unconst_f16(23652.7), unconst_f16(-12270.2), unconst_f16(10869.4)));
+  let ptr157: ptr<storage, T0, read_write> = &buffer96;
+  let ptr158: ptr<storage, array<atomic<u32>, 1>, read_write> = &(*ptr157).f0;
+  vf159 = f32(atomicLoad(&buffer96.f0[0]));
+  atomicMin(&buffer96.f0[u32(unconst_u32(237))], atomicLoad(&(*&buffer96).f0[0]));
+  let vf161: vec4f = unpack4x8unorm(u32(unconst_u32(119)));
+  vf160 = bitcast<vec4h>(unpack2x16float(u32(unconst_u32(496))));
+  vf160 = vec4h(f16(atomicLoad(&(*ptr157).f0[0])));
+  fn2(array<array<i32, 18>, 1>(array(i32(unconst_i32(33)), i32(unconst_i32(269)), i32(unconst_i32(228)), i32(unconst_i32(152)), i32(unconst_i32(97)), i32(unconst_i32(142)), i32(unconst_i32(10)), i32(unconst_i32(25)), i32(unconst_i32(138)), i32(unconst_i32(129)), i32(unconst_i32(153)), i32(unconst_i32(103)), i32(unconst_i32(12)), i32(unconst_i32(120)), i32(unconst_i32(8)), i32(unconst_i32(-10)), i32(unconst_i32(258)), i32(unconst_i32(51)))));
+  fn2(array<array<i32, 18>, 1>(array<i32, 18>(i32(unpack2x16float(u32(unconst_u32(57)))[1]), i32(unpack2x16float(u32(unconst_u32(57))).r), bitcast<vec2i>(unpack2x16float(u32(unconst_u32(57))))[1], vec2i(unpack2x16float(u32(unconst_u32(57))))[1], bitcast<vec2i>(unpack2x16float(u32(unconst_u32(57)))).r, i32(unpack2x16float(u32(unconst_u32(57))).g), bitcast<vec2i>(unpack2x16float(u32(unconst_u32(57)))).r, bitcast<i32>(unpack2x16float(u32(unconst_u32(57))).y), vec2i(unpack2x16float(u32(unconst_u32(57)))).y, vec2i(unpack2x16float(u32(unconst_u32(57)))).g, i32(unpack2x16float(u32(unconst_u32(57))).y), vec2i(unpack2x16float(u32(unconst_u32(57)))).r, vec2i(unpack2x16float(u32(unconst_u32(57)))).g, i32(unpack2x16float(u32(unconst_u32(57)))[0]), bitcast<vec2i>(unpack2x16float(u32(unconst_u32(57)))).y, i32(unpack2x16float(u32(unconst_u32(57)))[1]), bitcast<i32>(unpack2x16float(u32(unconst_u32(57))).g), i32(unpack2x16float(u32(unconst_u32(57)))[1]))));
+  let ptr159: ptr<storage, atomic<u32>, read_write> = &buffer96.f0[u32(unconst_u32(50))];
+  fn1();
+  return out;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder99 = device0.createCommandEncoder({});
+let textureView103 = texture102.createView({dimension: 'cube', mipLevelCount: 1, baseArrayLayer: 1});
+let texture108 = device0.createTexture({
+  size: [665, 1, 83],
+  mipLevelCount: 4,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({
+  label: '\uff8a\ucc8f\u96ba\u71c4\u0960\u0110\ua9fb\u748a\u4454\u{1f717}',
+  colorFormats: ['r8unorm'],
+  depthStencilFormat: 'stencil8',
+});
+let sampler55 = device0.createSampler({
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 49.62,
+  lodMaxClamp: 51.24,
+});
+try {
+computePassEncoder87.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup27, new Uint32Array(547), 113, 0);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer43, 'uint16', 2_644, 4_348);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+let arrayBuffer18 = buffer2.getMappedRange(1664, 0);
+let bindGroup56 = device0.createBindGroup({
+  label: '\u0c51\u6d66\u{1fec9}\u{1fdac}\u75c7\u53c6',
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 16, resource: {buffer: buffer7, offset: 256, size: 12072}},
+    {binding: 32, resource: textureView98},
+    {binding: 96, resource: textureView44},
+    {binding: 25, resource: {buffer: buffer66, offset: 0, size: 3592}},
+    {binding: 139, resource: textureView41},
+    {binding: 88, resource: {buffer: buffer41, offset: 0, size: 2012}},
+    {binding: 426, resource: {buffer: buffer66, offset: 1792, size: 1376}},
+    {binding: 3, resource: sampler15},
+    {binding: 142, resource: textureView20},
+    {binding: 779, resource: {buffer: buffer4, offset: 0, size: 684}},
+    {binding: 925, resource: textureView9},
+  ],
+});
+let commandEncoder100 = device0.createCommandEncoder();
+let renderPassEncoder6 = commandEncoder99.beginRenderPass({
+  colorAttachments: [{
+  view: textureView58,
+  depthSlice: 65,
+  clearValue: { r: 820.2, g: 185.8, b: -587.5, a: 872.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 24786212,
+});
+let sampler56 = device0.createSampler({
+  label: '\u0a06\u8df4\u6cd8\ubdf2\u9802\u0c33\u58fe',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  lodMaxClamp: 96.43,
+});
+try {
+computePassEncoder17.setBindGroup(0, bindGroup39, new Uint32Array(387), 0, 0);
+} catch {}
+let imageData9 = new ImageData(16, 40);
+let shaderModule10 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(302) var tex19: texture_2d<i32>;
+
+struct T0 {
+  @align(16) @size(48) f0: atomic<u32>,
+}
+
+struct T1 {
+  @align(16) f0: mat2x4h,
+  f1: vec4i,
+  @size(144) f2: array<u32>,
+}
+
+struct T2 {
+  @size(280) f0: array<u32>,
+}
+
+struct T3 {
+  @size(16) f0: array<array<atomic<i32>, 1>, 1>,
+  @size(72) f1: array<mat2x2h>,
+}
+
+struct S0 {
+  @location(3) @interpolate(perspective, centroid) f0: vec2h,
+  @location(12) @interpolate(flat, sample) f1: u32,
+  @location(7) f2: vec4u,
+  @location(2) @interpolate(linear) f3: vec4f,
+  @location(14) f4: i32,
+  @location(9) @interpolate(flat, center) f5: vec4i,
+  @location(10) @interpolate(flat) f6: vec2i,
+}
+
+struct VertexOutput10 {
+  @location(3) @interpolate(flat, centroid) f28: vec4u,
+  @builtin(position) f29: vec4f,
+}
+
+struct FragmentOutput6 {
+  @location(5) f0: vec2u,
+  @builtin(sample_mask) f1: u32,
+  @location(0) @interpolate(flat) f2: vec4u,
+}
+
+fn fn0() -> mat4x4h {
+  var out: mat4x4h;
+  let vf162: vec2f = unpack2x16snorm(u32(unconst_u32(306)));
+  vp23[u32(unconst_u32(162))] = unpack2x16snorm(u32(unconst_u32(17)))[0];
+  var vf163: u32 = textureNumLevels(tex19);
+  var vf164: vec2u = textureDimensions(tex19, i32(unconst_i32(146)));
+  let vf165: f16 = determinant(mat3x3h(unconst_f16(2295.0), unconst_f16(1071.6), unconst_f16(-9111.1), unconst_f16(60000.0), unconst_f16(31093.6), unconst_f16(1706.2), unconst_f16(4242.7), unconst_f16(19274.5), unconst_f16(9878.9)));
+  out = mat4x4h(f16(textureNumLevels(tex19)), f16(textureNumLevels(tex19)), f16(textureNumLevels(tex19)), f16(textureNumLevels(tex19)), f16(textureNumLevels(tex19)), f16(textureNumLevels(tex19)), f16(textureNumLevels(tex19)), f16(textureNumLevels(tex19)), f16(textureNumLevels(tex19)), f16(textureNumLevels(tex19)), f16(textureNumLevels(tex19)), f16(textureNumLevels(tex19)), f16(textureNumLevels(tex19)), f16(textureNumLevels(tex19)), f16(textureNumLevels(tex19)), f16(textureNumLevels(tex19)));
+  let ptr160: ptr<function, vec2u> = &vf164;
+  let vf166: u32 = vf164[u32(unconst_u32(122))];
+  return out;
+}
+
+var<private> vp23: array<f32, 11> = array(f32(0.03168), f32(0.03343), f32(0.1235), f32(0.2707), f32(0.1430), f32(0.01874), f32(0.4287), f32(0.01256), f32(0.00647), f32(0.2594), f32(0.03287));
+
+@vertex
+fn vertex11(a0: S0) -> VertexOutput10 {
+  var out: VertexOutput10;
+  out.f29 = vec4f(vp23[10]);
+  out.f28 &= unpack4xU8(u32(a0.f0[u32(unconst_u32(302))]));
+  out.f28 = unpack4xU8(a0.f1);
+  let vf167: u32 = a0.f2[u32(unconst_u32(142))];
+  let vf168: vec4i = a0.f5;
+  out.f29 = a0.f3;
+  return out;
+}
+
+@fragment
+fn fragment10() -> FragmentOutput6 {
+  var out: FragmentOutput6;
+  vp23[10] -= bitcast<vec4f>(textureLoad(tex19, vec2i(unconst_i32(108), unconst_i32(-103)), i32(unconst_i32(383)))).g;
+  var vf169 = fn0();
+  fn0();
+  vp23[u32(unconst_u32(348))] = vp23[10];
+  return out;
+}
+
+@compute @workgroup_size(1, 2, 1)
+fn compute8() {
+  workgroupBarrier();
+  let vf170: vec2f = acosh(vec2f(unconst_f32(0.00855), unconst_f32(0.1506)));
+  var vf171: vec4h = mix(vec4h(unconst_f16(19873.8), unconst_f16(22357.3), unconst_f16(19202.3), unconst_f16(-1359.8)), vec4h(unconst_f16(-761.6), unconst_f16(22202.8), unconst_f16(26503.3), unconst_f16(-12513.6)), f16(unconst_f16(27890.7)));
+  vp23[u32(unconst_u32(226))] = degrees(f32(faceForward(vec3h(unconst_f16(8900.2), unconst_f16(9245.5), unconst_f16(9140.0)), vec3h(unconst_f16(18215.6), unconst_f16(22320.0), unconst_f16(6792.2)), vec3h(unconst_f16(5633.8), unconst_f16(4133.9), unconst_f16(6630.6)))[2]));
+  vp23[u32(unconst_u32(11))] = ldexp(vec2f(unconst_f32(0.04147), unconst_f32(0.6919)), vec2i(unconst_i32(8), unconst_i32(109))).r;
+  let vf172: bool = any(bool(unconst_bool(false)));
+  let vf173: vec2u = textureDimensions(tex19);
+  var vf174: vec2f = ldexp(vec2f(unconst_f32(0.02271), unconst_f32(0.09134)), vec2i(unconst_i32(308), unconst_i32(69)));
+  vp23[u32(unconst_u32(17))] *= log2(f32(unconst_f32(0.4051)));
+  var vf175: vec2u = textureDimensions(tex19, i32(unconst_i32(540)));
+  let ptr161: ptr<private, f32> = &vp23[u32(unconst_u32(173))];
+  vf175 >>= vec2u(normalize(ldexp(vec3f(unconst_f32(0.1607), unconst_f32(0.05313), unconst_f32(0.07657)), vec3i(unconst_i32(16), unconst_i32(339), unconst_i32(15)))).rg);
+  let ptr162: ptr<function, vec4h> = &vf171;
+  vp23[u32(unconst_u32(18))] -= log2(vec4f(trunc(vec4h(f16(dot4I8Packed(u32(unconst_u32(17)), u32((*ptr161))))))).w);
+  vf174 = vec2f(vf170[u32(unconst_u32(13))]);
+  var vf176: vec2u = textureDimensions(tex19);
+  let ptr163: ptr<function, vec4h> = &vf171;
+  let ptr164: ptr<private, f32> = &vp23[10];
+  vp23[u32(unconst_u32(667))] += f32(textureDimensions(tex19, i32(unconst_i32(147))).r);
+  let vf177: vec2f = vf170;
+  vf174 -= vec2f((*ptr161));
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer98 = device0.createBuffer({
+  label: '\u7590\u40e8\u555b\u48c1\u29ed\u{1fcce}\u{1ff80}\u89e0\u{1f9d0}\ud501',
+  size: 10180,
+  usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView104 = texture79.createView({});
+try {
+computePassEncoder56.setBindGroup(0, bindGroup4, new Uint32Array(1180), 185, 2);
+} catch {}
+try {
+computePassEncoder54.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer68, 'uint16', 110, 4_366);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(4, buffer24, 0, 98);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer79, 'uint32', 164, 14);
+} catch {}
+try {
+commandEncoder100.resolveQuerySet(querySet10, 3, 64, buffer92, 4608);
+} catch {}
+try {
+commandEncoder100.insertDebugMarker('\u64a4');
+} catch {}
+let texture109 = device0.createTexture({
+  size: {width: 60, height: 24, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+try {
+renderPassEncoder1.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(3, bindGroup41, new Uint32Array(3978), 2_075, 0);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer78, 'uint32', 152, 152);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(4, buffer66, 884);
+} catch {}
+try {
+computePassEncoder15.insertDebugMarker('\u0333');
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let computePassEncoder92 = commandEncoder100.beginComputePass();
+try {
+computePassEncoder43.setBindGroup(0, bindGroup13, new Uint32Array(881), 9, 0);
+} catch {}
+try {
+computePassEncoder76.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer55, 'uint16', 284, 972);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer88, 676, new Int16Array(9115), 969, 512);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 9, depthOrArrayLayers: 372}
+*/
+{
+  source: videoFrame16,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture98,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 79},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer99 = device0.createBuffer({size: 45811, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+try {
+{ clearResourceUsages(device0, computePassEncoder43); computePassEncoder43.dispatchWorkgroupsIndirect(buffer76, 52); };
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(1, bindGroup7, []);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(2, bindGroup28, new Uint32Array(631), 2, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 9, depthOrArrayLayers: 372}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 5, y: 137 },
+  flipY: false,
+}, {
+  texture: texture98,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 11},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+globalThis.someLabel = buffer7.label;
+} catch {}
+let bindGroup57 = device0.createBindGroup({
+  label: '\uc85e\u7129\ue407\u{1fd73}\u{1f91f}\ud963\u089e',
+  layout: bindGroupLayout7,
+  entries: [{binding: 236, resource: sampler27}],
+});
+try {
+computePassEncoder40.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup54, new Uint32Array(1377), 98, 0);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(1, bindGroup28, new Uint32Array(602), 281, 0);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer64, 'uint32', 1_340, 592);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(2, buffer24, 0, 723);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let textureView105 = texture106.createView({dimension: '2d-array'});
+let renderBundle15 = renderBundleEncoder15.finish();
+try {
+computePassEncoder61.setBindGroup(2, bindGroup37);
+} catch {}
+try {
+computePassEncoder63.setPipeline(pipeline6);
+} catch {}
+try {
+computePassEncoder39.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer79, 'uint32', 36, 27);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(3, buffer42);
+} catch {}
+let commandEncoder101 = device0.createCommandEncoder({label: '\u4777\u7d44\ue3bd\u4596\ue6d9\u3bbe\ud761\uad44\u0fd6\u5ca1'});
+let sampler57 = device0.createSampler({
+  label: '\u2d26\u4d61\u{1f814}\u8901\u0ec7',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 67.82,
+  lodMaxClamp: 85.97,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder19.setBindGroup(2, bindGroup55);
+} catch {}
+try {
+computePassEncoder2.setBindGroup(3, bindGroup5, new Uint32Array(503), 73, 2);
+} catch {}
+try {
+computePassEncoder36.setPipeline(pipeline6);
+} catch {}
+let commandBuffer6 = commandEncoder101.finish({label: '\uecca\ue146\u0fa0'});
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({
+  label: '\u01d8\uf60c\u9682\uc509\u{1ffea}\ufd71\u05db\u6d68',
+  colorFormats: ['r16uint'],
+  depthStencilFormat: 'depth16unorm',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder3.setIndexBuffer(buffer64, 'uint32', 2_600, 328);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(4, buffer72, 508, 943);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(5, buffer68, 0, 745);
+} catch {}
+let bindGroupLayout16 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 80, visibility: 0, externalTexture: {}},
+    {
+      binding: 282,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 63,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 28,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16uint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 209,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 155,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '3d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 360,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: 'cube', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 999,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 222,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rg32uint', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 732,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '3d' },
+    },
+    {
+      binding: 254,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 182,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 92,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 9,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let texture110 = device0.createTexture({
+  size: {width: 10, height: 9, depthOrArrayLayers: 1},
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder87.setBindGroup(0, bindGroup5, [1280, 0]);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder43); computePassEncoder43.dispatchWorkgroupsIndirect(buffer70, 9_344); };
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer78, 'uint32', 112, 513);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(4, buffer64);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(1, bindGroup26, []);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(116).fill(114), /* required buffer size: 116 */
+{offset: 116, bytesPerRow: 163}, {width: 60, height: 24, depthOrArrayLayers: 0});
+} catch {}
+let texture111 = device0.createTexture({
+  size: [10, 9, 1],
+  mipLevelCount: 1,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture112 = device0.createTexture({
+  size: {width: 60, height: 24, depthOrArrayLayers: 116},
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder83.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup12, [512, 2304]);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(48);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer79, 'uint32', 372, 153);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(0, buffer42, 656, 73);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let commandEncoder102 = device0.createCommandEncoder({});
+let textureView106 = texture85.createView({dimension: 'cube', baseArrayLayer: 1});
+let computePassEncoder93 = commandEncoder102.beginComputePass({label: '\u0ffd\u9329\u05b7\udaf1\u0fd7\u9cac\u0971\u3d6e\u0d0a'});
+let sampler58 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 54.77,
+  lodMaxClamp: 59.80,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder92.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(0, bindGroup27);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(5, buffer42, 0, 222);
+} catch {}
+await gc();
+let bindGroup58 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 59, resource: sampler18}]});
+let commandEncoder103 = device0.createCommandEncoder({label: '\u628d\u01f4\u0004\u02f7\u0e81\ue665\u0ee3'});
+let texture113 = device0.createTexture({
+  size: [20, 19, 1],
+  sampleCount: 1,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder94 = commandEncoder103.beginComputePass();
+try {
+computePassEncoder4.setBindGroup(2, bindGroup11, new Uint32Array(1227), 139, 2);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup20);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer72, 'uint32', 1_168, 7);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(3, buffer73, 0, 270);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+}, new Uint8Array(185).fill(2), /* required buffer size: 185 */
+{offset: 185}, {width: 332, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 54, height: 141, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData0,
+  origin: { x: 6, y: 0 },
+  flipY: false,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 1, y: 8, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 15, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let texture114 = device0.createTexture({
+  size: [40, 39, 1],
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let externalTexture11 = device0.importExternalTexture({source: videoFrame1, colorSpace: 'srgb'});
+try {
+computePassEncoder23.setBindGroup(0, bindGroup11, [3584, 256]);
+} catch {}
+try {
+computePassEncoder89.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(4, buffer55, 72, 419);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(2, bindGroup16, [256, 0]);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(2, bindGroup40, new Uint32Array(1070), 553, 0);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(3, buffer4, 0, 64);
+} catch {}
+let promise10 = device0.queue.onSubmittedWorkDone();
+let pipeline7 = device0.createRenderPipeline({
+  layout: pipelineLayout3,
+  fragment: {module: shaderModule8, targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL}]},
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex5',
+    constants: {49_258: 0},
+    buffers: [
+      {
+        arrayStride: 20,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x2', offset: 0, shaderLocation: 7}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'front'},
+});
+try {
+  await promise10;
+} catch {}
+let texture115 = device0.createTexture({
+  label: '\ubb08\u5e59\u001a\u06c5\u0746\u1400\u0d33\u7ed8\u{1fcfc}\ub2d8\u0078',
+  size: [80, 78, 1],
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder44.setBindGroup(2, bindGroup50);
+} catch {}
+try {
+renderPassEncoder5.setStencilReference(1345);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline4);
+} catch {}
+let bindGroup59 = device0.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 148, resource: textureView11}]});
+let textureView107 = texture110.createView({label: '\u0da7\ub8ac', dimension: '2d-array', arrayLayerCount: 1});
+try {
+{ clearResourceUsages(device0, computePassEncoder43); computePassEncoder43.dispatchWorkgroupsIndirect(buffer61, 7_016); };
+} catch {}
+try {
+computePassEncoder26.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup58, new Uint32Array(1685), 186, 0);
+} catch {}
+try {
+renderPassEncoder6.setViewport(140.2490614270664, 0.4564855715764109, 69.27186403719959, 0.42613034979658676, 0.8660261346986632, 0.9998532475727883);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(1, buffer66, 0, 4);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(2, bindGroup50, new Uint32Array(308), 19, 0);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let buffer100 = device0.createBuffer({
+  label: '\u0403\u07ff\ua695\u{1fb89}\u1d81\u1622\u3419',
+  size: 10849,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView108 = texture111.createView({});
+let textureView109 = texture114.createView({label: '\u60f0\u617b\u0c81\u058f\uc213\u0c1b\u8e55\u8790\ub1bd'});
+try {
+computePassEncoder80.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup55);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(0, buffer24, 0, 439);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer21, 'uint32', 1_752, 5_167);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer73, 19792, new Float32Array(6683));
+} catch {}
+await gc();
+let textureView110 = texture115.createView({dimension: '2d-array', baseMipLevel: 0});
+let textureView111 = texture115.createView({dimension: '2d-array', arrayLayerCount: 1});
+let renderBundle16 = renderBundleEncoder16.finish();
+try {
+{ clearResourceUsages(device0, computePassEncoder43); computePassEncoder43.dispatchWorkgroupsIndirect(buffer6, 440); };
+} catch {}
+try {
+computePassEncoder72.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup2, []);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(7, buffer100, 0, 387);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(229).fill(26), /* required buffer size: 229 */
+{offset: 229}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder104 = device0.createCommandEncoder();
+let textureView112 = texture71.createView({aspect: 'all', mipLevelCount: 1, arrayLayerCount: 3});
+let computePassEncoder95 = commandEncoder104.beginComputePass();
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({colorFormats: ['r8unorm'], depthStencilFormat: 'stencil8', depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder6.setBindGroup(2, bindGroup33);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup29, new Uint32Array(2036), 338, 0);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(7, buffer66, 0, 33);
+} catch {}
+let promise11 = shaderModule5.getCompilationInfo();
+let buffer101 = device0.createBuffer({
+  size: 1977,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView113 = texture83.createView({label: '\u{1fedd}\u5339\u3096\u8a98\u0bee\u643b\ubf75', format: 'r8unorm', mipLevelCount: 1});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup9, new Uint32Array(616), 7, 2);
+} catch {}
+try {
+computePassEncoder65.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup28, []);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer54, 'uint32', 1_960, 49);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(1, bindGroup29);
+} catch {}
+let promise12 = device0.queue.onSubmittedWorkDone();
+let buffer102 = device0.createBuffer({
+  size: 822,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture116 = device0.createTexture({
+  size: [1330, 1, 1],
+  sampleCount: 4,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView114 = texture77.createView({label: '\u06a7\ueaf1\ub514\u0b81\u6835', format: 'r16uint', baseArrayLayer: 15, arrayLayerCount: 1});
+try {
+computePassEncoder6.setBindGroup(1, bindGroup25, new Uint32Array(308), 18, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder43); computePassEncoder43.dispatchWorkgroupsIndirect(buffer76, 4); };
+} catch {}
+try {
+computePassEncoder7.setPipeline(pipeline6);
+} catch {}
+try {
+computePassEncoder45.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(3, buffer44, 0, 1_068);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup37, new Uint32Array(1326), 540, 0);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer6, 'uint32', 6_880, 310);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(3, buffer72, 488, 279);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(83).fill(137), /* required buffer size: 83 */
+{offset: 83}, {width: 120, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup60 = device0.createBindGroup({
+  layout: bindGroupLayout14,
+  entries: [
+    {binding: 152, resource: sampler33},
+    {binding: 999, resource: textureView103},
+    {binding: 60, resource: textureView11},
+  ],
+});
+let texture117 = device0.createTexture({
+  size: [40, 39, 1],
+  mipLevelCount: 2,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let renderBundle17 = renderBundleEncoder17.finish();
+try {
+computePassEncoder63.setBindGroup(2, bindGroup55, new Uint32Array(1083), 8, 0);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer55, 'uint16', 726, 586);
+} catch {}
+try {
+  await buffer71.mapAsync(GPUMapMode.READ, 864, 1440);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 78, depthOrArrayLayers: 284}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 14, y: 8, z: 9},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let textureView115 = texture73.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder94.setBindGroup(3, bindGroup5, new Uint32Array(1173), 40, 2);
+} catch {}
+try {
+computePassEncoder10.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder5.setViewport(313.6640609758012, 0.8543414275334004, 2.276322640622666, 0.09236893089329197, 0.9328840566215758, 0.9531569440126327);
+} catch {}
+let sampler59 = device0.createSampler({
+  label: '\u543d\u1740\u05bc\ubf66\u0728\u{1f624}\uc567\u2ea3\u35b2\u{1fd82}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 95.55,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder1.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(2, buffer8);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+adapter0.label = '\u{1fb40}\u3c55\u0c23\u{1fba6}\ub9b7\u3e6a\u045e';
+} catch {}
+let sampler60 = device0.createSampler({
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 74.25,
+  lodMaxClamp: 98.85,
+});
+try {
+computePassEncoder63.setBindGroup(1, bindGroup34, new Uint32Array(4966), 736, 2);
+} catch {}
+try {
+computePassEncoder82.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(46);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline4);
+} catch {}
+let arrayBuffer19 = buffer2.getMappedRange(1928, 0);
+await gc();
+let bindGroup61 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 16, resource: {buffer: buffer98, offset: 256}},
+    {binding: 426, resource: {buffer: buffer27, offset: 256}},
+    {binding: 142, resource: textureView20},
+    {binding: 139, resource: textureView45},
+    {binding: 25, resource: {buffer: buffer94, offset: 16896, size: 4120}},
+    {binding: 96, resource: textureView12},
+    {binding: 925, resource: textureView20},
+    {binding: 779, resource: {buffer: buffer69, offset: 0, size: 1161}},
+    {binding: 32, resource: textureView19},
+    {binding: 88, resource: {buffer: buffer100, offset: 1536, size: 356}},
+    {binding: 3, resource: sampler52},
+  ],
+});
+let buffer103 = device0.createBuffer({
+  size: 17750,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup27);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(7, buffer68);
+} catch {}
+try {
+renderPassEncoder1.insertDebugMarker('\u0b69');
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.append(img0);
+let commandEncoder105 = device0.createCommandEncoder();
+let texture118 = device0.createTexture({
+  size: [120, 48, 1],
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let computePassEncoder96 = commandEncoder105.beginComputePass();
+let sampler61 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 66.81,
+  lodMaxClamp: 93.06,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder33.setBindGroup(1, bindGroup53);
+} catch {}
+try {
+computePassEncoder66.setBindGroup(1, bindGroup45, new Uint32Array(1130), 373, 0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup19);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline5);
+} catch {}
+let imageData10 = new ImageData(12, 36);
+let textureView116 = texture111.createView({
+  label: '\u{1fcb4}\u{1fbfb}\uafdf\uf1b5\u7618\u8ebd\ufa33\udc3c\u0515\ua12d\u6aed',
+  arrayLayerCount: 1,
+});
+let texture119 = device0.createTexture({
+  label: '\u{1ff85}\ud614\u1211\u{1fc17}\u{1f7db}\ub697',
+  size: [40, 39, 1],
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let renderBundleEncoder18 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle18 = renderBundleEncoder18.finish({label: '\u9e59\u00a0\u053f\u74a4\u03b1\u{1fc23}\uba13\u{1ff69}\u0b8a'});
+let sampler62 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', minFilter: 'nearest', lodMaxClamp: 60.09});
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup59, []);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup45, new Uint32Array(390), 17, 0);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(80);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle18, renderBundle13, renderBundle2, renderBundle18, renderBundle2]);
+} catch {}
+try {
+device0.queue.submit([commandBuffer6]);
+} catch {}
+let commandEncoder106 = device0.createCommandEncoder({});
+let texture120 = device0.createTexture({size: [332, 1, 61], dimension: '2d', format: 'stencil8', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let computePassEncoder97 = commandEncoder106.beginComputePass({});
+let externalTexture12 = device0.importExternalTexture({label: '\uea52\u{1ff13}\u{1f68c}\u{1ff23}\u3f82', source: videoFrame15});
+try {
+computePassEncoder54.setBindGroup(2, bindGroup20);
+} catch {}
+try {
+computePassEncoder81.end();
+} catch {}
+try {
+computePassEncoder94.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline5);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+commandEncoder86.clearBuffer(buffer69, 568, 1592);
+} catch {}
+try {
+computePassEncoder44.pushDebugGroup('\uef28');
+} catch {}
+try {
+device0.queue.submit([commandBuffer5]);
+} catch {}
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55); };
+} catch {}
+let buffer104 = device0.createBuffer({
+  size: 9421,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let renderPassEncoder7 = commandEncoder86.beginRenderPass({colorAttachments: [{view: textureView93, depthSlice: 10, loadOp: 'clear', storeOp: 'store'}]});
+let externalTexture13 = device0.importExternalTexture({source: videoFrame11});
+try {
+computePassEncoder76.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+computePassEncoder95.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline7);
+} catch {}
+let pipeline8 = device0.createComputePipeline({layout: pipelineLayout0, compute: {module: shaderModule2}});
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let imageData11 = new ImageData(44, 8);
+let videoFrame18 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'film', transfer: 'logSqrt'} });
+let buffer105 = device0.createBuffer({
+  size: 3432,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder107 = device0.createCommandEncoder({label: '\uda80\u078c\u1306\u0030'});
+let computePassEncoder98 = commandEncoder107.beginComputePass({});
+let sampler63 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 15.08,
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder77.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(6, buffer80, 464, 2_591);
+} catch {}
+try {
+computePassEncoder18.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+computePassEncoder85.setBindGroup(3, bindGroup34, new Uint32Array(4126), 1_171, 2);
+} catch {}
+try {
+computePassEncoder50.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer54, 'uint32', 1_496, 92);
+} catch {}
+let bindGroup62 = device0.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 148, resource: textureView9}]});
+let buffer106 = device0.createBuffer({
+  size: 11756,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let texture121 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 813},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8unorm'],
+});
+try {
+computePassEncoder53.setBindGroup(1, bindGroup28);
+} catch {}
+document.body.append(canvas0);
+let bindGroup63 = device0.createBindGroup({
+  layout: bindGroupLayout14,
+  entries: [
+    {binding: 60, resource: textureView9},
+    {binding: 999, resource: textureView103},
+    {binding: 152, resource: sampler20},
+  ],
+});
+let buffer107 = device0.createBuffer({size: 17095, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let commandEncoder108 = device0.createCommandEncoder({});
+let textureView117 = texture104.createView({arrayLayerCount: 2});
+let computePassEncoder99 = commandEncoder108.beginComputePass({});
+try {
+computePassEncoder76.setBindGroup(3, bindGroup8, [3328, 0]);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer21, 'uint32', 2_664, 525);
+} catch {}
+let buffer108 = device0.createBuffer({size: 6585, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder109 = device0.createCommandEncoder();
+let computePassEncoder100 = commandEncoder109.beginComputePass({label: '\u{1feaa}\u0bb2\u{1fed3}\u0dd4\u6aab\u0908\u{1fd9a}\u905d\uffdd\u{1fc9a}'});
+try {
+computePassEncoder7.setBindGroup(0, bindGroup44, new Uint32Array(2089), 32, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder76); computePassEncoder76.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder43); computePassEncoder43.dispatchWorkgroupsIndirect(buffer69, 872); };
+} catch {}
+let promise13 = device0.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let buffer109 = device0.createBuffer({size: 19028, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX});
+let commandEncoder110 = device0.createCommandEncoder({});
+let texture122 = device0.createTexture({size: [80, 78, 1], format: 'r8unorm', usage: GPUTextureUsage.COPY_SRC});
+let sampler64 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 72.29,
+  lodMaxClamp: 88.45,
+});
+try {
+computePassEncoder47.setBindGroup(3, bindGroup4, new Uint32Array(788), 16, 2);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder82); computePassEncoder82.dispatchWorkgroups(1); };
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture94,
+  mipLevel: 1,
+  origin: {x: 1, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(14).fill(17), /* required buffer size: 14 */
+{offset: 14, bytesPerRow: 22}, {width: 3, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let textureView118 = texture113.createView({dimension: '2d-array'});
+try {
+computePassEncoder91.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup57, new Uint32Array(415), 11, 0);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(28);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline5);
+} catch {}
+try {
+commandEncoder110.copyTextureToTexture({
+  texture: texture110,
+  mipLevel: 0,
+  origin: {x: 4, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture113,
+  mipLevel: 0,
+  origin: {x: 5, y: 5, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer106, 2620, new DataView(new ArrayBuffer(1207)), 968, 28);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(42).fill(35), /* required buffer size: 42 */
+{offset: 42, bytesPerRow: 88}, {width: 40, height: 39, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder66.label = '\u103f\ub238\u686b\u0a0e';
+} catch {}
+let commandEncoder111 = device0.createCommandEncoder({});
+let querySet12 = device0.createQuerySet({type: 'occlusion', count: 613});
+let texture123 = device0.createTexture({
+  size: {width: 80, height: 78, depthOrArrayLayers: 1},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder101 = commandEncoder110.beginComputePass();
+let sampler65 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 50.26,
+  lodMaxClamp: 59.72,
+  maxAnisotropy: 19,
+});
+try {
+renderPassEncoder4.executeBundles([renderBundle0, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder111.copyBufferToTexture({
+  /* bytesInLastRow: 5 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 233 */
+  offset: 233,
+  bytesPerRow: 34304,
+  rowsPerImage: 1764,
+  buffer: buffer103,
+}, {
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 16, y: 4, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 6, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 19, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame17,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture94,
+  mipLevel: 1,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img0);
+await gc();
+let commandEncoder112 = device0.createCommandEncoder({});
+let textureView119 = texture10.createView({});
+let computePassEncoder102 = commandEncoder112.beginComputePass({label: '\u5bcf\u2cbe\u{1fc58}\u6750\u1363\u{1ff9e}\u07d4\uf4c9\u040d\u{1fe79}\u3ea4'});
+try {
+computePassEncoder63.setBindGroup(3, bindGroup52);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer67, 'uint16', 1_992, 1_932);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(6, buffer100, 0, 3_091);
+} catch {}
+try {
+computePassEncoder44.popDebugGroup();
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let commandEncoder113 = device0.createCommandEncoder();
+let computePassEncoder103 = commandEncoder111.beginComputePass();
+let sampler66 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 26.78,
+});
+try {
+computePassEncoder102.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder100.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup2, new Uint32Array(706), 34, 0);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(6, buffer105, 0, 369);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let commandEncoder114 = device0.createCommandEncoder();
+let textureView120 = texture16.createView({mipLevelCount: 1});
+try {
+computePassEncoder35.setBindGroup(0, bindGroup48, new Uint32Array(2891), 640, 0);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle7]);
+} catch {}
+try {
+commandEncoder114.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1704 */
+  offset: 1704,
+  bytesPerRow: 11264,
+  rowsPerImage: 785,
+  buffer: buffer94,
+}, {
+  texture: texture113,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img0);
+let commandEncoder115 = device0.createCommandEncoder();
+try {
+computePassEncoder90.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup31, new Uint32Array(884), 178, 0);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: -674.0, g: 71.87, b: -958.8, a: -711.2, });
+} catch {}
+try {
+commandEncoder115.copyBufferToBuffer(buffer60, 500, buffer78, 432, 152);
+} catch {}
+try {
+commandEncoder115.clearBuffer(buffer81);
+} catch {}
+document.body.append(canvas0);
+let bindGroup64 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 194, resource: textureView86},
+    {binding: 267, resource: textureView63},
+    {binding: 362, resource: textureView117},
+    {binding: 87, resource: textureView21},
+  ],
+});
+let computePassEncoder104 = commandEncoder115.beginComputePass();
+try {
+computePassEncoder55.end();
+} catch {}
+try {
+computePassEncoder98.setPipeline(pipeline6);
+} catch {}
+let buffer110 = device0.createBuffer({
+  size: 9733,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let commandBuffer7 = commandEncoder56.finish({});
+let textureView121 = texture28.createView({});
+let sampler67 = device0.createSampler({
+  label: '\ubf5c\u4c13\ub279\u029b\uaaa3\u3b47\ubad7\u4682\u{1fddc}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 42.99,
+  lodMaxClamp: 67.76,
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder93.setBindGroup(0, bindGroup28, new Uint32Array(3191), 788, 0);
+} catch {}
+try {
+commandEncoder113.clearBuffer(buffer78, 272, 228);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer7]);
+} catch {}
+let bindGroup65 = device0.createBindGroup({
+  label: '\u0c56\u001e\u4ac8\uc327\u5328\u63a7\u4af8\u0b0f',
+  layout: bindGroupLayout7,
+  entries: [{binding: 236, resource: sampler22}],
+});
+let commandEncoder116 = device0.createCommandEncoder();
+let computePassEncoder105 = commandEncoder114.beginComputePass();
+let sampler68 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 61.69,
+  lodMaxClamp: 87.12,
+});
+try {
+computePassEncoder70.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder7.setViewport(5.356179463294741, 17.73220522584885, 4.227454576330349, 0.914214947877765, 0.3089737166572193, 0.8668134310519086);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(2, undefined, 212_260_877, 943_499_549);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer78, 52, new Int16Array(21848), 5173, 460);
+} catch {}
+let bindGroupLayout17 = device0.createBindGroupLayout({
+  label: '\u020a\u5542\u{1fad8}',
+  entries: [
+    {
+      binding: 219,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder117 = device0.createCommandEncoder({});
+let computePassEncoder106 = commandEncoder116.beginComputePass({label: '\u09d8\u048b\ua062\u8279\u66da'});
+let sampler69 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 71.52,
+  lodMaxClamp: 90.85,
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder19.setBindGroup(3, bindGroup64, new Uint32Array(1559), 212, 0);
+} catch {}
+try {
+computePassEncoder12.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup45);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer95, 'uint32', 204, 27);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline5);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 1040, new Int16Array(16666), 451, 776);
+} catch {}
+try {
+globalThis.someLabel = device0.queue.label;
+} catch {}
+let texture124 = device0.createTexture({
+  size: [120, 48, 1],
+  mipLevelCount: 2,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder107 = commandEncoder117.beginComputePass();
+let sampler70 = device0.createSampler({
+  label: '\u7fa6\u9af9\u8854\u{1fe2e}\u{1fc1e}\uf08f\u{1fb79}\u837e',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 89.36,
+  lodMaxClamp: 96.01,
+});
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup65);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: 686.4, g: -424.8, b: -691.8, a: -106.5, });
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer21, 'uint16', 1_466, 10_634);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(5, buffer11, 0, 10);
+} catch {}
+let arrayBuffer20 = buffer71.getMappedRange(1072, 880);
+try {
+buffer19.unmap();
+} catch {}
+let promise14 = device0.queue.onSubmittedWorkDone();
+let pipeline9 = device0.createComputePipeline({layout: pipelineLayout7, compute: {module: shaderModule10}});
+let pipelineLayout9 = device0.createPipelineLayout({label: '\u6e32\u{1fc90}\u01f0\u{1fff8}\u0e77\u51bd\u6cb7\u09e0', bindGroupLayouts: []});
+let buffer111 = device0.createBuffer({
+  size: 3679,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder108 = commandEncoder113.beginComputePass();
+try {
+computePassEncoder89.setBindGroup(1, bindGroup42, new Uint32Array(1427), 249, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder76); computePassEncoder76.dispatchWorkgroups(2); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder43); computePassEncoder43.dispatchWorkgroupsIndirect(buffer34, 1_784); };
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(45, 0, 18, 0);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer21, 'uint32', 6_672, 4_457);
+} catch {}
+let promise15 = device0.queue.onSubmittedWorkDone();
+try {
+computePassEncoder84.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup58, new Uint32Array(3249), 2_098, 0);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(33);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(69, 0, 8, 0);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+  await promise12;
+} catch {}
+await gc();
+let commandEncoder118 = device0.createCommandEncoder({});
+let texture125 = device0.createTexture({
+  size: {width: 40, height: 39, depthOrArrayLayers: 1},
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView122 = texture108.createView({aspect: 'all', mipLevelCount: 1, baseArrayLayer: 34, arrayLayerCount: 3});
+let computePassEncoder109 = commandEncoder118.beginComputePass();
+try {
+computePassEncoder76.end();
+} catch {}
+try {
+computePassEncoder107.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup48, new Uint32Array(6611), 258, 0);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle2, renderBundle7, renderBundle10, renderBundle18, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer78, 'uint32', 296, 326);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline0);
+} catch {}
+try {
+buffer57.unmap();
+} catch {}
+try {
+commandEncoder82.resolveQuerySet(querySet4, 75, 271, buffer105, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer44, 648, new Int16Array(14160), 1750, 588);
+} catch {}
+let commandEncoder119 = device0.createCommandEncoder();
+let texture126 = device0.createTexture({
+  size: {width: 1330, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler71 = device0.createSampler({
+  label: '\u7a1a\uafb6\u05c2\ub5ca\u{1f756}\u{1ff9b}\u{1f873}\u{1fdd9}\u6a90',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 83.23,
+});
+try {
+computePassEncoder48.setBindGroup(0, bindGroup12, [0, 3328]);
+} catch {}
+try {
+computePassEncoder96.setPipeline(pipeline6);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 54, height: 141, depthOrArrayLayers: 1}
+*/
+{
+  source: img0,
+  origin: { x: 0, y: 2 },
+  flipY: false,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 3, y: 11, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 15, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let pipelineLayout10 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout7]});
+let commandEncoder120 = device0.createCommandEncoder({});
+let textureView123 = texture114.createView({});
+let texture127 = device0.createTexture({size: [1330, 1, 1], format: 'rgb10a2uint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let textureView124 = texture69.createView({baseMipLevel: 0, mipLevelCount: 1});
+let computePassEncoder110 = commandEncoder120.beginComputePass();
+let sampler72 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 98.46,
+  lodMaxClamp: 99.37,
+});
+try {
+computePassEncoder59.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+computePassEncoder25.setBindGroup(1, bindGroup10, new Uint32Array(1629), 376, 0);
+} catch {}
+try {
+computePassEncoder85.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup58);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer56, 'uint32', 788, 3_111);
+} catch {}
+let arrayBuffer21 = buffer71.getMappedRange(2024, 16);
+try {
+renderPassEncoder6.insertDebugMarker('\u0a78');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer105, 864, new Int16Array(4732), 78, 256);
+} catch {}
+let promise16 = device0.queue.onSubmittedWorkDone();
+let texture128 = device0.createTexture({
+  label: '\ua704\u{1fe66}\u1286\u347c\uf2a2\u914f\u89ab\u8cc7\u0e03',
+  size: {width: 166, height: 1, depthOrArrayLayers: 1},
+  format: 'stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView125 = texture33.createView({label: '\u{1f621}\u0a15\u85cf\ua5af\u590d\u5068\u00dd\ucc5f', mipLevelCount: 1, arrayLayerCount: 1});
+let promise17 = shaderModule1.getCompilationInfo();
+try {
+commandEncoder119.copyBufferToTexture({
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1460 */
+  offset: 1460,
+  bytesPerRow: 9984,
+  rowsPerImage: 108,
+  buffer: buffer101,
+}, {
+  texture: texture118,
+  mipLevel: 0,
+  origin: {x: 10, y: 26, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder82.copyTextureToBuffer({
+  texture: texture100,
+  mipLevel: 0,
+  origin: {x: 56, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 292 widthInBlocks: 73 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3104 */
+  offset: 3104,
+  bytesPerRow: 768,
+  buffer: buffer27,
+}, {width: 73, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let textureView126 = texture41.createView({baseArrayLayer: 0});
+let renderPassEncoder8 = commandEncoder82.beginRenderPass({
+  colorAttachments: [{view: textureView58, depthSlice: 20, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet0,
+  maxDrawCount: 114924955,
+});
+try {
+computePassEncoder88.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer104, 'uint16', 1_430, 1_199);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 39, depthOrArrayLayers: 142}
+*/
+{
+  source: videoFrame10,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture83,
+  mipLevel: 1,
+  origin: {x: 1, y: 10, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture129 = device0.createTexture({
+  label: '\u436b\u{1f935}\u884c',
+  size: [332, 1, 1],
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder111 = commandEncoder119.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder43); computePassEncoder43.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder97.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(409);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer55, 'uint16', 252, 25);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(5, buffer4, 308, 277);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture105,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 9},
+  aspect: 'depth-only',
+}, new Uint8Array(356_406).fill(82), /* required buffer size: 356_406 */
+{offset: 260, bytesPerRow: 1386, rowsPerImage: 64}, {width: 665, height: 1, depthOrArrayLayers: 5});
+} catch {}
+let buffer112 = device0.createBuffer({
+  size: 11539,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView127 = texture40.createView({dimension: '1d'});
+let sampler73 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 43.55,
+  lodMaxClamp: 78.50,
+  maxAnisotropy: 6,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder82); computePassEncoder82.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder110.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup37, new Uint32Array(1385), 66, 0);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(5, undefined, 0, 1_001_359_437);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 39, depthOrArrayLayers: 142}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture83,
+  mipLevel: 1,
+  origin: {x: 8, y: 4, z: 38},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData12 = new ImageData(176, 20);
+let buffer113 = device0.createBuffer({size: 6622, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE});
+let sampler74 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 82.95,
+  lodMaxClamp: 83.26,
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder101.setBindGroup(1, bindGroup49);
+} catch {}
+try {
+computePassEncoder0.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer68, 'uint32', 412, 5_006);
+} catch {}
+let texture130 = device0.createTexture({
+  label: '\u05f0\u387d\ue2a7\u96f3\u{1f740}\u0f7e\u{1fe52}\uf9f1\u08cd',
+  size: {width: 15, height: 6, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView128 = texture114.createView({dimension: '2d-array'});
+let sampler75 = device0.createSampler({
+  label: '\u{1f891}\ude2b\u29fa\ub9da\u0506\u{1f60a}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 49.70,
+  lodMaxClamp: 99.96,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder34.setBindGroup(1, bindGroup59);
+} catch {}
+try {
+computePassEncoder103.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup43);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer111, 'uint16', 136, 574);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(0, buffer24, 0, 396);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 4, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(515).fill(96), /* required buffer size: 515 */
+{offset: 515, bytesPerRow: 131}, {width: 5, height: 7, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder121 = device0.createCommandEncoder({});
+let textureView129 = texture13.createView({dimension: '2d-array', baseArrayLayer: 0});
+let computePassEncoder112 = commandEncoder121.beginComputePass({});
+try {
+computePassEncoder46.setBindGroup(2, bindGroup45, new Uint32Array(2899), 50, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder43); computePassEncoder43.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder82); computePassEncoder82.dispatchWorkgroupsIndirect(buffer94, 2_324); };
+} catch {}
+try {
+computePassEncoder43.end();
+} catch {}
+try {
+computePassEncoder109.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup58);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline4);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+computePassEncoder66.pushDebugGroup('\u{1f97a}');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 665, height: 1, depthOrArrayLayers: 49}
+*/
+{
+  source: videoFrame12,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 28, y: 0, z: 8},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup66 = device0.createBindGroup({layout: bindGroupLayout6, entries: [{binding: 302, resource: textureView20}]});
+let buffer114 = device0.createBuffer({
+  size: 541,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder122 = device0.createCommandEncoder({});
+try {
+computePassEncoder67.setBindGroup(0, bindGroup12, [0, 0]);
+} catch {}
+try {
+computePassEncoder39.setBindGroup(1, bindGroup49, new Uint32Array(1097), 38, 0);
+} catch {}
+try {
+computePassEncoder108.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup57, new Uint32Array(74), 21, 0);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(4, buffer100, 0, 2_703);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 665, height: 1, depthOrArrayLayers: 49}
+*/
+{
+  source: videoFrame14,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 184, y: 0, z: 5},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let textureView130 = texture77.createView({dimension: '2d-array', aspect: 'all', format: 'r16uint', baseArrayLayer: 22, arrayLayerCount: 3});
+let computePassEncoder113 = commandEncoder44.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder82); computePassEncoder82.dispatchWorkgroupsIndirect(buffer44, 996); };
+} catch {}
+try {
+computePassEncoder58.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder122.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1332 */
+  offset: 1332,
+  bytesPerRow: 20224,
+  buffer: buffer81,
+}, {
+  texture: texture64,
+  mipLevel: 5,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+  await promise16;
+} catch {}
+let externalTexture14 = device0.importExternalTexture({source: videoFrame9, colorSpace: 'display-p3'});
+try {
+renderPassEncoder3.setIndexBuffer(buffer72, 'uint16', 12, 6);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let commandEncoder123 = device0.createCommandEncoder({});
+let computePassEncoder114 = commandEncoder122.beginComputePass({});
+let sampler76 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 56.77,
+  lodMaxClamp: 67.18,
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder113.setBindGroup(1, bindGroup38, [3584, 0]);
+} catch {}
+try {
+computePassEncoder93.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer70, 'uint16', 694, 253);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline5);
+} catch {}
+let arrayBuffer22 = buffer2.getMappedRange(2072, 36);
+try {
+commandEncoder123.clearBuffer(buffer67, 1372, 3848);
+} catch {}
+let promise18 = device0.queue.onSubmittedWorkDone();
+let videoFrame19 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte240m', primaries: 'smpte432', transfer: 'smpte170m'} });
+let sampler77 = device0.createSampler({
+  label: '\u46a7\u033c\u3953\u0c06\u9da7\u0da7\u3af9\u012c\u0c32\u5f85\u{1fa46}',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 64.58,
+  lodMaxClamp: 88.18,
+});
+try {
+computePassEncoder106.setBindGroup(3, bindGroup56, [512, 0]);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer26, 'uint32', 2_156, 2_248);
+} catch {}
+try {
+buffer78.unmap();
+} catch {}
+try {
+commandEncoder123.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1000 */
+  offset: 1000,
+  bytesPerRow: 18688,
+  buffer: buffer42,
+}, {
+  texture: texture115,
+  mipLevel: 0,
+  origin: {x: 22, y: 10, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 10, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+document.body.prepend(canvas0);
+let bindGroup67 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 13, resource: {buffer: buffer100, offset: 0, size: 1972}},
+    {binding: 50, resource: {buffer: buffer41, offset: 256, size: 2032}},
+    {binding: 452, resource: textureView54},
+    {binding: 283, resource: {buffer: buffer57, offset: 3072}},
+    {binding: 26, resource: {buffer: buffer20, offset: 1024, size: 1784}},
+    {binding: 41, resource: textureView86},
+    {binding: 66, resource: {buffer: buffer21, offset: 768, size: 2697}},
+    {binding: 294, resource: textureView17},
+    {binding: 125, resource: textureView98},
+    {binding: 39, resource: textureView11},
+    {binding: 49, resource: textureView43},
+  ],
+});
+let textureView131 = texture121.createView({mipLevelCount: 1});
+let computePassEncoder115 = commandEncoder123.beginComputePass({});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup58);
+} catch {}
+try {
+computePassEncoder38.setBindGroup(1, bindGroup65, new Uint32Array(115), 22, 0);
+} catch {}
+try {
+computePassEncoder88.setPipeline(pipeline6);
+} catch {}
+try {
+computePassEncoder48.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup63, new Uint32Array(570), 193, 0);
+} catch {}
+let textureView132 = texture67.createView({label: '\u{1f971}\u{1f7c8}', baseMipLevel: 1, mipLevelCount: 1});
+let sampler78 = device0.createSampler({
+  label: '\u0f7f\u{1fdf0}\ubcf9\u{1f68e}\uf239\u0396\u{1fddc}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 23.87,
+  lodMaxClamp: 46.30,
+  compare: 'less-equal',
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder93.setBindGroup(0, bindGroup49);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder82); computePassEncoder82.dispatchWorkgroupsIndirect(buffer87, 320); };
+} catch {}
+try {
+computePassEncoder112.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup65, new Uint32Array(1475), 561, 0);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer67, 284, 1_693);
+} catch {}
+let buffer115 = device0.createBuffer({size: 9478, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+let querySet13 = device0.createQuerySet({type: 'occlusion', count: 1293});
+let texture131 = device0.createTexture({
+  size: [665],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder8.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup25, new Uint32Array(1278), 518, 0);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle1, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(6, buffer54);
+} catch {}
+try {
+computePassEncoder66.popDebugGroup();
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer67, 688, new DataView(new ArrayBuffer(4461)), 358, 200);
+} catch {}
+document.body.prepend(img0);
+let offscreenCanvas3 = new OffscreenCanvas(42, 13);
+let commandEncoder124 = device0.createCommandEncoder();
+let texture132 = device0.createTexture({
+  size: {width: 1330, height: 1, depthOrArrayLayers: 3},
+  mipLevelCount: 5,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler79 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 39.98,
+});
+try {
+computePassEncoder113.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline4);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder124.copyBufferToBuffer(buffer79, 20, buffer73, 46972, 40);
+} catch {}
+try {
+  await promise11;
+} catch {}
+let buffer116 = device0.createBuffer({size: 1273, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let computePassEncoder116 = commandEncoder124.beginComputePass();
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({colorFormats: ['r8unorm'], depthStencilFormat: 'stencil8', stencilReadOnly: true});
+let renderBundle19 = renderBundleEncoder19.finish({});
+let sampler80 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 4.782,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder82); computePassEncoder82.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup45, new Uint32Array(411), 87, 0);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer56, 'uint16', 2_708, 1_796);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 665, height: 1, depthOrArrayLayers: 40}
+*/
+{
+  source: imageData0,
+  origin: { x: 12, y: 3 },
+  flipY: false,
+}, {
+  texture: texture72,
+  mipLevel: 1,
+  origin: {x: 306, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img0);
+await gc();
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup52, []);
+} catch {}
+try {
+computePassEncoder79.pushDebugGroup('\u{1fe51}');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await promise14;
+} catch {}
+let bindGroup68 = device0.createBindGroup({
+  layout: bindGroupLayout16,
+  entries: [
+    {binding: 63, resource: sampler40},
+    {binding: 28, resource: textureView118},
+    {binding: 999, resource: textureView91},
+    {binding: 80, resource: externalTexture14},
+    {binding: 92, resource: {buffer: buffer41, offset: 0, size: 5669}},
+    {binding: 222, resource: textureView111},
+    {binding: 732, resource: textureView72},
+    {binding: 155, resource: textureView72},
+    {binding: 282, resource: textureView108},
+    {binding: 9, resource: textureView100},
+    {binding: 360, resource: textureView106},
+    {binding: 254, resource: {buffer: buffer24, offset: 1792, size: 692}},
+    {binding: 209, resource: {buffer: buffer100, offset: 512, size: 8516}},
+    {binding: 182, resource: textureView60},
+  ],
+});
+let buffer117 = device0.createBuffer({
+  label: '\u{1ffe9}\u09b6\uba32\ub9d3\u6c6a\u036a\ubeca\u08ad\u8c59\u6199\u8ec9',
+  size: 2097,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView133 = texture80.createView({dimension: '2d', baseArrayLayer: 3});
+try {
+renderPassEncoder5.setViewport(82.22897354110223, 0.3900797842722019, 140.01013397394638, 0.006611662150113769, 0.9395694542533399, 0.9981071130252747);
+} catch {}
+try {
+querySet8.destroy();
+} catch {}
+try {
+  await promise17;
+} catch {}
+document.body.prepend(img0);
+let buffer118 = device0.createBuffer({
+  size: 361,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let texture133 = device0.createTexture({
+  size: [665, 1, 13],
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+computePassEncoder82.end();
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle0, renderBundle1]);
+} catch {}
+try {
+commandEncoder87.copyTextureToBuffer({
+  texture: texture64,
+  mipLevel: 3,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 720 */
+  offset: 720,
+  buffer: buffer12,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup69 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 60, resource: textureView60},
+    {binding: 35, resource: {buffer: buffer43, offset: 1536, size: 1832}},
+  ],
+});
+let querySet14 = device0.createQuerySet({type: 'occlusion', count: 124});
+let textureView134 = texture39.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 1});
+try {
+computePassEncoder111.setPipeline(pipeline8);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 19, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData8,
+  origin: { x: 10, y: 26 },
+  flipY: true,
+}, {
+  texture: texture94,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let pipeline10 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout7,
+  multisample: {mask: 0x5a17e15b},
+  fragment: {module: shaderModule10, constants: {}, targets: [{format: 'rgb10a2uint', writeMask: 0}]},
+  vertex: {
+    module: shaderModule10,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 208,
+        attributes: [
+          {format: 'uint32', offset: 28, shaderLocation: 7},
+          {format: 'sint32x2', offset: 8, shaderLocation: 10},
+          {format: 'uint8x2', offset: 14, shaderLocation: 12},
+          {format: 'sint8x4', offset: 56, shaderLocation: 9},
+          {format: 'sint32x2', offset: 36, shaderLocation: 14},
+          {format: 'float32x4', offset: 16, shaderLocation: 2},
+          {format: 'snorm8x2', offset: 166, shaderLocation: 3},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'back', unclippedDepth: true},
+});
+try {
+adapter0.label = '\u4490\u1b5c\u6180\u10bd\u03f5';
+} catch {}
+let commandEncoder125 = device0.createCommandEncoder();
+let texture134 = device0.createTexture({
+  label: '\uf782\u{1fb7d}\uff4f\u1faa',
+  size: [15, 6, 1],
+  sampleCount: 4,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder117 = commandEncoder87.beginComputePass({});
+let sampler81 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 28.14,
+  lodMaxClamp: 38.45,
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder92.setBindGroup(0, bindGroup16, [512, 5376]);
+} catch {}
+try {
+computePassEncoder111.setBindGroup(1, bindGroup44, new Uint32Array(1231), 106, 0);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(4, buffer93, 0);
+} catch {}
+let gpuCanvasContext3 = offscreenCanvas3.getContext('webgpu');
+let offscreenCanvas4 = new OffscreenCanvas(136, 177);
+let commandEncoder126 = device0.createCommandEncoder({});
+let texture135 = device0.createTexture({
+  size: [10, 9, 1],
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['depth16unorm'],
+});
+let computePassEncoder118 = commandEncoder125.beginComputePass({});
+try {
+computePassEncoder9.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup65);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(0, buffer11, 0, 28);
+} catch {}
+let bindGroup70 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [
+    {binding: 431, resource: sampler24},
+    {binding: 848, resource: textureView91},
+    {binding: 9, resource: {buffer: buffer21, offset: 768, size: 224}},
+    {binding: 242, resource: sampler42},
+    {binding: 110, resource: {buffer: buffer94, offset: 1280, size: 12288}},
+    {binding: 221, resource: textureView45},
+    {binding: 176, resource: textureView11},
+    {binding: 57, resource: textureView45},
+    {binding: 68, resource: {buffer: buffer100, offset: 768, size: 381}},
+    {binding: 4, resource: {buffer: buffer113, offset: 1792, size: 2396}},
+    {binding: 101, resource: textureView20},
+    {binding: 22, resource: {buffer: buffer70, offset: 2048, size: 1704}},
+    {binding: 39, resource: textureView9},
+    {binding: 174, resource: sampler22},
+    {binding: 107, resource: textureView75},
+    {binding: 187, resource: textureView100},
+    {binding: 252, resource: textureView89},
+  ],
+});
+let texture136 = device0.createTexture({
+  size: [16, 16, 2],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let computePassEncoder119 = commandEncoder126.beginComputePass({label: '\u0c81\ua1b0\u793f\ub09e\ubb0a\u0e95\u02fe\u{1f826}\u8627\u48ad\u0912'});
+try {
+computePassEncoder99.setBindGroup(3, bindGroup59);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup69, new Uint32Array(220), 23, 0);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle7, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline4);
+} catch {}
+let gpuCanvasContext4 = offscreenCanvas4.getContext('webgpu');
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let pipelineLayout11 = device0.createPipelineLayout({bindGroupLayouts: []});
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup45, new Uint32Array(1334), 102, 0);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(39);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline5);
+} catch {}
+let arrayBuffer23 = buffer2.getMappedRange(1672, 0);
+try {
+device0.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(1).fill(0), /* required buffer size: 1 */
+{offset: 1}, {width: 17, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap2 = await createImageBitmap(imageBitmap1);
+try {
+computePassEncoder104.setBindGroup(3, bindGroup2, new Uint32Array(2550), 23, 0);
+} catch {}
+try {
+computePassEncoder117.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup41);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup60, new Uint32Array(443), 54, 0);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle0, renderBundle4]);
+} catch {}
+try {
+  await shaderModule2.getCompilationInfo();
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let buffer119 = device0.createBuffer({
+  size: 222,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture137 = device0.createTexture({
+  size: {width: 1330, height: 1, depthOrArrayLayers: 169},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let sampler82 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 48.94,
+  lodMaxClamp: 76.15,
+});
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup44);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer78, 'uint16', 0, 210);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline7);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+  await promise18;
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let bindGroup71 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [
+    {binding: 39, resource: textureView20},
+    {binding: 221, resource: textureView10},
+    {binding: 187, resource: textureView7},
+    {binding: 57, resource: textureView109},
+    {binding: 4, resource: {buffer: buffer52, offset: 0}},
+    {binding: 848, resource: textureView91},
+    {binding: 252, resource: textureView74},
+    {binding: 9, resource: {buffer: buffer54, offset: 1792, size: 216}},
+    {binding: 176, resource: textureView11},
+    {binding: 107, resource: textureView72},
+    {binding: 110, resource: {buffer: buffer106, offset: 0}},
+    {binding: 431, resource: sampler41},
+    {binding: 174, resource: sampler30},
+    {binding: 22, resource: {buffer: buffer43, offset: 1280, size: 7428}},
+    {binding: 242, resource: sampler0},
+    {binding: 101, resource: textureView9},
+    {binding: 68, resource: {buffer: buffer3, offset: 256, size: 1153}},
+  ],
+});
+try {
+computePassEncoder26.setBindGroup(0, bindGroup7, new Uint32Array(130), 46, 0);
+} catch {}
+try {
+computePassEncoder72.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder64.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer20, 568);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer79, 'uint32', 88, 143);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(4, buffer55);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer68, 12760, new DataView(new ArrayBuffer(24684)), 148, 300);
+} catch {}
+try {
+adapter0.label = '\u090d\u08de';
+} catch {}
+let commandEncoder127 = device0.createCommandEncoder({});
+let textureView135 = texture15.createView({});
+let computePassEncoder120 = commandEncoder127.beginComputePass({});
+let sampler83 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 39.86,
+  lodMaxClamp: 85.39,
+});
+try {
+computePassEncoder101.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup69, new Uint32Array(1701), 273, 0);
+} catch {}
+try {
+renderPassEncoder5.setBlendConstant({ r: 634.1, g: 419.3, b: -989.3, a: -456.9, });
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(82, 0, 120, 16_477_588);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer34, 712);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(4, buffer101, 0);
+} catch {}
+let shaderModule11 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires pointer_composite_access;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(236) var sam5: sampler;
+
+struct T0 {
+  @align(32) @size(4096) f0: array<vec2f>,
+}
+
+struct T1 {
+  @align(128) @size(256) f0: array<mat2x4f, 1>,
+  @align(32) @size(640) f1: mat2x3h,
+}
+
+struct T2 {
+  f0: vec4f,
+  @size(16) f1: array<u32>,
+}
+
+struct S1 {
+  @location(11) f0: vec2u,
+  @builtin(instance_index) f1: u32,
+}
+
+struct VertexOutput11 {
+  @location(15) f30: vec2u,
+  @location(8) f31: u32,
+  @builtin(position) f32: vec4f,
+  @location(14) f33: u32,
+  @location(1) f34: vec4h,
+  @location(4) f35: i32,
+  @location(2) @interpolate(linear) f36: vec2h,
+  @location(9) @interpolate(flat, centroid) f37: vec4u,
+}
+
+struct FragmentOutput7 {
+  @location(0) f0: vec4u,
+  @builtin(sample_mask) f1: u32,
+}
+
+fn fn0() -> mat4x4h {
+  var out: mat4x4h;
+  var vf178: vec2h = tanh(vec2h(unconst_f16(2816.2), unconst_f16(560.1)));
+  var vf179: f16 = vf178[u32(unconst_u32(80))];
+  let vf180: vec4h = sin(vec4h(unconst_f16(6351.0), unconst_f16(10930.6), unconst_f16(4029.8), unconst_f16(14440.6)));
+  vf178 *= vec2h(vf179);
+  vf178 = tanh(vec2h(unconst_f16(3811.9), unconst_f16(12388.5)));
+  vf179 = f16(inverseSqrt(f32(unconst_f32(0.2025))));
+  return out;
+}
+
+fn fn1() {
+  var vf181: vec4i = unpack4xI8(u32(unconst_u32(219)));
+  let vf182: f32 = distance(f32(unconst_f32(0.03842)), f32(unconst_f32(0.00270)));
+  vf181 = bitcast<vec4i>(ceil(vec3f(unconst_f32(0.09696), unconst_f32(0.5001), unconst_f32(0.09809))).bgrg);
+  let vf183: vec4f = ceil(vec4f(unconst_f32(0.05809), unconst_f32(0.01814), unconst_f32(0.00300), unconst_f32(0.03195)));
+  vf181 += vec4i(bitcast<i32>(vf183[u32(unconst_u32(70))]));
+  var vf184: vec3h = normalize(vec3h(unconst_f16(3789.4), unconst_f16(3669.0), unconst_f16(26417.9)));
+  let vf185: vec4f = unpack4x8unorm(u32(unconst_u32(721)));
+  vf181 |= vf181;
+  let vf186: vec4f = vf183;
+  vf181 &= vec4i(i32(vf183[u32(unconst_u32(95))]));
+  var vf187: f16 = vf184[u32(unconst_u32(36))];
+  let vf188: vec4h = tanh(vec4h(unpack4x8unorm(u32(unconst_u32(319)))));
+  vf184 -= vec3h(vf186.arb);
+  vf184 = vec3h(vf183.yyy);
+  vf181 *= bitcast<vec4i>(vf185);
+  var vf189: vec3i = insertBits(vec3i(unconst_i32(137), unconst_i32(97), unconst_i32(374)), vec3i(unconst_i32(109), unconst_i32(120), unconst_i32(171)), u32(unconst_u32(38)), bitcast<u32>(vf183[u32(unconst_u32(111))]));
+}
+
+fn fn2() -> S1 {
+  var out: S1;
+  fn1();
+  let vf190: vec2h = reflect(vec2h(unconst_f16(60000.0), unconst_f16(11821.7)), reflect(vec2h(unconst_f16(5978.8), unconst_f16(4511.2)), bitcast<vec2h>(pack2x16float(vec2f(unconst_f32(0.02940), unconst_f32(0.1362))))));
+  out.f0 >>= vec2u(u32(vf190[u32(unconst_u32(181))]));
+  fn1();
+  var vf191: f32 = atanh(f32(unconst_f32(0.01279)));
+  var vf192: u32 = dot4U8Packed(u32(unconst_u32(147)), bitcast<u32>(atanh(f32(unconst_f32(0.1202)))));
+  fn1();
+  vf191 = f32(exp2(vec4h(vf190[u32(unconst_u32(70))])).x);
+  return out;
+}
+
+@vertex
+fn vertex12(a0: S1) -> VertexOutput11 {
+  var out: VertexOutput11;
+  fn0();
+  out.f30 = vec2u(pack2x16float(vec2f(unconst_f32(0.1435), unconst_f32(0.05403))));
+  fn1();
+  out.f31 *= bitcast<vec3u>(normalize(vec3f(unconst_f32(0.2365), unconst_f32(0.04920), unconst_f32(-0.03499)))).b;
+  let vf193: u32 = a0.f1;
+  out.f32 = vec4f(cosh(vec4h(unconst_f16(7161.1), unconst_f16(393.2), unconst_f16(1182.6), unconst_f16(10190.4))));
+  let vf194: f16 = length(vec2h(unconst_f16(6882.1), unconst_f16(32656.3)));
+  fn1();
+  fn0();
+  out.f30 = vec2u(a0.f1);
+  out.f31 ^= a0.f0[u32(unconst_u32(102))];
+  out.f30 &= vec2u(radians(vec2h(unconst_f16(10924.5), unconst_f16(6599.8))));
+  var vf195: f32 = length(f32(unconst_f32(0.1944)));
+  out.f31 -= u32(fma(f16(unconst_f16(4702.8)), f16(unconst_f16(60000.0)), f16(unconst_f16(16154.0))));
+  return out;
+}
+
+@fragment
+fn fragment11(@builtin(sample_index) a0: u32) -> FragmentOutput7 {
+  var out: FragmentOutput7;
+  let vf196: vec3f = sqrt(vec3f(unconst_f32(0.7062), unconst_f32(0.2452), unconst_f32(0.08481)));
+  var vf197: vec3f = vf196;
+  fn1();
+  var vf198: f16 = asinh(f16(unconst_f16(6798.2)));
+  fn1();
+  var vf199 = fn2();
+  let vf200: vec3f = trunc(vec3f(unconst_f32(0.2916), unconst_f32(0.02236), unconst_f32(-0.03922)));
+  out.f1 >>= pack4xI8Clamp(unpack4xI8(u32(unconst_u32(65))));
+  fn2();
+  vf199 = S1(vec2u(bitcast<u32>(dot4I8Packed(u32(unconst_u32(1)), u32(unconst_u32(54))))), u32(dot4I8Packed(u32(unconst_u32(1)), u32(unconst_u32(54)))));
+  let vf201: f32 = vf196[u32(unconst_u32(487))];
+  var vf202 = fn2();
+  discard;
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute9(@builtin(workgroup_id) a0: vec3u) {
+  var vf203 = fn0();
+  vf203 = mat4x4h(vec4h(insertBits(vec3i(unconst_i32(37), unconst_i32(9), unconst_i32(15)), vec3i(unconst_i32(5), unconst_i32(291), unconst_i32(-305)), u32(unconst_u32(199)), u32(unconst_u32(85))).bgbr), vec4h(insertBits(vec3i(unconst_i32(37), unconst_i32(9), unconst_i32(15)), vec3i(unconst_i32(5), unconst_i32(291), unconst_i32(-305)), u32(unconst_u32(199)), u32(unconst_u32(85))).rbgr), vec4h(insertBits(vec3i(unconst_i32(37), unconst_i32(9), unconst_i32(15)), vec3i(unconst_i32(5), unconst_i32(291), unconst_i32(-305)), u32(unconst_u32(199)), u32(unconst_u32(85))).brrg), vec4h(insertBits(vec3i(unconst_i32(37), unconst_i32(9), unconst_i32(15)), vec3i(unconst_i32(5), unconst_i32(291), unconst_i32(-305)), u32(unconst_u32(199)), u32(unconst_u32(85))).zzxy));
+  vf203 += mat4x4h(select(vec4h(unconst_f16(11653.4), unconst_f16(14512.6), unconst_f16(2079.4), unconst_f16(5047.0)), vec4h(unconst_f16(11264.9), unconst_f16(12717.3), unconst_f16(7217.1), unconst_f16(9413.4)), bool(unconst_bool(true))), select(vec4h(unconst_f16(11653.4), unconst_f16(14512.6), unconst_f16(2079.4), unconst_f16(5047.0)), vec4h(unconst_f16(11264.9), unconst_f16(12717.3), unconst_f16(7217.1), unconst_f16(9413.4)), bool(unconst_bool(true))), select(vec4h(unconst_f16(11653.4), unconst_f16(14512.6), unconst_f16(2079.4), unconst_f16(5047.0)), vec4h(unconst_f16(11264.9), unconst_f16(12717.3), unconst_f16(7217.1), unconst_f16(9413.4)), bool(unconst_bool(true))), select(vec4h(unconst_f16(11653.4), unconst_f16(14512.6), unconst_f16(2079.4), unconst_f16(5047.0)), vec4h(unconst_f16(11264.9), unconst_f16(12717.3), unconst_f16(7217.1), unconst_f16(9413.4)), bool(unconst_bool(true))));
+  vf203 = mat4x4h(vec4h(insertBits(vec3i(unconst_i32(106), unconst_i32(78), unconst_i32(406)), vec3i(unconst_i32(-2), unconst_i32(4), unconst_i32(18)), u32(unconst_u32(369)), u32(unconst_u32(153))).rgrb), vec4h(insertBits(vec3i(unconst_i32(106), unconst_i32(78), unconst_i32(406)), vec3i(unconst_i32(-2), unconst_i32(4), unconst_i32(18)), u32(unconst_u32(369)), u32(unconst_u32(153))).rrgb), vec4h(insertBits(vec3i(unconst_i32(106), unconst_i32(78), unconst_i32(406)), vec3i(unconst_i32(-2), unconst_i32(4), unconst_i32(18)), u32(unconst_u32(369)), u32(unconst_u32(153))).bbbr), vec4h(insertBits(vec3i(unconst_i32(106), unconst_i32(78), unconst_i32(406)), vec3i(unconst_i32(-2), unconst_i32(4), unconst_i32(18)), u32(unconst_u32(369)), u32(unconst_u32(153))).yxzy));
+}`,
+  hints: {},
+});
+let textureView136 = texture33.createView({});
+try {
+computePassEncoder108.setBindGroup(3, bindGroup37);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.draw(159, 0, 2_486_336_644);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer80, 2_648);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline4);
+} catch {}
+try {
+  await shaderModule9.getCompilationInfo();
+} catch {}
+let commandEncoder128 = device0.createCommandEncoder();
+let computePassEncoder121 = commandEncoder128.beginComputePass();
+try {
+computePassEncoder110.setBindGroup(1, bindGroup60);
+} catch {}
+try {
+computePassEncoder34.setBindGroup(2, bindGroup48, new Uint32Array(1487), 144, 0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup51);
+} catch {}
+try {
+renderPassEncoder5.draw(81, 0, 13_606_512);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(241, 0, 57, 1_390_889_089, 0);
+} catch {}
+try {
+  await shaderModule0.getCompilationInfo();
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+document.body.prepend(canvas0);
+let bindGroup72 = device0.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [{binding: 385, resource: {buffer: buffer114, offset: 0, size: 280}}],
+});
+let buffer120 = device0.createBuffer({
+  size: 24050,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder129 = device0.createCommandEncoder({});
+let texture138 = device0.createTexture({
+  size: {width: 30, height: 12, depthOrArrayLayers: 49},
+  mipLevelCount: 2,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder122 = commandEncoder129.beginComputePass({});
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup23);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup28, new Uint32Array(399), 25, 0);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(13, 0, 111, 794_770_414);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise13;
+} catch {}
+let offscreenCanvas5 = new OffscreenCanvas(28, 406);
+let buffer121 = device0.createBuffer({
+  label: '\u4683\ub7b8\u22cb\u0e16',
+  size: 4414,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let sampler84 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 14.28,
+  lodMaxClamp: 38.35,
+});
+try {
+computePassEncoder101.setBindGroup(2, bindGroup38, [256, 512]);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup41);
+} catch {}
+try {
+renderPassEncoder5.draw(183, 0, 192_972_332);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(70, 0, 74, 54_181_388);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer119, 148);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer87, 88);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer76, 'uint32', 12, 43);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline4);
+} catch {}
+try {
+  await promise15;
+} catch {}
+document.body.append(canvas0);
+let commandEncoder130 = device0.createCommandEncoder({});
+let textureView137 = texture115.createView({dimension: '2d'});
+let texture139 = device0.createTexture({
+  size: [1330, 1, 51],
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder123 = commandEncoder130.beginComputePass({});
+let sampler85 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 24.93,
+  lodMaxClamp: 36.73,
+  maxAnisotropy: 18,
+});
+try {
+renderPassEncoder5.draw(28, 0, 262_872_867);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer80, 3_092);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline5);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+document.body.prepend(img0);
+let texture140 = device0.createTexture({size: [1330, 1, 1], sampleCount: 1, format: 'stencil8', usage: GPUTextureUsage.COPY_SRC});
+try {
+computePassEncoder73.setBindGroup(1, bindGroup39);
+} catch {}
+try {
+renderPassEncoder5.draw(70, 0, 143_778_749);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(0, 0, 1, 545_744_859);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer92, 3_112);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer54, 'uint32', 3_468, 4_212);
+} catch {}
+document.body.append(img0);
+let imageData13 = new ImageData(48, 52);
+try {
+computePassEncoder113.setBindGroup(1, bindGroup44);
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(64, 0, 18, 0);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer34, 424);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline7);
+} catch {}
+let promise19 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 665, height: 1, depthOrArrayLayers: 49}
+*/
+{
+  source: videoFrame12,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 128, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView138 = texture63.createView({dimension: '2d-array', aspect: 'depth-only', format: 'depth16unorm', baseArrayLayer: 0});
+try {
+computePassEncoder41.setBindGroup(2, bindGroup56, [2816, 256]);
+} catch {}
+try {
+computePassEncoder106.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(56, 0, 51, 0);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer117, 76);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer64, 'uint16', 2_182, 699);
+} catch {}
+let commandEncoder131 = device0.createCommandEncoder({});
+let computePassEncoder124 = commandEncoder131.beginComputePass({});
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder5.draw(98, 0, 58_844_463);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+try {
+renderPassEncoder7.insertDebugMarker('\u872d');
+} catch {}
+let buffer122 = device0.createBuffer({
+  size: 12616,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let sampler86 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 61.77,
+  lodMaxClamp: 96.13,
+  compare: 'equal',
+});
+try {
+computePassEncoder51.setBindGroup(0, bindGroup11, [3584, 0]);
+} catch {}
+try {
+computePassEncoder51.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup57, new Uint32Array(994), 185, 0);
+} catch {}
+try {
+renderPassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(3, buffer4, 3_060, 166);
+} catch {}
+try {
+commandEncoder93.copyBufferToBuffer(buffer60, 372, buffer41, 676, 16);
+} catch {}
+try {
+commandEncoder93.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2432 */
+  offset: 2432,
+  buffer: buffer53,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 5},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+await gc();
+let videoFrame20 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'unspecified', primaries: 'smpte432', transfer: 'pq'} });
+let buffer123 = device0.createBuffer({
+  label: '\u0c6f\u{1fcbc}\u69af\u0f0f\u0c1a\u{1f6ff}\u02e7\u4e71\u{1f8fd}\u00dd',
+  size: 14926,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: false,
+});
+let commandBuffer8 = commandEncoder93.finish();
+try {
+computePassEncoder105.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+computePassEncoder105.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle3, renderBundle10, renderBundle10, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(3, buffer66, 316, 60);
+} catch {}
+let arrayBuffer24 = buffer2.getMappedRange(2008, 0);
+let commandEncoder132 = device0.createCommandEncoder({});
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup49, []);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup66, new Uint32Array(4900), 208, 0);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(55, 0, 27, 0);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(5, buffer92, 12, 2_397);
+} catch {}
+try {
+commandEncoder132.copyBufferToTexture({
+  /* bytesInLastRow: 120 widthInBlocks: 60 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 3312 */
+  offset: 3312,
+  buffer: buffer33,
+}, {
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 60, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 39, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData9,
+  origin: { x: 3, y: 0 },
+  flipY: false,
+}, {
+  texture: texture94,
+  mipLevel: 0,
+  origin: {x: 5, y: 4, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 14, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext5 = offscreenCanvas5.getContext('webgpu');
+let bindGroup73 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 87, resource: textureView37},
+    {binding: 267, resource: textureView88},
+    {binding: 362, resource: textureView128},
+    {binding: 194, resource: textureView100},
+  ],
+});
+let texture141 = device0.createTexture({size: [16], sampleCount: 1, dimension: '1d', format: 'r16uint', usage: GPUTextureUsage.TEXTURE_BINDING});
+try {
+{ clearResourceUsages(device0, computePassEncoder105); computePassEncoder105.dispatchWorkgroupsIndirect(buffer118, 40); };
+} catch {}
+try {
+computePassEncoder118.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup27);
+} catch {}
+try {
+buffer72.unmap();
+} catch {}
+try {
+commandEncoder132.copyBufferToBuffer(buffer120, 752, buffer106, 180, 2136);
+} catch {}
+try {
+commandEncoder132.clearBuffer(buffer56);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 1148, new Float32Array(7574), 762, 136);
+} catch {}
+try {
+  await promise19;
+} catch {}
+document.body.prepend(canvas0);
+try {
+renderPassEncoder0.label = '\u416f\ue916\u{1f7df}\u0ad6\u0a7d\ue739\u{1f8a1}';
+} catch {}
+let computePassEncoder125 = commandEncoder132.beginComputePass({});
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup60, []);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder133 = device0.createCommandEncoder();
+let textureView139 = texture61.createView({aspect: 'depth-only', mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder126 = commandEncoder133.beginComputePass({});
+try {
+computePassEncoder94.setBindGroup(1, bindGroup44);
+} catch {}
+try {
+computePassEncoder33.setBindGroup(1, bindGroup12, new Uint32Array(2653), 13, 2);
+} catch {}
+try {
+computePassEncoder126.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup70);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup64, new Uint32Array(97), 28, 0);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer111, 'uint32', 716, 275);
+} catch {}
+try {
+computePassEncoder79.popDebugGroup();
+} catch {}
+let commandEncoder134 = device0.createCommandEncoder();
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup66, new Uint32Array(516), 197, 0);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(5, buffer70);
+} catch {}
+try {
+buffer54.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer8]);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+let textureView140 = texture101.createView({});
+let computePassEncoder127 = commandEncoder134.beginComputePass({});
+let sampler87 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  lodMinClamp: 96.17,
+  lodMaxClamp: 98.13,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder105); computePassEncoder105.dispatchWorkgroupsIndirect(buffer72, 248); };
+} catch {}
+try {
+computePassEncoder115.setPipeline(pipeline6);
+} catch {}
+try {
+computePassEncoder38.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle7]);
+} catch {}
+try {
+buffer66.unmap();
+} catch {}
+try {
+computePassEncoder2.setBindGroup(3, bindGroup68, new Uint32Array(2269), 5, 0);
+} catch {}
+try {
+computePassEncoder122.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(1, buffer101, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 9, depthOrArrayLayers: 372}
+*/
+{
+  source: imageData7,
+  origin: { x: 2, y: 1 },
+  flipY: false,
+}, {
+  texture: texture98,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 16},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let textureView141 = texture86.createView({aspect: 'all', baseArrayLayer: 15, arrayLayerCount: 6});
+let sampler88 = device0.createSampler({
+  label: '\ub8d0\ue415\uee14\ub758\u{1fa12}\u{1f702}\u07cf',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 37.01,
+  lodMaxClamp: 96.77,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder124.setPipeline(pipeline6);
+} catch {}
+let commandEncoder135 = device0.createCommandEncoder({});
+let querySet15 = device0.createQuerySet({type: 'occlusion', count: 1976});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup5, new Uint32Array(3475), 66, 2);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup65, new Uint32Array(939), 42, 0);
+} catch {}
+let pipelineLayout12 = device0.createPipelineLayout({bindGroupLayouts: []});
+let textureView142 = texture104.createView({
+  label: '\u4777\u0032\u11ff\u81bb\u5f76\u43f8\u{1f8bc}\ucbde\u5692',
+  baseArrayLayer: 1,
+  arrayLayerCount: 11,
+});
+try {
+computePassEncoder52.setBindGroup(0, bindGroup15, new Uint32Array(1976), 168, 2);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(105).fill(18), /* required buffer size: 105 */
+{offset: 105}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup74 = device0.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [{binding: 385, resource: {buffer: buffer7, offset: 8960, size: 4416}}],
+});
+let texture142 = device0.createTexture({
+  size: {width: 1330, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let computePassEncoder128 = commandEncoder135.beginComputePass({});
+let sampler89 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 43.04,
+  lodMaxClamp: 96.23,
+});
+try {
+computePassEncoder48.setBindGroup(2, bindGroup40, new Uint32Array(2508), 68, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup55);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(0, buffer72, 340, 1_265);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let buffer124 = device0.createBuffer({size: 17890, usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE});
+let sampler90 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 72.47,
+  lodMaxClamp: 92.69,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder6); computePassEncoder6.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder30.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle0, renderBundle9, renderBundle18, renderBundle5, renderBundle4, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(2, buffer61, 0, 5_065);
+} catch {}
+try {
+buffer112.unmap();
+} catch {}
+try {
+gpuCanvasContext1.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+} catch {}
+document.body.append(img0);
+let commandEncoder136 = device0.createCommandEncoder({});
+let computePassEncoder129 = commandEncoder136.beginComputePass();
+try {
+computePassEncoder86.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup72, new Uint32Array(940), 4, 0);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(7, buffer67, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer11, 36, new BigUint64Array(2230), 86, 4);
+} catch {}
+let commandEncoder137 = device0.createCommandEncoder({});
+let textureView143 = texture106.createView({label: '\u02b9\u50de\ubf80\u552b\ubb41', dimension: '2d-array', aspect: 'all', baseMipLevel: 0});
+let computePassEncoder130 = commandEncoder137.beginComputePass({});
+let sampler91 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 27.99,
+});
+try {
+computePassEncoder56.setBindGroup(1, bindGroup55, new Uint32Array(2294), 551, 0);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer26, 'uint16', 542, 2_658);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(5, buffer8, 16_288);
+} catch {}
+document.body.prepend(img0);
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let commandEncoder138 = device0.createCommandEncoder({});
+let texture143 = device0.createTexture({
+  size: [60, 24, 51],
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView144 = texture92.createView({baseArrayLayer: 0});
+try {
+computePassEncoder60.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder56); computePassEncoder56.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder119.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer104, 'uint32', 804, 5_981);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let imageData14 = new ImageData(80, 44);
+try {
+computePassEncoder129.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(7, buffer66);
+} catch {}
+try {
+commandEncoder138.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 312 */
+  offset: 312,
+  bytesPerRow: 20480,
+  buffer: buffer92,
+}, {
+  texture: texture48,
+  mipLevel: 0,
+  origin: {x: 24, y: 33, z: 9},
+  aspect: 'all',
+}, {width: 4, height: 23, depthOrArrayLayers: 0});
+} catch {}
+let buffer125 = device0.createBuffer({size: 2538, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT});
+let computePassEncoder131 = commandEncoder138.beginComputePass({});
+try {
+computePassEncoder54.setBindGroup(0, bindGroup27, new Uint32Array(2021), 406, 0);
+} catch {}
+try {
+computePassEncoder6.end();
+} catch {}
+try {
+computePassEncoder121.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup55);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(74, 0, 8, 0);
+} catch {}
+try {
+commandEncoder7.copyTextureToBuffer({
+  texture: texture72,
+  mipLevel: 3,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 360 widthInBlocks: 45 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1888 */
+  offset: 1888,
+  buffer: buffer105,
+}, {width: 45, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder7.clearBuffer(buffer108, 1540, 416);
+} catch {}
+let buffer126 = device0.createBuffer({
+  label: '\u0a77\u1214\u034e\uef5c\ub4b6',
+  size: 3687,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder104.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant({ r: -644.2, g: -244.6, b: 596.0, a: -661.8, });
+} catch {}
+try {
+commandEncoder7.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 575 */
+  offset: 575,
+  bytesPerRow: 84480,
+  buffer: buffer26,
+}, {
+  texture: texture117,
+  mipLevel: 1,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder7.copyTextureToBuffer({
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 3 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2048 */
+  offset: 2048,
+  bytesPerRow: 14848,
+  buffer: buffer123,
+}, {width: 3, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout13 = device0.createPipelineLayout({label: '\ud258\u06b9\u0129\u{1ff16}\u0e69\ubc59\u0110\u0846', bindGroupLayouts: []});
+let commandEncoder139 = device0.createCommandEncoder({label: '\u{1f943}\u57cb\u0ead\uae67\u53d4\u0663'});
+try {
+computePassEncoder105.end();
+} catch {}
+try {
+computePassEncoder125.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer121, 'uint16', 222, 838);
+} catch {}
+try {
+buffer22.unmap();
+} catch {}
+try {
+commandEncoder7.copyBufferToTexture({
+  /* bytesInLastRow: 800 widthInBlocks: 100 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 432 */
+  offset: 432,
+  bytesPerRow: 42752,
+  buffer: buffer126,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 428, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 100, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 9, depthOrArrayLayers: 372}
+*/
+{
+  source: offscreenCanvas4,
+  origin: { x: 99, y: 0 },
+  flipY: false,
+}, {
+  texture: texture98,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 19},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let textureView145 = texture40.createView({dimension: '1d', baseMipLevel: 0});
+let computePassEncoder132 = commandEncoder7.beginComputePass({});
+let sampler92 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 9.447,
+  compare: 'less',
+});
+try {
+computePassEncoder124.setBindGroup(0, bindGroup40, new Uint32Array(2725), 525, 0);
+} catch {}
+try {
+computePassEncoder28.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder114.copyBufferToTexture({
+  /* bytesInLastRow: 1216 widthInBlocks: 76 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1168 */
+  offset: 1168,
+  rowsPerImage: 484,
+  buffer: buffer23,
+}, {
+  texture: texture96,
+  mipLevel: 0,
+  origin: {x: 324, y: 10, z: 0},
+  aspect: 'all',
+}, {width: 456, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder114.resolveQuerySet(querySet7, 116, 146, buffer4, 256);
+} catch {}
+await gc();
+let commandEncoder140 = device0.createCommandEncoder({});
+let texture144 = device0.createTexture({
+  size: [80, 78, 84],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder133 = commandEncoder139.beginComputePass({});
+let renderBundleEncoder20 = device0.createRenderBundleEncoder({colorFormats: ['r8unorm'], depthStencilFormat: 'stencil8'});
+try {
+computePassEncoder121.setBindGroup(2, bindGroup59, new Uint32Array(349), 25, 0);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle6, renderBundle9, renderBundle5, renderBundle10, renderBundle0, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(6, buffer105, 0, 40);
+} catch {}
+try {
+commandEncoder114.copyTextureToTexture({
+  texture: texture72,
+  mipLevel: 3,
+  origin: {x: 18, y: 0, z: 13},
+  aspect: 'all',
+},
+{
+  texture: texture72,
+  mipLevel: 2,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 18, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer127 = device0.createBuffer({
+  size: 2670,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandBuffer9 = commandEncoder114.finish({});
+let texture145 = device0.createTexture({
+  size: {width: 30, height: 12, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle20 = renderBundleEncoder20.finish();
+try {
+computePassEncoder53.setBindGroup(0, bindGroup51, new Uint32Array(1457), 134, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup42, new Uint32Array(135), 4, 0);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer120, 'uint16', 7_860, 2_059);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline7);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let computePassEncoder134 = commandEncoder140.beginComputePass();
+try {
+computePassEncoder123.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.beginOcclusionQuery(78);
+} catch {}
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(0, buffer105, 236, 118);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData15 = new ImageData(60, 72);
+try {
+adapter0.label = '\uddd0\u9672\u0b76\ub7da\uee64\u8dcf\u208d\ua570\ubc07';
+} catch {}
+let texture146 = gpuCanvasContext1.getCurrentTexture();
+let texture147 = device0.createTexture({
+  size: [60],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder37.setBindGroup(1, bindGroup48);
+} catch {}
+try {
+computePassEncoder9.setBindGroup(0, bindGroup4, new Uint32Array(773), 77, 2);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline4);
+} catch {}
+let bindGroup75 = device0.createBindGroup({
+  layout: bindGroupLayout17,
+  entries: [{binding: 219, resource: {buffer: buffer121, offset: 1536, size: 911}}],
+});
+let commandEncoder141 = device0.createCommandEncoder({});
+let computePassEncoder135 = commandEncoder141.beginComputePass({});
+try {
+computePassEncoder2.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup73, new Uint32Array(1399), 169, 0);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline10);
+} catch {}
+await gc();
+let textureView146 = texture104.createView({baseArrayLayer: 1, arrayLayerCount: 1});
+let sampler93 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 36.73,
+  lodMaxClamp: 36.92,
+});
+try {
+computePassEncoder135.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer123, 'uint16', 672, 48);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let promise20 = device0.queue.onSubmittedWorkDone();
+let texture148 = device0.createTexture({
+  size: [20, 19, 1],
+  mipLevelCount: 2,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder56.end();
+} catch {}
+try {
+computePassEncoder132.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder1.insertDebugMarker('\u{1f6ed}');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer79, 256, new DataView(new ArrayBuffer(968)), 204, 104);
+} catch {}
+let promise21 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise21;
+} catch {}
+let computePassEncoder136 = commandEncoder57.beginComputePass({});
+try {
+computePassEncoder115.setBindGroup(0, bindGroup60);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder7.setScissorRect(0, 0, 4, 5);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer70, 'uint32', 848, 394);
+} catch {}
+try {
+device0.queue.submit([commandBuffer9]);
+} catch {}
+document.body.prepend(canvas0);
+let imageData16 = new ImageData(80, 24);
+let bindGroup76 = device0.createBindGroup({
+  layout: bindGroupLayout16,
+  entries: [
+    {binding: 92, resource: {buffer: buffer122, offset: 256}},
+    {binding: 222, resource: textureView128},
+    {binding: 63, resource: sampler47},
+    {binding: 360, resource: textureView106},
+    {binding: 732, resource: textureView72},
+    {binding: 182, resource: textureView69},
+    {binding: 209, resource: {buffer: buffer100, offset: 512, size: 7248}},
+    {binding: 9, resource: textureView69},
+    {binding: 155, resource: textureView72},
+    {binding: 282, resource: textureView116},
+    {binding: 28, resource: textureView118},
+    {binding: 999, resource: textureView77},
+    {binding: 80, resource: externalTexture11},
+    {binding: 254, resource: {buffer: buffer54, offset: 1792, size: 1299}},
+  ],
+});
+let textureView147 = texture103.createView({});
+try {
+computePassEncoder110.setBindGroup(2, bindGroup63);
+} catch {}
+try {
+computePassEncoder131.setPipeline(pipeline9);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 39, depthOrArrayLayers: 142}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture83,
+  mipLevel: 1,
+  origin: {x: 8, y: 5, z: 19},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 83, height: 1, depthOrArrayLayers: 40}
+*/
+{
+  source: videoFrame9,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture72,
+  mipLevel: 4,
+  origin: {x: 12, y: 0, z: 11},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame21 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'smpteSt4281', transfer: 'bt1361ExtendedColourGamut'} });
+let videoFrame22 = videoFrame11.clone();
+let texture149 = device0.createTexture({
+  label: '\u69df\u800b\u4d98\u0c4a\u0489',
+  size: [20],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView148 = texture5.createView({});
+try {
+computePassEncoder102.setBindGroup(3, bindGroup64);
+} catch {}
+try {
+computePassEncoder114.setPipeline(pipeline9);
+} catch {}
+try {
+  await promise20;
+} catch {}
+let commandEncoder142 = device0.createCommandEncoder();
+let texture150 = device0.createTexture({size: [120], dimension: '1d', format: 'r8unorm', usage: GPUTextureUsage.COPY_DST});
+let computePassEncoder137 = commandEncoder142.beginComputePass({});
+try {
+renderPassEncoder8.setIndexBuffer(buffer101, 'uint32', 188, 169);
+} catch {}
+let texture151 = device0.createTexture({
+  size: {width: 665, height: 1, depthOrArrayLayers: 6},
+  mipLevelCount: 4,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+computePassEncoder133.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+computePassEncoder137.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer64, 'uint16', 1_106, 136);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 9, depthOrArrayLayers: 372}
+*/
+{
+  source: imageData8,
+  origin: { x: 14, y: 1 },
+  flipY: false,
+}, {
+  texture: texture98,
+  mipLevel: 0,
+  origin: {x: 5, y: 6, z: 61},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup77 = device0.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 148, resource: textureView9}]});
+let commandEncoder143 = device0.createCommandEncoder({});
+let commandBuffer10 = commandEncoder143.finish();
+try {
+computePassEncoder134.setPipeline(pipeline8);
+} catch {}
+try {
+computePassEncoder94.insertDebugMarker('\u5f24');
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder144 = device0.createCommandEncoder({label: '\uc71f\u0a7b'});
+let textureView149 = texture46.createView({dimension: '2d-array'});
+let computePassEncoder138 = commandEncoder144.beginComputePass({});
+try {
+computePassEncoder19.setBindGroup(2, bindGroup27, new Uint32Array(5), 0, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup57, []);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup77, new Uint32Array(71), 8, 0);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer121, 'uint32', 240, 346);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline10);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer12, 96, new DataView(new ArrayBuffer(45011)), 2384, 600);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 166, height: 1, depthOrArrayLayers: 40}
+*/
+{
+  source: imageData2,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture72,
+  mipLevel: 3,
+  origin: {x: 35, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas0);
+offscreenCanvas1.width = 829;
+try {
+globalThis.someLabel = externalTexture13.label;
+} catch {}
+try {
+computePassEncoder102.setBindGroup(2, bindGroup31);
+} catch {}
+try {
+computePassEncoder39.setBindGroup(2, bindGroup24, new Uint32Array(611), 96, 0);
+} catch {}
+try {
+computePassEncoder136.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder7.setViewport(9.715697991180436, 4.122331775991596, 2.4428242242936036, 1.7978478370375415, 0.5186999538815249, 0.6394170610400469);
+} catch {}
+let commandEncoder145 = device0.createCommandEncoder({});
+let computePassEncoder139 = commandEncoder145.beginComputePass({});
+try {
+computePassEncoder120.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup65, new Uint32Array(2736), 351, 0);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer55, 'uint32', 200, 27);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture35,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(42).fill(175), /* required buffer size: 42 */
+{offset: 42}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline11 = device0.createComputePipeline({layout: pipelineLayout3, compute: {module: shaderModule5, constants: {}}});
+try {
+if (!arrayBuffer18.detached) { new Uint8Array(arrayBuffer18).fill(0x55); };
+} catch {}
+try {
+externalTexture5.label = '\u{1f8bc}\ubb96\u8c60\u{1f804}\u0e7f\uc4d9\u9a98\u0953\u{1fb8c}\u{1fbae}';
+} catch {}
+let buffer128 = device0.createBuffer({
+  size: 33,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder146 = device0.createCommandEncoder();
+let textureView150 = texture144.createView({baseMipLevel: 1, mipLevelCount: 1});
+let computePassEncoder140 = commandEncoder146.beginComputePass();
+let renderBundleEncoder21 = device0.createRenderBundleEncoder({label: '\u49f1\u02e2\u8397\u{1f72e}\u9399', colorFormats: ['rgb10a2uint'], sampleCount: 1});
+try {
+computePassEncoder83.setBindGroup(2, bindGroup8, [3840, 0]);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer6, 'uint16', 230, 4_183);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(1, bindGroup66, new Uint32Array(1144), 182, 0);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer118, 'uint16', 12, 53);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline0);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(15).fill(242), /* required buffer size: 15 */
+{offset: 15}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder133.setPipeline(pipeline11);
+} catch {}
+try {
+computePassEncoder130.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder6.setStencilReference(732);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer118, 'uint16', 72, 130);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 332, height: 1, depthOrArrayLayers: 40}
+*/
+{
+  source: imageData5,
+  origin: { x: 4, y: 17 },
+  flipY: true,
+}, {
+  texture: texture72,
+  mipLevel: 2,
+  origin: {x: 46, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let videoFrame23 = new VideoFrame(videoFrame10, {timestamp: 0});
+let commandEncoder147 = device0.createCommandEncoder({});
+let querySet16 = device0.createQuerySet({type: 'occlusion', count: 2664});
+let texture152 = device0.createTexture({
+  label: '\u{1fbc3}\u{1fcf6}\u69c1',
+  size: [166, 1, 1],
+  format: 'rgb9e5ufloat',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder141 = commandEncoder147.beginComputePass();
+let sampler94 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 24.35,
+  lodMaxClamp: 52.32,
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup34, new Uint32Array(1678), 763, 2);
+} catch {}
+try {
+computePassEncoder29.end();
+} catch {}
+try {
+computePassEncoder99.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer10, 'uint16', 100, 8);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer76, 'uint32', 8, 18);
+} catch {}
+try {
+buffer34.unmap();
+} catch {}
+try {
+renderPassEncoder8.insertDebugMarker('\u{1f6e5}');
+} catch {}
+let commandEncoder148 = device0.createCommandEncoder({});
+let querySet17 = device0.createQuerySet({label: '\u83d7\u6c8b\u02d9\u{1fe7d}\u0a24\u8c6b', type: 'occlusion', count: 397});
+let texture153 = device0.createTexture({size: [20], dimension: '1d', format: 'r8sint', usage: GPUTextureUsage.COPY_DST});
+let textureView151 = texture84.createView({mipLevelCount: 1});
+let renderPassEncoder9 = commandEncoder18.beginRenderPass({
+  colorAttachments: [{
+  view: textureView70,
+  clearValue: { r: -537.9, g: 239.1, b: -394.8, a: -222.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView146,
+    depthClearValue: -7.9266701870841345,
+    depthReadOnly: false,
+    stencilLoadOp: 'clear',
+    stencilStoreOp: 'store',
+  },
+});
+try {
+computePassEncoder63.setBindGroup(1, bindGroup42);
+} catch {}
+try {
+computePassEncoder127.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer78, 'uint32', 172, 140);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(5, buffer24, 0, 342);
+} catch {}
+try {
+commandEncoder148.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2591 */
+  offset: 2591,
+  bytesPerRow: 34816,
+  buffer: buffer7,
+}, {
+  texture: texture117,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder60.pushDebugGroup('\u28fe');
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55); };
+} catch {}
+let bindGroup78 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 232, resource: {buffer: buffer81, offset: 1280}},
+    {binding: 83, resource: {buffer: buffer7, offset: 9472, size: 12192}},
+  ],
+});
+let commandEncoder149 = device0.createCommandEncoder({});
+let texture154 = device0.createTexture({size: [30, 12, 1], mipLevelCount: 2, format: 'r16uint', usage: GPUTextureUsage.COPY_DST});
+let computePassEncoder142 = commandEncoder148.beginComputePass({});
+try {
+computePassEncoder24.setBindGroup(3, bindGroup40, new Uint32Array(627), 186, 0);
+} catch {}
+try {
+computePassEncoder140.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup73);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(10);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer43, 'uint16', 2_964, 1_039);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(3, bindGroup58, new Uint32Array(922), 88, 0);
+} catch {}
+try {
+computePassEncoder60.popDebugGroup();
+} catch {}
+let buffer129 = device0.createBuffer({
+  size: 512,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder150 = device0.createCommandEncoder({});
+let textureView152 = texture144.createView({dimension: '3d', format: 'r8unorm', mipLevelCount: 2});
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup63);
+} catch {}
+try {
+device0.queue.submit([commandBuffer10]);
+} catch {}
+let buffer130 = device0.createBuffer({
+  size: 4311,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder151 = device0.createCommandEncoder({label: '\udfe7\ub0ce\u0ec7\u{1f8c9}\u{1f7a7}\u07e2\uad5f'});
+let textureView153 = texture0.createView({});
+let computePassEncoder143 = commandEncoder151.beginComputePass();
+try {
+computePassEncoder58.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+computePassEncoder128.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder8.beginOcclusionQuery(23);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder149.copyBufferToBuffer(buffer123, 3148, buffer61, 13508, 828);
+} catch {}
+let texture155 = gpuCanvasContext2.getCurrentTexture();
+let sampler95 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 19.28,
+});
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer110, 'uint32', 6_228, 332);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer118, 'uint32', 116, 14);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(4, buffer67, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer103, 872, new Int16Array(7682), 1578, 1184);
+} catch {}
+document.body.prepend(canvas0);
+let buffer131 = device0.createBuffer({
+  label: '\u{1fda0}\u0d5b\u7879\u0c52\u36f2\u65f3\u08a6\u0b58\ua1fb',
+  size: 2397,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder152 = device0.createCommandEncoder({});
+let sampler96 = device0.createSampler({
+  label: '\u{1ffc9}\u0484\u0ff5\u02c3',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 32.73,
+  lodMaxClamp: 81.38,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder142.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup29);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder6.setBlendConstant({ r: -810.3, g: 604.0, b: -507.4, a: 916.1, });
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(1, buffer42, 24, 228);
+} catch {}
+try {
+commandEncoder152.copyTextureToBuffer({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1196 */
+  offset: 1196,
+  buffer: buffer9,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture156 = device0.createTexture({
+  size: [20, 19, 1],
+  sampleCount: 4,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder139.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(1, buffer70, 1_976, 2_599);
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+let commandEncoder153 = device0.createCommandEncoder({});
+let textureView154 = texture79.createView({dimension: '2d-array', aspect: 'all'});
+try {
+computePassEncoder87.setBindGroup(3, bindGroup72, new Uint32Array(3301), 190, 0);
+} catch {}
+try {
+computePassEncoder141.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle2, renderBundle1, renderBundle18]);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer10, 'uint32', 52, 44);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline5);
+} catch {}
+try {
+commandEncoder152.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 16 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1320 */
+  offset: 1320,
+  bytesPerRow: 16128,
+  buffer: buffer8,
+}, {
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'depth-only',
+}, {width: 16, height: 16, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder149.resolveQuerySet(querySet9, 120, 118, buffer21, 7680);
+} catch {}
+let bindGroup79 = device0.createBindGroup({
+  label: '\u86e3\u078b\uc827\uc1c1',
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 16, resource: {buffer: buffer98, offset: 0}},
+    {binding: 925, resource: textureView11},
+    {binding: 779, resource: {buffer: buffer59, offset: 256, size: 591}},
+    {binding: 142, resource: textureView9},
+    {binding: 96, resource: textureView29},
+    {binding: 88, resource: {buffer: buffer67, offset: 0, size: 7616}},
+    {binding: 3, resource: sampler58},
+    {binding: 25, resource: {buffer: buffer121, offset: 512, size: 3576}},
+    {binding: 139, resource: textureView123},
+    {binding: 426, resource: {buffer: buffer114, offset: 0, size: 192}},
+    {binding: 32, resource: textureView48},
+  ],
+});
+let computePassEncoder144 = commandEncoder150.beginComputePass({label: '\u0afa\u4eea'});
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup22, new Uint32Array(1940), 430, 0);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle5]);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer10, 'uint16', 60, 28);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(0, bindGroup73, new Uint32Array(854), 31, 0);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(0, buffer101, 0, 627);
+} catch {}
+try {
+commandEncoder153.copyBufferToTexture({
+  /* bytesInLastRow: 1600 widthInBlocks: 100 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1248 */
+  offset: 1248,
+  bytesPerRow: 5888,
+  buffer: buffer131,
+}, {
+  texture: texture96,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 600, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 0, y: 56, z: 0},
+  aspect: 'all',
+}, new Uint8Array(288).fill(132), /* required buffer size: 288 */
+{offset: 288, bytesPerRow: 51}, {width: 4, height: 16, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55); };
+} catch {}
+document.body.append(canvas0);
+let buffer132 = device0.createBuffer({size: 14053, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture157 = device0.createTexture({
+  size: [166, 1, 1],
+  sampleCount: 4,
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture158 = device0.createTexture({
+  size: [40, 39, 1],
+  mipLevelCount: 4,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView155 = texture133.createView({aspect: 'stencil-only', arrayLayerCount: 1});
+let computePassEncoder145 = commandEncoder153.beginComputePass({});
+let renderBundle21 = renderBundleEncoder21.finish({});
+try {
+computePassEncoder84.setBindGroup(2, bindGroup77, new Uint32Array(5748), 929, 0);
+} catch {}
+try {
+computePassEncoder143.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(6, buffer61, 0, 5_548);
+} catch {}
+let bindGroup80 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 83, resource: {buffer: buffer3, offset: 0, size: 2776}},
+    {binding: 232, resource: {buffer: buffer130, offset: 0, size: 940}},
+  ],
+});
+let buffer133 = device0.createBuffer({
+  label: '\ud7ae\u{1fe3a}\ubd88\ubabf\u{1fab7}\u0d77',
+  size: 4947,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let texture159 = device0.createTexture({
+  size: {width: 15, height: 6, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView156 = texture71.createView({dimension: '2d', aspect: 'all', mipLevelCount: 1});
+let renderPassEncoder10 = commandEncoder152.beginRenderPass({
+  colorAttachments: [{
+  view: textureView93,
+  depthSlice: 44,
+  clearValue: { r: -517.9, g: -209.0, b: -983.8, a: -736.1, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 28313085,
+});
+try {
+computePassEncoder138.setBindGroup(0, bindGroup54, new Uint32Array(5478), 113, 0);
+} catch {}
+try {
+computePassEncoder138.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup33, new Uint32Array(251), 3, 0);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle5, renderBundle7]);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+commandEncoder149.copyTextureToBuffer({
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 51, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 76 widthInBlocks: 19 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 576 */
+  offset: 576,
+  buffer: buffer100,
+}, {width: 19, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let buffer134 = device0.createBuffer({
+  size: 11932,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let textureView157 = texture41.createView({});
+let renderPassEncoder11 = commandEncoder149.beginRenderPass({
+  colorAttachments: [{
+  view: textureView93,
+  depthSlice: 31,
+  clearValue: { r: -331.7, g: -846.4, b: -29.70, a: 733.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder145.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup70, new Uint32Array(11), 0, 0);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline0);
+} catch {}
+let bindGroupLayout18 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 116,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 2,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+    {
+      binding: 157,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 23,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let bindGroup81 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 267, resource: textureView122},
+    {binding: 194, resource: textureView139},
+    {binding: 362, resource: textureView142},
+    {binding: 87, resource: textureView21},
+  ],
+});
+let texture160 = device0.createTexture({
+  size: {width: 166, height: 1, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView158 = texture140.createView({aspect: 'stencil-only', arrayLayerCount: 1});
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup17, new Uint32Array(48), 5, 2);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(0, buffer11, 0, 14);
+} catch {}
+try {
+renderPassEncoder4.insertDebugMarker('\u{1fc62}');
+} catch {}
+let promise22 = device0.queue.onSubmittedWorkDone();
+let texture161 = device0.createTexture({
+  size: [80, 78, 1],
+  mipLevelCount: 1,
+  sampleCount: 4,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture162 = device0.createTexture({
+  label: '\u{1fff6}\u{1ff0a}\u{1fe78}',
+  size: {width: 80, height: 78, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  dimension: '2d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let textureView159 = texture130.createView({dimension: '2d-array', aspect: 'depth-only', baseMipLevel: 0, mipLevelCount: 1, arrayLayerCount: 1});
+let sampler97 = device0.createSampler({
+  label: '\u0832\u0cee\u{1f83d}\u6fd1\uc65d\u{1ff43}\u1314\u{1f7e8}\u9e99\u0744\u0901',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 96.15,
+  lodMaxClamp: 97.85,
+  compare: 'equal',
+});
+try {
+computePassEncoder110.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(1, buffer111);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let arrayBuffer25 = buffer71.getMappedRange(2048, 60);
+try {
+  await promise22;
+} catch {}
+let buffer135 = device0.createBuffer({
+  label: '\u3c78\u0ee7\u03df\u0fa9',
+  size: 9431,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder154 = device0.createCommandEncoder();
+let textureView160 = texture157.createView({});
+let computePassEncoder146 = commandEncoder154.beginComputePass();
+try {
+computePassEncoder144.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup31, new Uint32Array(77), 49, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55); };
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let texture163 = device0.createTexture({
+  label: '\u{1f99c}\u67d4\u01d3\u790b\u060c\uf318\u8b94',
+  size: [332, 1, 1],
+  sampleCount: 4,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder25.setBindGroup(2, bindGroup21, new Uint32Array(2877), 62, 2);
+} catch {}
+try {
+computePassEncoder146.setPipeline(pipeline8);
+} catch {}
+let textureView161 = texture163.createView({});
+try {
+computePassEncoder7.setBindGroup(3, bindGroup66, new Uint32Array(2171), 534, 0);
+} catch {}
+try {
+computePassEncoder116.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(2, buffer66, 996, 320);
+} catch {}
+try {
+texture76.destroy();
+} catch {}
+let promise23 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 78, depthOrArrayLayers: 284}
+*/
+{
+  source: videoFrame23,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 3, y: 16, z: 97},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55); };
+} catch {}
+let commandEncoder155 = device0.createCommandEncoder({label: '\u0add\u03e2\u0af8\ucdf7'});
+let texture164 = device0.createTexture({
+  size: {width: 80, height: 78, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView162 = texture75.createView({dimension: 'cube', format: 'stencil8', baseArrayLayer: 1, arrayLayerCount: 6});
+let computePassEncoder147 = commandEncoder155.beginComputePass({});
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup50, new Uint32Array(7523), 46, 0);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer55, 'uint16', 750, 45);
+} catch {}
+let sampler98 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 77.02,
+  lodMaxClamp: 96.41,
+});
+try {
+computePassEncoder69.setBindGroup(0, bindGroup20, new Uint32Array(329), 31, 0);
+} catch {}
+try {
+computePassEncoder147.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup40, new Uint32Array(268), 18, 0);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let textureView163 = texture111.createView({dimension: '2d-array'});
+let sampler99 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 34.99,
+  lodMaxClamp: 95.36,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder84.setBindGroup(0, bindGroup74);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline0);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let texture165 = device0.createTexture({
+  size: {width: 15, height: 6, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16sint'],
+});
+let textureView164 = texture101.createView({arrayLayerCount: 1});
+try {
+computePassEncoder98.setBindGroup(0, bindGroup32);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup31);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(7, buffer55, 48, 273);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer95, 216, new Float32Array(1939), 114, 40);
+} catch {}
+document.body.append(canvas0);
+let buffer136 = device0.createBuffer({
+  size: 12810,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE,
+});
+try {
+computePassEncoder77.setBindGroup(0, bindGroup8, [7424, 0]);
+} catch {}
+try {
+computePassEncoder141.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer121, 'uint32', 48, 855);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 0, y: 21, z: 0},
+  aspect: 'all',
+}, new Uint8Array(155).fill(23), /* required buffer size: 155 */
+{offset: 155}, {width: 60, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout19 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 10,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let bindGroup82 = device0.createBindGroup({
+  label: '\u5c8e\u{1f8d5}\u{1fb68}\u8fe0',
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 35, resource: {buffer: buffer23, offset: 5632, size: 48}},
+    {binding: 60, resource: textureView55},
+  ],
+});
+let buffer137 = device0.createBuffer({size: 40, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let commandEncoder156 = device0.createCommandEncoder({label: '\u0310\u70bd\ub843\u0eb5\uc7c2\uddf9'});
+let renderPassEncoder12 = commandEncoder156.beginRenderPass({
+  colorAttachments: [{view: textureView154, loadOp: 'clear', storeOp: 'store'}],
+  depthStencilAttachment: {
+    view: textureView146,
+    depthClearValue: 4.2765536050725785,
+    depthReadOnly: true,
+    stencilLoadOp: 'load',
+    stencilStoreOp: 'store',
+  },
+});
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup63);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(1, buffer34, 0);
+} catch {}
+let bindGroup83 = device0.createBindGroup({
+  label: '\u8c36\u1780\u{1ff8a}\u0c24\u0edb\u9b2d',
+  layout: bindGroupLayout17,
+  entries: [{binding: 219, resource: {buffer: buffer23, offset: 5120, size: 197}}],
+});
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup52);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle21, renderBundle5, renderBundle6, renderBundle0, renderBundle3, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(11, 0, 26, 0);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer103, 1396, new Int16Array(3622), 77, 1504);
+} catch {}
+try {
+if (!arrayBuffer20.detached) { new Uint8Array(arrayBuffer20).fill(0x55); };
+} catch {}
+let videoFrame24 = new VideoFrame(offscreenCanvas0, {timestamp: 0});
+let bindGroupLayout20 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 20,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 165,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16float', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {binding: 21, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'uniform', hasDynamicOffset: false }},
+  ],
+});
+let bindGroup84 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 236, resource: sampler64}]});
+let buffer138 = device0.createBuffer({
+  size: 8331,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let texture166 = device0.createTexture({
+  label: '\uba88\u3e51\u02a2',
+  size: {width: 332, height: 1, depthOrArrayLayers: 1},
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView165 = texture72.createView({mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 11});
+let renderBundleEncoder22 = device0.createRenderBundleEncoder({colorFormats: ['r8unorm'], depthStencilFormat: 'stencil8'});
+try {
+computePassEncoder70.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+computePassEncoder125.setBindGroup(2, bindGroup60, new Uint32Array(1037), 35, 0);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(6, buffer13);
+} catch {}
+let imageData17 = new ImageData(44, 8);
+let buffer139 = device0.createBuffer({
+  label: '\uf543\ue4cc\ua3ca\u{1f6dd}\u{1fee4}',
+  size: 9908,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture167 = device0.createTexture({
+  size: [40, 39, 1],
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView166 = texture151.createView({dimension: '2d', aspect: 'depth-only', baseMipLevel: 1, mipLevelCount: 1});
+try {
+renderBundleEncoder22.setIndexBuffer(buffer67, 'uint32', 5_704, 1_602);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer74, 3368, new Int16Array(2567), 18, 916);
+} catch {}
+try {
+buffer73.label = '\u025b\u05a1\u07a8\u3a5b\uf6c4\ubd5b\u0d9e\u98cb';
+} catch {}
+let commandEncoder157 = device0.createCommandEncoder({});
+let textureView167 = texture111.createView({label: '\ub283\u{1fa3d}\u3e6f\u836f\ueccd\u{1fa90}\u36ff\uf046', dimension: '2d-array'});
+let texture168 = device0.createTexture({
+  size: {width: 60, height: 24, depthOrArrayLayers: 5},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView168 = texture123.createView({
+  label: '\u902e\u029f\u{1f8f0}\u{1f86f}\u0a37\u{1fc17}\u3abe\u0dd2\u0284\u5bb4\u0a57',
+  format: 'rgb10a2uint',
+  baseArrayLayer: 0,
+});
+try {
+renderPassEncoder6.setIndexBuffer(buffer26, 'uint16', 354, 4_353);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(2, buffer70, 164);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(6, buffer13, 340, 2_029);
+} catch {}
+let textureView169 = texture166.createView({dimension: '2d-array', baseMipLevel: 0});
+let textureView170 = texture157.createView({arrayLayerCount: 1});
+let renderPassEncoder13 = commandEncoder157.beginRenderPass({
+  colorAttachments: [{
+  view: textureView104,
+  clearValue: { r: 522.9, g: -671.0, b: 227.1, a: 178.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView146,
+    depthClearValue: 1.8370003233647392,
+    depthReadOnly: true,
+    stencilClearValue: 48337,
+    stencilLoadOp: 'load',
+    stencilStoreOp: 'discard',
+  },
+  occlusionQuerySet: querySet14,
+});
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup72);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup23, new Uint32Array(236), 14, 0);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline10);
+} catch {}
+let textureView171 = texture8.createView({baseMipLevel: 0});
+let renderBundle22 = renderBundleEncoder22.finish({});
+let sampler100 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 96.59,
+  lodMaxClamp: 99.09,
+});
+try {
+computePassEncoder95.setBindGroup(2, bindGroup32, new Uint32Array(1660), 57, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup53);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture169 = device0.createTexture({
+  size: {width: 332, height: 1, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler101 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 63.37,
+  lodMaxClamp: 96.94,
+});
+try {
+computePassEncoder112.setBindGroup(0, bindGroup11, new Uint32Array(4460), 210, 2);
+} catch {}
+try {
+renderPassEncoder6.setBlendConstant({ r: -237.0, g: -868.8, b: -607.7, a: 459.6, });
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer127, 'uint16', 1_116, 197);
+} catch {}
+try {
+if (!arrayBuffer22.detached) { new Uint8Array(arrayBuffer22).fill(0x55); };
+} catch {}
+try {
+  await promise23;
+} catch {}
+let textureView172 = texture88.createView({mipLevelCount: 1});
+try {
+renderPassEncoder6.setPipeline(pipeline5);
+} catch {}
+try {
+buffer102.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipelineLayout14 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder158 = device0.createCommandEncoder({});
+let computePassEncoder148 = commandEncoder158.beginComputePass();
+try {
+computePassEncoder148.setPipeline(pipeline11);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer111, 48, new Float32Array(8061), 2179, 180);
+} catch {}
+try {
+externalTexture10.label = '\u{1f8e9}\uc91f\u4ebd\u0988\ud5a2\u316d';
+} catch {}
+let commandEncoder159 = device0.createCommandEncoder({label: '\u8c0c\u{1fe0d}\u8826\ubabf\u0204\u3005'});
+let computePassEncoder149 = commandEncoder159.beginComputePass({label: '\u0a44\u{1f7fa}\u0389\u053f\u6673\uf909\ua158\ueefb\u{1fb9a}\u{1ffe8}'});
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup81);
+} catch {}
+try {
+renderPassEncoder13.beginOcclusionQuery(35);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer124, 'uint32', 2_912, 7_835);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(5, buffer101);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 41, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(42).fill(80), /* required buffer size: 42 */
+{offset: 42}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer140 = device0.createBuffer({size: 25644, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC});
+let texture170 = device0.createTexture({
+  size: [20, 19, 1],
+  mipLevelCount: 1,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup75);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup44, new Uint32Array(1360), 161, 0);
+} catch {}
+let imageData18 = new ImageData(64, 52);
+let commandEncoder160 = device0.createCommandEncoder({});
+let sampler102 = device0.createSampler({
+  label: '\u093b\ubbbc',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 67.46,
+  lodMaxClamp: 80.99,
+  compare: 'greater',
+});
+try {
+computePassEncoder100.setBindGroup(3, bindGroup28, []);
+} catch {}
+try {
+computePassEncoder73.setBindGroup(0, bindGroup58, new Uint32Array(9316), 296, 0);
+} catch {}
+try {
+computePassEncoder149.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder10.setViewport(10.040534189652234, 10.773737065486687, 5.451840838952196, 1.379628781546046, 0.7179399653632221, 0.8841735907903492);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(5, buffer8, 0, 4_968);
+} catch {}
+try {
+commandEncoder160.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1232 */
+  offset: 1232,
+  bytesPerRow: 10752,
+  buffer: buffer127,
+}, {
+  texture: texture64,
+  mipLevel: 4,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer100, 5048, new Float32Array(17988), 2789, 228);
+} catch {}
+let promise24 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise24;
+} catch {}
+let bindGroup85 = device0.createBindGroup({
+  layout: bindGroupLayout9,
+  entries: [{binding: 37, resource: {buffer: buffer101, offset: 1024, size: 104}}],
+});
+let buffer141 = device0.createBuffer({size: 30808, usage: GPUBufferUsage.INDIRECT});
+let computePassEncoder150 = commandEncoder160.beginComputePass({});
+try {
+computePassEncoder36.setBindGroup(3, bindGroup74, []);
+} catch {}
+try {
+computePassEncoder150.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup15, [256, 512]);
+} catch {}
+try {
+renderPassEncoder6.setBlendConstant({ r: -562.8, g: 915.6, b: 169.7, a: -167.3, });
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(0, buffer134, 0, 7_526);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+await gc();
+let texture171 = device0.createTexture({
+  size: {width: 60, height: 24, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView173 = texture160.createView({});
+try {
+computePassEncoder63.setBindGroup(0, bindGroup32);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup54);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup71, new Uint32Array(983), 323, 0);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(6, undefined, 63_606_507, 166_753_155);
+} catch {}
+let buffer142 = device0.createBuffer({size: 3258, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView174 = texture163.createView({aspect: 'all'});
+let texture172 = device0.createTexture({
+  size: {width: 10, height: 9, depthOrArrayLayers: 108},
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView175 = texture7.createView({mipLevelCount: 1, baseArrayLayer: 0});
+try {
+renderPassEncoder10.setViewport(2.7042601984941816, 2.9931536444607856, 14.233272545674827, 2.652900581631151, 0.39491313665356675, 0.42471918086282917);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(5, buffer105);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let canvas1 = document.createElement('canvas');
+let buffer143 = device0.createBuffer({
+  size: 2196,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let externalTexture15 = device0.importExternalTexture({source: videoFrame15});
+try {
+computePassEncoder11.insertDebugMarker('\u97ae');
+} catch {}
+offscreenCanvas2.width = 615;
+let sampler103 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 81.56,
+});
+try {
+computePassEncoder150.end();
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(1, buffer101, 0, 199);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture98,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 19},
+  aspect: 'all',
+}, new Uint8Array(82_139).fill(121), /* required buffer size: 82_139 */
+{offset: 121, bytesPerRow: 32, rowsPerImage: 36}, {width: 2, height: 8, depthOrArrayLayers: 72});
+} catch {}
+let texture173 = device0.createTexture({size: [120, 48, 1], mipLevelCount: 3, format: 'r16uint', usage: GPUTextureUsage.COPY_SRC});
+let computePassEncoder151 = commandEncoder160.beginComputePass({});
+try {
+computePassEncoder30.setBindGroup(2, bindGroup75, new Uint32Array(872), 5, 0);
+} catch {}
+try {
+computePassEncoder151.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup29);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(2, buffer126, 0, 313);
+} catch {}
+try {
+computePassEncoder38.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer56, 'uint32', 344, 91);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(0, buffer92);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+let gpuCanvasContext6 = canvas1.getContext('webgpu');
+let texture174 = device0.createTexture({
+  size: [120, 48, 17],
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'astc-10x8-unorm-srgb',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder87.setBindGroup(0, bindGroup80, new Uint32Array(6473), 905, 0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup60, new Uint32Array(1927), 125, 0);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline10);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let bindGroup86 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 60, resource: textureView60},
+    {binding: 35, resource: {buffer: buffer54, offset: 2304, size: 148}},
+  ],
+});
+let commandEncoder161 = device0.createCommandEncoder({label: '\u{1fd06}\u0ca8\ueb97'});
+let texture175 = device0.createTexture({
+  label: '\ufc35\u0eb1\u8b0c',
+  size: {width: 166, height: 1, depthOrArrayLayers: 30},
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView176 = texture35.createView({dimension: 'cube', format: 'r16uint', mipLevelCount: 1});
+try {
+computePassEncoder11.setBindGroup(2, bindGroup4, new Uint32Array(7977), 1_652, 2);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer124, 'uint32', 1_640, 7_062);
+} catch {}
+let buffer144 = device0.createBuffer({
+  size: 3292,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView177 = texture167.createView({dimension: '2d-array'});
+let texture176 = device0.createTexture({
+  label: '\u00d7\u0395\uf9bf\ue62e\u0a6b\u07f6\uf273',
+  size: {width: 120},
+  dimension: '1d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder152 = commandEncoder161.beginComputePass({});
+let sampler104 = device0.createSampler({
+  label: '\u7456\ueefc\u{1fbe0}\u{1f764}',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 59.25,
+  lodMaxClamp: 90.86,
+  maxAnisotropy: 18,
+});
+try {
+renderPassEncoder13.endOcclusionQuery();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer81, 1004, new DataView(new ArrayBuffer(15025)), 3279, 292);
+} catch {}
+document.body.prepend(canvas1);
+let commandEncoder162 = device0.createCommandEncoder({});
+let textureView178 = texture92.createView({});
+let renderPassEncoder14 = commandEncoder162.beginRenderPass({
+  colorAttachments: [{
+  view: textureView133,
+  clearValue: { r: 621.4, g: -410.4, b: -547.8, a: 594.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView155,
+    depthClearValue: -9.002331033020695,
+    stencilLoadOp: 'load',
+    stencilStoreOp: 'discard',
+  },
+});
+try {
+computePassEncoder110.setBindGroup(1, bindGroup69);
+} catch {}
+try {
+computePassEncoder24.setBindGroup(0, bindGroup28, new Uint32Array(1859), 194, 0);
+} catch {}
+try {
+computePassEncoder38.setPipeline(pipeline6);
+} catch {}
+try {
+computePassEncoder152.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer120, 'uint16', 1_984, 5_322);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline5);
+} catch {}
+let bindGroup87 = device0.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 148, resource: textureView11}]});
+let texture177 = device0.createTexture({
+  size: {width: 332},
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView179 = texture29.createView({dimension: '1d', baseArrayLayer: 0});
+try {
+renderPassEncoder14.setIndexBuffer(buffer55, 'uint16', 748, 110);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup72, new Uint32Array(930), 63, 0);
+} catch {}
+try {
+adapter0.label = '\u0f21\u{1fc50}\u0a71\u{1f9ef}\ua2cc';
+} catch {}
+let bindGroup88 = device0.createBindGroup({layout: bindGroupLayout19, entries: [{binding: 10, resource: textureView43}]});
+let sampler105 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 91.20,
+  lodMaxClamp: 94.88,
+});
+try {
+renderPassEncoder6.executeBundles([renderBundle6, renderBundle6, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer95, 'uint16', 32, 142);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(6, undefined, 0, 107_713_607);
+} catch {}
+document.body.append(img0);
+let bindGroupLayout21 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 416,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 0,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 592,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 327,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 231,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 9,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 453,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 51,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 425,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 42,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rg32float', access: 'write-only', viewDimension: '2d' },
+    },
+    {
+      binding: 72,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 215,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let texture178 = device0.createTexture({
+  size: {width: 332, height: 1, depthOrArrayLayers: 12},
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture179 = device0.createTexture({size: [665], dimension: '1d', format: 'r8sint', usage: GPUTextureUsage.COPY_DST});
+let renderBundleEncoder23 = device0.createRenderBundleEncoder({colorFormats: ['r8sint'], depthReadOnly: true});
+let renderBundle23 = renderBundleEncoder23.finish();
+try {
+computePassEncoder125.setBindGroup(3, bindGroup58, new Uint32Array(1102), 162, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup53);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(5, buffer135, 740, 102);
+} catch {}
+let buffer145 = device0.createBuffer({
+  size: 16129,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder163 = device0.createCommandEncoder({});
+let textureView180 = texture9.createView({dimension: 'cube-array', arrayLayerCount: 6});
+let computePassEncoder153 = commandEncoder163.beginComputePass({});
+let sampler106 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 52.29,
+  lodMaxClamp: 75.69,
+  compare: 'always',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder73.setBindGroup(1, bindGroup30, new Uint32Array(6025), 22, 0);
+} catch {}
+try {
+computePassEncoder153.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline0);
+} catch {}
+await gc();
+let buffer146 = device0.createBuffer({
+  label: '\u1e8c\u{1f6a7}\u55d0',
+  size: 35243,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView181 = texture178.createView({
+  label: '\u81ea\u09d1\u94df\u0455\u1c9b\u1881\u4923\u8a1d\u0022\u0e19',
+  dimension: '2d-array',
+  format: 'rg32float',
+  baseArrayLayer: 1,
+  arrayLayerCount: 2,
+});
+let texture180 = device0.createTexture({
+  size: {width: 20, height: 19, depthOrArrayLayers: 1},
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView182 = texture163.createView({label: '\u05a9\u0af9\u{1fe0f}\u0d24\u7f2f\u{1fe6d}\u{1f897}\u{1fe19}\u5366\u0de3\u0bc2'});
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let imageData19 = new ImageData(8, 44);
+let texture181 = device0.createTexture({
+  size: [120, 48, 1],
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture182 = device0.createTexture({size: {width: 40}, dimension: '1d', format: 'r16uint', usage: GPUTextureUsage.COPY_SRC});
+let sampler107 = device0.createSampler({
+  label: '\u3d17\ubd73\ub245\ub659\u5a58\ud5bf\u184c\uf1c8',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 84.80,
+  lodMaxClamp: 87.33,
+});
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer44, 592, 434);
+} catch {}
+let imageData20 = new ImageData(24, 4);
+let bindGroup89 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 3, resource: sampler84},
+    {binding: 16, resource: {buffer: buffer13, offset: 6144}},
+    {binding: 88, resource: {buffer: buffer70, offset: 2048, size: 48}},
+    {binding: 139, resource: textureView123},
+    {binding: 25, resource: {buffer: buffer70, offset: 256, size: 3856}},
+    {binding: 779, resource: {buffer: buffer59, offset: 0, size: 992}},
+    {binding: 96, resource: textureView33},
+    {binding: 142, resource: textureView140},
+    {binding: 925, resource: textureView175},
+    {binding: 32, resource: textureView98},
+    {binding: 426, resource: {buffer: buffer4, offset: 512, size: 1464}},
+  ],
+});
+let commandEncoder164 = device0.createCommandEncoder({});
+let textureView183 = texture178.createView({dimension: '2d', baseMipLevel: 0});
+try {
+computePassEncoder58.setBindGroup(3, bindGroup66);
+} catch {}
+try {
+computePassEncoder124.setBindGroup(0, bindGroup82, new Uint32Array(2288), 459, 0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup0, new Uint32Array(114), 31, 0);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline10);
+} catch {}
+try {
+commandEncoder164.clearBuffer(buffer144);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+try {
+computePassEncoder26.setBindGroup(2, bindGroup20);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup77, new Uint32Array(64), 27, 0);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle9, renderBundle21, renderBundle4, renderBundle10, renderBundle3, renderBundle3]);
+} catch {}
+let imageData21 = new ImageData(44, 140);
+try {
+adapter0.label = '\u06c3\u436a\u{1f92a}\u8b61\u0525\u{1fc55}\ue252\u382c';
+} catch {}
+try {
+externalTexture11.label = '\u{1f6e2}\u0928\u0024\u66ff\u004b';
+} catch {}
+let computePassEncoder154 = commandEncoder164.beginComputePass({});
+try {
+computePassEncoder42.setBindGroup(2, bindGroup19, new Uint32Array(23), 12, 0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup69, new Uint32Array(841), 2, 0);
+} catch {}
+let externalTexture16 = device0.importExternalTexture({source: videoFrame11});
+try {
+computePassEncoder12.setBindGroup(3, bindGroup19, new Uint32Array(2384), 348, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup32);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup90 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [
+    {binding: 101, resource: textureView11},
+    {binding: 187, resource: textureView124},
+    {binding: 176, resource: textureView9},
+    {binding: 848, resource: textureView106},
+    {binding: 242, resource: sampler107},
+    {binding: 22, resource: {buffer: buffer102, offset: 0, size: 176}},
+    {binding: 107, resource: textureView72},
+    {binding: 68, resource: {buffer: buffer41, offset: 2816, size: 1114}},
+    {binding: 174, resource: sampler23},
+    {binding: 4, resource: {buffer: buffer67, offset: 2048, size: 2896}},
+    {binding: 110, resource: {buffer: buffer55, offset: 0, size: 2008}},
+    {binding: 9, resource: {buffer: buffer76, offset: 0}},
+    {binding: 57, resource: textureView45},
+    {binding: 221, resource: textureView41},
+    {binding: 252, resource: textureView113},
+    {binding: 39, resource: textureView11},
+    {binding: 431, resource: sampler79},
+  ],
+});
+let commandEncoder165 = device0.createCommandEncoder({label: '\u3b5b\u{1f81d}\u0c15\u{1f811}\u0fbb\uee48\ubbb8\u91fe\u0783\u0c0e'});
+let texture183 = device0.createTexture({
+  size: {width: 40, height: 39, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+computePassEncoder151.setBindGroup(1, bindGroup26);
+} catch {}
+try {
+computePassEncoder154.setPipeline(pipeline9);
+} catch {}
+let arrayBuffer26 = buffer71.getMappedRange(888, 36);
+try {
+commandEncoder165.copyTextureToTexture({
+  texture: texture167,
+  mipLevel: 0,
+  origin: {x: 5, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 9, y: 28, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+await gc();
+let texture184 = device0.createTexture({
+  label: '\u0b12\u6c1d\uda29',
+  size: [15, 6, 78],
+  mipLevelCount: 2,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView184 = texture51.createView({dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 0});
+let renderPassEncoder15 = commandEncoder165.beginRenderPass({
+  colorAttachments: [{view: textureView104, loadOp: 'clear', storeOp: 'store'}],
+  depthStencilAttachment: {
+    view: textureView146,
+    depthReadOnly: false,
+    stencilClearValue: 6670,
+    stencilLoadOp: 'load',
+    stencilStoreOp: 'store',
+    stencilReadOnly: false,
+  },
+});
+try {
+computePassEncoder101.setBindGroup(2, bindGroup62);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder87); computePassEncoder87.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle9, renderBundle21, renderBundle7, renderBundle6, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder8.setBlendConstant({ r: 986.3, g: 256.7, b: -190.2, a: 234.2, });
+} catch {}
+let promise25 = shaderModule5.getCompilationInfo();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 39, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData8,
+  origin: { x: 6, y: 7 },
+  flipY: true,
+}, {
+  texture: texture167,
+  mipLevel: 0,
+  origin: {x: 0, y: 14, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let buffer147 = device0.createBuffer({
+  size: 3703,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+try {
+renderPassEncoder1.executeBundles([renderBundle6, renderBundle7, renderBundle0, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer64, 'uint16', 44, 816);
+} catch {}
+document.body.prepend(img0);
+let buffer148 = device0.createBuffer({
+  label: '\u{1fb2b}\u{1fdc3}\u{1fc94}\u7258\u2e93\u5d5a\u19b2',
+  size: 911,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let commandEncoder166 = device0.createCommandEncoder({});
+let renderBundleEncoder24 = device0.createRenderBundleEncoder({colorFormats: ['r8unorm'], depthStencilFormat: 'stencil8', depthReadOnly: true});
+try {
+computePassEncoder91.setBindGroup(3, bindGroup50, new Uint32Array(3281), 840, 0);
+} catch {}
+try {
+computePassEncoder87.end();
+} catch {}
+try {
+renderPassEncoder11.setViewport(10.304368780587723, 17.40883101726532, 4.77778524956516, 1.0545788374668255, 0.301198998039636, 0.9826896449524021);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture64,
+  mipLevel: 5,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(9).fill(131), /* required buffer size: 9 */
+{offset: 9}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise26 = device0.queue.onSubmittedWorkDone();
+await gc();
+let bindGroup91 = device0.createBindGroup({
+  layout: bindGroupLayout18,
+  entries: [
+    {binding: 157, resource: textureView140},
+    {binding: 116, resource: {buffer: buffer146, offset: 5376, size: 3796}},
+    {binding: 23, resource: textureView175},
+    {binding: 2, resource: textureView174},
+  ],
+});
+let commandEncoder167 = device0.createCommandEncoder();
+try {
+computePassEncoder16.setBindGroup(2, bindGroup65, new Uint32Array(784), 213, 0);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup79, new Uint32Array(1039), 372, 2);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer78, 'uint32', 4, 115);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(4, buffer11, 0, 1);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(2, bindGroup82, new Uint32Array(3826), 1_455, 0);
+} catch {}
+try {
+commandEncoder92.copyBufferToBuffer(buffer99, 1092, buffer78, 64, 136);
+} catch {}
+await gc();
+let bindGroup92 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [
+    {binding: 431, resource: sampler1},
+    {binding: 221, resource: textureView45},
+    {binding: 848, resource: textureView77},
+    {binding: 242, resource: sampler33},
+    {binding: 176, resource: textureView140},
+    {binding: 57, resource: textureView41},
+    {binding: 9, resource: {buffer: buffer137, offset: 0}},
+    {binding: 22, resource: {buffer: buffer103, offset: 768, size: 3592}},
+    {binding: 101, resource: textureView140},
+    {binding: 174, resource: sampler62},
+    {binding: 110, resource: {buffer: buffer100, offset: 1280, size: 1084}},
+    {binding: 252, resource: textureView74},
+    {binding: 68, resource: {buffer: buffer78, offset: 0, size: 199}},
+    {binding: 107, resource: textureView72},
+    {binding: 187, resource: textureView100},
+    {binding: 4, resource: {buffer: buffer21, offset: 4352, size: 12476}},
+    {binding: 39, resource: textureView140},
+  ],
+});
+let textureView185 = texture105.createView({baseArrayLayer: 8, arrayLayerCount: 1});
+let computePassEncoder155 = commandEncoder166.beginComputePass({});
+let renderPassEncoder16 = commandEncoder92.beginRenderPass({
+  colorAttachments: [{
+  view: textureView93,
+  depthSlice: 22,
+  clearValue: { r: 94.72, g: -177.3, b: -671.1, a: 188.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet11,
+});
+let renderBundle24 = renderBundleEncoder24.finish();
+try {
+computePassEncoder112.setBindGroup(1, bindGroup51, new Uint32Array(144), 49, 0);
+} catch {}
+try {
+computePassEncoder2.setPipeline(pipeline11);
+} catch {}
+offscreenCanvas2.width = 203;
+let bindGroup93 = device0.createBindGroup({
+  layout: bindGroupLayout14,
+  entries: [
+    {binding: 152, resource: sampler16},
+    {binding: 999, resource: textureView94},
+    {binding: 60, resource: textureView9},
+  ],
+});
+let texture185 = device0.createTexture({
+  size: [40, 39, 1],
+  mipLevelCount: 2,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder156 = commandEncoder167.beginComputePass({});
+try {
+computePassEncoder153.setBindGroup(3, bindGroup92);
+} catch {}
+try {
+computePassEncoder155.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup49, new Uint32Array(4778), 119, 0);
+} catch {}
+let promise27 = device0.queue.onSubmittedWorkDone();
+let buffer149 = device0.createBuffer({
+  size: 17673,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let textureView186 = texture113.createView({label: '\u{1f886}\u9729\u0f88\u1b32\ud836\u{1fdda}\u7a9e\u6a08\u0ae7', dimension: '2d-array'});
+let arrayBuffer27 = buffer71.getMappedRange(928, 8);
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 332, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame19,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture166,
+  mipLevel: 0,
+  origin: {x: 110, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img0);
+let textureView187 = texture149.createView({label: '\u0166\u0ded\u6b0f\u{1f715}\u00ef\u0ee2\ud10b\u08a8'});
+try {
+computePassEncoder156.setPipeline(pipeline11);
+} catch {}
+try {
+  await promise26;
+} catch {}
+let bindGroup94 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 16, resource: {buffer: buffer149, offset: 2048, size: 7572}},
+    {binding: 96, resource: textureView29},
+    {binding: 32, resource: textureView148},
+    {binding: 779, resource: {buffer: buffer3, offset: 0, size: 650}},
+    {binding: 88, resource: {buffer: buffer115, offset: 512, size: 496}},
+    {binding: 3, resource: sampler0},
+    {binding: 925, resource: textureView9},
+    {binding: 139, resource: textureView10},
+    {binding: 142, resource: textureView11},
+    {binding: 25, resource: {buffer: buffer54, offset: 1024, size: 4044}},
+    {binding: 426, resource: {buffer: buffer148, offset: 0, size: 360}},
+  ],
+});
+try {
+renderPassEncoder16.setBindGroup(1, bindGroup38, new Uint32Array(6177), 1_807, 2);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer43, 'uint32', 2_160, 1_226);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(7, buffer73, 0, 426);
+} catch {}
+let pipeline12 = await promise9;
+try {
+  await promise25;
+} catch {}
+let shaderModule12 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(59) var sam6: sampler_comparison;
+
+struct T0 {
+  @size(64) f0: mat2x4h,
+  f1: vec4f,
+  @size(256) f2: array<array<vec4h, 1>, 1>,
+}
+
+struct T1 {
+  @align(8) @size(768) f0: array<u32>,
+}
+
+struct T2 {
+  @size(32) f0: array<array<array<vec2i, 1>, 1>>,
+}
+
+struct T3 {
+  f0: u32,
+  @size(220) f1: array<atomic<i32>, 36>,
+}
+
+struct VertexOutput12 {
+  @builtin(position) f38: vec4f,
+}
+
+struct FragmentOutput8 {
+  @location(0) @interpolate(flat, centroid) f0: vec4u,
+  @location(7) f1: f32,
+}
+
+struct FragmentOutput9 {
+  @location(0) f0: i32,
+  @location(6) f1: f32,
+}
+
+alias vec3b = vec3<bool>;
+
+fn fn0() -> FragmentOutput9 {
+  var out: FragmentOutput9;
+  var vf204: vec2f = floor(vec2f(unconst_f32(0.00257), unconst_f32(0.2269)));
+  let vf205: vec2f = acosh(vec2f(bitcast<f32>(vp24.f0[u32(unconst_u32(76))])));
+  var vf206: f32 = determinant(mat4x4f());
+  var vf207: vec2f = unpack2x16unorm(u32(unconst_u32(218)));
+  out.f1 = vp24.f1;
+  let ptr165: ptr<private, FragmentOutput8> = &vp24;
+  out.f0 *= bitcast<vec2i>(vf207)[1];
+  let vf208: vec3i = countOneBits(vec3i(i32(determinant(mat2x2f(unconst_f32(0.04374), unconst_f32(-0.1792), unconst_f32(0.1381), unconst_f32(0.1703))))));
+  var vf209: f32 = vf204[u32(unconst_u32(89))];
+  var vf210: bool = all(bool(unconst_bool(false)));
+  let ptr166: ptr<private, f32> = &vp24.f1;
+  let ptr167: ptr<private, f32> = &(*ptr165).f1;
+  var vf211: i32 = max(i32(vp24.f1), i32(unconst_i32(8)));
+  vf207 = fma(vec3f(unconst_f32(-0.03503), unconst_f32(0.04059), unconst_f32(0.04502)), vec3f(unconst_f32(0.4763), unconst_f32(0.8516), unconst_f32(0.4055)), vec3f(unconst_f32(0.01048), unconst_f32(0.1931), unconst_f32(0.02387))).gg;
+  let vf212: vec2f = unpack2x16unorm(u32(unconst_u32(47)));
+  let ptr168: ptr<private, FragmentOutput8> = &vp24;
+  vf204 = vec2f(max(vec2u(unconst_u32(77), unconst_u32(62)), vec2u(unconst_u32(120), unconst_u32(9))));
+  var vf213: vec2f = vf212;
+  vf210 = bool(unpack2x16snorm(u32(unconst_u32(132))).g);
+  let ptr169: ptr<function, vec2f> = &vf207;
+  let ptr170: ptr<function, f32> = &vf206;
+  let ptr171: ptr<private, FragmentOutput8> = &(*ptr165);
+  var vf214: vec2u = max(vec2u(unconst_u32(90), unconst_u32(163)), vec2u(unconst_u32(404), unconst_u32(214)));
+  return out;
+}
+
+var<workgroup> vw32: vec2u;
+
+var<private> vp24: FragmentOutput8 = FragmentOutput8();
+
+@vertex
+fn vertex13(@location(13) a0: vec4h, @location(14) a1: f32, @location(1) @interpolate(linear, sample) a2: vec4f) -> VertexOutput12 {
+  var out: VertexOutput12;
+  fn0();
+  let vf215: f32 = distance(vec3f(unconst_f32(0.04947), unconst_f32(0.01884), unconst_f32(0.3000)), vec3f(unconst_f32(0.3071), unconst_f32(0.03066), unconst_f32(0.06625)));
+  var vf216: vec3f = atan2(vec3f(unconst_f32(0.03150), unconst_f32(0.4531), unconst_f32(0.3884)), vec3f(unconst_f32(0.1518), unconst_f32(0.07493), unconst_f32(-0.2601)));
+  vp24.f0 = vec4u(u32(a0[u32(vp24.f1)]));
+  vf216 -= vec3f(f32(all(vec2<bool>(unconst_bool(true), unconst_bool(true)))));
+  out = VertexOutput12(vec4f(sin(bitcast<vec2h>(vf215)).yxxx));
+  return out;
+}
+
+@fragment
+fn fragment12() -> FragmentOutput8 {
+  var out: FragmentOutput8;
+  var vf217 = fn0();
+  let vf218: u32 = vp24.f0[u32(unconst_u32(19))];
+  out.f0 |= vec4u(select(vec3i(unconst_i32(112), unconst_i32(170), unconst_i32(284)), vec3i(unconst_i32(103), unconst_i32(-178), unconst_i32(47)), vec3<bool>(sign(vec4f(unconst_f32(0.1007), unconst_f32(0.02501), unconst_f32(0.3252), unconst_f32(0.01888))).yxw)).gggb);
+  return out;
+}
+
+@fragment
+fn fragment13() -> FragmentOutput9 {
+  var out: FragmentOutput9;
+  var vf219 = fn0();
+  vf219 = FragmentOutput9(vec4i(sqrt(vec4h(unconst_f16(-7205.4), unconst_f16(19736.8), unconst_f16(7934.9), unconst_f16(3450.3)))).z, f32(sqrt(vec4h(unconst_f16(-7205.4), unconst_f16(19736.8), unconst_f16(7934.9), unconst_f16(3450.3)))[1]));
+  let vf220: vec3f = reflect(vec3f(unconst_f32(0.4241), unconst_f32(0.01433), unconst_f32(0.2961)), vec3f(unconst_f32(0.00163), unconst_f32(0.4302), unconst_f32(0.07674)));
+  fn0();
+  out.f1 = vf219.f1;
+  fn0();
+  vf219 = FragmentOutput9(bitcast<i32>(vf220[u32(unconst_u32(45))]), vf220[u32(unconst_u32(45))]);
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute10(@builtin(global_invocation_id) a0: vec3u) {
+  var vf221: vec2h = acos(vec2h(unconst_f16(-9145.0), unconst_f16(14809.0)));
+  let vf222: vec3i = extractBits(vec3i(unconst_i32(-445), unconst_i32(42), unconst_i32(129)), u32(unconst_u32(95)), u32(unconst_u32(5)));
+  var vf223: vec3i = vf222;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute11(@builtin(workgroup_id) a0: vec3u) {
+  vw32 *= vp24.f0.xz;
+  let ptr172: ptr<private, f32> = &vp24.f1;
+  var vf224: u32 = (*&vw32)[vp24.f0[u32(unconst_u32(302))]];
+  vf224 >>= u32(vp24.f1);
+  vw32 *= vec2u(u32((*ptr172)));
+  let ptr173: ptr<private, vec4u> = &vp24.f0;
+  var vf225: vec2f = quantizeToF16(vec2f(unconst_f32(0.5769), unconst_f32(0.1681)));
+  vp24.f1 *= vec4f((*ptr173))[2];
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer150 = device0.createBuffer({
+  size: 391,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder168 = device0.createCommandEncoder();
+let texture186 = device0.createTexture({
+  size: [120, 48, 175],
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let sampler108 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 77.58,
+  lodMaxClamp: 94.19,
+  maxAnisotropy: 2,
+});
+let externalTexture17 = device0.importExternalTexture({label: '\u0d26\u{1f961}', source: videoFrame20, colorSpace: 'srgb'});
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup52);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(5, buffer135);
+} catch {}
+try {
+renderPassEncoder4.insertDebugMarker('\u071b');
+} catch {}
+let bindGroup95 = device0.createBindGroup({
+  label: '\u051f\ua1e0\u904d\u{1ff9c}\uebaf\u0c32\u65ac\u0a0a',
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 35, resource: {buffer: buffer43, offset: 256, size: 2568}},
+    {binding: 60, resource: textureView43},
+  ],
+});
+let texture187 = device0.createTexture({
+  label: '\u01be\ucc89\u8897\u{1f638}\ub01a\u1276\u7e6c',
+  size: [40, 39, 1],
+  mipLevelCount: 2,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let textureView188 = texture130.createView({dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 0});
+let renderPassEncoder17 = commandEncoder168.beginRenderPass({
+  colorAttachments: [{
+  view: textureView93,
+  depthSlice: 40,
+  clearValue: { r: 889.8, g: 59.31, b: -717.7, a: -107.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let sampler109 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 14.60,
+  lodMaxClamp: 27.23,
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder57.setBindGroup(2, bindGroup42);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer101, 'uint32', 1_688, 171);
+} catch {}
+await gc();
+let pipelineLayout15 = device0.createPipelineLayout({bindGroupLayouts: []});
+let renderBundleEncoder25 = device0.createRenderBundleEncoder({
+  colorFormats: ['r16uint'],
+  depthStencilFormat: 'depth16unorm',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder4.executeBundles([renderBundle9, renderBundle9, renderBundle21, renderBundle7, renderBundle10, renderBundle10]);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline5);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(canvas0);
+try {
+adapter0.label = '\uecad\u391a\u033b\u0bd5\u{1fdcf}\uc083\u6b53\u56e2\udf80\u56f9\u7b49';
+} catch {}
+let bindGroup96 = device0.createBindGroup({layout: bindGroupLayout13, entries: [{binding: 46, resource: textureView55}]});
+let commandEncoder169 = device0.createCommandEncoder();
+let renderBundleEncoder26 = device0.createRenderBundleEncoder({
+  colorFormats: ['r16uint'],
+  depthStencilFormat: 'depth16unorm',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder147.setBindGroup(2, bindGroup59, new Uint32Array(2224), 341, 0);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup59);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup57, new Uint32Array(1740), 5, 0);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(366);
+} catch {}
+try {
+commandEncoder169.copyTextureToTexture({
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 7, y: 1, z: 7},
+  aspect: 'all',
+},
+{
+  texture: texture162,
+  mipLevel: 2,
+  origin: {x: 4, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder157 = commandEncoder169.beginComputePass({});
+let sampler110 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 7.689,
+  lodMaxClamp: 66.00,
+});
+try {
+computePassEncoder44.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(buffer67, 'uint16', 1_758, 1_831);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(0, buffer139, 0, 886);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 4192, new Float32Array(2373));
+} catch {}
+let imageData22 = new ImageData(84, 104);
+let commandEncoder170 = device0.createCommandEncoder({});
+let renderBundle25 = renderBundleEncoder26.finish();
+try {
+computePassEncoder85.setBindGroup(1, bindGroup40, new Uint32Array(4613), 3, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup60);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(5, buffer78, 0, 100);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+buffer27.unmap();
+} catch {}
+try {
+commandEncoder170.copyBufferToTexture({
+  /* bytesInLastRow: 92 widthInBlocks: 23 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3472 */
+  offset: 3472,
+  buffer: buffer94,
+}, {
+  texture: texture152,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 23, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup97 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 236, resource: sampler96}]});
+let buffer151 = device0.createBuffer({
+  size: 915,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView189 = texture111.createView({dimension: '2d-array'});
+let computePassEncoder158 = commandEncoder170.beginComputePass({});
+try {
+renderPassEncoder16.beginOcclusionQuery(595);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer61, 16788, new DataView(new ArrayBuffer(271)), 36, 8);
+} catch {}
+let promise28 = device0.queue.onSubmittedWorkDone();
+let textureView190 = texture181.createView({baseArrayLayer: 0});
+try {
+computePassEncoder53.setBindGroup(3, bindGroup49, new Uint32Array(262), 5, 0);
+} catch {}
+try {
+computePassEncoder157.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(1, buffer134, 32, 1_647);
+} catch {}
+let imageData23 = new ImageData(44, 16);
+let texture188 = device0.createTexture({
+  size: {width: 10, height: 9, depthOrArrayLayers: 13},
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder154.setBindGroup(3, bindGroup55);
+} catch {}
+try {
+computePassEncoder158.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(6, buffer61);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+let bindGroupLayout22 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 324,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 54,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let renderBundle26 = renderBundleEncoder25.finish({});
+try {
+computePassEncoder45.setBindGroup(3, bindGroup95);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let bindGroup98 = device0.createBindGroup({layout: bindGroupLayout5, entries: [{binding: 65, resource: textureView9}]});
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup62);
+} catch {}
+try {
+renderPassEncoder8.beginOcclusionQuery(379);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer139, 'uint16', 246, 2_108);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let commandEncoder171 = device0.createCommandEncoder({});
+let texture189 = device0.createTexture({
+  size: {width: 40, height: 39, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder159 = commandEncoder171.beginComputePass({});
+let sampler111 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 77.05,
+  lodMaxClamp: 90.98,
+});
+let externalTexture18 = device0.importExternalTexture({
+  label: '\uf92e\u{1fd83}\ud6c8\uab67\ua015\u03e5\u66f2\u0a47\uc978\u{1fa7f}\u{1f65a}',
+  source: videoFrame11,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder2.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder159.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(56);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(4, buffer134);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 39, depthOrArrayLayers: 1}
+*/
+{
+  source: img0,
+  origin: { x: 0, y: 8 },
+  flipY: false,
+}, {
+  texture: texture167,
+  mipLevel: 0,
+  origin: {x: 0, y: 5, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 12, height: 17, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout16 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder172 = device0.createCommandEncoder({});
+let querySet18 = device0.createQuerySet({type: 'occlusion', count: 669});
+try {
+computePassEncoder141.setBindGroup(3, bindGroup53);
+} catch {}
+try {
+  await promise28;
+} catch {}
+let bindGroup99 = device0.createBindGroup({layout: bindGroupLayout13, entries: [{binding: 46, resource: textureView124}]});
+let buffer152 = device0.createBuffer({
+  size: 18516,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder160 = commandEncoder172.beginComputePass({});
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup51, new Uint32Array(1658), 61, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer146, 'uint16', 16_358, 2_520);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+document.body.prepend(canvas0);
+let buffer153 = device0.createBuffer({size: 18756, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+let commandEncoder173 = device0.createCommandEncoder();
+let commandBuffer11 = commandEncoder173.finish();
+let sampler112 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 43.61,
+  lodMaxClamp: 86.27,
+});
+try {
+computePassEncoder69.setBindGroup(0, bindGroup48);
+} catch {}
+try {
+computePassEncoder50.setBindGroup(3, bindGroup40, new Uint32Array(2313), 246, 0);
+} catch {}
+try {
+computePassEncoder22.setPipeline(pipeline8);
+} catch {}
+try {
+computePassEncoder160.setPipeline(pipeline2);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 15, height: 6, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData23,
+  origin: { x: 43, y: 2 },
+  flipY: false,
+}, {
+  texture: texture159,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise27;
+} catch {}
+let externalTexture19 = device0.importExternalTexture({source: videoFrame3});
+try {
+computePassEncoder73.setBindGroup(2, bindGroup21, [10240, 0]);
+} catch {}
+try {
+computePassEncoder42.setBindGroup(0, bindGroup82, new Uint32Array(207), 2, 0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup13, []);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer136, 'uint32', 832, 448);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(2, undefined, 412_002_115);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let arrayBuffer28 = buffer2.getMappedRange(704, 28);
+let textureView191 = texture105.createView({dimension: '2d', baseMipLevel: 0, baseArrayLayer: 3});
+let renderBundleEncoder27 = device0.createRenderBundleEncoder({colorFormats: ['r8sint'], sampleCount: 1, stencilReadOnly: true});
+let sampler113 = device0.createSampler({
+  label: '\u1bab\uc18d\u7fb0\u0a9d\u{1f74c}',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 76.29,
+  lodMaxClamp: 90.64,
+  maxAnisotropy: 15,
+});
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup81, new Uint32Array(1118), 183, 0);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(1, buffer151, 0, 387);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(2, bindGroup95);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer135.unmap();
+} catch {}
+let img1 = await imageWithData(102, 56, '#10101010', '#20202020');
+try {
+renderPassEncoder11.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer10, 'uint32', 52, 11);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(1, buffer101, 784, 223);
+} catch {}
+document.body.prepend(canvas1);
+try {
+device0.queue.label = '\u4d18\u{1faae}\u{1f7ce}\u82b4\uc6ab\u{1f8c4}\ueb0d\u5efc';
+} catch {}
+let bindGroup100 = device0.createBindGroup({
+  label: '\u0048\u{1fa9b}\ua698',
+  layout: bindGroupLayout6,
+  entries: [{binding: 302, resource: textureView11}],
+});
+let textureView192 = texture184.createView({
+  label: '\u83ad\u2e74\u{1f969}\ud853\ue183\u05b5\u0b1b\u{1f9d1}',
+  dimension: '2d',
+  baseMipLevel: 0,
+  mipLevelCount: 1,
+  baseArrayLayer: 11,
+});
+try {
+renderPassEncoder6.draw(25, 22, 47_017_323, 1_918_272_606);
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(buffer102, 328);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer70, 'uint32', 1_016, 1_629);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(2, bindGroup16, [0, 3072]);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer105, 'uint16', 1_490, 43);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(1, buffer55);
+} catch {}
+let commandEncoder174 = device0.createCommandEncoder({});
+let computePassEncoder161 = commandEncoder174.beginComputePass({label: '\u5e8e\u008b\u038d\uc794\ubca8\u075f\udcad\u{1faf4}\u4c3e'});
+try {
+computePassEncoder63.setBindGroup(0, bindGroup64, []);
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(buffer76, 4);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(4, buffer55);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(4, buffer13);
+} catch {}
+try {
+renderBundleEncoder12.label = '\u{1ff19}\u08da\u2d1e\uc7a7\u471d\ua4a2\ua76e\u55f1\u9de7\u00bf\u27f6';
+} catch {}
+let bindGroup101 = device0.createBindGroup({
+  label: '\u6744\ub536',
+  layout: bindGroupLayout20,
+  entries: [
+    {binding: 21, resource: {buffer: buffer23, offset: 10240, size: 1872}},
+    {binding: 20, resource: {buffer: buffer116, offset: 512, size: 528}},
+    {binding: 165, resource: textureView169},
+  ],
+});
+let sampler114 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 56.19,
+  lodMaxClamp: 94.05,
+  maxAnisotropy: 4,
+});
+try {
+renderPassEncoder13.setIndexBuffer(buffer24, 'uint32', 32, 3_414);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(3, bindGroup65, new Uint32Array(755), 12, 0);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(3, buffer129, 0);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+renderPassEncoder17.insertDebugMarker('\u{1f607}');
+} catch {}
+let videoFrame25 = new VideoFrame(img0, {timestamp: 0});
+let shaderModule13 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(302) var tex20: texture_2d<i32>;
+
+struct T0 {
+  @size(4544) f0: array<atomic<u32>>,
+}
+
+struct T1 {
+  @size(832) f0: array<array<atomic<i32>, 1>>,
+}
+
+struct T2 {
+  @size(8) f0: array<u32>,
+}
+
+struct T3 {
+  @align(4) @size(132) f0: f16,
+}
+
+struct T4 {
+  f0: array<array<i32, 1>, 1>,
+}
+
+struct FragmentOutput10 {
+  @location(0) @interpolate(flat, center) f0: vec4u,
+  @location(5) @interpolate(flat) f1: i32,
+  @location(2) @interpolate(flat) f2: vec2f,
+}
+
+alias vec3b = vec3<bool>;
+
+override override4: u32 = 286;
+
+override override5: bool;
+
+@id(44182) override override6: bool;
+
+override override7: f32;
+
+var<workgroup> vw33: atomic<i32>;
+
+@vertex
+fn vertex14(@location(9) a0: vec2i, @location(11) a1: f32, @location(15) @interpolate(perspective) a2: f16) -> @builtin(position) vec4f {
+  var out: vec4f;
+  var vf226: vec4f = acosh(vec4f(unconst_f32(0.2702), unconst_f32(0.06169), unconst_f32(0.3150), unconst_f32(0.04379)));
+  var vf227: u32 = dot(vec3u(unconst_u32(221), unconst_u32(131), unconst_u32(172)), vec3u(unconst_u32(195), unconst_u32(17), unconst_u32(268)));
+  let vf228: vec4u = countTrailingZeros(vec4u(unconst_u32(28), unconst_u32(773), unconst_u32(158), unconst_u32(72)));
+  var vf229: vec2u = select(vec2u(unconst_u32(64), unconst_u32(373)), vec2u(unconst_u32(105), unconst_u32(210)), vec2<bool>(unconst_bool(true), unconst_bool(false)));
+  out *= bitcast<vec4f>(countTrailingZeros(vec4u(unconst_u32(42), unconst_u32(69), unconst_u32(97), unconst_u32(192))));
+  let vf230: vec2u = select(vec2u(unconst_u32(59), unconst_u32(219)), vec2u(unconst_u32(48), unconst_u32(57)), vec2<bool>(bool(dot(vec3u(unconst_u32(178), unconst_u32(79), unconst_u32(163)), vec3u(unconst_u32(0), unconst_u32(464), unconst_u32(255))))));
+  var vf231: f32 = a1;
+  var vf232: vec2i = a0;
+  let ptr174: ptr<function, vec4f> = &vf226;
+  var vf233: f32 = (*ptr174)[u32(unconst_u32(54))];
+  let ptr175: ptr<function, vec2u> = &vf229;
+  return out;
+}
+
+@fragment
+fn fragment14() -> FragmentOutput10 {
+  var out: FragmentOutput10;
+  var vf234: bool = any(vec3<bool>(unconst_bool(false), unconst_bool(true), unconst_bool(true)));
+  out.f2 *= log2(vec3f(unconst_f32(0.5562), unconst_f32(0.5283), unconst_f32(0.06193))).yx;
+  let vf235: vec4h = ldexp(vec4h(unconst_f16(14665.8), unconst_f16(38201.9), unconst_f16(12808.3), unconst_f16(8287.5)), vec4i(unconst_i32(179), unconst_i32(20), unconst_i32(-11), unconst_i32(-9)));
+  var vf236: vec4h = vf235;
+  out = FragmentOutput10(vec4u(quantizeToF16(vec3f(unconst_f32(0.8469), unconst_f32(0.1715), unconst_f32(0.07882))).xzxy), bitcast<i32>(quantizeToF16(vec3f(unconst_f32(0.8469), unconst_f32(0.1715), unconst_f32(0.07882)))[0]), quantizeToF16(vec3f(unconst_f32(0.8469), unconst_f32(0.1715), unconst_f32(0.07882))).rg);
+  vf234 = bool(textureNumLevels(tex20));
+  let vf237: vec4i = textureLoad(tex20, vec2i(unconst_i32(275), unconst_i32(114)), i32(unconst_i32(203)));
+  let vf238: vec3f = log2(vec3f(unconst_f32(0.01450), unconst_f32(0.1775), unconst_f32(0.02350)));
+  out.f0 &= textureDimensions(tex20).rrrr;
+  var vf239: u32 = pack4xU8(vec4u(unconst_u32(49), unconst_u32(269), unconst_u32(359), unconst_u32(3)));
+  discard;
+  vf234 = override6;
+  let vf240: vec4i = vf237;
+  out.f1 ^= vf240[0];
+  let vf241: u32 = textureNumLevels(tex20);
+  out = FragmentOutput10(vec4u(vf235), vec4i(vf235)[1], bitcast<vec2f>(vf235));
+  out.f0 ^= vec4u(ldexp(vec4h(unconst_f16(-728.5), unconst_f16(404.7), unconst_f16(5786.6), unconst_f16(11560.6)), vec4i(unconst_i32(42), unconst_i32(-406), unconst_i32(102), unconst_i32(129))));
+  var vf242: vec4i = textureLoad(tex20, vec2i(unconst_i32(13), unconst_i32(171)), i32(unconst_i32(501)));
+  return out;
+  _ = override6;
+}
+
+@compute @workgroup_size(1, 1, 2)
+fn compute12() {
+  var vf243: vec4f = ceil(vec4f(unconst_f32(0.05612), unconst_f32(0.1946), unconst_f32(0.3804), unconst_f32(0.07003)));
+  atomicCompareExchangeWeak(&vw33, unconst_i32(60), unconst_i32(13));
+  atomicAnd(&vw33, i32(unconst_i32(115)));
+  atomicAnd(&vw33, i32(unconst_i32(72)));
+  var vf244: u32 = pack4xU8(vec4u(unconst_u32(46), unconst_u32(40), unconst_u32(513), unconst_u32(59)));
+  atomicCompareExchangeWeak(&vw33, unconst_i32(-159), unconst_i32(-154));
+  let vf245: vec2i = countOneBits(vec2i(unconst_i32(95), unconst_i32(112)));
+  let vf246: f32 = asinh(f32(unconst_f32(0.1139)));
+  let vf247: mat4x4h = transpose(mat4x4h());
+  atomicSub(&vw33, bitcast<vec2i>(textureDimensions(tex20))[0]);
+  atomicStore(&vw33, bitcast<vec4i>(ceil(vec4f(unconst_f32(0.04149), unconst_f32(0.00313), unconst_f32(0.09183), unconst_f32(0.2062)))).z);
+  let vf248: i32 = atomicLoad(&vw33);
+  var vf249: f32 = vf243[u32(unconst_u32(410))];
+  let vf250: f16 = vf247[u32(unconst_u32(191))][u32(unconst_u32(330))];
+  vf243 -= vec4f(f32(override5));
+  atomicSub(&vw33, i32(unconst_i32(51)));
+  vf244 ^= u32(override7);
+  let vf251: f32 = vf246;
+  var vf252: f16 = vf250;
+  atomicXor(&vw33, i32(unconst_i32(113)));
+  let vf253: f32 = vf243[u32(unconst_u32(391))];
+  let vf254: u32 = pack4xU8(vec4u(unconst_u32(37), unconst_u32(275), unconst_u32(251), unconst_u32(341)));
+  _ = override7;
+  _ = override5;
+}`,
+  sourceMap: {},
+});
+let buffer154 = device0.createBuffer({
+  label: '\u027d\u786c\u{1fa38}\ud158\ud867\uc8cd\u7a0e',
+  size: 6615,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView193 = texture109.createView({aspect: 'depth-only', mipLevelCount: 1});
+let sampler115 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 80.24,
+  maxAnisotropy: 6,
+});
+try {
+renderPassEncoder6.draw(13, 227, 189_232_570, 552_024_616);
+} catch {}
+try {
+renderPassEncoder6.drawIndexed(236, 24, 41, 627_859_707, 381_397_448);
+} catch {}
+try {
+renderPassEncoder6.drawIndirect(buffer143, 484);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(3, buffer80);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer123, 'uint32', 732, 755);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer119, 56, new DataView(new ArrayBuffer(9083)), 401, 16);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 15, height: 6, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame11,
+  origin: { x: 1, y: 0 },
+  flipY: false,
+}, {
+  texture: texture159,
+  mipLevel: 0,
+  origin: {x: 1, y: 4, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer155 = device0.createBuffer({size: 53493, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let textureView194 = texture35.createView({dimension: 'cube-array', mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 6});
+let sampler116 = device0.createSampler({
+  label: '\u0590\u{1f978}\u0a18',
+  addressModeV: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 17.07,
+  lodMaxClamp: 89.66,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder117.setBindGroup(1, bindGroup77, new Uint32Array(3028), 904, 0);
+} catch {}
+try {
+computePassEncoder161.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(248);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(5, buffer4, 0);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(2, bindGroup63, new Uint32Array(507), 16, 0);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData24 = new ImageData(52, 20);
+let textureView195 = texture178.createView({label: '\u{1f9fb}\u8de1\u69fe\u1a21\u18b1\u0005', aspect: 'all', baseArrayLayer: 3, arrayLayerCount: 3});
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup24);
+} catch {}
+try {
+renderPassEncoder16.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer127, 'uint16', 308, 89);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(2, bindGroup39);
+} catch {}
+let querySet19 = device0.createQuerySet({type: 'occlusion', count: 670});
+let texture190 = device0.createTexture({size: [332, 1, 1], format: 'r16uint', usage: GPUTextureUsage.COPY_DST, viewFormats: ['r16uint']});
+try {
+renderPassEncoder11.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(3, bindGroup28, new Uint32Array(886), 207, 0);
+} catch {}
+let textureView196 = texture29.createView({});
+let renderBundle27 = renderBundleEncoder27.finish();
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup77);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup12, new Uint32Array(1971), 371, 2);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(91);
+} catch {}
+let arrayBuffer29 = buffer71.getMappedRange(2112, 120);
+document.body.prepend(canvas1);
+let buffer156 = device0.createBuffer({size: 6856, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let commandEncoder175 = device0.createCommandEncoder();
+let computePassEncoder162 = commandEncoder175.beginComputePass({});
+try {
+computePassEncoder94.setBindGroup(2, bindGroup1, new Uint32Array(2718), 646, 0);
+} catch {}
+try {
+computePassEncoder162.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup88);
+} catch {}
+try {
+renderPassEncoder13.beginOcclusionQuery(6);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(376).fill(223), /* required buffer size: 376 */
+{offset: 376}, {width: 32, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer157 = device0.createBuffer({
+  label: '\u0c42\ucf9b\u9c75\uc3ae\ud34b\u7100\u5174\u0ab1\u892d',
+  size: 575,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE,
+});
+let texture191 = device0.createTexture({
+  size: {width: 10, height: 9, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView197 = texture188.createView({mipLevelCount: 1});
+let textureView198 = texture96.createView({mipLevelCount: 1});
+let sampler117 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 18.91,
+  lodMaxClamp: 42.28,
+  compare: 'less-equal',
+  maxAnisotropy: 13,
+});
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup28);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup26, new Uint32Array(6892), 133, 0);
+} catch {}
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle5, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer136, 'uint32', 1_080, 660);
+} catch {}
+let bindGroup102 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 59, resource: sampler12}]});
+let buffer158 = device0.createBuffer({size: 7395, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder176 = device0.createCommandEncoder({});
+let computePassEncoder163 = commandEncoder176.beginComputePass({});
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup98, new Uint32Array(901), 42, 0);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle10, renderBundle21, renderBundle18]);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(2, buffer127, 0, 209);
+} catch {}
+try {
+sampler58.label = '\u0ef6\u7997\u847b\u00ff\u3aa4\u{1fe48}\u2b47\u263a\u06d3\ue6f0';
+} catch {}
+let buffer159 = device0.createBuffer({
+  size: 11452,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let textureView199 = texture167.createView({dimension: '2d-array', format: 'rgba16float', arrayLayerCount: 1});
+let texture192 = device0.createTexture({
+  label: '\u691f\u0cb5\u{1fd4d}\u{1fb8c}\u0251\u0b84\ub010\u01bf\u772d\u{1f6dc}\u0079',
+  size: [10, 9, 16],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r8sint'],
+});
+try {
+computePassEncoder36.setBindGroup(0, bindGroup93);
+} catch {}
+try {
+computePassEncoder163.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder13.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(2, buffer155, 0, 6_750);
+} catch {}
+let arrayBuffer30 = buffer2.getMappedRange(784, 64);
+try {
+device0.queue.writeTexture({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(149).fill(211), /* required buffer size: 149 */
+{offset: 149}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup103 = device0.createBindGroup({
+  label: '\u82f6\u0cbb\u1238\u943a\u09e1\u{1ff02}\u0898\u763e\u{1fd17}\u0f7b\u1793',
+  layout: bindGroupLayout9,
+  entries: [{binding: 37, resource: {buffer: buffer1, offset: 0, size: 1996}}],
+});
+let texture193 = device0.createTexture({
+  label: '\uea47\ucbba\u4117\uf44a\u8631\u0eb2\u5439\u304a\u{1fcba}',
+  size: {width: 120},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+renderPassEncoder6.end();
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(5, buffer120);
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let commandEncoder177 = device0.createCommandEncoder({});
+let computePassEncoder164 = commandEncoder99.beginComputePass({});
+let sampler118 = device0.createSampler({
+  label: '\u{1fb56}\u{1f659}\ufba2\u8e98\u{1f861}\ucca5\u0ba0\ueb10',
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 55.00,
+  lodMaxClamp: 58.30,
+  compare: 'not-equal',
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup84);
+} catch {}
+try {
+renderPassEncoder16.beginOcclusionQuery(944);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(4, buffer159);
+} catch {}
+try {
+commandEncoder177.copyBufferToTexture({
+  /* bytesInLastRow: 6 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 777 */
+  offset: 777,
+  bytesPerRow: 11520,
+  rowsPerImage: 636,
+  buffer: buffer110,
+}, {
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer160 = device0.createBuffer({size: 6537, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX});
+try {
+computePassEncoder18.setBindGroup(2, bindGroup71, new Uint32Array(330), 110, 0);
+} catch {}
+try {
+computePassEncoder164.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder177.copyBufferToTexture({
+  /* bytesInLastRow: 64 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 256 */
+  offset: 256,
+  bytesPerRow: 14336,
+  buffer: buffer100,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 16, z: 0},
+  aspect: 'all',
+}, {width: 32, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture194 = device0.createTexture({size: [20, 19, 1], format: 'depth24plus', usage: GPUTextureUsage.COPY_SRC});
+let textureView200 = texture7.createView({mipLevelCount: 1});
+let computePassEncoder165 = commandEncoder177.beginComputePass({});
+try {
+computePassEncoder165.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer105, 'uint16', 48, 521);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(0, buffer52, 0, 1_575);
+} catch {}
+try {
+device0.queue.submit([commandBuffer11]);
+} catch {}
+let texture195 = device0.createTexture({
+  label: '\ud907\u{1f6bd}\udc9c\u0657\u{1fe62}\u6609',
+  size: [166, 1, 7],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder15.setIndexBuffer(buffer123, 'uint32', 11_376, 1_151);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(3, buffer80, 0, 2_111);
+} catch {}
+let bindGroup104 = device0.createBindGroup({
+  layout: bindGroupLayout21,
+  entries: [
+    {binding: 425, resource: textureView100},
+    {binding: 215, resource: textureView37},
+    {binding: 231, resource: textureView180},
+    {binding: 327, resource: textureView181},
+    {binding: 592, resource: sampler10},
+    {binding: 0, resource: {buffer: buffer51, offset: 768}},
+    {binding: 42, resource: textureView183},
+    {binding: 51, resource: textureView18},
+    {binding: 416, resource: sampler44},
+    {binding: 453, resource: {buffer: buffer113, offset: 1024, size: 2500}},
+    {binding: 72, resource: {buffer: buffer19, offset: 1280, size: 1112}},
+    {binding: 9, resource: textureView124},
+  ],
+});
+let buffer161 = device0.createBuffer({
+  size: 2047,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder178 = device0.createCommandEncoder();
+let sampler119 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 46.95,
+  lodMaxClamp: 60.67,
+});
+try {
+computePassEncoder100.setBindGroup(1, bindGroup20, new Uint32Array(434), 19, 0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup50);
+} catch {}
+try {
+commandEncoder178.copyBufferToBuffer(buffer22, 808, buffer107, 2284, 168);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipelineLayout17 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder179 = device0.createCommandEncoder({label: '\u9ad4\udd95\uab62\u8bc7\u8838\u2d05\u5cd7'});
+try {
+computePassEncoder60.setBindGroup(3, bindGroup16, [256, 0]);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup54);
+} catch {}
+try {
+renderPassEncoder16.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder178.copyBufferToTexture({
+  /* bytesInLastRow: 208 widthInBlocks: 52 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 512 */
+  offset: 512,
+  rowsPerImage: 287,
+  buffer: buffer113,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 52, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise29 = device0.queue.onSubmittedWorkDone();
+let videoFrame26 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'rgb', primaries: 'jedecP22Phosphors', transfer: 'iec6196624'} });
+let buffer162 = device0.createBuffer({size: 13767, usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let texture196 = device0.createTexture({
+  label: '\u{1f77e}\u8410\u698c',
+  size: {width: 30},
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder166 = commandEncoder178.beginComputePass();
+try {
+computePassEncoder162.setBindGroup(1, bindGroup87, new Uint32Array(1673), 393, 0);
+} catch {}
+try {
+computePassEncoder166.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer161, 'uint16', 468, 241);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let imageData25 = new ImageData(72, 12);
+let bindGroup105 = device0.createBindGroup({
+  label: '\u3d0e\u0951\u28a0\u358b\ue8bc\ufd4c',
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 35, resource: {buffer: buffer55, offset: 256, size: 424}},
+    {binding: 60, resource: textureView198},
+  ],
+});
+let commandEncoder180 = device0.createCommandEncoder();
+let texture197 = device0.createTexture({
+  size: [40, 39, 1],
+  mipLevelCount: 3,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView201 = texture173.createView({mipLevelCount: 2});
+let sampler120 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 73.11,
+  lodMaxClamp: 89.70,
+  compare: 'never',
+});
+try {
+renderPassEncoder13.executeBundles([renderBundle17]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(774).fill(86), /* required buffer size: 774 */
+{offset: 142, bytesPerRow: 40, rowsPerImage: 25}, {width: 16, height: 16, depthOrArrayLayers: 1});
+} catch {}
+let texture198 = device0.createTexture({
+  size: {width: 40, height: 39, depthOrArrayLayers: 1},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder8.setIndexBuffer(buffer144, 'uint32', 632, 544);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(6, buffer119, 0, 5);
+} catch {}
+try {
+buffer78.unmap();
+} catch {}
+try {
+commandEncoder180.copyBufferToTexture({
+  /* bytesInLastRow: 160 widthInBlocks: 40 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1120 */
+  offset: 1120,
+  bytesPerRow: 3584,
+  buffer: buffer113,
+}, {
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 1, y: 10, z: 0},
+  aspect: 'all',
+}, {width: 40, height: 14, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder180.copyTextureToTexture({
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 665, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 332, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData23,
+  origin: { x: 3, y: 0 },
+  flipY: true,
+}, {
+  texture: texture166,
+  mipLevel: 0,
+  origin: {x: 53, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer22.detached) { new Uint8Array(arrayBuffer22).fill(0x55); };
+} catch {}
+document.body.prepend(img0);
+let commandEncoder181 = device0.createCommandEncoder({});
+let textureView202 = texture29.createView({label: '\u42e1\u587b\u0384\uccc4', aspect: 'all', format: 'rgb10a2uint'});
+let computePassEncoder167 = commandEncoder179.beginComputePass();
+let renderPassEncoder18 = commandEncoder180.beginRenderPass({
+  label: '\u04fc\ud549',
+  colorAttachments: [{
+  view: textureView70,
+  clearValue: { r: 977.2, g: -100.2, b: 151.8, a: 193.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {view: textureView146, stencilClearValue: 15882, stencilLoadOp: 'load', stencilStoreOp: 'store'},
+});
+try {
+computePassEncoder63.setBindGroup(2, bindGroup16, new Uint32Array(3491), 568, 2);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(1, bindGroup39, new Uint32Array(2652), 3, 0);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer135, 'uint16', 848, 2_406);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(0, buffer24);
+} catch {}
+document.body.prepend(canvas1);
+let buffer163 = device0.createBuffer({
+  label: '\u5048\ud65e\u10ae\u22f3\u9dd5',
+  size: 12152,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX,
+});
+let textureView203 = texture195.createView({label: '\ue841\u2c24\uc9af\u{1f959}', mipLevelCount: 1, arrayLayerCount: 1});
+let renderPassEncoder19 = commandEncoder181.beginRenderPass({
+  label: '\u8ec0\u7a15\u36bc\u0774\ufa85\u9bb7\u059b',
+  colorAttachments: [{view: textureView58, depthSlice: 58, loadOp: 'clear', storeOp: 'store'}],
+});
+try {
+renderPassEncoder19.setIndexBuffer(buffer127, 'uint32', 392, 21);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline12);
+} catch {}
+let bindGroup106 = device0.createBindGroup({layout: bindGroupLayout19, entries: [{binding: 10, resource: textureView70}]});
+let commandEncoder182 = device0.createCommandEncoder();
+let texture199 = device0.createTexture({
+  size: {width: 60, height: 24, depthOrArrayLayers: 9},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder168 = commandEncoder182.beginComputePass({label: '\u41a5\ue62b\uc867\u{1fc66}\u1e99\u{1ffa4}\u{1ff67}\u{1fd6f}\u63ff\u{1fb3c}\u0edb'});
+try {
+computePassEncoder50.setBindGroup(2, bindGroup9, new Uint32Array(448), 212, 2);
+} catch {}
+try {
+computePassEncoder167.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup73, new Uint32Array(1431), 115, 0);
+} catch {}
+try {
+renderPassEncoder7.setViewport(12.442012472982773, 16.18515816939398, 2.208328123839761, 2.2702010932284464, 0.704963128948597, 0.8437835024516316);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 332, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture166,
+  mipLevel: 0,
+  origin: {x: 98, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+globalThis.someLabel = externalTexture8.label;
+} catch {}
+let commandEncoder183 = device0.createCommandEncoder({});
+let querySet20 = device0.createQuerySet({type: 'occlusion', count: 1738});
+let texture200 = device0.createTexture({
+  size: {width: 30},
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder169 = commandEncoder183.beginComputePass();
+try {
+renderPassEncoder3.setIndexBuffer(buffer139, 'uint32', 824, 571);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline7);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(422).fill(150), /* required buffer size: 422 */
+{offset: 422, rowsPerImage: 6}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame27 = videoFrame25.clone();
+let commandEncoder184 = device0.createCommandEncoder();
+let computePassEncoder170 = commandEncoder184.beginComputePass();
+try {
+computePassEncoder169.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder8.beginOcclusionQuery(49);
+} catch {}
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer121, 'uint32', 156, 595);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer135);
+} catch {}
+try {
+  await promise29;
+} catch {}
+let textureView204 = texture76.createView({});
+let sampler121 = device0.createSampler({
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 32.09,
+  lodMaxClamp: 77.99,
+  compare: 'less',
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder144.setBindGroup(0, bindGroup19, new Uint32Array(2217), 64, 0);
+} catch {}
+try {
+computePassEncoder168.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup97);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer56, 'uint32', 1_116, 1_610);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame28 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'smpte240m', transfer: 'bt1361ExtendedColourGamut'} });
+let buffer164 = device0.createBuffer({
+  size: 14317,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder185 = device0.createCommandEncoder({});
+let texture201 = gpuCanvasContext4.getCurrentTexture();
+let externalTexture20 = device0.importExternalTexture({source: videoFrame24});
+try {
+computePassEncoder120.setBindGroup(2, bindGroup65, new Uint32Array(864), 98, 0);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup98, new Uint32Array(503), 5, 0);
+} catch {}
+document.body.prepend(canvas0);
+let buffer165 = device0.createBuffer({
+  size: 26142,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let commandEncoder186 = device0.createCommandEncoder();
+let computePassEncoder171 = commandEncoder185.beginComputePass();
+try {
+computePassEncoder72.setBindGroup(1, bindGroup50, new Uint32Array(4445), 109, 0);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline5);
+} catch {}
+try {
+commandEncoder186.copyBufferToTexture({
+  /* bytesInLastRow: 22 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 3322 */
+  offset: 3322,
+  rowsPerImage: 227,
+  buffer: buffer4,
+}, {
+  texture: texture119,
+  mipLevel: 0,
+  origin: {x: 0, y: 9, z: 0},
+  aspect: 'all',
+}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder160.pushDebugGroup('\u54be');
+} catch {}
+let promise30 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise30;
+} catch {}
+let bindGroup107 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 236, resource: sampler15}]});
+try {
+computePassEncoder11.setBindGroup(0, bindGroup56, new Uint32Array(2598), 749, 2);
+} catch {}
+try {
+computePassEncoder171.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle21, renderBundle10]);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(5, buffer70, 2_420, 501);
+} catch {}
+try {
+commandEncoder186.copyBufferToTexture({
+  /* bytesInLastRow: 18 widthInBlocks: 18 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 468 */
+  offset: 468,
+  rowsPerImage: 251,
+  buffer: buffer8,
+}, {
+  texture: texture200,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 18, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture202 = device0.createTexture({
+  size: [1330, 1, 62],
+  mipLevelCount: 2,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder94.setBindGroup(3, bindGroup73);
+} catch {}
+try {
+computePassEncoder170.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(3, buffer159, 912, 99);
+} catch {}
+try {
+commandEncoder186.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 60 */
+  offset: 60,
+  bytesPerRow: 11008,
+  rowsPerImage: 293,
+  buffer: buffer64,
+}, {
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise31 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise31;
+} catch {}
+await gc();
+let textureView205 = texture178.createView({aspect: 'all', baseArrayLayer: 9, arrayLayerCount: 1});
+let computePassEncoder172 = commandEncoder186.beginComputePass({});
+try {
+computePassEncoder111.setBindGroup(2, bindGroup49);
+} catch {}
+try {
+computePassEncoder172.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup41);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer153, 'uint16', 3_638, 3_027);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(7, buffer161, 196, 452);
+} catch {}
+try {
+computePassEncoder160.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let externalTexture21 = device0.importExternalTexture({source: videoFrame10});
+try {
+renderPassEncoder17.executeBundles([renderBundle9, renderBundle10]);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(5, buffer151, 708, 37);
+} catch {}
+try {
+if (!arrayBuffer16.detached) { new Uint8Array(arrayBuffer16).fill(0x55); };
+} catch {}
+document.body.prepend(img1);
+let buffer166 = device0.createBuffer({
+  size: 11847,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let querySet21 = device0.createQuerySet({type: 'occlusion', count: 111});
+let textureView206 = texture0.createView({label: '\u8976\u0ef8\udefd\uf4f1\u72f9\u0d6b\u02b5', dimension: '2d-array', baseArrayLayer: 0});
+try {
+renderPassEncoder19.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder13.setViewport(10.974606433766677, 2.6533717626097135, 2.8987225460208403, 2.272360068047134, 0.44064705143683236, 0.8699598306232104);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer67, 'uint32', 7_000, 911);
+} catch {}
+await gc();
+let commandEncoder187 = device0.createCommandEncoder({});
+let commandBuffer12 = commandEncoder187.finish();
+let texture203 = device0.createTexture({
+  size: [60, 24, 1],
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView207 = texture203.createView({});
+let sampler122 = device0.createSampler({
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 95.88,
+  lodMaxClamp: 95.95,
+});
+try {
+computePassEncoder139.setBindGroup(0, bindGroup81);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(2, bindGroup24);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(0, buffer145);
+} catch {}
+let arrayBuffer31 = buffer2.getMappedRange(736, 12);
+try {
+device0.queue.writeBuffer(buffer3, 2308, new BigUint64Array(2002), 202, 420);
+} catch {}
+let commandEncoder188 = device0.createCommandEncoder({});
+let renderBundleEncoder28 = device0.createRenderBundleEncoder({colorFormats: ['r8sint'], depthReadOnly: true});
+let renderBundle28 = renderBundleEncoder28.finish();
+try {
+renderPassEncoder13.setBlendConstant({ r: 275.2, g: -50.23, b: -639.6, a: -935.2, });
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(4, buffer55, 0, 290);
+} catch {}
+let bindGroup108 = device0.createBindGroup({layout: bindGroupLayout19, entries: [{binding: 10, resource: textureView133}]});
+let buffer167 = device0.createBuffer({
+  size: 21661,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let querySet22 = device0.createQuerySet({
+  label: '\u0835\u1bd3\u9c8a\u006f\u03ed\u0cde\ud40d\u06cd\u217d\u{1ffa6}',
+  type: 'occlusion',
+  count: 638,
+});
+let textureView208 = texture110.createView({dimension: '2d', baseArrayLayer: 0});
+let computePassEncoder173 = commandEncoder188.beginComputePass({});
+let externalTexture22 = device0.importExternalTexture({source: videoFrame7});
+try {
+computePassEncoder63.setBindGroup(3, bindGroup26);
+} catch {}
+try {
+computePassEncoder36.setBindGroup(1, bindGroup29, new Uint32Array(470), 41, 0);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup45);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer139, 'uint16', 672, 365);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 54, height: 141, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData11,
+  origin: { x: 15, y: 0 },
+  flipY: true,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 9, y: 11, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder189 = device0.createCommandEncoder({});
+try {
+computePassEncoder95.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder173.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup41, new Uint32Array(758), 33, 0);
+} catch {}
+try {
+renderPassEncoder16.setBlendConstant({ r: -648.0, g: -992.4, b: 816.4, a: -134.7, });
+} catch {}
+let pipeline13 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout10,
+  fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment11',
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule11,
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x4', offset: 360, shaderLocation: 11}],
+      },
+    ],
+  },
+});
+let buffer168 = device0.createBuffer({
+  size: 5531,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder36.setBindGroup(1, bindGroup85);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup97, new Uint32Array(145), 89, 0);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer55, 'uint16', 68, 1_205);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline12);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let texture204 = device0.createTexture({
+  size: [10, 9, 1],
+  mipLevelCount: 1,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder174 = commandEncoder189.beginComputePass({label: '\u2bd9\u06ae\u94b5\uef67'});
+try {
+computePassEncoder146.setBindGroup(2, bindGroup58);
+} catch {}
+try {
+computePassEncoder174.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(1, 1, 0, 3);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer168, 'uint32', 732, 2_146);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup109 = device0.createBindGroup({
+  layout: bindGroupLayout16,
+  entries: [
+    {binding: 209, resource: {buffer: buffer164, offset: 0, size: 7040}},
+    {binding: 254, resource: {buffer: buffer159, offset: 0}},
+    {binding: 222, resource: textureView128},
+    {binding: 282, resource: textureView108},
+    {binding: 80, resource: externalTexture11},
+    {binding: 92, resource: {buffer: buffer165, offset: 2560, size: 5835}},
+    {binding: 999, resource: textureView91},
+    {binding: 155, resource: textureView75},
+    {binding: 63, resource: sampler117},
+    {binding: 360, resource: textureView106},
+    {binding: 182, resource: textureView139},
+    {binding: 732, resource: textureView72},
+    {binding: 28, resource: textureView118},
+    {binding: 9, resource: textureView55},
+  ],
+});
+let commandEncoder190 = device0.createCommandEncoder();
+let computePassEncoder175 = commandEncoder190.beginComputePass({label: '\u658d\u0060\u0cce\uede5'});
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup87, []);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup110 = device0.createBindGroup({layout: bindGroupLayout5, entries: [{binding: 65, resource: textureView9}]});
+let commandEncoder191 = device0.createCommandEncoder({label: '\u{1fc1a}\u11ac\u3b55\u{1fd0a}\u03f5\u2cef\ua6f1'});
+let texture205 = device0.createTexture({
+  label: '\u5f2e\ucd7d',
+  size: [60, 24, 1],
+  mipLevelCount: 1,
+  sampleCount: 4,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler123 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 31.88,
+  lodMaxClamp: 99.96,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder4.setBindGroup(1, bindGroup2, new Uint32Array(107), 15, 0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup69);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(5, buffer135, 0);
+} catch {}
+let bindGroupLayout23 = device0.createBindGroupLayout({
+  label: '\ua99d\u773d\u0f8a\u74fa\u05e7\u3894\u96c2\u{1f94d}\uda2c\u09bf',
+  entries: [
+    {
+      binding: 71,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 388,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let commandEncoder192 = device0.createCommandEncoder();
+let computePassEncoder176 = commandEncoder192.beginComputePass({});
+try {
+computePassEncoder99.setBindGroup(1, bindGroup73, new Uint32Array(1460), 263, 0);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle4, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(6, buffer162);
+} catch {}
+let arrayBuffer32 = buffer2.getMappedRange(848, 0);
+try {
+commandEncoder191.copyBufferToBuffer(buffer150, 44, buffer23, 436, 72);
+} catch {}
+let imageData26 = new ImageData(16, 12);
+let bindGroup111 = device0.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [{binding: 385, resource: {buffer: buffer113, offset: 2560, size: 1164}}],
+});
+let buffer169 = device0.createBuffer({
+  label: '\u{1fdb1}\u0a56\u043f\u0ad4\u280e\u296a\u{1fd0c}\u4a55\ueea5\u531f\u1fd2',
+  size: 5977,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let texture206 = device0.createTexture({
+  size: {width: 332, height: 1, depthOrArrayLayers: 43},
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder9.setBindGroup(2, bindGroup81, new Uint32Array(2669), 248, 0);
+} catch {}
+try {
+computePassEncoder175.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.submit([commandBuffer12]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture151,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'depth-only',
+}, new Uint8Array(5).fill(85), /* required buffer size: 5 */
+{offset: 5}, {width: 166, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup112 = device0.createBindGroup({
+  layout: bindGroupLayout21,
+  entries: [
+    {binding: 0, resource: {buffer: buffer139, offset: 0}},
+    {binding: 42, resource: textureView190},
+    {binding: 51, resource: textureView18},
+    {binding: 215, resource: textureView32},
+    {binding: 327, resource: textureView205},
+    {binding: 425, resource: textureView139},
+    {binding: 592, resource: sampler84},
+    {binding: 453, resource: {buffer: buffer151, offset: 256, size: 168}},
+    {binding: 416, resource: sampler34},
+    {binding: 231, resource: textureView194},
+    {binding: 9, resource: textureView69},
+    {binding: 72, resource: {buffer: buffer100, offset: 512, size: 1580}},
+  ],
+});
+let buffer170 = device0.createBuffer({
+  size: 3526,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture207 = device0.createTexture({
+  size: [16, 16, 13],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder177 = commandEncoder191.beginComputePass({});
+try {
+computePassEncoder12.setBindGroup(3, bindGroup63, new Uint32Array(2345), 68, 0);
+} catch {}
+try {
+computePassEncoder177.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(2, buffer134);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture185,
+  mipLevel: 1,
+  origin: {x: 13, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(377).fill(96), /* required buffer size: 377 */
+{offset: 377, bytesPerRow: 74}, {width: 4, height: 5, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 39, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData9,
+  origin: { x: 0, y: 4 },
+  flipY: true,
+}, {
+  texture: texture167,
+  mipLevel: 0,
+  origin: {x: 1, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 12, depthOrArrayLayers: 0});
+} catch {}
+let texture208 = device0.createTexture({
+  size: [20, 19, 1],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder29 = device0.createRenderBundleEncoder({colorFormats: ['r8sint'], stencilReadOnly: true});
+try {
+computePassEncoder176.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder8.beginOcclusionQuery(200);
+} catch {}
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(6, buffer162, 1_056);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let bindGroup113 = device0.createBindGroup({layout: bindGroupLayout5, entries: [{binding: 65, resource: textureView20}]});
+let texture209 = device0.createTexture({
+  size: {width: 120, height: 48, depthOrArrayLayers: 21},
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture210 = device0.createTexture({
+  size: {width: 332, height: 1, depthOrArrayLayers: 22},
+  mipLevelCount: 3,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView209 = texture182.createView({label: '\u057c\u04ec\u10b0\ufb74\u9110\u0f61'});
+let renderBundle29 = renderBundleEncoder29.finish({label: '\u{1f841}\u{1ff42}\uf4d0\u1052\u1fff'});
+let sampler124 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 73.56,
+  lodMaxClamp: 91.56,
+  compare: 'greater-equal',
+  maxAnisotropy: 16,
+});
+let texture211 = device0.createTexture({
+  size: [1330, 1, 66],
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView210 = texture49.createView({});
+try {
+computePassEncoder36.setBindGroup(2, bindGroup74, new Uint32Array(1985), 5, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup99);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(1, buffer66);
+} catch {}
+try {
+gpuCanvasContext4.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.COPY_DST, colorSpace: 'display-p3'});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 2, y: 23, z: 50},
+  aspect: 'all',
+}, new Uint8Array(158_961).fill(30), /* required buffer size: 158_961 */
+{offset: 112, bytesPerRow: 61, rowsPerImage: 22}, {width: 5, height: 9, depthOrArrayLayers: 119});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let bindGroup114 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 50, resource: {buffer: buffer23, offset: 2048, size: 2372}},
+    {binding: 283, resource: {buffer: buffer144, offset: 512, size: 952}},
+    {binding: 66, resource: {buffer: buffer23, offset: 512, size: 57}},
+    {binding: 39, resource: textureView140},
+    {binding: 49, resource: textureView18},
+    {binding: 452, resource: textureView54},
+    {binding: 294, resource: textureView17},
+    {binding: 41, resource: textureView28},
+    {binding: 13, resource: {buffer: buffer87, offset: 256}},
+    {binding: 26, resource: {buffer: buffer98, offset: 512, size: 1072}},
+    {binding: 125, resource: textureView119},
+  ],
+});
+let commandEncoder193 = device0.createCommandEncoder({});
+let texture212 = device0.createTexture({
+  size: {width: 30, height: 12, depthOrArrayLayers: 43},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder178 = commandEncoder193.beginComputePass({});
+let sampler125 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 63.97,
+  compare: 'greater',
+});
+try {
+computePassEncoder24.setBindGroup(3, bindGroup43);
+} catch {}
+try {
+computePassEncoder32.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle4, renderBundle21]);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer67, 'uint16', 20, 2_239);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline5);
+} catch {}
+let pipeline14 = device0.createRenderPipeline({
+  layout: pipelineLayout7,
+  fragment: {
+  module: shaderModule13,
+  constants: {44_182: 0},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule13,
+    entryPoint: 'vertex14',
+    buffers: [
+      {
+        arrayStride: 252,
+        attributes: [
+          {format: 'sint32', offset: 8, shaderLocation: 9},
+          {format: 'unorm10-10-10-2', offset: 60, shaderLocation: 11},
+          {format: 'unorm8x2', offset: 26, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'cw', cullMode: 'front'},
+});
+let commandEncoder194 = device0.createCommandEncoder();
+let computePassEncoder179 = commandEncoder194.beginComputePass({label: '\u0c21\u0fe4\u{1f70f}\u{1fa48}\uf77b\u0503'});
+try {
+renderPassEncoder15.setBindGroup(1, bindGroup92, new Uint32Array(1749), 1_129, 0);
+} catch {}
+try {
+gpuCanvasContext6.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.STORAGE_BINDING, alphaMode: 'opaque'});
+} catch {}
+let bindGroup115 = device0.createBindGroup({
+  layout: bindGroupLayout17,
+  entries: [{binding: 219, resource: {buffer: buffer170, offset: 0, size: 168}}],
+});
+try {
+computePassEncoder40.setBindGroup(3, bindGroup86);
+} catch {}
+try {
+computePassEncoder178.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup15, [3840, 0]);
+} catch {}
+try {
+renderPassEncoder13.setViewport(9.891040874322618, 1.1981510292141628, 3.6793032616277643, 1.5204201355924596, 0.6466796252983051, 0.8913402077024096);
+} catch {}
+let pipeline15 = device0.createComputePipeline({layout: pipelineLayout3, compute: {module: shaderModule4}});
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let shaderModule14 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires pointer_composite_access;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(83) var<storage, read_write> buffer171: array<array<array<FragmentOutput11, 5>, 1>, 2>;
+
+@group(0) @binding(232) var<storage, read> buffer172: array<f32>;
+
+struct T0 {
+  @align(16) @size(80) f0: array<mat2x2h>,
+}
+
+struct T1 {
+  @size(80) f0: array<mat3x2f>,
+}
+
+struct T2 {
+  @align(16) @size(80) f0: array<array<i32, 1>>,
+}
+
+struct FragmentOutput11 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) @interpolate(flat, centroid) f1: i32,
+}
+
+fn fn0() -> vec2f {
+  var out: vec2f;
+  vp25 = mat4x3h(vec3h(reverseBits(vec2i(unconst_i32(77), unconst_i32(45))).xxy), vec3h(reverseBits(vec2i(unconst_i32(77), unconst_i32(45))).xxx), vec3h(reverseBits(vec2i(unconst_i32(77), unconst_i32(45))).xyx), vec3h(reverseBits(vec2i(unconst_i32(77), unconst_i32(45))).yyy));
+  let vf255: u32 = pack4xI8Clamp(vec4i(unconst_i32(379), unconst_i32(0), unconst_i32(-93), unconst_i32(53)));
+  vp25 += mat4x3h(f16(buffer172[arrayLength(&buffer172)]), f16(buffer172[arrayLength(&buffer172)]), f16(buffer172[arrayLength(&buffer172)]), f16(buffer172[arrayLength(&buffer172)]), f16(buffer172[arrayLength(&buffer172)]), f16(buffer172[arrayLength(&buffer172)]), f16(buffer172[arrayLength(&buffer172)]), f16(buffer172[arrayLength(&buffer172)]), f16(buffer172[arrayLength(&buffer172)]), f16(buffer172[arrayLength(&buffer172)]), f16(buffer172[arrayLength(&buffer172)]), f16(buffer172[arrayLength(&buffer172)]));
+  out = vec2f(f32(extractBits(i32(unconst_i32(539)), u32(unconst_u32(10)), u32(unconst_u32(336)))));
+  let ptr176: ptr<storage, array<f32>, read> = &(*&buffer172);
+  let vf256: vec4h = vp26[u32(unconst_u32(62))];
+  var vf257: bool = any(vec4<bool>(unconst_bool(false), unconst_bool(false), unconst_bool(false), unconst_bool(false)));
+  let ptr177: ptr<storage, array<f32>, read> = &buffer172;
+  vp26 = mat2x4h(f16((*&buffer172)[i32(unconst_i32(439))]), f16((*&buffer172)[i32(unconst_i32(439))]), f16((*&buffer172)[i32(unconst_i32(439))]), f16((*&buffer172)[i32(unconst_i32(439))]), f16((*&buffer172)[i32(unconst_i32(439))]), f16((*&buffer172)[i32(unconst_i32(439))]), f16((*&buffer172)[i32(unconst_i32(439))]), f16((*&buffer172)[i32(unconst_i32(439))]));
+  let ptr178: ptr<storage, f32, read> = &buffer172[u32(unconst_u32(214))];
+  vp25 = mat4x3h(f16((*ptr178)), f16((*ptr178)), f16((*ptr178)), f16((*ptr178)), f16((*ptr178)), f16((*ptr178)), f16((*ptr178)), f16((*ptr178)), f16((*ptr178)), f16((*ptr178)), f16((*ptr178)), f16((*ptr178)));
+  var vf258: u32 = vf255;
+  let ptr179: ptr<storage, f32, read> = &(*&buffer172)[u32(unconst_u32(591))];
+  var vf259: vec2f = unpack2x16unorm(u32(unconst_u32(64)));
+  vf259 = vec2f((*ptr177)[arrayLength(&(*ptr177))]);
+  vf257 = bool(vp26[u32(unconst_u32(197))][u32(unconst_u32(347))]);
+  vp25 -= mat4x3h(f16((*ptr177)[i32(unconst_i32(44))]), f16((*ptr177)[i32(unconst_i32(44))]), f16((*ptr177)[i32(unconst_i32(44))]), f16((*ptr177)[i32(unconst_i32(44))]), f16((*ptr177)[i32(unconst_i32(44))]), f16((*ptr177)[i32(unconst_i32(44))]), f16((*ptr177)[i32(unconst_i32(44))]), f16((*ptr177)[i32(unconst_i32(44))]), f16((*ptr177)[i32(unconst_i32(44))]), f16((*ptr177)[i32(unconst_i32(44))]), f16((*ptr177)[i32(unconst_i32(44))]), f16((*ptr177)[i32(unconst_i32(44))]));
+  let ptr180: ptr<storage, array<f32>, read> = &(*ptr176);
+  out = vec2f((*ptr180)[u32(unconst_u32(15))]);
+  out = vec2f((*ptr176)[arrayLength(&(*ptr176))]);
+  let vf260: vec4f = unpack4x8snorm(u32((*ptr178)));
+  out -= vec2f(buffer172[i32(unconst_i32(147))]);
+  return out;
+}
+
+fn fn1() -> i32 {
+  var out: i32;
+  vp26 = mat2x4h(f16((*&buffer172)[arrayLength(&(*&buffer172))]), f16((*&buffer172)[arrayLength(&(*&buffer172))]), f16((*&buffer172)[arrayLength(&(*&buffer172))]), f16((*&buffer172)[arrayLength(&(*&buffer172))]), f16((*&buffer172)[arrayLength(&(*&buffer172))]), f16((*&buffer172)[arrayLength(&(*&buffer172))]), f16((*&buffer172)[arrayLength(&(*&buffer172))]), f16((*&buffer172)[arrayLength(&(*&buffer172))]));
+  vp26 = mat2x4h(bitcast<vec4h>(countOneBits(vec2i(unconst_i32(147), unconst_i32(599)))), bitcast<vec4h>(countOneBits(vec2i(unconst_i32(147), unconst_i32(599)))));
+  vp26 += mat2x4h(bitcast<vec4h>(countOneBits(vec2i(unconst_i32(332), unconst_i32(338)))), bitcast<vec4h>(countOneBits(vec2i(unconst_i32(332), unconst_i32(338)))));
+  let ptr181: ptr<private, mat4x3h> = &vp25;
+  out = bitcast<i32>(buffer172[u32(unconst_u32(108))]);
+  vp26 = mat2x4h(f16((*&buffer172)[i32(unconst_i32(67))]), f16((*&buffer172)[i32(unconst_i32(67))]), f16((*&buffer172)[i32(unconst_i32(67))]), f16((*&buffer172)[i32(unconst_i32(67))]), f16((*&buffer172)[i32(unconst_i32(67))]), f16((*&buffer172)[i32(unconst_i32(67))]), f16((*&buffer172)[i32(unconst_i32(67))]), f16((*&buffer172)[i32(unconst_i32(67))]));
+  let ptr182: ptr<private, mat4x3h> = &vp25;
+  let vf261: vec3h = vp25[u32(unconst_u32(54))];
+  var vf262: vec2f = pow(vec2f(unconst_f32(0.06033), unconst_f32(0.02658)), vec2f(unconst_f32(0.04457), unconst_f32(0.2799)));
+  out -= i32((*ptr181)[u32(unconst_u32(286))][u32(unconst_u32(427))]);
+  vf262 = vec2f((*ptr181)[unconst_i32(1)].yy);
+  vp26 = mat2x4h(f16(buffer172[arrayLength(&buffer172)]), f16(buffer172[arrayLength(&buffer172)]), f16(buffer172[arrayLength(&buffer172)]), f16(buffer172[arrayLength(&buffer172)]), f16(buffer172[arrayLength(&buffer172)]), f16(buffer172[arrayLength(&buffer172)]), f16(buffer172[arrayLength(&buffer172)]), f16(buffer172[arrayLength(&buffer172)]));
+  vp26 = mat2x4h(bitcast<vec4h>(vf262), bitcast<vec4h>(vf262));
+  let vf263: u32 = arrayLength(&buffer172);
+  let vf264: vec2i = countOneBits(vec2i(unconst_i32(60), unconst_i32(51)));
+  return out;
+}
+
+var<private> vp25: mat4x3h = mat4x3h();
+
+var<private> vp26: mat2x4h = mat2x4h();
+
+@fragment
+fn fragment15() -> FragmentOutput11 {
+  var out: FragmentOutput11;
+  let ptr183: ptr<storage, array<array<FragmentOutput11, 5>, 1>, read_write> = &buffer171[1];
+  let ptr184: ptr<storage, i32, read_write> = &(*&buffer171)[1][u32(unconst_u32(172))][u32(unconst_u32(580))].f1;
+  let ptr185: ptr<storage, i32, read_write> = &buffer171[1][u32(unconst_u32(96))][4].f1;
+  let ptr186: ptr<storage, i32, read_write> = &(*ptr184);
+  let ptr187: ptr<storage, i32, read_write> = &(*ptr185);
+  vp25 = mat4x3h(f16(buffer171[1][0][4].f1), f16(buffer171[1][0][4].f1), f16(buffer171[1][0][4].f1), f16(buffer171[1][0][4].f1), f16(buffer171[1][0][4].f1), f16(buffer171[1][0][4].f1), f16(buffer171[1][0][4].f1), f16(buffer171[1][0][4].f1), f16(buffer171[1][0][4].f1), f16(buffer171[1][0][4].f1), f16(buffer171[1][0][4].f1), f16(buffer171[1][0][4].f1));
+  let ptr188: ptr<storage, array<FragmentOutput11, 5>, read_write> = &(*ptr183)[u32(unconst_u32(150))];
+  let ptr189: ptr<storage, i32, read_write> = &buffer171[1][u32(unconst_u32(31))][4].f1;
+  let ptr190: ptr<storage, u32, read_write> = &(*ptr183)[0][u32(unconst_u32(113))].f0;
+  out.f1 -= i32((*&buffer171)[1][0][4].f0);
+  let ptr191: ptr<storage, FragmentOutput11, read_write> = &buffer171[1][u32(unconst_u32(332))][u32(unconst_u32(398))];
+  let ptr192: ptr<storage, i32, read_write> = &buffer171[u32(unconst_u32(74))][u32(unconst_u32(134))][4].f1;
+  let ptr193: ptr<private, mat4x3h> = &vp25;
+  let ptr194: ptr<storage, FragmentOutput11, read_write> = &buffer171[u32(unconst_u32(117))][u32(unconst_u32(251))][4];
+  out.f1 = (*ptr187);
+  out.f1 &= i32((*&buffer171)[1][0][4].f0);
+  let ptr195: ptr<storage, FragmentOutput11, read_write> = &(*&buffer171)[u32(unconst_u32(190))][u32(unconst_u32(382))][4];
+  let ptr196: ptr<storage, array<FragmentOutput11, 5>, read_write> = &(*&buffer171)[u32(unconst_u32(46))][0];
+  let ptr197: ptr<storage, i32, read_write> = &(*ptr189);
+  out = (*ptr183)[0][u32(unconst_u32(48))];
+  vp26 = mat2x4h(f16((*&buffer171)[u32(unconst_u32(190))][0][4].f1), f16((*&buffer171)[u32(unconst_u32(190))][0][4].f1), f16((*&buffer171)[u32(unconst_u32(190))][0][4].f1), f16((*&buffer171)[u32(unconst_u32(190))][0][4].f1), f16((*&buffer171)[u32(unconst_u32(190))][0][4].f1), f16((*&buffer171)[u32(unconst_u32(190))][0][4].f1), f16((*&buffer171)[u32(unconst_u32(190))][0][4].f1), f16((*&buffer171)[u32(unconst_u32(190))][0][4].f1));
+  let ptr198: ptr<storage, FragmentOutput11, read_write> = &(*ptr183)[0][4];
+  out.f1 = (*ptr194).f1;
+  let ptr199: ptr<storage, i32, read_write> = &buffer171[u32(unconst_u32(24))][0][u32(unconst_u32(122))].f1;
+  return out;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout24 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 20,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let pipelineLayout18 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder195 = device0.createCommandEncoder();
+let texture213 = gpuCanvasContext5.getCurrentTexture();
+let renderPassEncoder20 = commandEncoder195.beginRenderPass({
+  label: '\u0f59\u0396\u0a6f\ub90b\ube8e\uc817\ue8ab\uae56',
+  colorAttachments: [{
+  view: textureView70,
+  clearValue: { r: -733.7, g: -741.7, b: -325.2, a: 277.5, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView146,
+    depthReadOnly: true,
+    stencilClearValue: 48366,
+    stencilLoadOp: 'load',
+    stencilStoreOp: 'discard',
+  },
+  maxDrawCount: 144291271,
+});
+try {
+computePassEncoder70.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+computePassEncoder179.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup115);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer124, 'uint16', 3_960, 1_784);
+} catch {}
+let buffer173 = device0.createBuffer({
+  size: 12967,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder196 = device0.createCommandEncoder({});
+let computePassEncoder180 = commandEncoder196.beginComputePass();
+let sampler126 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 49.24,
+  lodMaxClamp: 62.60,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder178.setBindGroup(3, bindGroup9, [256, 2304]);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(72);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline12);
+} catch {}
+document.body.prepend(canvas0);
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup49);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup10, new Uint32Array(846), 250, 0);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline10);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer139, 1324, new Int16Array(3803), 420, 640);
+} catch {}
+let bindGroup116 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 59, resource: sampler117}]});
+let buffer174 = device0.createBuffer({
+  size: 1510,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder126.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+computePassEncoder115.setBindGroup(0, bindGroup80, new Uint32Array(2518), 214, 0);
+} catch {}
+try {
+computePassEncoder180.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle24]);
+} catch {}
+try {
+renderPassEncoder18.setViewport(2.711846664805701, 3.524314060140928, 6.7322614747732485, 1.8313198324352566, 0.7703209309198387, 0.8975794261918362);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer144, 'uint32', 348, 293);
+} catch {}
+document.body.append(img0);
+let bindGroup117 = device0.createBindGroup({
+  layout: bindGroupLayout17,
+  entries: [{binding: 219, resource: {buffer: buffer25, offset: 6912, size: 12}}],
+});
+let texture214 = device0.createTexture({
+  size: [10, 9, 1],
+  sampleCount: 1,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView211 = texture185.createView({aspect: 'all', mipLevelCount: 1, arrayLayerCount: 1});
+try {
+computePassEncoder39.setBindGroup(1, bindGroup45, new Uint32Array(2061), 299, 0);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline13);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 39, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame13,
+  origin: { x: 0, y: 1 },
+  flipY: false,
+}, {
+  texture: texture167,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup118 = device0.createBindGroup({
+  layout: bindGroupLayout18,
+  entries: [
+    {binding: 23, resource: textureView140},
+    {binding: 116, resource: {buffer: buffer121, offset: 0, size: 1760}},
+    {binding: 2, resource: textureView173},
+    {binding: 157, resource: textureView164},
+  ],
+});
+let commandEncoder197 = device0.createCommandEncoder({});
+let texture215 = gpuCanvasContext6.getCurrentTexture();
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup113);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(1, bindGroup106, new Uint32Array(1216), 403, 0);
+} catch {}
+try {
+renderPassEncoder15.executeBundles([renderBundle11, renderBundle19, renderBundle11, renderBundle20, renderBundle19, renderBundle17, renderBundle19, renderBundle20]);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer78, 'uint32', 272, 68);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline0);
+} catch {}
+let arrayBuffer33 = buffer71.getMappedRange(1960, 0);
+try {
+commandEncoder197.copyTextureToBuffer({
+  texture: texture203,
+  mipLevel: 0,
+  origin: {x: 13, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2516 */
+  offset: 2516,
+  bytesPerRow: 2560,
+  buffer: buffer139,
+}, {width: 1, height: 2, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img1);
+let buffer175 = device0.createBuffer({size: 37158, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let commandEncoder198 = device0.createCommandEncoder({});
+let computePassEncoder181 = commandEncoder197.beginComputePass({});
+let renderBundleEncoder30 = device0.createRenderBundleEncoder({
+  colorFormats: ['r8unorm'],
+  depthStencilFormat: 'stencil8',
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+commandEncoder198.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 680 */
+  offset: 680,
+  bytesPerRow: 34048,
+  buffer: buffer27,
+}, {
+  texture: texture113,
+  mipLevel: 0,
+  origin: {x: 8, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let pipeline16 = device0.createComputePipeline({layout: pipelineLayout7, compute: {module: shaderModule10, constants: {}}});
+let bindGroup119 = device0.createBindGroup({
+  layout: bindGroupLayout20,
+  entries: [
+    {binding: 21, resource: {buffer: buffer146, offset: 5888, size: 5483}},
+    {binding: 20, resource: {buffer: buffer59, offset: 256, size: 847}},
+    {binding: 165, resource: textureView169},
+  ],
+});
+try {
+computePassEncoder94.setBindGroup(3, bindGroup112, new Uint32Array(619), 41, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder115); computePassEncoder115.dispatchWorkgroupsIndirect(buffer54, 3_432); };
+} catch {}
+try {
+computePassEncoder115.end();
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup30);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(3, bindGroup99);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(0, bindGroup118, new Uint32Array(1870), 175, 0);
+} catch {}
+let arrayBuffer34 = buffer71.getMappedRange(1952, 0);
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(453).fill(252), /* required buffer size: 453 */
+{offset: 453, bytesPerRow: 41}, {width: 16, height: 24, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup120 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 88, resource: {buffer: buffer66, offset: 0, size: 852}},
+    {binding: 925, resource: textureView175},
+    {binding: 96, resource: textureView44},
+    {binding: 142, resource: textureView9},
+    {binding: 779, resource: {buffer: buffer116, offset: 0, size: 704}},
+    {binding: 139, resource: textureView109},
+    {binding: 3, resource: sampler60},
+    {binding: 32, resource: textureView148},
+    {binding: 426, resource: {buffer: buffer136, offset: 768, size: 592}},
+    {binding: 25, resource: {buffer: buffer122, offset: 256}},
+    {binding: 16, resource: {buffer: buffer155, offset: 12800, size: 12088}},
+  ],
+});
+let textureView212 = texture130.createView({aspect: 'depth-only', mipLevelCount: 1});
+try {
+computePassEncoder181.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup27, new Uint32Array(885), 377, 0);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer146, 'uint32', 1_060, 1_327);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(1, bindGroup42);
+} catch {}
+try {
+if (!arrayBuffer25.detached) { new Uint8Array(arrayBuffer25).fill(0x55); };
+} catch {}
+let commandEncoder199 = device0.createCommandEncoder();
+let texture216 = gpuCanvasContext6.getCurrentTexture();
+let computePassEncoder182 = commandEncoder199.beginComputePass({});
+let renderBundle30 = renderBundleEncoder30.finish();
+try {
+buffer73.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 15, height: 6, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData18,
+  origin: { x: 2, y: 8 },
+  flipY: false,
+}, {
+  texture: texture159,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 9, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let textureView213 = texture110.createView({aspect: 'all'});
+let textureView214 = texture83.createView({dimension: '3d', mipLevelCount: 1});
+try {
+computePassEncoder182.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup70, new Uint32Array(265), 35, 0);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle30]);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline14);
+} catch {}
+try {
+commandEncoder123.copyBufferToBuffer(buffer120, 1328, buffer123, 136, 6632);
+} catch {}
+try {
+commandEncoder198.copyBufferToTexture({
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 854 */
+  offset: 854,
+  buffer: buffer158,
+}, {
+  texture: texture200,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+commandEncoder198.copyTextureToTexture({
+  texture: texture81,
+  mipLevel: 0,
+  origin: {x: 2, y: 2, z: 8},
+  aspect: 'all',
+},
+{
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData27 = new ImageData(8, 32);
+let bindGroup121 = device0.createBindGroup({
+  label: '\u{1feb1}\ub2b6\u85d3\u76ae\u{1f70b}\u01a5\u06cc\u{1fb4a}',
+  layout: bindGroupLayout22,
+  entries: [
+    {binding: 324, resource: textureView162},
+    {binding: 54, resource: {buffer: buffer127, offset: 512, size: 1054}},
+  ],
+});
+let texture217 = device0.createTexture({
+  label: '\u{1f957}\u810b\u48b2\uc74c\u9076',
+  size: [40, 39, 673],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8sint'],
+});
+let computePassEncoder183 = commandEncoder198.beginComputePass({});
+let sampler127 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 31.90,
+});
+try {
+commandEncoder123.copyBufferToTexture({
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 6816 */
+  offset: 6816,
+  buffer: buffer163,
+}, {
+  texture: texture192,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder123.clearBuffer(buffer78, 104, 8);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture175,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 5},
+  aspect: 'all',
+}, new Uint8Array(118).fill(29), /* required buffer size: 118 */
+{offset: 118, rowsPerImage: 6}, {width: 166, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let buffer176 = device0.createBuffer({
+  size: 9343,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder184 = commandEncoder123.beginComputePass({});
+let sampler128 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMaxClamp: 87.25,
+  compare: 'never',
+});
+let externalTexture23 = device0.importExternalTexture({source: videoFrame7, colorSpace: 'srgb'});
+try {
+computePassEncoder148.setBindGroup(2, bindGroup91);
+} catch {}
+try {
+computePassEncoder176.setBindGroup(1, bindGroup25, new Uint32Array(2154), 44, 0);
+} catch {}
+try {
+computePassEncoder183.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup118);
+} catch {}
+try {
+renderPassEncoder8.beginOcclusionQuery(34);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle21]);
+} catch {}
+let buffer177 = device0.createBuffer({
+  size: 1143,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+try {
+computePassEncoder64.setBindGroup(2, bindGroup57);
+} catch {}
+document.body.prepend(img0);
+let commandEncoder200 = device0.createCommandEncoder({});
+let texture218 = device0.createTexture({
+  size: [10, 9, 1],
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder185 = commandEncoder200.beginComputePass({});
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup60, new Uint32Array(627), 62, 0);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(16);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+globalThis.someLabel = externalTexture11.label;
+} catch {}
+let shaderModule15 = device0.createShaderModule({
+  label: '\u386f\u{1f7dc}\u3c00\u5a00',
+  code: `
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(3) var sam7: sampler;
+
+@group(0) @binding(16) var<storage, read_write> buffer178: array<array<array<array<array<array<array<array<f16, 1>, 5>, 1>, 1>, 1>, 11>, 1>, 64>;
+
+@group(0) @binding(32) var st10: texture_storage_1d<r32sint, read_write>;
+
+@group(0) @binding(96) var st11: texture_storage_2d<rgba16sint, write>;
+
+@group(0) @binding(139) var tex21: texture_2d<u32>;
+
+@group(0) @binding(142) var tex22: texture_2d<i32>;
+
+@group(0) @binding(426) var<storage, read_write> buffer180: array<array<vec2u, 17>>;
+
+@group(0) @binding(779) var<uniform> buffer181: array<mat3x3f, 1>;
+
+@group(0) @binding(925) var tex23: texture_2d<i32>;
+
+@group(1) @binding(35) var<storage, read_write> buffer182: array<array<atomic<u32>, 1>>;
+
+@group(1) @binding(60) var tex24: texture_2d<f32>;
+
+struct T0 {
+  @size(592) f0: mat4x4f,
+}
+
+struct T1 {
+  @align(4) @size(4) f0: array<f16>,
+}
+
+struct T2 {
+  @align(4) @size(4) f0: array<f16, 1>,
+}
+
+struct T3 {
+  @align(128) @size(7040) f0: array<T2>,
+}
+
+fn fn0() {
+  let ptr200: ptr<uniform, array<mat3x3f, 1>> = &buffer181;
+  let ptr201: ptr<uniform, mat3x3f> = &buffer181[0];
+  let vf265: vec4u = unpack4xU8(u32(unconst_u32(807)));
+  var vf266: u32 = pack4xI8Clamp(vec4i(unconst_i32(63), unconst_i32(159), unconst_i32(68), unconst_i32(23)));
+  vf266 |= u32((*ptr200)[u32(unconst_u32(13))][u32(unconst_u32(141))].r);
+  let vf267: f32 = (*&buffer181)[0][u32(unconst_u32(62))][u32(unconst_u32(4))];
+  vf266 &= vec4u(round(vec4h(unconst_f16(9058.6), unconst_f16(7240.2), unconst_f16(-2650.3), unconst_f16(3836.3))))[0];
+  let vf268: vec3f = buffer181[u32(unconst_u32(121))][u32(unconst_u32(721))];
+  vf266 |= bitcast<vec3u>((*&buffer181)[0][unconst_i32(2)]).g;
+  vf266 = u32(vf268[u32(unconst_u32(748))]);
+  let vf269: vec2u = textureDimensions(tex21);
+  let ptr202: ptr<uniform, array<mat3x3f, 1>> = &buffer181;
+  vf266 = bitcast<u32>((*ptr201)[unconst_i32(1)][1]);
+  let vf270: bool = all(vec2<bool>((*ptr201)[u32(unconst_u32(80))].xx));
+}
+
+var<workgroup> vw34: T2;
+
+var<workgroup> vw35: atomic<u32>;
+
+var<workgroup> vw36: vec2h;
+
+@fragment
+fn fragment16(@builtin(sample_index) a0: u32) -> @location(200) vec4u {
+  var out: vec4u;
+  let ptr203: ptr<storage, f16, read_write> = &buffer178[u32(unconst_u32(12))][0][u32(unconst_u32(149))][u32((*&buffer178)[u32(unconst_u32(262))][0][u32(unconst_u32(360))][u32(unconst_u32(77))][0][0][4][0])][0][u32(unconst_u32(365))][4][u32(unconst_u32(202))];
+  let ptr204: ptr<storage, f16, read_write> = &buffer178[63][u32(unconst_u32(211))][10][u32(buffer178[u32(unconst_u32(372))][u32(unconst_u32(41))][u32(unconst_u32(58))][0][0][0][4][0])][0][0][4][u32(unconst_u32(144))];
+  atomicMin(&buffer182[u32(unconst_u32(2))][u32(unconst_u32(32))], u32(unconst_u32(165)));
+  textureStore(st11, vec2i(unconst_i32(124), unconst_i32(8)), vec4i(vec4i(unconst_i32(20), unconst_i32(68), unconst_i32(230), unconst_i32(608))));
+  let ptr205: ptr<storage, f16, read_write> = &(*&buffer178)[u32((*&buffer178)[63][0][10][0][0][u32(unconst_u32(244))][u32(unconst_u32(185))][u32(buffer178[u32(buffer178[u32(unconst_u32(730))][u32(unconst_u32(14))][10][u32(unconst_u32(21))][u32(unconst_u32(20))][0][u32(unconst_u32(117))][0])][0][10][0][u32(unconst_u32(254))][u32(unconst_u32(95))][u32(unconst_u32(197))][u32(unconst_u32(327))])])][u32(unconst_u32(97))][u32(unconst_u32(378))][u32(unconst_u32(175))][0][u32(buffer178[63][u32(unconst_u32(307))][10][0][0][0][4][0])][u32(unconst_u32(220))][0];
+  let ptr206: ptr<storage, array<array<array<f16, 1>, 5>, 1>, read_write> = &buffer178[63][u32(unconst_u32(202))][10][0][u32(unconst_u32(261))];
+  let ptr207: ptr<storage, f16, read_write> = &(*&buffer178)[u32(unconst_u32(49))][0][u32(unconst_u32(672))][0][u32(unconst_u32(326))][0][4][u32(unconst_u32(191))];
+  let ptr208: ptr<storage, f16, read_write> = &(*&buffer178)[63][0][10][u32(unconst_u32(107))][0][0][4][u32(unconst_u32(47))];
+  return out;
+}`,
+  sourceMap: {},
+});
+try {
+computePassEncoder114.setBindGroup(2, bindGroup54);
+} catch {}
+try {
+computePassEncoder139.setBindGroup(1, bindGroup97, new Uint32Array(3622), 1_116, 0);
+} catch {}
+try {
+computePassEncoder185.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder16.end();
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer56, 'uint32', 592, 1_248);
+} catch {}
+document.body.append(canvas1);
+let bindGroup122 = device0.createBindGroup({layout: bindGroupLayout5, entries: [{binding: 65, resource: textureView175}]});
+let commandEncoder201 = device0.createCommandEncoder({label: '\ua1e4\u{1f957}\u7316'});
+let textureView215 = texture47.createView({});
+let computePassEncoder186 = commandEncoder92.beginComputePass({label: '\u{1f641}\ua81d\u5e1d'});
+try {
+renderPassEncoder4.setIndexBuffer(buffer117, 'uint16', 298, 40);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(4, buffer101);
+} catch {}
+document.body.prepend(canvas0);
+let commandEncoder202 = device0.createCommandEncoder({});
+let computePassEncoder187 = commandEncoder202.beginComputePass({});
+let renderPassEncoder21 = commandEncoder201.beginRenderPass({
+  colorAttachments: [{view: textureView93, depthSlice: 9, loadOp: 'load', storeOp: 'discard'}],
+  maxDrawCount: 192256193,
+});
+let externalTexture24 = device0.importExternalTexture({label: '\u0f08\u{1fa6e}\u9423\u23ba', source: videoFrame10});
+try {
+computePassEncoder138.setBindGroup(1, bindGroup25, new Uint32Array(872), 35, 0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup17, new Uint32Array(50), 5, 2);
+} catch {}
+document.body.prepend(img1);
+let videoFrame29 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'bt470m', transfer: 'logSqrt'} });
+let texture219 = device0.createTexture({
+  size: {width: 20, height: 19, depthOrArrayLayers: 1},
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView216 = texture25.createView({aspect: 'depth-only', mipLevelCount: 1, baseArrayLayer: 3, arrayLayerCount: 6});
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup66);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+buffer41.unmap();
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let bindGroupLayout25 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 21,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup123 = device0.createBindGroup({
+  label: '\u0b83\ud2dd\u2973\u1001\u0683\ud43c',
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 35, resource: {buffer: buffer149, offset: 0, size: 192}},
+    {binding: 60, resource: textureView124},
+  ],
+});
+let buffer183 = device0.createBuffer({size: 7625, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+try {
+renderPassEncoder18.setIndexBuffer(buffer55, 'uint16', 356, 8);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 332, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData20,
+  origin: { x: 6, y: 1 },
+  flipY: false,
+}, {
+  texture: texture166,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup124 = device0.createBindGroup({
+  layout: bindGroupLayout21,
+  entries: [
+    {binding: 42, resource: textureView183},
+    {binding: 51, resource: textureView25},
+    {binding: 592, resource: sampler50},
+    {binding: 215, resource: textureView34},
+    {binding: 416, resource: sampler12},
+    {binding: 0, resource: {buffer: buffer145, offset: 1280, size: 1547}},
+    {binding: 425, resource: textureView212},
+    {binding: 231, resource: textureView194},
+    {binding: 327, resource: textureView205},
+    {binding: 453, resource: {buffer: buffer155, offset: 6400, size: 4844}},
+    {binding: 72, resource: {buffer: buffer106, offset: 2048}},
+    {binding: 9, resource: textureView55},
+  ],
+});
+let pipelineLayout19 = device0.createPipelineLayout({label: '\u2724\u0c20\u{1feba}\u86ed\ub407\u07b2\u3353', bindGroupLayouts: []});
+let textureView217 = texture193.createView({baseMipLevel: 0, mipLevelCount: 1});
+let sampler129 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 59.25,
+  lodMaxClamp: 95.65,
+});
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup25);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer168, 'uint32', 2_764, 16);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline7);
+} catch {}
+try {
+buffer67.unmap();
+} catch {}
+let sampler130 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 78.04,
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder184.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder13.beginOcclusionQuery(34);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer61, 13428, new Int16Array(1468), 427, 120);
+} catch {}
+let commandEncoder203 = device0.createCommandEncoder();
+let textureView218 = texture37.createView({dimension: '2d', mipLevelCount: 1});
+let computePassEncoder188 = commandEncoder203.beginComputePass({});
+let sampler131 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 83.31,
+  lodMaxClamp: 90.04,
+  compare: 'greater',
+});
+try {
+renderPassEncoder11.setVertexBuffer(6, buffer151, 0, 187);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture192,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(200).fill(39), /* required buffer size: 200 */
+{offset: 200}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer30.detached) { new Uint8Array(arrayBuffer30).fill(0x55); };
+} catch {}
+let shaderModule16 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(302) var tex25: texture_2d<i32>;
+
+struct T0 {
+  @size(156) f0: array<u32>,
+}
+
+struct VertexOutput13 {
+  @builtin(position) f39: vec4f,
+}
+
+struct FragmentOutput12 {
+  @location(7) @interpolate(flat) f0: vec2i,
+  @builtin(sample_mask) f1: u32,
+  @location(0) @interpolate(flat) f2: vec2i,
+}
+
+alias vec3b = vec3<bool>;
+
+override override8: f16 = 31036.3;
+
+@id(17688) override override9: f16;
+
+@id(50655) override override10: f16 = 3591.1;
+
+@id(57075) override override11: u32;
+
+@id(61183) override override12: f16;
+
+@id(1989) override override13: u32 = 69;
+
+override override14: i32 = 377;
+
+override override15: f32;
+
+@id(38265) override override16: u32;
+
+override override17 = 0.3849;
+
+@id(56259) override override18: f32;
+
+override override19: i32;
+
+@id(51138) override override20 = false;
+
+override override21: f16 = 12906.0;
+
+@id(64770) override override22: f32;
+
+@id(61560) override override23: f16;
+
+@id(3920) override override24: i32;
+
+override override25: bool;
+
+@id(47695) override override26: f32;
+
+@id(4766) override override27 = 0.08421;
+
+override override28: u32;
+
+@id(35833) override override29: i32;
+
+fn fn0() -> array<u32, 1> {
+  var out: array<u32, 1>;
+  var vf271: i32 = vp27.f2[u32(unconst_u32(331))];
+  out[u32(unconst_u32(151))] += override13;
+  let vf272: u32 = override16;
+  out[u32(unconst_u32(510))] <<= u32(override23);
+  vp27.f2 ^= vec2i(bitcast<i32>(vp27.f1));
+  vp27.f0 = vec2i(quantizeToF16(vec3f(unconst_f32(0.01778), unconst_f32(0.09819), unconst_f32(0.1158))).xx);
+  var vf273: vec3h = sinh(vec3h(unconst_f16(860.1), unconst_f16(-7844.4), unconst_f16(-10525.2)));
+  return out;
+  _ = override16;
+  _ = override23;
+  _ = override13;
+}
+
+var<workgroup> vw37: mat3x3h;
+
+var<workgroup> vw38: FragmentOutput12;
+
+var<workgroup> vw39: array<vec4<bool>, 1>;
+
+var<workgroup> vw40: vec4h;
+
+var<private> vp27: FragmentOutput12 = FragmentOutput12();
+
+@vertex @must_use
+fn vertex15(@location(10) @interpolate(flat) a0: vec2u) -> VertexOutput13 {
+  var out: VertexOutput13;
+  out.f39 = vec4f(f32(override9));
+  vp27.f0 ^= vp27.f2;
+  let ptr209: ptr<private, vec2i> = &vp27.f2;
+  var vf274: f16 = override21;
+  var vf275: vec4u = unpack4xU8(u32(unconst_u32(101)));
+  vp27 = FragmentOutput12(vec2i(unpack4x8unorm(u32(unconst_u32(273))).br), pack4xU8Clamp(bitcast<vec4u>(unpack4x8unorm(u32(unconst_u32(273))))), vec2i(unpack4x8unorm(u32(unconst_u32(273))).gg));
+  vp27.f1 &= u32(reverseBits(vec3i(unconst_i32(-12), unconst_i32(174), unconst_i32(49)))[1]);
+  let vf276: u32 = override28;
+  vf275 = unpack4xU8(bitcast<u32>(override26));
+  out.f39 -= vec4f(override17);
+  let ptr210: ptr<private, FragmentOutput12> = &vp27;
+  let ptr211: ptr<private, FragmentOutput12> = &vp27;
+  var vf277: i32 = override19;
+  let vf278: vec4f = atan2(vec4f(unconst_f32(0.06144), unconst_f32(0.2073), unconst_f32(-0.1248), unconst_f32(0.2565)), unpack4x8snorm(override11));
+  let vf279: u32 = override28;
+  let vf280: i32 = (*ptr211).f2[bitcast<u32>(vp27.f0[0])];
+  vf277 += bitcast<vec4i>(atan2(vec4f(unconst_f32(0.09157), unconst_f32(0.08779), unconst_f32(0.09191), unconst_f32(0.06069)), vec4f(unconst_f32(0.2678), unconst_f32(-0.1011), unconst_f32(0.2746), unconst_f32(0.03169))))[2];
+  let vf281: f16 = override8;
+  return out;
+  _ = override11;
+  _ = override19;
+  _ = override9;
+  _ = override28;
+  _ = override8;
+  _ = override21;
+  _ = override17;
+  _ = override26;
+}
+
+@fragment
+fn fragment17() -> FragmentOutput12 {
+  var out: FragmentOutput12;
+  vp27.f1 <<= override16;
+  return out;
+  _ = override16;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+computePassEncoder103.setBindGroup(3, bindGroup49, new Uint32Array(1024), 291, 0);
+} catch {}
+try {
+computePassEncoder188.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup103, new Uint32Array(20), 4, 0);
+} catch {}
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder21.setViewport(16.6273618024321, 3.100320339102659, 0.604312659441967, 5.40124189342075, 0.887448777335567, 0.9150798888305314);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer170, 'uint16', 196, 76);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(4, buffer155);
+} catch {}
+try {
+computePassEncoder64.insertDebugMarker('\u{1ffa3}');
+} catch {}
+let buffer184 = device0.createBuffer({size: 5480, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder204 = device0.createCommandEncoder({});
+let renderPassEncoder22 = commandEncoder204.beginRenderPass({
+  colorAttachments: [{view: textureView86, loadOp: 'clear', storeOp: 'discard'}],
+  depthStencilAttachment: {view: textureView155, stencilLoadOp: 'clear', stencilStoreOp: 'discard'},
+  maxDrawCount: 198542243,
+});
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup58);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline4);
+} catch {}
+try {
+buffer144.unmap();
+} catch {}
+let commandEncoder205 = device0.createCommandEncoder({});
+let computePassEncoder189 = commandEncoder205.beginComputePass({});
+try {
+renderPassEncoder8.beginOcclusionQuery(497);
+} catch {}
+try {
+renderPassEncoder13.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline13);
+} catch {}
+let bindGroup125 = device0.createBindGroup({
+  label: '\uea08\u0df3\u761c\ufbc4',
+  layout: bindGroupLayout10,
+  entries: [
+    {binding: 82, resource: {buffer: buffer3, offset: 1280, size: 3832}},
+    {binding: 187, resource: textureView90},
+  ],
+});
+let commandEncoder206 = device0.createCommandEncoder();
+let querySet23 = device0.createQuerySet({
+  label: '\u0852\uc801\uac3c\ue1ed\uf9d8\u6f80\u733f\u0640\u2c75\u{1fd22}',
+  type: 'occlusion',
+  count: 411,
+});
+let renderPassEncoder23 = commandEncoder206.beginRenderPass({
+  colorAttachments: [{
+  view: textureView86,
+  clearValue: { r: 328.3, g: -236.4, b: 645.5, a: -456.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView155,
+    depthClearValue: -9.347562042406777,
+    depthReadOnly: true,
+    stencilLoadOp: 'clear',
+    stencilStoreOp: 'discard',
+  },
+  occlusionQuerySet: querySet14,
+  maxDrawCount: 261533214,
+});
+let renderBundleEncoder31 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint']});
+let renderBundle31 = renderBundleEncoder31.finish({});
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup42);
+} catch {}
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.setViewport(7.197491428010672, 18.20488398974363, 2.3740253663718036, 0.17169978411007308, 0.7328064321472244, 0.8520904315363124);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let texture220 = device0.createTexture({
+  size: [20, 19, 1],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder10.setVertexBuffer(6, buffer98);
+} catch {}
+let bindGroup126 = device0.createBindGroup({
+  layout: bindGroupLayout18,
+  entries: [
+    {binding: 23, resource: textureView11},
+    {binding: 116, resource: {buffer: buffer115, offset: 1792, size: 1984}},
+    {binding: 2, resource: textureView174},
+    {binding: 157, resource: textureView20},
+  ],
+});
+let buffer185 = device0.createBuffer({size: 30610, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder207 = device0.createCommandEncoder({label: '\uff82\u7878\u0741\u{1faf5}\u{1fa4b}\u5043\u{1f830}'});
+let texture221 = device0.createTexture({
+  size: {width: 10, height: 9, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder190 = commandEncoder207.beginComputePass({label: '\ucbcf\u{1fca7}\ud01c\u9e10\uc8c7'});
+try {
+computePassEncoder99.setBindGroup(0, bindGroup70, new Uint32Array(279), 8, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup102);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer157, 'uint32', 8, 52);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline12);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let commandEncoder208 = device0.createCommandEncoder();
+let textureView219 = texture199.createView({dimension: '2d'});
+let computePassEncoder191 = commandEncoder208.beginComputePass({});
+try {
+computePassEncoder190.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup25);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle20, renderBundle15, renderBundle24, renderBundle17]);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer127, 'uint16', 1_362, 180);
+} catch {}
+try {
+renderPassEncoder3.insertDebugMarker('\u{1f80d}');
+} catch {}
+let videoFrame30 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'fcc', primaries: 'jedecP22Phosphors', transfer: 'hlg'} });
+let buffer186 = device0.createBuffer({
+  size: 21311,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture222 = device0.createTexture({size: [332], dimension: '1d', format: 'r16uint', usage: GPUTextureUsage.COPY_SRC});
+try {
+computePassEncoder189.setBindGroup(0, bindGroup117, new Uint32Array(332), 17, 0);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(1, bindGroup86, new Uint32Array(658), 68, 0);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(0, buffer66, 0, 1_568);
+} catch {}
+let arrayBuffer35 = buffer2.getMappedRange(1936, 4);
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let imageData28 = new ImageData(192, 48);
+try {
+adapter0.label = '\u7688\u9466\u{1fcf3}\u15e4\u{1fc7b}\u70dd\uf2ad\u0300\u0faa\u4e04\ua81f';
+} catch {}
+let querySet24 = device0.createQuerySet({type: 'occlusion', count: 281});
+try {
+computePassEncoder99.setBindGroup(1, bindGroup39);
+} catch {}
+try {
+computePassEncoder191.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup28, new Uint32Array(1886), 117, 0);
+} catch {}
+try {
+renderPassEncoder19.insertDebugMarker('\u{1f604}');
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let bindGroupLayout26 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 118,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 75,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup93, new Uint32Array(2037), 784, 0);
+} catch {}
+try {
+renderPassEncoder12.setBlendConstant({ r: 232.3, g: -147.0, b: 131.1, a: 962.6, });
+} catch {}
+try {
+renderPassEncoder3.setViewport(201.92481167473179, 0.3752110171211087, 108.06120151964927, 0.023549618477444818, 0.673751315292992, 0.8693119215004478);
+} catch {}
+let arrayBuffer36 = buffer2.getMappedRange(752, 0);
+let imageData29 = new ImageData(44, 240);
+let bindGroup127 = device0.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 148, resource: textureView164}]});
+let buffer187 = device0.createBuffer({
+  size: 6279,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let querySet25 = device0.createQuerySet({type: 'occlusion', count: 386});
+try {
+computePassEncoder186.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder17.setViewport(8.323427882817182, 0.8230781099892219, 1.206382421386318, 16.804238382687807, 0.28251820735764255, 0.4974457972395458);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline14);
+} catch {}
+await gc();
+let img2 = await imageWithData(41, 58, '#10101010', '#20202020');
+let commandEncoder209 = device0.createCommandEncoder({label: '\u{1fa79}\u2aac\u8f5d\u0428\u0012\u7015\u{1fc7c}\ud1a7\u5ade'});
+let computePassEncoder192 = commandEncoder209.beginComputePass({});
+try {
+renderPassEncoder10.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(7, buffer152);
+} catch {}
+try {
+globalThis.someLabel = computePassEncoder100.label;
+} catch {}
+let bindGroup128 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 125, resource: textureView22},
+    {binding: 26, resource: {buffer: buffer177, offset: 0, size: 936}},
+    {binding: 66, resource: {buffer: buffer21, offset: 13056, size: 3675}},
+    {binding: 41, resource: textureView18},
+    {binding: 294, resource: textureView50},
+    {binding: 50, resource: {buffer: buffer156, offset: 2048}},
+    {binding: 452, resource: textureView95},
+    {binding: 13, resource: {buffer: buffer129, offset: 0}},
+    {binding: 49, resource: textureView104},
+    {binding: 283, resource: {buffer: buffer4, offset: 512, size: 846}},
+    {binding: 39, resource: textureView164},
+  ],
+});
+let pipelineLayout20 = device0.createPipelineLayout({bindGroupLayouts: []});
+let texture223 = device0.createTexture({
+  size: [40, 39, 1],
+  mipLevelCount: 3,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+computePassEncoder90.setBindGroup(3, bindGroup127, new Uint32Array(202), 12, 0);
+} catch {}
+try {
+computePassEncoder189.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer118, 'uint16', 16, 1);
+} catch {}
+try {
+buffer103.unmap();
+} catch {}
+let commandEncoder210 = device0.createCommandEncoder({});
+let textureView220 = texture180.createView({
+  label: '\u2b1e\ufb54\u0b44\u9aa2\uffae\u51c4\u0ca8\u{1f8e0}',
+  dimension: '2d-array',
+  format: 'stencil8',
+  mipLevelCount: 1,
+});
+let sampler132 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 6.689,
+  lodMaxClamp: 54.60,
+  compare: 'greater',
+});
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup85);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle6]);
+} catch {}
+let computePassEncoder193 = commandEncoder210.beginComputePass({});
+let sampler133 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 89.41,
+  lodMaxClamp: 90.29,
+});
+try {
+computePassEncoder131.setBindGroup(0, bindGroup77, new Uint32Array(1176), 75, 0);
+} catch {}
+try {
+computePassEncoder193.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer127, 'uint16', 272, 784);
+} catch {}
+try {
+computePassEncoder187.setPipeline(pipeline8);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let promise32 = device0.queue.onSubmittedWorkDone();
+let buffer188 = device0.createBuffer({size: 3417, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC});
+try {
+computePassEncoder44.setBindGroup(0, bindGroup36, [768, 256]);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup87);
+} catch {}
+let texture224 = device0.createTexture({size: [15, 6, 1], format: 'depth16unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let sampler134 = device0.createSampler({
+  label: '\ueb87\u89b5\u2eab\u{1fb70}\u{1f9e1}\u0b1d\uf5c8',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 92.74,
+  lodMaxClamp: 97.51,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder121.setBindGroup(3, bindGroup16, [512, 7168]);
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(250, 0, 6, 0);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(5, buffer92, 0);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+await gc();
+let imageData30 = new ImageData(8, 8);
+let bindGroup129 = device0.createBindGroup({
+  label: '\u6e65\u16fb\u{1fce1}\ube6d',
+  layout: bindGroupLayout24,
+  entries: [{binding: 20, resource: textureView124}],
+});
+let textureView221 = texture198.createView({arrayLayerCount: 1});
+try {
+computePassEncoder57.setBindGroup(2, bindGroup92);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup23);
+} catch {}
+try {
+computePassEncoder104.setBindGroup(0, bindGroup59);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle10, renderBundle5, renderBundle6, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder18.setViewport(10.53751249374236, 1.681775294570248, 2.551252136066405, 3.0340498228831163, 0.8179231352300484, 0.8854885992229999);
+} catch {}
+document.body.prepend(canvas0);
+try {
+{ clearResourceUsages(device0, computePassEncoder44); computePassEncoder44.dispatchWorkgroupsIndirect(buffer42, 68); };
+} catch {}
+try {
+computePassEncoder192.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(0, bindGroup58);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(img2);
+let bindGroupLayout27 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 244,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '1d' },
+    },
+  ],
+});
+let bindGroup130 = device0.createBindGroup({
+  layout: bindGroupLayout10,
+  entries: [
+    {binding: 187, resource: textureView45},
+    {binding: 82, resource: {buffer: buffer152, offset: 2304, size: 3898}},
+  ],
+});
+let commandEncoder211 = device0.createCommandEncoder({});
+let texture225 = device0.createTexture({
+  size: {width: 80},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+commandEncoder211.copyBufferToTexture({
+  /* bytesInLastRow: 544 widthInBlocks: 136 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2036 */
+  offset: 2036,
+  buffer: buffer126,
+}, {
+  texture: texture152,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 136, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture172,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(210).fill(118), /* required buffer size: 210 */
+{offset: 210, bytesPerRow: 54}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let textureView222 = texture225.createView({label: '\uc144\ud203\u{1f8d7}\u0217\uf37d', aspect: 'all', mipLevelCount: 1});
+let sampler135 = device0.createSampler({
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 18.87,
+  lodMaxClamp: 59.98,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder23.setIndexBuffer(buffer34, 'uint16', 130, 645);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(5, buffer175, 0);
+} catch {}
+let arrayBuffer37 = buffer2.getMappedRange(1608, 0);
+try {
+commandEncoder211.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 788 */
+  offset: 788,
+  buffer: buffer23,
+}, {
+  texture: texture193,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img0);
+let textureView223 = texture170.createView({format: 'depth16unorm'});
+try {
+computePassEncoder113.setBindGroup(3, bindGroup24, []);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder44); computePassEncoder44.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(3, bindGroup71, []);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([renderBundle24, renderBundle24, renderBundle24]);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(1, buffer116, 0, 23);
+} catch {}
+try {
+  await promise32;
+} catch {}
+let bindGroup131 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 59, resource: sampler117}]});
+let buffer189 = device0.createBuffer({
+  size: 5405,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView224 = texture82.createView({aspect: 'all'});
+let computePassEncoder194 = commandEncoder211.beginComputePass({});
+try {
+computePassEncoder13.setBindGroup(3, bindGroup6, new Uint32Array(4029), 174, 2);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(0, buffer155);
+} catch {}
+let bindGroup132 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 194, resource: textureView28},
+    {binding: 362, resource: textureView142},
+    {binding: 267, resource: textureView88},
+    {binding: 87, resource: textureView37},
+  ],
+});
+let textureView225 = texture212.createView({mipLevelCount: 1});
+try {
+{ clearResourceUsages(device0, computePassEncoder44); computePassEncoder44.dispatchWorkgroupsIndirect(buffer127, 812); };
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup122, new Uint32Array(4447), 17, 0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(6, buffer176);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let bindGroup133 = device0.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 148, resource: textureView9}]});
+let commandEncoder212 = device0.createCommandEncoder({label: '\u0b98\u6030\u{1fcee}\u9e05\u861c\u0fb2\ud844\uea63\ub7f2\u{1f718}\u{1f67d}'});
+let textureView226 = texture225.createView({});
+let textureView227 = texture178.createView({dimension: '2d', aspect: 'all', baseArrayLayer: 1});
+let externalTexture25 = device0.importExternalTexture({source: videoFrame21});
+try {
+computePassEncoder142.setBindGroup(1, bindGroup69);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder44); computePassEncoder44.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder97.setPipeline(pipeline8);
+} catch {}
+try {
+computePassEncoder194.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup102, new Uint32Array(1349), 191, 0);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(6, buffer8);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 54, height: 141, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData2,
+  origin: { x: 3, y: 7 },
+  flipY: false,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 3, y: 16, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup134 = device0.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 148, resource: textureView175}]});
+let commandEncoder213 = device0.createCommandEncoder({});
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup65);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup119, new Uint32Array(1932), 159, 0);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer54, 'uint16', 1_128, 29);
+} catch {}
+try {
+buffer94.unmap();
+} catch {}
+try {
+commandEncoder212.copyBufferToTexture({
+  /* bytesInLastRow: 117 widthInBlocks: 117 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 937 */
+  offset: 937,
+  bytesPerRow: 32768,
+  buffer: buffer44,
+}, {
+  texture: texture142,
+  mipLevel: 2,
+  origin: {x: 31, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 117, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img2);
+let buffer190 = device0.createBuffer({
+  label: '\u51c2\u{1f6a7}\ub6b5',
+  size: 4888,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView228 = texture27.createView({dimension: '3d'});
+let computePassEncoder195 = commandEncoder212.beginComputePass({});
+let renderPassEncoder24 = commandEncoder213.beginRenderPass({
+  label: '\u{1fc93}\u58f4\u0d67\u{1fac4}\u8563\u1e24\uc37d',
+  colorAttachments: [{view: textureView126, loadOp: 'load', storeOp: 'store'}],
+});
+try {
+computePassEncoder27.setBindGroup(1, bindGroup132, new Uint32Array(812), 5, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder44); computePassEncoder44.dispatchWorkgroupsIndirect(buffer129, 180); };
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+let img3 = await imageWithData(34, 18, '#10101010', '#20202020');
+let bindGroup135 = device0.createBindGroup({layout: bindGroupLayout17, entries: [{binding: 219, resource: {buffer: buffer89, offset: 1024}}]});
+let texture226 = device0.createTexture({
+  label: '\u6cb2\u7c99\uc08f\u79c4',
+  size: [10, 9, 1],
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView229 = texture22.createView({dimension: '2d-array', aspect: 'all', format: 'rgb10a2uint'});
+let sampler136 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 36.82,
+  lodMaxClamp: 68.67,
+  compare: 'never',
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder155.setBindGroup(2, bindGroup130, new Uint32Array(2352), 94, 0);
+} catch {}
+try {
+computePassEncoder195.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(1, bindGroup121);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(0, buffer129, 160);
+} catch {}
+document.body.append(img1);
+await gc();
+let bindGroupLayout28 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 51,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let textureView230 = texture24.createView({label: '\ub410\u0766\u5a09\ua1bd\u3575\u4133', mipLevelCount: 1});
+let sampler137 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 91.38,
+  maxAnisotropy: 4,
+});
+try {
+renderPassEncoder4.setVertexBuffer(5, buffer174, 456, 984);
+} catch {}
+let texture227 = device0.createTexture({
+  label: '\u161c\uf921',
+  size: [120, 48, 175],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder88.setBindGroup(2, bindGroup74, new Uint32Array(268), 46, 0);
+} catch {}
+try {
+computePassEncoder44.end();
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup75, new Uint32Array(1593), 107, 0);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(3, buffer52);
+} catch {}
+try {
+commandEncoder39.copyBufferToBuffer(buffer174, 132, buffer136, 1208, 92);
+} catch {}
+try {
+commandEncoder39.copyBufferToTexture({
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 725 */
+  offset: 725,
+  bytesPerRow: 1792,
+  buffer: buffer54,
+}, {
+  texture: texture200,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer32.detached) { new Uint8Array(arrayBuffer32).fill(0x55); };
+} catch {}
+videoFrame0.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame22.close();
+videoFrame23.close();
+videoFrame24.close();
+videoFrame25.close();
+videoFrame26.close();
+videoFrame28.close();
+videoFrame29.close();
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -1229,6 +1229,9 @@ Ref<BindGroup> Device::createBindGroup(const WGPUBindGroupDescriptor& descriptor
     argumentBuffer[ShaderStage::Fragment].label = bindGroupLayout->fragmentArgumentEncoder().label;
     argumentBuffer[ShaderStage::Compute].label = bindGroupLayout->computeArgumentEncoder().label;
 
+    std::sort(dynamicBuffers.begin(), dynamicBuffers.end(), [](const BindGroup::BufferAndType& a, const BindGroup::BufferAndType& b) {
+        return a.bindingIndex < b.bindingIndex;
+    });
     return BindGroup::create(argumentBuffer[ShaderStage::Vertex], argumentBuffer[ShaderStage::Fragment], argumentBuffer[ShaderStage::Compute], WTFMove(resources), bindGroupLayout, WTFMove(dynamicBuffers), WTFMove(samplersSet), WTFMove(externalTextureIndices), *this);
 #undef VALIDATION_ERROR
 #undef INTERNAL_ERROR_STRING


### PR DESCRIPTION
#### dbc582354bc67ac673bb343a49e41728c7706281
<pre>
[WebGPU] Dynamic offsets algorithm requires indices to be sorted
<a href="https://bugs.webkit.org/show_bug.cgi?id=284390">https://bugs.webkit.org/show_bug.cgi?id=284390</a>
<a href="https://rdar.apple.com/141199874">rdar://141199874</a>

Reviewed by Dan Glastonbury.

The setBindGroup() algorithm, <a href="https://www.w3.org/TR/webgpu/#dom-gpubindingcommandsmixin-setbindgroup-index-bindgroup-dynamicoffsetsdata-dynamicoffsetsdatastart-dynamicoffsetsdatalength">https://www.w3.org/TR/webgpu/#dom-gpubindingcommandsmixin-setbindgroup-index-bindgroup-dynamicoffsetsdata-dynamicoffsetsdatastart-dynamicoffsetsdatalength</a>,
described in the specification states:

    For each GPUBindGroupEntry entry in bindGroup.[[entries]] ordered in increasing values of entry.binding:

we had not sorted these, i.e., they were not &apos;ordered in increasing values of entry.binding&apos;

Fix this by sorting prior to BindGroup creation.

* LayoutTests/fast/webgpu/nocrash/fuzz-284390-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-284390.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::Device::createBindGroup):

Canonical link: <a href="https://commits.webkit.org/287645@main">https://commits.webkit.org/287645@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d76c6ac2929060cfa60d997a9b6a0b33e65dc7ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80334 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59340 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33809 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84855 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31316 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68402 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7641 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62794 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20600 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83403 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52863 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73143 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43097 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50183 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27298 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29775 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71321 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27812 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86289 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7559 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5350 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71079 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7734 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68979 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70319 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17518 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14310 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13250 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7521 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7360 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10880 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9166 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->