### PR TITLE
[scroll-animations] setting `iterations` to `Infinity` should throw for effects associated with a progress-based animation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/effect-updateTiming-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/effect-updateTiming-expected.txt
@@ -23,9 +23,7 @@ PASS Throws when setting invalid iterationStart value: NaN
 PASS Throws when setting invalid iterationStart value: Infinity
 PASS Throws when setting invalid iterationStart value: -Infinity
 PASS Allows setting iterations to a double value
-FAIL Throws when setting iterations to Infinity assert_throws_js: test function "() => {
-    anim.effect.updateTiming({ iterations: Infinity });
-  }" did not throw
+PASS Throws when setting iterations to Infinity
 PASS Allows setting the iterations of an animation in progress
 FAIL Allows setting the iterations of an animation in progress with duration "auto" assert_equals: progress after adding an iteration expected 1 but got 0
 PASS Allows setting the duration to 123.45

--- a/Source/WebCore/animation/AnimationEffect.cpp
+++ b/Source/WebCore/animation/AnimationEffect.cpp
@@ -190,6 +190,18 @@ ExceptionOr<void> AnimationEffect::updateTiming(Document& document, std::optiona
         }
     }
 
+    if (auto iterations = timing->iterations) {
+        // https://github.com/w3c/csswg-drafts/issues/11343
+        if (std::isinf(*iterations)) {
+            if (RefPtr animation = m_animation.get()) {
+                if (RefPtr timeline = animation->timeline()) {
+                    if (timeline->isProgressBased())
+                        return Exception { ExceptionCode::TypeError, "The number of iterations cannot be set to Infinity for progress-based animations"_s };
+                }
+            }
+        }
+    }
+
     // 4. If the easing member of input is present but cannot be parsed using the <timing-function> production [CSS-EASING-1], throw a TypeError and abort this procedure.
     if (!timing->easing.isNull()) {
         CSSParserContext parsingContext(document);


### PR DESCRIPTION
#### f731a48f59b73ad13ddbbb5299db26fa380b347e
<pre>
[scroll-animations] setting `iterations` to `Infinity` should throw for effects associated with a progress-based animation
<a href="https://bugs.webkit.org/show_bug.cgi?id=284446">https://bugs.webkit.org/show_bug.cgi?id=284446</a>
<a href="https://rdar.apple.com/141271158">rdar://141271158</a>

Reviewed by Tim Nguyen.

It does not make sense to have an infinite duration for a progress-based animation, so we
should throw in that situation. Since the relevant specifications do not call this out
specifically yet, even though it is tested that way in WPT and Chrome implements this
behavior, the following spec issue was filed: <a href="https://github.com/w3c/csswg-drafts/issues/11343.">https://github.com/w3c/csswg-drafts/issues/11343.</a>

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/effect-updateTiming-expected.txt:
* Source/WebCore/animation/AnimationEffect.cpp:
(WebCore::AnimationEffect::updateTiming):

Canonical link: <a href="https://commits.webkit.org/287663@main">https://commits.webkit.org/287663@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc00fe6cbf77e384d32728bbc44b8c9cde79b25e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80465 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59472 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34131 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84986 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31447 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82576 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68533 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7775 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62872 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20679 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83534 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52966 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73259 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43175 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50270 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27418 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29906 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71414 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27936 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86420 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7691 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71163 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7866 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69097 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70402 "") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14407 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13352 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12443 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7653 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/13172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7492 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11011 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9297 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->