### PR TITLE
Remove Quirk needsIPadMiniUserAgent for hsbc.ca and hsbc.com.ar

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1805,10 +1805,6 @@ bool Quirks::needsIPadMiniUserAgent(const URL& url)
             return true;
         if (host == "hsbc.com.mx"_s || host.endsWith(".hsbc.com.mx"_s))
             return true;
-        if (host == "hsbc.ca"_s || host.endsWith(".hsbc.ca"_s))
-            return true;
-        if (host == "hsbc.com.ar"_s || host.endsWith(".hsbc.com.ar"_s))
-            return true;
         if (host == "hsbc.com.ph"_s || host.endsWith(".hsbc.com.ph"_s))
             return true;
         if (host == "hsbc.com"_s || host.endsWith(".hsbc.com"_s))


### PR DESCRIPTION
#### 3dcfa50e41b3ad6b553ed7c295ad305154211f13
<pre>
Remove Quirk needsIPadMiniUserAgent for hsbc.ca and hsbc.com.ar
<a href="https://bugs.webkit.org/show_bug.cgi?id=284515">https://bugs.webkit.org/show_bug.cgi?id=284515</a>
<a href="https://rdar.apple.com/141339200">rdar://141339200</a>

Reviewed by Anne van Kesteren.

HSBC has stopped operating in Canada and Argentina. The online
banking for consumers is not available anymore. These quirks
were trying to solve an issue on the online banking system.
They are not necessary anymore.

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::needsIPadMiniUserAgent):

Canonical link: <a href="https://commits.webkit.org/287730@main">https://commits.webkit.org/287730@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f75739009ec9a0ba6500cba1303fecd69e54c0c4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80658 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59665 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34592 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85182 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31640 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82769 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68726 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7974 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/62993 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/20791 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83727 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/53123 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73422 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43298 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/50405 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27582 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30099 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71555 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28106 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86615 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7884 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/71286 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8059 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69258 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70527 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14545 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/13496 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12494 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7846 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/13365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7685 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11204 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9490 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->