### PR TITLE
Annotate RemoteRemoteCommandListenerProxy endpoints

### DIFF
--- a/Source/WebKit/GPUProcess/media/RemoteRemoteCommandListenerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteRemoteCommandListenerProxy.cpp
@@ -31,6 +31,7 @@
 #include "GPUConnectionToWebProcess.h"
 #include "GPUProcess.h"
 #include "RemoteRemoteCommandListenerMessages.h"
+#include "SharedPreferencesForWebProcess.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
@@ -55,6 +56,14 @@ void RemoteRemoteCommandListenerProxy::updateSupportedCommands(Vector<WebCore::P
 
     if (auto connection = m_gpuConnection.get())
         connection->updateSupportedRemoteCommands();
+}
+
+std::optional<SharedPreferencesForWebProcess> RemoteRemoteCommandListenerProxy::sharedPreferencesForWebProcess() const
+{
+    if (RefPtr gpuConnectionToWebProcess = m_gpuConnection.get())
+        return gpuConnectionToWebProcess->sharedPreferencesForWebProcess();
+
+    return std::nullopt;
 }
 
 }

--- a/Source/WebKit/GPUProcess/media/RemoteRemoteCommandListenerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteRemoteCommandListenerProxy.h
@@ -43,6 +43,7 @@ class Connection;
 namespace WebKit {
 
 class GPUConnectionToWebProcess;
+struct SharedPreferencesForWebProcess;
 
 class RemoteRemoteCommandListenerProxy : public RefCounted<RemoteRemoteCommandListenerProxy>, private IPC::MessageReceiver {
     WTF_MAKE_TZONE_ALLOCATED(RemoteRemoteCommandListenerProxy);
@@ -61,6 +62,8 @@ public:
     const WebCore::RemoteCommandListener::RemoteCommandsSet& supportedCommands() const { return m_supportedCommands; }
 
     RemoteRemoteCommandListenerIdentifier identifier() const { return m_identifier; }
+
+    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;

--- a/Source/WebKit/GPUProcess/media/RemoteRemoteCommandListenerProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteRemoteCommandListenerProxy.messages.in
@@ -26,9 +26,9 @@
 #if ENABLE(GPU_PROCESS)
 
 [
-    ExceptionForEnabledBy,
     DispatchedFrom=WebContent,
-    DispatchedTo=GPU
+    DispatchedTo=GPU,
+    EnabledBy=MediaPlaybackEnabled
 ]
 messages -> RemoteRemoteCommandListenerProxy {
     UpdateSupportedCommands(Vector<WebCore::PlatformMediaSessionRemoteControlCommandType> commands, bool supportsSeeking)


### PR DESCRIPTION
#### 3983d2f13f9049ade7fa9dcee836aa33831a1a88
<pre>
Annotate RemoteRemoteCommandListenerProxy endpoints
<a href="https://bugs.webkit.org/show_bug.cgi?id=284467">https://bugs.webkit.org/show_bug.cgi?id=284467</a>
<a href="https://rdar.apple.com/141289469">rdar://141289469</a>

Reviewed by Youenn Fablet.

Annotate RemoteRemoteCommandListenerProxy endpoints with MediaPlaybackEnabled

* Source/WebKit/GPUProcess/media/RemoteRemoteCommandListenerProxy.cpp:
(WebKit::RemoteRemoteCommandListenerProxy::sharedPreferencesForWebProcess const):
* Source/WebKit/GPUProcess/media/RemoteRemoteCommandListenerProxy.h:
* Source/WebKit/GPUProcess/media/RemoteRemoteCommandListenerProxy.messages.in:

Canonical link: <a href="https://commits.webkit.org/287941@main">https://commits.webkit.org/287941@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/177e17da2e421160b4e2dae777d3eb8800819e0b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81446 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/971 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35389 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85975 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32434 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/989 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8790 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63573 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/21317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84515 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/686 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74128 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43866 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/582 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30890 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28881 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87410 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8676 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71883 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8857 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69949 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/71121 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17698 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15184 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14097 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8638 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/14167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8474 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11995 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10282 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->