### PR TITLE
Improve the ability to copy the Bugzilla bug number alone

### DIFF
--- a/Websites/bugs.webkit.org/skins/custom/global.css
+++ b/Websites/bugs.webkit.org/skins/custom/global.css
@@ -1634,11 +1634,9 @@ label.required, .required_explanation {
     font-weight: 400;
 }
 
-#copy-commitlog:hover {
-    text-decoration: none;
-}
-
-#copy-commitlog:after {
+#copy-commitlog + #copy-commitlog-label:after {
+    display: inline-block;
+    overflow: visible;
     background-image: var(--copy-commitlog-glyph);
     background-color: transparent;
     background-repeat: no-repeat;
@@ -1646,19 +1644,23 @@ label.required, .required_explanation {
     background-position: 0.7rem 0.1rem;
 
     content: "Copy bug for commit log";
+    
+    text-wrap: nowrap;
 
-    padding-left: 3rem;
     font-weight: 400;
     color: var(--text-color-coolgray);
     opacity: 0;
-    transition: opacity 500ms ease-in-out;
+    width: 0;
+    padding-left: 3rem;
+    transition: width 0ms, opacity 500ms ease-in-out;
 }
 
-#copy-commitlog:hover:after {
+#copy-commitlog:hover + #copy-commitlog-label:after {
+    width: auto;
     opacity: 1;
 }
 
-#copy-commitlog.clicked:after {
+#copy-commitlog.clicked + #copy-commitlog-label:after {
     color: green;
     content: "Copied!";
 }

--- a/Websites/bugs.webkit.org/template/en/custom/bug/edit.html.tmpl
+++ b/Websites/bugs.webkit.org/template/en/custom/bug/edit.html.tmpl
@@ -141,8 +141,15 @@
             of [% "${terms.bug} ${bug.dup_id}" FILTER bug_link(bug.dup_id) FILTER none %]
           [% END %]
         [% END %]
-      </span><a href="show_bug.cgi?id=[% bug.bug_id %]" class="bug_id" [% IF user.id %]id="copy-commitlog"[% END %]>[% terms.Bug %]&nbsp;[% bug.bug_id FILTER html %]</a>      
+      </span><a href="show_bug.cgi?id=[% bug.bug_id %]" class="bug_id" [% IF user.id %]  id="copy-commitlog"[% END %]>[% bug.bug_id FILTER html %]</a> [% IF user.id %]<span id="copy-commitlog-label"></span>[% END %]
      </div>
+     <style>
+     a.bug_id::before {
+       content: "[% terms.Bug %] ";
+       -webkit-user-select: none;
+       user-select: none;
+     }
+     </style>
      <span id="summary_container" class="bz_default_hidden">
       [% IF bug.alias.size > 0 %]
         <span id="alias_nonedit_display">[% bug.alias.join(', ') FILTER html %]</span>
@@ -193,18 +200,14 @@
         }
     }
     
-    document.getElementById('commit-urls').addEventListener('click', (e) => {
-      selectText(e.target.parentElement);
-    });
-    
-    let clipboardButtonElement = document.getElementById('copy-commitlog');
-    clipboardButtonElement.addEventListener('click', (e) => {
+    let copyCommitlogElement = document.getElementById('copy-commitlog');
+    copyCommitlogElement.addEventListener('click', (e) => {
       e.preventDefault();
       let text = document.getElementById('short_desc').value + "\n" + document.getElementById('commit-urls').textContent;
       navigator.clipboard.writeText(text).then(function() {
-        clipboardButtonElement.classList.add('clicked');
+        copyCommitlogElement.classList.add('clicked');
         setTimeout(function () {
-          clipboardButtonElement.classList.remove('clicked');  
+          copyCommitlogElement.classList.remove('clicked');  
         }, 3000);
       });
     });


### PR DESCRIPTION
#### b92e5bb852c3b1969a6982dee5af597344112b75
<pre>
Improve the ability to copy the Bugzilla bug number alone
<a href="https://bugs.webkit.org/show_bug.cgi?id=284420">https://bugs.webkit.org/show_bug.cgi?id=284420</a>

Reviewed by Ryosuke Niwa.

Prevents the &quot;Bug&quot; prefix label from being selectable and
changes the copy commit log label to a separate element
that is not hover activated on its own. This allows text
selection to happen intuitively nearer to the bug number.

Canonical link: <a href="https://commits.webkit.org/287677@main">https://commits.webkit.org/287677@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84cac4da5f276837866e10b7bd3e7a79f4d6d108

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80402 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59408 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34016 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84923 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31384 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68470 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7711 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62831 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20643 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83471 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52917 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73204 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43135 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50228 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29843 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71368 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27877 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86357 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7627 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5393 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71116 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7802 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69041 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70357 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14358 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13301 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12452 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7589 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7428 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10948 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9234 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->