### PR TITLE
[IFC][SVG text] Enable by default

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7815,11 +7815,11 @@ UseIFCForSVGText:
   humanReadableDescription: "Use IFC for SVG text rendering"
   defaultValue:
     WebCore:
-      default: false
+      default: true
     WebKitLegacy:
-      default: false
+      default: true
     WebKit:
-      default: false
+      default: true
 
 UseImageDocumentForSubframePDF:
   type: bool


### PR DESCRIPTION
#### 3c08095cfafbb2587480b2664bf253954b4c0c40
<pre>
[IFC][SVG text] Enable by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=284469">https://bugs.webkit.org/show_bug.cgi?id=284469</a>
<a href="https://rdar.apple.com/141290720">rdar://141290720</a>

Reviewed by NOBODY (OOPS!).

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c08095cfafbb2587480b2664bf253954b4c0c40

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80509 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59516 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34444 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85030 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31491 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68577 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7821 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62908 "Found 59 new test failures: imported/mozilla/svg/text/multiple-x-anchor-end.svg imported/mozilla/svg/text/multiple-x-multiple-dx-anchor-end.svg imported/w3c/web-platform-tests/svg/import/animate-elem-40-t-manual.svg imported/w3c/web-platform-tests/svg/import/styling-pres-02-f-manual.svg imported/w3c/web-platform-tests/svg/import/text-align-05-b-manual.svg imported/w3c/web-platform-tests/svg/import/text-align-06-b-manual.svg imported/w3c/web-platform-tests/svg/import/text-intro-03-b-manual.svg imported/w3c/web-platform-tests/svg/import/text-spacing-01-b-manual.svg imported/w3c/web-platform-tests/svg/import/text-text-04-t-manual.svg imported/w3c/web-platform-tests/svg/import/text-text-05-t-manual.svg ... (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20720 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83578 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/53009 "Found 40 new test failures: imported/mozilla/svg/text/multiple-x-anchor-end.svg imported/mozilla/svg/text/multiple-x-multiple-dx-anchor-end.svg svg/W3C-SVG-1.1/animate-elem-40-t.svg svg/W3C-SVG-1.1/text-align-05-b.svg svg/W3C-SVG-1.1/text-align-06-b.svg svg/W3C-SVG-1.1/text-spacing-01-b.svg svg/W3C-SVG-1.1/text-text-04-t.svg svg/W3C-SVG-1.1/text-text-05-t.svg svg/W3C-SVG-1.1/text-text-06-t.svg svg/W3C-SVG-1.1/text-text-07-t.svg ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73325 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43211 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50312 "Found 13 new test failures: imported/w3c/web-platform-tests/svg/import/animate-elem-40-t-manual.svg imported/w3c/web-platform-tests/svg/import/styling-pres-02-f-manual.svg imported/w3c/web-platform-tests/svg/import/text-align-05-b-manual.svg imported/w3c/web-platform-tests/svg/import/text-align-06-b-manual.svg imported/w3c/web-platform-tests/svg/import/text-intro-03-b-manual.svg imported/w3c/web-platform-tests/svg/import/text-spacing-01-b-manual.svg imported/w3c/web-platform-tests/svg/import/text-text-04-t-manual.svg imported/w3c/web-platform-tests/svg/import/text-text-05-t-manual.svg imported/w3c/web-platform-tests/svg/import/text-text-06-t-manual.svg imported/w3c/web-platform-tests/svg/import/text-text-07-t-manual.svg ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27483 "Found 60 new test failures: fonts/font-weight-invalid-crash.html fonts/ligature.html http/tests/security/clipboard/copy-paste-html-cross-origin-iframe-across-origin.html http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-script-in-iframe.html imported/mozilla/svg/text/multiple-x-anchor-end.svg imported/mozilla/svg/text/multiple-x-multiple-dx-anchor-end.svg imported/w3c/web-platform-tests/content-security-policy/reporting/report-original-url-on-mixed-content-frame.https.sub.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-writing-modes-002.html imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-child-with-border.html imported/w3c/web-platform-tests/css/css-break/table/table-row-paint-htb-ltr.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29950 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/73489 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71456 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28006 "Found 60 new test failures: css3/color-filters/color-filter-current-color.html fast/canvas/image-buffer-resource-limits.html fast/editing/recursive-reapply-edit-command-crash.html fast/selectors/text-field-selection-window-inactive-stroke-color.html fast/table/neighboring-cells-when-collapsed-border-changes.html fast/table/overflow-percent-height-regression.html fast/text/emoji-gender-2-8.html http/tests/site-isolation/compositing/iframes/resize-from-zero-size.html http/tests/websocket/tests/hybi/close.html imported/mozilla/svg/text/multiple-x-anchor-end.svg ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86464 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/79568 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7735 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5467 "Found 60 new test failures: http/tests/images/gif-progressive-load.html http/tests/misc/repeat-open-cancel.html http/wpt/service-workers/basic-fetch-with-contentfilter.https.html imported/blink/fast/hidpi/border-background-align.html imported/mozilla/svg/text/multiple-x-anchor-end.svg imported/mozilla/svg/text/multiple-x-multiple-dx-anchor-end.svg imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-rendering-invalidation.html imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-mismatch-ident.html imported/w3c/web-platform-tests/css/cssom-view/cssom-getBoundingClientRect-003.html imported/w3c/web-platform-tests/editing/other/insertparagraph-in-child-of-html.tentative.html?designMode=on&white-space=normal ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71200 "Found 59 new test failures: imported/mozilla/svg/text/multiple-x-anchor-end.svg imported/mozilla/svg/text/multiple-x-multiple-dx-anchor-end.svg imported/w3c/web-platform-tests/svg/import/animate-elem-40-t-manual.svg imported/w3c/web-platform-tests/svg/import/styling-pres-02-f-manual.svg imported/w3c/web-platform-tests/svg/import/text-align-05-b-manual.svg imported/w3c/web-platform-tests/svg/import/text-align-06-b-manual.svg imported/w3c/web-platform-tests/svg/import/text-intro-03-b-manual.svg imported/w3c/web-platform-tests/svg/import/text-spacing-01-b-manual.svg imported/w3c/web-platform-tests/svg/import/text-text-04-t-manual.svg imported/w3c/web-platform-tests/svg/import/text-text-05-t-manual.svg ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7910 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69162 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70439 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14447 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13414 "Found 60 new test failures: fast/shadow-dom/link-element-in-shadow-tree.html imported/mozilla/svg/text/multiple-x-anchor-end.svg imported/mozilla/svg/text/multiple-x-multiple-dx-anchor-end.svg imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-ellipse-closest-farthest-corner.html imported/w3c/web-platform-tests/css/cssom-view/cssom-getBoundingClientRect-003.html imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-postMessage-MessagePort-frames.https.window.html imported/w3c/web-platform-tests/preload/link-header-on-subresource.html imported/w3c/web-platform-tests/preload/modulepreload.html imported/w3c/web-platform-tests/scroll-to-text-fragment/find-range-from-text-directive.html imported/w3c/web-platform-tests/svg/import/animate-elem-40-t-manual.svg ... (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/101975 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7697 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/24837 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7536 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11055 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9341 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->