### PR TITLE
Implement WebTransport incoming unidirectional and bidirectional streams

### DIFF
--- a/Source/WebCore/Modules/webtransport/WebTransport.h
+++ b/Source/WebCore/Modules/webtransport/WebTransport.h
@@ -47,6 +47,7 @@ class DatagramSource;
 class DeferredPromise;
 class JSDOMGlobalObject;
 class ReadableStream;
+class ReadableStreamSource;
 class ScriptExecutionContext;
 class SocketProvider;
 class WebTransportBidirectionalStreamSource;
@@ -56,6 +57,7 @@ class WebTransportReceiveStreamSource;
 class WebTransportSession;
 class WritableStream;
 
+struct WebTransportBidirectionalStreamConstructionParameters;
 struct WebTransportCloseInfo;
 struct WebTransportSendStreamOptions;
 struct WebTransportHash;
@@ -94,8 +96,8 @@ private:
     bool virtualHasPendingActivity() const final;
 
     void receiveDatagram(std::span<const uint8_t>) final;
-    void receiveIncomingUnidirectionalStream() final;
-    void receiveBidirectionalStream() final;
+    void receiveIncomingUnidirectionalStream(Ref<ReadableStreamSource>&&) final;
+    void receiveBidirectionalStream(WebTransportBidirectionalStreamConstructionParameters&&) final;
 
     ListHashSet<Ref<WritableStream>> m_sendStreams;
     ListHashSet<Ref<ReadableStream>> m_receiveStreams;

--- a/Source/WebCore/Modules/webtransport/WebTransportBidirectionalStream.idl
+++ b/Source/WebCore/Modules/webtransport/WebTransportBidirectionalStream.idl
@@ -26,7 +26,9 @@
 [
     EnabledBySetting=WebTransportEnabled,
     Exposed=(Window,Worker),
-    SecureContext
+    SecureContext,
+    JSGenerateToJSObject,
+    JSGenerateToNativeObject
 ] interface WebTransportBidirectionalStream {
     readonly attribute WebTransportReceiveStream readable;
     readonly attribute WebTransportSendStream writable;

--- a/Source/WebCore/Modules/webtransport/WebTransportBidirectionalStreamSource.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportBidirectionalStreamSource.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "WebTransportBidirectionalStreamSource.h"
 
+#include "JSWebTransportBidirectionalStream.h"
+
 namespace WebCore {
 
 void WebTransportBidirectionalStreamSource::doCancel()
@@ -33,11 +35,15 @@ void WebTransportBidirectionalStreamSource::doCancel()
     m_isCancelled = true;
 }
 
-void WebTransportBidirectionalStreamSource::receiveIncomingStream()
+void WebTransportBidirectionalStreamSource::receiveIncomingStream(JSC::JSGlobalObject& globalObject, Ref<WebTransportBidirectionalStream>&& stream)
 {
     if (m_isCancelled)
         return;
-    // FIXME: Add parameters and implement.
+    auto& jsDOMGlobalObject = *JSC::jsCast<JSDOMGlobalObject*>(&globalObject);
+    Locker<JSC::JSLock> locker(jsDOMGlobalObject.vm().apiLock());
+    auto value = toJS(&globalObject, &jsDOMGlobalObject, stream.get());
+    if (!controller().enqueue(value))
+        doCancel();
 }
 
 }

--- a/Source/WebCore/Modules/webtransport/WebTransportBidirectionalStreamSource.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportBidirectionalStreamSource.h
@@ -29,10 +29,12 @@
 
 namespace WebCore {
 
+class WebTransportBidirectionalStream;
+
 class WebTransportBidirectionalStreamSource : public RefCountedReadableStreamSource {
 public:
     static Ref<WebTransportBidirectionalStreamSource> create() { return adoptRef(*new WebTransportBidirectionalStreamSource()); }
-    void receiveIncomingStream();
+    void receiveIncomingStream(JSC::JSGlobalObject&, Ref<WebTransportBidirectionalStream>&&);
 private:
     void setActive() final { }
     void setInactive() final { }

--- a/Source/WebCore/Modules/webtransport/WebTransportReceiveStream.idl
+++ b/Source/WebCore/Modules/webtransport/WebTransportReceiveStream.idl
@@ -27,7 +27,9 @@
     EnabledBySetting=WebTransportEnabled,
     Exposed=(Window,Worker),
     SecureContext,
-    Transferable
+    Transferable,
+    JSGenerateToJSObject,
+    JSGenerateToNativeObject
 ] interface WebTransportReceiveStream : ReadableStream {
     Promise<WebTransportReceiveStreamStats> getStats();
 };

--- a/Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "WebTransportReceiveStreamSource.h"
 
+#include "JSWebTransportReceiveStream.h"
+
 namespace WebCore {
 
 void WebTransportReceiveStreamSource::doCancel()
@@ -33,11 +35,15 @@ void WebTransportReceiveStreamSource::doCancel()
     m_isCancelled = true;
 }
 
-void WebTransportReceiveStreamSource::receiveIncomingStream()
+void WebTransportReceiveStreamSource::receiveIncomingStream(JSC::JSGlobalObject& globalObject, Ref<WebTransportReceiveStream>&& stream)
 {
     if (m_isCancelled)
         return;
-    // FIXME: Add parameters and implement.
+    auto& jsDOMGlobalObject = *JSC::jsCast<JSDOMGlobalObject*>(&globalObject);
+    Locker<JSC::JSLock> locker(jsDOMGlobalObject.vm().apiLock());
+    auto value = toJS(&globalObject, &jsDOMGlobalObject, stream.get());
+    if (!controller().enqueue(value))
+        doCancel();
 }
 
 }

--- a/Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.h
@@ -29,10 +29,12 @@
 
 namespace WebCore {
 
+class WebTransportReceiveStream;
+
 class WebTransportReceiveStreamSource : public RefCountedReadableStreamSource {
 public:
     static Ref<WebTransportReceiveStreamSource> create() { return adoptRef(*new WebTransportReceiveStreamSource()); }
-    void receiveIncomingStream();
+    void receiveIncomingStream(JSC::JSGlobalObject&, Ref<WebTransportReceiveStream>&&);
 private:
     void setActive() final { }
     void setInactive() final { }

--- a/Source/WebCore/Modules/webtransport/WebTransportSessionClient.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportSessionClient.h
@@ -29,12 +29,15 @@
 
 namespace WebCore {
 
+class ReadableStreamSource;
+struct WebTransportBidirectionalStreamConstructionParameters;
+
 class WebTransportSessionClient : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebTransportSessionClient> {
 public:
     virtual ~WebTransportSessionClient() { }
     virtual void receiveDatagram(std::span<const uint8_t>) = 0;
-    virtual void receiveIncomingUnidirectionalStream() = 0;
-    virtual void receiveBidirectionalStream() = 0;
+    virtual void receiveIncomingUnidirectionalStream(Ref<ReadableStreamSource>&&) = 0;
+    virtual void receiveBidirectionalStream(WebTransportBidirectionalStreamConstructionParameters&&) = 0;
 };
 
 }

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp
@@ -116,14 +116,14 @@ void NetworkTransportSession::streamReceiveBytes(WebTransportStreamIdentifier id
     send(Messages::WebTransportSession::StreamReceiveBytes(identifier, bytes, withFin));
 }
 
-void NetworkTransportSession::receiveIncomingUnidirectionalStream()
+void NetworkTransportSession::receiveIncomingUnidirectionalStream(WebTransportStreamIdentifier identifier)
 {
-    // FIXME: Implement and send Messages::WebTransportSession::ReceiveIncomingUnidirectionalStream.
+    send(Messages::WebTransportSession::ReceiveIncomingUnidirectionalStream(identifier));
 }
 
-void NetworkTransportSession::receiveBidirectionalStream()
+void NetworkTransportSession::receiveBidirectionalStream(WebTransportStreamIdentifier identifier)
 {
-    // FIXME: Implement and send Messages::WebTransportSession::ReceiveBidirectionalStream.
+    send(Messages::WebTransportSession::ReceiveBidirectionalStream(identifier));
 }
 
 std::optional<SharedPreferencesForWebProcess> NetworkTransportSession::sharedPreferencesForWebProcess() const

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
@@ -71,8 +71,8 @@ public:
 
     void receiveDatagram(std::span<const uint8_t>);
     void streamReceiveBytes(WebTransportStreamIdentifier, std::span<const uint8_t>, bool withFin);
-    void receiveIncomingUnidirectionalStream();
-    void receiveBidirectionalStream();
+    void receiveIncomingUnidirectionalStream(WebTransportStreamIdentifier);
+    void receiveBidirectionalStream(WebTransportStreamIdentifier);
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;

--- a/Source/WebKit/WebProcess/Network/WebTransportReceiveStreamSource.cpp
+++ b/Source/WebKit/WebProcess/Network/WebTransportReceiveStreamSource.cpp
@@ -30,6 +30,18 @@
 
 namespace WebKit {
 
+WebTransportReceiveStreamSource::WebTransportReceiveStreamSource(WebTransportSession& session, WebTransportStreamIdentifier identifier)
+    : m_session(session)
+    , m_identifier(identifier)
+{
+    ASSERT(RunLoop::isMain());
+}
+
+WebTransportReceiveStreamSource::~WebTransportReceiveStreamSource()
+{
+    ASSERT(RunLoop::isMain());
+}
+
 void WebTransportReceiveStreamSource::receiveBytes(std::span<const uint8_t> bytes, bool)
 {
     ASSERT(RunLoop::isMain());

--- a/Source/WebKit/WebProcess/Network/WebTransportReceiveStreamSource.h
+++ b/Source/WebKit/WebProcess/Network/WebTransportReceiveStreamSource.h
@@ -29,12 +29,21 @@
 
 namespace WebKit {
 
+class WebTransportSession;
+
+struct WebTransportStreamIdentifierType;
+using WebTransportStreamIdentifier = ObjectIdentifier<WebTransportStreamIdentifierType>;
+
 class WebTransportReceiveStreamSource : public WebCore::RefCountedReadableStreamSource {
 public:
-    static Ref<WebTransportReceiveStreamSource> create() { return adoptRef(*new WebTransportReceiveStreamSource()); }
+    static Ref<WebTransportReceiveStreamSource> create(WebTransportSession& session, WebTransportStreamIdentifier identifier) { return adoptRef(*new WebTransportReceiveStreamSource(session, identifier)); }
+
+    ~WebTransportReceiveStreamSource();
 
     void receiveBytes(std::span<const uint8_t>, bool withFin);
 private:
+    WebTransportReceiveStreamSource(WebTransportSession&, WebTransportStreamIdentifier);
+
     void setActive() final { }
     void setInactive() final { }
     void doStart() final { }
@@ -42,6 +51,9 @@ private:
     void doCancel();
 
     bool m_isCancelled { false };
+
+    WeakPtr<WebTransportSession> m_session;
+    const WebTransportStreamIdentifier m_identifier;
 };
 
 }

--- a/Source/WebKit/WebProcess/Network/WebTransportSendStreamSink.h
+++ b/Source/WebKit/WebProcess/Network/WebTransportSendStreamSink.h
@@ -49,7 +49,7 @@ private:
     void error(String&&) final { }
 
     WeakPtr<WebTransportSession> m_session;
-    WebTransportStreamIdentifier m_identifier;
+    const WebTransportStreamIdentifier m_identifier;
 };
 
 }

--- a/Tools/TestWebKitAPI/WebTransportServer.h
+++ b/Tools/TestWebKitAPI/WebTransportServer.h
@@ -25,27 +25,27 @@
 
 #pragma once
 
+#if HAVE(WEB_TRANSPORT)
+
 #import "CoroutineUtilities.h"
 #import "NetworkConnection.h"
 #import <Network/Network.h>
-#import <wtf/RetainPtr.h>
-#import <wtf/Vector.h>
 
 namespace TestWebKitAPI {
 
-#if HAVE(WEB_TRANSPORT)
-
 class WebTransportServer {
 public:
-    WebTransportServer(Function<Task(Connection)>&&);
+    WebTransportServer(Function<Task(ConnectionGroup)>&&);
     ~WebTransportServer();
 
     uint16_t port() const;
 private:
     struct Data;
     Ref<Data> m_data;
+
+    void setupConnection(nw_connection_t);
 };
 
-#endif // HAVE(WEB_TRANSPORT)
-
 } // namespace TestWebKitAPI
+
+#endif // HAVE(WEB_TRANSPORT)


### PR DESCRIPTION
#### c84ec7e6f2079d76b34158a6085979defb7ceaa9
<pre>
Implement WebTransport incoming unidirectional and bidirectional streams
<a href="https://bugs.webkit.org/show_bug.cgi?id=284501">https://bugs.webkit.org/show_bug.cgi?id=284501</a>
<a href="https://rdar.apple.com/136262852">rdar://136262852</a>

Reviewed by Alex Christensen.

Incoming WebTransport streams are hooked up to the WebTransport session so data can be sent and received on them.
Two tests are added to validate incoming unidirectional and bidirectional streams.
* Source/WebCore/Modules/webtransport/WebTransport.cpp:
(WebCore::WebTransport::receiveIncomingUnidirectionalStream):
(WebCore::WebTransport::receiveBidirectionalStream):
* Source/WebCore/Modules/webtransport/WebTransport.h:
(WebCore::WebTransport::scriptExecutionContext const):
* Source/WebCore/Modules/webtransport/WebTransportBidirectionalStream.idl:
* Source/WebCore/Modules/webtransport/WebTransportBidirectionalStreamSource.cpp:
(WebCore::WebTransportBidirectionalStreamSource::receiveIncomingStream):
* Source/WebCore/Modules/webtransport/WebTransportBidirectionalStreamSource.h:
* Source/WebCore/Modules/webtransport/WebTransportReceiveStream.idl:
* Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.cpp:
(WebCore::WebTransportReceiveStreamSource::receiveIncomingStream):
* Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.h:
* Source/WebCore/Modules/webtransport/WebTransportSessionClient.h:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp:
(WebKit::NetworkTransportSession::receiveIncomingUnidirectionalStream):
(WebKit::NetworkTransportSession::receiveBidirectionalStream):
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h:
* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm:
(WebKit::NetworkTransportSession::setupConnectionHandler):
* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportStreamCocoa.mm:
(WebKit::NetworkTransportStream::receiveLoop):
* Source/WebKit/WebProcess/Network/WebTransportReceiveStreamSource.cpp:
(WebKit::WebTransportReceiveStreamSource::WebTransportReceiveStreamSource):
(WebKit::WebTransportReceiveStreamSource::~WebTransportReceiveStreamSource):
* Source/WebKit/WebProcess/Network/WebTransportReceiveStreamSource.h:
(WebKit::WebTransportReceiveStreamSource::create):
* Source/WebKit/WebProcess/Network/WebTransportSession.cpp:
(WebKit::WebTransportSession::receiveIncomingUnidirectionalStream):
(WebKit::WebTransportSession::receiveBidirectionalStream):
(WebKit::WebTransportSession::createBidirectionalStream):
* Tools/TestWebKitAPI/NetworkConnection.h:
(TestWebKitAPI::ConnectionGroup::ConnectionGroup):
* Tools/TestWebKitAPI/NetworkConnection.mm:
(TestWebKitAPI::ConnectionGroup::createWebTransportConnection const):
(TestWebKitAPI::ConnectionGroup::terminate):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm:
(TestWebKitAPI::TEST(WebTransport, DISABLE_ClientBidirectional)):
(TestWebKitAPI::TEST(WebTransport, DISABLE_Datagram)):
(TestWebKitAPI::TEST(WebTransport, DISABLE_Unidirectional)):
(TestWebKitAPI::TEST(WebTransport, DISABLE_ServerBidirectional)):
(TestWebKitAPI::TEST(WebTransport, DISABLED_ClientBidirectional)): Deleted.
(TestWebKitAPI::TEST(WebTransport, DISABLED_Datagram)): Deleted.
* Tools/TestWebKitAPI/WebTransportServer.h:
* Tools/TestWebKitAPI/WebTransportServer.mm:
(TestWebKitAPI::WebTransportServer::Data::create):
(TestWebKitAPI::WebTransportServer::Data::Data):
(TestWebKitAPI::WebTransportServer::WebTransportServer):
(TestWebKitAPI::WebTransportServer::port const):

Canonical link: <a href="https://commits.webkit.org/287777@main">https://commits.webkit.org/287777@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1cf51c505e5baecd82ce17e26aa2f1ff751c47a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80798 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/320 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34734 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85325 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31782 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82909 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/337 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8119 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/63092 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/20878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83867 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73542 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43395 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27702 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30239 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28235 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86757 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8025 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/71391 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8202 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69378 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70631 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14657 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/13594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12531 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7987 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/13508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7826 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11345 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9632 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->