### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE use in layout code

### DIFF
--- a/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
@@ -38,8 +38,6 @@
 #include <wtf/text/TextBreakIterator.h>
 #include <wtf/unicode/CharacterNames.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 namespace Layout {
 
@@ -61,8 +59,7 @@ static std::optional<WhitespaceContent> moveToNextNonWhitespacePosition(std::spa
         return isTreatedAsSpaceCharacter || character == tabCharacter;
     };
     auto nextNonWhiteSpacePosition = startPosition;
-    auto* rawCharacters = characters.data(); // Not using characters[nextNonWhiteSpacePosition] to bypass the bounds check.
-    while (nextNonWhiteSpacePosition < characters.size() && isWhitespaceCharacter(rawCharacters[nextNonWhiteSpacePosition])) {
+    while (nextNonWhiteSpacePosition < characters.size() && isWhitespaceCharacter(characters[nextNonWhiteSpacePosition])) {
         if (UNLIKELY(stopAtWordSeparatorBoundary && hasWordSeparatorCharacter && !isWordSeparatorCharacter))
             break;
         ++nextNonWhiteSpacePosition;
@@ -1043,5 +1040,3 @@ void InlineItemsBuilder::populateBreakingPositionCache(const InlineItemList& inl
 
 }
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLogicalOrderTraversal.cpp
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLogicalOrderTraversal.cpp
@@ -27,6 +27,7 @@
 #include "InlineIteratorLogicalOrderTraversal.h"
 
 #include "InlineIteratorLineBox.h"
+#include <algorithm>
 
 namespace WebCore {
 namespace InlineIterator {
@@ -94,8 +95,8 @@ static LineLogicalOrderCache makeLineLogicalOrderCache(const LineBoxIterator& li
     auto cache = makeUnique<LineLogicalOrderCacheData>();
 
     cache->lineBox = lineBox;
-    cache->boxes = leafBoxesInLogicalOrder(lineBox, [](auto first, auto last) {
-        std::reverse(first, last);
+    cache->boxes = leafBoxesInLogicalOrder(lineBox, [](auto span) {
+        std::ranges::reverse(span);
     });
 
     return cache;

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLogicalOrderTraversal.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLogicalOrderTraversal.h
@@ -29,8 +29,6 @@
 #include "InlineIteratorTextBox.h"
 #include "RenderBlockFlow.h"
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 namespace InlineIterator {
 
@@ -87,19 +85,18 @@ Vector<LeafBoxIterator> leafBoxesInLogicalOrder(const LineBoxIterator& lineBox, 
     if (!(minLevel % 2))
         ++minLevel;
 
-    auto end = boxes.end();
+    auto boxCount = boxes.size();
     for (; minLevel <= maxLevel; ++minLevel) {
-        auto box = boxes.begin();
-        while (box < end) {
-            while (box < end && (*box)->bidiLevel() < minLevel)
-                ++box;
+        size_t boxIndex = 0;
+        while (boxIndex < boxCount) {
+            while (boxIndex < boxCount && boxes[boxIndex]->bidiLevel() < minLevel)
+                ++boxIndex;
 
-            auto first = box;
-            while (box < end && (*box)->bidiLevel() >= minLevel)
-                ++box;
+            auto first = boxIndex;
+            while (boxIndex < boxCount && boxes[boxIndex]->bidiLevel() >= minLevel)
+                ++boxIndex;
 
-            auto last = box;
-            reverseFunction(first, last);
+            reverseFunction(boxes.mutableSpan().subspan(first, boxIndex - first));
         }
     }
 
@@ -108,5 +105,3 @@ Vector<LeafBoxIterator> leafBoxesInLogicalOrder(const LineBoxIterator& lineBox, 
 
 }
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.cpp
@@ -32,8 +32,6 @@
 #include "SVGTextFragment.h"
 #include "TextPainter.h"
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 namespace LayoutIntegration {
 
@@ -58,14 +56,14 @@ IteratorRange<const InlineDisplay::Box*> InlineContent::boxesForRect(const Layou
 
     // FIXME: Do the flips.
     if (formattingContextRoot().writingMode().isBlockFlipped())
-        return { &boxes.first(), &boxes.last() + 1 };
+        return { boxes.begin(), boxes.end() };
 
     if (lines.first().inkOverflow().maxY() > rect.y() && lines.last().inkOverflow().y() < rect.maxY())
-        return { &boxes.first(), &boxes.last() + 1 };
+        return { boxes.begin(), boxes.end() };
 
     // The optimization below relies on line paint bounds not exeeding those of the neighboring lines
     if (hasMultilinePaintOverlap)
-        return { &boxes.first(), &boxes.last() + 1 };
+        return { boxes.begin(), boxes.end() };
 
     auto height = lines.last().lineBoxBottom() - lines.first().lineBoxTop();
     auto averageLineHeight = height / lines.size();
@@ -88,9 +86,10 @@ IteratorRange<const InlineDisplay::Box*> InlineContent::boxesForRect(const Layou
     }
 
     auto firstBox = lines[startLine].firstBoxIndex();
-    auto lastBox = lines[endLine].firstBoxIndex() + lines[endLine].boxCount() - 1;
+    auto lastBox = lines[endLine].firstBoxIndex() + lines[endLine].boxCount();
 
-    return { &boxes[firstBox], &boxes[lastBox] + 1 };
+    auto boxSpan = boxes.subspan(firstBox, lastBox - firstBox);
+    return { std::to_address(boxSpan.begin()), std::to_address(boxSpan.end()) };
 }
 
 const RenderBlockFlow& InlineContent::formattingContextRoot() const
@@ -190,5 +189,3 @@ void InlineContent::shrinkToFit()
 
 }
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp
@@ -62,8 +62,6 @@
 #include <wtf/text/MakeString.h>
 #include <wtf/text/TextStream.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 namespace Layout {
 
@@ -94,9 +92,7 @@ template<typename CharacterType>
 static bool canUseSimplifiedTextMeasuringForCharacters(std::span<const CharacterType> characters, const FontCascade& fontCascade, bool whitespaceIsCollapsed)
 {
     auto& primaryFont = fontCascade.primaryFont();
-    auto* rawCharacters = characters.data();
-    for (unsigned i = 0; i < characters.size(); ++i) {
-        auto character = rawCharacters[i]; // Not using characters[i] to bypass the bounds check.
+    for (auto character : characters) {
         if (!fontCascade.canUseSimplifiedTextMeasuring(character, AutoVariant, whitespaceIsCollapsed, primaryFont))
             return false;
     }
@@ -592,5 +588,3 @@ void printLayoutTreeForLiveDocuments()
 
 }
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -606,7 +606,7 @@ static inline void findFirstAndLastAttributesInVector(Vector<SVGTextLayoutAttrib
 }
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-static inline void reverseInlineBoxRangeAndValueListsIfNeeded(Vector<SVGTextLayoutAttributes*>& attributes, Vector<InlineIterator::LeafBoxIterator>::iterator first, Vector<InlineIterator::LeafBoxIterator>::iterator last)
+static inline void reverseInlineBoxRangeAndValueListsIfNeeded(Vector<SVGTextLayoutAttributes*>& attributes, std::span<InlineIterator::LeafBoxIterator>::iterator first, std::span<InlineIterator::LeafBoxIterator>::iterator last)
 {
     // This is a copy of std::reverse(first, last). It additionally assures that the metrics map within the renderers belonging to the InlineBoxes are reordered as well.
     while (true)  {
@@ -651,8 +651,8 @@ void RenderSVGText::reorderValueListsToLogicalOrder()
     if (!lineBox)
         return;
 
-    InlineIterator::leafBoxesInLogicalOrder(lineBox, [&](auto first, auto last) {
-        reverseInlineBoxRangeAndValueListsIfNeeded(m_layoutAttributes, first, last);
+    InlineIterator::leafBoxesInLogicalOrder(lineBox, [&](auto span) {
+        reverseInlineBoxRangeAndValueListsIfNeeded(m_layoutAttributes, span.begin(), span.end());
     });
 
 }


### PR DESCRIPTION
#### 2279664ec878b6701e6e21b4a0fd82cffffda893
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE use in layout code
<a href="https://bugs.webkit.org/show_bug.cgi?id=284468">https://bugs.webkit.org/show_bug.cgi?id=284468</a>

Reviewed by Alan Baradlay.

* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp:
(WebCore::Layout::moveToNextNonWhitespacePosition):
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
(WebCore::Layout::canUseSimplifiedTextMeasuringForCharacters):
* Source/WebCore/layout/integration/inline/InlineIteratorLogicalOrderTraversal.cpp:
(WebCore::InlineIterator::makeLineLogicalOrderCache):
* Source/WebCore/layout/integration/inline/InlineIteratorLogicalOrderTraversal.h:
(WebCore::InlineIterator::leafBoxesInLogicalOrder):
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.cpp:
(WebCore::LayoutIntegration:: const):
* Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp:
(WebCore::Layout::canUseSimplifiedTextMeasuringForCharacters):
* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::reverseInlineBoxRangeAndValueListsIfNeeded):
(WebCore::RenderSVGText::reorderValueListsToLogicalOrder):

Canonical link: <a href="https://commits.webkit.org/287742@main">https://commits.webkit.org/287742@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd0054767779d8b7028e1aefb98d6d38bfefae67

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80546 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59553 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34460 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85067 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31528 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82657 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68614 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7858 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62927 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20733 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83615 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/53033 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73321 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43232 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50334 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27479 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29987 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71479 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28002 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86501 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7772 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5488 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71218 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-transforms/animation/rotate-animation-with-will-change-transform-001.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7947 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69158 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70459 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14466 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13410 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12503 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7734 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13253 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7573 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11092 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9378 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->