### PR TITLE
Implement URLPattern::hasRegExpGroup()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-hasregexpgroups.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-hasregexpgroups.any-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL urlpattern-hasregexpgroups assert_true: named regexp group in protocol expected true got false
+PASS urlpattern-hasregexpgroups
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-hasregexpgroups.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-hasregexpgroups.any.serviceworker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL urlpattern-hasregexpgroups assert_true: named regexp group in protocol expected true got false
+PASS urlpattern-hasregexpgroups
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-hasregexpgroups.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-hasregexpgroups.any.sharedworker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL urlpattern-hasregexpgroups assert_true: named regexp group in protocol expected true got false
+PASS urlpattern-hasregexpgroups
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-hasregexpgroups.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-hasregexpgroups.any.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL urlpattern-hasregexpgroups assert_true: named regexp group in protocol expected true got false
+PASS urlpattern-hasregexpgroups
 

--- a/Source/WebCore/Modules/url-pattern/URLPattern.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.cpp
@@ -446,4 +446,17 @@ ExceptionOr<std::optional<URLPatternResult>> URLPattern::match(ScriptExecutionCo
     return { result };
 }
 
+// https://urlpattern.spec.whatwg.org/#url-pattern-has-regexp-groups
+bool URLPattern::hasRegExpGroups() const
+{
+    return m_protocolComponent.hasRegexGroupsFromPartList()
+    || m_usernameComponent.hasRegexGroupsFromPartList()
+    || m_passwordComponent.hasRegexGroupsFromPartList()
+    || m_hostnameComponent.hasRegexGroupsFromPartList()
+    || m_pathnameComponent.hasRegexGroupsFromPartList()
+    || m_portComponent.hasRegexGroupsFromPartList()
+    || m_searchComponent.hasRegexGroupsFromPartList()
+    || m_hashComponent.hasRegexGroupsFromPartList();
+}
+
 }

--- a/Source/WebCore/Modules/url-pattern/URLPattern.h
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.h
@@ -67,7 +67,7 @@ public:
     const String& search() const { return m_searchComponent.patternString(); }
     const String& hash() const { return m_hashComponent.patternString(); }
 
-    bool hasRegExpGroups() const { return m_hasRegExpGroups; }
+    bool hasRegExpGroups() const;
 
 private:
     URLPattern();
@@ -82,8 +82,6 @@ private:
     URLPatternUtilities::URLPatternComponent m_portComponent;
     URLPatternUtilities::URLPatternComponent m_searchComponent;
     URLPatternUtilities::URLPatternComponent m_hashComponent;
-
-    bool m_hasRegExpGroups { false };
 };
 
 }

--- a/Source/WebCore/Modules/url-pattern/URLPatternComponent.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternComponent.cpp
@@ -37,11 +37,11 @@
 namespace WebCore {
 namespace URLPatternUtilities {
 
-URLPatternComponent::URLPatternComponent(String&& patternString, JSC::Strong<JSC::RegExp>&& regex, Vector<String>&& groupNameList, bool hasRegexpGroups)
+URLPatternComponent::URLPatternComponent(String&& patternString, JSC::Strong<JSC::RegExp>&& regex, Vector<String>&& groupNameList, bool hasRegexpGroupsFromPartsList)
     : m_patternString(WTFMove(patternString))
     , m_regularExpression(WTFMove(regex))
     , m_groupNameList(WTFMove(groupNameList))
-    , m_hasRegexpGroups(hasRegexpGroups)
+    , m_hasRegexGroupsFromPartList(hasRegexpGroupsFromPartsList)
 {
 }
 

--- a/Source/WebCore/Modules/url-pattern/URLPatternComponent.h
+++ b/Source/WebCore/Modules/url-pattern/URLPatternComponent.h
@@ -48,6 +48,7 @@ class URLPatternComponent {
 public:
     static ExceptionOr<URLPatternComponent> compile(Ref<JSC::VM>, StringView, EncodingCallbackType, const URLPatternStringOptions&);
     const String& patternString() const { return m_patternString; }
+    bool hasRegexGroupsFromPartList() const { return m_hasRegexGroupsFromPartList; }
     bool matchSpecialSchemeProtocol(ScriptExecutionContext&) const;
     JSC::JSValue componentExec(ScriptExecutionContext&, StringView) const;
     URLPatternComponentResult createComponentMatchResult(ScriptExecutionContext&, String&& input, const JSC::JSValue& execResult) const;
@@ -59,7 +60,7 @@ private:
     String m_patternString;
     JSC::Strong<JSC::RegExp> m_regularExpression;
     Vector<String> m_groupNameList;
-    bool m_hasRegexpGroups = false;
+    bool m_hasRegexGroupsFromPartList { false };
 };
 
 }


### PR DESCRIPTION
#### 9e068816a4d09501d860eac78027365a3e17905d
<pre>
Implement URLPattern::hasRegExpGroup()
<a href="https://bugs.webkit.org/show_bug.cgi?id=284499">https://bugs.webkit.org/show_bug.cgi?id=284499</a>
<a href="https://rdar.apple.com/141326011">rdar://141326011</a>

Reviewed by Chris Dumez and Sihui Liu.

See spec: <a href="https://urlpattern.spec.whatwg.org/#url-pattern-has-regexp-groups">https://urlpattern.spec.whatwg.org/#url-pattern-has-regexp-groups</a>

* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-hasregexpgroups.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-hasregexpgroups.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-hasregexpgroups.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-hasregexpgroups.any.worker-expected.txt:
* Source/WebCore/Modules/url-pattern/URLPattern.cpp:
(WebCore::URLPattern::hasRegExpGroups const):
* Source/WebCore/Modules/url-pattern/URLPattern.h:
* Source/WebCore/Modules/url-pattern/URLPatternComponent.cpp:
(WebCore::URLPatternUtilities::URLPatternComponent::URLPatternComponent):
* Source/WebCore/Modules/url-pattern/URLPatternComponent.h:
(WebCore::URLPatternUtilities::URLPatternComponent::hasRegexGroupsFromPartList const):

Canonical link: <a href="https://commits.webkit.org/287794@main">https://commits.webkit.org/287794@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/898db262f20d3fcfa73f2f7e25fdc10429e4330c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80717 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/239 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34653 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85244 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31701 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82828 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/256 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8036 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63043 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20836 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83786 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/96 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73474 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43345 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32 "layout-tests (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27634 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30158 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71594 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28160 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86676 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7944 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5613 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71334 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8121 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69310 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70575 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14599 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13544 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12538 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7906 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13427 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7745 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11264 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9551 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->