### PR TITLE
[iOS] [Unified PDF] Make it possible to select words by long pressing

### DIFF
--- a/Source/WebKit/Platform/spi/Cocoa/PDFKitSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/PDFKitSPI.h
@@ -146,18 +146,6 @@
 @end
 #endif
 
-#if HAVE(PDFDOCUMENT_SELECTION_WITH_GRANULARITY)
-typedef NS_ENUM(NSUInteger, PDFSelectionGranularity);
-
-#define PDFSelectionGranularityCharacter 0
-#define PDFSelectionGranularityWord 1
-#define PDFSelectionGranularityLine 2
-
-@interface PDFDocument (Staging_122179178)
-- (/*nullable*/ PDFSelection *)selectionFromPage:(PDFPage *)startPage atPoint:(PDFPoint)startPoint toPage:(PDFPage *)endPage atPoint:(PDFPoint)endPoint withGranularity:(PDFSelectionGranularity)granularity;
-@end
-#endif
-
 #if ENABLE(UNIFIED_PDF_DATA_DETECTION)
 
 #if HAVE(PDFDOCUMENT_ENABLE_DATA_DETECTORS)

--- a/Source/WebKit/Shared/EditorState.cpp
+++ b/Source/WebKit/Shared/EditorState.cpp
@@ -45,13 +45,13 @@ TextStream& operator<<(TextStream& ts, const EditorState& editorState)
         ts.dumpProperty("isContentRichlyEditable", editorState.isContentRichlyEditable);
     if (editorState.isInPasswordField)
         ts.dumpProperty("isInPasswordField", editorState.isInPasswordField);
-    if (editorState.isInPlugin)
-        ts.dumpProperty("isInPlugin", editorState.isInPlugin);
     if (editorState.hasComposition)
         ts.dumpProperty("hasComposition", editorState.hasComposition);
     if (editorState.triggeredByAccessibilitySelectionChange)
         ts.dumpProperty("triggeredByAccessibilitySelectionChange", editorState.triggeredByAccessibilitySelectionChange);
 #if PLATFORM(MAC)
+    if (editorState.isInPlugin)
+        ts.dumpProperty("isInPlugin", editorState.isInPlugin);
     if (!editorState.canEnableAutomaticSpellingCorrection)
         ts.dumpProperty("canEnableAutomaticSpellingCorrection", editorState.canEnableAutomaticSpellingCorrection);
 #endif

--- a/Source/WebKit/Shared/EditorState.h
+++ b/Source/WebKit/Shared/EditorState.h
@@ -83,10 +83,10 @@ struct EditorState {
     bool isContentEditable { false };
     bool isContentRichlyEditable { false };
     bool isInPasswordField { false };
-    bool isInPlugin { false };
     bool hasComposition { false };
     bool triggeredByAccessibilitySelectionChange { false };
 #if PLATFORM(MAC)
+    bool isInPlugin { false };
     bool canEnableAutomaticSpellingCorrection { true };
 #endif
 

--- a/Source/WebKit/Shared/EditorState.serialization.in
+++ b/Source/WebKit/Shared/EditorState.serialization.in
@@ -51,10 +51,10 @@ struct WebKit::EditorState {
     bool isContentEditable;
     bool isContentRichlyEditable;
     bool isInPasswordField;
-    bool isInPlugin;
     bool hasComposition;
     bool triggeredByAccessibilitySelectionChange;
 #if PLATFORM(MAC)
+    bool isInPlugin;
     bool canEnableAutomaticSpellingCorrection;
 #endif
     std::optional<WebKit::EditorState::PostLayoutData> postLayoutData;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -256,7 +256,7 @@ enum class TargetedPreviewPositioning : uint8_t {
 using InputViewUpdateDeferralSources = OptionSet<InputViewUpdateDeferralSource>;
 
 struct WKSelectionDrawingInfo {
-    enum class SelectionType { None, Plugin, Range };
+    enum class SelectionType : bool { None, Range };
     WKSelectionDrawingInfo();
     explicit WKSelectionDrawingInfo(const EditorState&);
     SelectionType type { SelectionType::None };

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -392,11 +392,6 @@ WKSelectionDrawingInfo::WKSelectionDrawingInfo(const EditorState& editorState)
         return;
     }
 
-    if (editorState.isInPlugin) {
-        type = SelectionType::Plugin;
-        return;
-    }
-
     type = SelectionType::Range;
     if (!editorState.postLayoutData)
         return;
@@ -453,7 +448,6 @@ static TextStream& operator<<(TextStream& stream, WKSelectionDrawingInfo::Select
 {
     switch (type) {
     case WKSelectionDrawingInfo::SelectionType::None: stream << "none"; break;
-    case WKSelectionDrawingInfo::SelectionType::Plugin: stream << "plugin"; break;
     case WKSelectionDrawingInfo::SelectionType::Range: stream << "range"; break;
     }
     

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -28,6 +28,7 @@
 
 #if ENABLE(PDF_PLUGIN)
 
+#import "EditorState.h"
 #import "Logging.h"
 #import "MessageSenderInlines.h"
 #import "PDFIncrementalLoader.h"
@@ -655,26 +656,6 @@ void PDFPluginBase::invalidateRect(const IntRect& rect)
     m_view->invalidateRect(rect);
 }
 
-IntPoint PDFPluginBase::convertFromRootViewToPlugin(const IntPoint& point) const
-{
-    return m_rootViewToPluginTransform.mapPoint(point);
-}
-
-IntRect PDFPluginBase::convertFromRootViewToPlugin(const IntRect& rect) const
-{
-    return m_rootViewToPluginTransform.mapRect(rect);
-}
-
-IntPoint PDFPluginBase::convertFromPluginToRootView(const IntPoint& point) const
-{
-    return m_rootViewToPluginTransform.inverse()->mapPoint(point);
-}
-
-IntRect PDFPluginBase::convertFromPluginToRootView(const IntRect& rect) const
-{
-    return m_rootViewToPluginTransform.inverse()->mapRect(rect);
-}
-
 IntRect PDFPluginBase::boundsOnScreen() const
 {
     return WebCore::Accessibility::retrieveValueFromMainThread<WebCore::IntRect>([&] () -> WebCore::IntRect {
@@ -1190,6 +1171,24 @@ id PDFPluginBase::accessibilityAssociatedPluginParentForElement(Element* element
 #endif
 
     return nil;
+}
+
+bool PDFPluginBase::populateEditorStateIfNeeded(EditorState& state) const
+{
+    if (platformPopulateEditorStateIfNeeded(state)) {
+        // Defer to platform-specific logic.
+        return true;
+    }
+
+    if (selectionString().isNull())
+        return false;
+
+    state.selectionIsNone = false;
+    state.selectionIsRange = true;
+#if PLATFORM(MAC)
+    state.isInPlugin = true;
+#endif
+    return true;
 }
 
 #if !LOG_DISABLED

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -69,6 +69,7 @@ class PDFPluginPasswordForm;
 class PDFPresentationController;
 class WebFrame;
 class WebMouseEvent;
+struct EditorState;
 struct PDFContextMenu;
 struct PDFContextMenuItem;
 
@@ -572,6 +573,11 @@ private:
     void setPresentationController(RefPtr<PDFPresentationController>&&);
 
     WebCore::FloatRect pageBoundsInContentsSpace(PDFDocumentLayout::PageIndex) const;
+
+#if PLATFORM(IOS_FAMILY)
+    void setSelectionRange(WebCore::FloatPoint pointInRootView, WebCore::TextGranularity) final;
+    bool platformPopulateEditorStateIfNeeded(EditorState&) const final;
+#endif
 
     RefPtr<PDFPresentationController> m_presentationController;
 

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -1110,11 +1110,23 @@ void PluginView::openWithPreview(CompletionHandler<void(const String&, FrameInfo
 }
 
 #if PLATFORM(IOS_FAMILY)
+
 void PluginView::pluginDidInstallPDFDocument(double initialScale)
 {
     protectedWebPage()->pluginDidInstallPDFDocument(initialScale);
 }
-#endif
+
+void PluginView::setSelectionRange(FloatPoint pointInRootView, TextGranularity granularity)
+{
+    protectedPlugin()->setSelectionRange(pointInRootView, granularity);
+}
+
+#endif // PLATFORM(IOS_FAMILY)
+
+bool PluginView::populateEditorStateIfNeeded(EditorState& state) const
+{
+    return protectedPlugin()->populateEditorStateIfNeeded(state);
+}
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -49,6 +49,7 @@ class LocalFrame;
 class RenderEmbeddedObject;
 class ShareableBitmap;
 class VoidCallback;
+enum class TextGranularity : uint8_t;
 }
 
 namespace WebKit {
@@ -56,6 +57,7 @@ namespace WebKit {
 class PDFPluginBase;
 class WebFrame;
 class WebPage;
+struct EditorState;
 struct FrameInfoData;
 struct WebHitTestResultData;
 
@@ -92,7 +94,10 @@ public:
     void pluginScaleFactorDidChange();
 #if PLATFORM(IOS_FAMILY)
     void pluginDidInstallPDFDocument(double initialScaleFactor);
+    void setSelectionRange(WebCore::FloatPoint pointInRootView, WebCore::TextGranularity);
 #endif
+
+    bool populateEditorStateIfNeeded(EditorState&) const;
 
     void topContentInsetDidChange();
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1535,14 +1535,8 @@ EditorState WebPage::editorState(ShouldPerformLayout shouldPerformLayout) const
     });
 
 #if ENABLE(PDF_PLUGIN)
-    if (auto* pluginView = focusedPluginViewForFrame(*frame)) {
-        if (!pluginView->selectionString().isNull()) {
-            result.selectionIsNone = false;
-            result.selectionIsRange = true;
-            result.isInPlugin = true;
-            return result;
-        }
-    }
+    if (RefPtr pluginView = pluginViewForFrame(frame.get()); pluginView && pluginView->populateEditorStateIfNeeded(result))
+        return result;
 #endif
 
     const VisibleSelection& selection = frame->selection().selection();


### PR DESCRIPTION
#### 6390ac13796720a15123cbb56cbe0971d9843e27
<pre>
[iOS] [Unified PDF] Make it possible to select words by long pressing
<a href="https://bugs.webkit.org/show_bug.cgi?id=284477">https://bugs.webkit.org/show_bug.cgi?id=284477</a>

Reviewed by Abrar Rahman Protyasha.

Work towards support for UIKit-based text interaction in PDFs when Unified PDF is enabled. This
patch only introduces the minimal support needed to allow long presses to select a single word in
a PDF document. See below for more details.

* Source/WebKit/Platform/spi/Cocoa/PDFKitSPI.h:

Remove some staging declarations that are no longer necessary, now that these enums are public API.

* Source/WebKit/Shared/EditorState.cpp:
(WebKit::operator&lt;&lt;):
* Source/WebKit/Shared/EditorState.h:

Move `isInPlugin` behind `PLATFORM(MAC)`. This flag is currently unused on iOS (no codepath sets it
to true).

* Source/WebKit/Shared/EditorState.serialization.in:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(WebKit::WKSelectionDrawingInfo::WKSelectionDrawingInfo):
(WebKit::operator&lt;&lt;):

Remove dead code on iOS, now that `isInPlugin` is only available on macOS.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::requires):
(WebKit::PDFPluginBase::convertFromRootViewToPlugin const):
(WebKit::PDFPluginBase::convertFromPluginToRootView const):

Turn these into templated coordinate space conversion helper methods, and use a `CanMakeFloatRect`
concept here to call `mapRect` for both `IntRect` and `FloatRect` at compile time; otherwise, call
`mapPoint` for both `IntPoint` and `FloatPoint`.

(WebKit::PDFPluginBase::setSelectionRange):
(WebKit::PDFPluginBase::platformPopulateEditorStateIfNeeded const):

Move logic to set the `isInPlugin` flag into `PDFPluginBase`, from `WebPage`. This, as far as I
could tell, was only used on iOS prior to PDFKit integration, when the legacy PDF plugin was still
utilized. It&apos;s now only required for macOS. On iOS, the unified PDF plugin instead populates the
relevant members of `EditorState` and its associated structs.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::populateEditorStateIfNeeded const):
(WebKit::PDFPluginBase::convertFromRootViewToPlugin const): Deleted.
(WebKit::PDFPluginBase::convertFromPluginToRootView const): Deleted.

See above.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::continueTrackingSelection):

Drive-by fix: remove some now-unneeded explicit casts to `PDFSelectionGranularity`.

(WebKit::UnifiedPDFPlugin::setCurrentSelection):
(WebKit::UnifiedPDFPlugin::setSelectionRange):

Add plumbing to set the current selection at the root view point, with the given granularity. This
is invoked when long pressing to set the selection. We map the root view point into plugin
coordinates, hit-test the `PDFDocument` for a selection under the point, and then update the current
selection.

(WebKit::UnifiedPDFPlugin::platformPopulateEditorStateIfNeeded const):

Add logic to assemble an `EditorState` representing the selected text range in the PDF plugin, based
on `PDFSelection`. For now, this just handles the case where the selection is a single piece of
left-to-right text on a single line; in future patches, we&apos;ll need the ability to coalesce adjacent
rects, handle bidirectional text, and a number of other use cases.

* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::setSelectionRange):
(WebKit::PluginView::populateEditorStateIfNeeded const):
* Source/WebKit/WebProcess/Plugins/PluginView.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::editorState const):

Refactor this to defer to the PDF plugin if needed.

* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::setFocusedFrameBeforeSelectingTextAtLocation):

Defer to the PDF plugin in the case where the focused or main frame is a PDF.

(WebKit::WebPage::setSelectionRange):

Canonical link: <a href="https://commits.webkit.org/287724@main">https://commits.webkit.org/287724@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc172a6733ba50dc1172495c2a828a09e83ee467

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80626 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59633 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34560 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85150 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31608 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68694 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7939 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62974 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20770 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83695 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/53095 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73395 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43279 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50383 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30067 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71529 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28077 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86583 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7852 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71267 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8027 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69231 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70507 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17571 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14524 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13469 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7814 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/13333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7653 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11172 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9458 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->