### PR TITLE
Web Inspector: support `DOMRect` in `console.screenshot`

### DIFF
--- a/LayoutTests/inspector/console/console-screenshot-expected.txt
+++ b/LayoutTests/inspector/console/console-screenshot-expected.txt
@@ -7,6 +7,9 @@ CONSOLE MESSAGE: [object HTMLDivElement]
 CONSOLE MESSAGE: [object ImageData]
 CONSOLE MESSAGE: [object ImageBitmap]
 CONSOLE MESSAGE: [object CanvasRenderingContext2D]
+CONSOLE MESSAGE: [object DOMRect]
+CONSOLE MESSAGE: [object DOMRectReadOnly]
+CONSOLE MESSAGE: Viewport
 CONSOLE MESSAGE: Viewport
 CONSOLE MESSAGE: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAAXNSR0IArs4c6QAAABNJREFUCB1j/M/AAEQMDEwgAgQAHxcCAmtAm/sAAAAASUVORK5CYII=
 CONSOLE MESSAGE: data:fake/mime
@@ -69,6 +72,24 @@ PASS: The added message should be an image.
 PASS: The image should not be empty.
 PASS: The image width should be 2px.
 PASS: The image height should be 2px.
+
+-- Running test case: console.screenshot.DOMRect
+PASS: The added message should be an image.
+PASS: The image should not be empty.
+PASS: The image width should be 2px.
+PASS: The image height should be 2px.
+
+-- Running test case: console.screenshot.DOMRectReadOnly
+PASS: The added message should be an image.
+PASS: The image should not be empty.
+PASS: The image width should be 2px.
+PASS: The image height should be 2px.
+
+-- Running test case: console.screenshot.DOMRectInit
+PASS: The added message should be an image.
+PASS: The image should not be empty.
+PASS: The image width should be greater than 2px.
+PASS: The image height should be greater than 2px.
 
 -- Running test case: console.screenshot.String.Valid
 PASS: The added message should be an image.

--- a/LayoutTests/inspector/console/console-screenshot.html
+++ b/LayoutTests/inspector/console/console-screenshot.html
@@ -163,6 +163,22 @@ function test()
     });
 
     addTest({
+        name: "console.screenshot.DOMRect",
+        expression: `console.screenshot(document.querySelector("#testNode").getBoundingClientRect())`,
+    });
+
+    addTest({
+        name: "console.screenshot.DOMRectReadOnly",
+        expression: `console.screenshot(DOMRectReadOnly.fromRect(document.querySelector("#testNode").getBoundingClientRect()))`,
+    });
+
+    addTest({
+        name: "console.screenshot.DOMRectInit",
+        expression: `console.screenshot({x: 0, y: 0, width: 2, height: 2})`,
+        shouldCaptureViewport: true,
+    });
+
+    addTest({
         name: "console.screenshot.String.Valid",
         expression: `console.screenshot("test")`,
         shouldCaptureViewport: true,


### PR DESCRIPTION
#### f6f9d60bae5c9a19941d4b09e0dc6654982083f2
<pre>
Web Inspector: support `DOMRect` in `console.screenshot`
<a href="https://bugs.webkit.org/show_bug.cgi?id=284423">https://bugs.webkit.org/show_bug.cgi?id=284423</a>

Reviewed by Tim Nguyen.

This will allow developers to customize what part of the page is captured instead of more coarse options like a `Node` or the entire `document`.

* Source/WebCore/page/PageConsoleClient.cpp:
(WebCore::PageConsoleClient::screenshot):

* LayoutTests/inspector/console/console-screenshot.html:
* LayoutTests/inspector/console/console-screenshot-expected.txt:

Canonical link: <a href="https://commits.webkit.org/288544@main">https://commits.webkit.org/288544@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e683993bda146be1cc01d09f13fbc79b50255ac5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80417 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59423 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34065 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84938 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31399 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82528 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68485 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7726 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62840 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20650 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83486 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52924 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73217 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43144 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50235 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27371 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29858 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71375 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27892 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86372 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7642 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5398 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71125 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7817 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69054 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70366 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18000 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14365 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13312 "Passed tests") | [⏳ 🛠 playstation ](https://ews-build.webkit.org/#/builders/PlayStation-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7604 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13124 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7443 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10963 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9249 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->