### PR TITLE
[cocoa] Support setting partitioned cookies from JS and storing partitioned cookies in cookie cache

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3359,6 +3359,7 @@ webkit.org/b/3652 http/tests/misc/prefetch-purpose.html [ Skip ]
 http/tests/cookies/only-accept-first-party-cookies.html [ Skip ]
 # Enable on appropriate platforms: rdar://140222322
 http/tests/cookies/accept-partitioned-first-and-third-party-cookies.https.html [ Skip ]
+http/tests/cookies/multiple-cookies-with-partitioned.https.html [ Skip ]
 http/tests/clear-site-data/set-and-clear-cookies.https.html [ Skip ]
 
 # Disabled WPT tests

--- a/LayoutTests/http/tests/cookies/multiple-cookies-with-partitioned.https-expected.txt
+++ b/LayoutTests/http/tests/cookies/multiple-cookies-with-partitioned.https-expected.txt
@@ -1,0 +1,16 @@
+This test checks that mulitple cookies are correctly set.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Check setting several cookies without clearing.
+PASS document.cookie is expectedCookies[0]
+PASS document.cookie is expectedCookies[1]
+FAIL document.cookie should be test=foobarPartitioned; test=foobarPath; test=foobar. Was test=foobarPartitioned; test=foobarPath.
+PASS cookie is 'test=foobarPartitioned'.
+PASS cookie is 'test=foobarPartitioned; test=foobarPath'.
+FAIL cookie was 'test=foobarPartitioned; test=foobarPath'. Expected 'test=foobar; test=foobarPartitioned; test=foobarPath'.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/cookies/multiple-cookies-with-partitioned.https.html
+++ b/LayoutTests/http/tests/cookies/multiple-cookies-with-partitioned.https.html
@@ -1,0 +1,45 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ OptInPartitionedCookiesEnabled=true ] -->
+<html>
+<head>
+<link rel="stylesheet" href="resources/cookies-test-style.css">
+<script src="resources/cookies-test-pre.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+<script>
+description(
+"This test checks that mulitple cookies are correctly set."
+);
+
+let expectedCookies = [ "test=foobarPartitioned", "test=foobarPartitioned; test=foobarPath", "test=foobarPartitioned; test=foobarPath; test=foobar" ];
+let testSetCookies = [ "test=foobarPartitioned;SameSite=None;Secure;Partitioned", "test=foobarPath;SameSite=None;Secure;Path=/", "test=foobar;SameSite=None;Secure" ];
+
+async function runTest() {
+    clearAllCookies();
+
+    debug("Check setting several cookies without clearing.");
+
+    document.cookie = testSetCookies[0]
+    shouldBe('document.cookie', 'expectedCookies[0]');
+    document.cookie = testSetCookies[1]
+    shouldBe('document.cookie', 'expectedCookies[1]');
+    document.cookie = testSetCookies[2]
+    shouldBe('document.cookie', 'expectedCookies[2]');
+
+    await fetch(`/clear-site-data/resources/clear-site-data-cookies.py`);
+
+    cookiesShouldBe(testSetCookies[0], expectedCookies[0]);
+    cookiesShouldBe(testSetCookies[1], expectedCookies[1]);
+    cookiesShouldBe(testSetCookies[2], expectedCookies[2]);
+
+    clearCookies();
+
+    successfullyParsed = true;
+}
+
+runTest();
+</script>
+<script src="resources/cookies-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h
@@ -228,6 +228,7 @@ typedef enum {
 - (id)_initWithIdentifier:(NSString *)identifier private:(bool)isPrivate;
 - (void)_getCookiesForURL:(NSURL *)url mainDocumentURL:(NSURL *)mainDocumentURL partition:(NSString *)partition completionHandler:(void (^)(NSArray *))completionHandler;
 - (void)_getCookiesForURL:(NSURL *)url mainDocumentURL:(NSURL *)mainDocumentURL partition:(NSString *)partition policyProperties:(NSDictionary*)props completionHandler:(void (NS_NOESCAPE ^)(NSArray *))completionHandler;
+- (void)_getCookiesForPartition:(NSString* __nullable) partition completionHandler:(void (NS_NOESCAPE ^) (NSArray* __nullable))completionHandler;
 - (void)_setCookies:(NSArray *)cookies forURL:(NSURL *)URL mainDocumentURL:(NSURL *)mainDocumentURL policyProperties:(NSDictionary*) props;
 - (void)removeCookiesSinceDate:(NSDate *)date;
 - (id)_initWithCFHTTPCookieStorage:(CFHTTPCookieStorageRef)cfStorage;

--- a/Source/WebCore/platform/network/NetworkStorageSession.cpp
+++ b/Source/WebCore/platform/network/NetworkStorageSession.cpp
@@ -70,7 +70,7 @@ void NetworkStorageSession::permitProcessToUseCookieAPI(bool value)
 }
 
 #if !PLATFORM(COCOA)
-Vector<Cookie> NetworkStorageSession::domCookiesForHost(const String&)
+Vector<Cookie> NetworkStorageSession::domCookiesForHost(const URL&)
 {
     ASSERT_NOT_IMPLEMENTED_YET();
     return { };

--- a/Source/WebCore/platform/network/NetworkStorageSession.h
+++ b/Source/WebCore/platform/network/NetworkStorageSession.h
@@ -222,7 +222,7 @@ public:
     WEBCORE_EXPORT std::pair<String, bool> cookieRequestHeaderFieldValue(const CookieRequestHeaderFieldProxy&) const;
     WEBCORE_EXPORT bool cookiesEnabled(const URL& firstParty, const URL&, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, ShouldRelaxThirdPartyCookieBlocking) const;
 
-    WEBCORE_EXPORT Vector<Cookie> domCookiesForHost(const String& host);
+    WEBCORE_EXPORT Vector<Cookie> domCookiesForHost(const URL&);
 
 #if HAVE(COOKIE_CHANGE_LISTENER_API)
     WEBCORE_EXPORT bool startListeningForCookieChangeNotifications(CookieChangeObserver&, const URL&, const URL& firstParty, FrameIdentifier, PageIdentifier, ShouldRelaxThirdPartyCookieBlocking);

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -906,15 +906,14 @@ void NetworkConnectionToWebProcess::setCookieFromDOMAsync(const URL& firstParty,
 
 void NetworkConnectionToWebProcess::domCookiesForHost(const URL& url, CompletionHandler<void(const Vector<WebCore::Cookie>&)>&& completionHandler)
 {
-    auto host = url.host().toString();
-    MESSAGE_CHECK_COMPLETION(HashSet<String>::isValidValue(host), completionHandler({ }));
+    MESSAGE_CHECK_COMPLETION(HashSet<String>::isValidValue(url.host().toString()), completionHandler({ }));
     MESSAGE_CHECK_COMPLETION(protectedNetworkProcess()->allowsFirstPartyForCookies(m_webProcessIdentifier, url), completionHandler({ }));
 
     auto* networkStorageSession = storageSession();
     if (!networkStorageSession)
         return completionHandler({ });
 
-    completionHandler(networkStorageSession->domCookiesForHost(host));
+    completionHandler(networkStorageSession->domCookiesForHost(url));
 }
 
 #if HAVE(COOKIE_CHANGE_LISTENER_API)

--- a/Source/WebKit/Shared/WebProcessDataStoreParameters.h
+++ b/Source/WebKit/Shared/WebProcessDataStoreParameters.h
@@ -60,6 +60,9 @@ struct WebProcessDataStoreParameters {
     std::optional<SandboxExtension::Handle> containerTemporaryDirectoryExtensionHandle;
 #endif
     bool trackingPreventionEnabled { false };
+#if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
+    bool isOptInCookiePartitioningEnabled { false };
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebProcessDataStoreParameters.serialization.in
+++ b/Source/WebKit/Shared/WebProcessDataStoreParameters.serialization.in
@@ -44,4 +44,7 @@
     std::optional<WebKit::SandboxExtensionHandle> containerTemporaryDirectoryExtensionHandle;
 #endif
     bool trackingPreventionEnabled;
+#if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
+    bool isOptInCookiePartitioningEnabled;
+#endif
 };

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6309,6 +6309,8 @@ void WebPageProxy::preferencesDidChange()
         } else
             webProcess.send(Messages::WebPage::PreferencesDidChange(preferencesStore(), sharedPreferencesVersion), pageID);
     });
+
+    websiteDataStore().propagateSettingUpdates();
 }
 
 void WebPageProxy::didCreateSubframe(IPC::Connection& connection, FrameIdentifier parentID, FrameIdentifier newFrameID, const String& frameName, SandboxFlags sandboxFlags, ScrollbarMode scrollingMode)

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -920,6 +920,9 @@ WebProcessDataStoreParameters WebProcessPool::webProcessDataStoreParameters(WebP
         WTFMove(containerTemporaryDirectoryExtensionHandle),
 #endif
         websiteDataStore.trackingPreventionEnabled()
+#if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
+        , websiteDataStore.isOptInCookiePartitioningEnabled()
+#endif
     };
 }
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -785,6 +785,13 @@ void WebProcessProxy::setThirdPartyCookieBlockingMode(ThirdPartyCookieBlockingMo
     sendWithAsyncReply(Messages::WebProcess::SetThirdPartyCookieBlockingMode(thirdPartyCookieBlockingMode), WTFMove(completionHandler));
 }
 
+#if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
+void WebProcessProxy::setOptInCookiePartitioningEnabled(bool enabled)
+{
+    send(Messages::WebProcess::SetOptInCookiePartitioningEnabled(enabled), 0);
+}
+#endif
+
 Ref<WebPageProxy> WebProcessProxy::createWebPage(PageClient& pageClient, Ref<API::PageConfiguration>&& pageConfiguration)
 {
     Ref webPage = WebPageProxy::create(pageClient, *this, WTFMove(pageConfiguration));

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -306,6 +306,9 @@ public:
     void deleteWebsiteDataForOrigins(PAL::SessionID, OptionSet<WebsiteDataType>, const Vector<WebCore::SecurityOriginData>&, CompletionHandler<void()>&&);
 
     void setThirdPartyCookieBlockingMode(WebCore::ThirdPartyCookieBlockingMode, CompletionHandler<void()>&&);
+#if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
+    void setOptInCookiePartitioningEnabled(bool);
+#endif
 
     void enableSuddenTermination();
     void disableSuddenTermination();

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -1930,6 +1930,9 @@ void WebsiteDataStore::propagateSettingUpdates()
         m_isOptInCookiePartitioningEnabled = enabled;
         networkProcess->send(Messages::NetworkProcess::SetOptInCookiePartitioningEnabled(sessionID(), enabled), 0);
 
+        for (Ref webProcess : processes())
+            webProcess->setOptInCookiePartitioningEnabled(enabled);
+
         if (m_isOptInCookiePartitioningEnabled && m_thirdPartyCookieBlockingMode == WebCore::ThirdPartyCookieBlockingMode::All) {
             RELEASE_LOG(Storage, "WebsiteDataStore::propagateSettingUpdates (%p) sessionID=%" PRIu64 ", OptInCookiePartitioning enabled, setting ThirdPartyCookieBlockingMode::AllExceptPartitioned" PRIu64, this, m_sessionID.toUInt64());
             setThirdPartyCookieBlockingMode(WebCore::ThirdPartyCookieBlockingMode::AllExceptPartitioned, []() { });

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebCookieCacheCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebCookieCacheCocoa.mm
@@ -47,4 +47,11 @@ NetworkStorageSession& WebCookieCache::inMemoryStorageSession()
     return *m_inMemoryStorageSession;
 }
 
+#if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
+void WebCookieCache::setOptInCookiePartitioningEnabled(bool enabled)
+{
+    inMemoryStorageSession().setOptInCookiePartitioningEnabled(enabled);
+}
+#endif
+
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/WebCookieCache.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieCache.cpp
@@ -168,6 +168,13 @@ NetworkStorageSession& WebCookieCache::inMemoryStorageSession()
     ASSERT_NOT_IMPLEMENTED_YET();
     return *m_inMemoryStorageSession;
 }
+
+#if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
+void WebCookieCache::setOptInCookiePartitioningEnabled(bool)
+{
+    ASSERT_NOT_IMPLEMENTED_YET();
+}
+#endif
 #endif
 
 bool WebCookieCache::cacheMayBeOutOfSync() const

--- a/Source/WebKit/WebProcess/WebPage/WebCookieCache.h
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieCache.h
@@ -61,6 +61,8 @@ public:
     void clear();
     void clearForHost(const String&);
 
+    void setOptInCookiePartitioningEnabled(bool);
+
 private:
     WebCore::NetworkStorageSession& inMemoryStorageSession();
     void pruneCacheIfNecessary();

--- a/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp
@@ -455,6 +455,13 @@ void WebCookieJar::removeChangeListener(const String& host, const WebCore::Cooki
 }
 #endif
 
+#if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
+void WebCookieJar::setOptInCookiePartitioningEnabled(bool enabled)
+{
+    m_cache.setOptInCookiePartitioningEnabled(enabled);
+}
+#endif
+
 #if !PLATFORM(COCOA)
 
 String WebCookieJar::cookiesInPartitionedCookieStorage(const WebCore::Document&, const URL&, const WebCore::SameSiteInfo&) const

--- a/Source/WebKit/WebProcess/WebPage/WebCookieJar.h
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieJar.h
@@ -76,6 +76,10 @@ public:
 
     void clearCache() final;
 
+#if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
+    void setOptInCookiePartitioningEnabled(bool);
+#endif
+
 private:
     WebCookieJar();
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -704,6 +704,10 @@ void WebProcess::setWebsiteDataStoreParameters(WebProcessDataStoreParameters&& p
     platformSetWebsiteDataStoreParameters(WTFMove(parameters));
     
     ensureNetworkProcessConnection();
+
+#if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
+    m_cookieJar->setOptInCookiePartitioningEnabled(parameters.isOptInCookiePartitioningEnabled);
+#endif
 }
 
 bool WebProcess::areAllPagesSuspended() const
@@ -1986,6 +1990,13 @@ void WebProcess::setEnabledServices(bool hasImageServices, bool hasSelectionServ
     m_hasImageServices = hasImageServices;
     m_hasSelectionServices = hasSelectionServices;
     m_hasRichContentServices = hasRichContentServices;
+}
+#endif
+
+#if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
+void WebProcess::setOptInCookiePartitioningEnabled(bool enabled)
+{
+    m_cookieJar->setOptInCookiePartitioningEnabled(enabled);
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -548,6 +548,9 @@ private:
     void seedResourceLoadStatisticsForTesting(const WebCore::RegistrableDomain& firstPartyDomain, const WebCore::RegistrableDomain& thirdPartyDomain, bool shouldScheduleNotification, CompletionHandler<void()>&&);
     void userPreferredLanguagesChanged(const Vector<String>&) const;
     void fullKeyboardAccessModeChanged(bool fullKeyboardAccessEnabled);
+#if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
+    void setOptInCookiePartitioningEnabled(bool);
+#endif
 
     void platformSetCacheModel(CacheModel);
 

--- a/Source/WebKit/WebProcess/WebProcess.messages.in
+++ b/Source/WebKit/WebProcess/WebProcess.messages.in
@@ -58,6 +58,9 @@ messages -> WebProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
     UserPreferredLanguagesChanged(Vector<String> languages)
     FullKeyboardAccessModeChanged(bool fullKeyboardAccessEnabled)
     UpdateStorageAccessUserAgentStringQuirks(HashMap<WebCore::RegistrableDomain, String> userAgentStringQuirks)
+#if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
+    SetOptInCookiePartitioningEnabled(bool enabled);
+#endif
 
 #if HAVE(MOUSE_DEVICE_OBSERVATION)
     SetHasMouseDevice(bool hasMouseDevice)


### PR DESCRIPTION
#### 16daa23d3ea0022332713096723573f218e149d8
<pre>
[cocoa] Support setting partitioned cookies from JS and storing partitioned cookies in cookie cache
<a href="https://bugs.webkit.org/show_bug.cgi?id=284550">https://bugs.webkit.org/show_bug.cgi?id=284550</a>
<a href="https://rdar.apple.com/141358106">rdar://141358106</a>

Reviewed by Sihui Liu.

This patch:
 - sets the appropriate partition key when setting a cookie from JavaScript
 - enables partitioned cookies in the in-process cookie cache
 - extends NetworkStorageSession::domCookiesForHost so it returns first-party partitioned cookies

Covered by new layout test. The expected result shows that the implementation
does not currently support two cookies with the same name where one is
partitioned and the other is not.

* LayoutTests/TestExpectations:
* LayoutTests/http/tests/cookies/multiple-cookies-with-partitioned.https-expected.txt: Added.
* LayoutTests/http/tests/cookies/multiple-cookies-with-partitioned.https.html: Added.
* Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h:
* Source/WebCore/platform/network/NetworkStorageSession.cpp:
(WebCore::NetworkStorageSession::domCookiesForHost):
* Source/WebCore/platform/network/NetworkStorageSession.h:
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::parseDOMCookie):
(WebCore::NetworkStorageSession::setCookiesFromDOM const):
(WebCore::NetworkStorageSession::domCookiesForHost):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::domCookiesForHost):
* Source/WebKit/Shared/WebProcessDataStoreParameters.h:
* Source/WebKit/Shared/WebProcessDataStoreParameters.serialization.in:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::preferencesDidChange):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::webProcessDataStoreParameters):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::setOptInCookiePartitioningEnabled):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::propagateSettingUpdates):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebCookieCacheCocoa.mm:
(WebKit::WebCookieCache::setOptInCookiePartitioningEnabled):
* Source/WebKit/WebProcess/WebPage/WebCookieCache.cpp:
(WebKit::WebCookieCache::setOptInCookiePartitioningEnabled):
* Source/WebKit/WebProcess/WebPage/WebCookieCache.h:
* Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp:
(WebKit::WebCookieJar::setOptInCookiePartitioningEnabled):
* Source/WebKit/WebProcess/WebPage/WebCookieJar.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::setWebsiteDataStoreParameters):
(WebKit::WebProcess::setOptInCookiePartitioningEnabled):
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/WebProcess.messages.in:

Canonical link: <a href="https://commits.webkit.org/288727@main">https://commits.webkit.org/288727@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a548b2640db1b24d980b6eb3fca47164f2102e08

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3824 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38507 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89279 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35212 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86288 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3912 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11797 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65500 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23336 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87249 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2933 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76516 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45793 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2881 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30746 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34261 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73797 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31510 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90660 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11470 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8327 "Found 1 new test failure: fast/selectors/selection-window-inactive-stroke-color.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73955 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11696 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72341 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73157 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17463 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2835 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13032 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11422 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16898 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11271 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14747 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13044 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->