### PR TITLE
Add support for documentId to webRequest.

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -534,10 +534,11 @@ ResourceLoadInfo NetworkResourceLoader::resourceLoadInfo()
         return ResourceLoadInfo::Type::Other;
     };
 
-    return ResourceLoadInfo {
+    return {
         m_resourceLoadID,
         m_parameters.webFrameID,
         m_parameters.parentFrameID,
+        m_parameters.options.resultingClientIdentifier ?: m_parameters.options.clientIdentifier,
         originalRequest().url(),
         originalRequest().httpMethod(),
         WallTime::now(),

--- a/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -74,7 +74,6 @@ UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.mm
 UIProcess/WebAuthentication/Virtual/VirtualService.mm
 UIProcess/WebProcessProxy.cpp
 UIProcess/mac/WebViewImpl.mm
-WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestCocoa.mm
 WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp
 WebProcess/GPU/graphics/WebGPU/RemoteXRBindingProxy.cpp
 WebProcess/GPU/graphics/WebGPU/WebGPUDowncastConvertToBackingContext.cpp

--- a/Source/WebKit/Shared/ResourceLoadInfo.h
+++ b/Source/WebKit/Shared/ResourceLoadInfo.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,12 +29,12 @@
 #include "NetworkResourceLoadIdentifier.h"
 #include <WebCore/FrameIdentifier.h>
 #include <wtf/URL.h>
+#include <wtf/UUID.h>
 #include <wtf/WallTime.h>
 
 namespace WebKit {
 
 struct ResourceLoadInfo {
-
     enum class Type : uint8_t {
         ApplicationManifest,
         Beacon,
@@ -52,10 +52,11 @@ struct ResourceLoadInfo {
         XMLHTTPRequest,
         XSLT
     };
-    
+
     NetworkResourceLoadIdentifier resourceLoadID;
     std::optional<WebCore::FrameIdentifier> frameID;
     std::optional<WebCore::FrameIdentifier> parentFrameID;
+    Markable<WTF::UUID> documentID;
     URL originalURL;
     String originalHTTPMethod;
     WallTime eventTimestamp;

--- a/Source/WebKit/Shared/ResourceLoadInfo.serialization.in
+++ b/Source/WebKit/Shared/ResourceLoadInfo.serialization.in
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Apple Inc. All rights reserved.
+# Copyright (C) 2023-2024 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -42,6 +42,7 @@ struct WebKit::ResourceLoadInfo {
     WebKit::NetworkResourceLoadIdentifier resourceLoadID;
     std::optional<WebCore::FrameIdentifier> frameID;
     std::optional<WebCore::FrameIdentifier> parentFrameID;
+    Markable<WTF::UUID> documentID;
     URL originalURL;
     String originalHTTPMethod;
     WallTime eventTimestamp;

--- a/Source/WebKit/UIProcess/API/APIResourceLoadInfo.h
+++ b/Source/WebKit/UIProcess/API/APIResourceLoadInfo.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -43,6 +43,7 @@ public:
     WebKit::NetworkResourceLoadIdentifier resourceLoadID() const { return m_info.resourceLoadID; }
     std::optional<WebCore::FrameIdentifier> frameID() const { return m_info.frameID; }
     std::optional<WebCore::FrameIdentifier> parentFrameID() const { return m_info.parentFrameID; }
+    Markable<WTF::UUID> documentID() const { return m_info.documentID; }
     const WTF::URL& originalURL() const { return m_info.originalURL; }
     const WTF::String& originalHTTPMethod() const { return m_info.originalHTTPMethod; }
     WallTime eventTimestamp() const { return m_info.eventTimestamp; }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadInfo.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadInfo.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -56,6 +56,7 @@ WK_CLASS_AVAILABLE(macos(11.0), ios(14.0))
 @property (nonatomic, readonly) uint64_t resourceLoadID;
 @property (nonatomic, readonly) _WKFrameHandle *frame;
 @property (nonatomic, readonly, nullable) _WKFrameHandle *parentFrame;
+@property (nonatomic, readonly, nullable) NSUUID *documentID;
 @property (nonatomic, readonly) NSURL *originalURL;
 @property (nonatomic, readonly) NSString *originalHTTPMethod;
 @property (nonatomic, readonly) NSDate *eventTimestamp;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWebNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWebNavigation.mm
@@ -63,16 +63,16 @@ TEST(WKWebExtensionAPIWebNavigation, BeforeNavigateEvent)
 
     auto *backgroundScript = Util::constructScript(@[
         @"browser.webNavigation.onBeforeNavigate.addListener((details) => {",
-        @"    browser.test.assertEq(details?.frameId, 0, 'details.frameId should be:')",
-        @"    browser.test.assertEq(details?.parentFrameId, -1, 'details.parentFrameId should be:')",
+        @"    browser.test.assertEq(details?.frameId, 0, 'details.frameId should be')",
+        @"    browser.test.assertEq(details?.parentFrameId, -1, 'details.parentFrameId should be')",
 
-        @"    browser.test.assertEq(typeof details?.url, 'string', 'details.url should be:')",
+        @"    browser.test.assertEq(typeof details?.url, 'string', 'details.url should be')",
         @"    browser.test.assertTrue(details?.url?.includes('localhost'), 'details.url should include localhost')",
 
-        @"    browser.test.assertEq(typeof details?.tabId, 'number', 'details.tabId should be:')",
-        @"    browser.test.assertEq(typeof details?.timeStamp, 'number', 'details.timeStamp should be:')",
+        @"    browser.test.assertEq(typeof details?.tabId, 'number', 'details.tabId should be')",
+        @"    browser.test.assertEq(typeof details?.timeStamp, 'number', 'details.timeStamp should be')",
 
-        @"    browser.test.assertEq(details?.documentId, undefined, 'details.documentId should be:')",
+        @"    browser.test.assertEq(details?.documentId, undefined, 'details.documentId should be')",
 
         @"    browser.test.notifyPass()",
         @"})",
@@ -105,17 +105,17 @@ TEST(WKWebExtensionAPIWebNavigation, CommittedEvent)
 
     auto *backgroundScript = Util::constructScript(@[
         @"browser.webNavigation.onCommitted.addListener((details) => {",
-        @"    browser.test.assertEq(details?.frameId, 0, 'details.frameId should be:')",
-        @"    browser.test.assertEq(details?.parentFrameId, -1, 'details.parentFrameId should be:')",
+        @"    browser.test.assertEq(details?.frameId, 0, 'details.frameId should be')",
+        @"    browser.test.assertEq(details?.parentFrameId, -1, 'details.parentFrameId should be')",
 
-        @"    browser.test.assertEq(typeof details?.url, 'string', 'details.url should be:')",
+        @"    browser.test.assertEq(typeof details?.url, 'string', 'details.url should be')",
         @"    browser.test.assertTrue(details?.url?.includes('localhost'), 'details.url should include localhost')",
 
-        @"    browser.test.assertEq(typeof details?.tabId, 'number', 'details.tabId should be:')",
-        @"    browser.test.assertEq(typeof details?.timeStamp, 'number', 'details.timeStamp should be:')",
+        @"    browser.test.assertEq(typeof details?.tabId, 'number', 'details.tabId should be')",
+        @"    browser.test.assertEq(typeof details?.timeStamp, 'number', 'details.timeStamp should be')",
 
-        @"    browser.test.assertEq(typeof details?.documentId, 'string', 'details.documentId should be:')",
-        @"    browser.test.assertEq(details?.documentId?.length, 36, 'details.documentId.length should be:')",
+        @"    browser.test.assertEq(typeof details?.documentId, 'string', 'details.documentId should be')",
+        @"    browser.test.assertEq(details?.documentId?.length, 36, 'details.documentId.length should be')",
 
         @"    browser.test.notifyPass()",
         @"})",
@@ -148,17 +148,17 @@ TEST(WKWebExtensionAPIWebNavigation, DOMContentLoadedEvent)
 
     auto *backgroundScript = Util::constructScript(@[
         @"browser.webNavigation.onDOMContentLoaded.addListener((details) => {",
-        @"    browser.test.assertEq(details?.frameId, 0, 'details.frameId should be:')",
-        @"    browser.test.assertEq(details?.parentFrameId, -1, 'details.parentFrameId should be:')",
+        @"    browser.test.assertEq(details?.frameId, 0, 'details.frameId should be')",
+        @"    browser.test.assertEq(details?.parentFrameId, -1, 'details.parentFrameId should be')",
 
-        @"    browser.test.assertEq(typeof details?.url, 'string', 'details.url should be:')",
+        @"    browser.test.assertEq(typeof details?.url, 'string', 'details.url should be')",
         @"    browser.test.assertTrue(details?.url?.includes('localhost'), 'details.url should include localhost')",
 
-        @"    browser.test.assertEq(typeof details?.tabId, 'number', 'details.tabId should be:')",
-        @"    browser.test.assertEq(typeof details?.timeStamp, 'number', 'details.timeStamp should be:')",
+        @"    browser.test.assertEq(typeof details?.tabId, 'number', 'details.tabId should be')",
+        @"    browser.test.assertEq(typeof details?.timeStamp, 'number', 'details.timeStamp should be')",
 
-        @"    browser.test.assertEq(typeof details?.documentId, 'string', 'details.documentId should be:')",
-        @"    browser.test.assertEq(details?.documentId?.length, 36, 'details.documentId.length should be:')",
+        @"    browser.test.assertEq(typeof details?.documentId, 'string', 'details.documentId should be')",
+        @"    browser.test.assertEq(details?.documentId?.length, 36, 'details.documentId.length should be')",
 
         @"    browser.test.notifyPass()",
         @"})",
@@ -191,17 +191,17 @@ TEST(WKWebExtensionAPIWebNavigation, CompletedEvent)
 
     auto *backgroundScript = Util::constructScript(@[
         @"browser.webNavigation.onCompleted.addListener((details) => {",
-        @"    browser.test.assertEq(details?.frameId, 0, 'details.frameId should be:')",
-        @"    browser.test.assertEq(details?.parentFrameId, -1, 'details.parentFrameId should be:')",
+        @"    browser.test.assertEq(details?.frameId, 0, 'details.frameId should be')",
+        @"    browser.test.assertEq(details?.parentFrameId, -1, 'details.parentFrameId should be')",
 
-        @"    browser.test.assertEq(typeof details?.url, 'string', 'details.url should be:')",
+        @"    browser.test.assertEq(typeof details?.url, 'string', 'details.url should be')",
         @"    browser.test.assertTrue(details?.url?.includes('localhost'), 'details.url should include localhost')",
 
-        @"    browser.test.assertEq(typeof details?.tabId, 'number', 'details.tabId should be:')",
-        @"    browser.test.assertEq(typeof details?.timeStamp, 'number', 'details.timeStamp should be:')",
+        @"    browser.test.assertEq(typeof details?.tabId, 'number', 'details.tabId should be')",
+        @"    browser.test.assertEq(typeof details?.timeStamp, 'number', 'details.timeStamp should be')",
 
-        @"    browser.test.assertEq(typeof details?.documentId, 'string', 'details.documentId should be:')",
-        @"    browser.test.assertEq(details?.documentId?.length, 36, 'details.documentId.length should be:')",
+        @"    browser.test.assertEq(typeof details?.documentId, 'string', 'details.documentId should be')",
+        @"    browser.test.assertEq(details?.documentId?.length, 36, 'details.documentId.length should be')",
 
         @"    browser.test.notifyPass()",
         @"})",
@@ -317,6 +317,58 @@ TEST(WKWebExtensionAPIWebNavigation, AllEventsFired)
         @"browser.webNavigation.onCommitted.addListener(onCommittedHandler)",
         @"browser.webNavigation.onDOMContentLoaded.addListener(onDOMContentLoadedHandler)",
         @"browser.webNavigation.onCompleted.addListener(onCompletedHandler)",
+
+        @"browser.test.yield('Load Tab')"
+    ]);
+
+    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:webNavigationManifest resources:@{ @"background.js": backgroundScript }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
+
+    auto *urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+
+    [manager loadAndRun];
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
+
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
+
+    [manager run];
+}
+
+TEST(WKWebExtensionAPIWebNavigation, DocumentIdAcrossEvents)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"let documentId = null",
+
+        @"browser.webNavigation.onBeforeNavigate.addListener((details) => {",
+        @"  browser.test.assertEq(details?.documentId, undefined, 'details.documentId should be')",
+        @"})",
+
+        @"browser.webNavigation.onCommitted.addListener((details) => {",
+        @"  browser.test.assertEq(documentId, null, 'documentId should be')",
+
+        @"  browser.test.assertEq(typeof details?.documentId, 'string', 'details.documentId should be')",
+        @"  browser.test.assertEq(details?.documentId?.length, 36, 'details.documentId.length should be')",
+
+        @"  documentId = details?.documentId",
+        @"})",
+
+        @"browser.webNavigation.onDOMContentLoaded.addListener((details) => {",
+        @"  browser.test.assertEq(documentId, details?.documentId, 'details.documentId should stay consistent in onDOMContentLoaded')",
+        @"})",
+
+        @"browser.webNavigation.onCompleted.addListener((details) => {",
+        @"  browser.test.assertEq(documentId, details?.documentId, 'details.documentId should stay consistent in onCompleted')",
+
+        @"  browser.test.notifyPass()",
+        @"})",
 
         @"browser.test.yield('Load Tab')"
     ]);


### PR DESCRIPTION
#### 37cb94762ceed8686a43727fa19f76973b544597
<pre>
Add support for documentId to webRequest.
<a href="https://webkit.org/b/284174">https://webkit.org/b/284174</a>
<a href="https://rdar.apple.com/problem/141058456">rdar://problem/141058456</a>

Reviewed by Brian Weinstein.

Add support for `documentId` to `webRequest` event details.
Also added support for `type` to `webRequest` event details.

* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::resourceLoadInfo):
* Source/WebKit/Shared/ResourceLoadInfo.h:
* Source/WebKit/Shared/ResourceLoadInfo.serialization.in:
* Source/WebKit/UIProcess/API/APIResourceLoadInfo.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadInfo.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadInfo.mm:
(-[_WKResourceLoadInfo documentID]): Added.
(-[_WKResourceLoadInfo initWithCoder:]):
(-[_WKResourceLoadInfo encodeWithCoder:]):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestCocoa.mm:
(WebKit::toWebAPI):
(WebKit::webRequestDetailsForResourceLoad):
(WebKit::convertHeaderFieldsToWebExtensionFormat):
(WebKit::headersReceivedDetails):
(WebKit::WebExtensionContextProxy::resourceLoadDidSendRequest):
(WebKit::WebExtensionContextProxy::resourceLoadDidPerformHTTPRedirection):
(WebKit::WebExtensionContextProxy::resourceLoadDidReceiveChallenge):
(WebKit::WebExtensionContextProxy::resourceLoadDidReceiveResponse):
(WebKit::WebExtensionContextProxy::resourceLoadDidCompleteWithError):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWebNavigation.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIWebNavigation, BeforeNavigateEvent)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebNavigation, CommittedEvent)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebNavigation, DOMContentLoadedEvent)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebNavigation, CompletedEvent)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebNavigation, AllEventsFired)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebNavigation, DocumentIdAcrossEvents)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWebRequest.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, EventListenerRegistration)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, BeforeRequestEvent)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, BeforeRequestEventForSubresource)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, HeadersReceivedEvent)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, HeadersReceivedEventForSubresource)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, ErrorOccurredEvent)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, RedirectOccurredEvent)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, RedirectOccurredEventForSubresource)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, ResponseStartedEvent)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, ResponseStartedEventForSubresource)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, CompletedEvent)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, CompletedEventForSubresource)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, AllowedFilter)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, DeniedFilter)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, AllEventsFired)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, DocumentIdAcrossEvents)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, RemoveListenerDuringEvent)):

Canonical link: <a href="https://commits.webkit.org/287683@main">https://commits.webkit.org/287683@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c194631223375d4f466a3425f0454c9f41829b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80537 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/59544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/34405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/85058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/31519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82648 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/68605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/7849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/85058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/31519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83606 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/68605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/34405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/85058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/68605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/34405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/29978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/68605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/34405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/86492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/7763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/7849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/86492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/7938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/34405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/86492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/34405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12456 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/7725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/13244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/7564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/11083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/9369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->