### PR TITLE
Suppress "refcounted class without virtual destructor" warning in derived classes of StyleRuleBase

### DIFF
--- a/Source/WebCore/css/CSSCounterStyleRule.h
+++ b/Source/WebCore/css/CSSCounterStyleRule.h
@@ -32,7 +32,7 @@
 #include <wtf/text/AtomString.h>
 
 namespace WebCore {
-class StyleRuleCounterStyle final : public StyleRuleBase {
+class SUPPRESS_REFCOUNTED_WITHOUT_VIRTUAL_DESTRUCTOR StyleRuleCounterStyle final : public StyleRuleBase {
 public:
     static Ref<StyleRuleCounterStyle> create(const AtomString&, CSSCounterStyleDescriptors&&);
     ~StyleRuleCounterStyle();

--- a/Source/WebCore/css/CSSKeyframeRule.h
+++ b/Source/WebCore/css/CSSKeyframeRule.h
@@ -35,7 +35,7 @@ class CSSKeyframesRule;
 class StyleProperties;
 class StyleRuleCSSStyleDeclaration;
 
-class StyleRuleKeyframe final : public StyleRuleBase {
+class SUPPRESS_REFCOUNTED_WITHOUT_VIRTUAL_DESTRUCTOR StyleRuleKeyframe final : public StyleRuleBase {
 public:
     static Ref<StyleRuleKeyframe> create(Ref<StyleProperties>&&);
     static Ref<StyleRuleKeyframe> create(Vector<double>&& keys, Ref<StyleProperties>&&);

--- a/Source/WebCore/css/CSSKeyframesRule.h
+++ b/Source/WebCore/css/CSSKeyframesRule.h
@@ -37,7 +37,7 @@ class CSSKeyframeRule;
 class CSSRuleList;
 class StyleRuleKeyframe;
 
-class StyleRuleKeyframes final : public StyleRuleBase {
+class SUPPRESS_REFCOUNTED_WITHOUT_VIRTUAL_DESTRUCTOR StyleRuleKeyframes final : public StyleRuleBase {
 public:
     static Ref<StyleRuleKeyframes> create(const AtomString& name);
     ~StyleRuleKeyframes();

--- a/Source/WebCore/css/CSSPositionTryRule.h
+++ b/Source/WebCore/css/CSSPositionTryRule.h
@@ -36,7 +36,7 @@ namespace WebCore {
 class CSSStyleDeclaration;
 class StyleRuleCSSStyleDeclaration;
 
-class StyleRulePositionTry final : public StyleRuleBase {
+class SUPPRESS_REFCOUNTED_WITHOUT_VIRTUAL_DESTRUCTOR StyleRulePositionTry final : public StyleRuleBase {
 public:
     static Ref<StyleRulePositionTry> create(AtomString&& name, Ref<StyleProperties>&&);
 

--- a/Source/WebCore/css/CSSViewTransitionRule.h
+++ b/Source/WebCore/css/CSSViewTransitionRule.h
@@ -37,7 +37,7 @@ enum class ViewTransitionNavigation : bool {
     None,
 };
 
-class StyleRuleViewTransition final : public StyleRuleBase {
+class SUPPRESS_REFCOUNTED_WITHOUT_VIRTUAL_DESTRUCTOR StyleRuleViewTransition final : public StyleRuleBase {
 public:
     static Ref<StyleRuleViewTransition> create(Ref<StyleProperties>&&);
     ~StyleRuleViewTransition();

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -52,6 +52,15 @@ class StyleSheetContents;
 using CascadeLayerName = Vector<AtomString>;
     
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleRuleBase);
+
+// Base class to be derived by concrete style rule implementations.
+// NOTE: StyleRuleBase doesn't have (or need) a virtual destructor, as it defines
+// a custom "destroying delete" operator, which calls  the appropriate destructor for
+// the derived type before deallocating itself. This avoids the performance overhead
+// of storing and accessing a vtable. The Safer C++ checker would raise false positives
+// about "refcounted base class without virtual destructor" though, so every derived
+// classes of StyleRuleBase should be marked with
+// "SUPPRESS_REFCOUNTED_WITHOUT_VIRTUAL_DESTRUCTOR" to suppress this warning.
 class StyleRuleBase : public RefCounted<StyleRuleBase> {
     WTF_MAKE_STRUCT_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(StyleRuleBase);
 public:
@@ -115,7 +124,7 @@ private:
 };
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleRule);
-class StyleRule : public StyleRuleBase {
+class SUPPRESS_REFCOUNTED_WITHOUT_VIRTUAL_DESTRUCTOR StyleRule : public StyleRuleBase {
     WTF_MAKE_STRUCT_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(StyleRule);
 public:
     static Ref<StyleRule> create(Ref<StyleProperties>&&, bool hasDocumentSecurityOrigin, CSSSelectorList&&);
@@ -202,7 +211,7 @@ private:
     StyleRuleNestedDeclarations(const StyleRuleNestedDeclarations&) = default;
 };
 
-class StyleRuleFontFace final : public StyleRuleBase {
+class SUPPRESS_REFCOUNTED_WITHOUT_VIRTUAL_DESTRUCTOR StyleRuleFontFace final : public StyleRuleBase {
 public:
     static Ref<StyleRuleFontFace> create(Ref<StyleProperties>&& properties) { return adoptRef(*new StyleRuleFontFace(WTFMove(properties))); }
     ~StyleRuleFontFace();
@@ -219,7 +228,7 @@ private:
     Ref<StyleProperties> m_properties;
 };
 
-class StyleRuleFontPaletteValues final : public StyleRuleBase {
+class SUPPRESS_REFCOUNTED_WITHOUT_VIRTUAL_DESTRUCTOR StyleRuleFontPaletteValues final : public StyleRuleBase {
 public:
     static Ref<StyleRuleFontPaletteValues> create(const AtomString& name, Vector<AtomString>&& fontFamilies, std::optional<FontPaletteIndex> basePalette, Vector<FontPaletteValues::OverriddenColor>&&);
 
@@ -240,7 +249,7 @@ private:
     FontPaletteValues m_fontPaletteValues;
 };
 
-class StyleRuleFontFeatureValuesBlock final : public StyleRuleBase {
+class SUPPRESS_REFCOUNTED_WITHOUT_VIRTUAL_DESTRUCTOR StyleRuleFontFeatureValuesBlock final : public StyleRuleBase {
 public:
     static Ref<StyleRuleFontFeatureValuesBlock> create(FontFeatureValuesType type, const Vector<FontFeatureValuesTag>& tags)
     {
@@ -262,7 +271,7 @@ private:
     Vector<FontFeatureValuesTag> m_tags;
 };
 
-class StyleRuleFontFeatureValues final : public StyleRuleBase {
+class SUPPRESS_REFCOUNTED_WITHOUT_VIRTUAL_DESTRUCTOR StyleRuleFontFeatureValues final : public StyleRuleBase {
 public:
     static Ref<StyleRuleFontFeatureValues> create(const Vector<AtomString>& fontFamilies, Ref<FontFeatureValues>&&);
     
@@ -282,7 +291,7 @@ private:
     Ref<FontFeatureValues> m_value;
 };
 
-class StyleRulePage final : public StyleRuleBase {
+class SUPPRESS_REFCOUNTED_WITHOUT_VIRTUAL_DESTRUCTOR StyleRulePage final : public StyleRuleBase {
 public:
     static Ref<StyleRulePage> create(Ref<StyleProperties>&&, CSSSelectorList&&);
 
@@ -304,7 +313,7 @@ private:
     CSSSelectorList m_selectorList;
 };
 
-class StyleRuleGroup : public StyleRuleBase {
+class SUPPRESS_REFCOUNTED_WITHOUT_VIRTUAL_DESTRUCTOR StyleRuleGroup : public StyleRuleBase {
 public:
     const Vector<Ref<StyleRuleBase>>& childRules() const;
 
@@ -388,7 +397,7 @@ private:
     CQ::ContainerQuery m_containerQuery;
 };
 
-class StyleRuleProperty final : public StyleRuleBase {
+class SUPPRESS_REFCOUNTED_WITHOUT_VIRTUAL_DESTRUCTOR StyleRuleProperty final : public StyleRuleBase {
 public:
     struct Descriptor {
         AtomString name;
@@ -448,7 +457,7 @@ private:
 };
 
 // This is only used by the CSS parser.
-class StyleRuleCharset final : public StyleRuleBase {
+class SUPPRESS_REFCOUNTED_WITHOUT_VIRTUAL_DESTRUCTOR StyleRuleCharset final : public StyleRuleBase {
 public:
     static Ref<StyleRuleCharset> create() { return adoptRef(*new StyleRuleCharset); }
     Ref<StyleRuleCharset> copy() const { return adoptRef(*new StyleRuleCharset(*this)); }
@@ -458,7 +467,7 @@ private:
     StyleRuleCharset(const StyleRuleCharset&) = default;
 };
 
-class StyleRuleNamespace final : public StyleRuleBase {
+class SUPPRESS_REFCOUNTED_WITHOUT_VIRTUAL_DESTRUCTOR StyleRuleNamespace final : public StyleRuleBase {
 public:
     static Ref<StyleRuleNamespace> create(const AtomString& prefix, const AtomString& uri);
 

--- a/Source/WebCore/css/StyleRuleImport.h
+++ b/Source/WebCore/css/StyleRuleImport.h
@@ -33,7 +33,7 @@ class CachedCSSStyleSheet;
 class StyleSheetContents;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleRuleImport);
-class StyleRuleImport final : public StyleRuleBase {
+class SUPPRESS_REFCOUNTED_WITHOUT_VIRTUAL_DESTRUCTOR StyleRuleImport final : public StyleRuleBase {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(StyleRuleImport);
 public:
     struct SupportsCondition {


### PR DESCRIPTION
#### 560a5d3c86660aed7eeca628d87486020856c606
<pre>
Suppress &quot;refcounted class without virtual destructor&quot; warning in derived classes of StyleRuleBase
<a href="https://rdar.apple.com/141314048">rdar://141314048</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=284489">https://bugs.webkit.org/show_bug.cgi?id=284489</a>

Reviewed by NOBODY (OOPS!).

StyleRuleBase defines a custom &quot;destroying delete&quot; operator, which calls the
appropriate derived type destructor before deallocating the object. This
avoid the need for virtual destructor and improves performance/memory usage,
as there&apos;s no vtable to store and consult. However the safer C++ checker doesn&apos;t
know about this and throw the &quot;refcounted class without virtual destructor&quot;
warning, so suppress it. This has to be done for each derived classes of
StyleRuleBase.

* Source/WebCore/css/CSSCounterStyleRule.h:
* Source/WebCore/css/CSSKeyframeRule.h:
* Source/WebCore/css/CSSKeyframesRule.h:
* Source/WebCore/css/CSSPositionTryRule.h:
* Source/WebCore/css/CSSViewTransitionRule.h:
* Source/WebCore/css/StyleRule.h:
* Source/WebCore/css/StyleRuleImport.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/560a5d3c86660aed7eeca628d87486020856c606

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80713 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/235 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34649 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85240 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31697 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82824 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/252 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8032 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63038 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20834 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83782 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/95 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73472 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43340 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled-keyboard.tentative.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27632 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30154 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71593 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28157 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86672 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7940 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5612 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71333 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8117 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69308 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70574 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14594 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13542 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7902 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13423 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7741 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11260 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9547 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->