### PR TITLE
Non-unified build fixes, partial

### DIFF
--- a/Source/WebCore/Modules/fetch/FetchLoader.cpp
+++ b/Source/WebCore/Modules/fetch/FetchLoader.cpp
@@ -44,6 +44,7 @@
 #include "SharedBuffer.h"
 #include "TextResourceDecoder.h"
 #include "ThreadableBlobRegistry.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/dom/InternalObserverReduce.h
+++ b/Source/WebCore/dom/InternalObserverReduce.h
@@ -27,6 +27,10 @@
 
 #include <wtf/Forward.h>
 
+namespace JSC {
+class JSValue;
+}
+
 namespace WebCore {
 
 class DeferredPromise;

--- a/Source/WebCore/html/parser/HTMLDocumentParser.h
+++ b/Source/WebCore/html/parser/HTMLDocumentParser.h
@@ -35,6 +35,7 @@
 
 namespace WebCore {
 
+class CustomElementRegistry;
 class DocumentFragment;
 class Element;
 class HTMLDocument;

--- a/Source/WebCore/rendering/style/StyleInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleInheritedData.h
@@ -27,6 +27,7 @@
 #include "FontCascade.h"
 #include "Length.h"
 #include "StyleColor.h"
+#include "StyleFontData.h"
 #include <wtf/DataRef.h>
 
 namespace WTF {
@@ -34,8 +35,6 @@ class TextStream;
 }
 
 namespace WebCore {
-
-class StyleFontData;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleInheritedData);
 class StyleInheritedData : public RefCounted<StyleInheritedData> {

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -275,6 +275,7 @@ static const ASCIILiteral appleCameraUserClientIOKitClientClass { "H11ANEInDirec
 static const ASCIILiteral appleCameraUserClientIOKitServiceClass { "H11ANEIn"_s };
 #endif
 
+#if PLATFORM(COCOA)
 static inline bool addCameraSandboxExtensions(Vector<SandboxExtension::Handle>& extensions)
 {
     auto sandboxExtensionHandle = SandboxExtension::createHandleForGenericExtension("com.apple.webkit.camera"_s);
@@ -339,6 +340,7 @@ static inline bool addMicrophoneSandboxExtension(Vector<SandboxExtension::Handle
     extensions.append(WTFMove(*sandboxExtensionHandle));
     return true;
 }
+#endif // PLATFORM(COCOA)
 
 #if HAVE(SCREEN_CAPTURE_KIT)
 static inline bool addDisplayCaptureSandboxExtension(std::optional<audit_token_t> auditToken, Vector<SandboxExtension::Handle>& extensions)

--- a/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.cpp
+++ b/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.cpp
@@ -35,6 +35,7 @@
 #include "WebPage.h"
 #include "WebProcess.h"
 #include "XRDeviceInfo.h"
+#include <WebCore/Page.h>
 #include <WebCore/SecurityOrigin.h>
 #include <wtf/Vector.h>
 


### PR DESCRIPTION
#### 59d192f155d55a303f6f105778b261615f2dc2d0
<pre>
Non-unified build fixes, partial
<a href="https://bugs.webkit.org/show_bug.cgi?id=284473">https://bugs.webkit.org/show_bug.cgi?id=284473</a>

Unreviewed build fix.

* Source/WebCore/Modules/fetch/FetchLoader.cpp:
* Source/WebCore/dom/InternalObserverReduce.h:
* Source/WebCore/html/parser/HTMLDocumentParser.h:
* Source/WebCore/rendering/style/StyleInheritedData.h:
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
* Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.cpp:

Canonical link: <a href="https://commits.webkit.org/287693@main">https://commits.webkit.org/287693@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f41859bdd88d547010d50351455307d5add6bb89

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80525 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59532 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34291 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85046 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31507 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82636 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68593 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7837 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62916 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20724 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83594 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/53023 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73309 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43219 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50325 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27467 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29966 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71470 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27990 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86480 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7751 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71210 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7926 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69146 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70450 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14459 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13402 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12461 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7713 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/13232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7552 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11071 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9357 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->