### PR TITLE
Correctly repaint <input type=range> track after setValue

### DIFF
--- a/LayoutTests/fast/forms/range/range-set-value-repaint-expected.html
+++ b/LayoutTests/fast/forms/range/range-set-value-repaint-expected.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.sc { /* slider container, size not dependent on content */
+width: 200px;
+height: 32px;
+border: solid 1px;
+display: flex;
+align-items: center;
+}
+.s { /* slider */
+width: 160px;
+height: 16px;
+overflow: hidden;
+}
+</style>
+</head>
+<body>
+<div class="sc"><input class="s" type="range" min="0" max="100" value="100"><br></div><br>
+<div class="sc"><input class="s" type="range" min="0" max="100" value="80"><br></div><br>
+<div class="sc"><input class="s" type="range" min="0" max="100" value="50"><br></div><br>
+<div class="sc"><input class="s" type="range" min="0" max="100" value="25"><br></div><br>
+<div class="sc"><input class="s" type="range" min="0" max="100" value="1"><br></div><br>
+<div class="sc"><input class="s" type="range" min="0" max="100" value="0"><br></div><br>
+<div class="sc"><input class="s" type="range" min="0" max="100" value="0"><br></div><br>
+<div class="sc"><input class="s" type="range" min="0" max="100" value="50"><br></div><br>
+<div class="sc"><input class="s" type="range" min="0" max="100" value="80"><br></div><br>
+<div class="sc"><input class="s" type="range" min="0" max="100" value="99"><br></div><br>
+<div class="sc"><input class="s" type="range" min="0" max="100" value="90"><br></div><br>
+<div class="sc"><input class="s" type="range" min="0" max="100" value="10"><br></div><br>
+</body>
+</html>

--- a/LayoutTests/fast/forms/range/range-set-value-repaint.html
+++ b/LayoutTests/fast/forms/range/range-set-value-repaint.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="fuzzy" content="maxDifference=0-30; totalPixels=0-81">
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+.sc { /* slider container, size not dependent on content */
+width: 200px;
+height: 32px;
+border: solid 1px;
+display: flex;
+align-items: center;
+}
+.s { /* slider */
+width: 160px;
+height: 16px;
+overflow: hidden;
+}
+</style>
+</head>
+<body>
+<!-- id contains "initial_target" values -->
+<div class="sc"><input class="s" type="range" min="0" max="100" id="0_100"><br></div><br>
+<div class="sc"><input class="s" type="range" min="0" max="100" id="0_80"><br></div><br>
+<div class="sc"><input class="s" type="range" min="0" max="100" id="0_50"><br></div><br>
+<div class="sc"><input class="s" type="range" min="0" max="100" id="0_25"><br></div><br>
+<div class="sc"><input class="s" type="range" min="0" max="100" id="0_1"><br></div><br>
+<div class="sc"><input class="s" type="range" min="0" max="100" id="0_0"><br></div><br>
+<div class="sc"><input class="s" type="range" min="0" max="100" id="100_0"><br></div><br>
+<div class="sc"><input class="s" type="range" min="0" max="100" id="100_50"><br></div><br>
+<div class="sc"><input class="s" type="range" min="0" max="100" id="100_80"><br></div><br>
+<div class="sc"><input class="s" type="range" min="0" max="100" id="100_99"><br></div><br>
+<div class="sc"><input class="s" type="range" min="0" max="100" id="10_90"><br></div><br>
+<div class="sc"><input class="s" type="range" min="0" max="100" id="90_10"><br></div><br>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    if (testRunner.dontForceRepaint)
+        testRunner.dontForceRepaint();
+}
+
+async function runTest() {
+    for (range of document.getElementsByTagName("input"))
+        range.value = range.id.split("_")[0];
+
+    var inputs = document.getElementsByTagName("input");
+    for (var input of inputs) {
+        // Force rendering previous changes, so that large groups of dirty rects don't get united.
+        await UIHelper.renderingUpdate();
+        await UIHelper.renderingUpdate();
+        input.value = input.id.split("_")[1];
+    }
+
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+onload = () => requestAnimationFrame(() => requestAnimationFrame(runTest));
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/shadow/SliderThumbElement.cpp
+++ b/Source/WebCore/html/shadow/SliderThumbElement.cpp
@@ -183,6 +183,7 @@ void RenderSliderContainer::layout()
             thumbLocation.setX(thumbLocation.x() - offset);
     }
     thumb->setLocation(thumbLocation);
+    track->repaint();
     thumb->repaint();
 }
 


### PR DESCRIPTION
#### c89abf514d7dc4445ccf652175a61263edd647fb
<pre>
Correctly repaint &lt;input type=range&gt; track after setValue
<a href="https://bugs.webkit.org/show_bug.cgi?id=284773">https://bugs.webkit.org/show_bug.cgi?id=284773</a>
<a href="https://rdar.apple.com/138049784">rdar://138049784</a>

Reviewed by Alan Baradlay.

When the input was set to a specific value, internally the
thumb was moved to the correct position, which marked as
dirty both areas for the previous and new positions.
However, nothing else was marked dirty, including the track
itself, so if the thumb moved from (say) 0% to 100%, some
of the middle part may not have been marked as dirty.
On iOS, the track has a different color on each side of
the thumb position, so the non-dirty part was staying the
same color as it was before.

The fix is to ensure that the track gets repainted, so that
any needed color change happens along its length.

* LayoutTests/fast/forms/range/range-set-value-repaint-expected.html: Added.
* LayoutTests/fast/forms/range/range-set-value-repaint.html: Added.
* Source/WebCore/html/shadow/SliderThumbElement.cpp:
(WebCore::RenderSliderContainer::layout):

Canonical link: <a href="https://commits.webkit.org/287976@main">https://commits.webkit.org/287976@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0d032fb07bc93bce52309a51dbc1f6ad19dc9db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81429 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/954 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35372 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85958 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32416 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83539 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/972 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8773 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63559 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21310 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84498 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/675 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74113 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43852 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/570 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28277 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30873 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72048 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28866 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87393 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8659 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6151 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71873 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8840 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69934 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71111 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17720 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15173 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14082 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8621 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14150 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8457 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11978 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10265 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->