### PR TITLE
Thread safety in Observables visitAdditionalChildren methods

### DIFF
--- a/Source/WebCore/dom/InternalObserverDrop.cpp
+++ b/Source/WebCore/dom/InternalObserverDrop.cpp
@@ -82,7 +82,7 @@ public:
 
         bool hasCallback() const final { return true; }
 
-        Ref<Observable> m_sourceObservable;
+        const Ref<Observable> m_sourceObservable;
         uint64_t m_amount;
     };
 
@@ -110,7 +110,7 @@ private:
 
     void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
     {
-        protectedSubscriber()->visitAdditionalChildren(visitor);
+        m_subscriber->visitAdditionalChildren(visitor);
     }
 
     Ref<Subscriber> protectedSubscriber() const { return m_subscriber; }
@@ -121,7 +121,7 @@ private:
         , m_amount(amount)
     { }
 
-    Ref<Subscriber> m_subscriber;
+    const Ref<Subscriber> m_subscriber;
     uint64_t m_amount;
 };
 

--- a/Source/WebCore/dom/InternalObserverEvery.cpp
+++ b/Source/WebCore/dom/InternalObserverEvery.cpp
@@ -99,7 +99,7 @@ private:
 
     void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
     {
-        protectedCallback()->visitJSFunction(visitor);
+        m_callback->visitJSFunction(visitor);
     }
 
     Ref<AbortSignal> protectedSignal() const { return m_signal; }
@@ -115,9 +115,9 @@ private:
     }
 
     uint64_t m_idx { 0 };
-    Ref<PredicateCallback> m_callback;
-    Ref<AbortSignal> m_signal;
-    Ref<DeferredPromise> m_promise;
+    const Ref<PredicateCallback> m_callback;
+    const Ref<AbortSignal> m_signal;
+    const Ref<DeferredPromise> m_promise;
 };
 
 void createInternalObserverOperatorEvery(ScriptExecutionContext& context, Observable& observable, Ref<PredicateCallback>&& callback, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)

--- a/Source/WebCore/dom/InternalObserverFilter.cpp
+++ b/Source/WebCore/dom/InternalObserverFilter.cpp
@@ -83,8 +83,8 @@ public:
 
         bool hasCallback() const final { return true; }
 
-        Ref<Observable> m_sourceObservable;
-        Ref<PredicateCallback> m_predicate;
+        const Ref<Observable> m_sourceObservable;
+        const Ref<PredicateCallback> m_predicate;
     };
 
 private:
@@ -135,8 +135,8 @@ private:
 
     void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
     {
-        protectedSubscriber()->visitAdditionalChildren(visitor);
-        protectedPredicate()->visitJSFunction(visitor);
+        m_subscriber->visitAdditionalChildren(visitor);
+        m_predicate->visitJSFunction(visitor);
     }
 
     Ref<Subscriber> protectedSubscriber() const { return m_subscriber; }
@@ -148,8 +148,8 @@ private:
         , m_predicate(predicate)
     { }
 
-    Ref<Subscriber> m_subscriber;
-    Ref<PredicateCallback> m_predicate;
+    const Ref<Subscriber> m_subscriber;
+    const Ref<PredicateCallback> m_predicate;
     uint64_t m_idx { 0 };
 };
 

--- a/Source/WebCore/dom/InternalObserverFind.cpp
+++ b/Source/WebCore/dom/InternalObserverFind.cpp
@@ -100,7 +100,7 @@ private:
 
     void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
     {
-        protectedCallback()->visitJSFunction(visitor);
+        m_callback->visitJSFunction(visitor);
     }
 
     Ref<DeferredPromise> protectedPromise() const { return m_promise; }
@@ -116,9 +116,9 @@ private:
     }
 
     uint64_t m_idx { 0 };
-    Ref<PredicateCallback> m_callback;
-    Ref<AbortSignal> m_signal;
-    Ref<DeferredPromise> m_promise;
+    const Ref<PredicateCallback> m_callback;
+    const Ref<AbortSignal> m_signal;
+    const Ref<DeferredPromise> m_promise;
 };
 
 void createInternalObserverOperatorFind(ScriptExecutionContext& context, Observable& observable, Ref<PredicateCallback>&& callback, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)

--- a/Source/WebCore/dom/InternalObserverFirst.cpp
+++ b/Source/WebCore/dom/InternalObserverFirst.cpp
@@ -80,8 +80,8 @@ private:
     {
     }
 
-    Ref<AbortSignal> m_signal;
-    Ref<DeferredPromise> m_promise;
+    const Ref<AbortSignal> m_signal;
+    const Ref<DeferredPromise> m_promise;
 };
 
 void createInternalObserverOperatorFirst(ScriptExecutionContext& context, Observable& observable, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)

--- a/Source/WebCore/dom/InternalObserverForEach.cpp
+++ b/Source/WebCore/dom/InternalObserverForEach.cpp
@@ -88,7 +88,7 @@ private:
 
     void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
     {
-        protectedCallback()->visitJSFunction(visitor);
+        m_callback->visitJSFunction(visitor);
     }
 
     Ref<DeferredPromise> protectedPromise() const { return m_promise; }
@@ -103,9 +103,9 @@ private:
     }
 
     uint64_t m_idx { 0 };
-    Ref<VisitorCallback> m_callback;
-    Ref<AbortSignal> m_signal;
-    Ref<DeferredPromise> m_promise;
+    const Ref<VisitorCallback> m_callback;
+    const Ref<AbortSignal> m_signal;
+    const Ref<DeferredPromise> m_promise;
 };
 
 void createInternalObserverOperatorForEach(ScriptExecutionContext& context, Observable& observable, Ref<VisitorCallback>&& callback, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)

--- a/Source/WebCore/dom/InternalObserverInspect.cpp
+++ b/Source/WebCore/dom/InternalObserverInspect.cpp
@@ -102,8 +102,8 @@ public:
             , m_inspector(WTFMove(inspector))
         { }
 
-        Ref<Observable> m_sourceObservable;
-        ObservableInspector m_inspector;
+        const Ref<Observable> m_sourceObservable;
+        const ObservableInspector m_inspector;
     };
 
 private:
@@ -175,17 +175,17 @@ private:
 
     void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
     {
-        protectedSubscriber()->visitAdditionalChildren(visitor);
-        if (RefPtr next = m_inspector.next)
-            next->visitJSFunction(visitor);
-        if (RefPtr error = m_inspector.error)
-            error->visitJSFunction(visitor);
-        if (RefPtr complete = m_inspector.complete)
-            complete->visitJSFunction(visitor);
-        if (RefPtr subscribe = m_inspector.subscribe)
-            subscribe->visitJSFunction(visitor);
-        if (RefPtr abort = m_inspector.abort)
-            abort->visitJSFunction(visitor);
+        m_subscriber->visitAdditionalChildren(visitor);
+        if (m_inspector.next)
+            SUPPRESS_UNCOUNTED_ARG m_inspector.next->visitJSFunction(visitor);
+        if (m_inspector.error)
+            SUPPRESS_UNCOUNTED_ARG m_inspector.error->visitJSFunction(visitor);
+        if (m_inspector.complete)
+            SUPPRESS_UNCOUNTED_ARG m_inspector.complete->visitJSFunction(visitor);
+        if (m_inspector.subscribe)
+            SUPPRESS_UNCOUNTED_ARG m_inspector.subscribe->visitJSFunction(visitor);
+        if (m_inspector.abort)
+            SUPPRESS_UNCOUNTED_ARG m_inspector.abort->visitJSFunction(visitor);
     }
 
     void removeAbortHandler()
@@ -222,8 +222,8 @@ private:
         }
     }
 
-    Ref<Subscriber> m_subscriber;
-    ObservableInspector m_inspector;
+    const Ref<Subscriber> m_subscriber;
+    const ObservableInspector m_inspector;
     std::optional<uint32_t> m_abortAlgorithmHandler;
 };
 

--- a/Source/WebCore/dom/InternalObserverLast.cpp
+++ b/Source/WebCore/dom/InternalObserverLast.cpp
@@ -86,7 +86,7 @@ private:
     }
 
     JSValueInWrappedObject m_lastValue;
-    Ref<DeferredPromise> m_promise;
+    const Ref<DeferredPromise> m_promise;
 };
 
 void createInternalObserverOperatorLast(ScriptExecutionContext& context, Observable& observable, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)

--- a/Source/WebCore/dom/InternalObserverReduce.cpp
+++ b/Source/WebCore/dom/InternalObserverReduce.cpp
@@ -101,7 +101,7 @@ private:
 
     void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
     {
-        protectedCallback()->visitJSFunction(visitor);
+        m_callback->visitJSFunction(visitor);
         m_accumulator.visit(visitor);
     }
 
@@ -119,10 +119,10 @@ private:
     }
 
     uint64_t m_index { 0 };
-    Ref<AbortSignal> m_signal;
-    Ref<ReducerCallback> m_callback;
+    const Ref<AbortSignal> m_signal;
+    const Ref<ReducerCallback> m_callback;
     JSValueInWrappedObject m_accumulator;
-    Ref<DeferredPromise> m_promise;
+    const Ref<DeferredPromise> m_promise;
 };
 
 void createInternalObserverOperatorReduce(ScriptExecutionContext& context, Observable& observable, Ref<ReducerCallback>&& callback, JSC::JSValue initialValue, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)

--- a/Source/WebCore/dom/InternalObserverSome.cpp
+++ b/Source/WebCore/dom/InternalObserverSome.cpp
@@ -100,7 +100,7 @@ private:
 
     void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
     {
-        protectedCallback()->visitJSFunction(visitor);
+        m_callback->visitJSFunction(visitor);
     }
 
     Ref<DeferredPromise> protectedPromise() const { return m_promise; }
@@ -116,9 +116,9 @@ private:
     }
 
     uint64_t m_idx { 0 };
-    Ref<PredicateCallback> m_callback;
-    Ref<AbortSignal> m_signal;
-    Ref<DeferredPromise> m_promise;
+    const Ref<PredicateCallback> m_callback;
+    const Ref<AbortSignal> m_signal;
+    const Ref<DeferredPromise> m_promise;
 };
 
 void createInternalObserverOperatorSome(ScriptExecutionContext& context, Observable& observable, Ref<PredicateCallback>&& callback, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)

--- a/Source/WebCore/dom/InternalObserverTake.cpp
+++ b/Source/WebCore/dom/InternalObserverTake.cpp
@@ -82,7 +82,7 @@ public:
 
         bool hasCallback() const final { return true; }
 
-        Ref<Observable> m_sourceObservable;
+        const Ref<Observable> m_sourceObservable;
         uint64_t m_amount;
     };
 
@@ -111,7 +111,7 @@ private:
 
     void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
     {
-        protectedSubscriber()->visitAdditionalChildren(visitor);
+        m_subscriber->visitAdditionalChildren(visitor);
     }
 
     Ref<Subscriber> protectedSubscriber() const { return m_subscriber; }
@@ -122,7 +122,7 @@ private:
         , m_amount(amount)
     { }
 
-    Ref<Subscriber> m_subscriber;
+    const Ref<Subscriber> m_subscriber;
     uint64_t m_amount;
 };
 


### PR DESCRIPTION
#### af27e9ed9ef2f1e26eea8a4541f36ff7c39cb6d0
<pre>
Thread safety in Observables visitAdditionalChildren methods
<a href="https://bugs.webkit.org/show_bug.cgi?id=284500">https://bugs.webkit.org/show_bug.cgi?id=284500</a>

Reviewed by Ryosuke Niwa and Chris Dumez.

visitAdditionalChildren should not ref/deref objects that are
single-threaded ref counted since this function gets called
concurrently to the main thread.

* Source/WebCore/dom/InternalObserverDrop.cpp:
* Source/WebCore/dom/InternalObserverEvery.cpp:
* Source/WebCore/dom/InternalObserverFilter.cpp:
* Source/WebCore/dom/InternalObserverFind.cpp:
* Source/WebCore/dom/InternalObserverFirst.cpp:
* Source/WebCore/dom/InternalObserverForEach.cpp:
* Source/WebCore/dom/InternalObserverInspect.cpp:
* Source/WebCore/dom/InternalObserverLast.cpp:
* Source/WebCore/dom/InternalObserverReduce.cpp:
* Source/WebCore/dom/InternalObserverSome.cpp:
* Source/WebCore/dom/InternalObserverTake.cpp:

Canonical link: <a href="https://commits.webkit.org/287733@main">https://commits.webkit.org/287733@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/adac4d3bd85e5e1f38907323630558767b5ee018

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80648 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59655 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34582 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85172 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31630 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82759 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68716 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7963 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62987 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20780 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83717 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/53117 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73416 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43292 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50400 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27576 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30089 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71549 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28100 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86605 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7874 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5555 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71279 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8049 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69252 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70528 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17575 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14540 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13490 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7836 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13355 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7675 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11194 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9480 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->