### PR TITLE
[ResourceMonitor] Add handling of queries while rule list is not set up correctly.

### DIFF
--- a/Source/WebCore/loader/ResourceMonitorChecker.h
+++ b/Source/WebCore/loader/ResourceMonitorChecker.h
@@ -46,21 +46,24 @@ public:
 
     static ResourceMonitorChecker& singleton();
 
+    ~ResourceMonitorChecker();
+
     void checkEligibility(ContentExtensions::ResourceLoadInfo&&, CompletionHandler<void(Eligibility)>&&);
-    Eligibility checkEligibilityForTesting(const ContentExtensions::ResourceLoadInfo&);
 
     void setContentRuleList(ContentExtensions::ContentExtensionsBackend&&);
 
 private:
     ResourceMonitorChecker();
 
+    Eligibility checkEligibility(const ContentExtensions::ResourceLoadInfo&);
+    void finishPendingQueries(Function<Eligibility(const ContentExtensions::ResourceLoadInfo&)> checker);
+
     Ref<WorkQueue> protectedWorkQueue() { return m_workQueue; }
 
-    Eligibility checkEligibilityWithLock(const ContentExtensions::ResourceLoadInfo&) WTF_REQUIRES_LOCK(m_lock);
-
     Ref<WorkQueue> m_workQueue;
-    std::unique_ptr<ContentExtensions::ContentExtensionsBackend> m_ruleList WTF_GUARDED_BY_LOCK(m_lock);
-    Lock m_lock;
+    std::unique_ptr<ContentExtensions::ContentExtensionsBackend> m_ruleList;
+    Vector<std::pair<ContentExtensions::ResourceLoadInfo, CompletionHandler<void(Eligibility)>>> m_pendingQueries;
+    bool m_ruleListIsPreparing { true };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 789e26cf9388e22172ea29272c4656f96b32ddc8
<pre>
[ResourceMonitor] Add handling of queries while rule list is not set up correctly.
<a href="https://bugs.webkit.org/show_bug.cgi?id=284466">https://bugs.webkit.org/show_bug.cgi?id=284466</a>
<a href="https://rdar.apple.com/137691088">rdar://137691088</a>

Reviewed by Ben Nham.

At the very beginning of the lifecycle, content rule list may not be set up yet.

Adding queue to keep the queries and handle them when rule list is set. Also add timeout to
giving up to wait the list set up correctly for some reason.

* Source/WebCore/loader/ResourceMonitorChecker.cpp:
(WebCore::ResourceMonitorChecker::~ResourceMonitorChecker):
(WebCore::ResourceMonitorChecker::checkEligibility):
(WebCore::ResourceMonitorChecker::setContentRuleList):
(WebCore::ResourceMonitorChecker::finishPendingQueries):
(WebCore::ResourceMonitorChecker::checkEligibilityForTesting): Deleted.
(WebCore::ResourceMonitorChecker::checkEligibilityWithLock): Deleted.
* Source/WebCore/loader/ResourceMonitorChecker.h:

Canonical link: <a href="https://commits.webkit.org/287688@main">https://commits.webkit.org/287688@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e0327bd2a25d887420a0efda252ebddf7d1e92e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80526 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59533 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34311 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85047 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31508 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82637 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68594 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7838 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62914 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20719 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83595 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/53022 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73304 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43217 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/50324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27462 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29967 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/71469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27987 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86481 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7752 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/71207 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7927 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69141 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70447 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17549 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14456 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13397 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7714 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/13233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7553 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/11072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9358 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->