### PR TITLE
[cocoa] Add quirk for billpaysite.com

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -61,6 +61,7 @@
 #include "QuirksData.h"
 #include "RegistrableDomain.h"
 #include "ResourceLoadObserver.h"
+#include "ResourceRequest.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGPathElement.h"
 #include "SVGSVGElement.h"
@@ -1453,6 +1454,13 @@ bool Quirks::needsIPhoneUserAgent(const URL& url)
 bool Quirks::needsDesktopUserAgent(const URL& url)
 {
     return needsDesktopUserAgentInternal(url);
+}
+
+bool Quirks::needsPartitionedCookies(const ResourceRequest& request)
+{
+    if (request.isTopSite())
+        return false;
+    return request.url().protocolIsInHTTPFamily() && request.url().host().endsWith(".billpaysite.com"_s);
 }
 
 // premierleague.com: rdar://123721211

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -45,6 +45,7 @@ class LocalFrame;
 class Node;
 class PlatformMouseEvent;
 class RegistrableDomain;
+class ResourceRequest;
 class RenderStyle;
 class SecurityOriginData;
 class WeakPtrImplWithEventTargetData;
@@ -105,6 +106,8 @@ public:
     WEBCORE_EXPORT static bool needsIPadMiniUserAgent(const URL&);
     WEBCORE_EXPORT static bool needsIPhoneUserAgent(const URL&);
     WEBCORE_EXPORT static bool needsDesktopUserAgent(const URL&);
+
+    WEBCORE_EXPORT static bool needsPartitionedCookies(const ResourceRequest&);
 
     WEBCORE_EXPORT static std::optional<Vector<HashSet<String>>> defaultVisibilityAdjustmentSelectors(const URL&);
 

--- a/Source/WebCore/platform/network/NetworkStorageSession.h
+++ b/Source/WebCore/platform/network/NetworkStorageSession.h
@@ -234,6 +234,9 @@ public:
     static String cookiePartitionIdentifier(const URL&);
 #if PLATFORM(COCOA)
     WEBCORE_EXPORT static NSHTTPCookie *capExpiryOfPersistentCookie(NSHTTPCookie *, Seconds cap);
+#if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
+    WEBCORE_EXPORT static NSHTTPCookie *setCookiePartition(NSHTTPCookie *, NSString*);
+#endif
 #endif
     WEBCORE_EXPORT bool hasHadUserInteractionAsFirstParty(const RegistrableDomain&) const;
     WEBCORE_EXPORT void setPrevalentDomainsToBlockAndDeleteCookiesFor(const Vector<RegistrableDomain>&);

--- a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
@@ -346,6 +346,26 @@ NSHTTPCookie *NetworkStorageSession::capExpiryOfPersistentCookie(NSHTTPCookie *c
     return cookie;
 }
 
+#if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
+NSHTTPCookie *NetworkStorageSession::setCookiePartition(NSHTTPCookie *cookie, NSString* partitionKey)
+{
+    if (!cookie)
+        return cookie;
+
+    if (!partitionKey)
+        return cookie;
+
+    if (cookie._storagePartition) {
+        ASSERT(cookie._storagePartition == partitionKey);
+        return cookie;
+    }
+
+    auto properties = adoptNS([[cookie properties] mutableCopy]);
+    [properties setObject:(NSString *)partitionKey forKey:@"StoragePartition"];
+    return [NSHTTPCookie cookieWithProperties:properties.get()];
+}
+#endif
+
 RetainPtr<NSArray> NetworkStorageSession::cookiesForURL(const URL& firstParty, const SameSiteInfo& sameSiteInfo, const URL& url, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, ApplyTrackingPrevention applyTrackingPrevention, ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking) const
 {
     auto thirdPartyCookieBlockingDecision = thirdPartyCookieBlockingDecisionForRequest(firstParty, url, frameID, pageID, shouldRelaxThirdPartyCookieBlocking);

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -335,8 +335,7 @@ NetworkDataTaskCocoa::NetworkDataTaskCocoa(NetworkSession& session, NetworkDataT
 #endif
     }
 
-    if (!isTopLevelNavigation())
-        applyCookiePolicyForThirdPartyCloaking(request);
+    setCookieTransform(request);
     if (shouldBlockCookies(thirdPartyCookieBlockingDecision)) {
 #if !RELEASE_LOG_DISABLED
         if (m_session->shouldLogCookieInformation())

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.h
@@ -57,7 +57,7 @@ protected:
 
     static NSHTTPCookieStorage *statelessCookieStorage();
     bool shouldApplyCookiePolicyForThirdPartyCloaking() const;
-    void applyCookiePolicyForThirdPartyCloaking(const WebCore::ResourceRequest&);
+    void setCookieTransform(const WebCore::ResourceRequest&);
     void blockCookies();
     void unblockCookies();
     static void updateTaskWithFirstPartyForSameSiteCookies(NSURLSessionTask*, const WebCore::ResourceRequest&);
@@ -73,6 +73,9 @@ protected:
     virtual WebCore::StoredCredentialsPolicy storedCredentialsPolicy() const = 0;
 
 private:
+    void setCookieTransformForFirstPartyRequest(const WebCore::ResourceRequest&);
+    void setCookieTransformForThirdPartyRequest(const WebCore::ResourceRequest&);
+
     WeakPtr<NetworkSession> m_networkSession;
     bool m_hasBeenSetToUseStatelessCookieStorage { false };
     Seconds m_ageCapForCNAMECloakedCookies { 24_h * 7 };


### PR DESCRIPTION
#### b0f069e44cd98013c9db57ec2e031111bbcead45
<pre>
[cocoa] Add quirk for billpaysite.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=284503">https://bugs.webkit.org/show_bug.cgi?id=284503</a>
<a href="https://rdar.apple.com/141328971">rdar://141328971</a>

Reviewed by Wenson Hsieh.

As a third party, billpaysite.com relies on access to cookies. These cookies
don&apos;t need to be first party cookies, because a user typically doesn&apos;t interact
with billpaysite.com as a first party. Unfortunately, the site has not adopted
CHIPS yet, either. As a workaround, we can leverage CHIPS and opt the site into
partitioned cookies when it is loaded as a third party.

On Cocoa platforms, we use the _cookieTransform callback where we modify the
cookie&apos;s partition key before it is saved in the cookie store.

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::needsPartitionedCookies):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/platform/network/NetworkStorageSession.h:
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::NetworkStorageSession::setCookiePartition):
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::NetworkDataTaskCocoa):
* Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm:
(WebKit::NetworkTaskCocoa::setCookieTransformForFirstPartyRequest):
(WebKit::NetworkTaskCocoa::setCookieTransformForThirdPartyRequest):
(WebKit::NetworkTaskCocoa::setCookieTransform):
(WebKit::NetworkTaskCocoa::willPerformHTTPRedirection):
(WebKit::NetworkTaskCocoa::applyCookiePolicyForThirdPartyCloaking): Deleted.

Canonical link: <a href="https://commits.webkit.org/288096@main">https://commits.webkit.org/288096@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7673603f47f9430d8a4b64c478d92d08a8a22e94

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81873 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1399 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35827 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86427 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32869 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83979 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1432 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9222 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/63861 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21586 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84943 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1055 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74507 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44146 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/954 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28684 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31322 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29293 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87857 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9113 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6494 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/72217 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9298 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70328 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71439 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15532 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14455 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12684 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9064 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14596 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8905 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12428 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10713 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->