### PR TITLE
AX: Serve AXLeftLineTextMarkerRangeForTextMarker, AXRightLineTextMarkerRangeForTextMarker, and AXStyleTextMarkerRangeForTextMarker off the main-thread

### DIFF
--- a/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/left-line-range-expected.txt
+++ b/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/left-line-range-expected.txt
@@ -1,0 +1,12 @@
+This test ensures basic left-line text marker functionality works.
+
+PASS: webArea.stringForTextMarkerRange(webArea.leftLineTextMarkerRangeForTextMarker(marker)) === 'First text'
+PASS: webArea.stringForTextMarkerRange(webArea.leftLineTextMarkerRangeForTextMarker(marker)) === 'Foo and bar'
+PASS: webArea.stringForTextMarkerRange(webArea.leftLineTextMarkerRangeForTextMarker(webArea.endTextMarkerForTextMarkerRange(markerRange))) === 'Foo and bar'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+First text
+
+Foo and bar

--- a/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/left-line-range.html
+++ b/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/left-line-range.html
@@ -1,0 +1,40 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ runSingly=true AccessibilityThreadTextApisEnabled=true ] -->
+<!-- This is a new test added as part of the AccessibilityThreadTextApisEnabled effort. When the feature is enabled by default, move it to LayoutTests/accessibility/mac. -->
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p>First text</p>
+<p id="p1">Foo and bar</p>
+
+<script>
+var output = "This test ensures basic left-line text marker functionality works.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    var webArea = accessibilityController.rootElement.childAtIndex(0);
+
+    var marker, markerRange;
+    setTimeout(async function() {
+        markerRange = await selectElementTextById("p1", webArea);
+        marker = webArea.startTextMarkerForTextMarkerRange(markerRange);
+
+        // When we're on a line start, left-line should return the previous line.
+        output += expect("webArea.stringForTextMarkerRange(webArea.leftLineTextMarkerRangeForTextMarker(marker))", "'First text'");
+        // Move forwards off the line-start, making the left-line return the current line range.
+        marker = webArea.nextTextMarker(marker);
+        output += expect("webArea.stringForTextMarkerRange(webArea.leftLineTextMarkerRangeForTextMarker(marker))", "'Foo and bar'");
+        // For left-line, a marker pointing to the end of the line returns the current line range.
+        output += expect("webArea.stringForTextMarkerRange(webArea.leftLineTextMarkerRangeForTextMarker(webArea.endTextMarkerForTextMarkerRange(markerRange)))", "'Foo and bar'");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/right-line-range-expected.txt
+++ b/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/right-line-range-expected.txt
@@ -1,0 +1,15 @@
+This test ensures basic right-line text marker functionality works.
+
+PASS: webArea.stringForTextMarkerRange(webArea.rightLineTextMarkerRangeForTextMarker(startMarker)) === 'Foo and bar'
+PASS: webArea.stringForTextMarkerRange(webArea.rightLineTextMarkerRangeForTextMarker(startMarker)) === 'Foo and bar'
+PASS: webArea.stringForTextMarkerRange(webArea.rightLineTextMarkerRangeForTextMarker(endMarker)) === 'Last text'
+PASS: webArea.stringForTextMarkerRange(webArea.rightLineTextMarkerRangeForTextMarker(endMarker)) === 'Foo and bar'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+First text
+
+Foo and bar
+
+Last text

--- a/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/right-line-range.html
+++ b/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/right-line-range.html
@@ -1,0 +1,46 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ runSingly=true AccessibilityThreadTextApisEnabled=true ] -->
+<!-- This is a new test added as part of the AccessibilityThreadTextApisEnabled effort. When the feature is enabled by default, move it to LayoutTests/accessibility/mac. -->
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p>First text</p>
+<p id="p1">Foo and bar</p>
+<p>Last text</p>
+
+<script>
+var output = "This test ensures basic right-line text marker functionality works.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    var webArea = accessibilityController.rootElement.childAtIndex(0);
+
+    var startMarker, endMarker, markerRange;
+    setTimeout(async function() {
+        markerRange = await selectElementTextById("p1", webArea);
+        startMarker = webArea.startTextMarkerForTextMarkerRange(markerRange);
+
+        // When we're on a line start, right-line should return current line range.
+        output += expect("webArea.stringForTextMarkerRange(webArea.rightLineTextMarkerRangeForTextMarker(startMarker))", "'Foo and bar'");
+        // Move forwards off the line-start. We should still return the current line range.
+        startMarker = webArea.nextTextMarker(startMarker);
+        output += expect("webArea.stringForTextMarkerRange(webArea.rightLineTextMarkerRangeForTextMarker(startMarker))", "'Foo and bar'");
+
+        endMarker = webArea.endTextMarkerForTextMarkerRange(markerRange);
+        // For right-line, a marker pointing to the end of the line returns the next line range.
+        output += expect("webArea.stringForTextMarkerRange(webArea.rightLineTextMarkerRangeForTextMarker(endMarker))", "'Last text'");
+        // Move backwards one, meaning right-line should return the current line range.
+        endMarker = webArea.previousTextMarker(endMarker);
+        output += expect("webArea.stringForTextMarkerRange(webArea.rightLineTextMarkerRangeForTextMarker(endMarker))", "'Foo and bar'");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/accessibility/ax-thread-text-apis/style-range-expected.txt
+++ b/LayoutTests/accessibility/ax-thread-text-apis/style-range-expected.txt
@@ -1,0 +1,29 @@
+This test ensures we compute the right range when serving AXStyleTextMarkerRangeForTextMarker.
+
+PASS: The style range for the start marker of #p2 was "One
+
+Two
+
+Three".
+PASS: The style range for the start marker of #p2 was "One
+
+Two
+
+Three".
+PASS: The style range for the start marker of #p1 was "One".
+PASS: The style range for the start marker of #p2 was "Two".
+PASS: The style range for the start marker of #p3 was "Three".
+PASS: The style range for the start marker of #p3 was "Three
+
+Four".
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+One
+
+Two
+
+Three
+
+Four

--- a/LayoutTests/accessibility/ax-thread-text-apis/style-range.html
+++ b/LayoutTests/accessibility/ax-thread-text-apis/style-range.html
@@ -1,0 +1,56 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ runSingly=true AccessibilityThreadTextApisEnabled=true ] -->
+<!-- This is a new test added as part of the AccessibilityThreadTextApisEnabled effort. When the feature is enabled by default, move it to LayoutTests/accessibility/mac. -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="p1">One</p>
+<p id="p2">Two</p>
+<p id="p3">Three</p>
+
+<script>
+var output = "This test ensures we compute the right range when serving AXStyleTextMarkerRangeForTextMarker.\n\n";
+
+async function styleRangeForElementMatches(id, expectedString, moveOffStartBy = 0) {
+    let marker = webArea.startTextMarkerForTextMarkerRange(await selectElementTextById(id, webArea));
+    for (let i = 0; i < moveOffStartBy; i++)
+        marker = webArea.nextTextMarker(marker);
+
+    await waitFor(() => {
+        return expectedString == webArea.stringForTextMarkerRange(webArea.styleTextMarkerRangeForTextMarker(marker));
+    });
+    output += `PASS: The style range for the start marker of #${id} was "${expectedString}".\n`
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var webArea = accessibilityController.rootElement.childAtIndex(0);
+
+    setTimeout(async function() {
+        await styleRangeForElementMatches("p2", "One\n\nTwo\n\nThree");
+        await styleRangeForElementMatches("p2", "One\n\nTwo\n\nThree", /* moveOffStartBy */ 2);
+
+        // Break up the style range dynamically.
+        document.getElementById("p2").setAttribute("style", "font-style: italic;");
+        await styleRangeForElementMatches("p1", "One", 1);
+        await styleRangeForElementMatches("p2", "Two");
+        await styleRangeForElementMatches("p3", "Three", 4);
+
+        // Create a new element with default styles, which should form a style range with sibling #p3.
+        let p = document.createElement("p");
+        p.innerHTML = "<div><span><div>Four</div></span></div>";
+        document.body.appendChild(p);
+        await styleRangeForElementMatches("p3", "Three\n\nFour");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -742,6 +742,7 @@ struct LineDecorationStyle {
         , hasLinethrough(hasLinethrough)
         , linethroughColor(linethroughColor)
     { }
+    bool operator==(const LineDecorationStyle&) const = default;
 
     String debugDescription() const;
 };
@@ -756,6 +757,8 @@ struct AttributedStringStyle {
     bool isSuperscript { false };
     bool hasTextShadow { false };
     LineDecorationStyle lineStyle;
+
+    bool operator==(const AttributedStringStyle&) const = default;
 
     bool hasUnderline() const { return lineStyle.hasUnderline; }
     Color underlineColor() const { return lineStyle.underlineColor; }

--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -204,6 +204,8 @@ public:
     AXTextMarkerRange sentenceRange(SentenceRangeType) const;
     // Creates a range for the paragraph at the current marker.
     AXTextMarkerRange paragraphRange() const;
+    // Returns a range pointing to the start and end positions that have the same text styles as `this`.
+    AXTextMarkerRange rangeWithSameStyle() const;
     // Given a character offset relative to this marker, find the next marker the offset points to.
     AXTextMarker nextMarkerFromOffset(unsigned) const;
     // Returns the number of intermediate text markers between this and the root.

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -80,6 +80,7 @@ public:
     AXIsolatedObject* clickableSelfOrAncestor(ClickHandlerFilter filter = ClickHandlerFilter::ExcludeBody) const final { return Accessibility::clickableSelfOrAncestor(*this, filter); };
     AXIsolatedObject* editableAncestor() const final { return Accessibility::editableAncestor(*this); };
     bool canSetFocusAttribute() const final { return boolAttributeValue(AXPropertyName::CanSetFocusAttribute); }
+    AttributedStringStyle stylesForAttributedString() const final;
 
 #if ENABLE(AX_THREAD_TEXT_APIS)
     const AXTextRuns* textRuns() const;
@@ -505,7 +506,6 @@ private:
     unsigned textLength() const final;
 #if PLATFORM(COCOA)
     RetainPtr<NSAttributedString> attributedStringForTextMarkerRange(AXTextMarkerRange&&, SpellCheck) const final;
-    AttributedStringStyle stylesForAttributedString() const final;
 #endif
     AXObjectCache* axObjectCache() const final;
     Element* actionElement() const final;

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp
@@ -119,6 +119,7 @@ RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::leftLineTextMarkerR
 RefPtr<AccessibilityTextMarker> AccessibilityUIElement::previousLineStartTextMarkerForTextMarker(AccessibilityTextMarker*) { return nullptr; }
 RefPtr<AccessibilityTextMarker> AccessibilityUIElement::nextLineEndTextMarkerForTextMarker(AccessibilityTextMarker*) { return nullptr; }
 int AccessibilityUIElement::lineIndexForTextMarker(AccessibilityTextMarker*) const { return -1; }
+RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::styleTextMarkerRangeForTextMarker(AccessibilityTextMarker*) { return nullptr; }
 RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::textMarkerRangeForUnorderedMarkers(AccessibilityTextMarker*, AccessibilityTextMarker*) { return nullptr; }
 RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::textMarkerRangeForRange(unsigned, unsigned) { return nullptr; }
 RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::selectedTextMarkerRange() { return nullptr; }

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
@@ -328,6 +328,7 @@ public:
     RefPtr<AccessibilityTextMarker> previousLineStartTextMarkerForTextMarker(AccessibilityTextMarker*);
     RefPtr<AccessibilityTextMarker> nextLineEndTextMarkerForTextMarker(AccessibilityTextMarker*);
     int lineIndexForTextMarker(AccessibilityTextMarker*) const;
+    RefPtr<AccessibilityTextMarkerRange> styleTextMarkerRangeForTextMarker(AccessibilityTextMarker*);
     RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForSearchPredicate(JSContextRef, AccessibilityTextMarkerRange* startRange, bool forward, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly);
     RefPtr<AccessibilityTextMarkerRange> misspellingTextMarkerRange(AccessibilityTextMarkerRange* start, bool forward);
     RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForElement(AccessibilityUIElement*);

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl
@@ -244,6 +244,7 @@ interface AccessibilityUIElement {
     AccessibilityTextMarker previousLineStartTextMarkerForTextMarker(AccessibilityTextMarker textMarker);
     AccessibilityTextMarker nextLineEndTextMarkerForTextMarker(AccessibilityTextMarker textMarker);
     long lineIndexForTextMarker(AccessibilityTextMarker textMarker);
+    AccessibilityTextMarkerRange styleTextMarkerRangeForTextMarker(AccessibilityTextMarker textMarker);
     AccessibilityTextMarkerRange textMarkerRangeForSearchPredicate(AccessibilityTextMarkerRange startRange, boolean forward, object searchKey, DOMString searchText, boolean visibleOnly, boolean immediateDescendantsOnly);
     AccessibilityTextMarkerRange misspellingTextMarkerRange(AccessibilityTextMarkerRange start, boolean forward);
     AccessibilityTextMarkerRange textMarkerRangeForElement(AccessibilityUIElement element);

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
@@ -2174,6 +2174,19 @@ int AccessibilityUIElement::lineIndexForTextMarker(AccessibilityTextMarker* mark
     return -1;
 }
 
+RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::styleTextMarkerRangeForTextMarker(AccessibilityTextMarker* marker)
+{
+    if (!marker)
+        return nullptr;
+
+    BEGIN_AX_OBJC_EXCEPTIONS
+    auto textMarkerRange = attributeValueForParameter(@"AXStyleTextMarkerRangeForTextMarker", marker->platformTextMarker());
+    return AccessibilityTextMarkerRange::create(textMarkerRange.get());
+    END_AX_OBJC_EXCEPTIONS
+
+    return nullptr;
+}
+
 RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::textMarkerRangeForSearchPredicate(JSContextRef context, AccessibilityTextMarkerRange *startRange, bool forward, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly)
 {
     BEGIN_AX_OBJC_EXCEPTIONS


### PR DESCRIPTION
#### c9870e67e54ff9ed67d6283ae72fcfd1b9e7b2bf
<pre>
AX: Serve AXLeftLineTextMarkerRangeForTextMarker, AXRightLineTextMarkerRangeForTextMarker, and AXStyleTextMarkerRangeForTextMarker off the main-thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=284564">https://bugs.webkit.org/show_bug.cgi?id=284564</a>
<a href="https://rdar.apple.com/141365741">rdar://141365741</a>

Reviewed by Chris Fleizach.

This commit adds accessibility-thread implementations for these attributes, and adds new layout tests to ensure we
behave correctly.

* LayoutTests/accessibility/ax-thread-text-apis/attributed-string/left-line-range-expected.txt: Added.
* LayoutTests/accessibility/ax-thread-text-apis/attributed-string/left-line-range.html: Added.
* LayoutTests/accessibility/ax-thread-text-apis/attributed-string/right-line-range-expected.txt: Added.
* LayoutTests/accessibility/ax-thread-text-apis/attributed-string/right-line-range.html: Added.
* LayoutTests/accessibility/ax-thread-text-apis/style-range-expected.txt: Added.
* LayoutTests/accessibility/ax-thread-text-apis/style-range.html: Added.
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::rangeWithSameStyle const):
(WebCore::AXTextMarker::lineRange const):
(WebCore::AXTextMarker::wordRange const):
(WebCore::AXTextMarker::sentenceRange const):
(WebCore::AXTextMarker::paragraphRange const):
* Source/WebCore/accessibility/AXTextMarker.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper lineTextMarkerRangeForTextMarker:forUnit:]):
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:forParameter:]):
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp:
(WTR::AccessibilityUIElement::styleTextMarkerRangeForTextMarker):
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl:
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
(WTR::AccessibilityUIElement::styleTextMarkerRangeForTextMarker):

Canonical link: <a href="https://commits.webkit.org/287990@main">https://commits.webkit.org/287990@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/726d12d8961a9c79eea0fed4dce9e25af0088ded

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81525 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1051 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35473 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86141 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32519 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83635 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1070 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8869 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/63671 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21363 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84594 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/760 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74200 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43960 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/659 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28369 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30972 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28962 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87493 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8758 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6216 "Found 1 new test failure: media/video-canvas-createPattern.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71963 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8939 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70017 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71196 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17729 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15248 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14166 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8718 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14246 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8556 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12078 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10363 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->