### PR TITLE
[Site isolation] Implement backends for DisplayList ImageBuffer

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2099,6 +2099,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/ImageBufferAllocator.h
     platform/graphics/ImageBufferBackend.h
     platform/graphics/ImageBufferBackendParameters.h
+    platform/graphics/ImageBufferDisplayListBackend.h
     platform/graphics/ImageBufferPixelFormat.h
     platform/graphics/ImageBufferPlatformBackend.h
     platform/graphics/ImageBufferResourceLimits.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2500,6 +2500,7 @@ platform/graphics/ImageBuffer.cpp
 platform/graphics/ImageBufferAllocator.cpp
 platform/graphics/ImageBufferBackend.cpp
 platform/graphics/ImageBufferContextSwitcher.cpp
+platform/graphics/ImageBufferDisplayListBackend.cpp
 platform/graphics/ImageDecoder.cpp
 platform/graphics/ImageFrame.cpp
 platform/graphics/ImageFrameAnimator.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -2811,6 +2811,7 @@
 		721B3E9629679E38004F5FF6 /* InnerSpinButtonPart.h in Headers */ = {isa = PBXBuildFile; fileRef = 721B3E9529679E38004F5FF6 /* InnerSpinButtonPart.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		721B3ECF29680811004F5FF6 /* ColorWellPart.h in Headers */ = {isa = PBXBuildFile; fileRef = 721B3ECE29680811004F5FF6 /* ColorWellPart.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		721B3EF52968F47D004F5FF6 /* MenuListButtonPart.h in Headers */ = {isa = PBXBuildFile; fileRef = 721B3EF42968F47D004F5FF6 /* MenuListButtonPart.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		721CC4CE2D14D8FC00FE277B /* ImageBufferDisplayListBackend.h in Headers */ = {isa = PBXBuildFile; fileRef = 721CC4CC2D14D89A00FE277B /* ImageBufferDisplayListBackend.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7220742F2D07C7F6009FA90F /* ImageBufferCGPDFDocumentBackend.h in Headers */ = {isa = PBXBuildFile; fileRef = 72D1DC382D03583800B52E57 /* ImageBufferCGPDFDocumentBackend.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		722AF2DE27E1C2060078D997 /* GraphicsContextStateSaver.h in Headers */ = {isa = PBXBuildFile; fileRef = 722AF2DB27E1C2040078D997 /* GraphicsContextStateSaver.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		722AF2DF27E1C2060078D997 /* GraphicsContextState.h in Headers */ = {isa = PBXBuildFile; fileRef = 722AF2DC27E1C2050078D997 /* GraphicsContextState.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -13255,6 +13256,8 @@
 		721B3EF22968F45D004F5FF6 /* MenuListButtonMac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MenuListButtonMac.h; sourceTree = "<group>"; };
 		721B3EF32968F45E004F5FF6 /* MenuListButtonMac.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MenuListButtonMac.mm; sourceTree = "<group>"; };
 		721B3EF42968F47D004F5FF6 /* MenuListButtonPart.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuListButtonPart.h; sourceTree = "<group>"; };
+		721CC4CC2D14D89A00FE277B /* ImageBufferDisplayListBackend.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ImageBufferDisplayListBackend.h; sourceTree = "<group>"; };
+		721CC4CD2D14D89A00FE277B /* ImageBufferDisplayListBackend.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ImageBufferDisplayListBackend.cpp; sourceTree = "<group>"; };
 		7224ABCF2C0174EE00D85362 /* BitmapImageDescriptor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BitmapImageDescriptor.h; sourceTree = "<group>"; };
 		7225E8062A3E298C00947EBF /* RotationDirection.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RotationDirection.cpp; sourceTree = "<group>"; };
 		722623BF29486B28006DCCF1 /* ControlFactory.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ControlFactory.cpp; sourceTree = "<group>"; };
@@ -33827,6 +33830,8 @@
 				86BBA9EF2987EBF100A78986 /* ImageBufferBackendParameters.h */,
 				72FE4047292F3D3B001D3855 /* ImageBufferContextSwitcher.cpp */,
 				72FE4046292F3D3A001D3855 /* ImageBufferContextSwitcher.h */,
+				721CC4CD2D14D89A00FE277B /* ImageBufferDisplayListBackend.cpp */,
+				721CC4CC2D14D89A00FE277B /* ImageBufferDisplayListBackend.h */,
 				3D0F80C52BCA014D006C8023 /* ImageBufferPixelFormat.h */,
 				72BAC3A623E17328008D741C /* ImageBufferPlatformBackend.h */,
 				322B61142C50C22D00FB5440 /* ImageBufferResourceLimits.h */,
@@ -41336,6 +41341,7 @@
 				550640B02407587E00AAE045 /* ImageBufferCGBackend.h in Headers */,
 				2D7705C925528D34001D0C94 /* ImageBufferCGBitmapBackend.h in Headers */,
 				7220742F2D07C7F6009FA90F /* ImageBufferCGPDFDocumentBackend.h in Headers */,
+				721CC4CE2D14D8FC00FE277B /* ImageBufferDisplayListBackend.h in Headers */,
 				727A7F3A24078B84004D2931 /* ImageBufferIOSurfaceBackend.h in Headers */,
 				3DFAB6FE2BCDA7AB00EDC3C4 /* ImageBufferPixelFormat.h in Headers */,
 				2D7705C7255276CD001D0C94 /* ImageBufferPlatformBackend.h in Headers */,

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -34,6 +34,7 @@
 #include "FilterResults.h"
 #include "GraphicsContext.h"
 #include "HostWindow.h"
+#include "ImageBufferDisplayListBackend.h"
 #include "ImageBufferPlatformBackend.h"
 #include "MIMETypeRegistry.h"
 #include "ProcessCapabilities.h"
@@ -107,7 +108,7 @@ RefPtr<ImageBuffer> ImageBuffer::create(const FloatSize& size, RenderingMode ren
 #endif
 
     case RenderingMode::DisplayList:
-        return nullptr;
+        return ImageBuffer::create<ImageBufferDisplayListBackend>(size, resolutionScale, colorSpace, pixelFormat, purpose, { });
     }
 
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.h
@@ -164,7 +164,7 @@ public:
 
     static constexpr RenderingMode renderingMode = RenderingMode::Unaccelerated;
 
-    virtual bool canMapBackingStore() const = 0;
+    virtual bool canMapBackingStore() const { return false; }
     virtual void ensureNativeImagesHaveCopiedBackingStore() { }
 
     virtual ImageBufferBackendSharing* toBackendSharing() { return nullptr; }

--- a/Source/WebCore/platform/graphics/ImageBufferDisplayListBackend.cpp
+++ b/Source/WebCore/platform/graphics/ImageBufferDisplayListBackend.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2024 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ImageBufferDisplayListBackend.h"
+
+#include "ImageBuffer.h"
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+
+std::unique_ptr<ImageBufferDisplayListBackend> ImageBufferDisplayListBackend::create(const Parameters& parameters, const ImageBufferCreationContext&)
+{
+    return std::unique_ptr<ImageBufferDisplayListBackend>(new ImageBufferDisplayListBackend(parameters));
+}
+
+ImageBufferDisplayListBackend::ImageBufferDisplayListBackend(const Parameters& parameters)
+    : ImageBufferBackend(parameters)
+    , m_drawingContext(parameters.backendSize)
+{
+}
+
+GraphicsContext& ImageBufferDisplayListBackend::context()
+{
+    return m_drawingContext.context();
+}
+
+RefPtr<NativeImage> ImageBufferDisplayListBackend::copyNativeImage()
+{
+    RefPtr buffer = ImageBuffer::create(size(), RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, 1, DestinationColorSpace::SRGB(), ImageBufferPixelFormat::BGRA8);
+    if (!buffer)
+        return nullptr;
+
+    auto& context = buffer->context();
+    m_drawingContext.replayDisplayList(context);
+
+    return ImageBuffer::sinkIntoNativeImage(WTFMove(buffer));
+}
+
+String ImageBufferDisplayListBackend::debugDescription() const
+{
+    TextStream stream;
+    stream << "ImageBufferDisplayListBackend " << this;
+    return stream.release();
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/ImageBufferDisplayListBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferDisplayListBackend.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2024 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "DisplayListDrawingContext.h"
+#include "ImageBufferBackend.h"
+
+namespace WebCore {
+
+class ImageBufferDisplayListBackend : public ImageBufferBackend {
+public:
+    WEBCORE_EXPORT static std::unique_ptr<ImageBufferDisplayListBackend> create(const Parameters&, const ImageBufferCreationContext&);
+    static size_t calculateMemoryCost(const Parameters&) { return 0; }
+
+    static constexpr RenderingMode renderingMode = RenderingMode::DisplayList;
+
+private:
+    ImageBufferDisplayListBackend(const Parameters&);
+
+    unsigned bytesPerRow() const final { return 0; }
+    GraphicsContext& context() final;
+
+    RefPtr<NativeImage> copyNativeImage() final;
+    RefPtr<NativeImage> createNativeImageReference() final { return copyNativeImage(); }
+    void getPixelBuffer(const IntRect&, PixelBuffer&) final { }
+    void putPixelBuffer(const PixelBuffer&, const IntRect&, const IntPoint&, AlphaPremultiplication) final { }
+
+    String debugDescription() const final;
+
+    DisplayList::DrawingContext m_drawingContext;
+};
+
+} // namespace WebCore

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -55,6 +55,7 @@
 #include "SwapBuffersDisplayRequirement.h"
 #include "WebPageProxy.h"
 #include <WebCore/HTMLCanvasElement.h>
+#include <WebCore/ImageBufferDisplayListBackend.h>
 #include <WebCore/NullImageBufferBackend.h>
 #include <WebCore/RenderingResourceIdentifier.h>
 #include <wtf/CheckedArithmetic.h>
@@ -304,6 +305,7 @@ static RefPtr<ImageBuffer> allocateImageBufferInternal(const FloatSize& logicalS
         break;
 
     case RenderingMode::DisplayList:
+        imageBuffer = ImageBuffer::create<ImageBufferDisplayListBackend, ImageBufferType>(logicalSize, resolutionScale, colorSpace, pixelFormat, purpose, creationContext, imageBufferIdentifier);
         break;
     }
 

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -740,6 +740,7 @@ WebProcess/GPU/graphics/WebGPU/RemoteXRProjectionLayerProxy.cpp
 WebProcess/GPU/graphics/WebGPU/RemoteXRSubImageProxy.cpp
 WebProcess/GPU/graphics/WebGPU/RemoteXRViewProxy.cpp
 WebProcess/GPU/graphics/WebGPU/WebGPUDowncastConvertToBackingContext.cpp
+WebProcess/GPU/graphics/ImageBufferRemoteDisplayListBackend.cpp
 WebProcess/GPU/graphics/ImageBufferRemotePDFDocumentBackend.cpp
 WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
 WebProcess/GPU/graphics/PrepareBackingStoreBuffersData.cpp

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -6370,6 +6370,8 @@
 		71FB810A2260627A00323677 /* WebsiteSimulatedMouseEventsDispatchPolicy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebsiteSimulatedMouseEventsDispatchPolicy.h; sourceTree = "<group>"; };
 		7203449A26A6C44C000A5F54 /* MonotonicObjectIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MonotonicObjectIdentifier.h; sourceTree = "<group>"; };
 		7203449B26A6C476000A5F54 /* RenderingUpdateID.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RenderingUpdateID.h; sourceTree = "<group>"; };
+		721CC4CA2D14CCA500FE277B /* ImageBufferRemoteDisplayListBackend.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ImageBufferRemoteDisplayListBackend.h; sourceTree = "<group>"; };
+		721CC4CB2D14CCA500FE277B /* ImageBufferRemoteDisplayListBackend.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ImageBufferRemoteDisplayListBackend.cpp; sourceTree = "<group>"; };
 		722074302D07D671009FA90F /* ImageBufferRemotePDFDocumentBackend.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ImageBufferRemotePDFDocumentBackend.h; sourceTree = "<group>"; };
 		722074312D07D671009FA90F /* ImageBufferRemotePDFDocumentBackend.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ImageBufferRemotePDFDocumentBackend.cpp; sourceTree = "<group>"; };
 		723C90A22A377AB400038126 /* PathSegment.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = PathSegment.serialization.in; sourceTree = "<group>"; };
@@ -12715,6 +12717,8 @@
 				7B64C0B6254C5C250006B4AF /* GraphicsContextGLIdentifier.h */,
 				727A7F39240788F1004D2931 /* ImageBufferBackendHandle.h */,
 				0FA7467E27BB611800B5FF5A /* ImageBufferBackendHandleSharing.h */,
+				721CC4CB2D14CCA500FE277B /* ImageBufferRemoteDisplayListBackend.cpp */,
+				721CC4CA2D14CCA500FE277B /* ImageBufferRemoteDisplayListBackend.h */,
 				722074312D07D671009FA90F /* ImageBufferRemotePDFDocumentBackend.cpp */,
 				722074302D07D671009FA90F /* ImageBufferRemotePDFDocumentBackend.h */,
 				727A7F37240788F0004D2931 /* ImageBufferShareableBitmapBackend.cpp */,

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferRemoteDisplayListBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferRemoteDisplayListBackend.cpp
@@ -1,0 +1,60 @@
+/*
+* Copyright (C) 2024 Apple Inc.  All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+* EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+* PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+* CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+* EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+* PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+* OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "config.h"
+#include "ImageBufferRemoteDisplayListBackend.h"
+
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebKit {
+using namespace WebCore;
+
+WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(ImageBufferRemoteDisplayListBackend);
+
+std::unique_ptr<ImageBufferRemoteDisplayListBackend> ImageBufferRemoteDisplayListBackend::create(const Parameters& parameters, RemoteRenderingBackendProxy& remoteRenderingBackendProxy, RenderingResourceIdentifier imageBufferIdentifier)
+{
+    return std::unique_ptr<ImageBufferRemoteDisplayListBackend> { new ImageBufferRemoteDisplayListBackend { parameters, remoteRenderingBackendProxy, imageBufferIdentifier } };
+}
+
+ImageBufferRemoteDisplayListBackend::ImageBufferRemoteDisplayListBackend(const Parameters& parameters, RemoteRenderingBackendProxy& remoteRenderingBackendProxy, RenderingResourceIdentifier imageBufferIdentifier)
+    : WebCore::NullImageBufferBackend(parameters)
+{
+}
+
+ImageBufferRemoteDisplayListBackend::~ImageBufferRemoteDisplayListBackend() = default;
+
+RefPtr<NativeImage> ImageBufferRemoteDisplayListBackend::createNativeImageReference()
+{
+    return nullptr;
+}
+
+String ImageBufferRemoteDisplayListBackend::debugDescription() const
+{
+    TextStream stream;
+    stream << "ImageBufferRemoteDisplayListBackend " << this;
+    return stream.release();
+}
+
+} // namespace WebCore

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferRemoteDisplayListBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferRemoteDisplayListBackend.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/NullImageBufferBackend.h>
+#include <wtf/TZoneMalloc.h>
+
+namespace WebKit {
+
+class RemoteRenderingBackendProxy;
+
+class ImageBufferRemoteDisplayListBackend : public WebCore::NullImageBufferBackend {
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(ImageBufferRemoteDisplayListBackend);
+    WTF_MAKE_NONCOPYABLE(ImageBufferRemoteDisplayListBackend);
+public:
+    static std::unique_ptr<ImageBufferRemoteDisplayListBackend> create(const Parameters&, RemoteRenderingBackendProxy&, WebCore::RenderingResourceIdentifier);
+
+    virtual ~ImageBufferRemoteDisplayListBackend();
+
+    static constexpr WebCore::RenderingMode renderingMode = WebCore::RenderingMode::DisplayList;
+
+private:
+    ImageBufferRemoteDisplayListBackend(const Parameters&, RemoteRenderingBackendProxy&, WebCore::RenderingResourceIdentifier);
+
+    RefPtr<WebCore::NativeImage> createNativeImageReference() override;
+    String debugDescription() const override;
+};
+
+} // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -30,6 +30,7 @@
 
 #include "BufferIdentifierSet.h"
 #include "GPUConnectionToWebProcess.h"
+#include "ImageBufferRemoteDisplayListBackend.h"
 #include "ImageBufferRemotePDFDocumentBackend.h"
 #include "ImageBufferShareableBitmapBackend.h"
 #include "Logging.h"
@@ -252,6 +253,7 @@ RefPtr<ImageBuffer> RemoteRenderingBackendProxy::createImageBuffer(const FloatSi
         break;
 
     case RenderingMode::DisplayList:
+        imageBuffer = RemoteImageBufferProxy::create<ImageBufferRemoteDisplayListBackend>(size, resolutionScale, colorSpace, pixelFormat, purpose, *this);
         break;
     }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(GPU_PROCESS)
 
 #include "RemoteCompositorIntegrationMessages.h"
+#include "RemoteDeviceProxy.h"
 #include "RemoteGPUProxy.h"
 #include "WebGPUConvertToBackingContext.h"
 #include <WebCore/ImageBuffer.h>

--- a/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
@@ -48,6 +48,7 @@
 #endif
 
 namespace WebKit {
+using namespace WebCore;
 
 WebMediaStrategy::~WebMediaStrategy() = default;
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.cpp
@@ -49,6 +49,7 @@
 #endif
 
 namespace WebKit {
+using namespace WebCore;
 
 Ref<WebPermissionController> WebPermissionController::create(WebProcess& process)
 {

--- a/Tools/TestWebKitAPI/Tests/WebCore/ImageBufferTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ImageBufferTests.cpp
@@ -235,6 +235,46 @@ TEST(ImageBufferTests, DISABLED_DrawImageBufferDoesNotReferenceExtraMemory)
     EXPECT_TRUE(memoryFootprintChangedBy(lastFootprint, 0, footprintError));
 }
 
+TEST(ImageBufferTests, ImageBufferDisplayListBackend)
+{
+    auto colorSpace = DestinationColorSpace::SRGB();
+    auto pixelFormat = ImageBufferPixelFormat::BGRA8;
+    FloatSize logicalSize { 4096, 4096 };
+    float scale = 1;
+
+    auto sourceDisplayList = ImageBuffer::create(logicalSize, RenderingMode::DisplayList, RenderingPurpose::Unspecified, scale, colorSpace, pixelFormat);
+    auto destinationDisplayList = ImageBuffer::create(logicalSize, RenderingMode::DisplayList, RenderingPurpose::Unspecified, scale, colorSpace, pixelFormat);
+    auto destinationBitmap = ImageBuffer::create(logicalSize, RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, scale, colorSpace, pixelFormat);
+
+    auto blueRatio = 0.25;
+    auto blueRect = FloatRect { FloatPoint { logicalSize.scaled((1 - blueRatio) / 2) }, logicalSize.scaled(blueRatio) };
+    sourceDisplayList->context().fillRect(blueRect, Color::blue);
+
+    auto greenRatio = 0.5;
+    auto greenRect = FloatRect { FloatPoint { logicalSize.scaled((1 - greenRatio) / 2) }, logicalSize.scaled(greenRatio) };
+    destinationDisplayList->context().fillRect(greenRect, Color::green);
+    destinationDisplayList->context().drawImageBuffer(*sourceDisplayList, FloatPoint());
+
+    auto redRect = FloatRect { { }, logicalSize };
+    destinationBitmap->context().fillRect(redRect, Color::red);
+    destinationBitmap->context().drawImageBuffer(*destinationDisplayList, FloatPoint());
+
+    EXPECT_TRUE(imageBufferPixelIs(Color::red, *destinationBitmap, redRect.x() + 1, redRect.y() + 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::red, *destinationBitmap, redRect.maxX() - 1, redRect.y() + 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::red, *destinationBitmap, redRect.x() + 1, redRect.maxY() - 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::red, *destinationBitmap, redRect.maxX() - 1, redRect.maxY() - 1));
+
+    EXPECT_TRUE(imageBufferPixelIs(Color::green, *destinationBitmap, greenRect.x() + 1, greenRect.y() + 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::green, *destinationBitmap, greenRect.maxX() - 1, greenRect.y() + 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::green, *destinationBitmap, greenRect.x() + 1, greenRect.maxY() - 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::green, *destinationBitmap, greenRect.maxX() - 1, greenRect.maxY() - 1));
+
+    EXPECT_TRUE(imageBufferPixelIs(Color::blue, *destinationBitmap, blueRect.x() + 1, blueRect.y() + 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::blue, *destinationBitmap, blueRect.maxX() - 1, blueRect.y() + 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::blue, *destinationBitmap, blueRect.x() + 1, blueRect.maxY() - 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::blue, *destinationBitmap, blueRect.maxX() - 1, blueRect.maxY() - 1));
+}
+
 enum class TestPreserveResolution : bool { No, Yes };
 
 void PrintTo(TestPreserveResolution value, ::std::ostream* o)


### PR DESCRIPTION
#### 2a65b243f27c79be51399bb7e27790d9cc6c8d01
<pre>
[Site isolation] Implement backends for DisplayList ImageBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=284568">https://bugs.webkit.org/show_bug.cgi?id=284568</a>
<a href="https://rdar.apple.com/141372911">rdar://141372911</a>

Reviewed by NOBODY (OOPS!).

We need a way to store the drawing of the iframes in GPUProcess till all of them
finish drawing. Once the drawing is complete, all the drawing will be composited
in the correct order. The result can be a NativeImage or a PDFDocument.

For this purpose, new backends are introduced to record the drawing in Display-
Lists. Connecting the DisplayLists and compositing them will happen in later PRs.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::create):
* Source/WebCore/platform/graphics/ImageBufferBackend.h:
(WebCore::ImageBufferBackend::canMapBackingStore const):
* Source/WebCore/platform/graphics/ImageBufferDisplayListBackend.cpp: Added.
(WebCore::ImageBufferDisplayListBackend::create):
(WebCore::ImageBufferDisplayListBackend::ImageBufferDisplayListBackend):
(WebCore::ImageBufferDisplayListBackend::context):
(WebCore::ImageBufferDisplayListBackend::copyNativeImage):
(WebCore::ImageBufferDisplayListBackend::debugDescription const):
* Source/WebCore/platform/graphics/ImageBufferDisplayListBackend.h: Added.
(WebCore::ImageBufferDisplayListBackend::calculateMemoryCost):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::allocateImageBufferInternal):
* Source/WebKit/Sources.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/GPU/graphics/ImageBufferRemoteDisplayListBackend.cpp: Added.
(WebKit::ImageBufferRemoteDisplayListBackend::create):
(WebKit::ImageBufferRemoteDisplayListBackend::ImageBufferRemoteDisplayListBackend):
(WebKit::ImageBufferRemoteDisplayListBackend::createNativeImageReference):
(WebKit::ImageBufferRemoteDisplayListBackend::debugDescription const):
* Source/WebKit/WebProcess/GPU/graphics/ImageBufferRemoteDisplayListBackend.h: Added.
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::createImageBuffer):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp:
* Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.cpp:
* Tools/TestWebKitAPI/Tests/WebCore/ImageBufferTests.cpp:
(TestWebKitAPI::TEST(ImageBufferTests, ImageBufferDisplayListBackend)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a65b243f27c79be51399bb7e27790d9cc6c8d01

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81945 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1472 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35902 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86502 "Failed to checkout and rebase branch from PR 37846") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32977 "Failed to checkout and rebase branch from PR 37846") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84051 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1507 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9295 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/86502 "Failed to checkout and rebase branch from PR 37846") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/32977 "Failed to checkout and rebase branch from PR 37846") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85015 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1117 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74569 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/86502 "Failed to checkout and rebase branch from PR 37846") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1019 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28746 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31396 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72347 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29357 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87933 "Failed to checkout and rebase branch from PR 37846") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9187 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6549 "Found 60 new test failures: fast/events/scroll-to-anchor-vertical-writing-mode.html fast/forms/search-field-buttons-do-not-have-focus-rings.html fast/selectors/hover-descendant-shadow-tree.html fast/selectors/hover-invalidation-descendant-clear.html fast/selectors/is-with-pseudo-element.html fast/selectors/lang-dynamic.html fast/selectors/matches-with-pseudo-element.html fast/selectors/non-visited-link-backround-color.html fast/text/emoji-gender-fe0f-5.html fast/writing-mode/english-rl-text-with-spelling-marker.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/87933 "Failed to checkout and rebase branch from PR 37846") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9372 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70388 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/87933 "Failed to checkout and rebase branch from PR 37846") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15594 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14515 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/573 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9138 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14674 "Failed to checkout and rebase branch from PR 37846") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8978 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12503 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10786 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->