### PR TITLE
[web-animations] Update the procedure to set the playback rate of an animation to account for non-monotonic timelines

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-animation-effect-phases.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-animation-effect-phases.tentative-expected.txt
@@ -22,7 +22,7 @@ PASS Current times and effect phase at timeline boundary when delay = 250 and en
 PASS Current times and effect phase at timeline start when delay = -125 and endDelay = -125 |
 PASS Current times and effect phase in active range when delay = -125 and endDelay = -125 |
 PASS Current times and effect phase at timeline end when delay = -125 and endDelay = -125 |
-FAIL Playback rate affects whether active phase boundary is inclusive. assert_equals: Animation effect is in after phase when current time is 50% (progress is null with 'none' fill mode) expected (object) null but got (number) 0.2500000000000001
+FAIL Playback rate affects whether active phase boundary is inclusive. assert_not_equals: Animation effect is in active phase when current time is 100%. got disallowed value null
 PASS Verify that (play -> pause -> play) doesn't change phase/progress.
 PASS Pause in before phase, scroll timeline into active phase, animation should remain in the before phase
 PASS Pause in before phase, set animation current time to be in active range, animation should become active. Scrolling should have no effect.

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-playback-rate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-playback-rate-expected.txt
@@ -2,15 +2,15 @@
 PASS Zero current time is not affected by playbackRate set while the animation is in idle state.
 PASS Zero current time is not affected by playbackRate set while the animation is in play-pending state.
 PASS Initial current time is scaled by playbackRate set while scroll-linked animation is in running state.
-FAIL The current time is scaled by playbackRate set while the scroll-linked animation is in play state. assert_approx_equals: values do not match for "The current time is scaled by the playback rate." expected 40 +/- 0.125 but got 20
+PASS The current time is scaled by playbackRate set while the scroll-linked animation is in play state.
 PASS The playback rate set before scroll-linked animation started playing affects the rate of progress of the current time
 PASS The playback rate affects the rate of progress of the current time when scrolling
 PASS Setting the playback rate while play-pending does not scale current time.
-FAIL Setting the playback rate while playing scales current time. assert_approx_equals: values do not match for "undefined" expected 50 +/- 0.125 but got 25
-FAIL Setting the playback rate while playing scales the set current time. assert_approx_equals: values do not match for "undefined" expected 50 +/- 0.125 but got 25
+PASS Setting the playback rate while playing scales current time.
+PASS Setting the playback rate while playing scales the set current time.
 PASS Negative initial playback rate should correctly modify initial current time.
 PASS Reversing the playback rate while playing correctly impacts current time during future scrolls
 PASS Zero initial playback rate should correctly modify initial current time.
-FAIL Setting a zero playback rate while running preserves the start time assert_approx_equals: values do not match for "undefined" expected 0 +/- 0.125 but got 20
-FAIL Reversing an animation with non-boundary aligned start time symmetrically adjusts the start time assert_approx_equals: values do not match for "undefined" expected 60 +/- 0.125 but got -0
+PASS Setting a zero playback rate while running preserves the start time
+PASS Reversing an animation with non-boundary aligned start time symmetrically adjusts the start time
 


### PR DESCRIPTION
#### 2395da7da3af3de706f8f6f535406d87e663264f
<pre>
[web-animations] Update the procedure to set the playback rate of an animation to account for non-monotonic timelines
<a href="https://bugs.webkit.org/show_bug.cgi?id=284455">https://bugs.webkit.org/show_bug.cgi?id=284455</a>
<a href="https://rdar.apple.com/141277730">rdar://141277730</a>

Reviewed by Anne van Kesteren.

The procedure to set the playback rate of an animation [0] was updated to account for non-monotonic timelines,
which in practice means scroll-driven animations.

[0] <a href="https://drafts.csswg.org/web-animations-1/#setting-the-playback-rate-of-an-animation">https://drafts.csswg.org/web-animations-1/#setting-the-playback-rate-of-an-animation</a>

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-animation-effect-phases.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-playback-rate-expected.txt:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::setPlaybackRate):

Canonical link: <a href="https://commits.webkit.org/287674@main">https://commits.webkit.org/287674@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76e504cee2742c67b1189e17bee6a52b064d3187

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80496 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59503 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34168 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85017 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/31478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82607 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68564 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7808 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/62899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/31478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83565 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/53002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/73289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/43202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/50305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/27447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/29937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/71449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/27968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/86451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7722 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/86451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7897 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/69126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/86451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/14438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/13382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12450 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7684 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/13203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7523 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11042 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9328 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->