### PR TITLE
Reduce use of memmove()

### DIFF
--- a/Source/WTF/wtf/URLHelpers.cpp
+++ b/Source/WTF/wtf/URLHelpers.cpp
@@ -35,6 +35,7 @@
 #include <unicode/uidna.h>
 #include <unicode/uscript.h>
 #include <wtf/IteratorRange.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/text/WTFString.h>
 
 namespace WTF {
@@ -937,7 +938,7 @@ String userVisibleURL(const CString& url)
         // as we convert.
         int afterlength = afterIndex;
         auto p = after.mutableSpan().subspan(bufferLength.value() - afterlength - 1);
-        memmove(p.data(), after.data(), afterlength + 1); // copies trailing '\0'
+        memmoveSpan(p, after.span().first(afterlength + 1)); // copies trailing '\0'
         afterIndex = 0;
         while (p.front()) {
             unsigned char c = p.front();

--- a/Source/WTF/wtf/cocoa/NSURLExtras.mm
+++ b/Source/WTF/wtf/cocoa/NSURLExtras.mm
@@ -32,6 +32,7 @@
 #import <mutex>
 #import <wtf/Function.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/StdLibExtras.h>
 #import <wtf/URL.h>
 #import <wtf/URLHelpers.h>
 #import <wtf/Vector.h>
@@ -288,7 +289,7 @@ static NSURL *URLByRemovingComponentAndSubsequentCharacter(NSURL *URL, CFURLComp
     if (numBytes < range.location + range.length)
         range.length = numBytes - range.location;
 
-    memmove(urlBytes.subspan(range.location).data(), urlBytes.subspan(range.location + range.length).data(), numBytes - range.location + range.length);
+    memmoveSpan(urlBytes.subspan(range.location), urlBytes.subspan(range.location + range.length, numBytes - range.location + range.length));
 
     auto result = adoptCF(CFURLCreateWithBytes(nullptr, urlBytes.data(), numBytes - range.length, kCFStringEncodingUTF8, nullptr));
     if (!result)

--- a/Source/WTF/wtf/dtoa/utils.h
+++ b/Source/WTF/wtf/dtoa/utils.h
@@ -31,6 +31,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <wtf/Assertions.h>
+#include <wtf/StdLibExtras.h>
 
 #ifndef UNIMPLEMENTED
 #define UNIMPLEMENTED() ASSERT_NOT_REACHED()
@@ -276,7 +277,7 @@ class StringBuilder {
   void AddSubstring(const char* s, int n) {
     ASSERT_WITH_SECURITY_IMPLICATION(!is_finalized() && position_ + n < static_cast<int>(buffer_.length()));
     ASSERT_WITH_SECURITY_IMPLICATION(static_cast<size_t>(n) <= strnlen(s, n));
-    memmove(&buffer_[position_], s, n * kCharSize);
+    memmoveSpan(buffer_.start().subspan(position_), unsafeMakeSpan(s, n));
     position_ += n;
   }
 
@@ -291,7 +292,7 @@ class StringBuilder {
   void RemoveCharacters(size_t start, size_t end) {
     ASSERT_WITH_SECURITY_IMPLICATION(start <= end);
     ASSERT_WITH_SECURITY_IMPLICATION(static_cast<int>(end) <= position_);
-    std::memmove(&buffer_[start], &buffer_[end], position_ - end);
+    memmoveSpan(buffer_.start().subspan(start), buffer_.start().subspan(end, position_ - end));
     position_ -= end - start;
   }
 
@@ -353,7 +354,7 @@ inline Dest BitCast(const Source& source) {
 #endif
 
   Dest dest;
-  memmove(&dest, &source, sizeof(dest));
+  memmoveSpan(asMutableByteSpan(dest), asByteSpan(source));
   return dest;
 }
 

--- a/Source/WebCore/Modules/webaudio/AudioBuffer.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBuffer.cpp
@@ -41,6 +41,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/TypedArrayInlines.h>
 #include <wtf/CheckedArithmetic.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -248,13 +249,13 @@ ExceptionOr<void> AudioBuffer::copyFromChannel(Ref<Float32Array>&& destination, 
     size_t count = dataLength - bufferOffset;
     count = std::min(destination.get().length(), count);
     
-    const float* src = channelData->data();
-    float* dst = destination->data();
+    auto src = channelData->typedSpan();
+    auto dst = destination->typedMutableSpan();
     
-    ASSERT(src);
-    ASSERT(dst);
+    ASSERT(src.data());
+    ASSERT(dst.data());
     
-    memmove(dst, src + bufferOffset, count * sizeof(*src));
+    memmoveSpan(dst, src.subspan(bufferOffset, count));
     return { };
 }
 
@@ -276,13 +277,13 @@ ExceptionOr<void> AudioBuffer::copyToChannel(Ref<Float32Array>&& source, unsigne
     size_t count = dataLength - bufferOffset;
     count = std::min(source.get().length(), count);
     
-    const float* src = source->data();
-    float* dst = channelData->data();
+    auto src = source->typedSpan();
+    auto dst = channelData->typedMutableSpan();
     
-    ASSERT(src);
-    ASSERT(dst);
+    ASSERT(src.data());
+    ASSERT(dst.data());
     
-    memmove(dst + bufferOffset, src, count * sizeof(*dst));
+    memmoveSpan(dst.subspan(bufferOffset), src.first(count));
     m_noiseInjectionMultiplier = 0;
     return { };
 }

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -147,13 +147,14 @@ template<typename CharacterType> static CSSValueID cssValueKeywordID(std::span<c
 
     // In most cases, if the prefix is -apple-, change it to -webkit-. This makes the string one character longer.
     auto length = characters.size();
-    if (buffer[0] == '-' && isAppleLegacyCSSValueKeyword(std::span { buffer }.first(length))) {
-        memmove(buffer.data() + 7, buffer.data() + 6, length - 6);
-        memcpy(buffer.data() + 1, "webkit", 6);
+    std::span bufferSpan { buffer };
+    if (buffer[0] == '-' && isAppleLegacyCSSValueKeyword(bufferSpan.first(length))) {
+        memmoveSpan(bufferSpan.subspan(7), bufferSpan.subspan(6, length - 6));
+        memcpySpan(bufferSpan.subspan(1), "webkit"_span);
         ++length;
     }
 
-    return findCSSValueKeyword(std::span { buffer }.first(length));
+    return findCSSValueKeyword(bufferSpan.first(length));
 }
 
 CSSValueID cssValueKeywordID(StringView string)

--- a/Source/WebCore/platform/graphics/PixelBuffer.cpp
+++ b/Source/WebCore/platform/graphics/PixelBuffer.cpp
@@ -109,7 +109,7 @@ bool PixelBuffer::setRange(std::span<const uint8_t> data, size_t byteOffset)
     if (!isSumSmallerThanOrEqual(byteOffset, data.size(), m_bytes.size()))
         return false;
 
-    memmove(m_bytes.data() + byteOffset, data.data(), data.size());
+    memmoveSpan(m_bytes.subspan(byteOffset), data);
     return true;
 }
 

--- a/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp
@@ -55,6 +55,7 @@
 #include <WebCore/UserContentProvider.h>
 #include <WebCore/WebSocketChannelClient.h>
 #include <WebCore/WebSocketHandshake.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>
@@ -437,11 +438,11 @@ bool WebSocketChannel::appendToBuffer(std::span<const uint8_t> data)
     return true;
 }
 
-void WebSocketChannel::skipBuffer(size_t len)
+void WebSocketChannel::skipBuffer(size_t length)
 {
-    ASSERT_WITH_SECURITY_IMPLICATION(len <= m_buffer.size());
-    memmove(m_buffer.data(), m_buffer.data() + len, m_buffer.size() - len);
-    m_buffer.shrink(m_buffer.size() - len);
+    ASSERT_WITH_SECURITY_IMPLICATION(length <= m_buffer.size());
+    memmoveSpan(m_buffer.mutableSpan(), m_buffer.subspan(length));
+    m_buffer.shrink(m_buffer.size() - length);
 }
 
 bool WebSocketChannel::processBuffer()


### PR DESCRIPTION
#### 61b0c05932486217ebf55c9edb730f9e63f1961f
<pre>
Reduce use of memmove()
<a href="https://bugs.webkit.org/show_bug.cgi?id=284481">https://bugs.webkit.org/show_bug.cgi?id=284481</a>

Reviewed by Darin Adler.

Reduce use of memmove() in favor of safer alternatives.

* Source/WTF/wtf/URLHelpers.cpp:
(WTF::URLHelpers::userVisibleURL):
* Source/WTF/wtf/cocoa/NSURLExtras.mm:
(WTF::URLByRemovingComponentAndSubsequentCharacter):
* Source/WTF/wtf/darwin/OSLogPrintStream.mm:
(WTF::OSLogPrintStream::vprintf):
* Source/WTF/wtf/dtoa/utils.h:
(WTF::double_conversion::StringBuilder::AddSubstring):
(WTF::double_conversion::StringBuilder::RemoveCharacters):
(WTF::double_conversion::BitCast):
* Source/WebCore/Modules/webaudio/AudioBuffer.cpp:
(WebCore::AudioBuffer::copyFromChannel):
(WebCore::AudioBuffer::copyToChannel):
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::cssValueKeywordID):
(WebCore::CSSPropertyParser::CSSPropertyParser): Deleted.
(WebCore::CSSPropertyParser::addProperty): Deleted.
(WebCore::CSSPropertyParser::addExpandedProperty): Deleted.
(WebCore::CSSPropertyParser::parseValue): Deleted.
(WebCore::maybeConsumeCSSWideKeyword): Deleted.
(WebCore::CSSPropertyParser::parseSingleValue): Deleted.
(WebCore::CSSPropertyParser::parseTypedCustomPropertyValue): Deleted.
(WebCore::CSSPropertyParser::parseTypedCustomPropertyInitialValue): Deleted.
(WebCore::CSSPropertyParser::collectParsedCustomPropertyValueDependencies): Deleted.
(WebCore::CSSPropertyParser::isValidCustomPropertyValueForSyntax): Deleted.
(WebCore::CSSPropertyParser::parseValueStart): Deleted.
(WebCore::CSSPropertyParser::consumeCSSWideKeyword): Deleted.
(WebCore::CSSPropertyParser::consumeCustomPropertyValueWithSyntax): Deleted.
(WebCore::CSSPropertyParser::parseCounterStyleDescriptor): Deleted.
(WebCore::CSSPropertyParser::parseViewTransitionDescriptor): Deleted.
(WebCore::propertyAllowedInPositionTryRule): Deleted.
(WebCore::CSSPropertyParser::parsePositionTryDescriptor): Deleted.
(WebCore::CSSPropertyParser::parseFontFaceDescriptor): Deleted.
(WebCore::CSSPropertyParser::parseFontFaceDescriptorShorthand): Deleted.
(WebCore::CSSPropertyParser::parseKeyframeDescriptor): Deleted.
(WebCore::CSSPropertyParser::parsePropertyDescriptor): Deleted.
(WebCore::CSSPropertyParser::parseFontPaletteValuesDescriptor): Deleted.
(WebCore::CSSPropertyParser::parsePageDescriptor): Deleted.
(WebCore::CSSPropertyParser::consumeFont): Deleted.
(WebCore::CSSPropertyParser::consumeTextDecorationSkip): Deleted.
(WebCore::CSSPropertyParser::consumeFontVariantShorthand): Deleted.
(WebCore::CSSPropertyParser::consumeFontSynthesis): Deleted.
(WebCore::CSSPropertyParser::consumeBorderSpacing): Deleted.
(WebCore::CSSPropertyParser::consumeColumns): Deleted.
(WebCore::initialValueForLonghand): Deleted.
(WebCore::isValueIDPair): Deleted.
(WebCore::isNumber): Deleted.
(WebCore::isValueID): Deleted.
(WebCore::isNumericQuad): Deleted.
(WebCore::isInitialValueForLonghand): Deleted.
(WebCore::initialValueTextForLonghand): Deleted.
(WebCore::initialValueIDForLonghand): Deleted.
(WebCore::CSSPropertyParser::consumeShorthandGreedily): Deleted.
(WebCore::CSSPropertyParser::consumeFlex): Deleted.
(WebCore::CSSPropertyParser::consumeBorderShorthand): Deleted.
(WebCore::CSSPropertyParser::consume2ValueShorthand): Deleted.
(WebCore::CSSPropertyParser::consume4ValueShorthand): Deleted.
(WebCore::CSSPropertyParser::consumeBorderRadius): Deleted.
(WebCore::CSSPropertyParser::consumeBorderImage): Deleted.
(WebCore::mapFromPageBreakBetween): Deleted.
(WebCore::mapFromColumnBreakBetween): Deleted.
(WebCore::mapFromColumnRegionOrPageBreakInside): Deleted.
(WebCore::mapFromLegacyBreakProperty): Deleted.
(WebCore::CSSPropertyParser::consumeLegacyBreakProperty): Deleted.
(WebCore::CSSPropertyParser::consumeLegacyTextOrientation): Deleted.
(WebCore::isValidAnimationPropertyList): Deleted.
(WebCore::consumeAnimationValueForShorthand): Deleted.
(WebCore::CSSPropertyParser::consumeAnimationShorthand): Deleted.
(WebCore::consumeBackgroundPosition): Deleted.
(WebCore::consumeBackgroundComponent): Deleted.
(WebCore::CSSPropertyParser::consumeBackgroundShorthand): Deleted.
(WebCore::CSSPropertyParser::consumeOverflowShorthand): Deleted.
(WebCore::isCustomIdentValue): Deleted.
(WebCore::CSSPropertyParser::consumeGridItemPositionShorthand): Deleted.
(WebCore::CSSPropertyParser::consumeGridAreaShorthand): Deleted.
(WebCore::CSSPropertyParser::consumeGridTemplateRowsAndAreasAndColumns): Deleted.
(WebCore::CSSPropertyParser::consumeGridTemplateShorthand): Deleted.
(WebCore::consumeImplicitGridAutoFlow): Deleted.
(WebCore::CSSPropertyParser::consumeGridShorthand): Deleted.
(WebCore::CSSPropertyParser::consumeAlignShorthand): Deleted.
(WebCore::CSSPropertyParser::consumeBlockStepShorthand): Deleted.
(WebCore::CSSPropertyParser::consumeOverscrollBehaviorShorthand): Deleted.
(WebCore::CSSPropertyParser::consumeContainerShorthand): Deleted.
(WebCore::CSSPropertyParser::consumeContainIntrinsicSizeShorthand): Deleted.
(WebCore::CSSPropertyParser::consumeTransformOrigin): Deleted.
(WebCore::CSSPropertyParser::consumePerspectiveOrigin): Deleted.
(WebCore::CSSPropertyParser::consumePrefixedPerspective): Deleted.
(WebCore::CSSPropertyParser::consumeOffset): Deleted.
(WebCore::CSSPropertyParser::consumeListStyleShorthand): Deleted.
(WebCore::CSSPropertyParser::consumeLineClampShorthand): Deleted.
(WebCore::CSSPropertyParser::consumeTextBoxShorthand): Deleted.
(WebCore::CSSPropertyParser::consumeTextWrapShorthand): Deleted.
(WebCore::CSSPropertyParser::consumeWhiteSpaceShorthand): Deleted.
(WebCore::CSSPropertyParser::consumeAnimationRangeShorthand): Deleted.
(WebCore::CSSPropertyParser::consumeScrollTimelineShorthand): Deleted.
(WebCore::CSSPropertyParser::consumeViewTimelineShorthand): Deleted.
(WebCore::CSSPropertyParser::parseShorthand): Deleted.
* Source/WebCore/platform/graphics/PixelBuffer.cpp:
(WebCore::PixelBuffer::setRange):
* Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp:
(WebCore::WebSocketChannel::skipBuffer):

Canonical link: <a href="https://commits.webkit.org/287756@main">https://commits.webkit.org/287756@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d32ba3be9349b3f8238a9f360441a5fc8c368ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80569 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59576 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34502 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85090 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31551 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82680 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68637 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7881 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62942 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20747 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83638 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/53053 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73349 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43247 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50348 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27507 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30010 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/73549 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71494 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28030 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86524 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/79628 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7795 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5500 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71243 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7970 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69186 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70483 "Found 2 new API test failures: /TestWebKit:WebKit.LoadCanceledNoServerRedirectCallback, /TestWebKit:WebKit2UserMessageRoundTripTest.WKURL (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14483 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13428 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/102035 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12514 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7757 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13276 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/24843 "Found 2 new JSC stress test failures: wasm.yaml/wasm/stress/struct-new_default-small-members.js.wasm-bbq, wasm.yaml/wasm/stress/struct-new_default-small-members.js.wasm-collect-continuously (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7596 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11115 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9401 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->