### PR TITLE
[margin-trim] Change RenderLayoutState's m_blockStartTrimming to bool.

### DIFF
--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -75,6 +75,7 @@
 #include "TextBoxTrimmer.h"
 #include "TextUtil.h"
 #include "VisiblePosition.h"
+#include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -728,21 +729,20 @@ void RenderBlockFlow::layoutBlockChildren(bool relayoutChildren, LayoutUnit& max
     // The margin struct caches all our current margin collapsing state.
     MarginInfo marginInfo(*this, beforeEdge, afterEdge);
 
-    auto hasMarginTrimState = false;
-    auto updateMarginTrimStateIfNeeded = [&] {
-        auto containingBlockTrimmingState = layoutState->blockStartTrimming();
+    bool blockStartTrimmingFromContainingBlock = layoutState->blockStartTrimming();
+    bool newBlockStartTrimmingForSubtree = [&] {
         if (style().marginTrim().contains(MarginTrimType::BlockStart))
-            layoutState->pushBlockStartTrimming(true);
-        else if (!marginInfo.canCollapseMarginBeforeWithChildren() && containingBlockTrimmingState)
-            layoutState->pushBlockStartTrimming(false);
-        else if (marginInfo.canCollapseMarginBeforeWithChildren() && containingBlockTrimmingState)
-            layoutState->pushBlockStartTrimming(containingBlockTrimmingState.value());
-        else
-            return;
-        hasMarginTrimState = true;
-    };
+            return true;
+        if (!marginInfo.canCollapseMarginBeforeWithChildren() && blockStartTrimmingFromContainingBlock)
+            return false;
+        return blockStartTrimmingFromContainingBlock;
+    }();
 
-    updateMarginTrimStateIfNeeded();
+    layoutState->setBlockStartTrimming(newBlockStartTrimmingForSubtree);
+    auto resetBlockStartTrimming = WTF::makeScopeExit([&] {
+        layoutState->setBlockStartTrimming(blockStartTrimmingFromContainingBlock);
+    });
+
 
     // Fieldsets need to find their legend and position it inside the border of the object.
     // The legend then gets skipped during normal layout. The same is true for ruby text.
@@ -806,8 +806,6 @@ void RenderBlockFlow::layoutBlockChildren(bool relayoutChildren, LayoutUnit& max
     // Now do the handling of the bottom of the block, adding in our bottom border/padding and
     // determining the correct collapsed bottom margin information.
     handleAfterSideOfBlock(beforeEdge, afterEdge, marginInfo);
-    if (hasMarginTrimState)
-        layoutState->popBlockStartTrimming();
 }
 
 
@@ -1035,10 +1033,8 @@ void RenderBlockFlow::layoutBlockChild(RenderBox& child, MarginInfo& marginInfo,
     if (marginInfo.atBeforeSideOfBlock() && !child.isSelfCollapsingBlock()) {
         marginInfo.setAtBeforeSideOfBlock(false);
 
-        if (auto* layoutState = frame().view()->layoutContext().layoutState(); layoutState && layoutState->blockStartTrimming()) {
-            layoutState->popBlockStartTrimming();
-            layoutState->pushBlockStartTrimming(false);
-        }
+        if (auto* layoutState = frame().view()->layoutContext().layoutState(); layoutState && layoutState->blockStartTrimming())
+            layoutState->setBlockStartTrimming(false);
     }
     // Now place the child in the correct left position
     determineLogicalLeftPositionForChild(child, ApplyLayoutDelta);
@@ -1349,7 +1345,7 @@ LayoutUnit RenderBlockFlow::collapseMarginsWithChildInfo(RenderBox* child, Margi
             setTrimmedMarginForChild(*child, MarginTrimType::BlockEnd);
         }
     };
-    if (frame().view()->layoutContext().layoutState()->blockStartTrimming().value_or(false)) {
+    if (frame().view()->layoutContext().layoutState()->blockStartTrimming()) {
         ASSERT(marginInfo.atBeforeSideOfBlock());
         trimChildBlockMargins();
     }

--- a/Source/WebCore/rendering/RenderLayoutState.cpp
+++ b/Source/WebCore/rendering/RenderLayoutState.cpp
@@ -48,7 +48,7 @@ RenderLayoutState::RenderLayoutState(RenderElement& renderer)
 #if ASSERT_ENABLED
     , m_layoutDeltaXSaturated(false)
     , m_layoutDeltaYSaturated(false)
-    , m_blockStartTrimming(Vector<bool>(0))
+    , m_blockStartTrimming(false)
     , m_renderer(&renderer)
 #endif
 {
@@ -77,7 +77,7 @@ RenderLayoutState::RenderLayoutState(const LocalFrameViewLayoutContext::LayoutSt
     , m_layoutDeltaXSaturated(false)
     , m_layoutDeltaYSaturated(false)
 #endif
-    , m_blockStartTrimming(Vector<bool>(0))
+    , m_blockStartTrimming(false)
     , m_lineClamp(lineClamp)
     , m_legacyLineClamp(legacyLineClamp)
     , m_textBoxTrim(textBoxTrim)

--- a/Source/WebCore/rendering/RenderLayoutState.h
+++ b/Source/WebCore/rendering/RenderLayoutState.h
@@ -71,7 +71,7 @@ public:
         , m_layoutDeltaXSaturated(false)
         , m_layoutDeltaYSaturated(false)
 #endif
-        , m_blockStartTrimming(Vector<bool>(0))
+        , m_blockStartTrimming(false)
     {
     }
     RenderLayoutState(const LocalFrameViewLayoutContext::LayoutStateStack&, RenderBox&, const LayoutSize& offset, LayoutUnit pageHeight, bool pageHeightChanged, std::optional<LineClamp>, std::optional<LegacyLineClamp>, std::optional<TextBoxTrim>);
@@ -122,12 +122,8 @@ public:
     bool hasTextBoxTrimEnd(const RenderBlockFlow& candidate) const { return m_textBoxTrim && m_textBoxTrim->lastFormattedLineRoot.get() == &candidate; }
     void removeTextBoxTrimStart();
 
-    void pushBlockStartTrimming(bool blockStartTrimming) { m_blockStartTrimming.append(blockStartTrimming); }
-    std::optional<bool> blockStartTrimming() const { return m_blockStartTrimming.isEmpty() ? std::nullopt : std::optional(m_blockStartTrimming.last()); }
-    void popBlockStartTrimming() 
-    {
-        m_blockStartTrimming.removeLast(); 
-    }
+    void setBlockStartTrimming(bool blockStartTrimming) { m_blockStartTrimming = blockStartTrimming; }
+    bool blockStartTrimming() const { return m_blockStartTrimming; }
 
 private:
     void computeOffsets(const RenderLayoutState& ancestor, RenderBox&, LayoutSize offset);
@@ -147,7 +143,7 @@ private:
     bool m_layoutDeltaXSaturated : 1;
     bool m_layoutDeltaYSaturated : 1;
 #endif
-    Vector<bool> m_blockStartTrimming;
+    bool m_blockStartTrimming : 1 { false };
 
     // The current line grid that we're snapping to and the offset of the start of the grid.
     SingleThreadWeakPtr<RenderBlockFlow> m_lineGrid;


### PR DESCRIPTION
#### fdd47d1fbc4d9dc87074fe3d75bafc240e194b0b
<pre>
[margin-trim] Change RenderLayoutState&apos;s m_blockStartTrimming to bool.
<a href="https://bugs.webkit.org/show_bug.cgi?id=284566">https://bugs.webkit.org/show_bug.cgi?id=284566</a>
<a href="https://rdar.apple.com/problem/141370964">rdar://problem/141370964</a>

Reviewed by Alan Baradlay.

In preparation to fix a margin-trim invalidation bug, let&apos;s change the
m_blockStartTrimming field in RenderLayoutState from a Vector&lt;bool&gt;
to being simply a bool. This makes it easier to maintain and can be used
to perform the same task.

This field is supposed to be a stack which keeps track of whether or not
we should be attempting to trim the block-start margins for a
particular subtree. A block container checks to see what the value is at
the top of the stack in order to determine if it should trim the
margins of its children. The container may set this value to false to
indicate that it should no longer trim its children&apos;s margins (e.g.
because maybe the child&apos;s and subsequent children&apos;s margins will no
longer be at the block-start side of the block container). This would
also mean that any subtree from this point should no longer try to trim
margins.

If we change this field to a bool we can achieve the same effect by:
1.) Having the block container keep track of the old value of
blockStartTrimming (that was propagated from its containing block) and
compute a new value that it will use for its children.
2.) Restore the old value when it’s done laying out its children so that
its containing block can continue to use the value it computed before.

This should be essentially the same logic that we were performing
before but are just holding onto the information slightly differently.

* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::layoutBlockChildren):
Previously, we were pushing a newly computed value for blockStartTrimming
that would be used by the block container. We will continue to
compute this same value but also keep track of the old one. The only
difference is that there was previously a scenario in which we did not
modify RenderLayoutState at all if there was no trimming being done, but
let&apos;s just coalesce this into the logic of further propagating the
value we got from our containing block to make things simpler.

At the end of the method, instead of popping from the stack, just restore
the old value via a ScopeExit.

(WebCore::RenderBlockFlow::layoutBlockChild):
Here we would set blockStartTrimming to false if we could no longer
trim the margins for the subtree. Do this by directly updating the
value on RenderLayoutState.

(WebCore::RenderBlockFlow::collapseMarginsWithChildInfo):
We would only trim the margins if the value at the top of the stack
(i.e. the value computed for this block container) was true. We can
continue to do this by directly checking the value on RenderLayoutState.

* Source/WebCore/rendering/RenderLayoutState.cpp:
(WebCore::RenderLayoutState::RenderLayoutState):
* Source/WebCore/rendering/RenderLayoutState.h:
(WebCore::RenderLayoutState::RenderLayoutState):
(WebCore::RenderLayoutState::setBlockStartTrimming):
(WebCore::RenderLayoutState::blockStartTrimming const):
(WebCore::RenderLayoutState::pushBlockStartTrimming): Deleted.
(WebCore::RenderLayoutState::popBlockStartTrimming): Deleted.

Canonical link: <a href="https://commits.webkit.org/287885@main">https://commits.webkit.org/287885@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2fa984af6d331b779442f638bbc20633e04af1d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80930 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/452 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34866 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85461 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31918 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83041 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/470 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8253 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63201 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20973 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83999 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/275 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73663 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43499 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/160 "Build was cancelled. Recent messages:OS: Sequoia (15.2), Xcode: 16.2") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27816 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30376 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71733 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28356 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86896 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8162 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5772 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71502 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8339 "Failed to checkout and rebase branch from PR 37848") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69492 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70736 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17665 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13694 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8119 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13646 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7960 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11480 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9768 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->