### PR TITLE
[css-anchor-position-1] Implement anchor name encapsulation within shadow trees

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-cross-shadow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-cross-shadow-expected.txt
@@ -1,4 +1,4 @@
 
-PASS Should be able to set anchor-name to a shadow DOM part and anchor to it
+FAIL Should be able to set anchor-name to a shadow DOM part and anchor to it assert_equals: expected 15 but got 0
 PASS Should be able to set anchor-name to the shadow host and anchor to it
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-in-shadow-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-in-shadow-002-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Anchor names in different tree scopes should not be confused assert_equals: expected 0 but got 200
+PASS Anchor names in different tree scopes should not be confused
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-in-shadow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-in-shadow-expected.txt
@@ -1,4 +1,4 @@
 
 PASS anchor-name should not leak out of a shadow tree
-FAIL anchor() in shadow tree should not match host anchor-name assert_equals: #anchored is positioned using fallback expected 37 but got 8
+PASS anchor() in shadow tree should not match host anchor-name
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scope-shadow-flat-tree-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scope-shadow-flat-tree-expected.txt
@@ -1,3 +1,3 @@
 
-PASS anchor-scope scopes to the flat tree
+FAIL anchor-scope scopes to the flat tree assert_equals: expected "20px" but got "1px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-002-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Transition with anchor names defined in different tree scopes assert_equals: expected 250 but got 400
+FAIL Transition with anchor names defined in different tree scopes assert_equals: expected 250 but got 300
 

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1645,7 +1645,7 @@ const Element* RenderElement::defaultAnchor() const
     if (!element())
         return nullptr;
 
-    auto& anchorPositionedMap = document().styleScope().anchorPositionedToAnchorMap();
+    auto& anchorPositionedMap = Style::Scope::forNode(*RenderObject::node()).anchorPositionedToAnchorMap();
     auto it = anchorPositionedMap.find(*element());
     if (it == anchorPositionedMap.end())
         return nullptr;

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -44,6 +44,7 @@
 #include "RenderStyleInlines.h"
 #include "RenderStyleSetters.h"
 #include "RenderView.h"
+#include "ShadowRoot.h"
 #include "StyleBuilderConverter.h"
 #include "StyleBuilderState.h"
 #include "StyleScope.h"
@@ -797,6 +798,11 @@ static bool isAcceptableAnchorElement(const RenderBoxModelObject& anchorRenderer
     if (!anchorElement)
         return false;
 
+    // An element is not acceptable anchor element if positioned element uses different style scope (as it resides in (different) shadow tree).
+    // FIXME: Add support for ::part().
+    if (&Style::Scope::forNode(*anchorElement) != &Style::Scope::forNode(anchorPositionedElement))
+        return false;
+
     if (auto anchorScopeElement = anchorScopeForAnchorElement(*anchorElement, anchorRenderer.style().anchorNames())) {
         // If the anchor is scoped, the anchor-positioned element must also be in the same scope.
         if (!anchorPositionedElement->isComposedTreeDescendantOf(*anchorScopeElement))
@@ -899,7 +905,7 @@ void AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayou
                 for (auto& anchorElement : state.anchorElements.values())
                     anchors.append(dynamicDowncast<RenderBoxModelObject>(anchorElement->renderer()));
 
-                document.styleScope().anchorPositionedToAnchorMap().set(element.get(), WTFMove(anchors));
+                Style::Scope::forNode(element.get()).anchorPositionedToAnchorMap().set(element.get(), WTFMove(anchors));
             }
             state.stage = renderer && renderer->style().usesAnchorFunctions() ? AnchorPositionResolutionStage::ResolveAnchorFunctions : AnchorPositionResolutionStage::Resolved;
             continue;
@@ -925,7 +931,8 @@ void AnchorPositionEvaluator::updateSnapshottedScrollOffsets(Document& document)
 {
     // https://drafts.csswg.org/css-anchor-position-1/#scroll
 
-    for (auto elementAndAnchors : document.styleScope().anchorPositionedToAnchorMap()) {
+    visitAllAnchorPositionedToAnchorMaps(document, [](auto& anchorPositionedToAnchorMap) {
+    for (auto elementAndAnchors : anchorPositionedToAnchorMap) {
         CheckedRef anchorPositionedElement = elementAndAnchors.key;
         if (!anchorPositionedElement->renderer())
             continue;
@@ -963,6 +970,7 @@ void AnchorPositionEvaluator::updateSnapshottedScrollOffsets(Document& document)
 
         anchorPositionedRenderer->layer()->setSnapshottedScrollOffsetForAnchorPositioning(scrollOffset);
     }
+    });
 }
 
 auto AnchorPositionEvaluator::makeAnchorPositionedForAnchorMap(AnchorPositionedToAnchorMap& toAnchorMap) -> AnchorToAnchorPositionedMap
@@ -980,6 +988,13 @@ auto AnchorPositionEvaluator::makeAnchorPositionedForAnchorMap(AnchorPositionedT
         }
     }
     return map;
+}
+
+void AnchorPositionEvaluator::visitAllAnchorPositionedToAnchorMaps(Document& document, std::function<void(AnchorPositionedToAnchorMap&)> visitor)
+{
+    visitor(document.styleScope().anchorPositionedToAnchorMap());
+    for (Ref shadowRoot : document.inDocumentShadowRoots())
+        visitor(const_cast<ShadowRoot&>(shadowRoot.get()).styleScope().anchorPositionedToAnchorMap());
 }
 
 bool AnchorPositionEvaluator::isLayoutTimeAnchorPositioned(const RenderStyle& style)

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -113,6 +113,8 @@ public:
 
     static bool overflowsInsetModifiedContainingBlock(const RenderBox& anchoredBox);
 
+    static void visitAllAnchorPositionedToAnchorMaps(Document&, std::function<void(AnchorPositionedToAnchorMap&)> visitor);
+
 private:
     static AnchorElements findAnchorsForAnchorPositionedElement(const Element&, const UncheckedKeyHashSet<AtomString>& anchorNames, const AnchorsForAnchorName&);
 };


### PR DESCRIPTION
#### 193393074115a6fe74618ee0d798ae79dc501268
<pre>
[css-anchor-position-1] Implement anchor name encapsulation within shadow trees
<a href="https://bugs.webkit.org/show_bug.cgi?id=281963">https://bugs.webkit.org/show_bug.cgi?id=281963</a>

Reviewed by NOBODY (OOPS!).

This change makes anchor names encapsulated within shadow trees as specified in:
<a href="https://drafts.csswg.org/css-anchor-position-1/#target">https://drafts.csswg.org/css-anchor-position-1/#target</a>

Effectively, this change spreads the data (originally stored only in AnchorPositionedStates
of Document&apos;s Style::Scope) across all the Style::Scopes - including ones of shadow trees.
The above means that the anchor names defined by styles in one shadow tree won’t be seen
by anchor functions in styles in a different shadow tree.

This change leaves the &apos;::part()&apos; code path not implemented as it requires different kind of
changes all across the anchoring code. Namely, any reference to AnchorPositionedStates will
have to be done in the context of particular Style::Scope that is applicable due to certain
part being used. This in turn may require major refactoring. Therefore this part is left
for a follow-up.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-cross-shadow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-in-shadow-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-in-shadow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scope-shadow-flat-tree-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-002-expected.txt:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::defaultAnchor const):
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::isAcceptableAnchorElement):
(WebCore::Style::AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayout):
(WebCore::Style::AnchorPositionEvaluator::updateSnapshottedScrollOffsets):
(WebCore::Style::AnchorPositionEvaluator::visitAllAnchorPositionedToAnchorMaps):
* Source/WebCore/style/AnchorPositionEvaluator.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/193393074115a6fe74618ee0d798ae79dc501268

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96844 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16458 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6638 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101917 "Hash 19339307 for PR 37826 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47364 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98889 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16754 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24903 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/101917 "Hash 19339307 for PR 37826 does not build (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31005 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99847 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12616 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87603 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/101917 "Hash 19339307 for PR 37826 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12376 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5421 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46692 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82470 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5501 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103940 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23912 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17446 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82842 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24163 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83675 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82232 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26895 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4443 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17405 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23874 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29029 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23533 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27013 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25274 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->