### PR TITLE
[MediaRecorder] MediaRecorderPrivateEncoder should write its frames in batches

### DIFF
--- a/Source/WebCore/platform/PlatformMediaError.cpp
+++ b/Source/WebCore/platform/PlatformMediaError.cpp
@@ -47,6 +47,7 @@ String convertEnumerationToString(PlatformMediaError enumerationValue)
         MAKE_STATIC_STRING_IMPL("DecoderCreationError"),
         MAKE_STATIC_STRING_IMPL("NotSupportedError"),
         MAKE_STATIC_STRING_IMPL("NetworkError"),
+        MAKE_STATIC_STRING_IMPL("NotReady"),
     };
     static_assert(!static_cast<size_t>(PlatformMediaError::AppendError), "PlatformMediaError::AppendError is not 0 as expected");
     static_assert(static_cast<size_t>(PlatformMediaError::ClientDisconnected) == 1, "PlatformMediaError::ClientDisconnected is not 1 as expected");
@@ -60,6 +61,7 @@ String convertEnumerationToString(PlatformMediaError enumerationValue)
     static_assert(static_cast<size_t>(PlatformMediaError::DecoderCreationError) == 9, "PlatformMediaError::DecoderCreationError is not 9 as expected");
     static_assert(static_cast<size_t>(PlatformMediaError::NotSupportedError) == 10, "PlatformMediaError::NotSupportedError is not 10 as expected");
     static_assert(static_cast<size_t>(PlatformMediaError::NetworkError) == 11, "PlatformMediaError::NetworkError is not 11 as expected");
+    static_assert(static_cast<size_t>(PlatformMediaError::NotReady) == 12, "PlatformMediaError::NotReady is not 12 as expected");
     ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }

--- a/Source/WebCore/platform/PlatformMediaError.h
+++ b/Source/WebCore/platform/PlatformMediaError.h
@@ -43,6 +43,7 @@ enum class PlatformMediaError : uint8_t {
     DecoderCreationError,
     NotSupportedError,
     NetworkError,
+    NotReady
 };
 
 using MediaPromise = NativePromise<void, PlatformMediaError>;

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h
@@ -116,9 +116,9 @@ private:
     void partiallyFlushEncodedQueues();
     Ref<GenericPromise> waitForMatchingAudio(const MediaTime&);
     using Result = MediaRecorderPrivateWriter::Result;
-    std::pair<Result, MediaTime> flushToEndSegment(const MediaTime&);
+    MediaTime flushToEndSegment(const MediaTime&);
     void flushAllEncodedQueues();
-    Result muxNextFrame();
+    void interleaveAndEnqueueNextFrame();
 
     void maybeStartWriter();
     bool hasMuxedDataSinceEndSegment() const;
@@ -169,6 +169,7 @@ private:
     RefPtr<VideoEncoder> m_videoEncoder WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     Deque<std::pair<Ref<VideoFrame>, MediaTime>> m_pendingVideoFrames WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     Deque<Ref<MediaSample>> m_encodedVideoFrames WTF_GUARDED_BY_CAPABILITY(queueSingleton());
+    Deque<Ref<MediaSample>> m_interleavedFrames WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     bool m_firstVideoFrameProcessed WTF_GUARDED_BY_CAPABILITY(queueSingleton()) { false };
     MediaTime m_lastEnqueuedRawVideoFrame WTF_GUARDED_BY_CAPABILITY(queueSingleton()) { MediaTime::negativeInfiniteTime() };
     MediaTime m_lastVideoKeyframeTime WTF_GUARDED_BY_CAPABILITY(queueSingleton());

--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.h
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.h
@@ -48,7 +48,7 @@ private:
     std::optional<uint8_t> addAudioTrack(CMFormatDescriptionRef) final;
     std::optional<uint8_t> addVideoTrack(CMFormatDescriptionRef, const std::optional<CGAffineTransform>&) final;
     bool allTracksAdded() final;
-    Result muxFrame(const MediaSample&, uint8_t) final;
+    Result writeFrame(const MediaSample&) final;
     void forceNewSegment(const WTF::MediaTime&) final;
     Ref<GenericPromise> close(const WTF::MediaTime&) final;
 

--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.mm
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.mm
@@ -155,19 +155,19 @@ bool MediaRecorderPrivateWriterAVFObjC::allTracksAdded()
     return true;
 }
 
-MediaRecorderPrivateWriterAVFObjC::Result MediaRecorderPrivateWriterAVFObjC::muxFrame(const MediaSample& sample, uint8_t trackIndex)
+MediaRecorderPrivateWriterAVFObjC::Result MediaRecorderPrivateWriterAVFObjC::writeFrame(const MediaSample& sample)
 {
-    if (trackIndex == m_audioTrackIndex) {
+    if (sample.trackID() == m_audioTrackIndex) {
         if (![m_audioAssetWriterInput isReadyForMoreMediaData])
             return Result::NotReady;
 
         auto result = [m_audioAssetWriterInput appendSampleBuffer:downcast<MediaSampleAVFObjC>(sample).sampleBuffer()] ? Result::Success : Result::Failure;
         if (result != Result::Success)
-            RELEASE_LOG_ERROR(MediaStream, "MediaRecorderPMediaRecorderPrivateWriterAVFObjC::muxFrame audio failed with %ld", static_cast<long>([m_writer error].code));
+            RELEASE_LOG_ERROR(MediaStream, "MediaRecorderPMediaRecorderPrivateWriterAVFObjC::writeFrame audio failed with %ld", static_cast<long>([m_writer error].code));
         return result;
     }
 
-    ASSERT(trackIndex == m_videoTrackIndex);
+    ASSERT(sample.trackID() == m_videoTrackIndex);
     if (![m_videoAssetWriterInput isReadyForMoreMediaData])
         return Result::NotReady;
 

--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.cpp
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.cpp
@@ -162,7 +162,7 @@ std::optional<uint8_t> MediaRecorderPrivateWriterWebM::addVideoTrack(CMFormatDes
     return m_delegate->addVideoTrack(dimensions.width, dimensions.height, mkvCodeIcForMediaVideoCodecId(codec));
 }
 
-MediaRecorderPrivateWriterWebM::Result MediaRecorderPrivateWriterWebM::muxFrame(const MediaSample& sample, uint8_t trackIndex)
+MediaRecorderPrivateWriterWebM::Result MediaRecorderPrivateWriterWebM::writeFrame(const MediaSample& sample)
 {
     RetainPtr sampleBuffer = downcast<MediaSampleAVFObjC>(sample).sampleBuffer();
     RetainPtr buffer = PAL::CMSampleBufferGetDataBuffer(sampleBuffer.get());
@@ -174,7 +174,7 @@ MediaRecorderPrivateWriterWebM::Result MediaRecorderPrivateWriterWebM::muxFrame(
 
     bool isKeyFrame = sample.flags() & MediaSample::IsSync;
 
-    return m_delegate->addFrame({ reinterpret_cast<const uint8_t*>(srcData), srcSize }, trackIndex, Seconds { sample.presentationTime().toDouble() }.nanosecondsAs<uint64_t>(), isKeyFrame) ? Result::Success : Result::Failure;
+    return m_delegate->addFrame({ reinterpret_cast<const uint8_t*>(srcData), srcSize }, sample.trackID(), Seconds { sample.presentationTime().toDouble() }.nanosecondsAs<uint64_t>(), isKeyFrame) ? Result::Success : Result::Failure;
 }
 
 void MediaRecorderPrivateWriterWebM::forceNewSegment(const MediaTime&)

--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.h
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.h
@@ -46,7 +46,7 @@ private:
     std::optional<uint8_t> addAudioTrack(CMFormatDescriptionRef) final;
     std::optional<uint8_t> addVideoTrack(CMFormatDescriptionRef, const std::optional<CGAffineTransform>&) final;
     bool allTracksAdded() final { return true; }
-    Result muxFrame(const MediaSample&, uint8_t) final;
+    Result writeFrame(const MediaSample&) final;
     void forceNewSegment(const WTF::MediaTime&) final;
     Ref<GenericPromise> close(const WTF::MediaTime&) final;
 


### PR DESCRIPTION
#### a88de4763fdabaf8b2f14f29d1407c068083158c
<pre>
[MediaRecorder] MediaRecorderPrivateEncoder should write its frames in batches
<a href="https://bugs.webkit.org/show_bug.cgi?id=284513">https://bugs.webkit.org/show_bug.cgi?id=284513</a>
<a href="https://rdar.apple.com/141339068">rdar://141339068</a>

Reviewed by Youenn Fablet.

In preparation for moving the MediaRecorderPrivateWriter back to the GPU process
we promisify the use of the writer and write frames in batches.

The writer will now only be called with all the data used for a new segment,
we no longer need for the encoder to instruct the writer to start a new
segment, it is implied that a new segment is required once the current
batch has been written.

* Source/WebCore/platform/PlatformMediaError.cpp:
(WebCore::convertEnumerationToString):
* Source/WebCore/platform/PlatformMediaError.h:
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp:
(WebCore::MediaRecorderPrivateEncoder::partiallyFlushEncodedQueues):
(WebCore::MediaRecorderPrivateEncoder::flushToEndSegment):
(WebCore::MediaRecorderPrivateEncoder::flushAllEncodedQueues):
(WebCore::MediaRecorderPrivateEncoder::interleaveAndEnqueueNextFrame):
(WebCore::MediaRecorderPrivateEncoder::stopRecording):
(WebCore::MediaRecorderPrivateEncoder::flushPendingData):
(WebCore::MediaRecorderPrivateEncoder::muxNextFrame): Deleted.
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h:
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateWriter.cpp:
(WebCore::MediaRecorderPrivateWriter::writeFrames):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateWriter.h:
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.h:
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.mm:
(WebCore::MediaRecorderPrivateWriterAVFObjC::writeFrame):
(WebCore::MediaRecorderPrivateWriterAVFObjC::muxFrame): Deleted.
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.cpp:
(WebCore::MediaRecorderPrivateWriterWebM::writeFrame):
(WebCore::MediaRecorderPrivateWriterWebM::muxFrame): Deleted.
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.h:

Canonical link: <a href="https://commits.webkit.org/287869@main">https://commits.webkit.org/287869@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22d430c5b156a1ad1135f1d400b9b5d15a884212

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81122 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/647 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35065 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85651 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32108 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83232 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/665 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8463 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63331 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21096 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84191 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/417 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73828 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43629 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/314 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27990 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30566 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71843 "Found 1 new API test failure: TestWebKitAPI.GPUProcess.ExitsUnderMemoryPressureWebRTCCase (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28548 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87086 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8352 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5923 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71634 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8530 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69663 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70869 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17651 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14913 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13836 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8313 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13836 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8150 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11670 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9958 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->