### PR TITLE
REGRESSION (287477@main): [ iOS ] editing/selection/ios/tap-to-change-selection-after-accepting-inline-prediction.html is constantly timing out on iOS 18, consistently on 17.

### DIFF
--- a/LayoutTests/editing/selection/ios/tap-to-change-selection-after-accepting-inline-prediction.html
+++ b/LayoutTests/editing/selection/ios/tap-to-change-selection-after-accepting-inline-prediction.html
@@ -10,6 +10,12 @@ body, html {
     margin: 0;
 }
 
+#start {
+    width: 100%;
+    height: 120px;
+    border: 1px solid orange;
+}
+
 #target {
     padding: 4px;
     border: 1px solid tomato;
@@ -41,7 +47,7 @@ addEventListener("load", async () => {
     getSelection().setPosition(document.body, 0);
 
     console.log("1. Focusing editor");
-    await UIHelper.activateAndWaitForInputSessionAt(10, 10);
+    await UIHelper.activateElementAndWaitForInputSession(document.getElementById("start"));
 
     console.log("2. Typing in editor");
     for (let character of [..."i want to c"]) {
@@ -78,7 +84,7 @@ addEventListener("load", async () => {
 </script>
 </head>
 <body contenteditable>
-    <div><br></div>
+    <div id="start"><br></div>
     <p id="description"></p>
     <div id="target"><br></div>
 </body>


### PR DESCRIPTION
#### 6050fb33cdc9dc453b9da8da9a108ccfd051ec88
<pre>
REGRESSION (287477@main): [ iOS ] editing/selection/ios/tap-to-change-selection-after-accepting-inline-prediction.html is constantly timing out on iOS 18, consistently on 17.
<a href="https://bugs.webkit.org/show_bug.cgi?id=284380">https://bugs.webkit.org/show_bug.cgi?id=284380</a>
<a href="https://rdar.apple.com/141228404">rdar://141228404</a>

Reviewed by Abrar Rahman Protyasha.

Speculatively try to fix this flaky test by making the initial tap target taller, and replacing the
hard-coded tap location with a point computed from the bounds of the target element. Telemetry taken
from test runners shows that we&apos;re failing to even tap on the contentEditable body to focus it —
it&apos;s possible that this is because the hit-tested location is obscured by either the status bar, or
safe area inset.

* LayoutTests/editing/selection/ios/tap-to-change-selection-after-accepting-inline-prediction.html:

Canonical link: <a href="https://commits.webkit.org/287635@main">https://commits.webkit.org/287635@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a27aa1b10fab0dc8a6ee3fb5629fab51ed46c6f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80368 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59374 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33881 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/84889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/31350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68436 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7677 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/84889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/31350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83437 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/52893 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73178 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/84889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/50211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27333 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/29809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/71350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27849 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86323 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7593 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/71096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7768 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69016 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/70336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14332 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13277 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12428 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7555 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7394 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/10914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9200 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->