### PR TITLE
Make WebPageProxy::wrapCryptoKey take CryptoKey instead of serialized key data

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -855,8 +855,22 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     contentextensions/Term.h
     contentextensions/URLFilterParser.h
 
+    crypto/CryptoAlgorithmIdentifier.h
+    crypto/CryptoKey.h
+    crypto/CryptoKeyData.h
+    crypto/CryptoKeyType.h
+    crypto/CryptoKeyUsage.h
+    crypto/JsonWebKey.h
+    crypto/RsaOtherPrimesInfo.h
     crypto/SerializedCryptoKeyWrap.h
     crypto/WrappedCryptoKey.h
+
+    crypto/keys/CryptoAesKeyAlgorithm.h
+    crypto/keys/CryptoEcKeyAlgorithm.h
+    crypto/keys/CryptoHmacKeyAlgorithm.h
+    crypto/keys/CryptoKeyAlgorithm.h
+    crypto/keys/CryptoRsaHashedKeyAlgorithm.h
+    crypto/keys/CryptoRsaKeyAlgorithm.h
 
     css/CSSAttrValue.h
     css/CSSColorValue.h

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -966,13 +966,13 @@ protected:
     StackCheck m_stackCheck;
 };
 
-static std::optional<Vector<uint8_t>> wrapCryptoKey(JSGlobalObject* lexicalGlobalObject, const Vector<uint8_t>& key)
+static std::optional<Vector<uint8_t>> serializeAndWrapCryptoKey(JSGlobalObject* lexicalGlobalObject, WebCore::CryptoKeyData&& key)
 {
     auto context = executionContext(lexicalGlobalObject);
     if (!context)
         return std::nullopt;
 
-    return context->wrapCryptoKey(key);
+    return context->serializeAndWrapCryptoKey(WTFMove(key));
 }
 
 static std::optional<Vector<uint8_t>> unwrapCryptoKey(JSGlobalObject* lexicalGlobalObject, const Vector<uint8_t>& wrappedKey)
@@ -1037,6 +1037,60 @@ static void validateSerializedResult(CloneSerializer&, SerializationReturnCode, 
 class CloneSerializer : public CloneBase {
     WTF_FORBID_HEAP_ALLOCATION;
 public:
+    static Vector<uint8_t> serializeCryptoKey(JSC::JSGlobalObject& globalObject, const CryptoKey& key)
+    {
+        Vector<uint8_t> serializedKey;
+        Vector<URLKeepingBlobAlive> dummyBlobHandles;
+        Vector<Ref<MessagePort>> dummyMessagePorts;
+        Vector<RefPtr<JSC::ArrayBuffer>> dummyArrayBuffers;
+#if ENABLE(WEB_CODECS)
+        Vector<RefPtr<WebCodecsEncodedVideoChunkStorage>> dummyVideoChunks;
+        Vector<RefPtr<WebCodecsVideoFrame>> dummyVideoFrames;
+        Vector<RefPtr<WebCodecsEncodedAudioChunkStorage>> dummyAudioChunks;
+        Vector<RefPtr<WebCodecsAudioData>> dummyAudioData;
+#endif
+#if ENABLE(MEDIA_STREAM)
+        Vector<RefPtr<MediaStreamTrack>> dummyMediaStreamTracks;
+#endif
+#if ENABLE(WEBASSEMBLY)
+        WasmModuleArray dummyModules;
+        WasmMemoryHandleArray dummyMemoryHandles;
+#endif
+        ArrayBufferContentsArray dummySharedBuffers;
+#if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
+        Vector<RefPtr<OffscreenCanvas>> dummyInMemoryOffscreenCanvases;
+#endif
+        Vector<Ref<MessagePort>> dummyInMemoryMessagePorts;
+        CloneSerializer rawKeySerializer(&globalObject, dummyMessagePorts, dummyArrayBuffers, { },
+#if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
+            { },
+            dummyInMemoryOffscreenCanvases,
+#endif
+            dummyInMemoryMessagePorts,
+#if ENABLE(WEB_RTC)
+            { },
+#endif
+#if ENABLE(MEDIA_SOURCE_IN_WORKERS)
+            { },
+#endif
+#if ENABLE(WEB_CODECS)
+            dummyVideoChunks,
+            dummyVideoFrames,
+            dummyAudioChunks,
+            dummyAudioData,
+#endif
+#if ENABLE(MEDIA_STREAM)
+            dummyMediaStreamTracks,
+#endif
+#if ENABLE(WEBASSEMBLY)
+            dummyModules,
+            dummyMemoryHandles,
+#endif
+            dummyBlobHandles, serializedKey, SerializationContext::Default, dummySharedBuffers, SerializationForStorage::No);
+        rawKeySerializer.write(&key);
+        return serializedKey;
+    }
+
     static SerializationReturnCode serialize(JSGlobalObject* lexicalGlobalObject, JSValue value, Vector<Ref<MessagePort>>& messagePorts, Vector<RefPtr<JSC::ArrayBuffer>>& arrayBuffers, const Vector<RefPtr<ImageBitmap>>& imageBitmaps,
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
             const Vector<RefPtr<OffscreenCanvas>>& offscreenCanvases,
@@ -1978,57 +2032,7 @@ private:
             }
             if (auto* key = JSCryptoKey::toWrapped(vm, obj)) {
                 write(CryptoKeyTag);
-                Vector<uint8_t> serializedKey;
-                Vector<URLKeepingBlobAlive> dummyBlobHandles;
-                Vector<Ref<MessagePort>> dummyMessagePorts;
-                Vector<RefPtr<JSC::ArrayBuffer>> dummyArrayBuffers;
-#if ENABLE(WEB_CODECS)
-                Vector<RefPtr<WebCodecsEncodedVideoChunkStorage>> dummyVideoChunks;
-                Vector<RefPtr<WebCodecsVideoFrame>> dummyVideoFrames;
-                Vector<RefPtr<WebCodecsEncodedAudioChunkStorage>> dummyAudioChunks;
-                Vector<RefPtr<WebCodecsAudioData>> dummyAudioData;
-#endif
-#if ENABLE(MEDIA_STREAM)
-                Vector<RefPtr<MediaStreamTrack>> dummyMediaStreamTracks;
-#endif
-#if ENABLE(WEBASSEMBLY)
-                WasmModuleArray dummyModules;
-                WasmMemoryHandleArray dummyMemoryHandles;
-#endif
-                ArrayBufferContentsArray dummySharedBuffers;
-#if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
-                Vector<RefPtr<OffscreenCanvas>> dummyInMemoryOffscreenCanvases;
-#endif
-                Vector<Ref<MessagePort>> dummyInMemoryMessagePorts;
-                CloneSerializer rawKeySerializer(m_lexicalGlobalObject, dummyMessagePorts, dummyArrayBuffers, { },
-#if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
-                    { },
-                    dummyInMemoryOffscreenCanvases,
-#endif
-                    dummyInMemoryMessagePorts,
-#if ENABLE(WEB_RTC)
-                    { },
-#endif
-#if ENABLE(MEDIA_SOURCE_IN_WORKERS)
-                    { },
-#endif
-#if ENABLE(WEB_CODECS)
-                    dummyVideoChunks,
-                    dummyVideoFrames,
-                    dummyAudioChunks,
-                    dummyAudioData,
-#endif
-#if ENABLE(MEDIA_STREAM)
-                    dummyMediaStreamTracks,
-#endif
-#if ENABLE(WEBASSEMBLY)
-                    dummyModules,
-                    dummyMemoryHandles,
-#endif
-                    dummyBlobHandles, serializedKey, SerializationContext::Default, dummySharedBuffers, m_forStorage);
-                rawKeySerializer.write(key);
-
-                auto wrappedKey = wrapCryptoKey(m_lexicalGlobalObject, serializedKey);
+                auto wrappedKey = serializeAndWrapCryptoKey(m_lexicalGlobalObject, key->data());
                 if (!wrappedKey) {
                     code = SerializationReturnCode::DataCloneError;
                     return true;
@@ -6322,6 +6326,15 @@ RefPtr<SerializedScriptValue> SerializedScriptValue::create(JSContextRef originC
     }
     ASSERT(serializedValue);
     return serializedValue;
+}
+
+Vector<uint8_t> SerializedScriptValue::serializeCryptoKey(JSContextRef context, const WebCore::CryptoKey& key)
+{
+    JSGlobalObject* lexicalGlobalObject = toJS(context);
+    VM& vm = lexicalGlobalObject->vm();
+    JSLockHolder locker(vm);
+
+    return CloneSerializer::serializeCryptoKey(*lexicalGlobalObject, key);
 }
 
 String SerializedScriptValue::toString() const

--- a/Source/WebCore/bindings/js/SerializedScriptValue.h
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.h
@@ -73,6 +73,7 @@ namespace WebCore {
 class DetachedOffscreenCanvas;
 class OffscreenCanvas;
 #endif
+class CryptoKey;
 class IDBValue;
 class MessagePort;
 class DetachedImageBitmap;
@@ -121,6 +122,7 @@ public:
     // API implementation helpers. These don't expose special behavior for ArrayBuffers or MessagePorts.
     WEBCORE_EXPORT static RefPtr<SerializedScriptValue> create(JSContextRef, JSValueRef, JSValueRef* exception);
     WEBCORE_EXPORT JSValueRef deserialize(JSContextRef, JSValueRef* exception);
+    WEBCORE_EXPORT static Vector<uint8_t> serializeCryptoKey(JSContextRef, const WebCore::CryptoKey&);
 
     bool hasBlobURLs() const { return !m_internals.blobHandles.isEmpty(); }
 

--- a/Source/WebCore/crypto/CryptoKey.cpp
+++ b/Source/WebCore/crypto/CryptoKey.cpp
@@ -27,6 +27,12 @@
 #include "CryptoKey.h"
 
 #include "CryptoAlgorithmRegistry.h"
+#include "CryptoKeyAES.h"
+#include "CryptoKeyEC.h"
+#include "CryptoKeyHMAC.h"
+#include "CryptoKeyOKP.h"
+#include "CryptoKeyRSA.h"
+#include "CryptoKeyRaw.h"
 #include "WebCoreOpaqueRoot.h"
 #include <wtf/CryptographicallyRandomNumber.h>
 
@@ -78,5 +84,42 @@ Vector<uint8_t> CryptoKey::randomData(size_t size)
     return result;
 }
 #endif
+
+RefPtr<CryptoKey> CryptoKey::create(CryptoKey::Data&& data)
+{
+    switch (data.keyClass) {
+    case CryptoKeyClass::AES: {
+        if (data.jwk)
+            return CryptoKeyAES::importJwk(data.algorithmIdentifier, WTFMove(*data.jwk), data.extractable, data.usages, [](auto, auto) { return true; });
+        break;
+    }
+    case CryptoKeyClass::EC: {
+        if (data.namedCurveString && data.jwk)
+            return CryptoKeyEC::importJwk(data.algorithmIdentifier, *data.namedCurveString, WTFMove(*data.jwk), data.extractable, data.usages);
+        break;
+    }
+    case CryptoKeyClass::HMAC:
+        if (data.hashAlgorithmIdentifier && data.lengthBits && data.jwk)
+            return CryptoKeyHMAC::importJwk(*data.lengthBits, *data.hashAlgorithmIdentifier, WTFMove(*data.jwk), data.extractable, data.usages, [](auto, auto) { return true; });
+        break;
+    case CryptoKeyClass::OKP:
+        if (data.namedCurveString && data.key && data.type) {
+            if (auto namedCurve = CryptoKeyOKP::namedCurveFromString(*data.namedCurveString))
+                return CryptoKeyOKP::create(data.algorithmIdentifier, *namedCurve, *data.type, WTFMove(*data.key), data.extractable, data.usages);
+        }
+        break;
+    case CryptoKeyClass::RSA: {
+        if (data.jwk)
+            return CryptoKeyRSA::importJwk(data.algorithmIdentifier, data.hashAlgorithmIdentifier, WTFMove(*data.jwk), data.extractable, data.usages);
+        break;
+    }
+    case CryptoKeyClass::Raw:
+        if (data.key)
+            return CryptoKeyRaw::create(data.algorithmIdentifier, WTFMove(*data.key), data.usages);
+        break;
+    }
+
+    return nullptr;
+}
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/CryptoKey.h
+++ b/Source/WebCore/crypto/CryptoKey.h
@@ -26,12 +26,10 @@
 #pragma once
 
 #include "CryptoAesKeyAlgorithm.h"
-#include "CryptoAlgorithmIdentifier.h"
 #include "CryptoEcKeyAlgorithm.h"
 #include "CryptoHmacKeyAlgorithm.h"
 #include "CryptoKeyAlgorithm.h"
-#include "CryptoKeyType.h"
-#include "CryptoKeyUsage.h"
+#include "CryptoKeyData.h"
 #include "CryptoRsaHashedKeyAlgorithm.h"
 #include "CryptoRsaKeyAlgorithm.h"
 #include <variant>
@@ -45,18 +43,10 @@ namespace WebCore {
 
 class WebCoreOpaqueRoot;
 
-enum class CryptoKeyClass : uint8_t {
-    AES,
-    EC,
-    HMAC,
-    OKP,
-    RSA,
-    Raw,
-};
-
 class CryptoKey : public ThreadSafeRefCounted<CryptoKey> {
 public:
     using Type = CryptoKeyType;
+    using Data = CryptoKeyData;
     using KeyAlgorithm = std::variant<CryptoKeyAlgorithm, CryptoAesKeyAlgorithm, CryptoEcKeyAlgorithm, CryptoHmacKeyAlgorithm, CryptoRsaHashedKeyAlgorithm, CryptoRsaKeyAlgorithm>;
 
     CryptoKey(CryptoAlgorithmIdentifier, Type, bool extractable, CryptoKeyUsageBitmap);
@@ -66,8 +56,11 @@ public:
     bool extractable() const { return m_extractable; }
     Vector<CryptoKeyUsage> usages() const;
     virtual KeyAlgorithm algorithm() const = 0;
-
     virtual CryptoKeyClass keyClass() const = 0;
+    virtual bool isValid() const { return true; }
+
+    WEBCORE_EXPORT virtual Data data() const = 0;
+    WEBCORE_EXPORT static RefPtr<CryptoKey> create(Data&&);
 
     CryptoAlgorithmIdentifier algorithmIdentifier() const { return m_algorithmIdentifier; }
     CryptoKeyUsageBitmap usagesBitmap() const { return m_usages; }

--- a/Source/WebCore/crypto/CryptoKeyData.h
+++ b/Source/WebCore/crypto/CryptoKeyData.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CryptoAlgorithmIdentifier.h"
+#include "CryptoKeyType.h"
+#include "CryptoKeyUsage.h"
+#include "JsonWebKey.h"
+
+namespace WebCore {
+
+enum class CryptoKeyClass : uint8_t {
+    AES,
+    EC,
+    HMAC,
+    OKP,
+    RSA,
+    Raw
+};
+
+struct CryptoKeyData {
+    CryptoKeyData(CryptoKeyClass keyClass, CryptoAlgorithmIdentifier algorithmIdentifier, bool extractable, CryptoKeyUsageBitmap usages, std::optional<Vector<uint8_t>> key, std::optional<JsonWebKey> jwk = std::nullopt, std::optional<CryptoAlgorithmIdentifier> hashAlgorithmIdentifier = std::nullopt, std::optional<String>&& namedCurveString = std::nullopt, std::optional<size_t> lengthBits = std::nullopt, std::optional<CryptoKeyType> type = std::nullopt)
+        : keyClass(keyClass)
+        , algorithmIdentifier(algorithmIdentifier)
+        , extractable(extractable)
+        , usages(usages)
+        , key(WTFMove(key))
+        , jwk(WTFMove(jwk))
+        , hashAlgorithmIdentifier(hashAlgorithmIdentifier)
+        , namedCurveString(WTFMove(namedCurveString))
+        , lengthBits(lengthBits)
+        , type(type)
+    {
+    }
+    CryptoKeyData isolatedCopy() && {
+        return {
+            keyClass,
+            algorithmIdentifier,
+            extractable,
+            usages,
+            key,
+            crossThreadCopy(WTFMove(jwk)),
+            hashAlgorithmIdentifier,
+            crossThreadCopy(WTFMove(namedCurveString)),
+            lengthBits,
+            type
+        };
+    }
+
+    CryptoKeyClass keyClass;
+    CryptoAlgorithmIdentifier algorithmIdentifier;
+    bool extractable { false };
+    CryptoKeyUsageBitmap usages { 0 };
+    std::optional<Vector<uint8_t>> key;
+    std::optional<JsonWebKey> jwk;
+    std::optional<CryptoAlgorithmIdentifier> hashAlgorithmIdentifier;
+    std::optional<String> namedCurveString;
+    std::optional<size_t> lengthBits;
+    std::optional<CryptoKeyType> type;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/crypto/JsonWebKey.h
+++ b/Source/WebCore/crypto/JsonWebKey.h
@@ -32,6 +32,30 @@
 namespace WebCore {
 
 struct JsonWebKey {
+    JsonWebKey isolatedCopy() && {
+        return {
+            crossThreadCopy(WTFMove(kty)),
+            crossThreadCopy(WTFMove(use)),
+            key_ops,
+            usages,
+            crossThreadCopy(WTFMove(alg)),
+            ext,
+            crossThreadCopy(WTFMove(crv)),
+            crossThreadCopy(WTFMove(x)),
+            crossThreadCopy(WTFMove(y)),
+            crossThreadCopy(WTFMove(d)),
+            crossThreadCopy(WTFMove(n)),
+            crossThreadCopy(WTFMove(e)),
+            crossThreadCopy(WTFMove(p)),
+            crossThreadCopy(WTFMove(q)),
+            crossThreadCopy(WTFMove(dp)),
+            crossThreadCopy(WTFMove(dq)),
+            crossThreadCopy(WTFMove(qi)),
+            crossThreadCopy(WTFMove(oth)),
+            crossThreadCopy(WTFMove(k))
+        };
+    }
+
     String kty;
     String use;
     // FIXME: Consider merging key_ops and usages.

--- a/Source/WebCore/crypto/RsaOtherPrimesInfo.h
+++ b/Source/WebCore/crypto/RsaOtherPrimesInfo.h
@@ -25,11 +25,20 @@
 
 #pragma once
 
+#include <wtf/CrossThreadCopier.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
 struct RsaOtherPrimesInfo {
+    RsaOtherPrimesInfo isolatedCopy() && {
+        return {
+            crossThreadCopy(WTFMove(r)),
+            crossThreadCopy(WTFMove(d)),
+            crossThreadCopy(WTFMove(t))
+        };
+    }
+
     String r;
     String d;
     String t;

--- a/Source/WebCore/crypto/keys/CryptoKeyAES.cpp
+++ b/Source/WebCore/crypto/keys/CryptoKeyAES.cpp
@@ -107,6 +107,7 @@ JsonWebKey CryptoKeyAES::exportJwk() const
     result.kty = "oct"_s;
     result.k = base64URLEncodeToString(m_key);
     result.key_ops = usages();
+    result.usages = usagesBitmap();
     result.ext = extractable();
     return result;
 }
@@ -125,6 +126,18 @@ auto CryptoKeyAES::algorithm() const -> KeyAlgorithm
     result.name = CryptoAlgorithmRegistry::singleton().name(algorithmIdentifier());
     result.length = m_key.size() * 8;
     return result;
+}
+
+CryptoKey::Data CryptoKeyAES::data() const
+{
+    return CryptoKey::Data {
+        CryptoKeyClass::AES,
+        algorithmIdentifier(),
+        extractable(),
+        usagesBitmap(),
+        std::nullopt,
+        exportJwk()
+    };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/keys/CryptoKeyAES.h
+++ b/Source/WebCore/crypto/keys/CryptoKeyAES.h
@@ -68,6 +68,7 @@ private:
     CryptoKeyAES(CryptoAlgorithmIdentifier, Vector<uint8_t>&& key, bool extractable, CryptoKeyUsageBitmap);
 
     KeyAlgorithm algorithm() const final;
+    CryptoKey::Data data() const final;
 
     Vector<uint8_t> m_key;
 };

--- a/Source/WebCore/crypto/keys/CryptoKeyEC.cpp
+++ b/Source/WebCore/crypto/keys/CryptoKeyEC.cpp
@@ -164,6 +164,7 @@ ExceptionOr<JsonWebKey> CryptoKeyEC::exportJwk() const
         break;
     }
     result.key_ops = usages();
+    result.usages = usagesBitmap();
     result.ext = extractable();
     if (!platformAddFieldElements(result))
         return Exception { ExceptionCode::OperationError };
@@ -231,5 +232,24 @@ auto CryptoKeyEC::algorithm() const -> KeyAlgorithm
 
     return result;
 }
+
+CryptoKey::Data CryptoKeyEC::data() const
+{
+    auto jwkOrException = exportJwk();
+    auto jwk = jwkOrException.hasException() ? std::nullopt : std::optional<JsonWebKey> { jwkOrException.releaseReturnValue() };
+    return CryptoKey::Data {
+        CryptoKeyClass::EC,
+        algorithmIdentifier(),
+        extractable(),
+        usagesBitmap(),
+        std::nullopt,
+        WTFMove(jwk),
+        std::nullopt,
+        namedCurveString(),
+        std::nullopt,
+        type()
+    };
+}
+
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/keys/CryptoKeyEC.h
+++ b/Source/WebCore/crypto/keys/CryptoKeyEC.h
@@ -104,8 +104,9 @@ private:
     CryptoKeyEC(CryptoAlgorithmIdentifier, NamedCurve, CryptoKeyType, PlatformECKeyContainer&&, bool extractable, CryptoKeyUsageBitmap);
 
     CryptoKeyClass keyClass() const final { return CryptoKeyClass::EC; }
-
     KeyAlgorithm algorithm() const final;
+    CryptoKey::Data data() const final;
+
     static bool platformSupportedCurve(NamedCurve);
     static std::optional<CryptoKeyPair> platformGeneratePair(CryptoAlgorithmIdentifier, NamedCurve, bool extractable, CryptoKeyUsageBitmap);
     static RefPtr<CryptoKeyEC> platformImportRaw(CryptoAlgorithmIdentifier, NamedCurve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap);

--- a/Source/WebCore/crypto/keys/CryptoKeyHMAC.cpp
+++ b/Source/WebCore/crypto/keys/CryptoKeyHMAC.cpp
@@ -123,6 +123,7 @@ JsonWebKey CryptoKeyHMAC::exportJwk() const
     result.kty = "oct"_s;
     result.k = base64URLEncodeToString(m_key);
     result.key_ops = usages();
+    result.usages = usagesBitmap();
     result.ext = extractable();
     return result;
 }
@@ -144,6 +145,22 @@ auto CryptoKeyHMAC::algorithm() const -> KeyAlgorithm
     result.hash.name = CryptoAlgorithmRegistry::singleton().name(m_hash);
     result.length = m_key.size() * 8;
     return result;
+}
+
+CryptoKey::Data CryptoKeyHMAC::data() const
+{
+    auto keyData = key();
+    return CryptoKey::Data {
+        CryptoKeyClass::HMAC,
+        algorithmIdentifier(),
+        extractable(),
+        usagesBitmap(),
+        std::nullopt,
+        exportJwk(),
+        hashAlgorithmIdentifier(),
+        std::nullopt,
+        key().size() * CHAR_BIT, // Size in bits.
+    };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/keys/CryptoKeyHMAC.h
+++ b/Source/WebCore/crypto/keys/CryptoKeyHMAC.h
@@ -62,6 +62,7 @@ private:
     CryptoKeyHMAC(Vector<uint8_t>&& key, CryptoAlgorithmIdentifier hash, bool extractable, CryptoKeyUsageBitmap);
 
     KeyAlgorithm algorithm() const final;
+    CryptoKey::Data data() const final;
 
     CryptoAlgorithmIdentifier m_hash;
     Vector<uint8_t> m_key;

--- a/Source/WebCore/crypto/keys/CryptoKeyOKP.cpp
+++ b/Source/WebCore/crypto/keys/CryptoKeyOKP.cpp
@@ -162,6 +162,7 @@ ExceptionOr<JsonWebKey> CryptoKeyOKP::exportJwk() const
     }
 
     result.key_ops = usages();
+    result.usages = usagesBitmap();
     result.ext = extractable();
 
     switch (type()) {
@@ -177,6 +178,17 @@ ExceptionOr<JsonWebKey> CryptoKeyOKP::exportJwk() const
     }
 
     return result;
+}
+
+std::optional<CryptoKeyOKP::NamedCurve> CryptoKeyOKP::namedCurveFromString(const String& curveString)
+{
+    if (curveString == X25519)
+        return NamedCurve::X25519;
+
+    if (curveString == Ed25519)
+        return NamedCurve::Ed25519;
+
+    return std::nullopt;
 }
 
 String CryptoKeyOKP::namedCurveString() const
@@ -200,6 +212,23 @@ bool CryptoKeyOKP::isValidOKPAlgorithm(CryptoAlgorithmIdentifier algorithm)
 auto CryptoKeyOKP::algorithm() const -> KeyAlgorithm
 {
     return CryptoKeyAlgorithm { CryptoAlgorithmRegistry::singleton().name(algorithmIdentifier()) };
+}
+
+CryptoKey::Data CryptoKeyOKP::data() const
+{
+    auto key = platformKey();
+    return CryptoKey::Data {
+        CryptoKeyClass::OKP,
+        algorithmIdentifier(),
+        extractable(),
+        usagesBitmap(),
+        WTFMove(key),
+        std::nullopt,
+        std::nullopt,
+        namedCurveString(),
+        std::nullopt,
+        type()
+    };
 }
 
 #if !PLATFORM(COCOA) && !USE(GCRYPT)

--- a/Source/WebCore/crypto/keys/CryptoKeyOKP.h
+++ b/Source/WebCore/crypto/keys/CryptoKeyOKP.h
@@ -55,6 +55,7 @@ public:
     ExceptionOr<Vector<uint8_t>> exportSpki() const;
     ExceptionOr<Vector<uint8_t>> exportPkcs8() const;
 
+    static std::optional<NamedCurve> namedCurveFromString(const String&);
     NamedCurve namedCurve() const { return m_curve; }
     String namedCurveString() const;
 
@@ -69,6 +70,7 @@ private:
 
     CryptoKeyClass keyClass() const final { return CryptoKeyClass::OKP; }
     KeyAlgorithm algorithm() const final;
+    CryptoKey::Data data() const final;
 
     String generateJwkD() const;
     String generateJwkX() const;

--- a/Source/WebCore/crypto/keys/CryptoKeyRSA.cpp
+++ b/Source/WebCore/crypto/keys/CryptoKeyRSA.cpp
@@ -133,6 +133,7 @@ JsonWebKey CryptoKeyRSA::exportJwk() const
     JsonWebKey result;
     result.kty = "RSA"_s;
     result.key_ops = usages();
+    result.usages = usagesBitmap();
     result.ext = extractable();
 
     auto rsaComponents = exportData();
@@ -169,6 +170,23 @@ JsonWebKey CryptoKeyRSA::exportJwk() const
     }
     result.oth = WTFMove(oth);
     return result;
+}
+
+CryptoKey::Data CryptoKeyRSA::data() const
+{
+    auto jwk = exportJwk();
+    std::optional<CryptoAlgorithmIdentifier> hash;
+    if (m_restrictedToSpecificHash)
+        hash = hashAlgorithmIdentifier();
+    return CryptoKey::Data {
+        CryptoKeyClass::RSA,
+        algorithmIdentifier(),
+        extractable(),
+        usagesBitmap(),
+        std::nullopt,
+        WTFMove(jwk),
+        hash
+    };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/keys/CryptoKeyRSA.h
+++ b/Source/WebCore/crypto/keys/CryptoKeyRSA.h
@@ -96,8 +96,8 @@ private:
     CryptoKeyRSA(CryptoAlgorithmIdentifier, CryptoAlgorithmIdentifier hash, bool hasHash, CryptoKeyType, PlatformRSAKeyContainer&&, bool extractable, CryptoKeyUsageBitmap);
 
     CryptoKeyClass keyClass() const final { return CryptoKeyClass::RSA; }
-
     KeyAlgorithm algorithm() const final;
+    CryptoKey::Data data() const final;
 
     PlatformRSAKeyContainer m_platformKey;
 

--- a/Source/WebCore/crypto/keys/CryptoKeyRaw.cpp
+++ b/Source/WebCore/crypto/keys/CryptoKeyRaw.cpp
@@ -43,4 +43,15 @@ auto CryptoKeyRaw::algorithm() const -> KeyAlgorithm
     return result;
 }
 
+CryptoKey::Data CryptoKeyRaw::data() const
+{
+    return CryptoKey::Data {
+        CryptoKeyClass::Raw,
+        algorithmIdentifier(),
+        extractable(),
+        usagesBitmap(),
+        { key() },
+    };
+}
+
 } // namespace WebCore

--- a/Source/WebCore/crypto/keys/CryptoKeyRaw.h
+++ b/Source/WebCore/crypto/keys/CryptoKeyRaw.h
@@ -42,8 +42,8 @@ private:
     CryptoKeyRaw(CryptoAlgorithmIdentifier, Vector<uint8_t>&& keyData, CryptoKeyUsageBitmap);
 
     CryptoKeyClass keyClass() const final { return CryptoKeyClass::Raw; }
-
     KeyAlgorithm algorithm() const final;
+    CryptoKey::Data data() const final;
 
     Vector<uint8_t> m_key;
 };

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -9330,6 +9330,15 @@ std::optional<Vector<uint8_t>> Document::wrapCryptoKey(const Vector<uint8_t>& ke
     return page->cryptoClient().wrapCryptoKey(key);
 }
 
+std::optional<Vector<uint8_t>> Document::serializeAndWrapCryptoKey(CryptoKeyData&& keyData)
+{
+    RefPtr page = this->page();
+    if (!page)
+        return std::nullopt;
+
+    return page->cryptoClient().serializeAndWrapCryptoKey(WTFMove(keyData));
+}
+
 std::optional<Vector<uint8_t>>Document::unwrapCryptoKey(const Vector<uint8_t>& wrappedKey)
 {
     RefPtr page = this->page();

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1621,6 +1621,7 @@ public:
     void setVisualUpdatesAllowedByClient(bool);
 
     std::optional<Vector<uint8_t>> wrapCryptoKey(const Vector<uint8_t>&) final;
+    std::optional<Vector<uint8_t>> serializeAndWrapCryptoKey(CryptoKeyData&&) final;
     std::optional<Vector<uint8_t>> unwrapCryptoKey(const Vector<uint8_t>&) final;
 
     void setHasStyleWithViewportUnits() { m_hasStyleWithViewportUnits = true; }

--- a/Source/WebCore/dom/EmptyScriptExecutionContext.h
+++ b/Source/WebCore/dom/EmptyScriptExecutionContext.h
@@ -80,6 +80,7 @@ public:
     EventTarget* errorEventTarget() final { return nullptr; };
 
     std::optional<Vector<uint8_t>> wrapCryptoKey(const Vector<uint8_t>&) final { return std::nullopt; }
+    std::optional<Vector<uint8_t>> serializeAndWrapCryptoKey(CryptoKeyData&&) final { return std::nullopt; }
     std::optional<Vector<uint8_t>> unwrapCryptoKey(const Vector<uint8_t>&) final { return std::nullopt; }
 
     JSC::VM& vm() final { return m_vm; }

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -91,6 +91,7 @@ enum class LoadedFromOpaqueSource : bool;
 enum class NoiseInjectionPolicy : uint8_t;
 enum class ScriptTelemetryCategory : uint8_t;
 enum class TaskSource : uint8_t;
+struct CryptoKeyData;
 
 #if ENABLE(NOTIFICATIONS)
 class NotificationClient;
@@ -289,6 +290,7 @@ public:
     // used for things that utilize the same structure clone algorithm, for example, message passing between
     // worker and document.
     virtual std::optional<Vector<uint8_t>> wrapCryptoKey(const Vector<uint8_t>& key) = 0;
+    virtual std::optional<Vector<uint8_t>> serializeAndWrapCryptoKey(CryptoKeyData&&) = 0;
     virtual std::optional<Vector<uint8_t>> unwrapCryptoKey(const Vector<uint8_t>& wrappedKey) = 0;
 
     int timerNestingLevel() const { return m_timerNestingLevel; }

--- a/Source/WebCore/page/CryptoClient.h
+++ b/Source/WebCore/page/CryptoClient.h
@@ -30,6 +30,7 @@
 #include <wtf/Vector.h>
 
 namespace WebCore {
+struct CryptoKeyData;
 
 class CryptoClient {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(CryptoClient);
@@ -38,6 +39,7 @@ protected:
 public:
     virtual ~CryptoClient() = default;
     virtual std::optional<Vector<uint8_t>> wrapCryptoKey(const Vector<uint8_t>&) const { return std::nullopt; };
+    virtual std::optional<Vector<uint8_t>> serializeAndWrapCryptoKey(WebCore::CryptoKeyData&&) const { return std::nullopt; };
     virtual std::optional<Vector<uint8_t>> unwrapCryptoKey(const Vector<uint8_t>&) const { return std::nullopt; };
 };
 } // namespace WebKit

--- a/Source/WebCore/workers/WorkerGlobalScope.h
+++ b/Source/WebCore/workers/WorkerGlobalScope.h
@@ -53,6 +53,7 @@ class CSSValuePool;
 class CacheStorageConnection;
 class ContentSecurityPolicyResponseHeaders;
 class Crypto;
+class CryptoKey;
 class FileSystemStorageConnection;
 class FontFaceSet;
 class MessagePortChannelProvider;
@@ -208,6 +209,7 @@ private:
     bool shouldBypassMainWorldContentSecurityPolicy() const final { return m_shouldBypassMainWorldContentSecurityPolicy; }
 
     std::optional<Vector<uint8_t>> wrapCryptoKey(const Vector<uint8_t>& key) final;
+    std::optional<Vector<uint8_t>> serializeAndWrapCryptoKey(CryptoKeyData&&) final;
     std::optional<Vector<uint8_t>> unwrapCryptoKey(const Vector<uint8_t>& wrappedKey) final;
 
     // ReportingClient.

--- a/Source/WebCore/worklets/WorkletGlobalScope.h
+++ b/Source/WebCore/worklets/WorkletGlobalScope.h
@@ -106,6 +106,7 @@ private:
     EventTarget* errorEventTarget() final { return this; }
 
     std::optional<Vector<uint8_t>> wrapCryptoKey(const Vector<uint8_t>&) final { RELEASE_ASSERT_NOT_REACHED(); return std::nullopt; }
+    std::optional<Vector<uint8_t>> serializeAndWrapCryptoKey(CryptoKeyData&&) final { RELEASE_ASSERT_NOT_REACHED(); return std::nullopt; }
     std::optional<Vector<uint8_t>> unwrapCryptoKey(const Vector<uint8_t>&) final { RELEASE_ASSERT_NOT_REACHED(); return std::nullopt; }
     URL completeURL(const String&, ForceUTF8 = ForceUTF8::No) const final;
     String userAgent(const URL&) const final;

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -897,6 +897,7 @@ def headers_for_type(type):
         'WebCore::ColorSchemePreference': ['<WebCore/DocumentLoader.h>'],
         'WebCore::CompositeMode': ['<WebCore/GraphicsTypes.h>'],
         'WebCore::CompositeOperator': ['<WebCore/GraphicsTypes.h>'],
+        'WebCore::CryptoKey::Data': ['<WebCore/CryptoKey.h>'],
         'WebCore::COOPDisposition': ['<WebCore/CrossOriginOpenerPolicy.h>'],
         'WebCore::CreateNewGroupForHighlight': ['<WebCore/AppHighlight.h>'],
         'WebCore::CrossOriginOpenerPolicyValue': ['<WebCore/CrossOriginOpenerPolicy.h>'],

--- a/Source/WebKit/Shared/API/APISerializedScriptValue.cpp
+++ b/Source/WebKit/Shared/API/APISerializedScriptValue.cpp
@@ -165,4 +165,13 @@ WKRetainPtr<WKTypeRef> SerializedScriptValue::deserializeWK(WebCore::SerializedS
     return valueToWKObject(context.get(), value);
 }
 
+Vector<uint8_t> SerializedScriptValue::serializeCryptoKey(const WebCore::CryptoKey& key)
+{
+    ASSERT(RunLoop::isMain());
+    JSRetainPtr context = SharedJSContextWK::singleton().ensureContext();
+    ASSERT(context);
+
+    return WebCore::SerializedScriptValue::serializeCryptoKey(context.get(), key);
+}
+
 } // API

--- a/Source/WebKit/Shared/API/APISerializedScriptValue.h
+++ b/Source/WebKit/Shared/API/APISerializedScriptValue.h
@@ -27,6 +27,7 @@
 
 #include "APIObject.h"
 #include "WKRetainPtr.h"
+#include <WebCore/CryptoKey.h>
 #include <WebCore/SerializedScriptValue.h>
 #include <wtf/RefPtr.h>
 
@@ -68,6 +69,7 @@ public:
     }
 
     static WKRetainPtr<WKTypeRef> deserializeWK(WebCore::SerializedScriptValue&);
+    static Vector<uint8_t> serializeCryptoKey(const WebCore::CryptoKey&);
 
 #if PLATFORM(COCOA) && defined(__OBJC__)
     static id deserialize(WebCore::SerializedScriptValue&);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8726,6 +8726,98 @@ enum class WebCore::FileSystemWriteCommandType : uint8_t {
 
 enum class WebCore::FileSystemWriteCloseReason : bool;
 
+struct WebCore::RsaOtherPrimesInfo {
+    String r;
+    String d;
+    String t;
+};
+
+enum class WebCore::CryptoKeyUsage : uint8_t {
+    Encrypt,
+    Decrypt,
+    Sign,
+    Verify,
+    DeriveKey,
+    DeriveBits,
+    WrapKey,
+    UnwrapKey
+};
+
+struct WebCore::JsonWebKey {
+    String kty;
+    String use
+    std::optional<Vector<WebCore::CryptoKeyUsage>> key_ops;
+    int usages;
+    String alg;
+    std::optional<bool> ext;
+    String crv;
+    String x;
+    String y;
+    String d;
+    String n;
+    String e;
+    String p;
+    String q;
+    String dp;
+    String dq;
+    String qi;
+    std::optional<Vector<WebCore::RsaOtherPrimesInfo>> oth;
+    String k;
+};
+
+enum class WebCore::CryptoAlgorithmIdentifier : uint8_t {
+    RSAES_PKCS1_v1_5,
+    RSASSA_PKCS1_v1_5,
+    RSA_PSS,
+    RSA_OAEP,
+    ECDSA,
+    ECDH,
+    AES_CTR,
+    AES_CBC,
+    AES_GCM,
+    AES_CFB,
+    AES_KW,
+    HMAC,
+    SHA_1,
+    SHA_224,
+    SHA_256,
+    SHA_384,
+    SHA_512,
+    HKDF,
+    PBKDF2,
+    Ed25519,
+    X25519
+};
+
+header: <WebCore/CryptoKeyData.h>
+[CustomHeader] enum class WebCore::CryptoKeyClass : uint8_t {
+    AES,
+    EC,
+    HMAC,
+    OKP,
+    RSA,
+    Raw
+};
+
+enum class WebCore::CryptoKeyType : uint8_t {
+    Public,
+    Private,
+    Secret
+};
+
+struct WebCore::CryptoKeyData {
+    WebCore::CryptoKeyClass keyClass;
+    WebCore::CryptoAlgorithmIdentifier algorithmIdentifier;
+    bool extractable;
+    int usages;
+    std::optional<Vector<uint8_t>> key;
+    std::optional<WebCore::JsonWebKey> jwk;
+    std::optional<WebCore::CryptoAlgorithmIdentifier> hashAlgorithmIdentifier;
+    std::optional<String> namedCurveString;
+    std::optional<size_t> lengthBits;
+    std::optional<WebCore::CryptoKeyType> type;
+};
+
 [Nested] enum class WebCore::ResourceError::IsSanitized : bool
 
 #if ENABLE(DOM_AUDIO_SESSION)

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -59,6 +59,8 @@
 #include "ExtensionCapabilityGrant.h"
 #endif
 
+#include "WebPageProxyMessages.h"
+
 namespace WebKit {
 
 static HashMap<IPC::Connection::UniqueID, WeakPtr<AuxiliaryProcessProxy>>& connectionToProcessMap()

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -239,6 +239,7 @@
 #include <WebCore/ResourceLoadStatistics.h>
 #include <WebCore/RunJavaScriptParameters.h>
 #include <WebCore/SerializedCryptoKeyWrap.h>
+#include <WebCore/SerializedScriptValue.h>
 #include <WebCore/ShareData.h>
 #include <WebCore/SharedBuffer.h>
 #include <WebCore/ShouldTreatAsContinuingLoad.h>
@@ -12802,6 +12803,15 @@ void WebPageProxy::wrapCryptoKey(Vector<uint8_t>&& key, CompletionHandler<void(s
             return completionHandler(WTFMove(wrappedKey));
         completionHandler(std::nullopt);
     });
+}
+
+void WebPageProxy::serializeAndWrapCryptoKey(IPC::Connection& connection, WebCore::CryptoKeyData&& keyData, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&& completionHandler)
+{
+    auto key = WebCore::CryptoKey::create(WTFMove(keyData));
+    MESSAGE_CHECK_COMPLETION_BASE(key->isValid(), connection, completionHandler(std::nullopt));
+
+    auto serializedKey = API::SerializedScriptValue::serializeCryptoKey(*key);
+    wrapCryptoKey(WTFMove(serializedKey), WTFMove(completionHandler));
 }
 
 void WebPageProxy::unwrapCryptoKey(WrappedCryptoKey&& wrappedKey, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&& completionHandler)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -27,6 +27,7 @@
 
 #include "APIObject.h"
 #include "MessageReceiver.h"
+#include <WebCore/CryptoKeyData.h>
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/LayerTreeAsTextOptions.h>
 #include <WebCore/NavigationIdentifier.h>
@@ -1846,6 +1847,7 @@ public:
 #endif
 
     void wrapCryptoKey(Vector<uint8_t>&&, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);
+    void serializeAndWrapCryptoKey(IPC::Connection&, WebCore::CryptoKeyData&&, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);
     void unwrapCryptoKey(WebCore::WrappedCryptoKey&&, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);
 
     void takeSnapshot(WebCore::IntRect, WebCore::IntSize bitmapSize, SnapshotOptions, CompletionHandler<void(std::optional<WebCore::ShareableBitmapHandle>&&)>&&);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -434,6 +434,7 @@ messages -> WebPageProxy {
     DidUpdateActivityState() CanDispatchOutOfOrder
 
     WrapCryptoKey(Vector<uint8_t> key) -> (std::optional<Vector<uint8_t>> wrappedKey) Synchronous
+    SerializeAndWrapCryptoKey(struct WebCore::CryptoKeyData key) -> (std::optional<Vector<uint8_t>> wrappedKey) Synchronous
     UnwrapCryptoKey(struct WebCore::WrappedCryptoKey wrappedKey) -> (std::optional<Vector<uint8_t>> key) Synchronous
 
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -29,6 +29,7 @@
 #include "APIFrameHandle.h"
 #include "APIPageConfiguration.h"
 #include "APIPageHandle.h"
+#include "APISerializedScriptValue.h"
 #include "APIUIClient.h"
 #include "AuthenticatorManager.h"
 #include "DownloadProxyMap.h"
@@ -2828,6 +2829,15 @@ void WebProcessProxy::wrapCryptoKey(Vector<uint8_t>&& key, CompletionHandler<voi
             return completionHandler(WTFMove(wrappedKey));
         completionHandler(std::nullopt);
     });
+}
+
+void WebProcessProxy::serializeAndWrapCryptoKey(WebCore::CryptoKeyData&& keyData, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&& completionHandler)
+{
+    auto key = WebCore::CryptoKey::create(WTFMove(keyData));
+    MESSAGE_CHECK_COMPLETION(key, completionHandler(std::nullopt));
+
+    auto serializedKey = API::SerializedScriptValue::serializeCryptoKey(*key);
+    wrapCryptoKey(WTFMove(serializedKey), WTFMove(completionHandler));
 }
 
 void WebProcessProxy::unwrapCryptoKey(WrappedCryptoKey&& wrappedKey, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&& completionHandler)

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -87,6 +87,7 @@ class PageConfiguration;
 namespace WebCore {
 class DeferrableOneShotTimer;
 class ResourceRequest;
+struct CryptoKeyData;
 struct NotificationData;
 struct PluginInfo;
 struct PrewarmInformation;
@@ -486,6 +487,7 @@ public:
 #endif
     void getNotifications(const URL&, const String&, CompletionHandler<void(Vector<WebCore::NotificationData>&&)>&&);
     void wrapCryptoKey(Vector<uint8_t>&&, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);
+    void serializeAndWrapCryptoKey(WebCore::CryptoKeyData&&, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);
     void unwrapCryptoKey(WebCore::WrappedCryptoKey&&, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);
 
     void setAppBadge(std::optional<WebPageProxyIdentifier>, const WebCore::SecurityOriginData&, std::optional<uint64_t> badge);

--- a/Source/WebKit/UIProcess/WebProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebProcessProxy.messages.in
@@ -96,6 +96,7 @@ messages -> WebProcessProxy WantsDispatchMessage {
     [EnabledBy=AppBadgeEnabled] SetClientBadge(WebKit::WebPageProxyIdentifier pageIdentifier, WebCore::SecurityOriginData origin, std::optional<uint64_t> badge)
 
     WrapCryptoKey(Vector<uint8_t> key) -> (std::optional<Vector<uint8_t>> wrappedKey) Synchronous
+    SerializeAndWrapCryptoKey(struct WebCore::CryptoKeyData key) -> (std::optional<Vector<uint8_t>> wrappedKey) Synchronous
     UnwrapCryptoKey(struct WebCore::WrappedCryptoKey wrappedKey) -> (std::optional<Vector<uint8_t>> key) Synchronous
 
 #if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebCryptoClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebCryptoClient.cpp
@@ -51,6 +51,19 @@ std::optional<Vector<uint8_t>> WebCryptoClient::wrapCryptoKey(const Vector<uint8
     return wrappedKey;
 }
 
+std::optional<Vector<uint8_t>> WebCryptoClient::serializeAndWrapCryptoKey(WebCore::CryptoKeyData&& keyData) const
+{
+    if (m_pageIdentifier) {
+        auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPageProxy::SerializeAndWrapCryptoKey(WTFMove(keyData)), *m_pageIdentifier);
+        auto [wrappedKey] = sendResult.takeReplyOr(std::nullopt);
+        return wrappedKey;
+    }
+    auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebProcessProxy::SerializeAndWrapCryptoKey(WTFMove(keyData)), 0);
+
+    auto [wrappedKey] = sendResult.takeReplyOr(std::nullopt);
+    return wrappedKey;
+}
+
 std::optional<Vector<uint8_t>> WebCryptoClient::unwrapCryptoKey(const Vector<uint8_t>& wrappedKey) const
 {
     auto deserializedKey = WebCore::readSerializedCryptoKey(wrappedKey);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebCryptoClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebCryptoClient.h
@@ -41,6 +41,7 @@ public:
     WebCryptoClient() = default;
     ~WebCryptoClient() = default;
     std::optional<Vector<uint8_t>> wrapCryptoKey(const Vector<uint8_t>&) const override;
+    std::optional<Vector<uint8_t>> serializeAndWrapCryptoKey(WebCore::CryptoKeyData&&) const override;
     std::optional<Vector<uint8_t>> unwrapCryptoKey(const Vector<uint8_t>&) const override;
 private:
     std::optional<WebCore::PageIdentifier> m_pageIdentifier;

--- a/Source/WebKitLegacy/WebCoreSupport/WebCryptoClient.h
+++ b/Source/WebKitLegacy/WebCoreSupport/WebCryptoClient.h
@@ -29,6 +29,9 @@
 #import <WebCore/CryptoClient.h>
 #import <wtf/TZoneMalloc.h>
 
+namespace WebCore {
+struct CryptoKeyData;
+}
 
 class WebCryptoClient:  public WebCore::CryptoClient {
     WTF_MAKE_TZONE_ALLOCATED(WebCryptoClient);
@@ -37,6 +40,7 @@ public:
     ~WebCryptoClient() = default;
     WebCryptoClient(WebView *);
     std::optional<Vector<uint8_t>> wrapCryptoKey(const Vector<uint8_t>&) const override;
+    std::optional<Vector<uint8_t>> serializeAndWrapCryptoKey(WebCore::CryptoKeyData&&) const override;
     std::optional<Vector<uint8_t>> unwrapCryptoKey(const Vector<uint8_t>&) const override;
 private:
     __weak WebView * m_webView;

--- a/Source/WebKitLegacy/WebCoreSupport/WebCryptoClient.mm
+++ b/Source/WebKitLegacy/WebCoreSupport/WebCryptoClient.mm
@@ -26,8 +26,11 @@
 #import "WebCryptoClient.h"
 
 #import "WebDelegateImplementationCaching.h"
+#import "WebFramePrivate.h"
 #import "WebUIDelegatePrivate.h"
+#import <WebCore/CryptoKey.h>
 #import <WebCore/SerializedCryptoKeyWrap.h>
+#import <WebCore/SerializedScriptValue.h>
 #import <WebCore/WrappedCryptoKey.h>
 #import <optional>
 #import <wtf/TZoneMallocInlines.h>
@@ -52,6 +55,17 @@ std::optional<Vector<uint8_t>> WebCryptoClient::wrapCryptoKey(const Vector<uint8
     if (!WebCore::wrapSerializedCryptoKey(WTFMove(*masterKey), key, wrappedKey))
         return std::nullopt;
     return wrappedKey;
+}
+
+std::optional<Vector<uint8_t>> WebCryptoClient::serializeAndWrapCryptoKey(WebCore::CryptoKeyData&& keyData) const
+{
+    auto key = WebCore::CryptoKey::create(WTFMove(keyData));
+    if (!key)
+        return std::nullopt;
+
+    JSContextRef context = [[m_webView mainFrame] globalContext];
+    auto serializedKey = WebCore::SerializedScriptValue::serializeCryptoKey(context, *key);
+    return wrapCryptoKey(serializedKey);
 }
 
 std::optional<Vector<uint8_t>> WebCryptoClient::unwrapCryptoKey(const Vector<uint8_t>& serializedKey) const


### PR DESCRIPTION
#### 22614e8356bdb8a3270eda1f4fd34186dc9b8c9e
<pre>
Make WebPageProxy::wrapCryptoKey take CryptoKey instead of serialized key data
<a href="https://bugs.webkit.org/show_bug.cgi?id=284444">https://bugs.webkit.org/show_bug.cgi?id=284444</a>
<a href="https://rdar.apple.com/141265745">rdar://141265745</a>

Reviewed by Pascoe and Matthew Finkel.

In current implementation of wrapping crypto key, web process serializes key into bytes and sends the bytes to UI
process for encryption. On receiving the bytes, UI process is not able to validate that the bytes actually represent
crypto key, as it does not know the serialization format. To ensure UI process can do validation, now we make web
process send structured crypto key data to UI process, by introducing WebCore::CryptoKeyData and adding IPC
serialization for it. If UI process cannot recreate crypto key from the data, it will reject the request; otherwise it
will do both serialization and encryption.

There should be no user-visible behavior change after this patch.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::serializeAndWrapCryptoKey):
(WebCore::CloneSerializer::serializeCryptoKey):
(WebCore::CloneSerializer::dumpIfTerminal):
(WebCore::SerializedScriptValue::serializeCryptoKey):
(WebCore::wrapCryptoKey): Deleted.
* Source/WebCore/bindings/js/SerializedScriptValue.h:
* Source/WebCore/crypto/CryptoKey.cpp:
(WebCore::CryptoKey::create):
* Source/WebCore/crypto/CryptoKey.h:
(WebCore::CryptoKey::isValid const):
* Source/WebCore/crypto/CryptoKeyData.h: Added.
(WebCore::CryptoKeyData::CryptoKeyData):
(WebCore::CryptoKeyData::isolatedCopy):
* Source/WebCore/crypto/JsonWebKey.h:
(WebCore::JsonWebKey::isolatedCopy):
* Source/WebCore/crypto/RsaOtherPrimesInfo.h:
(WebCore::RsaOtherPrimesInfo::isolatedCopy):
* Source/WebCore/crypto/keys/CryptoKeyAES.cpp:
(WebCore::CryptoKeyAES::exportJwk const):
(WebCore::CryptoKeyAES::data const):
* Source/WebCore/crypto/keys/CryptoKeyAES.h:
* Source/WebCore/crypto/keys/CryptoKeyEC.cpp:
(WebCore::CryptoKeyEC::exportJwk const):
(WebCore::CryptoKeyEC::data const):
* Source/WebCore/crypto/keys/CryptoKeyEC.h:
* Source/WebCore/crypto/keys/CryptoKeyHMAC.cpp:
(WebCore::CryptoKeyHMAC::exportJwk const):
(WebCore::CryptoKeyHMAC::data const):
* Source/WebCore/crypto/keys/CryptoKeyHMAC.h:
* Source/WebCore/crypto/keys/CryptoKeyOKP.cpp:
(WebCore::CryptoKeyOKP::exportJwk const):
(WebCore::CryptoKeyOKP::namedCurveFromString):
(WebCore::CryptoKeyOKP::data const):
* Source/WebCore/crypto/keys/CryptoKeyOKP.h:
* Source/WebCore/crypto/keys/CryptoKeyRSA.cpp:
(WebCore::CryptoKeyRSA::exportJwk const):
(WebCore::CryptoKeyRSA::data const):
* Source/WebCore/crypto/keys/CryptoKeyRSA.h:
* Source/WebCore/crypto/keys/CryptoKeyRaw.cpp:
(WebCore::CryptoKeyRaw::data const):
* Source/WebCore/crypto/keys/CryptoKeyRaw.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::serializeAndWrapCryptoKey):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/EmptyScriptExecutionContext.h:
* Source/WebCore/dom/ScriptExecutionContext.h:
* Source/WebCore/page/CryptoClient.h:
(WebCore::CryptoClient::serializeAndWrapCryptoKey const):
* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::WorkerGlobalScope::serializeAndWrapCryptoKey):
* Source/WebCore/workers/WorkerGlobalScope.h:
* Source/WebCore/worklets/WorkletGlobalScope.h:
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/API/APISerializedScriptValue.cpp:
(API::SerializedScriptValue::serializeCryptoKey):
* Source/WebKit/Shared/API/APISerializedScriptValue.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::serializeAndWrapCryptoKey):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::serializeAndWrapCryptoKey):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/WebProcessProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebCryptoClient.cpp:
(WebKit::WebCryptoClient::serializeAndWrapCryptoKey const):
* Source/WebKit/WebProcess/WebCoreSupport/WebCryptoClient.h:
* Source/WebKitLegacy/WebCoreSupport/WebCryptoClient.h:
* Source/WebKitLegacy/WebCoreSupport/WebCryptoClient.mm:
(WebCryptoClient::serializeAndWrapCryptoKey const):

Canonical link: <a href="https://commits.webkit.org/287927@main">https://commits.webkit.org/287927@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52ae16626cdf650d42c7837f99c88be5ae681c5f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81386 "7 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/911 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35329 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85915 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32372 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83496 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/929 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8730 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63526 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/21277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84455 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/639 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74070 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43821 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/80843 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/534 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28234 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30830 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28819 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87350 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8616 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71832 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8797 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69891 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71068 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17687 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15134 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14041 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8578 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/14101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8414 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11935 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10222 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->