### PR TITLE
[WebDriver][socket] support capabilites.acceptInsecureCerts

### DIFF
--- a/Source/WebDriver/socket/SessionHostSocket.cpp
+++ b/Source/WebDriver/socket/SessionHostSocket.cpp
@@ -263,9 +263,16 @@ void SessionHost::startAutomationSession(Function<void (bool, std::optional<Stri
     m_startSessionCompletionHandler = WTFMove(completionHandler);
     m_sessionID = createVersion4UUIDString();
 
+    auto capabilitiesObject = JSON::Object::create();
+    capabilitiesObject->setBoolean("acceptInsecureCerts"_s, m_capabilities.acceptInsecureCerts.value_or(false));
+
+    auto messageObject = JSON::Object::create();
+    messageObject->setString("sessionID"_s, m_sessionID);
+    messageObject->setObject("capabilities"_s, capabilitiesObject);
+
     auto sendMessageEvent = JSON::Object::create();
     sendMessageEvent->setString("event"_s, "StartAutomationSession"_s);
-    sendMessageEvent->setString("message"_s, m_sessionID);
+    sendMessageEvent->setString("message"_s, messageObject->toJSONString());
     sendWebInspectorEvent(sendMessageEvent->toJSONString());
 }
 

--- a/Source/WebKit/UIProcess/win/AutomationClientWin.h
+++ b/Source/WebKit/UIProcess/win/AutomationClientWin.h
@@ -41,7 +41,7 @@ namespace WebKit {
 
 class AutomationSessionClient final : public API::AutomationSessionClient {
 public:
-    explicit AutomationSessionClient(const String&);
+    explicit AutomationSessionClient(const String&, const Inspector::RemoteInspector::Client::SessionCapabilities&);
 
     String sessionIdentifier() const override { return m_sessionIdentifier; }
 
@@ -53,8 +53,13 @@ public:
 
 private:
     String m_sessionIdentifier;
+    Inspector::RemoteInspector::Client::SessionCapabilities m_capabilities { };
 
     static void close(WKPageRef, const void*);
+
+    static void didReceiveAuthenticationChallenge(WKPageRef, WKAuthenticationChallengeRef, const void*);
+    void didReceiveAuthenticationChallenge(WKPageRef, WKAuthenticationChallengeRef);
+
     HashSet<Ref<WebView>> m_webViews;
 };
 


### PR DESCRIPTION
#### fe03aff9178c035539ba05b2a7f97b24df765f6a
<pre>
[WebDriver][socket] support capabilites.acceptInsecureCerts
<a href="https://bugs.webkit.org/show_bug.cgi?id=284440">https://bugs.webkit.org/show_bug.cgi?id=284440</a>

Reviewed by Fujii Hironori.

Before this change, win port WebDriver does not check the capabilities.

The W3C spec defines that self-signed or invalid certificates are
implicitly trusted if the value of `capabilities.acceptInsecureCerts`
is true.
<a href="https://www.w3.org/TR/webdriver2/#capabilities">https://www.w3.org/TR/webdriver2/#capabilities</a>

For example, the tests in web-platform-tests use self-signed
certificates to start an http server.
Support for acceptInsecureCerts would be helpful to run those tests
over https.

* Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocket.cpp:
(Inspector::RemoteInspector::startAutomationSession):
* Source/WebDriver/socket/SessionHostSocket.cpp:
(WebDriver::SessionHost::startAutomationSession):
* Source/WebKit/UIProcess/win/AutomationClientWin.cpp:
(WebKit::AutomationSessionClient::AutomationSessionClient):
(WebKit::AutomationSessionClient::didReceiveAuthenticationChallenge):
(WebKit::AutomationSessionClient::requestNewPageWithOptions):
(WebKit::AutomationClient::requestAutomationSession):
* Source/WebKit/UIProcess/win/AutomationClientWin.h:

Canonical link: <a href="https://commits.webkit.org/287707@main">https://commits.webkit.org/287707@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f01be4e1a0a985e55f84132e9ac3bd32ca2359b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80602 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/59609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34535 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/85126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/31584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68670 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/7915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/85126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/31584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83671 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/53076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/73375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/85126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/50368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/27535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/30043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/73582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/71514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/28058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/86559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/79661 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/7828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/7915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/86559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/8003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/69212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/86559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/13452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/102068 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12475 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/7790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/13309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/24850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/7629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/11148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/9434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->