### PR TITLE
[webkitpy] SimulatedDeviceManager.initialize_devices should rebuild the dyld shared cache before booting simulators with none already booted.

### DIFF
--- a/Tools/Scripts/webkitpy/xcode/simulated_device_unittest.py
+++ b/Tools/Scripts/webkitpy/xcode/simulated_device_unittest.py
@@ -164,41 +164,51 @@ simctl_json_output = """{
  ],
  "runtimes" : [
    {
-     "runtimeRoot" : "/path/to/RuntimeRoot",
+     "runtimeRoot" : "/path/to/bundle.simruntime/path/to/RuntimeRoot",
+     "bundlePath" : "/path/to/bundle.simruntime",
      "buildversion" : "13E233",
      "availability" : "(available)",
+     "platform" : "iOS",
      "name" : "iOS 9.3",
      "identifier" : "com.apple.CoreSimulator.SimRuntime.iOS-9-3",
      "version" : "9.3"
    },
    {
-     "runtimeRoot" : "/path/to/RuntimeRoot",
+     "runtimeRoot" : "/path/to/bundle.simruntime/path/to/RuntimeRoot",
+     "bundlePath" : "/path/to/bundle.simruntime",
      "buildversion" : "15A8401",
      "availability" : "(available)",
+     "platform" : "iOS",
      "name" : "iOS 11.0",
      "identifier" : "com.apple.CoreSimulator.SimRuntime.iOS-11-0",
      "version" : "11.0.1"
    },
    {
-     "runtimeRoot" : "/path/to/RuntimeRoot",
+     "runtimeRoot" : "/path/to/bundle.simruntime/path/to/RuntimeRoot",
+     "bundlePath" : "/path/to/bundle.simruntime",
      "buildversion" : "15J380",
      "availability" : "(available)",
+     "platform" : "tvOS",
      "name" : "tvOS 11.0",
      "identifier" : "com.apple.CoreSimulator.SimRuntime.tvOS-11-0",
      "version" : "11.0"
    },
    {
-     "runtimeRoot" : "/path/to/RuntimeRoot",
+     "runtimeRoot" : "/path/to/bundle.simruntime/path/to/RuntimeRoot",
+     "bundlePath" : "/path/to/bundle.simruntime",
      "buildversion" : "15R372",
      "availability" : "(available)",
+     "platform" : "watchOS",
      "name" : "watchOS 4.0",
      "identifier" : "com.apple.CoreSimulator.SimRuntime.watchOS-4-0",
      "version" : "4.0"
    },
    {
-     "runtimeRoot" : "/path/to/RuntimeRoot",
+     "runtimeRoot" : "/path/to/bundle.simruntime/path/to/RuntimeRoot",
+     "bundlePath" : "/path/to/bundle.simruntime",
      "buildversion" : "16A367",
      "isAvailable" : "YES",
+     "platform" : "iOS",
      "name" : "iOS 12.0",
      "identifier" : "com.apple.CoreSimulator.SimRuntime.iOS-12-0",
      "version" : "12.0"


### PR DESCRIPTION
#### 50140920094471b706bb200855128b5d25b6976a
<pre>
[webkitpy] SimulatedDeviceManager.initialize_devices should rebuild the dyld shared cache before booting simulators with none already booted.
<a href="https://bugs.webkit.org/show_bug.cgi?id=284494">https://bugs.webkit.org/show_bug.cgi?id=284494</a>
<a href="https://rdar.apple.com/141316056">rdar://141316056</a>

Reviewed by Jonathan Bedard.

If booted before the dyld shared cache has a chance to populate, simulator
processes under SimulatorTrampoline appear to load all of the relevant
frameworks into memory for each process. This is causing severe simulator
performance regressions, which slows down testing and eats into host device
swap memory (especially when using multiple simulators in parallel).

Anecdotal API test stats (running 1 simulator):
 - No dyld shared cache: 3:00:51
 - With dyld shared cache: 1:44:57

For this reason, if no simulators are booted, we should rebuild the dyld shared
cache before booting new ones.

* Tools/Scripts/webkitpy/xcode/simulated_device.py:
    -&gt; (SimulatedDeviceManager.Runtime.__init__): Add new properties.
    -&gt; (SimulatedDeviceManager.Runtime.rebuild_dyld_shared_cache): Add new function that rebuilds the shared cache for the runtime.
    -&gt; (SimulatedDeviceManager.initialize_devices): Call rebuild_dyld_shared_cache if no simulators are booted.
* Tools/Scripts/webkitpy/xcode/simulated_device_unittest.py: Adjusting unit test mock input from simctl json.

Canonical link: <a href="https://commits.webkit.org/287716@main">https://commits.webkit.org/287716@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab38c3a535583e943e0c80577b5dad8a73b1e0d1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80598 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59605 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34531 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85122 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31580 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82709 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68666 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7911 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62957 "Found 27 new test failures: imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-position-under-left-001.xht imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-position-under-right-001.xht imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-auto-last-word-001.html imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-character.html imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-vs-float-clearance-002.html imported/w3c/web-platform-tests/css/css-transforms/animation/transform-non-invertible-discrete-interpolation.html imported/w3c/web-platform-tests/css/css-transforms/transform-box/cssbox-content-box-002.html imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-exit.html imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-match-ident.html imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-match-multiple.html ... (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/20760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83667 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/53068 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73373 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/43262 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/80056 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50362 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27533 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30039 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71508 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28056 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86555 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7824 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/71256 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7999 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69210 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/70496 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14504 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13450 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12483 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7786 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7625 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/11144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9430 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->