### PR TITLE
imported/w3c/web-platform-tests/css/css-view-transitions/no-white-flash-before-activation.html can time out

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -11014,6 +11014,8 @@ void Document::clearRenderingIsSuppressedForViewTransition()
     if (std::exchange(m_renderingIsSuppressedForViewTransition, false)) {
         if (CheckedPtr view = renderView())
             view->compositor().setRenderingIsSuppressed(false);
+
+        scheduleRenderingUpdate({ });
     }
 }
 
@@ -11026,6 +11028,7 @@ void Document::flushDeferredRenderingIsSuppressedForViewTransitionChanges()
 // https://drafts.csswg.org/css-view-transitions/#ViewTransition-prepare
 RefPtr<ViewTransition> Document::startViewTransition(StartViewTransitionCallbackOptions&& callbackOptions)
 {
+    LOG_WITH_STREAM(ViewTransitions, stream << "Document " << this << " startViewTransition");
     if (!globalObject())
         return nullptr;
 

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -43,6 +43,10 @@ namespace JSC {
 class JSValue;
 }
 
+namespace WTF {
+class TextStream;
+}
+
 namespace WebCore {
 
 class DOMPromise;
@@ -246,4 +250,6 @@ private:
     Ref<ViewTransitionTypeSet> m_types;
 };
 
-}
+WTF::TextStream& operator<<(WTF::TextStream&, ViewTransitionPhase);
+
+} // namespace WebCore


### PR DESCRIPTION
#### 5715565a4b6c459a2350fbcd90f71339e80d3866
<pre>
imported/w3c/web-platform-tests/css/css-view-transitions/no-white-flash-before-activation.html can time out
<a href="https://bugs.webkit.org/show_bug.cgi?id=284405">https://bugs.webkit.org/show_bug.cgi?id=284405</a>
<a href="https://rdar.apple.com/141243828">rdar://141243828</a>

Reviewed by Matt Woodrow.

imported/w3c/web-platform-tests/css/css-view-transitions/no-white-flash-before-activation.html can time out in some cases
(seen on iOS and Intel bots on <a href="https://github.com/WebKit/WebKit/pull/22531).">https://github.com/WebKit/WebKit/pull/22531).</a>

This probably happens with that PR because nothing else triggers a rendering update after clearing rendering
suppression. So fix `Document::clearRenderingIsSuppressedForViewTransition()` to schedule a rendering update.

Also add more to the ViewTransition log channel.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::clearRenderingIsSuppressedForViewTransition):
(WebCore::Document::startViewTransition):
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::createSamePage):
(WebCore::ViewTransition::skipViewTransition):
(WebCore::ViewTransition::callUpdateCallback):
(WebCore::operator&lt;&lt;):
* Source/WebCore/dom/ViewTransition.h:

Canonical link: <a href="https://commits.webkit.org/287643@main">https://commits.webkit.org/287643@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee04c0b500b0dc36031a8c2ea4a3c71f955551e0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80373 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59379 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33889 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84894 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31355 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82484 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68441 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7682 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/62817 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/20625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83442 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52897 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73183 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43120 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/50214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27338 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29814 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71353 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27855 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86328 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7598 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71101 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-pseudo/marker-animate-002.html imported/w3c/web-platform-tests/css/css-transforms/backface-visibility-hidden-animated-001.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7773 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69021 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70341 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17516 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14338 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13282 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7560 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/13080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7399 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10919 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9205 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->