### PR TITLE
Fix safer C++ checker failures in WebCore

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -399,6 +399,7 @@ JSWebAnimation.cpp
 JSWebCodecsAudioData.cpp
 JSWebCodecsAudioDecoder.cpp
 JSWebCodecsAudioEncoder.cpp
+JSWebCodecsEncodedVideoChunk.cpp
 JSWebCodecsVideoDecoder.cpp
 JSWebCodecsVideoEncoder.cpp
 JSWebCodecsVideoFrame.cpp

--- a/Source/WebCore/dom/DocumentFullscreen.cpp
+++ b/Source/WebCore/dom/DocumentFullscreen.cpp
@@ -43,7 +43,7 @@ bool DocumentFullscreen::webkitFullscreenEnabled(Document& document)
 
 Element* DocumentFullscreen::webkitFullscreenElement(Document& document)
 {
-    return document.ancestorElementInThisScope(document.fullscreenManager().fullscreenElement());
+    return document.ancestorElementInThisScope(document.fullscreenManager().protectedFullscreenElement().get());
 }
 
 bool DocumentFullscreen::webkitIsFullScreen(Document& document)
@@ -58,7 +58,7 @@ bool DocumentFullscreen::webkitFullScreenKeyboardInputAllowed(Document& document
 
 Element* DocumentFullscreen::webkitCurrentFullScreenElement(Document& document)
 {
-    return document.ancestorElementInThisScope(document.fullscreenManager().currentFullscreenElement());
+    return document.ancestorElementInThisScope(document.fullscreenManager().protectedCurrentFullscreenElement().get());
 }
 
 void DocumentFullscreen::webkitCancelFullScreen(Document& document)

--- a/Source/WebCore/dom/FullscreenManager.h
+++ b/Source/WebCore/dom/FullscreenManager.h
@@ -61,6 +61,7 @@ public:
 
     // WHATWG Fullscreen API
     WEBCORE_EXPORT Element* fullscreenElement() const;
+    RefPtr<Element> protectedFullscreenElement() const { return fullscreenElement(); }
     WEBCORE_EXPORT bool isFullscreenEnabled() const;
     WEBCORE_EXPORT void exitFullscreen(RefPtr<DeferredPromise>&&);
 
@@ -68,6 +69,7 @@ public:
     bool isFullscreen() const { return m_fullscreenElement.get(); }
     bool isFullscreenKeyboardInputAllowed() const { return m_fullscreenElement.get() && m_areKeysEnabledInFullscreen; }
     Element* currentFullscreenElement() const { return m_fullscreenElement.get(); }
+    RefPtr<Element> protectedCurrentFullscreenElement() const { return currentFullscreenElement(); }
     WEBCORE_EXPORT void cancelFullscreen();
 
     enum FullscreenCheckType {

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -237,11 +237,12 @@ TextUtil::EnclosingGlyphBounds TextUtil::enclosingGlyphBounds(StringView textCon
         auto isRightToLeftInlineDirection = style.writingMode().isBidiRTL();
 
         auto firstGlyphData = fontCascade.glyphDataForCharacter(textContent[0], isRightToLeftInlineDirection);
-        auto firstGlyphOverflow = -(firstGlyphData.font ? *firstGlyphData.font : primaryFont).boundsForGlyph(firstGlyphData.glyph).x();
+        Ref fontForFirstGlyph = firstGlyphData.font ? *firstGlyphData.font : primaryFont;
+        auto firstGlyphOverflow = -fontForFirstGlyph->boundsForGlyph(firstGlyphData.glyph).x();
 
         auto lastGlyphData = fontCascade.glyphDataForCharacter(textContent[textContent.length() - 1], isRightToLeftInlineDirection);
-        auto& fontForLastGlyph = lastGlyphData.font ? *lastGlyphData.font : primaryFont;
-        auto lastGlyphOverflow = fontForLastGlyph.boundsForGlyph(lastGlyphData.glyph).maxX() - fontForLastGlyph.widthForGlyph(lastGlyphData.glyph);
+        Ref fontForLastGlyph = lastGlyphData.font ? *lastGlyphData.font : primaryFont;
+        auto lastGlyphOverflow = fontForLastGlyph->boundsForGlyph(lastGlyphData.glyph).maxX() - fontForLastGlyph->widthForGlyph(lastGlyphData.glyph);
 #if PLATFORM(IOS_FAMILY)
         // FIXME: Find out why we get false subpixel overflow values on iOS.
         firstGlyphOverflow -= 0.1f;


### PR DESCRIPTION
#### 947842d43629bf5be4103998c59438652dfb17e3
<pre>
Fix safer C++ checker failures in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=284413">https://bugs.webkit.org/show_bug.cgi?id=284413</a>

Reviewed by Geoffrey Garen.

Fixed safer C++ clang static analyzer warnings in WebCore and added one JS binding code to exceptions.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/dom/DocumentFullscreen.cpp:
(WebCore::DocumentFullscreen::webkitFullscreenElement):
(WebCore::DocumentFullscreen::webkitCurrentFullScreenElement):
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::protectedFullscreenElement const):
(WebCore::FullscreenManager::protectedTopDocument): Deleted.
* Source/WebCore/dom/FullscreenManager.h:
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
(WebCore::Layout::TextUtil::enclosingGlyphBounds):

Canonical link: <a href="https://commits.webkit.org/287676@main">https://commits.webkit.org/287676@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37760fdf6b5509af9a0c56974eaeb0e9f79a0884

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80414 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59420 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34061 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84935 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31396 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82525 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68482 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7723 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62839 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20647 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83483 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52925 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73215 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43143 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50236 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27369 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29855 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71376 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27890 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86369 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7639 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5399 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71124 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7814 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69052 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70365 "Found 2 new API test failures: /TestWebKit:WebKit.FirstMeaningfulPaint, /TestWebKit:WebKit.EnumerateDevicesCrash (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14363 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13310 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12451 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7601 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13121 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7440 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10960 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9246 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->