### PR TITLE
[WebCodecs] Limit the number of codec operations we can enqueue

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -650,6 +650,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/webcodecs/WebCodecsAlphaOption.h
     Modules/webcodecs/WebCodecsAudioData.h
     Modules/webcodecs/WebCodecsAudioInternalData.h
+    Modules/webcodecs/WebCodecsBase.h
     Modules/webcodecs/WebCodecsEncodedAudioChunk.h
     Modules/webcodecs/WebCodecsEncodedAudioChunkData.h
     Modules/webcodecs/WebCodecsEncodedAudioChunkType.h

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h
@@ -28,16 +28,12 @@
 
 #if ENABLE(WEB_CODECS)
 
-#include "ActiveDOMObject.h"
 #include "AudioDecoder.h"
-#include "EventTarget.h"
 #include "JSDOMPromiseDeferredForward.h"
 #include "WebCodecsAudioDecoderConfig.h"
 #include "WebCodecsAudioDecoderSupport.h"
-#include "WebCodecsCodecState.h"
-#include "WebCodecsControlMessage.h"
+#include "WebCodecsBase.h"
 #include "WebCodecsEncodedAudioChunkType.h"
-#include <wtf/Deque.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -46,10 +42,7 @@ class WebCodecsEncodedAudioChunk;
 class WebCodecsErrorCallback;
 class WebCodecsAudioDataOutputCallback;
 
-class WebCodecsAudioDecoder
-    : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebCodecsAudioDecoder>
-    , public ActiveDOMObject
-    , public EventTarget {
+class WebCodecsAudioDecoder : public WebCodecsBase {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WebCodecsAudioDecoder);
 public:
     ~WebCodecsAudioDecoder();
@@ -61,8 +54,7 @@ public:
 
     static Ref<WebCodecsAudioDecoder> create(ScriptExecutionContext&, Init&&);
 
-    WebCodecsCodecState state() const { return m_state; }
-    size_t decodeQueueSize() const { return m_decodeQueueSize; }
+    size_t decodeQueueSize() const { return codecQueueSize(); }
 
     ExceptionOr<void> configure(ScriptExecutionContext&, WebCodecsAudioDecoderConfig&&);
     ExceptionOr<void> decode(Ref<WebCodecsEncodedAudioChunk>&&);
@@ -71,10 +63,6 @@ public:
     ExceptionOr<void> close();
 
     static void isConfigSupported(ScriptExecutionContext&, WebCodecsAudioDecoderConfig&&, Ref<DeferredPromise>&&);
-
-    // ActiveDOMObject.
-    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
-    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
 
     WebCodecsAudioDataOutputCallback& outputCallbackConcurrently() { return m_output.get(); }
     WebCodecsErrorCallback& errorCallbackConcurrently() { return m_error.get(); }
@@ -85,32 +73,19 @@ private:
     // ActiveDOMObject.
     void stop() final;
     void suspend(ReasonForSuspension) final;
-    bool virtualHasPendingActivity() const final;
 
     // EventTarget
-    void refEventTarget() final { ref(); }
-    void derefEventTarget() final { deref(); }
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::WebCodecsAudioDecoder; }
-    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
 
     ExceptionOr<void> closeDecoder(Exception&&);
     ExceptionOr<void> resetDecoder(const Exception&);
     void setInternalDecoder(Ref<AudioDecoder>&&);
-    void scheduleDequeueEvent();
 
-    void queueControlMessageAndProcess(WebCodecsControlMessage<WebCodecsAudioDecoder>&&);
-    void processControlMessageQueue();
-
-    WebCodecsCodecState m_state { WebCodecsCodecState::Unconfigured };
-    size_t m_decodeQueueSize { 0 };
     Ref<WebCodecsAudioDataOutputCallback> m_output;
     Ref<WebCodecsErrorCallback> m_error;
     RefPtr<AudioDecoder> m_internalDecoder;
-    bool m_dequeueEventScheduled { false };
     Vector<Ref<DeferredPromise>> m_pendingFlushPromises;
     bool m_isKeyChunkRequired { false };
-    Deque<WebCodecsControlMessage<WebCodecsAudioDecoder>> m_controlMessageQueue;
-    bool m_isMessageQueueBlocked { false };
     size_t m_decoderCount { 0 };
 };
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.h
@@ -28,14 +28,10 @@
 
 #if ENABLE(WEB_CODECS)
 
-#include "ActiveDOMObject.h"
 #include "AudioEncoder.h"
-#include "EventTarget.h"
 #include "JSDOMPromiseDeferredForward.h"
 #include "WebCodecsAudioEncoderConfig.h"
-#include "WebCodecsCodecState.h"
-#include "WebCodecsControlMessage.h"
-#include <wtf/RefCounted.h>
+#include "WebCodecsBase.h"
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -46,10 +42,7 @@ class WebCodecsEncodedAudioChunkOutputCallback;
 class WebCodecsAudioData;
 struct WebCodecsEncodedAudioChunkMetadata;
 
-class WebCodecsAudioEncoder
-    : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebCodecsAudioEncoder>
-    , public ActiveDOMObject
-    , public EventTarget {
+class WebCodecsAudioEncoder : public WebCodecsBase {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WebCodecsAudioEncoder);
 public:
     ~WebCodecsAudioEncoder();
@@ -61,8 +54,7 @@ public:
 
     static Ref<WebCodecsAudioEncoder> create(ScriptExecutionContext&, Init&&);
 
-    WebCodecsCodecState state() const { return m_state; }
-    size_t encodeQueueSize() const { return m_encodeQueueSize; }
+    size_t encodeQueueSize() const { return codecQueueSize(); }
 
     ExceptionOr<void> configure(ScriptExecutionContext&, WebCodecsAudioEncoderConfig&&);
     ExceptionOr<void> encode(Ref<WebCodecsAudioData>&&);
@@ -72,10 +64,6 @@ public:
 
     static void isConfigSupported(ScriptExecutionContext&, WebCodecsAudioEncoderConfig&&, Ref<DeferredPromise>&&);
 
-    // ActiveDOMObject.
-    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
-    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
-
     WebCodecsEncodedAudioChunkOutputCallback& outputCallbackConcurrently() { return m_output.get(); }
     WebCodecsErrorCallback& errorCallbackConcurrently() { return m_error.get(); }
 private:
@@ -84,33 +72,22 @@ private:
     // ActiveDOMObject.
     void stop() final;
     void suspend(ReasonForSuspension) final;
-    bool virtualHasPendingActivity() const final;
 
     // EventTarget.
-    void refEventTarget() final { ref(); }
-    void derefEventTarget() final { deref(); }
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::WebCodecsAudioEncoder; }
-    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
 
     ExceptionOr<void> closeEncoder(Exception&&);
     ExceptionOr<void> resetEncoder(const Exception&);
     void setInternalEncoder(Ref<AudioEncoder>&&);
-    void scheduleDequeueEvent();
 
-    void queueControlMessageAndProcess(WebCodecsControlMessage<WebCodecsAudioEncoder>&&);
-    void processControlMessageQueue();
     WebCodecsEncodedAudioChunkMetadata createEncodedChunkMetadata();
 
-    WebCodecsCodecState m_state { WebCodecsCodecState::Unconfigured };
     size_t m_encodeQueueSize { 0 };
     Ref<WebCodecsEncodedAudioChunkOutputCallback> m_output;
     Ref<WebCodecsErrorCallback> m_error;
     RefPtr<AudioEncoder> m_internalEncoder;
-    bool m_dequeueEventScheduled { false };
     Vector<Ref<DeferredPromise>> m_pendingFlushPromises;
     bool m_isKeyChunkRequired { false };
-    Deque<WebCodecsControlMessage<WebCodecsAudioEncoder>> m_controlMessageQueue;
-    bool m_isMessageQueueBlocked { false };
     WebCodecsAudioEncoderConfig m_baseConfiguration;
     AudioEncoder::ActiveConfiguration m_activeConfiguration;
     bool m_hasNewActiveConfiguration { false };

--- a/Source/WebCore/Modules/webcodecs/WebCodecsBase.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsBase.cpp
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebCodecsBase.h"
+
+#if ENABLE(WEB_CODECS)
+
+#include "Event.h"
+#include "EventNames.h"
+#include "WebCodecsControlMessage.h"
+
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WebCodecsBase);
+
+WebCodecsBase::WebCodecsBase(ScriptExecutionContext& context)
+    : ActiveDOMObject(&context)
+{
+}
+
+WebCodecsBase::~WebCodecsBase() = default;
+
+void WebCodecsBase::queueControlMessageAndProcess(WebCodecsControlMessage&& message)
+{
+    if (m_isMessageQueueBlocked) {
+        m_controlMessageQueue.append(WTFMove(message));
+        return;
+    }
+    m_controlMessageQueue.append(WTFMove(message));
+    processControlMessageQueue();
+}
+
+void WebCodecsBase::queueCodecControlMessageAndProcess(WebCodecsControlMessage&& message)
+{
+    incrementCodecQueueSize();
+    // message holds a strong ref to ourselves already.
+    queueControlMessageAndProcess({ *this, [this, message = WTFMove(message)]() mutable {
+        if (isCodecSaturated())
+            return WebCodecsControlMessageOutcome::NotProcessed;
+        decrementCodecQueueSizeAndScheduleDequeueEvent();
+        return message();
+    } });
+}
+
+void WebCodecsBase::scheduleDequeueEvent()
+{
+    if (m_dequeueEventScheduled)
+        return;
+
+    m_dequeueEventScheduled = true;
+    queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this]() mutable {
+        dispatchEvent(Event::create(eventNames().dequeueEvent, Event::CanBubble::No, Event::IsCancelable::No));
+        m_dequeueEventScheduled = false;
+    });
+}
+
+void WebCodecsBase::processControlMessageQueue()
+{
+    while (!m_isMessageQueueBlocked && !m_controlMessageQueue.isEmpty()) {
+        auto& frontMessage = m_controlMessageQueue.first();
+        auto outcome = frontMessage();
+        if (outcome == WebCodecsControlMessageOutcome::NotProcessed)
+            break;
+        m_controlMessageQueue.removeFirst();
+    }
+}
+
+void WebCodecsBase::incrementCodecQueueSize()
+{
+    m_codecControlMessagesPending++;
+}
+
+// Equivalent to spec's "Decrement [[encodeQueueSize]] or "Decrement [[decodeQueueSize]]" and run the Schedule Dequeue Event algorithm"
+void WebCodecsBase::decrementCodecQueueSizeAndScheduleDequeueEvent()
+{
+    m_codecControlMessagesPending--;
+    scheduleDequeueEvent();
+}
+
+void WebCodecsBase::decrementCodecOperationCountAndMaybeProcessControlMessageQueue()
+{
+    ASSERT(m_codecOperationsPending > 0);
+    m_codecOperationsPending--;
+    if (!isCodecSaturated())
+        processControlMessageQueue();
+}
+
+void WebCodecsBase::clearControlMessageQueue()
+{
+    m_controlMessageQueue.clear();
+}
+
+void WebCodecsBase::clearControlMessageQueueAndMaybeScheduleDequeueEvent()
+{
+    clearControlMessageQueue();
+    if (m_codecControlMessagesPending) {
+        m_codecControlMessagesPending = 0;
+        scheduleDequeueEvent();
+    }
+}
+
+void WebCodecsBase::blockControlMessageQueue()
+{
+    m_isMessageQueueBlocked = true;
+}
+
+void WebCodecsBase::unblockControlMessageQueue()
+{
+    m_isMessageQueueBlocked = false;
+    processControlMessageQueue();
+}
+
+bool WebCodecsBase::virtualHasPendingActivity() const
+{
+    return m_state == WebCodecsCodecState::Configured && (m_codecControlMessagesPending || m_isMessageQueueBlocked);
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_CODECS)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsBase.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsBase.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_CODECS)
+
+#include "ActiveDOMObject.h"
+#include "EventTarget.h"
+#include "WebCodecsCodecState.h"
+#include <wtf/Deque.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeWeakPtr.h>
+
+namespace WebCore {
+
+class WebCodecsControlMessage;
+
+// WebCodecsBase implements the "Control Message Queue"
+// as per https://w3c.github.io/webcodecs/#control-message-queue-slot
+// And handle "Codec Saturation"
+// as per https://w3c.github.io/webcodecs/#saturated
+class WebCodecsBase
+    : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebCodecsBase>
+    , public ActiveDOMObject
+    , public EventTarget {
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WebCodecsBase);
+public:
+    virtual ~WebCodecsBase();
+
+    WebCodecsCodecState state() const { return m_state; }
+
+    // ActiveDOMObject.
+    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
+    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
+    bool virtualHasPendingActivity() const final;
+
+protected:
+    WebCodecsBase(ScriptExecutionContext&);
+    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
+
+    void setState(WebCodecsCodecState state) { m_state = state; }
+
+    size_t codecQueueSize() const { return m_codecControlMessagesPending; }
+    void queueControlMessageAndProcess(WebCodecsControlMessage&&);
+    void queueCodecControlMessageAndProcess(WebCodecsControlMessage&&);
+    void processControlMessageQueue();
+    void clearControlMessageQueue();
+    void clearControlMessageQueueAndMaybeScheduleDequeueEvent();
+    void blockControlMessageQueue();
+    void unblockControlMessageQueue();
+
+    virtual size_t maximumCodecOperationsEnqueued() const { return 1; }
+    void incrementCodecOperationCount() { m_codecOperationsPending++; };
+    void decrementCodecOperationCountAndMaybeProcessControlMessageQueue();
+
+private:
+    // EventTarget
+    void refEventTarget() final { ref(); }
+    void derefEventTarget() final { deref(); }
+
+    // Equivalent to spec's "Increment [[encodeQueueSize]]." or "Increment [[decodeQueueSize]]"
+    void incrementCodecQueueSize();
+    // Equivalent to spec's "Decrement [[encodeQueueSize]] or "Decrement [[decodeQueueSize]]" and run the Schedule Dequeue Event algorithm"
+    void decrementCodecQueueSizeAndScheduleDequeueEvent();
+    bool isCodecSaturated() const { return m_codecOperationsPending >= maximumCodecOperationsEnqueued(); }
+    void scheduleDequeueEvent();
+
+    bool m_isMessageQueueBlocked { false };
+    size_t m_codecControlMessagesPending { 0 };
+    size_t m_codecOperationsPending { 0 };
+    bool m_dequeueEventScheduled { false };
+    Deque<WebCodecsControlMessage> m_controlMessageQueue;
+    WebCodecsCodecState m_state { WebCodecsCodecState::Unconfigured };
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_CODECS)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsControlMessage.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsControlMessage.h
@@ -27,15 +27,19 @@
 
 #if ENABLE(WEB_CODECS)
 
-#include "ActiveDOMObject.h"
+#include "WebCodecsBase.h"
 #include <wtf/Function.h>
 
 namespace WebCore {
 
-template <typename CodecType>
+enum class WebCodecsControlMessageOutcome : bool {
+    NotProcessed,
+    Processed
+};
+
 class WebCodecsControlMessage final {
 public:
-    WebCodecsControlMessage(CodecType& codec, Function<void()>&& message)
+    WebCodecsControlMessage(WebCodecsBase& codec, Function<WebCodecsControlMessageOutcome()>&& message)
         : m_pendingActivity(codec.makePendingActivity(codec))
         , m_message(WTFMove(message))
     {
@@ -47,14 +51,14 @@ public:
     {
     }
 
-    void operator()()
+    WebCodecsControlMessageOutcome operator()()
     {
-        m_message();
+        return m_message();
     }
 
 private:
-    Ref<ActiveDOMObject::PendingActivity<CodecType>> m_pendingActivity;
-    Function<void()> m_message;
+    Ref<ActiveDOMObject::PendingActivity<WebCodecsBase>> m_pendingActivity;
+    Function<WebCodecsControlMessageOutcome()> m_message;
 };
 
 }

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
@@ -31,8 +31,6 @@
 #include "CSSStyleImageValue.h"
 #include "ContextDestructionObserverInlines.h"
 #include "DOMException.h"
-#include "Event.h"
-#include "EventNames.h"
 #include "HTMLCanvasElement.h"
 #include "HTMLImageElement.h"
 #include "HTMLVideoElement.h"
@@ -42,12 +40,13 @@
 #include "OffscreenCanvas.h"
 #include "SVGImageElement.h"
 #include "ScriptExecutionContext.h"
-#include <variant>
+#include "WebCodecsControlMessage.h"
 #include "WebCodecsEncodedVideoChunk.h"
 #include "WebCodecsErrorCallback.h"
 #include "WebCodecsUtilities.h"
 #include "WebCodecsVideoFrame.h"
 #include "WebCodecsVideoFrameOutputCallback.h"
+#include <variant>
 #include <wtf/ASCIICType.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -65,7 +64,7 @@ Ref<WebCodecsVideoDecoder> WebCodecsVideoDecoder::create(ScriptExecutionContext&
 }
 
 WebCodecsVideoDecoder::WebCodecsVideoDecoder(ScriptExecutionContext& context, Init&& init)
-    : ActiveDOMObject(&context)
+    : WebCodecsBase(context)
     , m_output(init.output.releaseNonNull())
     , m_error(init.error.releaseNonNull())
 {
@@ -137,10 +136,10 @@ ExceptionOr<void> WebCodecsVideoDecoder::configure(ScriptExecutionContext& conte
     if (!isValidDecoderConfig(config))
         return Exception { ExceptionCode::TypeError, "Config is not valid"_s };
 
-    if (m_state == WebCodecsCodecState::Closed || !scriptExecutionContext())
+    if (state() == WebCodecsCodecState::Closed || !scriptExecutionContext())
         return Exception { ExceptionCode::InvalidStateError, "VideoDecoder is closed"_s };
 
-    m_state = WebCodecsCodecState::Configured;
+    setState(WebCodecsCodecState::Configured);
     m_isKeyChunkRequired = true;
 
     bool isSupportedCodec = isSupportedDecoderCodec(config.codec, context.settingsValues());
@@ -149,17 +148,17 @@ ExceptionOr<void> WebCodecsVideoDecoder::configure(ScriptExecutionContext& conte
 
         auto identifier = context->identifier();
 
-        m_isMessageQueueBlocked = true;
+        blockControlMessageQueue();
         if (!isSupportedCodec) {
             postTaskToCodec<WebCodecsVideoDecoder>(identifier, *this, [] (auto& decoder) {
                 decoder.closeDecoder(Exception { ExceptionCode::NotSupportedError, "Codec is not supported"_s });
             });
-            return;
+            return WebCodecsControlMessageOutcome::Processed;
         }
 
         Ref createDecoderPromise = VideoDecoder::create(config.codec, createVideoDecoderConfig(config), [identifier, weakThis = ThreadSafeWeakPtr { *this }, decoderCount = ++m_decoderCount] (auto&& result) {
             postTaskToCodec<WebCodecsVideoDecoder>(identifier, weakThis, [result = WTFMove(result), decoderCount] (auto& decoder) mutable {
-                if (decoder.m_state != WebCodecsCodecState::Configured || decoder.m_decoderCount != decoderCount)
+                if (decoder.state() != WebCodecsCodecState::Configured || decoder.m_decoderCount != decoderCount)
                     return;
 
                 if (!result) {
@@ -189,16 +188,17 @@ ExceptionOr<void> WebCodecsVideoDecoder::configure(ScriptExecutionContext& conte
                 return;
             }
             protectedThis->setInternalDecoder(WTFMove(*result));
-            protectedThis->m_isMessageQueueBlocked = false;
-            protectedThis->processControlMessageQueue();
+            protectedThis->unblockControlMessageQueue();
         });
+
+        return WebCodecsControlMessageOutcome::Processed;
     } });
     return { };
 }
 
 ExceptionOr<void> WebCodecsVideoDecoder::decode(Ref<WebCodecsEncodedVideoChunk>&& chunk)
 {
-    if (m_state != WebCodecsCodecState::Configured)
+    if (state() != WebCodecsCodecState::Configured)
         return Exception { ExceptionCode::InvalidStateError, "VideoDecoder is not configured"_s };
 
     if (m_isKeyChunkRequired) {
@@ -207,26 +207,28 @@ ExceptionOr<void> WebCodecsVideoDecoder::decode(Ref<WebCodecsEncodedVideoChunk>&
         m_isKeyChunkRequired = false;
     }
 
-    ++m_decodeQueueSize;
-    queueControlMessageAndProcess({ *this, [this, chunk = WTFMove(chunk)]() mutable {
-        --m_decodeQueueSize;
-        scheduleDequeueEvent();
-
+    queueCodecControlMessageAndProcess({ *this, [this, chunk = WTFMove(chunk)]() mutable {
+        incrementCodecOperationCount();
         Ref internalDecoder = *m_internalDecoder;
         protectedScriptExecutionContext()->enqueueTaskWhenSettled(internalDecoder->decode({ chunk->span(), chunk->type() == WebCodecsEncodedVideoChunkType::Key, chunk->timestamp(), chunk->duration() }), TaskSource::MediaElement, [weakThis = ThreadSafeWeakPtr { * this }, pendingActivity = makePendingActivity(*this)] (auto&& result) {
             RefPtr protectedThis = weakThis.get();
-            if (!protectedThis || !!result)
+            if (!protectedThis)
                 return;
 
-            protectedThis->closeDecoder(Exception { ExceptionCode::EncodingError, WTFMove(result.error()) });
+            if (!result) {
+                protectedThis->closeDecoder(Exception { ExceptionCode::EncodingError, WTFMove(result.error()) });
+                return;
+            }
+            protectedThis->decrementCodecOperationCountAndMaybeProcessControlMessageQueue();
         });
+        return WebCodecsControlMessageOutcome::Processed;
     } });
     return { };
 }
 
 ExceptionOr<void> WebCodecsVideoDecoder::flush(Ref<DeferredPromise>&& promise)
 {
-    if (m_state != WebCodecsCodecState::Configured)
+    if (state() != WebCodecsCodecState::Configured)
         return Exception { ExceptionCode::InvalidStateError, "VideoDecoder is not configured"_s };
 
     m_isKeyChunkRequired = true;
@@ -238,6 +240,7 @@ ExceptionOr<void> WebCodecsVideoDecoder::flush(Ref<DeferredPromise>&& promise)
             if (RefPtr protectedThis = weakThis.get())
                 protectedThis->m_pendingFlushPromises.removeFirstMatching([&](auto& flushPromise) { return promise.ptr() == flushPromise.ptr(); });
         });
+        return WebCodecsControlMessageOutcome::Processed;
     } });
     return { };
 }
@@ -275,7 +278,7 @@ ExceptionOr<void> WebCodecsVideoDecoder::closeDecoder(Exception&& exception)
     auto result = resetDecoder(exception);
     if (result.hasException())
         return result;
-    m_state = WebCodecsCodecState::Closed;
+    setState(WebCodecsCodecState::Closed);
     m_internalDecoder = nullptr;
     if (exception.code() != ExceptionCode::AbortError)
         m_error->handleEvent(DOMException::create(WTFMove(exception)));
@@ -285,17 +288,13 @@ ExceptionOr<void> WebCodecsVideoDecoder::closeDecoder(Exception&& exception)
 
 ExceptionOr<void> WebCodecsVideoDecoder::resetDecoder(const Exception& exception)
 {
-    if (m_state == WebCodecsCodecState::Closed)
+    if (state() == WebCodecsCodecState::Closed)
         return Exception { ExceptionCode::InvalidStateError, "VideoDecoder is closed"_s };
 
-    m_state = WebCodecsCodecState::Unconfigured;
+    setState(WebCodecsCodecState::Unconfigured);
     if (RefPtr internalDecoder = std::exchange(m_internalDecoder, { }))
         internalDecoder->reset();
-    m_controlMessageQueue.clear();
-    if (m_decodeQueueSize) {
-        m_decodeQueueSize = 0;
-        scheduleDequeueEvent();
-    }
+    clearControlMessageQueueAndMaybeScheduleDequeueEvent();
 
     auto promises = std::exchange(m_pendingFlushPromises, { });
     for (auto& promise : promises)
@@ -304,42 +303,9 @@ ExceptionOr<void> WebCodecsVideoDecoder::resetDecoder(const Exception& exception
     return { };
 }
 
-void WebCodecsVideoDecoder::scheduleDequeueEvent()
-{
-    if (m_dequeueEventScheduled)
-        return;
-
-    m_dequeueEventScheduled = true;
-    queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this]() mutable {
-        dispatchEvent(Event::create(eventNames().dequeueEvent, Event::CanBubble::No, Event::IsCancelable::No));
-        m_dequeueEventScheduled = false;
-    });
-}
-
 void WebCodecsVideoDecoder::setInternalDecoder(Ref<VideoDecoder>&& internalDecoder)
 {
     m_internalDecoder = WTFMove(internalDecoder);
-}
-
-void WebCodecsVideoDecoder::queueControlMessageAndProcess(WebCodecsControlMessage<WebCodecsVideoDecoder>&& message)
-{
-    if (m_isMessageQueueBlocked) {
-        m_controlMessageQueue.append(WTFMove(message));
-        return;
-    }
-    if (m_controlMessageQueue.isEmpty()) {
-        message();
-        return;
-    }
-
-    m_controlMessageQueue.append(WTFMove(message));
-    processControlMessageQueue();
-}
-
-void WebCodecsVideoDecoder::processControlMessageQueue()
-{
-    while (!m_isMessageQueueBlocked && !m_controlMessageQueue.isEmpty())
-        m_controlMessageQueue.takeFirst()();
 }
 
 void WebCore::WebCodecsVideoDecoder::suspend(ReasonForSuspension)
@@ -348,15 +314,10 @@ void WebCore::WebCodecsVideoDecoder::suspend(ReasonForSuspension)
 
 void WebCodecsVideoDecoder::stop()
 {
-    m_state = WebCodecsCodecState::Closed;
+    setState(WebCodecsCodecState::Closed);
     m_internalDecoder = nullptr;
-    m_controlMessageQueue.clear();
+    clearControlMessageQueue();
     m_pendingFlushPromises.clear();
-}
-
-bool WebCodecsVideoDecoder::virtualHasPendingActivity() const
-{
-    return m_state == WebCodecsCodecState::Configured && (m_decodeQueueSize || m_isMessageQueueBlocked);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h
@@ -27,15 +27,11 @@
 
 #if ENABLE(WEB_CODECS)
 
-#include "ActiveDOMObject.h"
-#include "EventTarget.h"
 #include "JSDOMPromiseDeferredForward.h"
 #include "VideoDecoder.h"
-#include "WebCodecsCodecState.h"
-#include "WebCodecsControlMessage.h"
+#include "WebCodecsBase.h"
 #include "WebCodecsEncodedVideoChunkType.h"
 #include "WebCodecsVideoDecoderSupport.h"
-#include <wtf/Deque.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -44,10 +40,7 @@ class WebCodecsEncodedVideoChunk;
 class WebCodecsErrorCallback;
 class WebCodecsVideoFrameOutputCallback;
 
-class WebCodecsVideoDecoder
-    : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebCodecsVideoDecoder>
-    , public ActiveDOMObject
-    , public EventTarget {
+class WebCodecsVideoDecoder : public WebCodecsBase {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WebCodecsVideoDecoder);
 public:
     ~WebCodecsVideoDecoder();
@@ -59,8 +52,7 @@ public:
 
     static Ref<WebCodecsVideoDecoder> create(ScriptExecutionContext&, Init&&);
 
-    WebCodecsCodecState state() const { return m_state; }
-    size_t decodeQueueSize() const { return m_decodeQueueSize; }
+    size_t decodeQueueSize() const { return codecQueueSize(); }
 
     WebCodecsVideoFrameOutputCallback& outputCallbackConcurrently() { return m_output.get(); }
     WebCodecsErrorCallback& errorCallbackConcurrently() { return m_error.get(); }
@@ -73,42 +65,26 @@ public:
 
     static void isConfigSupported(ScriptExecutionContext&, WebCodecsVideoDecoderConfig&&, Ref<DeferredPromise>&&);
 
-    // ActiveDOMObject.
-    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
-    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
-
 private:
     WebCodecsVideoDecoder(ScriptExecutionContext&, Init&&);
+    size_t maximumCodecOperationsEnqueued() const final { return 4; }
 
     // ActiveDOMObject.
     void stop() final;
     void suspend(ReasonForSuspension) final;
-    bool virtualHasPendingActivity() const final;
 
     // EventTarget.
-    void refEventTarget() final { ref(); }
-    void derefEventTarget() final { deref(); }
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::WebCodecsVideoDecoder; }
-    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
 
     ExceptionOr<void> closeDecoder(Exception&&);
     ExceptionOr<void> resetDecoder(const Exception&);
     void setInternalDecoder(Ref<VideoDecoder>&&);
-    void scheduleDequeueEvent();
 
-    void queueControlMessageAndProcess(WebCodecsControlMessage<WebCodecsVideoDecoder>&&);
-    void processControlMessageQueue();
-
-    WebCodecsCodecState m_state { WebCodecsCodecState::Unconfigured };
-    size_t m_decodeQueueSize { 0 };
     Ref<WebCodecsVideoFrameOutputCallback> m_output;
     Ref<WebCodecsErrorCallback> m_error;
     RefPtr<VideoDecoder> m_internalDecoder;
-    bool m_dequeueEventScheduled { false };
     Vector<Ref<DeferredPromise>> m_pendingFlushPromises;
     bool m_isKeyChunkRequired { false };
-    Deque<WebCodecsControlMessage<WebCodecsVideoDecoder>> m_controlMessageQueue;
-    bool m_isMessageQueueBlocked { false };
     size_t m_decoderCount { 0 };
 };
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
@@ -30,11 +30,10 @@
 
 #include "ContextDestructionObserverInlines.h"
 #include "DOMException.h"
-#include "Event.h"
-#include "EventNames.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSWebCodecsVideoEncoderSupport.h"
 #include "Logging.h"
+#include "WebCodecsControlMessage.h"
 #include "WebCodecsEncodedVideoChunk.h"
 #include "WebCodecsEncodedVideoChunkMetadata.h"
 #include "WebCodecsEncodedVideoChunkOutputCallback.h"
@@ -60,7 +59,7 @@ Ref<WebCodecsVideoEncoder> WebCodecsVideoEncoder::create(ScriptExecutionContext&
 
 
 WebCodecsVideoEncoder::WebCodecsVideoEncoder(ScriptExecutionContext& context, Init&& init)
-    : ActiveDOMObject(&context)
+    : WebCodecsBase(context)
     , m_output(init.output.releaseNonNull())
     , m_error(init.error.releaseNonNull())
 {
@@ -119,21 +118,20 @@ void WebCodecsVideoEncoder::updateRates(const WebCodecsVideoEncoderConfig& confi
     auto bitrate = config.bitrate.value_or(0);
     auto framerate = config.framerate.value_or(0);
 
-    m_isMessageQueueBlocked = true;
+    blockControlMessageQueue();
     protectedScriptExecutionContext()->enqueueTaskWhenSettled(Ref { *m_internalEncoder }->setRates(bitrate, framerate), TaskSource::MediaElement, [weakThis = ThreadSafeWeakPtr { *this }, bitrate, framerate] (auto&&) mutable {
         auto protectedThis = weakThis.get();
         if (!protectedThis)
             return;
 
-        if (protectedThis->m_state == WebCodecsCodecState::Closed || !protectedThis->scriptExecutionContext())
+        if (protectedThis->state() == WebCodecsCodecState::Closed || !protectedThis->scriptExecutionContext())
             return;
 
         if (bitrate)
             protectedThis->m_baseConfiguration.bitrate = bitrate;
         if (framerate)
             protectedThis->m_baseConfiguration.framerate = framerate;
-        protectedThis->m_isMessageQueueBlocked = false;
-        protectedThis->processControlMessageQueue();
+        protectedThis->unblockControlMessageQueue();
     });
 }
 
@@ -142,31 +140,31 @@ ExceptionOr<void> WebCodecsVideoEncoder::configure(ScriptExecutionContext& conte
     if (!isValidEncoderConfig(config))
         return Exception { ExceptionCode::TypeError, "Config is invalid"_s };
 
-    if (m_state == WebCodecsCodecState::Closed || !scriptExecutionContext())
+    if (state() == WebCodecsCodecState::Closed || !scriptExecutionContext())
         return Exception { ExceptionCode::InvalidStateError, "VideoEncoder is closed"_s };
 
-    m_state = WebCodecsCodecState::Configured;
+    setState(WebCodecsCodecState::Configured);
     m_isKeyChunkRequired = true;
 
     if (m_internalEncoder) {
         queueControlMessageAndProcess({ *this, [this, config]() mutable {
             if (isSameConfigurationExceptBitrateAndFramerate(m_baseConfiguration, config)) {
                 updateRates(config);
-                return;
+                return WebCodecsControlMessageOutcome::Processed;
             }
 
-            m_isMessageQueueBlocked = true;
+            blockControlMessageQueue();
             protectedScriptExecutionContext()->enqueueTaskWhenSettled(Ref { *m_internalEncoder }->flush(), TaskSource::MediaElement, [weakThis = ThreadSafeWeakPtr { *this }, config = WTFMove(config), pendingActivity = makePendingActivity(*this)] (auto&&) mutable {
                 RefPtr protectedThis = weakThis.get();
                 if (!protectedThis)
                     return;
 
-                if (protectedThis->m_state == WebCodecsCodecState::Closed || !protectedThis->scriptExecutionContext())
+                if (protectedThis->state() == WebCodecsCodecState::Closed || !protectedThis->scriptExecutionContext())
                     return;
 
-                protectedThis->m_isMessageQueueBlocked = false;
-                protectedThis->processControlMessageQueue();
+                protectedThis->unblockControlMessageQueue();
             });
+            return WebCodecsControlMessageOutcome::Processed;
         } });
     }
 
@@ -174,18 +172,18 @@ ExceptionOr<void> WebCodecsVideoEncoder::configure(ScriptExecutionContext& conte
     queueControlMessageAndProcess({ *this, [this, config = WTFMove(config), isSupportedCodec]() mutable {
         if (isSupportedCodec && isSameConfigurationExceptBitrateAndFramerate(m_baseConfiguration, config)) {
             updateRates(config);
-            return;
+            return WebCodecsControlMessageOutcome::Processed;
         }
 
         auto identifier = scriptExecutionContext()->identifier();
 
-        m_isMessageQueueBlocked = true;
+        blockControlMessageQueue();
 
         if (!isSupportedCodec) {
             postTaskToCodec<WebCodecsVideoEncoder>(identifier, *this, [] (auto& encoder) {
                 encoder.closeEncoder(Exception { ExceptionCode::NotSupportedError, "Codec is not supported"_s });
             });
-            return;
+            return WebCodecsControlMessageOutcome::Processed;
         }
 
         auto encoderConfig = createVideoEncoderConfig(config);
@@ -193,7 +191,7 @@ ExceptionOr<void> WebCodecsVideoEncoder::configure(ScriptExecutionContext& conte
             postTaskToCodec<WebCodecsVideoEncoder>(identifier, *this, [message = encoderConfig.releaseException().message()] (auto& encoder) mutable {
                 encoder.closeEncoder(Exception { ExceptionCode::NotSupportedError, WTFMove(message) });
             });
-            return;
+            return WebCodecsControlMessageOutcome::Processed;
         }
 
         m_baseConfiguration = config;
@@ -205,7 +203,7 @@ ExceptionOr<void> WebCodecsVideoEncoder::configure(ScriptExecutionContext& conte
             });
         }, [identifier, weakThis = ThreadSafeWeakPtr { *this }, encoderCount = ++m_encoderCount](auto&& result) {
             postTaskToCodec<WebCodecsVideoEncoder>(identifier, weakThis, [result = WTFMove(result), encoderCount] (auto& encoder) mutable {
-                if (encoder.m_state != WebCodecsCodecState::Configured || encoder.m_encoderCount != encoderCount)
+                if (encoder.state() != WebCodecsCodecState::Configured || encoder.m_encoderCount != encoderCount)
                     return;
 
                 RefPtr<JSC::ArrayBuffer> buffer = JSC::ArrayBuffer::create(result.data);
@@ -229,9 +227,10 @@ ExceptionOr<void> WebCodecsVideoEncoder::configure(ScriptExecutionContext& conte
             }
             protectedThis->setInternalEncoder(WTFMove(*result));
             protectedThis->m_hasNewActiveConfiguration = true;
-            protectedThis->m_isMessageQueueBlocked = false;
-            protectedThis->processControlMessageQueue();
+            protectedThis->unblockControlMessageQueue();
         });
+
+        return WebCodecsControlMessageOutcome::Processed;
     } });
     return { };
 }
@@ -281,30 +280,32 @@ ExceptionOr<void> WebCodecsVideoEncoder::encode(Ref<WebCodecsVideoFrame>&& frame
     }
     ASSERT(!frame->isDetached());
 
-    if (m_state != WebCodecsCodecState::Configured)
+    if (state() != WebCodecsCodecState::Configured)
         return Exception { ExceptionCode::InvalidStateError, "VideoEncoder is not configured"_s };
 
-    ++m_encodeQueueSize;
-    queueControlMessageAndProcess({ *this, [this, internalFrame = internalFrame.releaseNonNull(), timestamp = frame->timestamp(), duration = frame->duration(), options = WTFMove(options)]() mutable {
-        --m_encodeQueueSize;
-        scheduleDequeueEvent();
-
+    queueCodecControlMessageAndProcess({ *this, [this, internalFrame = internalFrame.releaseNonNull(), timestamp = frame->timestamp(), duration = frame->duration(), options = WTFMove(options)]() mutable {
+        incrementCodecOperationCount();
         protectedScriptExecutionContext()->enqueueTaskWhenSettled(Ref { *m_internalEncoder }->encode({ WTFMove(internalFrame), timestamp, duration }, options.keyFrame), TaskSource::MediaElement, [weakThis = ThreadSafeWeakPtr { *this }, pendingActivity = makePendingActivity(*this)] (auto&& result) {
             RefPtr protectedThis = weakThis.get();
-            if (!protectedThis || !!result)
+            if (!protectedThis)
                 return;
 
-            if (RefPtr context = protectedThis->scriptExecutionContext())
-                context->addConsoleMessage(MessageSource::JS, MessageLevel::Error, makeString("VideoEncoder encode failed: "_s, result.error()));
-            protectedThis->closeEncoder(Exception { ExceptionCode::EncodingError, WTFMove(result.error()) });
+            if (!result) {
+                if (RefPtr context = protectedThis->scriptExecutionContext())
+                    context->addConsoleMessage(MessageSource::JS, MessageLevel::Error, makeString("VideoEncoder encode failed: "_s, result.error()));
+                protectedThis->closeEncoder(Exception { ExceptionCode::EncodingError, WTFMove(result.error()) });
+                return;
+            }
+            protectedThis->decrementCodecOperationCountAndMaybeProcessControlMessageQueue();
         });
+        return WebCodecsControlMessageOutcome::Processed;
     } });
     return { };
 }
 
 void WebCodecsVideoEncoder::flush(Ref<DeferredPromise>&& promise)
 {
-    if (m_state != WebCodecsCodecState::Configured) {
+    if (state() != WebCodecsCodecState::Configured) {
         promise->reject(Exception { ExceptionCode::InvalidStateError, "VideoEncoder is not configured"_s });
         return;
     }
@@ -316,6 +317,7 @@ void WebCodecsVideoEncoder::flush(Ref<DeferredPromise>&& promise)
             if (RefPtr protectedThis = weakThis.get())
                 protectedThis->m_pendingFlushPromises.removeFirstMatching([&](auto& flushPromise) { return promise.ptr() == flushPromise.ptr(); });
         });
+        return WebCodecsControlMessageOutcome::Processed;
     } });
 }
 
@@ -358,7 +360,7 @@ ExceptionOr<void> WebCodecsVideoEncoder::closeEncoder(Exception&& exception)
     auto result = resetEncoder(exception);
     if (result.hasException())
         return result;
-    m_state = WebCodecsCodecState::Closed;
+    setState(WebCodecsCodecState::Closed);
     m_internalEncoder = nullptr;
     if (exception.code() != ExceptionCode::AbortError)
         m_error->handleEvent(DOMException::create(WTFMove(exception)));
@@ -368,17 +370,13 @@ ExceptionOr<void> WebCodecsVideoEncoder::closeEncoder(Exception&& exception)
 
 ExceptionOr<void> WebCodecsVideoEncoder::resetEncoder(const Exception& exception)
 {
-    if (m_state == WebCodecsCodecState::Closed)
+    if (state() == WebCodecsCodecState::Closed)
         return Exception { ExceptionCode::InvalidStateError, "VideoEncoder is closed"_s };
 
-    m_state = WebCodecsCodecState::Unconfigured;
+    setState(WebCodecsCodecState::Unconfigured);
     if (RefPtr internalEncoder = std::exchange(m_internalEncoder, { }))
         internalEncoder->reset();
-    m_controlMessageQueue.clear();
-    if (m_encodeQueueSize) {
-        m_encodeQueueSize = 0;
-        scheduleDequeueEvent();
-    }
+    clearControlMessageQueueAndMaybeScheduleDequeueEvent();
 
     auto promises = std::exchange(m_pendingFlushPromises, { });
     for (auto& promise : promises)
@@ -387,42 +385,9 @@ ExceptionOr<void> WebCodecsVideoEncoder::resetEncoder(const Exception& exception
     return { };
 }
 
-void WebCodecsVideoEncoder::scheduleDequeueEvent()
-{
-    if (m_dequeueEventScheduled)
-        return;
-
-    m_dequeueEventScheduled = true;
-    queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this]() mutable {
-        dispatchEvent(Event::create(eventNames().dequeueEvent, Event::CanBubble::No, Event::IsCancelable::No));
-        m_dequeueEventScheduled = false;
-    });
-}
-
 void WebCodecsVideoEncoder::setInternalEncoder(Ref<VideoEncoder>&& internalEncoder)
 {
     m_internalEncoder = WTFMove(internalEncoder);
-}
-
-void WebCodecsVideoEncoder::queueControlMessageAndProcess(WebCodecsControlMessage<WebCodecsVideoEncoder>&& message)
-{
-    if (m_isMessageQueueBlocked) {
-        m_controlMessageQueue.append(WTFMove(message));
-        return;
-    }
-    if (m_controlMessageQueue.isEmpty()) {
-        message();
-        return;
-    }
-
-    m_controlMessageQueue.append(WTFMove(message));
-    processControlMessageQueue();
-}
-
-void WebCodecsVideoEncoder::processControlMessageQueue()
-{
-    while (!m_isMessageQueueBlocked && !m_controlMessageQueue.isEmpty())
-        m_controlMessageQueue.takeFirst()();
 }
 
 void WebCore::WebCodecsVideoEncoder::suspend(ReasonForSuspension)
@@ -431,15 +396,10 @@ void WebCore::WebCodecsVideoEncoder::suspend(ReasonForSuspension)
 
 void WebCodecsVideoEncoder::stop()
 {
-    m_state = WebCodecsCodecState::Closed;
+    setState(WebCodecsCodecState::Closed);
     m_internalEncoder = nullptr;
-    m_controlMessageQueue.clear();
+    clearControlMessageQueue();
     m_pendingFlushPromises.clear();
-}
-
-bool WebCodecsVideoEncoder::virtualHasPendingActivity() const
-{
-    return m_state == WebCodecsCodecState::Configured && (m_encodeQueueSize || m_isMessageQueueBlocked);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
@@ -27,12 +27,9 @@
 
 #if ENABLE(WEB_CODECS)
 
-#include "ActiveDOMObject.h"
-#include "EventTarget.h"
 #include "JSDOMPromiseDeferredForward.h"
 #include "VideoEncoder.h"
-#include "WebCodecsCodecState.h"
-#include "WebCodecsControlMessage.h"
+#include "WebCodecsBase.h"
 #include "WebCodecsVideoEncoderConfig.h"
 #include <wtf/Vector.h>
 
@@ -45,10 +42,7 @@ class WebCodecsVideoFrame;
 struct WebCodecsEncodedVideoChunkMetadata;
 struct WebCodecsVideoEncoderEncodeOptions;
 
-class WebCodecsVideoEncoder
-    : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebCodecsVideoEncoder>
-    , public ActiveDOMObject
-    , public EventTarget {
+class WebCodecsVideoEncoder : public WebCodecsBase {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WebCodecsVideoEncoder);
 public:
     ~WebCodecsVideoEncoder();
@@ -60,8 +54,7 @@ public:
 
     static Ref<WebCodecsVideoEncoder> create(ScriptExecutionContext&, Init&&);
 
-    WebCodecsCodecState state() const { return m_state; }
-    size_t encodeQueueSize() const { return m_encodeQueueSize; }
+    size_t encodeQueueSize() const { return codecQueueSize(); }
 
     ExceptionOr<void> configure(ScriptExecutionContext&, WebCodecsVideoEncoderConfig&&);
     ExceptionOr<void> encode(Ref<WebCodecsVideoFrame>&&, WebCodecsVideoEncoderEncodeOptions&&);
@@ -71,47 +64,32 @@ public:
 
     static void isConfigSupported(ScriptExecutionContext&, WebCodecsVideoEncoderConfig&&, Ref<DeferredPromise>&&);
 
-    // ActiveDOMObject.
-    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
-    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
-
     WebCodecsEncodedVideoChunkOutputCallback& outputCallbackConcurrently() { return m_output.get(); }
     WebCodecsErrorCallback& errorCallbackConcurrently() { return m_error.get(); }
 
 private:
     WebCodecsVideoEncoder(ScriptExecutionContext&, Init&&);
+    size_t maximumCodecOperationsEnqueued() const final { return 4; }
 
     // ActiveDOMObject.
     void stop() final;
     void suspend(ReasonForSuspension) final;
-    bool virtualHasPendingActivity() const final;
 
     // EventTarget
-    void refEventTarget() final { ref(); }
-    void derefEventTarget() final { deref(); }
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::WebCodecsVideoEncoder; }
-    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
 
     ExceptionOr<void> closeEncoder(Exception&&);
     ExceptionOr<void> resetEncoder(const Exception&);
     void setInternalEncoder(Ref<VideoEncoder>&&);
-    void scheduleDequeueEvent();
 
-    void queueControlMessageAndProcess(WebCodecsControlMessage<WebCodecsVideoEncoder>&&);
-    void processControlMessageQueue();
     WebCodecsEncodedVideoChunkMetadata createEncodedChunkMetadata(std::optional<unsigned>);
     void updateRates(const WebCodecsVideoEncoderConfig&);
 
-    WebCodecsCodecState m_state { WebCodecsCodecState::Unconfigured };
-    size_t m_encodeQueueSize { 0 };
     Ref<WebCodecsEncodedVideoChunkOutputCallback> m_output;
     Ref<WebCodecsErrorCallback> m_error;
     RefPtr<VideoEncoder> m_internalEncoder;
-    bool m_dequeueEventScheduled { false };
     Vector<Ref<DeferredPromise>> m_pendingFlushPromises;
     bool m_isKeyChunkRequired { false };
-    Deque<WebCodecsControlMessage<WebCodecsVideoEncoder>> m_controlMessageQueue;
-    bool m_isMessageQueueBlocked { false };
     WebCodecsVideoEncoderConfig m_baseConfiguration;
     VideoEncoder::ActiveConfiguration m_activeConfiguration;
     bool m_hasNewActiveConfiguration { false };

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -462,6 +462,7 @@ Modules/webcodecs/WebCodecsAudioDecoder.cpp
 Modules/webcodecs/WebCodecsAudioData.cpp
 Modules/webcodecs/WebCodecsAudioDataAlgorithms.cpp
 Modules/webcodecs/WebCodecsAudioEncoder.cpp
+Modules/webcodecs/WebCodecsBase.cpp
 Modules/webcodecs/WebCodecsEncodedAudioChunk.cpp
 Modules/webcodecs/WebCodecsEncodedVideoChunk.cpp
 Modules/webcodecs/WebCodecsVideoDecoder.cpp


### PR DESCRIPTION
#### 53a8065088fbe559932c62608a687cf6000cb798
<pre>
[WebCodecs] Limit the number of codec operations we can enqueue
<a href="https://bugs.webkit.org/show_bug.cgi?id=284448">https://bugs.webkit.org/show_bug.cgi?id=284448</a>
<a href="https://rdar.apple.com/141272065">rdar://141272065</a>

Reviewed by Youenn Fablet.

While the WebCodecs specs clearly allows for boundless queue for calculating
&quot;Codec Saturdation&quot;, a side effect is that both decodeQueueSize and encodeQueueSize
can only ever be observed with a size of 0.
The value of decodeQueueSize and encodeQueueSize is used by some site (including W3C&apos;s WebCodecs&apos;s own example)
as a way to limit how much in advance it will attempt to encode or decode.

Both Chrome and Firefox have a limit on how many codecs operations (1 for Firefox, between 1 and 8 for Chrome)
they will enqueue concurrently.
To minimise web compatibility issue, in addition to lodging a spec bug (<a href="https://github.com/w3c/webcodecs/issues/864)">https://github.com/w3c/webcodecs/issues/864)</a>
we also introduce a limit on how many frames with submit to the internal decoder/encoder
before submitting more:
- 1 for Audio
- 4 for Video.

In order of not having to replicate 4 times the code in {Audio|Video}{Encoder|Decoder}
we create a new WebCodecsBase that handles all the control message queue operations
as well as handle how many codec operations have been submitted, and of which
all WebCodecs inherit from.
Doing so allows to remove a lot of similar code across all webcodecs and get
us closer to the verbiage of the specs.

Another benefit is that WebCodecsControlMessage no longer needs to be a templated class,
and we make it return a &quot;Processed&quot; or &quot;Not Processed&quot; value as the specs does.

No change in observable behaviours with existing WPT.
Tested that it allows the WebCodecs reference player to work.
No new tests as none of the work above is per spec.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp:
(WebCore::WebCodecsAudioDecoder::WebCodecsAudioDecoder):
(WebCore::WebCodecsAudioDecoder::configure):
(WebCore::WebCodecsAudioDecoder::decode):
(WebCore::WebCodecsAudioDecoder::flush):
(WebCore::WebCodecsAudioDecoder::closeDecoder):
(WebCore::WebCodecsAudioDecoder::resetDecoder):
(WebCore::WebCodecsAudioDecoder::stop):
(WebCore::WebCodecsAudioDecoder::scheduleDequeueEvent): Deleted.
(WebCore::WebCodecsAudioDecoder::queueControlMessageAndProcess): Deleted.
(WebCore::WebCodecsAudioDecoder::processControlMessageQueue): Deleted.
(WebCore::WebCodecsAudioDecoder::virtualHasPendingActivity const): Deleted.
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h:
(WebCore::WebCodecsAudioDecoder::decodeQueueSize const):
(WebCore::WebCodecsAudioDecoder::state const): Deleted.
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp:
(WebCore::WebCodecsAudioEncoder::WebCodecsAudioEncoder):
(WebCore::WebCodecsAudioEncoder::configure):
(WebCore::WebCodecsAudioEncoder::encode): FlyBy: we need to check the configuration of the AudioData
against the original configuration of the encoder, not the internal configuration which may not always match.
(WebCore::WebCodecsAudioEncoder::flush):
(WebCore::WebCodecsAudioEncoder::closeEncoder):
(WebCore::WebCodecsAudioEncoder::resetEncoder):
(WebCore::WebCodecsAudioEncoder::stop):
(WebCore::WebCodecsAudioEncoder::scheduleDequeueEvent): Deleted.
(WebCore::WebCodecsAudioEncoder::queueControlMessageAndProcess): Deleted.
(WebCore::WebCodecsAudioEncoder::processControlMessageQueue): Deleted.
(WebCore::WebCodecsAudioEncoder::virtualHasPendingActivity const): Deleted.
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.h:
(WebCore::WebCodecsAudioEncoder::encodeQueueSize const):
(WebCore::WebCodecsAudioEncoder::state const): Deleted.
* Source/WebCore/Modules/webcodecs/WebCodecsBase.cpp: Added.
(WebCore::WebCodecsBase::WebCodecsBase):
(WebCore::WebCodecsBase::queueControlMessageAndProcess):
(WebCore::WebCodecsBase::queueCodecControlMessageAndProcess):
(WebCore::WebCodecsBase::scheduleDequeueEvent):
(WebCore::WebCodecsBase::processControlMessageQueue):
(WebCore::WebCodecsBase::incrementCodecQueueSize):
(WebCore::WebCodecsBase::decrementCodecQueueSizeAndScheduleDequeueEvent):
(WebCore::WebCodecsBase::decrementCodecOperationCountAndMaybeProcessControlMessageQueue):
(WebCore::WebCodecsBase::clearControlMessageQueue):
(WebCore::WebCodecsBase::clearControlMessageQueueAndMaybeScheduleDequeueEvent):
(WebCore::WebCodecsBase::blockControlMessageQueue):
(WebCore::WebCodecsBase::unblockControlMessageQueue):
(WebCore::WebCodecsBase::virtualHasPendingActivity const):
* Source/WebCore/Modules/webcodecs/WebCodecsBase.h: Copied from Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h.
(WebCore::WebCodecsBase::state const):
(WebCore::WebCodecsBase::setState):
(WebCore::WebCodecsBase::codecQueueSize const):
(WebCore::WebCodecsBase::maximumCodecOperationsEnqueued const):
(WebCore::WebCodecsBase::incrementCodecOperationCount):
(WebCore::WebCodecsBase::isCodecSaturated const):
* Source/WebCore/Modules/webcodecs/WebCodecsControlMessage.h:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp:
(WebCore::WebCodecsVideoDecoder::WebCodecsVideoDecoder):
(WebCore::WebCodecsVideoDecoder::configure):
(WebCore::WebCodecsVideoDecoder::decode):
(WebCore::WebCodecsVideoDecoder::flush):
(WebCore::WebCodecsVideoDecoder::closeDecoder):
(WebCore::WebCodecsVideoDecoder::resetDecoder):
(WebCore::WebCodecsVideoDecoder::stop):
(WebCore::WebCodecsVideoDecoder::scheduleDequeueEvent): Deleted.
(WebCore::WebCodecsVideoDecoder::queueControlMessageAndProcess): Deleted.
(WebCore::WebCodecsVideoDecoder::processControlMessageQueue): Deleted.
(WebCore::WebCodecsVideoDecoder::virtualHasPendingActivity const): Deleted.
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h:
(WebCore::WebCodecsVideoDecoder::decodeQueueSize const):
(WebCore::WebCodecsVideoDecoder::state const): Deleted.
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp:
(WebCore::WebCodecsVideoEncoder::WebCodecsVideoEncoder):
(WebCore::WebCodecsVideoEncoder::updateRates):
(WebCore::WebCodecsVideoEncoder::configure):
(WebCore::WebCodecsVideoEncoder::encode):
(WebCore::WebCodecsVideoEncoder::flush):
(WebCore::WebCodecsVideoEncoder::closeEncoder):
(WebCore::WebCodecsVideoEncoder::resetEncoder):
(WebCore::WebCodecsVideoEncoder::stop):
(WebCore::WebCodecsVideoEncoder::scheduleDequeueEvent): Deleted.
(WebCore::WebCodecsVideoEncoder::queueControlMessageAndProcess): Deleted.
(WebCore::WebCodecsVideoEncoder::processControlMessageQueue): Deleted.
(WebCore::WebCodecsVideoEncoder::virtualHasPendingActivity const): Deleted.
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h:
(WebCore::WebCodecsVideoEncoder::encodeQueueSize const):
(WebCore::WebCodecsVideoEncoder::state const): Deleted.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/287798@main">https://commits.webkit.org/287798@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93922fa1a842371d316eeb578effee40976f2dc1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80894 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/417 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85422 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31878 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83005 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/435 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8217 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/63170 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20938 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83963 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/237 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73630 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43472 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27790 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30336 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/71700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28329 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86856 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8121 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5737 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71469 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8298 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69466 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70709 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17604 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14738 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/13670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8083 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13604 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7922 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11441 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9728 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->