### PR TITLE
Fix more C++ smart pointer warnings in WebKit

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -698,8 +698,7 @@ Ref<RemoteAudioSessionProxy> GPUConnectionToWebProcess::protectedAudioSessionPro
 RemoteImageDecoderAVFProxy& GPUConnectionToWebProcess::imageDecoderAVFProxy()
 {
     if (!m_imageDecoderAVFProxy)
-        m_imageDecoderAVFProxy = makeUniqueWithoutRefCountedCheck<RemoteImageDecoderAVFProxy>(*this);
-
+        lazyInitialize(m_imageDecoderAVFProxy, makeUniqueWithoutRefCountedCheck<RemoteImageDecoderAVFProxy>(*this));
     return *m_imageDecoderAVFProxy;
 }
 

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -420,7 +420,7 @@ private:
     RefPtr<RemoteLegacyCDMFactoryProxy> m_legacyCdmFactoryProxy;
 #endif
 #if HAVE(AVASSETREADER)
-    std::unique_ptr<RemoteImageDecoderAVFProxy> m_imageDecoderAVFProxy;
+    const std::unique_ptr<RemoteImageDecoderAVFProxy> m_imageDecoderAVFProxy;
 #endif
 
     std::unique_ptr<RemoteMediaEngineConfigurationFactoryProxy> m_mediaEngineConfigurationFactoryProxy;

--- a/Source/WebKit/NetworkProcess/CustomProtocols/Cocoa/LegacyCustomProtocolManagerCocoa.mm
+++ b/Source/WebKit/NetworkProcess/CustomProtocols/Cocoa/LegacyCustomProtocolManagerCocoa.mm
@@ -80,7 +80,7 @@ void LegacyCustomProtocolManager::networkProcessCreated(NetworkProcess& networkP
 + (BOOL)canInitWithRequest:(NSURLRequest *)request
 {
     // FIXME: This code runs in a dispatch queue so we can't ref NetworkProcess here.
-    if (auto* customProtocolManager = protectedFirstNetworkProcess()->supplement<LegacyCustomProtocolManager>())
+    if (SUPPRESS_UNCOUNTED_LOCAL auto* customProtocolManager = protectedFirstNetworkProcess()->supplement<LegacyCustomProtocolManager>())
         SUPPRESS_UNCOUNTED_ARG return customProtocolManager->supportsScheme([[[request URL] scheme] lowercaseString]);
     return NO;
 }

--- a/Source/WebKit/NetworkProcess/EarlyHintsResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/EarlyHintsResourceLoader.cpp
@@ -118,18 +118,19 @@ ResourceRequest EarlyHintsResourceLoader::constructPreconnectRequest(const Resou
 void EarlyHintsResourceLoader::startPreconnectTask(const URL& baseURL, const LinkHeader& header, const ContentSecurityPolicy& contentSecurityPolicy)
 {
 #if ENABLE(SERVER_PRECONNECT)
-    if (!m_loader || !m_loader->parameters().linkPreconnectEarlyHintsEnabled)
+    RefPtr loader = m_loader.get();
+    if (!loader || !loader->parameters().linkPreconnectEarlyHintsEnabled)
         return;
 
     URL url(baseURL, header.url());
     if (!url.isValid() || url.protocol() != "https"_s)
         return;
 
-    const auto& originalRequest = m_loader->originalRequest();
+    const auto& originalRequest = loader->originalRequest();
     if (!contentSecurityPolicy.allowConnectToSource(url, ContentSecurityPolicy::RedirectResponseReceived::No, originalRequest.url()))
         return;
 
-    auto* networkSession = m_loader->protectedConnectionToWebProcess()->networkSession();
+    auto* networkSession = loader->protectedConnectionToWebProcess()->networkSession();
     if (!networkSession)
         return;
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebProcessSyncClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebProcessSyncClient.cpp
@@ -49,7 +49,7 @@ Ref<WebPage> WebProcessSyncClient::protectedPage() const
 
 bool WebProcessSyncClient::siteIsolationEnabled()
 {
-    RefPtr<WebCore::Page> corePage = m_page->protectedCorePage();
+    RefPtr<WebCore::Page> corePage = protectedPage()->protectedCorePage();
     return corePage ? corePage->settings().siteIsolationEnabled() : false;
 }
 


### PR DESCRIPTION
#### e47b2a9d69c64db1802f728e907d026ce4f7cda1
<pre>
Fix more C++ smart pointer warnings in WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=284512">https://bugs.webkit.org/show_bug.cgi?id=284512</a>

Reviewed by Jean-Yves Avenard and Anne van Kesteren.

Address more clang static analyzer warnings in WebKit.

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::imageDecoderAVFProxy):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/CustomProtocols/Cocoa/LegacyCustomProtocolManagerCocoa.mm:
(+[WKCustomProtocol canInitWithRequest:]):
* Source/WebKit/NetworkProcess/EarlyHintsResourceLoader.cpp:
(WebKit::EarlyHintsResourceLoader::startPreconnectTask):
* Source/WebKit/WebProcess/WebCoreSupport/WebProcessSyncClient.cpp:
(WebKit::WebProcessSyncClient::siteIsolationEnabled):

Canonical link: <a href="https://commits.webkit.org/287748@main">https://commits.webkit.org/287748@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42fcc08e35b21f8ee3254882028ad98d41e661f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80656 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59663 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34590 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85180 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31638 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68724 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7971 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62990 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20787 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83725 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/53122 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73423 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43295 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50404 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30097 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71554 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28107 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86613 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7882 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5559 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71284 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8057 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69259 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70525 "Found 10 new API test failures: /TestWebKit:WebKit.PageLoadBasic, /TestWebKit:WebKit.CanHandleRequest, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/title-change, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/test-page-list, /TestWebKit:WebKit.PageLoadDidChangeLocationWithinPage, /TestWebKit:WebKit.WillSendSubmitEvent, /TestWebKit:WebKit.GeolocationBasicWithHighAccuracy, /TestWebKit:WebKit.DownloadDecideDestinationCrash, /TestWebKit:WebKit2.ProvisionalURLAfterWillSendRequestCallback, /TestWebKit:WebKit.DocumentStartUserScriptAlertCrashTest (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14544 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13497 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12508 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7844 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13363 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7683 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11202 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9488 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->