### PR TITLE
Thread safety assertion failure in InternalObserverMap::visitAdditionalChildren

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1965,9 +1965,6 @@ webkit.org/b/284190 [ Sequoia+ ] http/tests/privateClickMeasurement/send-attribu
 # webkit.org/b/284186 [macOS Debug] media/media-vp8-hiddenframes.html is timing out (flaky in EWS)
 [ Debug ] media/media-vp8-hiddenframes.html [ Pass Timeout ]
 
-# webkit.org/b/284391 [macOS Debug]: ASSERTION FAILED: Unsafe to ref/deref from different threads m_isOwnedByMainThread == isMainThread() result of crash in (flaky in EWS)
-[ Sonoma+ Debug ] imported/w3c/web-platform-tests/dom/observable/tentative/observable-map.any.worker.html [ Pass Crash ]
-
 webkit.org/b/284492 [ Sequoia+ ] imported/w3c/web-platform-tests/fetch/api/cors/cors-cookies-redirect.any.html [ Failure ]
 webkit.org/b/284492 [ Sequoia+ ] imported/w3c/web-platform-tests/fetch/api/cors/cors-cookies-redirect.any.worker.html [ Failure ]
 

--- a/Source/WebCore/dom/InternalObserverMap.cpp
+++ b/Source/WebCore/dom/InternalObserverMap.cpp
@@ -83,8 +83,8 @@ public:
 
         bool hasCallback() const final { return true; }
 
-        Ref<Observable> m_sourceObservable;
-        Ref<MapperCallback> m_mapper;
+        const Ref<Observable> m_sourceObservable;
+        const Ref<MapperCallback> m_mapper;
     };
 
 private:
@@ -130,8 +130,8 @@ private:
 
     void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
     {
-        protectedSubscriber()->visitAdditionalChildren(visitor);
-        protectedMapper()->visitJSFunction(visitor);
+        m_subscriber->visitAdditionalChildren(visitor);
+        m_mapper->visitJSFunction(visitor);
     }
 
     Ref<Subscriber> protectedSubscriber() const { return m_subscriber; }
@@ -143,8 +143,8 @@ private:
         , m_mapper(mapper)
     { }
 
-    Ref<Subscriber> m_subscriber;
-    Ref<MapperCallback> m_mapper;
+    const Ref<Subscriber> m_subscriber;
+    const Ref<MapperCallback> m_mapper;
     uint64_t m_idx { 0 };
 };
 


### PR DESCRIPTION
#### a1ec566561621b3f8b2cdbd51f963530655f01f3
<pre>
Thread safety assertion failure in InternalObserverMap::visitAdditionalChildren
<a href="https://bugs.webkit.org/show_bug.cgi?id=284391">https://bugs.webkit.org/show_bug.cgi?id=284391</a>
<a href="https://rdar.apple.com/141232149">rdar://141232149</a>

Reviewed by Chris Dumez.

InternalObserverMap::visitAdditionalChildren should not ref/deref objects that
are single-threaded ref counted like Subscriber and MapperCallback since this
function gets called concurrently to the main thread.

* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/dom/InternalObserverMap.cpp:

Canonical link: <a href="https://commits.webkit.org/287723@main">https://commits.webkit.org/287723@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c5b268488b817437a63ffe682bd78e8164e737b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80609 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59616 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34543 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85133 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31591 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82720 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68677 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7922 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62963 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20762 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83678 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/53079 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73383 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43268 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50370 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27542 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30050 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71516 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28065 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86566 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7835 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5522 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71257 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-animations/animation-offscreen-to-onscreen.html imported/w3c/web-platform-tests/css/css-pseudo/marker-animate-002.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8010 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69219 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70497 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14509 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13458 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12489 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7797 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/13316 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7636 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11155 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9441 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->