### PR TITLE
Remove unreachable code from Python tools

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/subprocess.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/subprocess.py
@@ -154,7 +154,6 @@ class Subprocess(ContextStack):
             return candidates
 
         raise FileNotFoundError("No such file or directory: '{path}': '{path}'".format(path=program))
-        raise OSError('[Errno 2] No such file or directory')
 
     @classmethod
     def completion_for(cls, *args, **kwargs):

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/terminal.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/terminal.py
@@ -36,6 +36,3 @@ class Terminal(object):
             return args[cls.index - 1]
 
         return patch('builtins.input', new=function)
-
-        import __builtin__
-        return patch.object(__builtin__, 'raw_input', new=function)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/scm_base.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/scm_base.py
@@ -25,7 +25,6 @@ import re
 import sys
 import time
 
-from datetime import datetime
 from logging import NullHandler
 from webkitscmpy import Commit, Contributor, CommitClassifier, log
 from webkitcorepy import string_utils
@@ -45,9 +44,6 @@ class ScmBase(object):
     @classmethod
     def gmtoffset(cls):
         return int(time.localtime().tm_gmtoff * 100 / (60 * 60))
-
-        ts = time.time()
-        return int((datetime.fromtimestamp(ts) - datetime.utcfromtimestamp(ts)).total_seconds() * 100 / (60 * 60))
 
     def __init__(self, dev_branches=None, prod_branches=None, contributors=None, id=None, classifier=None):
         self.dev_branches = dev_branches or self.DEV_BRANCHES

--- a/Tools/Scripts/webkitpy/port/gtk.py
+++ b/Tools/Scripts/webkitpy/port/gtk.py
@@ -201,4 +201,3 @@ class GtkPort(GLibPort):
 
         except (webkitpy.common.system.executive.ScriptError, IOError, OSError):
             return False
-        return False

--- a/Tools/flatpak/flatpakutils.py
+++ b/Tools/flatpak/flatpakutils.py
@@ -16,7 +16,6 @@
 # Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
 # Boston, MA 02110-1301, USA.
 import argparse
-import atexit
 import logging
 try:
     import configparser
@@ -1150,8 +1149,6 @@ class WebkitFlatpak:
         except KeyboardInterrupt:
             return 0
 
-        return 0
-
     def main(self):
         if self.check_available:
             return 0
@@ -1248,7 +1245,6 @@ class WebkitFlatpak:
             Console.error_message("The following command returned a non-zero exit status: %s\n"
                                   "Output: %s", ' '.join(error.cmd), error.output)
             return error.returncode
-        return 0
 
     def has_environment(self):
         return os.path.exists(self.flatpak_build_path)


### PR DESCRIPTION
#### b7a2c9869a47caee7ce6d6212307b0933ef9e1c7
<pre>
Remove unreachable code from Python tools
<a href="https://bugs.webkit.org/show_bug.cgi?id=284480">https://bugs.webkit.org/show_bug.cgi?id=284480</a>

Reviewed by Jonathan Bedard.

Most of this was left behind in 287424@main as a result of limitations
of how it was automatically rewritten, but this also fixes other
pre-existing cases.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/subprocess.py:
(Subprocess.completion_generator_for):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/terminal.py:
(Terminal.input):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/scm_base.py:
(ScmBase.gmtoffset):
* Tools/Scripts/webkitpy/port/gtk.py:
(GtkPort._is_gtk4_build):
* Tools/flatpak/flatpakutils.py:
(WebkitFlatpak.run_in_sandbox):
(WebkitFlatpak.run):

Canonical link: <a href="https://commits.webkit.org/287692@main">https://commits.webkit.org/287692@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/492cb6feacf0cfa07060351cabfb24aa9eccff29

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80557 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59564 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34490 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85078 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31539 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82668 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68625 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7869 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/62934 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/20741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83626 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/53039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73330 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43239 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/80014 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/50339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/27488 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29998 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/71485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28011 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86512 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7783 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/71228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/80200 "Passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/7958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69167 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/70469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12460 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/7745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/7584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/11103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9389 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->