### PR TITLE
Revert 287714@main

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h
@@ -145,10 +145,11 @@ bool nw_resolver_set_update_handler(nw_resolver_t, dispatch_queue_t, nw_resolver
 bool nw_resolver_cancel(nw_resolver_t);
 void nw_context_set_privacy_level(nw_context_t, nw_context_privacy_level_t);
 void nw_parameters_set_context(nw_parameters_t, nw_context_t);
-
 nw_context_t nw_context_create(const char *);
 size_t nw_array_get_count(nw_array_t);
 nw_object_t nw_array_get_object_at_index(nw_array_t, size_t);
+nw_parameters_t nw_parameters_create_quic_stream(nw_parameters_configure_protocol_block_t, nw_parameters_configure_protocol_block_t);
+sec_protocol_options_t nw_quic_connection_copy_sec_protocol_options(nw_protocol_options_t);
 #ifdef __cplusplus
 }
 #endif

--- a/Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h
@@ -58,13 +58,6 @@ nw_interface_t nw_path_copy_interface(nw_path_t);
 
 bool nw_settings_get_unified_http_enabled(void);
 
-void nw_parameters_set_server_mode(nw_parameters_t, bool);
-nw_parameters_t nw_parameters_create_webtransport_http(nw_parameters_configure_protocol_block_t, nw_parameters_configure_protocol_block_t, nw_parameters_configure_protocol_block_t, nw_parameters_configure_protocol_block_t);
-nw_protocol_options_t nw_webtransport_create_options(void);
-bool nw_protocol_options_is_webtransport(nw_protocol_options_t);
-void nw_webtransport_options_set_is_unidirectional(nw_protocol_options_t, bool);
-void nw_webtransport_options_set_is_datagram(nw_protocol_options_t, bool);
-void nw_webtransport_options_set_connection_max_sessions(nw_protocol_options_t, uint64_t);
 WTF_EXTERN_C_END
 
 #endif // USE(APPLE_INTERNAL_SDK)

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp
@@ -64,14 +64,16 @@ void NetworkTransportSession::sendDatagram(std::span<const uint8_t>, CompletionH
 
 void NetworkTransportSession::sendStreamSendBytes(WebTransportStreamIdentifier identifier, std::span<const uint8_t> bytes, bool withFin, CompletionHandler<void()>&& completionHandler)
 {
-    if (RefPtr stream = m_streams.get(identifier))
+    if (RefPtr stream = m_sendStreams.get(identifier))
         stream->sendBytes(bytes, withFin);
     completionHandler();
 }
 
 void NetworkTransportSession::streamSendBytes(WebTransportStreamIdentifier identifier, std::span<const uint8_t> bytes, bool withFin, CompletionHandler<void()>&& completionHandler)
 {
-    if (RefPtr stream = m_streams.get(identifier))
+    if (RefPtr stream = m_bidirectionalStreams.get(identifier))
+        stream->sendBytes(bytes, withFin);
+    else if (RefPtr stream = m_sendStreams.get(identifier))
         stream->sendBytes(bytes, withFin);
     completionHandler();
 }
@@ -90,14 +92,14 @@ void NetworkTransportSession::createBidirectionalStream(CompletionHandler<void(s
 
 void NetworkTransportSession::destroyOutgoingUnidirectionalStream(WebTransportStreamIdentifier identifier)
 {
-    ASSERT(m_streams.contains(identifier));
-    m_streams.remove(identifier);
+    ASSERT(m_sendStreams.contains(identifier));
+    m_sendStreams.remove(identifier);
 }
 
 void NetworkTransportSession::destroyBidirectionalStream(WebTransportStreamIdentifier identifier)
 {
-    ASSERT(m_streams.contains(identifier));
-    m_streams.remove(identifier);
+    ASSERT(m_bidirectionalStreams.contains(identifier));
+    m_bidirectionalStreams.remove(identifier);
 }
 
 void NetworkTransportSession::terminate(uint32_t, CString&&)

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
@@ -41,7 +41,6 @@ namespace WebKit {
 
 class NetworkConnectionToWebProcess;
 class NetworkTransportStream;
-enum class NetworkTransportStreamType : uint8_t;
 
 struct SharedPreferencesForWebProcess;
 struct WebTransportSessionIdentifierType;
@@ -84,18 +83,15 @@ private:
 
     IPC::Connection* messageSenderConnection() const final;
     uint64_t messageSenderDestinationID() const final;
-    void setupConnectionHandler();
-    void setupDatagramConnection(CompletionHandler<void(RefPtr<NetworkTransportSession>&&)>&&);
-    void receiveDatagramLoop();
-    void createStream(NetworkTransportStreamType, CompletionHandler<void(std::optional<WebTransportStreamIdentifier>)>&&);
 
-    HashMap<WebTransportStreamIdentifier, Ref<NetworkTransportStream>> m_streams;
+    HashMap<WebTransportStreamIdentifier, Ref<NetworkTransportStream>> m_bidirectionalStreams;
+    HashMap<WebTransportStreamIdentifier, Ref<NetworkTransportStream>> m_receiveStreams;
+    HashMap<WebTransportStreamIdentifier, Ref<NetworkTransportStream>> m_sendStreams;
     WeakPtr<NetworkConnectionToWebProcess> m_connectionToWebProcess;
 
 #if PLATFORM(COCOA)
     const RetainPtr<nw_connection_group_t> m_connectionGroup;
     const RetainPtr<nw_endpoint_t> m_endpoint;
-    RetainPtr<nw_connection_t> m_datagramConnection;
 #endif
 };
 

--- a/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
@@ -28,7 +28,7 @@
 
 #import "NetworkConnectionToWebProcess.h"
 #import "NetworkTransportStream.h"
-#import <pal/spi/cocoa/NetworkSPI.h>
+#import <pal/spi/cf/CFNetworkSPI.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/CompletionHandler.h>
 #import <wtf/RetainPtr.h>
@@ -42,90 +42,96 @@ NetworkTransportSession::NetworkTransportSession(NetworkConnectionToWebProcess& 
     , m_connectionGroup(connectionGroup)
     , m_endpoint(endpoint)
 {
-    setupConnectionHandler();
+    constexpr uint32_t maximumMessageSize { std::numeric_limits<uint32_t>::max() };
+    constexpr bool rejectOversizedMessages { false };
+    nw_connection_group_set_receive_handler(connectionGroup, maximumMessageSize, rejectOversizedMessages, makeBlockPtr([weakThis = WeakPtr { *this }] (dispatch_data_t datagram, nw_content_context_t, bool) {
+        RefPtr strongThis = weakThis.get();
+        if (!strongThis)
+            return;
+
+        // FIXME: Not only is this an unnecessary string copy, but it's also something that should probably be in WTF or FragmentedSharedBuffer.
+        auto vectorFromData = [](dispatch_data_t content) {
+            ASSERT(content);
+            Vector<uint8_t> request;
+            dispatch_data_apply_span(content, [&](std::span<const uint8_t> data) {
+                request.append(data);
+                return true;
+            });
+            return request;
+        };
+
+        strongThis->receiveDatagram(vectorFromData(datagram).span());
+    }).get());
+
+    // FIXME: Use nw_connection_group_set_new_connection_handler to receive incoming connections.
 }
 
-#if HAVE(WEB_TRANSPORT)
-static RetainPtr<nw_parameters_t> createParameters()
+void NetworkTransportSession::initialize(NetworkConnectionToWebProcess& connectionToWebProcess, URL&& url, CompletionHandler<void(RefPtr<NetworkTransportSession>&&)>&& completionHandler)
 {
-    auto configureWebTransport = [](nw_protocol_options_t options) {
-        nw_webtransport_options_set_is_unidirectional(options, false);
-        nw_webtransport_options_set_is_datagram(options, true);
-    };
+    // FIXME: Use nw_endpoint_create_url to support all URLs on systems where rdar://135036170 is fixed.
+    auto port = url.port() ? url.port() : defaultPortForProtocol(url.protocol());
+    if (!port)
+        return completionHandler(nullptr);
+
+    RetainPtr endpoint = adoptNS(nw_endpoint_create_host(url.host().utf8().data(), makeString(*port).utf8().data()));
+    if (!endpoint) {
+        ASSERT_NOT_REACHED();
+        return completionHandler(nullptr);
+    }
+
+    RetainPtr descriptor = adoptNS(nw_group_descriptor_create_multiplex(endpoint.get()));
+    if (!descriptor) {
+        ASSERT_NOT_REACHED();
+        return completionHandler(nullptr);
+    }
 
     auto configureTLS = [](nw_protocol_options_t options) {
-        RetainPtr securityOptions = adoptNS(nw_tls_copy_sec_protocol_options(options));
+        RetainPtr securityOptions = adoptNS(nw_quic_connection_copy_sec_protocol_options(options));
         sec_protocol_options_set_peer_authentication_required(securityOptions.get(), true);
         sec_protocol_options_set_verify_block(securityOptions.get(), makeBlockPtr([](sec_protocol_metadata_t metadata, sec_trust_t trust, sec_protocol_verify_complete_t completion) {
             // FIXME: Hook this up with WKNavigationDelegate.didReceiveChallenge.
             completion(true);
         }).get(), dispatch_get_main_queue());
         // FIXME: Pipe client cert auth into this too, probably.
+        sec_protocol_options_add_tls_application_protocol(securityOptions.get(), "h3");
     };
 
-    auto configureQUIC = [](nw_protocol_options_t options) {
-        nw_quic_set_initial_max_streams_bidirectional(options, std::numeric_limits<uint32_t>::max());
-        nw_quic_set_initial_max_streams_unidirectional(options, std::numeric_limits<uint32_t>::max());
-        nw_quic_set_max_datagram_frame_size(options, std::numeric_limits<uint16_t>::max());
-    };
+    RetainPtr parameters = adoptNS(nw_parameters_create_quic_stream(NW_PARAMETERS_DEFAULT_CONFIGURATION, configureTLS));
 
-    return adoptNS(nw_parameters_create_webtransport_http(configureWebTransport, configureTLS, configureQUIC, NW_PARAMETERS_DEFAULT_CONFIGURATION));
-}
-#endif // HAVE(WEB_TRANSPORT)
-
-void NetworkTransportSession::initialize(NetworkConnectionToWebProcess& connectionToWebProcess, URL&& url, CompletionHandler<void(RefPtr<NetworkTransportSession>&&)>&& completionHandler)
-{
-#if HAVE(WEB_TRANSPORT)
-    RetainPtr endpoint = adoptNS(nw_endpoint_create_url(url.string().utf8().data()));
-    if (!endpoint) {
-        ASSERT_NOT_REACHED();
-        return completionHandler(nullptr);
-    }
-
-    RetainPtr parameters = createParameters();
     if (!parameters) {
         ASSERT_NOT_REACHED();
         return completionHandler(nullptr);
     }
 
-    RetainPtr groupDescriptor = adoptNS(nw_group_descriptor_create_multiplex(endpoint.get()));
-    if (!groupDescriptor) {
-        ASSERT_NOT_REACHED();
-        return completionHandler(nullptr);
-    }
-
-    RetainPtr connectionGroup = adoptNS(nw_connection_group_create(groupDescriptor.get(), parameters.get()));
+    RetainPtr connectionGroup = adoptNS(nw_connection_group_create(descriptor.get(), parameters.get()));
     if (!connectionGroup) {
         ASSERT_NOT_REACHED();
         return completionHandler(nullptr);
     }
 
     Ref networkTransportSession = NetworkTransportSession::create(connectionToWebProcess, connectionGroup.get(), endpoint.get());
-
-    auto creationCompletionHandler = [
-        completionHandler = WTFMove(completionHandler)
-    ] (RefPtr<NetworkTransportSession>&& session) mutable {
-        if (!completionHandler)
-            return;
-        if (!session)
-            completionHandler(nullptr);
-        session->setupDatagramConnection(WTFMove(completionHandler));
+    WeakPtr weakNetworkTransportSession { networkTransportSession };
+    auto creationCompletionHandler = [completionHandler = WTFMove(completionHandler)] (RefPtr<NetworkTransportSession>&& session) mutable {
+        if (completionHandler)
+            completionHandler(WTFMove(session));
     };
-
     nw_connection_group_set_state_changed_handler(connectionGroup.get(), makeBlockPtr([
         networkTransportSession = WTFMove(networkTransportSession),
+        weakNetworkTransportSession = WTFMove(weakNetworkTransportSession),
         creationCompletionHandler = WTFMove(creationCompletionHandler)
     ] (nw_connection_group_state_t state, nw_error_t error) mutable {
         if (error)
             return creationCompletionHandler(nullptr);
         switch (state) {
+        case nw_connection_group_state_invalid:
+            return creationCompletionHandler(nullptr);
         case nw_connection_group_state_waiting:
             return; // We will get another callback with another state change.
         case nw_connection_group_state_ready:
             return creationCompletionHandler(WTFMove(networkTransportSession));
         case nw_connection_group_state_failed:
         case nw_connection_group_state_cancelled:
-        case nw_connection_group_state_invalid:
+            // FIXME: Use weakNetworkTransportSession to pipe the failure to JS.
             return creationCompletionHandler(nullptr);
         }
         RELEASE_ASSERT_NOT_REACHED();
@@ -133,113 +139,19 @@ void NetworkTransportSession::initialize(NetworkConnectionToWebProcess& connecti
 
     nw_connection_group_set_queue(connectionGroup.get(), dispatch_get_main_queue());
     nw_connection_group_start(connectionGroup.get());
-#else
-    completionHandler(nullptr);
-#endif // HAVE(WEB_TRANSPORT)
-}
-
-void NetworkTransportSession::createBidirectionalStream(CompletionHandler<void(std::optional<WebTransportStreamIdentifier>)>&& completionHandler)
-{
-    createStream(NetworkTransportStreamType::Bidirectional, WTFMove(completionHandler));
-}
-
-void NetworkTransportSession::createOutgoingUnidirectionalStream(CompletionHandler<void(std::optional<WebTransportStreamIdentifier>)>&& completionHandler)
-{
-    createStream(NetworkTransportStreamType::OutgoingUnidirectional, WTFMove(completionHandler));
-}
-
-void NetworkTransportSession::setupDatagramConnection(CompletionHandler<void(RefPtr<NetworkTransportSession>&&)>&& completionHandler)
-{
-#if HAVE(WEB_TRANSPORT)
-    ASSERT(!m_datagramConnection);
-    ASSERT(completionHandler);
-
-    RetainPtr webtransportOptions = adoptNS(nw_webtransport_create_options());
-    if (!webtransportOptions) {
-        ASSERT_NOT_REACHED();
-        return completionHandler(nullptr);
-    }
-    nw_webtransport_options_set_is_unidirectional(webtransportOptions.get(), false);
-    nw_webtransport_options_set_is_datagram(webtransportOptions.get(), true);
-
-    m_datagramConnection = adoptNS(nw_connection_group_extract_connection(m_connectionGroup.get(), nil, webtransportOptions.get()));
-    if (!m_datagramConnection) {
-        ASSERT_NOT_REACHED();
-        return completionHandler(nullptr);
-    }
-
-    nw_connection_set_state_changed_handler(m_datagramConnection.get(), makeBlockPtr([
-        protectedThis = RefPtr { this },
-        completionHandler = WTFMove(completionHandler)
-    ] (nw_connection_state_t state, nw_error_t error) mutable {
-        if (!protectedThis)
-            return completionHandler(nullptr);
-        if (error) {
-            protectedThis = nullptr;
-            return completionHandler(nullptr); // FIXME: Pipe the failure to JS
-        }
-        switch (state) {
-        case nw_connection_state_waiting:
-        case nw_connection_state_preparing: {
-            return; // We will get another callback with another state change.
-        }
-        case nw_connection_state_ready: {
-            protectedThis->receiveDatagramLoop();
-            return completionHandler(std::exchange(protectedThis, nullptr));
-        }
-        case nw_connection_state_invalid:
-        case nw_connection_state_failed:
-        case nw_connection_state_cancelled: {
-            protectedThis = nullptr;
-            return completionHandler(nullptr); // FIXME: Pipe the failure to JS
-        }
-        }
-        RELEASE_ASSERT_NOT_REACHED();
-    }).get());
-    nw_connection_set_queue(m_datagramConnection.get(), dispatch_get_main_queue());
-    nw_connection_start(m_datagramConnection.get());
-#else
-    completionHandler(nullptr);
-#endif // HAVE(WEB_TRANSPORT)
 }
 
 void NetworkTransportSession::sendDatagram(std::span<const uint8_t> data, CompletionHandler<void()>&& completionHandler)
 {
-#if HAVE(WEB_TRANSPORT)
-    ASSERT(m_datagramConnection);
-    nw_connection_send(m_datagramConnection.get(), makeDispatchData(Vector(data)).get(), NW_CONNECTION_DEFAULT_MESSAGE_CONTEXT, true, makeBlockPtr([completionHandler = WTFMove(completionHandler)] (nw_error_t error) mutable {
-        ASSERT(!error);
+    nw_connection_group_send_message(m_connectionGroup.get(), makeDispatchData(Vector(data)).get(), m_endpoint.get(), NW_CONNECTION_DEFAULT_MESSAGE_CONTEXT, makeBlockPtr([completionHandler = WTFMove(completionHandler)] (nw_error_t error) mutable {
         // FIXME: Pass any error through to JS.
         completionHandler();
     }).get());
-#else
-    completionHandler();
-#endif // HAVE(WEB_TRANSPORT)
 }
 
-void NetworkTransportSession::setupConnectionHandler()
+void NetworkTransportSession::createBidirectionalStream(CompletionHandler<void(std::optional<WebTransportStreamIdentifier>)>&& completionHandler)
 {
-#if HAVE(WEB_TRANSPORT)
-    nw_connection_group_set_new_connection_handler(m_connectionGroup.get(), makeBlockPtr([weakThis = WeakPtr { *this }] (nw_connection_t inboundConnection) mutable {
-        ASSERT_UNUSED(weakThis, weakThis);
-        // FIXME: Implement incoming connection handler
-    }).get());
-#endif // HAVE(WEB_TRANSPORT)
-}
-
-void NetworkTransportSession::createStream(NetworkTransportStreamType streamType, CompletionHandler<void(std::optional<WebTransportStreamIdentifier>)>&& completionHandler)
-{
-#if HAVE(WEB_TRANSPORT)
-    ASSERT(streamType != NetworkTransportStreamType::IncomingUnidirectional);
-    RetainPtr webtransportOptions = adoptNS(nw_webtransport_create_options());
-    if (!webtransportOptions) {
-        ASSERT_NOT_REACHED();
-        return completionHandler(std::nullopt);
-    }
-    nw_webtransport_options_set_is_unidirectional(webtransportOptions.get(), streamType != NetworkTransportStreamType::Bidirectional);
-    nw_webtransport_options_set_is_datagram(webtransportOptions.get(), false);
-
-    RetainPtr connection = adoptNS(nw_connection_group_extract_connection(m_connectionGroup.get(), nil, webtransportOptions.get()));
+    RetainPtr connection = adoptNS(nw_connection_group_extract_connection(m_connectionGroup.get(), m_endpoint.get(), nullptr));
     if (!connection) {
         ASSERT_NOT_REACHED();
         return completionHandler(std::nullopt);
@@ -255,12 +167,12 @@ void NetworkTransportSession::createStream(NetworkTransportStreamType streamType
         if (!strongThis || !stream)
             return completionHandler(std::nullopt);
         auto identifier = stream->identifier();
-        ASSERT(!strongThis->m_streams.contains(identifier));
-        strongThis->m_streams.set(identifier, stream.releaseNonNull());
+        ASSERT(!strongThis->m_bidirectionalStreams.contains(identifier));
+        strongThis->m_bidirectionalStreams.set(identifier, stream.releaseNonNull());
         completionHandler(identifier);
     };
 
-    Ref stream = NetworkTransportStream::create(*this, connection.get(), streamType);
+    Ref stream = NetworkTransportStream::create(*this, connection.get(), NetworkTransportStreamType::Bidirectional);
 
     nw_connection_set_state_changed_handler(connection.get(), makeBlockPtr([
         creationCompletionHandler = WTFMove(creationCompletionHandler),
@@ -284,36 +196,12 @@ void NetworkTransportSession::createStream(NetworkTransportStreamType streamType
     }).get());
     nw_connection_set_queue(connection.get(), dispatch_get_main_queue());
     nw_connection_start(connection.get());
-#else
-    completionHandler(std::nullopt);
-#endif // HAVE(WEB_TRANSPORT)
 }
 
-void NetworkTransportSession::receiveDatagramLoop()
+void NetworkTransportSession::createOutgoingUnidirectionalStream(CompletionHandler<void(std::optional<WebTransportStreamIdentifier>)>&& completionHandler)
 {
-#if HAVE(WEB_TRANSPORT)
-    ASSERT(m_datagramConnection);
-    nw_connection_receive(m_datagramConnection.get(), 1, std::numeric_limits<uint32_t>::max(), makeBlockPtr([weakThis = WeakPtr { *this }] (dispatch_data_t content, nw_content_context_t, bool withFin, nw_error_t error) {
-        RefPtr strongThis = weakThis.get();
-        if (!strongThis)
-            return;
-        if (error)
-            return; // FIXME: Pipe this error to JS.
-
-        // FIXME: Not only is this an unnecessary string copy, but it's also something that should probably be in WTF or FragmentedSharedBuffer.
-        auto vectorFromData = [](dispatch_data_t content) {
-            ASSERT(content);
-            Vector<uint8_t> request;
-            dispatch_data_apply_span(content, [&](std::span<const uint8_t> buffer) {
-                request.append(buffer);
-                return true;
-            });
-            return request;
-        };
-
-        strongThis->receiveDatagram(vectorFromData(content).span());
-        strongThis->receiveDatagramLoop();
-    }).get());
-#endif // HAVE(WEB_TRANSPORT)
+    // FIXME: Call nw_connection_group_extract_connection and make a NetworkTransportStream and add to m_sendStreams like NetworkTransportSession::createBidirectionalStream.
+    completionHandler(std::nullopt);
 }
+
 }

--- a/Source/WebKit/WebProcess/Network/WebTransportSession.cpp
+++ b/Source/WebKit/WebProcess/Network/WebTransportSession.cpp
@@ -85,8 +85,6 @@ void WebTransportSession::receiveDatagram(std::span<const uint8_t> datagram)
     ASSERT(RunLoop::isMain());
     if (auto strongClient = m_client.get())
         strongClient->receiveDatagram(datagram);
-    else
-        ASSERT_NOT_REACHED();
 }
 
 void WebTransportSession::receiveIncomingUnidirectionalStream(WebTransportStreamIdentifier)

--- a/Tools/TestWebKitAPI/WebTransportServer.mm
+++ b/Tools/TestWebKitAPI/WebTransportServer.mm
@@ -23,13 +23,12 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if HAVE(WEB_TRANSPORT)
 #import "config.h"
 #import "WebTransportServer.h"
 
 #import "HTTPServer.h"
 #import "Utilities.h"
-#import <pal/spi/cocoa/NetworkSPI.h>
+#import <pal/spi/cf/CFNetworkSPI.h>
 #import <wtf/BlockPtr.h>
 
 namespace TestWebKitAPI {
@@ -41,7 +40,7 @@ struct WebTransportServer::Data : public RefCounted<WebTransportServer::Data> {
 
     Function<Task(Connection)> connectionHandler;
     RetainPtr<nw_listener_t> listener;
-    RetainPtr<nw_connection_group_t> connectionGroup;
+    Vector<RetainPtr<nw_connection_group_t>> connectionGroups;
     Vector<RetainPtr<nw_connection_t>> connections;
     Vector<CoroutineHandle<Task::promise_type>> coroutineHandles;
 };
@@ -49,59 +48,34 @@ struct WebTransportServer::Data : public RefCounted<WebTransportServer::Data> {
 WebTransportServer::WebTransportServer(Function<Task(Connection)>&& connectionHandler)
     : m_data(Data::create(WTFMove(connectionHandler)))
 {
-    auto configureWebTransport = [](nw_protocol_options_t options) {
-        nw_webtransport_options_set_is_datagram(options, true);
-        nw_webtransport_options_set_is_unidirectional(options, false);
-        nw_webtransport_options_set_connection_max_sessions(options, 1);
-    };
-
     auto configureTLS = [](nw_protocol_options_t options) {
-        RetainPtr securityOptions = adoptNS(nw_tls_copy_sec_protocol_options(options));
+        RetainPtr securityOptions = adoptNS(nw_quic_connection_copy_sec_protocol_options(options));
         sec_protocol_options_set_local_identity(securityOptions.get(), adoptNS(sec_identity_create(testIdentity().get())).get());
+        sec_protocol_options_add_tls_application_protocol(securityOptions.get(), "h3");
     };
 
-    auto configureQUIC = [](nw_protocol_options_t options) {
-        nw_quic_set_initial_max_streams_bidirectional(options, std::numeric_limits<uint32_t>::max());
-        nw_quic_set_initial_max_streams_unidirectional(options, std::numeric_limits<uint32_t>::max());
-        nw_quic_set_max_datagram_frame_size(options, std::numeric_limits<uint16_t>::max());
-    };
-
-    RetainPtr parameters = adoptNS(nw_parameters_create_webtransport_http(configureWebTransport, configureTLS, configureQUIC, NW_PARAMETERS_DEFAULT_CONFIGURATION));
-    ASSERT(parameters);
-    nw_parameters_set_server_mode(parameters.get(), true);
-
-    RetainPtr webtransportOptions = adoptNS(nw_webtransport_create_options());
-    ASSERT(webtransportOptions);
-    nw_webtransport_options_set_is_unidirectional(webtransportOptions.get(), false);
-    nw_webtransport_options_set_is_datagram(webtransportOptions.get(), true);
+    RetainPtr parameters = adoptNS(nw_parameters_create_quic_stream(NW_PARAMETERS_DEFAULT_CONFIGURATION, configureTLS));
 
     RetainPtr listener = adoptNS(nw_listener_create(parameters.get()));
 
-    nw_listener_set_new_connection_group_handler(listener.get(), [data = m_data, webtransportOptions = webtransportOptions] (nw_connection_group_t connectionGroup) {
-        ASSERT(!data->connectionGroup);
-        data->connectionGroup = connectionGroup;
-
-        nw_connection_group_set_state_changed_handler(connectionGroup, [data = data, webtransportOptions = webtransportOptions](nw_connection_group_state_t state, nw_error_t error) {
-            if (state == nw_connection_group_state_ready) {
-                // We need to peel off the datagram connection.
-                nw_connection_t datagramConnection = nw_connection_group_extract_connection(data->connectionGroup.get(), nil, webtransportOptions.get());
-                data->connections.append(datagramConnection);
-                data->coroutineHandles.append(data->connectionHandler(datagramConnection).handle);
-                nw_connection_set_queue(datagramConnection, dispatch_get_main_queue());
-                nw_connection_start(datagramConnection);
-            }
+    nw_listener_set_new_connection_group_handler(listener.get(), [data = m_data] (nw_connection_group_t connectionGroup) {
+        constexpr uint32_t maximumMessageSize { std::numeric_limits<uint32_t>::max() };
+        constexpr bool rejectOversizedMessages { false };
+        nw_connection_group_set_receive_handler(connectionGroup, maximumMessageSize, rejectOversizedMessages, ^(dispatch_data_t, nw_content_context_t, bool) {
+            // FIXME: Implement and test datagrams with WebTransport.
         });
 
-        nw_connection_group_set_new_connection_handler(connectionGroup, [data = data] (nw_connection_t connection) {
+        nw_connection_group_set_new_connection_handler(connectionGroup, [data] (nw_connection_t connection) {
             data->connections.append(connection);
-            data->coroutineHandles.append(data->connectionHandler(connection).handle);
             nw_connection_set_queue(connection, dispatch_get_main_queue());
             nw_connection_start(connection);
+            data->coroutineHandles.append(data->connectionHandler(connection).handle);
         });
+
         nw_connection_group_set_queue(connectionGroup, dispatch_get_main_queue());
         nw_connection_group_start(connectionGroup);
+        data->connectionGroups.append(connectionGroup);
     });
-
     nw_listener_set_queue(listener.get(), dispatch_get_main_queue());
 
     __block bool ready = false;
@@ -124,5 +98,3 @@ uint16_t WebTransportServer::port() const
 }
 
 } // namespace TestWebKitAPI
-
-#endif // HAVE(WEB_TRANSPORT)


### PR DESCRIPTION
#### d0c7644ba528ad3f9f1ec39fa91384b6b97c01e2
<pre>
Revert 287714@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=284505">https://bugs.webkit.org/show_bug.cgi?id=284505</a>
<a href="https://rdar.apple.com/141331343">rdar://141331343</a>

Unreviewed.

It broke a build on some internal SDKs.

* Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h:
* Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp:
(WebKit::NetworkTransportSession::sendStreamSendBytes):
(WebKit::NetworkTransportSession::streamSendBytes):
(WebKit::NetworkTransportSession::destroyOutgoingUnidirectionalStream):
(WebKit::NetworkTransportSession::destroyBidirectionalStream):
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h:
* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm:
(WebKit::NetworkTransportSession::NetworkTransportSession):
(WebKit::NetworkTransportSession::initialize):
(WebKit::NetworkTransportSession::sendDatagram):
(WebKit::NetworkTransportSession::createBidirectionalStream):
(WebKit::NetworkTransportSession::createOutgoingUnidirectionalStream):
(WebKit::createParameters): Deleted.
(WebKit::NetworkTransportSession::setupDatagramConnection): Deleted.
(WebKit::NetworkTransportSession::setupConnectionHandler): Deleted.
(WebKit::NetworkTransportSession::createStream): Deleted.
(WebKit::NetworkTransportSession::receiveDatagramLoop): Deleted.
* Source/WebKit/WebProcess/Network/WebTransportSession.cpp:
(WebKit::WebTransportSession::receiveDatagram):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm:
(TestWebKitAPI::TEST(WebTransport, Basic)):
(TestWebKitAPI::TEST(WebTransport, DISABLED_ClientBidirectional)): Deleted.
(TestWebKitAPI::TEST(WebTransport, DISABLED_Datagram)): Deleted.
* Tools/TestWebKitAPI/WebTransportServer.mm:
(TestWebKitAPI::WebTransportServer::WebTransportServer):

Canonical link: <a href="https://commits.webkit.org/287720@main">https://commits.webkit.org/287720@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a2e64720ceed9bbe5a37dad663b8f078091d7c4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80636 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/59643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34570 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/85160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/31618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82747 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/68704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7950 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/85160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/31618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83705 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/68704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/73402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/85160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/68704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/27562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/30077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/68704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/28086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/86593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/7862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/86593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/8037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/69238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/86593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/13476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12486 "Failed to checkout and rebase branch from PR 37815") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/7824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/13343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/7663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/11182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9468 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->