### PR TITLE
[iOS] It should be possible to change presentingApplicationAuditToken after a WKWebView is created

### DIFF
--- a/Source/WTF/wtf/RuntimeApplicationChecks.cpp
+++ b/Source/WTF/wtf/RuntimeApplicationChecks.cpp
@@ -45,19 +45,28 @@ static std::optional<int>& presentingApplicationPIDOverride()
     return pid;
 }
 
-int presentingApplicationPID()
+int legacyPresentingApplicationPID()
 {
     const auto& pid = presentingApplicationPIDOverride();
     ASSERT(!pid || RunLoop::isMain());
     return pid ? pid.value() : getCurrentProcessID();
 }
 
-void setPresentingApplicationPID(int pid)
+void setLegacyPresentingApplicationPID(int pid)
 {
     ASSERT(RunLoop::isMain());
-    ASSERT_WITH_MESSAGE(!presentingApplicationPIDOverrideWasQueried, "presentingApplicationPID() should not be called before setPresentingApplicationPID()");
+    ASSERT_WITH_MESSAGE(!presentingApplicationPIDOverrideWasQueried, "legacyPresentingApplicationPID() should not be called before setLegacyPresentingApplicationPID()");
     presentingApplicationPIDOverride() = pid;
 }
+
+#if HAVE(AUDIT_TOKEN)
+ProcessID pidFromAuditToken(const audit_token_t& auditToken)
+{
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+    return auditToken.val[5];
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+}
+#endif
 
 static std::optional<AuxiliaryProcessType>& auxiliaryProcessType()
 {

--- a/Source/WTF/wtf/RuntimeApplicationChecks.h
+++ b/Source/WTF/wtf/RuntimeApplicationChecks.h
@@ -27,11 +27,16 @@
 
 #include <optional>
 #include <wtf/Forward.h>
+#include <wtf/ProcessID.h>
 
 namespace WTF {
 
-WTF_EXPORT_PRIVATE void setPresentingApplicationPID(int);
-WTF_EXPORT_PRIVATE int presentingApplicationPID();
+WTF_EXPORT_PRIVATE void setLegacyPresentingApplicationPID(int);
+WTF_EXPORT_PRIVATE int legacyPresentingApplicationPID();
+
+#if HAVE(AUDIT_TOKEN)
+WTF_EXPORT_PRIVATE ProcessID pidFromAuditToken(const audit_token_t&);
+#endif
 
 enum class AuxiliaryProcessType : uint8_t {
     WebContent,
@@ -80,9 +85,13 @@ using WTF::isInGPUProcess;
 using WTF::isInModelProcess;
 using WTF::isInNetworkProcess;
 using WTF::isInWebProcess;
-using WTF::presentingApplicationPID;
+using WTF::legacyPresentingApplicationPID;
 using WTF::processType;
 using WTF::processTypeDescription;
 using WTF::setAuxiliaryProcessType;
 using WTF::setAuxiliaryProcessTypeForTesting;
-using WTF::setPresentingApplicationPID;
+using WTF::setLegacyPresentingApplicationPID;
+
+#if HAVE(AUDIT_TOKEN)
+using WTF::pidFromAuditToken;
+#endif

--- a/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
+++ b/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
@@ -139,7 +139,9 @@ void UserMediaRequest::start()
         break;
     }
 
-    PlatformMediaSessionManager::singleton().prepareToSendUserMediaPermissionRequest();
+    ASSERT(document.page());
+    if (RefPtr page = document.protectedPage())
+        PlatformMediaSessionManager::singleton().prepareToSendUserMediaPermissionRequestForPage(*page);
     controller->requestUserMediaAccess(*this);
 }
 

--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -681,6 +681,16 @@ void AudioContext::isActiveNowPlayingSessionChanged()
     }
 }
 
+ProcessID AudioContext::presentingApplicationPID() const
+{
+    if (RefPtr document = this->document()) {
+        if (RefPtr page = document->protectedPage())
+            return page->presentingApplicationPID();
+    }
+
+    return { };
+}
+
 #if !RELEASE_LOG_DISABLED
 const Logger& AudioContext::logger() const
 {

--- a/Source/WebCore/Modules/webaudio/AudioContext.h
+++ b/Source/WebCore/Modules/webaudio/AudioContext.h
@@ -142,6 +142,7 @@ private:
     std::optional<NowPlayingInfo> nowPlayingInfo() const final;
     WeakPtr<PlatformMediaSession> selectBestMediaSession(const Vector<WeakPtr<PlatformMediaSession>>&, PlatformMediaSession::PlaybackControlsPurpose) final;
     void isActiveNowPlayingSessionChanged() final;
+    ProcessID presentingApplicationPID() const final;
 
     // MediaCanStartListener.
     void mediaCanStart(Document&) final;

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -919,7 +919,7 @@ protected:
     unsigned getLengthForTextRange() const;
 
 private:
-    ProcessID processID() const final { return presentingApplicationPID(); }
+    ProcessID processID() const final { return legacyPresentingApplicationPID(); }
     bool hasAncestorFlag(AXAncestorFlag flag) const { return ancestorFlagsAreInitialized() && m_ancestorFlags.contains(flag); }
     std::optional<SimpleRange> rangeOfStringClosestToRangeInDirection(const SimpleRange&, AccessibilitySearchDirection, const Vector<String>&) const;
     std::optional<SimpleRange> selectionRange() const;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -517,7 +517,7 @@ private:
 
     void objectChangedIgnoredState(const AccessibilityObject&);
 
-    const ProcessID m_processID { presentingApplicationPID() };
+    const ProcessID m_processID { legacyPresentingApplicationPID() };
     unsigned m_maxTreeDepth { 0 };
     WeakPtr<AXObjectCache> m_axObjectCache;
     OptionSet<ActivityState> m_pageActivityState;

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -9821,6 +9821,14 @@ void HTMLMediaElement::isActiveNowPlayingSessionChanged()
         page->hasActiveNowPlayingSessionChanged();
 }
 
+ProcessID HTMLMediaElement::presentingApplicationPID() const
+{
+    if (RefPtr page = protectedDocument()->protectedPage())
+        return page->presentingApplicationPID();
+
+    return { };
+}
+
 #if HAVE(SPATIAL_TRACKING_LABEL)
 void HTMLMediaElement::updateSpatialTrackingLabel()
 {

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -246,6 +246,7 @@ public:
 
     WEBCORE_EXPORT bool isActiveNowPlayingSession() const;
     void isActiveNowPlayingSessionChanged() final;
+    ProcessID presentingApplicationPID() const final;
 
 // DOM API
 // error state

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -58,6 +58,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/OptionSet.h>
+#include <wtf/ProcessID.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RobinHoodHashSet.h>
@@ -1257,6 +1258,13 @@ public:
 
     WEBCORE_EXPORT bool isAlwaysOnLoggingAllowed() const;
 
+    ProcessID presentingApplicationPID() const;
+
+#if HAVE(AUDIT_TOKEN)
+    const std::optional<audit_token_t>& presentingApplicationAuditToken() const;
+    WEBCORE_EXPORT void setPresentingApplicationAuditToken(std::optional<audit_token_t>);
+#endif
+
 private:
     explicit Page(PageConfiguration&&);
 
@@ -1690,6 +1698,10 @@ private:
     bool m_shouldDeferScrollEvents { false };
 
     UniqueRef<DocumentSyncData> m_documentSyncData;
+
+#if HAVE(AUDIT_TOKEN)
+    std::optional<audit_token_t> m_presentingApplicationAuditToken;
+#endif
 }; // class Page
 
 inline Page* Frame::page() const

--- a/Source/WebCore/page/PageConfiguration.h
+++ b/Source/WebCore/page/PageConfiguration.h
@@ -231,6 +231,10 @@ public:
 #if PLATFORM(VISION) && ENABLE(GAMEPAD)
     ShouldRequireExplicitConsentForGamepadAccess gamepadAccessRequiresExplicitConsent { ShouldRequireExplicitConsentForGamepadAccess::No };
 #endif
+
+#if HAVE(AUDIT_TOKEN)
+    std::optional<audit_token_t> presentingApplicationAuditToken;
+#endif
 };
 
 }

--- a/Source/WebCore/platform/audio/PlatformMediaSession.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.cpp
@@ -34,6 +34,7 @@
 #include "NowPlayingInfo.h"
 #include "PlatformMediaSessionManager.h"
 #include <wtf/MediaTime.h>
+#include <wtf/RuntimeApplicationChecks.h>
 #include <wtf/SetForScope.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
@@ -493,6 +494,11 @@ void PlatformMediaSession::setActiveNowPlayingSession(bool isActiveNowPlayingSes
 
     m_isActiveNowPlayingSession = isActiveNowPlayingSession;
     client().isActiveNowPlayingSessionChanged();
+}
+
+ProcessID PlatformMediaSession::presentingApplicationPID() const
+{
+    return client().presentingApplicationPID();
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/audio/PlatformMediaSession.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.h
@@ -31,6 +31,7 @@
 #include <wtf/Logger.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/ProcessID.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
@@ -251,6 +252,8 @@ public:
     bool isActiveNowPlayingSession() const { return m_isActiveNowPlayingSession; }
     void setActiveNowPlayingSession(bool);
 
+    ProcessID presentingApplicationPID() const;
+
 #if !RELEASE_LOG_DISABLED
     virtual String description() const;
 #endif
@@ -330,6 +333,8 @@ public:
     virtual WeakPtr<PlatformMediaSession> selectBestMediaSession(const Vector<WeakPtr<PlatformMediaSession>>&, PlatformMediaSession::PlaybackControlsPurpose) { return nullptr; }
 
     virtual void isActiveNowPlayingSessionChanged() = 0;
+
+    virtual ProcessID presentingApplicationPID() const = 0;
 
 #if !RELEASE_LOG_DISABLED
     virtual const Logger& logger() const = 0;

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
@@ -39,6 +39,7 @@
 
 namespace WebCore {
 
+class Page;
 class PlatformMediaSession;
 struct MediaConfiguration;
 struct NowPlayingInfo;
@@ -103,7 +104,7 @@ public:
     virtual std::optional<MediaUniqueIdentifier> lastUpdatedNowPlayingInfoUniqueIdentifier() const { return std::nullopt; }
     virtual bool registeredAsNowPlayingApplication() const { return false; }
     virtual bool haveEverRegisteredAsNowPlayingApplication() const { return false; }
-    virtual void prepareToSendUserMediaPermissionRequest() { }
+    virtual void prepareToSendUserMediaPermissionRequestForPage(Page&) { }
 
     bool willIgnoreSystemInterruptions() const { return m_willIgnoreSystemInterruptions; }
     void setWillIgnoreSystemInterruptions(bool ignore) { m_willIgnoreSystemInterruptions = ignore; }
@@ -200,6 +201,8 @@ public:
     WEBCORE_EXPORT void removeNowPlayingMetadataObserver(const NowPlayingMetadataObserver&);
 
     bool hasActiveNowPlayingSessionInGroup(std::optional<MediaSessionGroupIdentifier>);
+
+    virtual void updatePresentingApplicationPIDIfNecessary(ProcessID) { }
 
 protected:
     friend class PlatformMediaSession;

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
@@ -60,7 +60,7 @@ public:
     bool registeredAsNowPlayingApplication() const final { return m_registeredAsNowPlayingApplication; }
     bool haveEverRegisteredAsNowPlayingApplication() const final { return m_haveEverRegisteredAsNowPlayingApplication; }
 
-    void prepareToSendUserMediaPermissionRequest() final;
+    void prepareToSendUserMediaPermissionRequestForPage(Page&) final;
 
     std::optional<NowPlayingInfo> nowPlayingInfo() const final { return m_nowPlayingInfo; }
     static WEBCORE_EXPORT void clearNowPlayingInfo();
@@ -90,7 +90,7 @@ protected:
     void clientCharacteristicsChanged(PlatformMediaSession&, bool) final;
     void sessionCanProduceAudioChanged() final;
 
-    virtual void providePresentingApplicationPIDIfNecessary() { }
+    virtual void providePresentingApplicationPIDIfNecessary(ProcessID) { }
 
     WeakPtr<PlatformMediaSession> nowPlayingEligibleSession();
 

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -35,6 +35,7 @@
 #import "MediaPlayer.h"
 #import "MediaStrategy.h"
 #import "NowPlayingInfo.h"
+#import "Page.h"
 #import "PlatformMediaSession.h"
 #import "PlatformStrategies.h"
 #import "SharedBuffer.h"
@@ -238,9 +239,9 @@ void MediaSessionManagerCocoa::beginInterruption(PlatformMediaSession::Interrupt
     PlatformMediaSessionManager::beginInterruption(type);
 }
 
-void MediaSessionManagerCocoa::prepareToSendUserMediaPermissionRequest()
+void MediaSessionManagerCocoa::prepareToSendUserMediaPermissionRequestForPage(Page& page)
 {
-    providePresentingApplicationPIDIfNecessary();
+    providePresentingApplicationPIDIfNecessary(page.presentingApplicationPID());
 }
 
 String MediaSessionManagerCocoa::audioTimePitchAlgorithmForMediaPlayerPitchCorrectionAlgorithm(MediaPlayer::PitchCorrectionAlgorithm pitchCorrectionAlgorithm, bool preservesPitch, double rate)
@@ -526,7 +527,7 @@ void MediaSessionManagerCocoa::updateNowPlayingInfo()
     }
     if (!m_registeredAsNowPlayingApplication) {
         m_registeredAsNowPlayingApplication = true;
-        providePresentingApplicationPIDIfNecessary();
+        providePresentingApplicationPIDIfNecessary(session->presentingApplicationPID());
     }
 
     updateActiveNowPlayingSession(session);

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
@@ -54,7 +54,6 @@ public:
 
     bool hasWirelessTargetsAvailable() override;
     bool isMonitoringWirelessTargets() const override;
-    static WEBCORE_EXPORT void providePresentingApplicationPID();
 
     USING_CAN_MAKE_WEAKPTR(MediaSessionHelperClient);
 
@@ -68,7 +67,8 @@ private:
 #endif
 
     void configureWirelessTargetMonitoring() final;
-    void providePresentingApplicationPIDIfNecessary() final;
+    void providePresentingApplicationPIDIfNecessary(ProcessID) final;
+    void updatePresentingApplicationPIDIfNecessary(ProcessID) final;
     bool sessionWillBeginPlayback(PlatformMediaSession&) final;
     void sessionWillEndPlayback(PlatformMediaSession&, DelayCallingUpdateNowPlaying) final;
 

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm
@@ -117,19 +117,22 @@ void MediaSessionManageriOS::configureWirelessTargetMonitoring()
 #endif
 }
 
-void MediaSessionManageriOS::providePresentingApplicationPIDIfNecessary()
+void MediaSessionManageriOS::providePresentingApplicationPIDIfNecessary(ProcessID pid)
 {
 #if HAVE(MEDIAEXPERIENCE_AVSYSTEMCONTROLLER)
     if (m_havePresentedApplicationPID)
         return;
     m_havePresentedApplicationPID = true;
-    MediaSessionHelper::sharedHelper().providePresentingApplicationPID(presentingApplicationPID());
+    MediaSessionHelper::sharedHelper().providePresentingApplicationPID(pid);
 #endif
 }
 
-void MediaSessionManageriOS::providePresentingApplicationPID()
+void MediaSessionManageriOS::updatePresentingApplicationPIDIfNecessary(ProcessID pid)
 {
-    MediaSessionHelper::sharedHelper().providePresentingApplicationPID(presentingApplicationPID());
+#if HAVE(MEDIAEXPERIENCE_AVSYSTEMCONTROLLER)
+    if (m_havePresentedApplicationPID)
+        MediaSessionHelper::sharedHelper().providePresentingApplicationPID(pid, MediaSessionHelper::ShouldOverride::Yes);
+#endif
 }
 
 bool MediaSessionManageriOS::sessionWillBeginPlayback(PlatformMediaSession& session)
@@ -145,7 +148,7 @@ bool MediaSessionManageriOS::sessionWillBeginPlayback(PlatformMediaSession& sess
     session.setShouldPlayToPlaybackTarget(playbackTargetSupportsAirPlayVideo);
 #endif
 
-    providePresentingApplicationPIDIfNecessary();
+    providePresentingApplicationPIDIfNecessary(session.presentingApplicationPID());
 
     return true;
 }

--- a/Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.mm
+++ b/Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.mm
@@ -69,7 +69,7 @@ void NetworkExtensionContentFilter::initialize(const URL* url)
     ASSERT_UNUSED(url, !url);
     m_neFilterSource = adoptNS([[NEFilterSource alloc] initWithDecisionQueue:m_queue.get()]);
     [m_neFilterSource setSourceAppIdentifier:applicationBundleIdentifier()];
-    [m_neFilterSource setSourceAppPid:presentingApplicationPID()];
+    [m_neFilterSource setSourceAppPid:legacyPresentingApplicationPID()];
 }
 
 void NetworkExtensionContentFilter::willSendRequest(ResourceRequest& request, const ResourceResponse& redirectResponse)

--- a/Source/WebCore/platform/mediastream/ios/MediaCaptureStatusBarManager.mm
+++ b/Source/WebCore/platform/mediastream/ios/MediaCaptureStatusBarManager.mm
@@ -78,7 +78,7 @@ using namespace WebCore;
     ASSERT(!m_coordinator);
 
     UIStatusBarStyleOverrides overrides = UIStatusBarStyleOverrideWebRTCAudioCapture;
-    m_statusBarStyleOverride = [getSBSStatusBarStyleOverridesAssertionClass() assertionWithStatusBarStyleOverrides:overrides forPID:presentingApplicationPID() exclusive:YES showsWhenForeground:YES];
+    m_statusBarStyleOverride = [getSBSStatusBarStyleOverridesAssertionClass() assertionWithStatusBarStyleOverrides:overrides forPID:legacyPresentingApplicationPID() exclusive:YES showsWhenForeground:YES];
     m_coordinator = adoptNS([[getSBSStatusBarStyleOverridesCoordinatorClass() alloc] init]);
     m_coordinator.get().delegate = self;
 

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -247,7 +247,10 @@ public:
     RemoteRenderingBackend* remoteRenderingBackend(RenderingBackendIdentifier);
 
 #if HAVE(AUDIT_TOKEN)
-    const std::optional<audit_token_t>& presentingApplicationAuditToken() const { return m_presentingApplicationAuditToken; }
+    const HashMap<WebCore::PageIdentifier, CoreIPCAuditToken>& presentingApplicationAuditTokens() const { return m_presentingApplicationAuditTokens; }
+    std::optional<audit_token_t> presentingApplicationAuditToken(WebCore::PageIdentifier) const;
+    ProcessID presentingApplicationPID(WebCore::PageIdentifier) const;
+    void setPresentingApplicationAuditToken(WebCore::PageIdentifier, std::optional<CoreIPCAuditToken>&&);
 #endif
 #if PLATFORM(COCOA)
     const String& applicationBundleIdentifier() const { return m_applicationBundleIdentifier; }
@@ -394,7 +397,7 @@ private:
     IPC::ScopedActiveMessageReceiveQueue<LibWebRTCCodecsProxy> m_libWebRTCCodecsProxy;
 #endif
 #if HAVE(AUDIT_TOKEN)
-    const std::optional<audit_token_t> m_presentingApplicationAuditToken;
+    HashMap<WebCore::PageIdentifier, CoreIPCAuditToken> m_presentingApplicationAuditTokens;
 #endif
 #if PLATFORM(COCOA)
     const String m_applicationBundleIdentifier;

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -269,8 +269,6 @@ void GPUProcess::initializeGPUProcess(GPUProcessCreationParameters&& parameters,
     // Match the QoS of the UIProcess since the GPU process is doing rendering on its behalf.
     WTF::Thread::setCurrentThreadIsUserInteractive(0);
 
-    setPresentingApplicationPID(parameters.parentPID);
-
     if (!parameters.overrideLanguages.isEmpty())
         overrideUserPreferredLanguages(parameters.overrideLanguages);
 
@@ -634,6 +632,14 @@ void GPUProcess::webXRPromptAccepted(std::optional<WebCore::ProcessIdentity> pro
 {
     m_processIdentity = processIdentity;
     completionHandler(true);
+}
+#endif
+
+#if HAVE(AUDIT_TOKEN)
+void GPUProcess::setPresentingApplicationAuditToken(WebCore::ProcessIdentifier processIdentifier, WebCore::PageIdentifier pageIdentifier, std::optional<WebKit::CoreIPCAuditToken>&& auditToken)
+{
+    if (RefPtr connection = m_webProcessConnections.get(processIdentifier))
+        connection->setPresentingApplicationAuditToken(pageIdentifier, WTFMove(auditToken));
 }
 #endif
 

--- a/Source/WebKit/GPUProcess/GPUProcess.h
+++ b/Source/WebKit/GPUProcess/GPUProcess.h
@@ -33,6 +33,7 @@
 #include "WebPageProxyIdentifier.h"
 #include <WebCore/IntDegrees.h>
 #include <WebCore/MediaPlayerIdentifier.h>
+#include <WebCore/PageIdentifier.h>
 #include <WebCore/ProcessIdentity.h>
 #include <WebCore/ShareableBitmap.h>
 #include <WebCore/Timer.h>
@@ -69,6 +70,7 @@ namespace WebKit {
 
 class GPUConnectionToWebProcess;
 class RemoteAudioSessionProxyManager;
+struct CoreIPCAuditToken;
 struct GPUProcessConnectionParameters;
 struct GPUProcessCreationParameters;
 struct GPUProcessSessionParameters;
@@ -142,6 +144,10 @@ public:
 #endif
 #if ENABLE(WEBXR)
     std::optional<WebCore::ProcessIdentity> immersiveModeProcessIdentity() const;
+#endif
+
+#if HAVE(AUDIT_TOKEN)
+    void setPresentingApplicationAuditToken(WebCore::ProcessIdentifier, WebCore::PageIdentifier, std::optional<CoreIPCAuditToken>&&);
 #endif
 
 private:

--- a/Source/WebKit/GPUProcess/GPUProcess.messages.in
+++ b/Source/WebKit/GPUProcess/GPUProcess.messages.in
@@ -94,6 +94,9 @@ messages -> GPUProcess : AuxiliaryProcess {
 #if ENABLE(WEBXR)
     WebXRPromptAccepted(std::optional<WebCore::ProcessIdentity> processIdentity) -> (bool accepted)
 #endif
+#if HAVE(AUDIT_TOKEN)
+    SetPresentingApplicationAuditToken(WebCore::ProcessIdentifier processIdentifier, WebCore::PageIdentifier pageIdentifier, std::optional<WebKit::CoreIPCAuditToken> auditToken);
+#endif
 }
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/GPUProcess/GPUProcessCreationParameters.h
+++ b/Source/WebKit/GPUProcess/GPUProcessCreationParameters.h
@@ -50,7 +50,6 @@ struct GPUProcessCreationParameters {
 #if USE(MODERN_AVCONTENTKEYSESSION)
     bool shouldUseModernAVContentKeySession { false };
 #endif
-    ProcessID parentPID;
 
 #if USE(SANDBOX_EXTENSIONS_FOR_CACHE_AND_TEMP_DIRECTORY_ACCESS)
     SandboxExtension::Handle containerCachesDirectoryExtensionHandle;

--- a/Source/WebKit/GPUProcess/GPUProcessCreationParameters.serialization.in
+++ b/Source/WebKit/GPUProcess/GPUProcessCreationParameters.serialization.in
@@ -37,8 +37,6 @@
     bool shouldUseModernAVContentKeySession;
 #endif
 
-    ProcessID parentPID;
-
 #if USE(SANDBOX_EXTENSIONS_FOR_CACHE_AND_TEMP_DIRECTORY_ACCESS)
     WebKit::SandboxExtensionHandle containerCachesDirectoryExtensionHandle;
     WebKit::SandboxExtensionHandle containerTemporaryDirectoryExtensionHandle;

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
@@ -240,8 +240,8 @@ void RemoteAudioSessionProxyManager::updatePresentingProcesses()
     m_proxies.forEach([&](auto& proxy) {
         if (!proxy.isActive())
             return;
-        if (auto& token = proxy.gpuConnectionToWebProcess()->presentingApplicationAuditToken())
-            presentingProcesses.append(*token);
+        for (auto& token : proxy.gpuConnectionToWebProcess()->presentingApplicationAuditTokens().values())
+            presentingProcesses.append(token.auditToken());
     });
     AudioSession::protectedSharedSession()->setPresentingProcesses(WTFMove(presentingProcesses));
 }

--- a/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.cpp
@@ -79,10 +79,10 @@ void RemoteMediaSessionHelperProxy::stopMonitoringWirelessRoutes()
     MediaSessionHelper::sharedHelper().stopMonitoringWirelessRoutes();
 }
 
-void RemoteMediaSessionHelperProxy::providePresentingApplicationPID(int pid)
+void RemoteMediaSessionHelperProxy::providePresentingApplicationPID(int pid, MediaSessionHelper::ShouldOverride shouldOverride)
 {
     m_presentingApplicationPID = pid;
-    MediaSessionHelper::sharedHelper().providePresentingApplicationPID(pid);
+    MediaSessionHelper::sharedHelper().providePresentingApplicationPID(pid, shouldOverride);
 }
 
 void RemoteMediaSessionHelperProxy::overridePresentingApplicationPIDIfNeeded()

--- a/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.h
+++ b/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.h
@@ -60,7 +60,7 @@ private:
     // Messages
     void startMonitoringWirelessRoutes();
     void stopMonitoringWirelessRoutes();
-    void providePresentingApplicationPID(int);
+    void providePresentingApplicationPID(int, WebCore::MediaSessionHelper::ShouldOverride);
 
     // MediaSessionHelperClient
     void applicationWillEnterForeground(SuspendedUnderLock) final;

--- a/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.messages.in
@@ -37,7 +37,7 @@ messages -> RemoteMediaSessionHelperProxy {
     StartMonitoringWirelessRoutes()
     StopMonitoringWirelessRoutes()
 #endif
-    ProvidePresentingApplicationPID(int pid)
+    ProvidePresentingApplicationPID(int pid, WebCore::MediaSessionHelper::ShouldOverride shouldOverride)
 }
 
 #endif

--- a/Source/WebKit/ModelProcess/ModelProcess.cpp
+++ b/Source/WebKit/ModelProcess/ModelProcess.cpp
@@ -192,8 +192,6 @@ void ModelProcess::initializeModelProcess(ModelProcessCreationParameters&& param
     // Match the QoS of the UIProcess since the model process is doing rendering on its behalf.
     WTF::Thread::setCurrentThreadIsUserInteractive(0);
 
-    setPresentingApplicationPID(parameters.parentPID);
-
 #if USE(OS_STATE)
     registerWithStateDumper("ModelProcess state"_s);
 #endif

--- a/Source/WebKit/ModelProcess/ModelProcessCreationParameters.h
+++ b/Source/WebKit/ModelProcess/ModelProcessCreationParameters.h
@@ -34,7 +34,6 @@ namespace WebKit {
 
 struct ModelProcessCreationParameters {
     AuxiliaryProcessCreationParameters auxiliaryProcessParameters;
-    ProcessID parentPID;
     String applicationVisibleName;
 };
 

--- a/Source/WebKit/ModelProcess/ModelProcessCreationParameters.serialization.in
+++ b/Source/WebKit/ModelProcess/ModelProcessCreationParameters.serialization.in
@@ -26,7 +26,6 @@ headers: "ModelProcessCreationParameters.h" "AuxiliaryProcessCreationParameters.
 
 [RValue] struct WebKit::ModelProcessCreationParameters {
     WebKit::AuxiliaryProcessCreationParameters auxiliaryProcessParameters;
-    ProcessID parentPID;
     String applicationVisibleName;
 };
 

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -347,7 +347,7 @@ void NetworkProcess::initializeNetworkProcess(NetworkProcessCreationParameters&&
 
     updateStorageAccessPromptQuirks(WTFMove(parameters.storageAccessPromptQuirksData));
 
-    RELEASE_LOG(Process, "%p - NetworkProcess::initializeNetworkProcess: Presenting processPID=%d", this, presentingApplicationPID());
+    RELEASE_LOG(Process, "%p - NetworkProcess::initializeNetworkProcess: Presenting processPID=%d", this, legacyPresentingApplicationPID());
 }
 
 void NetworkProcess::initializeConnection(IPC::Connection* connection)

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -545,6 +545,7 @@ def types_that_cannot_be_forward_declared():
 
 def conditions_for_header(header):
     conditions = {
+        '"CoreIPCAuditToken.h"': ["HAVE(AUDIT_TOKEN)"],
         '"DMABufRendererBufferFormat.h"': ["PLATFORM(GTK)", "PLATFORM(WPE)"],
         '"GestureTypes.h"': ["PLATFORM(IOS_FAMILY)"],
         '"InputMethodState.h"': ["PLATFORM(GTK)", "PLATFORM(WPE)"],
@@ -970,6 +971,7 @@ def headers_for_type(type):
         'WebCore::MediaProducerMediaState': ['<WebCore/MediaProducer.h>'],
         'WebCore::MediaProducerMutedState': ['<WebCore/MediaProducer.h>'],
         'WebCore::MediaPromise::Result': ['<WebCore/MediaPromiseTypes.h>'],
+        'WebCore::MediaSessionHelper::ShouldOverride': ['<WebCore/MediaSessionHelperIOS.h>'],
         'WebCore::MediaSettingsRange': ['<WebCore/MediaSettingsRange.h>'],
         'WebCore::MediaSourcePrivateAddStatus': ['<WebCore/MediaSourcePrivate.h>'],
         'WebCore::MediaSourcePrivateEndOfStreamStatus': ['<WebCore/MediaSourcePrivate.h>'],

--- a/Source/WebKit/Shared/Cocoa/CoreIPCAuditToken.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCAuditToken.h
@@ -30,13 +30,28 @@
 
 namespace WebKit {
 
+static std::array<unsigned, 8> invalidAuditToken()
+{
+    static std::array<unsigned, 8> invalidAuditToken;
+    invalidAuditToken.fill(std::numeric_limits<unsigned>::max());
+    return invalidAuditToken;
+}
+
 struct CoreIPCAuditToken {
+    CoreIPCAuditToken()
+        : CoreIPCAuditToken { invalidAuditToken() }
+    {
+    }
+
     CoreIPCAuditToken(audit_token_t input)
     {
         memcpy(token.data(), &input, sizeof(token));
     }
-    CoreIPCAuditToken(std::array<int, 8> token)
-        : token(token) { }
+
+    CoreIPCAuditToken(std::array<unsigned, 8> token)
+        : token { WTFMove(token) }
+    {
+    }
 
     audit_token_t auditToken() const
     {
@@ -45,7 +60,7 @@ struct CoreIPCAuditToken {
         return result;
     }
 
-    std::array<int, 8> token;
+    std::array<unsigned, 8> token;
     static_assert(sizeof(token) == sizeof(audit_token_t));
 };
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCAuditToken.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCAuditToken.serialization.in
@@ -21,5 +21,5 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 struct WebKit::CoreIPCAuditToken {
-    std::array<int, 8> token
+    std::array<unsigned, 8> token
 }

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
@@ -512,3 +512,7 @@ using WebCore::WritingTools::Session::ID = WTF::UUID
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
 using WebCore::MediaControlsContextMenuItem::ID = uint64_t;
 #endif
+
+#if PLATFORM(IOS_FAMILY)
+[Nested] enum class WebCore::MediaSessionHelper::ShouldOverride : bool
+#endif

--- a/Source/WebKit/Shared/GPUProcessConnectionParameters.h
+++ b/Source/WebKit/Shared/GPUProcessConnectionParameters.h
@@ -33,6 +33,7 @@
 
 #if HAVE(AUDIT_TOKEN)
 #include "CoreIPCAuditToken.h"
+#include <WebCore/PageIdentifier.h>
 #endif
 
 namespace WebKit {
@@ -45,7 +46,7 @@ struct GPUProcessConnectionParameters {
     bool ignoreInvalidMessageForTesting { false };
 #endif
 #if HAVE(AUDIT_TOKEN)
-    std::optional<CoreIPCAuditToken> presentingApplicationAuditToken;
+    HashMap<WebCore::PageIdentifier, CoreIPCAuditToken> presentingApplicationAuditTokens;
 #endif
 #if PLATFORM(COCOA)
     String applicationBundleIdentifier;

--- a/Source/WebKit/Shared/GPUProcessConnectionParameters.serialization.in
+++ b/Source/WebKit/Shared/GPUProcessConnectionParameters.serialization.in
@@ -30,7 +30,7 @@
     bool ignoreInvalidMessageForTesting;
 #endif
 #if HAVE(AUDIT_TOKEN)
-    std::optional<WebKit::CoreIPCAuditToken> presentingApplicationAuditToken;
+    HashMap<WebCore::PageIdentifier, WebKit::CoreIPCAuditToken> presentingApplicationAuditTokens;
 #endif
 #if PLATFORM(COCOA)
     String applicationBundleIdentifier;

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -84,6 +84,10 @@
 #include <WebCore/ShouldRequireExplicitConsentForGamepadAccess.h>
 #endif
 
+#if HAVE(AUDIT_TOKEN)
+#include "CoreIPCAuditToken.h"
+#endif
+
 namespace WebCore {
 enum class SandboxFlag : uint16_t;
 using SandboxFlags = OptionSet<SandboxFlag>;
@@ -343,6 +347,10 @@ struct WebPageCreationParameters {
 
 #if PLATFORM(VISION) && ENABLE(GAMEPAD)
     WebCore::ShouldRequireExplicitConsentForGamepadAccess gamepadAccessRequiresExplicitConsent { WebCore::ShouldRequireExplicitConsentForGamepadAccess::No };
+#endif
+
+#if HAVE(AUDIT_TOKEN)
+    std::optional<CoreIPCAuditToken> presentingApplicationAuditToken;
 #endif
 };
 

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -268,6 +268,10 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
 #if PLATFORM(VISION) && ENABLE(GAMEPAD)
     WebCore::ShouldRequireExplicitConsentForGamepadAccess gamepadAccessRequiresExplicitConsent;
 #endif
+
+#if HAVE(AUDIT_TOKEN)
+    std::optional<WebKit::CoreIPCAuditToken> presentingApplicationAuditToken;
+#endif
 }
 
 [Nested] struct WebKit::RemotePageParameters {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -5352,6 +5352,16 @@ struct WKWebViewData {
     }
 }
 
+- (audit_token_t)presentingApplicationAuditToken
+{
+    return self._protectedPage->presentingApplicationAuditToken().value_or(audit_token_t { });
+}
+
+- (void)setPresentingApplicationAuditToken:(audit_token_t)presentingApplicationAuditToken
+{
+    self._protectedPage->setPresentingApplicationAuditToken(presentingApplicationAuditToken);
+}
+
 @end
 
 @implementation WKWebView (WKDeprecated)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -608,6 +608,8 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
 - (void)_fetchDataOfTypes:(_WKWebViewDataType)dataTypes completionHandler:(WK_SWIFT_UI_ACTOR void (^)(NSData *))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 - (void)_restoreData:(NSData *)data completionHandler:(WK_SWIFT_UI_ACTOR void(^)(BOOL))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
+@property (nonatomic) audit_token_t presentingApplicationAuditToken WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
 @end
 
 #if TARGET_OS_IPHONE

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
@@ -542,7 +542,7 @@ CaptureSourceOrError UserMediaCaptureManagerProxy::createCameraSource(const Capt
 
 void UserMediaCaptureManagerProxy::createMediaSourceForCaptureDeviceWithConstraints(RealtimeMediaSourceIdentifier id, const CaptureDevice& device, WebCore::MediaDeviceHashSalts&& hashSalts, MediaConstraints&& mediaConstraints, bool shouldUseGPUProcessRemoteFrames, PageIdentifier pageIdentifier, CreateSourceCallback&& completionHandler)
 {
-    if (!m_connectionProxy->willStartCapture(device.type())) {
+    if (!m_connectionProxy->willStartCapture(device.type(), pageIdentifier)) {
         completionHandler({ "Request is not allowed"_s, WebCore::MediaAccessDenialReason::PermissionDenied }, { }, { });
         return;
     }

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h
@@ -66,7 +66,7 @@ public:
         virtual void removeMessageReceiver(IPC::ReceiverName) = 0;
         virtual IPC::Connection& connection() = 0;
         Ref<IPC::Connection> protectedConnection() { return connection(); }
-        virtual bool willStartCapture(WebCore::CaptureDevice::DeviceType) const = 0;
+        virtual bool willStartCapture(WebCore::CaptureDevice::DeviceType, WebCore::PageIdentifier) const = 0;
         virtual Logger& logger() = 0;
         Ref<Logger> protectedLogger() { return logger(); };
         virtual bool setCaptureAttributionString() { return true; }

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -180,8 +180,6 @@ GPUProcessProxy::GPUProcessProxy()
 #endif
 #endif // ENABLE(MEDIA_STREAM)
 
-    parameters.parentPID = getCurrentProcessID();
-
 #if USE(SANDBOX_EXTENSIONS_FOR_CACHE_AND_TEMP_DIRECTORY_ACCESS)
     parameters.containerCachesDirectory = resolveAndCreateReadWriteDirectoryForSandboxExtension(gpuProcessCachesDirectory());
     auto containerTemporaryDirectory = WebsiteDataStore::defaultResolvedContainerTemporaryDirectory();
@@ -905,6 +903,13 @@ void GPUProcessProxy::statusBarWasTapped(CompletionHandler<void()>&& completionH
 }
 #endif
 #endif // ENABLE(MEDIA_STREAM)
+
+#if HAVE(AUDIT_TOKEN)
+void GPUProcessProxy::setPresentingApplicationAuditToken(WebCore::ProcessIdentifier processIdentifier, WebCore::PageIdentifier pageIdentifier, std::optional<CoreIPCAuditToken> auditToken)
+{
+    send(Messages::GPUProcess::SetPresentingApplicationAuditToken(processIdentifier, pageIdentifier, auditToken), 0);
+}
+#endif
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
@@ -72,6 +72,7 @@ class WebPageProxy;
 class WebProcessProxy;
 class WebsiteDataStore;
 
+struct CoreIPCAuditToken;
 struct GPUProcessConnectionParameters;
 struct GPUProcessCreationParameters;
 struct SharedPreferencesForWebProcess;
@@ -158,6 +159,10 @@ public:
 #if PLATFORM(COCOA) && ENABLE(REMOTE_INSPECTOR)
     bool hasSentGPUToolsSandboxExtensions() const { return m_hasSentGPUToolsSandboxExtensions; }
     static Vector<SandboxExtensionHandle> createGPUToolsSandboxExtensionHandlesIfNeeded();
+#endif
+
+#if HAVE(AUDIT_TOKEN)
+    void setPresentingApplicationAuditToken(WebCore::ProcessIdentifier, WebCore::PageIdentifier, std::optional<CoreIPCAuditToken>);
 #endif
 
 private:

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2617,6 +2617,11 @@ public:
     void fetchSessionStorage(CompletionHandler<void(HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&)>&&);
     void restoreSessionStorage(HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&, CompletionHandler<void(bool)>&&);
 
+#if HAVE(AUDIT_TOKEN)
+    const std::optional<audit_token_t>& presentingApplicationAuditToken() const;
+    void setPresentingApplicationAuditToken(const audit_token_t&);
+#endif
+
 private:
     void getWebCryptoMasterKey(CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);
     WebPageProxy(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);
@@ -3777,6 +3782,10 @@ private:
 #if PLATFORM(VISION)
     bool m_gamepadsConnected { false };
 #endif
+#endif
+
+#if HAVE(AUDIT_TOKEN)
+    std::optional<audit_token_t> m_presentingApplicationAuditToken;
 #endif
 
     RefPtr<WebPageProxyTesting> m_pageForTesting;

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -573,9 +573,6 @@ void WebProcessPool::gpuProcessExited(ProcessID identifier, ProcessTerminationRe
 
 void WebProcessPool::createGPUProcessConnection(WebProcessProxy& webProcessProxy, IPC::Connection::Handle&& connectionIdentifier, WebKit::GPUProcessConnectionParameters&& parameters)
 {
-#if HAVE(AUDIT_TOKEN)
-    parameters.presentingApplicationAuditToken = configuration().presentingApplicationProcessToken();
-#endif
 #if PLATFORM(COCOA)
     parameters.applicationBundleIdentifier = applicationBundleIdentifier();
 #endif

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -530,6 +530,10 @@ public:
     void registerServiceWorkerClients(CompletionHandler<void()>&&);
     void resetHasRegisteredServiceWorkerClients() { m_hasRegisteredServiceWorkerClients = false; }
 
+#if HAVE(AUDIT_TOKEN)
+    HashMap<WebCore::PageIdentifier, CoreIPCAuditToken> presentingApplicationAuditTokens() const;
+#endif
+
 private:
     Type type() const final { return Type::WebContent; }
 

--- a/Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.cpp
@@ -73,8 +73,7 @@ void RemoteMediaSessionHelper::stopMonitoringWirelessRoutesInternal()
 
 void RemoteMediaSessionHelper::providePresentingApplicationPID(int pid, ShouldOverride shouldOverride)
 {
-    ASSERT_UNUSED(shouldOverride, shouldOverride == ShouldOverride::No);
-    ensureConnection().send(Messages::RemoteMediaSessionHelperProxy::ProvidePresentingApplicationPID(pid), { });
+    ensureConnection().send(Messages::RemoteMediaSessionHelperProxy::ProvidePresentingApplicationPID(pid, shouldOverride), { });
 }
 
 void RemoteMediaSessionHelper::activeVideoRouteDidChange(SupportsAirPlayVideo supportsAirPlayVideo, MediaPlaybackTargetContextSerialized&& targetContext)

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -410,7 +410,7 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
     loadParameters.webPageProxyID = trackingParameters.webPageProxyID;
     loadParameters.webPageID = trackingParameters.pageID;
     loadParameters.webFrameID = trackingParameters.frameID;
-    loadParameters.parentPID = presentingApplicationPID();
+    loadParameters.parentPID = legacyPresentingApplicationPID();
 #if HAVE(AUDIT_TOKEN)
     loadParameters.networkProcessAuditToken = WebProcess::singleton().ensureNetworkProcessConnection().networkProcessAuditToken();
 #endif
@@ -761,7 +761,7 @@ void WebLoaderStrategy::loadResourceSynchronously(FrameLoader& frameLoader, WebC
     loadParameters.webPageProxyID = webPageProxyID;
     loadParameters.webPageID = pageID;
     loadParameters.webFrameID = frameID;
-    loadParameters.parentPID = presentingApplicationPID();
+    loadParameters.parentPID = legacyPresentingApplicationPID();
 #if HAVE(AUDIT_TOKEN)
     loadParameters.networkProcessAuditToken = WebProcess::singleton().ensureNetworkProcessConnection().networkProcessAuditToken();
 #endif
@@ -845,7 +845,7 @@ void WebLoaderStrategy::startPingLoad(LocalFrame& frame, ResourceRequest& reques
     loadParameters.request = request;
     loadParameters.sourceOrigin = &document->securityOrigin();
     loadParameters.topOrigin = &document->topOrigin();
-    loadParameters.parentPID = presentingApplicationPID();
+    loadParameters.parentPID = legacyPresentingApplicationPID();
 #if HAVE(AUDIT_TOKEN)
     loadParameters.networkProcessAuditToken = WebProcess::singleton().ensureNetworkProcessConnection().networkProcessAuditToken();
 #endif
@@ -933,7 +933,7 @@ void WebLoaderStrategy::preconnectTo(WebCore::ResourceRequest&& request, WebPage
     parameters.webPageProxyID = webPage.webPageProxyIdentifier();
     parameters.webPageID = webPage.identifier();
     parameters.webFrameID = webFrame.frameID();
-    parameters.parentPID = presentingApplicationPID();
+    parameters.parentPID = legacyPresentingApplicationPID();
 #if HAVE(AUDIT_TOKEN)
     parameters.networkProcessAuditToken = WebProcess::singleton().ensureNetworkProcessConnection().networkProcessAuditToken();
 #endif

--- a/Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
@@ -56,7 +56,7 @@
     // We are setting the presenter ID of the WKAccessibilityPDFDocumentObject to the hosting application's PID.
     // This way VoiceOver can set AX observers on all the PDF AX nodes which are descendant of this element.
     if ([self respondsToSelector:@selector(accessibilitySetPresenterProcessIdentifier:)])
-        [(id)self accessibilitySetPresenterProcessIdentifier:presentingApplicationPID()];
+        [(id)self accessibilitySetPresenterProcessIdentifier:legacyPresentingApplicationPID()];
     return self;
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -1898,7 +1898,7 @@ void WebLocalFrameLoaderClient::sendH2Ping(const URL& url, CompletionHandler<voi
     parameters.webPageProxyID = webPage->webPageProxyIdentifier();
     parameters.webPageID = webPage->identifier();
     parameters.webFrameID = m_frame->frameID();
-    parameters.parentPID = presentingApplicationPID();
+    parameters.parentPID = legacyPresentingApplicationPID();
 #if HAVE(AUDIT_TOKEN)
     parameters.networkProcessAuditToken = WebProcess::singleton().ensureNetworkProcessConnection().networkProcessAuditToken();
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -469,6 +469,10 @@
 #include "PDFPluginBase.h"
 #endif
 
+#if HAVE(AUDIT_TOKEN)
+#include "CoreIPCAuditToken.h"
+#endif
+
 #if PLATFORM(COCOA)
 #include <pal/cf/CoreTextSoftLink.h>
 #endif
@@ -860,6 +864,10 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
 
 #if PLATFORM(VISION) && ENABLE(GAMEPAD)
     pageConfiguration.gamepadAccessRequiresExplicitConsent = parameters.gamepadAccessRequiresExplicitConsent;
+#endif
+
+#if HAVE(AUDIT_TOKEN)
+    pageConfiguration.presentingApplicationAuditToken = parameters.presentingApplicationAuditToken ? std::optional(parameters.presentingApplicationAuditToken->auditToken()) : std::nullopt;
 #endif
 
     m_page = Page::create(WTFMove(pageConfiguration));
@@ -10193,6 +10201,14 @@ void WebPage::callAfterPendingSyntheticClick(CompletionHandler<void(SyntheticCli
     completion(SyntheticClickResult::Failed);
 }
 
+#endif
+
+#if HAVE(AUDIT_TOKEN)
+void WebPage::setPresentingApplicationAuditToken(CoreIPCAuditToken&& presentingApplicationAuditToken)
+{
+    if (RefPtr page = protectedCorePage())
+        page->setPresentingApplicationAuditToken(presentingApplicationAuditToken.auditToken());
+}
 #endif
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -437,6 +437,7 @@ enum class TextInteractionSource : uint8_t;
 enum class TextRecognitionUpdateResult : uint8_t;
 
 struct ContentWorldData;
+struct CoreIPCAuditToken;
 #if (PLATFORM(GTK) || PLATFORM(WPE)) && USE(GBM)
 struct DMABufRendererBufferFormat;
 #endif
@@ -1902,6 +1903,10 @@ public:
     void didDispatchClickEvent(const WebCore::PlatformMouseEvent&, WebCore::Node&);
 
     bool isClosed() const { return m_isClosed; }
+
+#if HAVE(AUDIT_TOKEN)
+    void setPresentingApplicationAuditToken(CoreIPCAuditToken&&);
+#endif
 
 private:
     WebPage(WebCore::PageIdentifier, WebPageCreationParameters&&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -867,4 +867,8 @@ messages -> WebPage WantsAsyncDispatchMessage {
 
     SimulateClickOverFirstMatchingTextInViewportWithUserInteraction(String targetText) -> (bool success)
     UpdateOpener(WebCore::FrameIdentifier frameID, WebCore::FrameIdentifier newOpener)
+
+#if HAVE(AUDIT_TOKEN)
+    SetPresentingApplicationAuditToken(struct WebKit::CoreIPCAuditToken auditToken)
+#endif
 }

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -126,7 +126,7 @@ void WebPage::platformInitializeAccessibility()
     [NSApplication _accessibilityInitialize];
 
     // Get the pid for the starting process.
-    pid_t pid = presentingApplicationPID();
+    pid_t pid = legacyPresentingApplicationPID();
     createMockAccessibilityElement(pid);
     RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
     if (localMainFrame)

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -430,7 +430,7 @@ void WebProcess::initializeWebProcess(WebProcessCreationParameters&& parameters,
     if (parameters.websiteDataStoreParameters)
         setWebsiteDataStoreParameters(WTFMove(*parameters.websiteDataStoreParameters));
 
-    setPresentingApplicationPID(parameters.presentingApplicationPID);
+    setLegacyPresentingApplicationPID(parameters.presentingApplicationPID);
 
 #if OS(LINUX)
     MemoryPressureHandler::ReliefLogger::setLoggingEnabled(parameters.shouldEnableMemoryPressureReliefLogging);
@@ -625,7 +625,7 @@ void WebProcess::initializeWebProcess(WebProcessCreationParameters&& parameters,
 #if ENABLE(REMOTE_INSPECTOR) && PLATFORM(COCOA)
     if (std::optional<audit_token_t> auditToken = parentProcessConnection()->getAuditToken()) {
         RetainPtr<CFDataRef> auditData = adoptCF(CFDataCreate(nullptr, (const UInt8*)&*auditToken, sizeof(*auditToken)));
-        Inspector::RemoteInspector::singleton().setParentProcessInformation(presentingApplicationPID(), auditData);
+        Inspector::RemoteInspector::singleton().setParentProcessInformation(legacyPresentingApplicationPID(), auditData);
     }
     // We need to connect to webinspectord before the first page load for the XPC connection to be successfully opened.
     // This is because we block launchd before the first page load, and launchd is required to establish the connection.
@@ -662,7 +662,7 @@ void WebProcess::initializeWebProcess(WebProcessCreationParameters&& parameters,
     WebCore::NavigatorGamepad::setGamepadsRecentlyAccessedThreshold(WebPageProxy::gamepadsRecentlyAccessedThreshold / 3);
 #endif
 
-    WEBPROCESS_RELEASE_LOG(Process, "initializeWebProcess: Presenting processPID=%d", presentingApplicationPID());
+    WEBPROCESS_RELEASE_LOG(Process, "initializeWebProcess: Presenting processPID=%d", legacyPresentingApplicationPID());
 }
 
 void WebProcess::setWebsiteDataStoreParameters(WebProcessDataStoreParameters&& parameters)


### PR DESCRIPTION
#### 79dad443efe68f5aee4f3d4dd15cfa1232978c63
<pre>
[iOS] It should be possible to change presentingApplicationAuditToken after a WKWebView is created
<a href="https://bugs.webkit.org/show_bug.cgi?id=284483">https://bugs.webkit.org/show_bug.cgi?id=284483</a>
<a href="https://rdar.apple.com/137618821">rdar://137618821</a>

Reviewed by Youenn Fablet.

_WKProcessPoolConfiguration has a presentingApplicationProcessToken SPI that allows the client to
set an audit token representing the application that is presenting the web content hosted in this
process pool. This SPI is necessary because in some clients the application that presents web
content on screen differs from the UI process that owns the WKWebView.

Having this SPI on _WKProcessPoolConfiguration limits these clients in the following ways:
1. It&apos;s not possible for a client to present WKWebViews from the same process pool in two different
   presenting applications.
2. If a presenting application exits and relaunches, it&apos;s not possible for a client to restore an
   existing WKWebView into this new presenting application instance.

Resolved these limitations by adding a readwrite property to WKWebView for clients to set the
presenting application audit token. The audit token is stored on WebPageProxy as well as (a) on the
Page in corresponding WebContent processes and (b) on GPUConnectionToWebProcess. Media SPIs that
rely on knowing the presenting application&apos;s PID or audit token read these values when needed.

Previously the presenting application PID was read from a global value (presentingApplicationPID()),
but since this value is now per-Page, this function was renamed to legacyPresentingApplicationPID().

* Source/WTF/wtf/RuntimeApplicationChecks.cpp:
(WTF::legacyPresentingApplicationPID):
(WTF::setLegacyPresentingApplicationPID):
(WTF::presentingApplicationPID): Deleted.
(WTF::setPresentingApplicationPID): Deleted.
* Source/WebCore/Modules/mediastream/UserMediaRequest.cpp:
(WebCore::UserMediaRequest::start):
* Source/WebCore/Modules/webaudio/AudioContext.cpp:
(WebCore::AudioContext::presentingApplicationPID const):
* Source/WebCore/Modules/webaudio/AudioContext.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::presentingApplicationPID const):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/page/Page.cpp:
(WebCore::m_presentingApplicationAuditToken):
(WebCore::Page::presentingApplicationPID const):
(WebCore::Page::presentingApplicationAuditToken const):
(WebCore::Page::setPresentingApplicationAuditToken):
(WebCore::m_activeNowPlayingSessionUpdateTimer): Deleted.
* Source/WebCore/page/Page.h:
* Source/WebCore/page/PageConfiguration.h:
* Source/WebCore/platform/audio/PlatformMediaSession.cpp:
(WebCore::PlatformMediaSession::presentingApplicationPID const):
* Source/WebCore/platform/audio/PlatformMediaSession.h:
* Source/WebCore/platform/audio/PlatformMediaSessionManager.h:
(WebCore::PlatformMediaSessionManager::prepareToSendUserMediaPermissionRequest):
(WebCore::PlatformMediaSessionManager::updatePresentingApplicationPIDIfNecessary):
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h:
(WebCore::MediaSessionManagerCocoa::providePresentingApplicationPIDIfNecessary):
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::prepareToSendUserMediaPermissionRequest):
(WebCore::MediaSessionManagerCocoa::updateNowPlayingInfo):
* Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h:
* Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm:
(WebCore::MediaSessionManageriOS::providePresentingApplicationPIDIfNecessary):
(WebCore::MediaSessionManageriOS::updatePresentingApplicationPIDIfNecessary):
(WebCore::MediaSessionManageriOS::sessionWillBeginPlayback):
(WebCore::MediaSessionManageriOS::providePresentingApplicationPID): Deleted.
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::overridePresentingApplicationPIDIfNeeded):
(WebKit::GPUConnectionToWebProcess::legacyCdmFactoryProxy):
(WebKit::GPUConnectionToWebProcess::presentingApplicationAuditToken const):
(WebKit::GPUConnectionToWebProcess::presentingApplicationPID const):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
(WebKit::GPUConnectionToWebProcess::presentingApplicationAuditTokens const):
(WebKit::GPUConnectionToWebProcess::presentingApplicationAuditToken const): Deleted.
* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::initializeGPUProcess):
(WebKit::GPUProcess::setPresentingApplicationAuditToken):
* Source/WebKit/GPUProcess/GPUProcess.h:
* Source/WebKit/GPUProcess/GPUProcess.messages.in:
* Source/WebKit/GPUProcess/GPUProcessCreationParameters.h:
* Source/WebKit/GPUProcess/GPUProcessCreationParameters.serialization.in:
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp:
(WebKit::RemoteAudioSessionProxyManager::updatePresentingProcesses):
* Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.cpp:
(WebKit::RemoteMediaSessionHelperProxy::providePresentingApplicationPID):
* Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.h:
* Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.messages.in:
* Source/WebKit/ModelProcess/ModelProcess.cpp:
(WebKit::ModelProcess::initializeModelProcess):
* Source/WebKit/ModelProcess/ModelProcessCreationParameters.h:
* Source/WebKit/ModelProcess/ModelProcessCreationParameters.serialization.in:
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/Cocoa/CoreIPCAuditToken.h:
(WebKit::invalidAuditToken):
(WebKit::CoreIPCAuditToken::CoreIPCAuditToken):
* Source/WebKit/Shared/GPUProcessConnectionParameters.h:
* Source/WebKit/Shared/GPUProcessConnectionParameters.serialization.in:
* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/Shared/WebPageCreationParameters.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView presentingApplicationAuditToken]):
(-[WKWebView setPresentingApplicationAuditToken:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp:
(WebKit::UserMediaCaptureManagerProxy::createMediaSourceForCaptureDeviceWithConstraints):
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h:
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::GPUProcessProxy):
(WebKit::GPUProcessProxy::setPresentingApplicationAuditToken):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::m_pageForTesting):
(WebKit::WebPageProxy::~WebPageProxy):
(WebKit::WebPageProxy::creationParameters):
(WebKit::WebPageProxy::presentingApplicationAuditToken const):
(WebKit::WebPageProxy::setPresentingApplicationAuditToken):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::createGPUProcessConnection):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::createGPUProcessConnection):
(WebKit::WebProcessProxy::presentingApplicationAuditTokens const):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.cpp:
(WebKit::RemoteMediaSessionHelper::providePresentingApplicationPID):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::WebPage):
(WebKit::m_textAnimationController):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/287782@main">https://commits.webkit.org/287782@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94ef4734380786c7d0c267a6c59189c5637d69e5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80746 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/268 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34682 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85273 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31730 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82857 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/285 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8065 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63064 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20852 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83815 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/118 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73500 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43366 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/80204 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/50 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27660 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30187 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/73726 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71613 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28191 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86705 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/79805 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7973 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5635 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71372 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8150 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69336 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70601 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17593 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14622 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13565 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/102212 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7935 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13456 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/24865 "Found 2 new JSC stress test failures: wasm.yaml/wasm/stress/struct-new_default-small-members.js.wasm-collect-continuously, wasm.yaml/wasm/stress/struct-new_default-small-members.js.wasm-eager-jettison (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7774 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11293 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9580 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->