### PR TITLE
ASAN_TRAP | WebCore::Style::fontVariationSettingsFromCSSValue

### DIFF
--- a/LayoutTests/fast/dom/StyleSheet/css-font-variation-settings-crash-expected.txt
+++ b/LayoutTests/fast/dom/StyleSheet/css-font-variation-settings-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if WebKit does not crash.
+
+PASS. WebKit did not crash

--- a/LayoutTests/fast/dom/StyleSheet/css-font-variation-settings-crash.html
+++ b/LayoutTests/fast/dom/StyleSheet/css-font-variation-settings-crash.html
@@ -1,0 +1,9 @@
+<p>This test passes if WebKit does not crash.</p>
+<script>
+globalThis.testRunner?.dumpAsText();
+
+const node = document.body;
+node.attributeStyleMap.set('font-variation-settings', node.computedStyleMap().get('color-scheme'));
+
+document.write('PASS. WebKit did not crash');
+</script>

--- a/Source/WebCore/style/StyleResolveForFont.cpp
+++ b/Source/WebCore/style/StyleResolveForFont.cpp
@@ -422,7 +422,10 @@ FontVariationSettings fontVariationSettingsFromCSSValue(const CSSValue& value, c
     }
 
     FontVariationSettings settings;
-    for (Ref item : downcast<CSSValueList>(value)) {
+    auto list = dynamicDowncast<CSSValueList>(value);
+    if (!list)
+        return { };
+    for (Ref item : *list) {
         auto& feature = downcast<CSSFontVariationValue>(item.get());
         settings.insert({ feature.tag(), feature.value().resolveAsNumber<float>(conversionData) });
     }


### PR DESCRIPTION
#### 5d3f580ff61cbe1165dd2b28ca0b9bfea267fd8a
<pre>
ASAN_TRAP | WebCore::Style::fontVariationSettingsFromCSSValue
<a href="https://bugs.webkit.org/show_bug.cgi?id=284248">https://bugs.webkit.org/show_bug.cgi?id=284248</a>
<a href="https://rdar.apple.com/141022736">rdar://141022736</a>

Reviewed by Ryosuke Niwa.

Changed to use result of dynamicDowncast ColorScheme for safe dereferencing.

* LayoutTests/fast/dom/StyleSheet/css-font-variation-settings-crash-expected.txt: Added.
* LayoutTests/fast/dom/StyleSheet/css-font-variation-settings-crash.html: Added.
* Source/WebCore/style/StyleResolveForFont.cpp:
(WebCore::Style::fontVariationSettingsFromCSSValue):

Canonical link: <a href="https://commits.webkit.org/287706@main">https://commits.webkit.org/287706@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67900eb4700e5510137acd2bc81087ada7e0c899

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80551 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59558 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34484 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85072 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31533 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82662 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68619 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7863 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62930 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20736 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83620 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/53038 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73331 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43235 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50338 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27489 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29992 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71484 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28012 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86506 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7777 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5491 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71224 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7952 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69168 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70465 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14472 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13416 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12474 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7739 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/13258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7578 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11097 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9383 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->