### PR TITLE
[margin-trim][cleanup] Remove margin-trim rare data bit.

### DIFF
--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2965,19 +2965,15 @@ void RenderBlock::setTrimmedMarginForChild(RenderBox &child, MarginTrimType marg
     switch (marginTrimType) {
     case MarginTrimType::BlockStart:
         setMarginBeforeForChild(child, 0_lu);
-        child.markMarginAsTrimmed(MarginTrimType::BlockStart);
         break;
     case MarginTrimType::BlockEnd:
         setMarginAfterForChild(child, 0_lu);
-        child.markMarginAsTrimmed(MarginTrimType::BlockEnd);
         break;
     case MarginTrimType::InlineStart:
         setMarginStartForChild(child, 0_lu);
-        child.markMarginAsTrimmed(MarginTrimType::InlineStart);
         break;
     case MarginTrimType::InlineEnd:
         setMarginEndForChild(child, 0_lu);
-        child.markMarginAsTrimmed(MarginTrimType::InlineEnd);
         break;
     default:
         ASSERT_NOT_IMPLEMENTED_YET();

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -302,10 +302,6 @@ public:
     void clearOverridingLogicalHeightLength();
     void clearOverridingLogicalWidthLength();
 
-    void markMarginAsTrimmed(MarginTrimType);
-    void clearTrimmedMarginsMarkings();
-    bool hasTrimmedMargin(std::optional<MarginTrimType>) const;
-
     LayoutSize offsetFromContainer(RenderElement&, const LayoutPoint&, bool* offsetDependsOnPoint = nullptr) const override;
     
     LayoutUnit adjustBorderBoxLogicalWidthForBoxSizing(const Length& logicalWidth) const;

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -1690,9 +1690,6 @@ FlexLayoutItem RenderFlexibleBox::constructFlexLayoutItem(RenderBox& flexItem, b
     if (CheckedPtr flexibleBox = dynamicDowncast<RenderFlexibleBox>(flexItem))
         flexibleBox->resetHasDefiniteHeight();
 
-    if (everHadLayout && flexItem.hasTrimmedMargin(std::optional<MarginTrimType> { }))
-        flexItem.clearTrimmedMarginsMarkings();
-    
     if (flexItem.needsPreferredWidthsRecalculation())
         flexItem.setPreferredLogicalWidthsDirty(true, MarkingBehavior::MarkOnlyThis);
 

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -1309,7 +1309,6 @@ private:
 
         bool hasReflection { false };
         bool hasOutlineAutoAncestor { false };
-        OptionSet<MarginTrimType> trimmedMargins;
 
         // From RenderElement
         std::unique_ptr<ReferencedSVGResources> referencedSVGResources;


### PR DESCRIPTION
#### f88293484c47104605b954ad84b681c1a3266b1e
<pre>
[margin-trim][cleanup] Remove margin-trim rare data bit.
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

wip

* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle const):
(WebCore::rendererCanHaveTrimmedMargin): Deleted.
(WebCore::physicalToFlowRelativeDirection): Deleted.
(WebCore::toMarginTrimType): Deleted.
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::setTrimmedMarginForChild):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::computeOrTrimInlineMargin const):
(WebCore::RenderBox::constrainBlockMarginInAvailableSpaceOrTrim const):
(WebCore::RenderBox::markMarginAsTrimmed): Deleted.
(WebCore::RenderBox::clearTrimmedMarginsMarkings): Deleted.
(WebCore::RenderBox::hasTrimmedMargin const): Deleted.
* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::constructFlexLayoutItem):
* Source/WebCore/rendering/RenderObject.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f88293484c47104605b954ad84b681c1a3266b1e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80406 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59412 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34023 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84927 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31388 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82517 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68474 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7767 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62838 "Found 13 new test failures: css3/calc/margin.html css3/viewport-percentage-lengths/css3-viewport-percentage-lengths-getStyle.html css3/viewport-percentage-lengths/viewport-percentage-lengths-calc.html fast/css/getComputedStyle/getComputedStyle-margin-length.html fast/css/getComputedStyle/getComputedStyle-margin-shorthand.html fast/css/getComputedStyle/getComputedStyle-resolved-values.html fast/css/getComputedStyle/getComputedStyle-with-pseudo-element.html fast/sub-pixel/computedstylemargin.html imported/w3c/web-platform-tests/css/css-box/parsing/margin-computed.html imported/w3c/web-platform-tests/css/css-logical/inheritance.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20649 "Found 7 new test failures: css3/calc/margin.html css3/viewport-percentage-lengths/css3-viewport-percentage-lengths-getStyle.html css3/viewport-percentage-lengths/viewport-percentage-lengths-calc.html fast/css/getComputedStyle/getComputedStyle-margin-length.html fast/css/getComputedStyle/getComputedStyle-margin-shorthand.html fast/css/getComputedStyle/getComputedStyle-resolved-values.html fast/css/getComputedStyle/getComputedStyle-with-pseudo-element.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83475 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52919 "Found 8 new test failures: css3/calc/margin.html css3/viewport-percentage-lengths/css3-viewport-percentage-lengths-getStyle.html css3/viewport-percentage-lengths/viewport-percentage-lengths-calc.html fast/css/getComputedStyle/getComputedStyle-margin-length.html fast/css/getComputedStyle/getComputedStyle-margin-shorthand.html fast/css/getComputedStyle/getComputedStyle-resolved-values.html fast/css/getComputedStyle/getComputedStyle-with-pseudo-element.html fast/sub-pixel/computedstylemargin.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73210 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43142 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50230 "Found 5 new test failures: imported/w3c/web-platform-tests/css/css-box/parsing/margin-computed.html imported/w3c/web-platform-tests/css/css-logical/inheritance.html imported/w3c/web-platform-tests/css/cssom/getComputedStyle-margins-roundtrip.html imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/legend.html imported/w3c/web-platform-tests/html/rendering/pixel-length-attributes.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27364 "Found 14 new test failures: css3/calc/margin.html css3/viewport-percentage-lengths/css3-viewport-percentage-lengths-getStyle.html css3/viewport-percentage-lengths/viewport-percentage-lengths-calc.html fast/css/getComputedStyle/getComputedStyle-margin-length.html fast/css/getComputedStyle/getComputedStyle-margin-shorthand.html fast/css/getComputedStyle/getComputedStyle-resolved-values.html fast/css/getComputedStyle/getComputedStyle-with-pseudo-element.html fast/sub-pixel/computedstylemargin.html imported/w3c/web-platform-tests/css/css-box/parsing/margin-computed.html imported/w3c/web-platform-tests/css/css-logical/inheritance.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29847 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71370 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27884 "Found 13 new test failures: css3/calc/margin.html css3/viewport-percentage-lengths/css3-viewport-percentage-lengths-getStyle.html css3/viewport-percentage-lengths/viewport-percentage-lengths-calc.html fast/css/getComputedStyle/getComputedStyle-margin-length.html fast/css/getComputedStyle/getComputedStyle-margin-shorthand.html fast/css/getComputedStyle/getComputedStyle-resolved-values.html fast/css/getComputedStyle/getComputedStyle-with-pseudo-element.html fast/sub-pixel/computedstylemargin.html imported/w3c/web-platform-tests/css/css-box/parsing/margin-computed.html imported/w3c/web-platform-tests/css/css-logical/inheritance.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86361 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7631 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5427 "Found 60 new test failures: css3/calc/margin.html css3/viewport-percentage-lengths/css3-viewport-percentage-lengths-getStyle.html css3/viewport-percentage-lengths/viewport-percentage-lengths-calc.html fast/css/getComputedStyle/getComputedStyle-margin-length.html fast/css/getComputedStyle/getComputedStyle-margin-shorthand.html fast/css/getComputedStyle/getComputedStyle-resolved-values.html fast/css/getComputedStyle/getComputedStyle-with-pseudo-element.html fast/forms/switch/click-animation-twice.html fast/scrolling/mac/rubberband-axis-locking.html fast/selectors/hover-descendant-shadow-tree.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71122 "Found 13 new test failures: css3/calc/margin.html css3/viewport-percentage-lengths/css3-viewport-percentage-lengths-getStyle.html css3/viewport-percentage-lengths/viewport-percentage-lengths-calc.html fast/css/getComputedStyle/getComputedStyle-margin-length.html fast/css/getComputedStyle/getComputedStyle-margin-shorthand.html fast/css/getComputedStyle/getComputedStyle-resolved-values.html fast/css/getComputedStyle/getComputedStyle-with-pseudo-element.html fast/sub-pixel/computedstylemargin.html imported/w3c/web-platform-tests/css/css-box/parsing/margin-computed.html imported/w3c/web-platform-tests/css/css-logical/inheritance.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7806 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69047 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70363 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14364 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13306 "Found 13 new test failures: css3/calc/margin.html css3/viewport-percentage-lengths/css3-viewport-percentage-lengths-getStyle.html css3/viewport-percentage-lengths/viewport-percentage-lengths-calc.html fast/css/getComputedStyle/getComputedStyle-margin-length.html fast/css/getComputedStyle/getComputedStyle-margin-shorthand.html fast/css/getComputedStyle/getComputedStyle-resolved-values.html fast/css/getComputedStyle/getComputedStyle-with-pseudo-element.html fast/sub-pixel/computedstylemargin.html imported/w3c/web-platform-tests/css/css-box/parsing/margin-computed.html imported/w3c/web-platform-tests/css/css-logical/inheritance.html ... (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7593 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13113 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7432 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10952 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9238 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->