### PR TITLE
Reduce use of memcpy()

### DIFF
--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
@@ -47,6 +47,7 @@
 #include "WebCodecsErrorCallback.h"
 #include "WebCodecsUtilities.h"
 #include <JavaScriptCore/ArrayBuffer.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
@@ -270,7 +271,7 @@ WebCodecsEncodedAudioChunkMetadata WebCodecsAudioEncoder::createEncodedChunkMeta
             auto arrayBuffer = ArrayBuffer::tryCreateUninitialized(m_activeConfiguration.description->size(), 1);
             RELEASE_LOG_ERROR_IF(!!arrayBuffer, Media, "Cannot create array buffer for WebCodecs encoder description");
             if (arrayBuffer) {
-                memcpy(static_cast<uint8_t*>(arrayBuffer->data()), m_activeConfiguration.description->data(), m_activeConfiguration.description->size());
+                memcpySpan(arrayBuffer->mutableSpan(), m_activeConfiguration.description->span());
                 metadata.decoderConfig->description = WTFMove(arrayBuffer);
             }
         }

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
@@ -43,6 +43,7 @@
 #include "WebCodecsVideoEncoderEncodeOptions.h"
 #include "WebCodecsVideoFrame.h"
 #include <JavaScriptCore/ArrayBuffer.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
@@ -258,7 +259,7 @@ WebCodecsEncodedVideoChunkMetadata WebCodecsVideoEncoder::createEncodedChunkMeta
             auto arrayBuffer = ArrayBuffer::tryCreateUninitialized(m_activeConfiguration.description->size(), 1);
             RELEASE_LOG_ERROR_IF(!!arrayBuffer, Media, "Cannot create array buffer for WebCodecs encoder description");
             if (arrayBuffer) {
-                memcpy(static_cast<uint8_t*>(arrayBuffer->data()), m_activeConfiguration.description->data(), m_activeConfiguration.description->size());
+                memcpySpan(arrayBuffer->mutableSpan(), m_activeConfiguration.description->span());
                 metadata.decoderConfig->description = WTFMove(arrayBuffer);
             }
         }

--- a/Source/WebCore/Modules/webtransport/DatagramSource.cpp
+++ b/Source/WebCore/Modules/webtransport/DatagramSource.cpp
@@ -27,6 +27,7 @@
 #include "DatagramSource.h"
 
 #include <JavaScriptCore/ArrayBuffer.h>
+#include <wtf/StdLibExtras.h>
 
 namespace WebCore {
 
@@ -40,7 +41,7 @@ void DatagramSource::receiveDatagram(std::span<const uint8_t> datagram)
         return;
     auto arrayBuffer = ArrayBuffer::tryCreateUninitialized(datagram.size(), 1);
     if (arrayBuffer)
-        memcpy(static_cast<uint8_t*>(arrayBuffer->data()), datagram.data(), datagram.size());
+        memcpySpan(arrayBuffer->mutableSpan(), datagram);
     if (!controller().enqueue(WTFMove(arrayBuffer)))
         doCancel();
 }

--- a/Source/WebCore/bindings/js/StructuredClone.cpp
+++ b/Source/WebCore/bindings/js/StructuredClone.cpp
@@ -87,7 +87,7 @@ JSC_DEFINE_HOST_FUNCTION(structuredCloneForStream, (JSGlobalObject* globalObject
             return nullptr;
         }
 
-        memcpy(result->data(), buffer.data(), byteLength);
+        memcpySpan(result->mutableSpan(), buffer.span().first(byteLength));
         return result;
     };
 

--- a/Source/WebCore/loader/TextResourceDecoder.cpp
+++ b/Source/WebCore/loader/TextResourceDecoder.cpp
@@ -459,7 +459,7 @@ bool TextResourceDecoder::checkForCSSCharset(std::span<const uint8_t> data, bool
 
     size_t oldSize = m_buffer.size();
     m_buffer.grow(oldSize + data.size());
-    memcpy(m_buffer.data() + oldSize, data.data(), data.size());
+    memcpySpan(m_buffer.mutableSpan().subspan(oldSize), data);
 
     movedDataToBuffer = true;
 
@@ -505,7 +505,7 @@ bool TextResourceDecoder::checkForHeadCharset(std::span<const uint8_t> data, boo
 
     size_t oldSize = m_buffer.size();
     m_buffer.grow(oldSize + data.size());
-    memcpy(m_buffer.data() + oldSize, data.data(), data.size());
+    memcpySpan(m_buffer.mutableSpan().subspan(oldSize), data);
 
     movedDataToBuffer = true;
 
@@ -635,7 +635,7 @@ String TextResourceDecoder::decode(std::span<const uint8_t> data)
     if (!movedDataToBuffer) {
         size_t oldSize = m_buffer.size();
         m_buffer.grow(oldSize + data.size());
-        memcpy(m_buffer.data() + oldSize, data.data(), data.size());
+        memcpySpan(m_buffer.mutableSpan().subspan(oldSize), data);
     }
 
     String result = m_codec->decode(m_buffer.subspan(lengthOfBOM), false, m_contentType == XML && !m_useLenientXMLDecoding, m_sawError);

--- a/Source/WebCore/platform/audio/AudioChannel.cpp
+++ b/Source/WebCore/platform/audio/AudioChannel.cpp
@@ -35,6 +35,7 @@
 #include "VectorMath.h"
 #include <algorithm>
 #include <math.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -60,7 +61,7 @@ void AudioChannel::copyFrom(const AudioChannel* sourceChannel)
         zero();
         return;
     }
-    memcpy(mutableData(), sourceChannel->data(), sizeof(float) * length());
+    memcpySpan(mutableSpan(), sourceChannel->span().first(length()));
 }
 
 void AudioChannel::copyFromRange(const AudioChannel* sourceChannel, unsigned startFrame, unsigned endFrame)

--- a/Source/WebCore/platform/audio/FFTConvolver.cpp
+++ b/Source/WebCore/platform/audio/FFTConvolver.cpp
@@ -33,6 +33,7 @@
 #include "FFTConvolver.h"
 
 #include "VectorMath.h"
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -103,7 +104,7 @@ void FFTConvolver::process(FFTFrame* fftKernel, const float* sourceP, float* des
             if (!isCopyGood3)
                 return;
 
-            memcpy(m_lastOverlapBuffer.data(), m_outputBuffer.data() + halfSize, sizeof(float) * halfSize);
+            memcpySpan(m_lastOverlapBuffer.span(), m_outputBuffer.span().subspan(halfSize, halfSize));
 
             // Reset index back to start for next time
             m_readWriteIndex = 0;

--- a/Source/WebCore/platform/audio/mac/FFTFrameMac.cpp
+++ b/Source/WebCore/platform/audio/mac/FFTFrameMac.cpp
@@ -98,8 +98,8 @@ FFTFrame::FFTFrame(const FFTFrame& frame)
     m_frame.imagp = m_imagData.data();
 
     // Copy/setup frame data
-    memcpy(realData().data(), frame.m_frame.realp, sizeof(float) * realData().size());
-    memcpy(imagData().data(), frame.m_frame.imagp, sizeof(float) * imagData().size());
+    memcpySpan(realData().span(), unsafeMakeSpan(frame.m_frame.realp, realData().size()));
+    memcpySpan(imagData().span(), unsafeMakeSpan(frame.m_frame.imagp, imagData().size()));
 }
 
 FFTFrame::~FFTFrame() = default;

--- a/Source/WebCore/platform/graphics/avfoundation/ISOFairPlayStreamingPsshBox.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/ISOFairPlayStreamingPsshBox.cpp
@@ -27,6 +27,7 @@
 #include "ISOFairPlayStreamingPsshBox.h"
 
 #include <JavaScriptCore/DataView.h>
+#include <wtf/StdLibExtras.h>
 
 namespace WebCore {
 
@@ -68,7 +69,7 @@ bool ISOFairPlayStreamingKeyRequestInfoBox::parse(JSC::DataView& view, unsigned&
     m_keyID.resize(m_keyID.capacity());
     if (keyID->byteLength() < m_keyID.capacity())
         return false;
-    memcpy(m_keyID.data(), keyID->data(), m_keyID.capacity());
+    memcpySpan(m_keyID.mutableSpan(), keyID->span().first(m_keyID.capacity()));
 
     offset = localOffset;
     return true;
@@ -100,7 +101,7 @@ bool ISOFairPlayStreamingKeyAssetIdBox::parse(JSC::DataView& view, unsigned& off
     m_data.resize(dataSize);
     if (parsedData->byteLength() < dataSize)
         return false;
-    memcpy(m_data.data(), parsedData->data(), dataSize);
+    memcpySpan(m_data.mutableSpan(), parsedData->span().first(dataSize));
     offset = localOffset;
     return true;
 }
@@ -131,7 +132,7 @@ bool ISOFairPlayStreamingKeyContextBox::parse(JSC::DataView& view, unsigned& off
     m_data.resize(dataSize);
     if (parsedData->byteLength() < dataSize)
         return false;
-    memcpy(m_data.data(), parsedData->data(), dataSize);
+    memcpySpan(m_data.mutableSpan(), parsedData->span().first(dataSize));
     offset = localOffset;
     return true;
 }

--- a/Source/WebCore/platform/graphics/filters/FilterImage.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterImage.cpp
@@ -187,13 +187,15 @@ static void copyImageBytes(const PixelBuffer& sourcePixelBuffer, PixelBuffer& de
     if (UNLIKELY(size.hasOverflowed() || destinationBytesPerRow.hasOverflowed() || sourceBytesPerRow.hasOverflowed() || destinationOffset.hasOverflowed() || sourceOffset.hasOverflowed()))
         return;
 
-    uint8_t* destinationPixel = destinationPixelBuffer.bytes().data() + destinationOffset.value();
-    const uint8_t* sourcePixel = sourcePixelBuffer.bytes().data() + sourceOffset.value();
+    auto destinationPixel = destinationPixelBuffer.bytes().subspan(destinationOffset.value());
+    auto sourcePixel = sourcePixelBuffer.bytes().subspan(sourceOffset.value());
 
     for (int y = 0; y < sourceRectClipped.height(); ++y) {
-        memcpy(destinationPixel, sourcePixel, size);
-        destinationPixel += destinationBytesPerRow;
-        sourcePixel += sourceBytesPerRow;
+        if (y) {
+            destinationPixel = destinationPixel.subspan(destinationBytesPerRow);
+            sourcePixel = sourcePixel.subspan(sourceBytesPerRow);
+        }
+        memcpySpan(destinationPixel, sourcePixel.first(size));
     }
 }
 

--- a/Source/WebCore/platform/graphics/filters/software/FEGaussianBlurSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEGaussianBlurSoftwareApplier.cpp
@@ -35,6 +35,7 @@
 #include "PixelBuffer.h"
 #include <JavaScriptCore/TypedArrayInlines.h>
 #include <wtf/MathExtras.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
 #if USE(ACCELERATE)
@@ -290,7 +291,7 @@ inline void FEGaussianBlurSoftwareApplier::boxBlurAccelerated(PixelBuffer& ioBuf
 
     // The final result should be stored in ioBuffer.
     ASSERT(ioBuffer.bytes().size() == tempBuffer.bytes().size());
-    memcpy(ioBuffer.bytes().data(), tempBuffer.bytes().data(), ioBuffer.bytes().size());
+    memcpySpan(ioBuffer.bytes(), tempBuffer.bytes().first(ioBuffer.bytes().size()));
 }
 #endif
 
@@ -335,7 +336,7 @@ inline void FEGaussianBlurSoftwareApplier::boxBlurUnaccelerated(PixelBuffer& ioB
     // The final result should be stored in ioBuffer.
     if (&ioBuffer != fromBuffer) {
         ASSERT(ioBuffer.bytes().size() == fromBuffer->bytes().size());
-        memcpy(ioBuffer.bytes().data(), fromBuffer->bytes().data(), ioBuffer.bytes().size());
+        memcpySpan(ioBuffer.bytes(), fromBuffer->bytes().first(ioBuffer.bytes().size()));
     }
 }
 
@@ -396,7 +397,7 @@ inline void FEGaussianBlurSoftwareApplier::applyPlatform(PixelBuffer& ioBuffer, 
                 } else {
                     params.ioBuffer = ioBuffer.createScratchPixelBuffer(blockSize);
                     params.tempBuffer = tempBuffer.createScratchPixelBuffer(blockSize);
-                    memcpy(params.ioBuffer->bytes().data(), ioBuffer.bytes().data() + startY * scanline, params.ioBuffer->bytes().size());
+                    memcpySpan(params.ioBuffer->bytes(), ioBuffer.bytes().subspan(startY * scanline, params.ioBuffer->bytes().size()));
                 }
 
                 params.width = paintSize.width();
@@ -423,7 +424,7 @@ inline void FEGaussianBlurSoftwareApplier::applyPlatform(PixelBuffer& ioBuffer, 
                 destinationOffset = currentY * scanline;
                 size = adjustedBlockHeight * scanline;
 
-                memcpy(ioBuffer.bytes().data() + destinationOffset, params.ioBuffer->bytes().data() + sourceOffset, size);
+                memcpySpan(ioBuffer.bytes().subspan(destinationOffset), params.ioBuffer->bytes().subspan(sourceOffset, size));
             }
             return;
         }

--- a/Source/WebCore/platform/graphics/iso/ISOProtectionSystemSpecificHeaderBox.cpp
+++ b/Source/WebCore/platform/graphics/iso/ISOProtectionSystemSpecificHeaderBox.cpp
@@ -29,6 +29,7 @@
 #include "ISOProtectionSystemSpecificHeaderBox.h"
 
 #include <JavaScriptCore/DataView.h>
+#include <wtf/StdLibExtras.h>
 
 using JSC::DataView;
 
@@ -64,7 +65,7 @@ bool ISOProtectionSystemSpecificHeaderBox::parse(DataView& view, unsigned& offse
     if (systemID->byteLength() < 16)
         return false;
 
-    memcpy(m_systemID.data(), systemID->data(), 16);
+    memcpySpan(m_systemID.mutableSpan(), systemID->span().first(16));
 
     if (m_version) {
         uint32_t keyIDCount = 0;
@@ -82,7 +83,7 @@ bool ISOProtectionSystemSpecificHeaderBox::parse(DataView& view, unsigned& offse
             offset += 16;
             if (parsedKeyID->byteLength() < 16)
                 continue;
-            memcpy(currentKeyID.data(), parsedKeyID->data(), 16);
+            memcpySpan(currentKeyID.mutableSpan(), parsedKeyID->span().first(16));
         }
     }
 
@@ -98,7 +99,7 @@ bool ISOProtectionSystemSpecificHeaderBox::parse(DataView& view, unsigned& offse
     if (parsedData->byteLength() < dataSize)
         return false;
 
-    memcpy(m_data.data(), parsedData->data(), dataSize);
+    memcpySpan(m_data.mutableSpan(), parsedData->span().first(dataSize));
 
     return true;
 }

--- a/Source/WebCore/platform/graphics/iso/ISOTrackEncryptionBox.cpp
+++ b/Source/WebCore/platform/graphics/iso/ISOTrackEncryptionBox.cpp
@@ -27,6 +27,7 @@
 #include "ISOTrackEncryptionBox.h"
 
 #include <JavaScriptCore/DataView.h>
+#include <wtf/StdLibExtras.h>
 
 using JSC::DataView;
 
@@ -86,7 +87,7 @@ bool ISOTrackEncryptionBox::parsePayload(DataView& view, unsigned& offset)
     if (keyIDBuffer->byteLength() < 16)
         return false;
 
-    memcpy(m_defaultKID.data(), keyIDBuffer->data(), 16);
+    memcpySpan(m_defaultKID.mutableSpan(), keyIDBuffer->span().first(16));
 
     if (m_defaultIsProtected == 1 && !m_defaultPerSampleIVSize) {
         int8_t defaultConstantIVSize = 0;

--- a/Source/WebCore/platform/graphics/texmap/ClipStack.cpp
+++ b/Source/WebCore/platform/graphics/texmap/ClipStack.cpp
@@ -22,6 +22,8 @@
 #include "config.h"
 #include "ClipStack.h"
 
+#include <array>
+#include <wtf/StdLibExtras.h>
 #include "TextureMapperGLHeaders.h"
 
 namespace WebCore {
@@ -88,9 +90,7 @@ void ClipStack::addRoundedRect(const FloatRoundedRect& roundedRect, const Transf
 
     // Copy the TransformationMatrix components to the appropriate position in the array.
     basePosition = clipState.roundedRectCount * s_roundedRectInverseTransformComponentsPerRect;
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib/Win port
-    memcpy(m_roundedRectInverseTransformComponents.data() + basePosition, matrix.toColumnMajorFloatArray().data(), s_roundedRectInverseTransformComponentsPerRect * sizeof(float));
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    memcpySpan(m_roundedRectInverseTransformComponents.mutableSpan().subspan(basePosition), std::span<const float, 16> { matrix.toColumnMajorFloatArray() }.first(s_roundedRectInverseTransformComponentsPerRect));
 
     clipState.roundedRectCount++;
 }

--- a/Source/WebCore/platform/image-decoders/bmp/BMPImageReader.h
+++ b/Source/WebCore/platform/image-decoders/bmp/BMPImageReader.h
@@ -32,6 +32,7 @@
 
 #include "ScalableImageDecoder.h"
 #include <stdint.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
@@ -46,7 +47,7 @@ public:
     static inline uint16_t readUint16(const SharedBuffer& data, int offset)
     {
         uint16_t result;
-        memcpy(&result, &data.span()[offset], 2);
+        memcpySpan(asMutableByteSpan(result), data.span().subspan(offset, 2));
 #if CPU(BIG_ENDIAN)
         result = ((result & 0xff) << 8) | ((result & 0xff00) >> 8);
 #endif
@@ -56,7 +57,7 @@ public:
     static inline uint32_t readUint32(const SharedBuffer& data, int offset)
     {
         uint32_t result;
-        memcpy(&result, &data.span()[offset], 4);
+        memcpySpan(asMutableByteSpan(result), data.span().subspan(offset, 4));
 #if CPU(BIG_ENDIAN)
         result = ((result & 0xff) << 24) | ((result & 0xff00) << 8) | ((result & 0xff0000) >> 8) | ((result & 0xff000000) >> 24);
 #endif
@@ -205,7 +206,7 @@ private:
             // of the return value here in little-endian mode, the caller
             // won't read it.
             uint32_t pixel;
-            memcpy(&pixel, &m_data->span()[m_decodedOffset + offset], 3);
+            memcpySpan(asMutableByteSpan(pixel), m_data->span().subspan(m_decodedOffset + offset, 3));
 #if CPU(BIG_ENDIAN)
             pixel = ((pixel & 0xff00) << 8) | ((pixel & 0xff0000) >> 8) | ((pixel & 0xff000000) >> 24);
 #endif

--- a/Source/WebCore/platform/image-decoders/png/PNGImageDecoder.h
+++ b/Source/WebCore/platform/image-decoders/png/PNGImageDecoder.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "ScalableImageDecoder.h"
+#include <array>
 #include <png.h>
 
 #if USE(LCMS)
@@ -124,9 +125,9 @@ namespace WebCore {
         unsigned m_delayDenominator;
         unsigned m_dispose;
         unsigned m_blend;
-        png_byte m_dataIHDR[12 + 13];
-        png_byte m_dataPLTE[12 + 256 * 3];
-        png_byte m_datatRNS[12 + 256];
+        std::array<png_byte, 12 + 13> m_dataIHDR;
+        std::array<png_byte, 12 + 256 * 3> m_dataPLTE;
+        std::array<png_byte, 12 + 256> m_datatRNS;
 #if USE(LCMS)
     LCMSTransformPtr m_iccTransform;
 #endif

--- a/Source/WebCore/platform/network/BlobResourceHandle.cpp
+++ b/Source/WebCore/platform/network/BlobResourceHandle.cpp
@@ -48,6 +48,7 @@
 #include <wtf/FileSystem.h>
 #include <wtf/MainThread.h>
 #include <wtf/Ref.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/URL.h>
 
 namespace WebCore {
@@ -377,7 +378,7 @@ int BlobResourceHandle::readDataSync(const BlobDataItem& item, std::span<uint8_t
 
     long long remaining = item.length() - m_currentItemReadSize;
     long long bytesToRead = std::min(std::min<long long>(remaining, buffer.size()), m_totalRemainingSize);
-    memcpy(buffer.data(), item.data()->span().subspan(item.offset() + m_currentItemReadSize).data(), bytesToRead);
+    memcpySpan(buffer, item.data()->span().subspan(item.offset() + m_currentItemReadSize).first(bytesToRead));
     m_totalRemainingSize -= bytesToRead;
 
     m_currentItemReadSize += bytesToRead;

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -58,6 +58,7 @@
 #include <WebCore/SWServer.h>
 #include <numeric>
 #include <wtf/RuntimeApplicationChecks.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(COCOA)
@@ -135,7 +136,7 @@ static WebPushD::WebPushDaemonConnectionConfiguration configurationWithHostAudit
     auto token = networkProcess.parentProcessConnection()->getAuditToken();
     if (token) {
         Vector<uint8_t> auditTokenData(sizeof(*token));
-        memcpy(auditTokenData.data(), &(*token), sizeof(*token));
+        memcpySpan(auditTokenData.mutableSpan(), asByteSpan(*token));
         configuration.hostAppAuditTokenData = WTFMove(auditTokenData);
     }
 #endif

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -66,6 +66,7 @@
 #import <wtf/ObjCRuntimeExtras.h>
 #import <wtf/ProcessPrivilege.h>
 #import <wtf/SoftLinking.h>
+#import <wtf/StdLibExtras.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/URL.h>
 #import <wtf/WeakObjCPtr.h>
@@ -2322,7 +2323,7 @@ void NetworkSessionCocoa::setProxyConfigData(const Vector<std::pair<Vector<uint8
     bool recreateSessions = false;
     for (auto& config : proxyConfigurations) {
         uuid_t identifier;
-        memcpy(identifier, config.second.span().data(), sizeof(uuid_t));
+        memcpySpan(asMutableByteSpan(identifier), config.second.span().first(sizeof(uuid_t)));
 
         auto nwProxyConfig = adoptNS(createProxyConfig(config.first.data(), config.first.size(), identifier));
 

--- a/Source/WebKit/Shared/API/APIClient.h
+++ b/Source/WebKit/Shared/API/APIClient.h
@@ -72,7 +72,7 @@ public:
         if (client && client->version < latestClientVersion) {
             auto interfaceSizes = InterfaceSizes<ClientVersions>::sizes();
 
-            memcpy(&m_client, client, interfaceSizes[client->version]);
+            memcpySpan(asMutableByteSpan(m_client), unsafeMakeSpan(reinterpret_cast<const uint8_t*>(client), interfaceSizes[client->version]));
         }
     }
 

--- a/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
@@ -42,9 +42,11 @@
 #import <wtf/FileSystem.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/RuntimeApplicationChecks.h>
+#import <wtf/StdLibExtras.h>
 #import <wtf/cocoa/Entitlements.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #import <wtf/cocoa/SoftLinking.h>
+#import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/text/MakeString.h>
 
 #if ENABLE(CFPREFS_DIRECT_MODE)
@@ -166,7 +168,7 @@ void AuxiliaryProcess::registerWithStateDumper(ASCIILiteral title)
                 os_state->osd_type = OS_STATE_DATA_SERIALIZED_NSCF_OBJECT;
                 os_state->osd_data_size = data.length;
                 strlcpy(os_state->osd_title, title.characters(), sizeof(os_state->osd_title));
-                memcpy(os_state->osd_data, data.bytes, data.length);
+                memcpySpan(unsafeMakeSpan(os_state->osd_data, os_state->osd_data_size), span(data));
             }
 
             return os_state;

--- a/Source/WebKit/Shared/Cocoa/CoreIPCAuditToken.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCAuditToken.h
@@ -28,6 +28,8 @@
 #include <array>
 #include <mach/mach.h>
 
+#include <wtf/StdLibExtras.h>
+
 namespace WebKit {
 
 static std::array<unsigned, 8> invalidAuditToken()
@@ -45,7 +47,7 @@ struct CoreIPCAuditToken {
 
     CoreIPCAuditToken(audit_token_t input)
     {
-        memcpy(token.data(), &input, sizeof(token));
+        memcpySpan(asMutableByteSpan(token), asByteSpan(input));
     }
 
     CoreIPCAuditToken(std::array<unsigned, 8> token)
@@ -56,7 +58,7 @@ struct CoreIPCAuditToken {
     audit_token_t auditToken() const
     {
         audit_token_t result;
-        memcpy(&result, token.data(), sizeof(token));
+        memcpySpan(asMutableByteSpan(result), asByteSpan(token));
         return result;
     }
 

--- a/Source/WebKit/Shared/RTCNetwork.cpp
+++ b/Source/WebKit/Shared/RTCNetwork.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "RTCNetwork.h"
 
+#include <wtf/StdLibExtras.h>
+
 #if USE(LIBWEBRTC)
 
 namespace WebKit {
@@ -86,7 +88,7 @@ static std::array<uint32_t, 4> fromIPv6Address(const struct in6_addr& address)
 {
     std::array<uint32_t, 4> array;
     static_assert(sizeof(array) == sizeof(address));
-    memcpy(array.data(), &address, sizeof(array));
+    memcpySpan(asMutableByteSpan(array), asByteSpan(address));
     return array;
 }
 
@@ -135,7 +137,7 @@ rtc::IPAddress IPAddress::rtcAddress() const
     }, [] (std::array<uint32_t, 4> ipv6) {
         in6_addr result;
         static_assert(sizeof(ipv6) == sizeof(result));
-        memcpy(&result, ipv6.data(), sizeof(ipv6));
+        memcpySpan(asMutableByteSpan(result), asByteSpan(ipv6));
         return rtc::IPAddress(result);
     });
 }

--- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
@@ -52,6 +52,7 @@
 #import <wtf/SafeStrerror.h>
 #import <wtf/Scope.h>
 #import <wtf/SoftLinking.h>
+#import <wtf/StdLibExtras.h>
 #import <wtf/SystemTracing.h>
 #import <wtf/WTFProcess.h>
 #import <wtf/WallTime.h>
@@ -501,7 +502,7 @@ static bool tryApplyCachedSandbox(const SandboxInfo& info)
         profile.builtin = cstringBuffer.data();
         if (builtin.isNull())
             return false;
-        memcpy(profile.builtin, sandboxBuiltin.data(), cachedSandboxHeader.builtinSize);
+        memcpySpan(builtin.mutableSpan(), sandboxBuiltin.first(cachedSandboxHeader.builtinSize));
     }
     ASSERT(sandboxData.subspan(profile.size).data() <= std::to_address(cachedSandboxContents.end()));
     profile.data = sandboxData.data();

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushDaemonConnection.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushDaemonConnection.mm
@@ -38,6 +38,7 @@
 #import <wtf/BlockPtr.h>
 #import <wtf/CompletionHandler.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/StdLibExtras.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
 @implementation _WKWebPushDaemonConnectionConfiguration
@@ -75,7 +76,7 @@
 #if !USE(EXTENSIONKIT)
     auto hostAppAuditToken = configuration.hostApplicationAuditToken;
     Vector<uint8_t> hostAppAuditTokenData(sizeof(hostAppAuditToken));
-    memcpy(hostAppAuditTokenData.data(), &hostAppAuditToken, sizeof(hostAppAuditToken));
+    memcpySpan(hostAppAuditTokenData.mutableSpan(), asByteSpan(hostAppAuditToken));
     connectionConfiguration.hostAppAuditTokenData = WTFMove(hostAppAuditTokenData);
 #endif
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "RemoteGraphicsContextGLProxy.h"
 
+#include <wtf/StdLibExtras.h>
+
 #if ENABLE(GPU_PROCESS) && ENABLE(WEBGL)
 
 namespace WebKit {
@@ -671,7 +673,7 @@ void RemoteGraphicsContextGLProxy::getFloatv(GCGLenum pname, std::span<GCGLfloat
         return;
     }
     auto& [valueReply] = sendResult.reply();
-    memcpy(value.data(), valueReply.data(), value.size() * sizeof(const float));
+    memcpySpan(value, valueReply);
 }
 
 void RemoteGraphicsContextGLProxy::getIntegerv(GCGLenum pname, std::span<GCGLint> value)
@@ -684,7 +686,7 @@ void RemoteGraphicsContextGLProxy::getIntegerv(GCGLenum pname, std::span<GCGLint
         return;
     }
     auto& [valueReply] = sendResult.reply();
-    memcpy(value.data(), valueReply.data(), value.size() * sizeof(const int32_t));
+    memcpySpan(value, valueReply);
 }
 
 void RemoteGraphicsContextGLProxy::getIntegeri_v(GCGLenum pname, GCGLuint index, std::span<GCGLint, 4> value) // NOLINT
@@ -697,7 +699,7 @@ void RemoteGraphicsContextGLProxy::getIntegeri_v(GCGLenum pname, GCGLuint index,
         return;
     }
     auto& [valueReply] = sendResult.reply();
-    memcpy(value.data(), valueReply.data(), value.size() * sizeof(const int32_t));
+    memcpySpan(value, valueReply);
 }
 
 GCGLint64 RemoteGraphicsContextGLProxy::getInteger64(GCGLenum pname)
@@ -749,7 +751,7 @@ void RemoteGraphicsContextGLProxy::getBooleanv(GCGLenum pname, std::span<GCGLboo
         return;
     }
     auto& [valueReply] = sendResult.reply();
-    memcpy(value.data(), valueReply.data(), value.size() * sizeof(const bool));
+    memcpySpan(value, valueReply);
 }
 
 GCGLint RemoteGraphicsContextGLProxy::getFramebufferAttachmentParameteri(GCGLenum target, GCGLenum attachment, GCGLenum pname)
@@ -827,7 +829,7 @@ void RemoteGraphicsContextGLProxy::getShaderPrecisionFormat(GCGLenum shaderType,
         return;
     }
     auto& [rangeReply, precisionReply] = sendResult.reply();
-    memcpy(range.data(), rangeReply.data(), range.size() * sizeof(const int32_t));
+    memcpySpan(range, rangeReply);
     if (precision)
         *precision = precisionReply;
 }
@@ -881,7 +883,7 @@ void RemoteGraphicsContextGLProxy::getUniformfv(PlatformGLObject program, GCGLin
         return;
     }
     auto& [valueReply] = sendResult.reply();
-    memcpy(value.data(), valueReply.data(), value.size() * sizeof(const float));
+    memcpySpan(value, valueReply);
 }
 
 void RemoteGraphicsContextGLProxy::getUniformiv(PlatformGLObject program, GCGLint location, std::span<GCGLint> value)
@@ -894,7 +896,7 @@ void RemoteGraphicsContextGLProxy::getUniformiv(PlatformGLObject program, GCGLin
         return;
     }
     auto& [valueReply] = sendResult.reply();
-    memcpy(value.data(), valueReply.data(), value.size() * sizeof(const int32_t));
+    memcpySpan(value, valueReply);
 }
 
 void RemoteGraphicsContextGLProxy::getUniformuiv(PlatformGLObject program, GCGLint location, std::span<GCGLuint> value)
@@ -907,7 +909,7 @@ void RemoteGraphicsContextGLProxy::getUniformuiv(PlatformGLObject program, GCGLi
         return;
     }
     auto& [valueReply] = sendResult.reply();
-    memcpy(value.data(), valueReply.data(), value.size() * sizeof(const uint32_t));
+    memcpySpan(value, valueReply);
 }
 
 GCGLint RemoteGraphicsContextGLProxy::getUniformLocation(PlatformGLObject arg0, const String& name)
@@ -2720,7 +2722,7 @@ void RemoteGraphicsContextGLProxy::getActiveUniformBlockiv(PlatformGLObject prog
         return;
     }
     auto& [paramsReply] = sendResult.reply();
-    memcpy(params.data(), paramsReply.data(), params.size() * sizeof(const int32_t));
+    memcpySpan(params, paramsReply);
 }
 
 String RemoteGraphicsContextGLProxy::getTranslatedShaderSourceANGLE(PlatformGLObject arg0)
@@ -3033,7 +3035,7 @@ void RemoteGraphicsContextGLProxy::getInternalformativ(GCGLenum target, GCGLenum
         return;
     }
     auto& [paramsReply] = sendResult.reply();
-    memcpy(params.data(), paramsReply.data(), params.size() * sizeof(const int32_t));
+    memcpySpan(params, paramsReply);
 }
 
 void RemoteGraphicsContextGLProxy::setDrawingBufferColorSpace(const WebCore::DestinationColorSpace& arg0)

--- a/Source/WebKit/WebProcess/Network/WebTransportReceiveStreamSource.cpp
+++ b/Source/WebKit/WebProcess/Network/WebTransportReceiveStreamSource.cpp
@@ -27,6 +27,7 @@
 #include "WebTransportReceiveStreamSource.h"
 
 #include <wtf/RunLoop.h>
+#include <wtf/StdLibExtras.h>
 
 namespace WebKit {
 
@@ -49,7 +50,7 @@ void WebTransportReceiveStreamSource::receiveBytes(std::span<const uint8_t> byte
         return;
     auto arrayBuffer = ArrayBuffer::tryCreateUninitialized(bytes.size(), 1);
     if (arrayBuffer)
-        memcpy(static_cast<uint8_t*>(arrayBuffer->data()), bytes.data(), bytes.size());
+        memcpySpan(arrayBuffer->mutableSpan(), bytes);
     if (!controller().enqueue(WTFMove(arrayBuffer)))
         doCancel();
 }

--- a/Source/WebKit/webpushd/PushClientConnection.mm
+++ b/Source/WebKit/webpushd/PushClientConnection.mm
@@ -41,6 +41,7 @@
 #import <WebCore/PushPermissionState.h>
 #import <wtf/ASCIICType.h>
 #import <wtf/HexNumber.h>
+#import <wtf/StdLibExtras.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/Vector.h>
 #import <wtf/cocoa/Entitlements.h>
@@ -169,7 +170,7 @@ RefPtr<PushClientConnection> PushClientConnection::create(xpc_connection_t conne
         return nullptr;
     }
 
-    memcpy(&hostAppAuditToken, configuration.hostAppAuditTokenData.data(), sizeof(hostAppAuditToken));
+    memcpySpan(asMutableByteSpan(hostAppAuditToken), configuration.hostAppAuditTokenData.span());
 #endif
 
     bool hostAppHasWebPushEntitlement = hostAppHasEntitlement(hostAppAuditToken, hostAppWebPushEntitlement);

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
@@ -39,6 +39,7 @@
 #import <wtf/BlockPtr.h>
 #import <wtf/MainThread.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/StdLibExtras.h>
 #import <wtf/TZoneMallocInlines.h>
 
 namespace WebPushTool {
@@ -142,7 +143,7 @@ void Connection::sendAuditToken()
 
     Vector<uint8_t> tokenVector;
     tokenVector.resize(32);
-    memcpy(tokenVector.data(), &token, sizeof(token));
+    memcpySpan(tokenVector.mutableSpan(), asByteSpan(token));
     configuration.hostAppAuditTokenData = WTFMove(tokenVector);
 
     sendWithoutUsingIPCConnection(Messages::PushClientConnection::InitializeConnection(WTFMove(configuration)));


### PR DESCRIPTION
#### 195caf5eb22b17389d588a3340c1a6975bf8c0f8
<pre>
Reduce use of memcpy()
<a href="https://bugs.webkit.org/show_bug.cgi?id=284509">https://bugs.webkit.org/show_bug.cgi?id=284509</a>

Reviewed by Geoffrey Garen.

Reduce use of memcpy() in favor of safer variants.

* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp:
(WebCore::WebCodecsAudioEncoder::createEncodedChunkMetadata):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp:
(WebCore::WebCodecsVideoEncoder::createEncodedChunkMetadata):
* Source/WebCore/Modules/webtransport/DatagramSource.cpp:
(WebCore::DatagramSource::receiveDatagram):
* Source/WebCore/bindings/js/StructuredClone.cpp:
(WebCore::JSC_DEFINE_HOST_FUNCTION):
* Source/WebCore/loader/TextResourceDecoder.cpp:
(WebCore::TextResourceDecoder::checkForCSSCharset):
(WebCore::TextResourceDecoder::checkForHeadCharset):
(WebCore::TextResourceDecoder::decode):
* Source/WebCore/platform/audio/AudioChannel.cpp:
(WebCore::AudioChannel::copyFrom):
* Source/WebCore/platform/audio/FFTConvolver.cpp:
(WebCore::FFTConvolver::process):
* Source/WebCore/platform/audio/mac/FFTFrameMac.cpp:
(WebCore::FFTFrame::FFTFrame):
* Source/WebCore/platform/graphics/avfoundation/ISOFairPlayStreamingPsshBox.cpp:
(WebCore::ISOFairPlayStreamingKeyRequestInfoBox::parse):
(WebCore::ISOFairPlayStreamingKeyAssetIdBox::parse):
(WebCore::ISOFairPlayStreamingKeyContextBox::parse):
* Source/WebCore/platform/graphics/filters/FilterImage.cpp:
(WebCore::copyImageBytes):
* Source/WebCore/platform/graphics/filters/software/FEGaussianBlurSoftwareApplier.cpp:
(WebCore::FEGaussianBlurSoftwareApplier::boxBlurAccelerated):
(WebCore::FEGaussianBlurSoftwareApplier::boxBlurUnaccelerated):
(WebCore::FEGaussianBlurSoftwareApplier::applyPlatform):
* Source/WebCore/platform/graphics/iso/ISOProtectionSystemSpecificHeaderBox.cpp:
(WebCore::ISOProtectionSystemSpecificHeaderBox::parse):
* Source/WebCore/platform/graphics/iso/ISOTrackEncryptionBox.cpp:
(WebCore::ISOTrackEncryptionBox::parsePayload):
* Source/WebCore/platform/graphics/texmap/ClipStack.cpp:
(WebCore::ClipStack::addRoundedRect):
* Source/WebCore/platform/image-decoders/bmp/BMPImageReader.h:
(WebCore::BMPImageReader::readUint16):
(WebCore::BMPImageReader::readUint32):
(WebCore::BMPImageReader::readCurrentPixel const):
* Source/WebCore/platform/image-decoders/png/PNGImageDecoder.cpp:
(WebCore::PNGImageDecoder::headerAvailable):
(WebCore::PNGImageDecoder::readChunks):
(WebCore::PNGImageDecoder::processingStart):
* Source/WebCore/platform/image-decoders/png/PNGImageDecoder.h:
* Source/WebCore/platform/network/BlobResourceHandle.cpp:
(WebCore::BlobResourceHandle::readDataSync):
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::configurationWithHostAuditToken):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::setProxyConfigData):
* Source/WebKit/Shared/API/APIClient.h:
(API::Client::initialize):
* Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm:
(WebKit::AuxiliaryProcess::registerWithStateDumper):
* Source/WebKit/Shared/Cocoa/CoreIPCAuditToken.h:
(WebKit::CoreIPCAuditToken::CoreIPCAuditToken):
(WebKit::CoreIPCAuditToken::auditToken const):
* Source/WebKit/Shared/RTCNetwork.cpp:
(WebKit::RTC::Network::fromIPv6Address):
(WebKit::RTC::Network::IPAddress::rtcAddress const):
* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::tryApplyCachedSandbox):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebPushDaemonConnection.mm:
(-[_WKWebPushDaemonConnection initWithConfiguration:]):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp:
(WebKit::RemoteGraphicsContextGLProxy::getFloatv):
(WebKit::RemoteGraphicsContextGLProxy::getIntegerv):
(WebKit::RemoteGraphicsContextGLProxy::getIntegeri_v):
(WebKit::RemoteGraphicsContextGLProxy::getBooleanv):
(WebKit::RemoteGraphicsContextGLProxy::getShaderPrecisionFormat):
(WebKit::RemoteGraphicsContextGLProxy::getUniformfv):
(WebKit::RemoteGraphicsContextGLProxy::getUniformiv):
(WebKit::RemoteGraphicsContextGLProxy::getUniformuiv):
(WebKit::RemoteGraphicsContextGLProxy::getActiveUniformBlockiv):
(WebKit::RemoteGraphicsContextGLProxy::getInternalformativ):
* Source/WebKit/WebProcess/Network/WebTransportReceiveStreamSource.cpp:
(WebKit::WebTransportReceiveStreamSource::receiveBytes):
* Source/WebKit/webpushd/PushClientConnection.mm:
(WebPushD::PushClientConnection::create):
* Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm:
(WebPushTool::Connection::sendAuditToken):

Canonical link: <a href="https://commits.webkit.org/287825@main">https://commits.webkit.org/287825@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9a5277ff1a1b3b3cca7ef509e743642ff505402

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81021 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/546 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34964 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/85550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/32007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83131 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/564 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8347 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/85550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/32007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84090 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73739 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/85550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27900 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/30465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/71778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/28450 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/86985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8251 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/86985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8428 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69574 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/86985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17615 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/14829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/13752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8212 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/13735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/8049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/11569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/9857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->