### PR TITLE
REGRESSION (285606@main): [visionOS] "Sign in with Google" pop-up is unexpectedly in dark mode

### DIFF
--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -3994,8 +3994,9 @@ bool Page::useDarkAppearance() const
         return m_useDarkAppearanceOverride.value();
 
     if (RefPtr documentLoader = localMainFrame->loader().documentLoader()) {
-        if (documentLoader->colorSchemePreference() == ColorSchemePreference::Dark)
-            return true;
+        auto colorSchemePreference = documentLoader->colorSchemePreference();
+        if (colorSchemePreference != ColorSchemePreference::NoPreference)
+            return colorSchemePreference == ColorSchemePreference::Dark;
     }
 
     return m_useDarkAppearance;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm
@@ -1748,6 +1748,7 @@ TEST(WebpagePreferences, UserExplicitlyPrefersColorSchemeLight)
     configuration.get().defaultWebpagePreferences._colorSchemePreference = _WKWebsiteColorSchemePreferenceLight;
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView forceDarkMode];
 
     [webView loadTestPageNamed:@"color-scheme"];
     [webView waitForMessage:@"light-detected"];


### PR DESCRIPTION
#### e0fe6971e0ffcdef26794cc3698b3b1570ec1d9e
<pre>
REGRESSION (285606@main): [visionOS] &quot;Sign in with Google&quot; pop-up is unexpectedly in dark mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=284465">https://bugs.webkit.org/show_bug.cgi?id=284465</a>
<a href="https://rdar.apple.com/140862101">rdar://140862101</a>

Reviewed by Richard Robinson and Abrar Rahman Protyasha.

Safari uses `-[WKWebpagePreferences _setColorSchemePreference:]` on visionOS to
ensure content is always displayed in light mode. 285606@main broke this
functionality, as it modified logic to only allow a dark mode override, whereas
Safari uses a light mode override.

Fix by restoring the original logic.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::useDarkAppearance const):

Undo the change made to this section of code in 285606@main. An override via
`WKWebpagePreferences` must always be honored if the preference is not
`ColorSchemePreference::NoPreference`.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm:
((WebpagePreferences, UserExplicitlyPrefersColorSchemeLight)):

Update test to effectively protect against this regression. Previously, this
test would trivially pass as the web view was already using light mode. Now,
force the web view to use dark mode, so that a light mode override is actually
tested.

Canonical link: <a href="https://commits.webkit.org/287694@main">https://commits.webkit.org/287694@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/165b6ee58625884c36741aee06221e89cbf5e427

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80499 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59506 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34172 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85020 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31481 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82610 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68567 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7811 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62901 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20709 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83568 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/53000 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73294 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43204 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50303 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27452 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29940 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71447 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27974 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86454 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7725 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5463 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71202 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7900 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69131 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70441 "Found 5 new API test failures: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/submit-form, /TestWebKit:WebKit.FrameMIMETypePNG, /TestWebKit:WebKit.InjectedBundleInitializationUserDataCallbackWins, /TestWebKit:WebKit.DownloadDecideDestinationCrash, /TestWebKit:WebKit2UserMessageRoundTripTest.WKURL (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14436 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13387 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12463 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7687 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/13206 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7526 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11045 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9331 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->