### PR TITLE
[Skia] Ignore warnings in some Skia headers to fix non-unified clang build

### DIFF
--- a/Source/WebCore/platform/graphics/filters/skia/FEComponentTransferSkiaApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/skia/FEComponentTransferSkiaApplier.cpp
@@ -33,7 +33,9 @@
 #include "GraphicsContext.h"
 #include "ImageBuffer.h"
 #include "NativeImage.h"
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN // GLib/Win ports
 #include <skia/core/SkCanvas.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #include <skia/core/SkColorFilter.h>
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebCore/platform/graphics/filters/skia/FEDropShadowSkiaApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/skia/FEDropShadowSkiaApplier.cpp
@@ -34,7 +34,9 @@
 #include "GraphicsContext.h"
 #include "ImageBuffer.h"
 #include "NativeImage.h"
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN // GLib/Win ports
 #include <skia/core/SkCanvas.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #include <skia/effects/SkImageFilters.h>
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebCore/platform/graphics/filters/skia/FEGaussianBlurSkiaApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/skia/FEGaussianBlurSkiaApplier.cpp
@@ -33,7 +33,9 @@
 #include "FilterImage.h"
 #include "GraphicsContext.h"
 #include "NativeImage.h"
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN // GLib/Win ports
 #include <skia/core/SkCanvas.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #include <skia/effects/SkImageFilters.h>
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebCore/platform/graphics/filters/skia/SourceGraphicSkiaApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/skia/SourceGraphicSkiaApplier.cpp
@@ -33,7 +33,9 @@
 #include "GraphicsContext.h"
 #include "ImageBuffer.h"
 #include "NativeImage.h"
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN // GLib/Win ports
 #include <skia/core/SkCanvas.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/graphics/skia/FloatRectSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FloatRectSkia.cpp
@@ -27,7 +27,9 @@
 #include "FloatRect.h"
 
 #if USE(SKIA)
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN // GLib/Win ports
 #include <skia/core/SkRect.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/graphics/skia/IntRectSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/IntRectSkia.cpp
@@ -27,7 +27,9 @@
 #include "IntRect.h"
 
 #if USE(SKIA)
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN // GLib/Win ports
 #include <skia/core/SkRect.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp
@@ -33,13 +33,12 @@
 #include "PlatformDisplay.h"
 #include <skia/core/SkData.h>
 #include <skia/core/SkImage.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN // GLib/Win ports
 #include <skia/gpu/ganesh/GrBackendSurface.h>
 #include <skia/gpu/ganesh/SkImageGanesh.h>
 #include <skia/private/chromium/SkImageChromium.h>
-
-IGNORE_CLANG_WARNINGS_BEGIN("cast-align")
 #include <skia/core/SkPixmap.h>
-IGNORE_CLANG_WARNINGS_END
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/graphics/skia/ShareableBitmapSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/ShareableBitmapSkia.cpp
@@ -31,9 +31,9 @@
 #include "GraphicsContextSkia.h"
 #include "NotImplemented.h"
 
-IGNORE_CLANG_WARNINGS_BEGIN("cast-align")
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN // GLib/Win ports
 #include <skia/core/SkSurface.h>
-IGNORE_CLANG_WARNINGS_END
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/graphics/skia/TransformationMatrixSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/TransformationMatrixSkia.cpp
@@ -28,7 +28,9 @@
 
 #if USE(SKIA)
 #include "AffineTransform.h"
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN // GLib/Win ports
 #include <skia/core/SkM44.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 namespace WebCore {
 


### PR DESCRIPTION
#### e9f0264df880b259e9c1fc9725f0e50ee7259bd8
<pre>
[Skia] Ignore warnings in some Skia headers to fix non-unified clang build
<a href="https://bugs.webkit.org/show_bug.cgi?id=284472">https://bugs.webkit.org/show_bug.cgi?id=284472</a>

Reviewed by Michael Catanzaro.

These headers pull Skia headers that do unsafe buffer usages, in unified builds
they are somehow already ignored, but in non-unified builds they are not,
so ignore them explicitly.

* Source/WebCore/platform/graphics/filters/skia/FEComponentTransferSkiaApplier.cpp:
* Source/WebCore/platform/graphics/filters/skia/FEDropShadowSkiaApplier.cpp:
* Source/WebCore/platform/graphics/filters/skia/FEGaussianBlurSkiaApplier.cpp:
* Source/WebCore/platform/graphics/filters/skia/SourceGraphicSkiaApplier.cpp:
* Source/WebCore/platform/graphics/skia/FloatRectSkia.cpp:
* Source/WebCore/platform/graphics/skia/IntRectSkia.cpp:
* Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp:
* Source/WebCore/platform/graphics/skia/ShareableBitmapSkia.cpp:
* Source/WebCore/platform/graphics/skia/TransformationMatrixSkia.cpp:

Canonical link: <a href="https://commits.webkit.org/287685@main">https://commits.webkit.org/287685@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d3ac7ecbea469c5cb799bc9b4e45936d0674d0e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80544 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/59551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34447 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85065 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/31526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82655 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68612 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7856 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/62925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/31526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83613 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/53031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/73317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/43230 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/50332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/27475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29985 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/71477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/27998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86499 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/7770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/71216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/7945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69154 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/70456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/13409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12458 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/7732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/13251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/7571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/11090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/9376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->