### PR TITLE
[scroll-animations] https://scroll-driven-animations.style/demos/parallax-carousel/css/ does not work

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-nearest-dirty-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-nearest-dirty-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Unrelated style mutation does not affect anonymous timeline assert_equals: expected "100" but got "auto"
+PASS Unrelated style mutation does not affect anonymous timeline
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-root-dirty-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-root-dirty-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Unrelated style mutation does not affect anonymous timeline (root) assert_equals: expected "100" but got "auto"
+PASS Unrelated style mutation does not affect anonymous timeline (root)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/siblings-with-anonymous-timelines-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/siblings-with-anonymous-timelines-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Setting "animation-timeline: scroll()" yields a unique scroll timeline for siblings matching the same CSS rules
+PASS Setting "animation-timeline: view()" yields a unique view timeline for siblings matching the same CSS rules
+

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/siblings-with-anonymous-timelines.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/siblings-with-anonymous-timelines.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="help" src="https://drafts.csswg.org/scroll-animations-1/#scroll-timelines-anonymous">
+<link rel="help" src="https://drafts.csswg.org/scroll-animations-1/#view-timelines-anonymous">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/scroll-animations/scroll-timelines/testcommon.js"></script>
+<title>The "animation-timeline" CSS property yields a unique anonymous timeline for siblings matching the same CSS rules</title>
+<style>
+
+  @keyframes anim {
+    from { opacity: 0 }
+  }
+
+  .scroller {
+    overflow-y: scroll;
+    width: 100px;
+    height: 100px;
+  }
+
+  .scroller > div {
+    width: 100%;
+    height: 100%;
+
+    animation: anim auto linear;
+  }
+
+  .scroller.scroll > div {
+    animation-timeline: scroll();
+  }
+
+  .scroller.view > div {
+    animation-timeline: view();
+  }
+
+</style>
+</head>
+<body>
+
+  <div class="scroller scroll">
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+  </div>
+
+  <div class="scroller view">
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+  </div>
+
+  <script>
+
+const types = ["scroll", "view"];
+
+types.forEach(type => {
+  test(t => {
+    const scroller = document.querySelector(`.scroller.${type}`);
+
+    const animations = scroller.getAnimations({ subtree: true });
+    const numberOfChildren = scroller.childElementCount;
+    assert_equals(animations.length, numberOfChildren, "There are as many animations as there are children");
+
+    const timelines = new Set;
+    for (const animation of animations)
+      timelines.add(animation.timeline);
+    assert_equals(timelines.size, numberOfChildren, `There are as many ${type} timelines as there are children`);
+  }, `Setting "animation-timeline: ${type}()" yields a unique ${type} timeline for siblings matching the same CSS rules`);
+});
+
+  </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/contain-alignment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/contain-alignment-expected.txt
@@ -2,5 +2,5 @@
 
 
 
-FAIL Stability of animated elements aligned to the bounds of a contain region assert_approx_equals: a: Unexpected progress expected 1 +/- 0.001 but got 0
+FAIL Stability of animated elements aligned to the bounds of a contain region assert_approx_equals: a: Unexpected progress expected a number but got a "object"
 

--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -132,12 +132,15 @@ void CSSAnimation::syncPropertiesWithBackingAnimation()
             }, [&] (const AtomString& name) {
                 CheckedRef timelinesController = document->ensureTimelinesController();
                 timelinesController->setTimelineForName(name, target, *this);
-            }, [&] (Ref<ScrollTimeline> anonymousTimeline) {
-                if (RefPtr viewTimeline = dynamicDowncast<ViewTimeline>(anonymousTimeline))
-                    viewTimeline->setSubject(target.ptr());
-                else
-                    anonymousTimeline->setSource(target.ptr());
-                setTimeline(RefPtr { anonymousTimeline.ptr() });
+            }, [&] (const Animation::AnonymousScrollTimeline& anonymousScrollTimeline) {
+                auto scrollTimeline = ScrollTimeline::create(anonymousScrollTimeline.scroller, anonymousScrollTimeline.axis);
+                scrollTimeline->setSource(target.ptr());
+                setTimeline(WTFMove(scrollTimeline));
+            }, [&] (const Animation::AnonymousViewTimeline& anonymousViewTimeline) {
+                auto insets = anonymousViewTimeline.insets;
+                auto viewTimeline = ViewTimeline::create(nullAtom(), anonymousViewTimeline.axis, WTFMove(insets));
+                viewTimeline->setSubject(target.ptr());
+                setTimeline(WTFMove(viewTimeline));
             }
         );
     }

--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -36,7 +36,6 @@
 namespace WebCore {
 
 class AnimationTimelinesController;
-class CSSScrollValue;
 class Document;
 class Element;
 class RenderStyle;
@@ -44,11 +43,15 @@ class ScrollableArea;
 
 struct TimelineRange;
 
+enum class Scroller : uint8_t { Nearest, Root, Self };
+
+TextStream& operator<<(TextStream&, Scroller);
+
 class ScrollTimeline : public AnimationTimeline {
 public:
     static Ref<ScrollTimeline> create(Document&, ScrollTimelineOptions&& = { });
     static Ref<ScrollTimeline> create(const AtomString&, ScrollAxis);
-    static Ref<ScrollTimeline> createFromCSSValue(const CSSScrollValue&);
+    static Ref<ScrollTimeline> create(Scroller, ScrollAxis);
 
     virtual Element* source() const;
     void setSource(const Element*);
@@ -58,9 +61,6 @@ public:
 
     const AtomString& name() const { return m_name; }
     void setName(const AtomString& name) { m_name = name; }
-
-    virtual void dump(TextStream&) const;
-    virtual Ref<CSSValue> toCSSValue(const RenderStyle&) const;
 
     AnimationTimeline::ShouldUpdateAnimationsAndSendEvents documentWillUpdateAnimationsAndSendEvents() override;
 
@@ -94,8 +94,6 @@ protected:
     std::optional<ResolvedScrollDirection> resolvedScrollDirection() const;
 
 private:
-    enum class Scroller : uint8_t { Nearest, Root, Self };
-
     explicit ScrollTimeline();
     explicit ScrollTimeline(Scroller, ScrollAxis);
 

--- a/Source/WebCore/animation/ViewTimeline.h
+++ b/Source/WebCore/animation/ViewTimeline.h
@@ -38,7 +38,6 @@ namespace Style {
 class BuilderState;
 }
 
-class CSSViewValue;
 class Element;
 
 struct TimelineRange;
@@ -53,7 +52,6 @@ class ViewTimeline final : public ScrollTimeline {
 public:
     static Ref<ViewTimeline> create(ViewTimelineOptions&& = { });
     static Ref<ViewTimeline> create(const AtomString&, ScrollAxis, ViewTimelineInsets&&);
-    static Ref<ViewTimeline> createFromCSSValue(const Style::BuilderState&, const CSSViewValue&);
 
     Element* subject() const { return m_subject.get(); }
     void setSubject(const Element*);
@@ -78,8 +76,6 @@ private:
     explicit ViewTimeline(ViewTimelineOptions&& = { });
     explicit ViewTimeline(const AtomString&, ScrollAxis, ViewTimelineInsets&&);
 
-    void dump(TextStream&) const final;
-    Ref<CSSValue> toCSSValue(const RenderStyle&) const final;
     bool isViewTimeline() const final { return true; }
 
     struct CurrentTimeData {

--- a/Source/WebCore/css/CSSScrollValue.h
+++ b/Source/WebCore/css/CSSScrollValue.h
@@ -49,8 +49,8 @@ public:
 
     String customCSSText() const;
 
-    RefPtr<CSSValue> scroller() const { return m_scroller; }
-    RefPtr<CSSValue> axis() const { return m_axis; }
+    const RefPtr<CSSValue>& scroller() const { return m_scroller; }
+    const RefPtr<CSSValue>& axis() const { return m_axis; }
 
     bool equals(const CSSScrollValue&) const;
 

--- a/Source/WebCore/css/CSSViewValue.h
+++ b/Source/WebCore/css/CSSViewValue.h
@@ -49,9 +49,9 @@ public:
 
     String customCSSText() const;
 
-    RefPtr<CSSValue> axis() const { return m_axis; }
-    RefPtr<CSSValue> startInset() const { return m_startInset; }
-    RefPtr<CSSValue> endInset() const { return m_endInset; }
+    const RefPtr<CSSValue>& axis() const { return m_axis; }
+    const RefPtr<CSSValue>& startInset() const { return m_startInset; }
+    const RefPtr<CSSValue>& endInset() const { return m_endInset; }
 
     bool equals(const CSSViewValue&) const;
 

--- a/Source/WebCore/platform/animation/Animation.h
+++ b/Source/WebCore/platform/animation/Animation.h
@@ -30,6 +30,7 @@
 #include "ScopedName.h"
 #include "ScrollTimeline.h"
 #include "TimingFunction.h"
+#include "ViewTimeline.h"
 #include "WebAnimationTypes.h"
 
 namespace WebCore {
@@ -134,7 +135,17 @@ public:
     };
 
     enum class TimelineKeyword : bool { None, Auto };
-    using Timeline = std::variant<TimelineKeyword, AtomString, Ref<ScrollTimeline>>;
+    struct AnonymousScrollTimeline {
+        Scroller scroller;
+        ScrollAxis axis;
+        bool operator==(const AnonymousScrollTimeline& o) const { return scroller == o.scroller && axis == o.axis; }
+    };
+    struct AnonymousViewTimeline {
+        ScrollAxis axis;
+        ViewTimelineInsets insets;
+        bool operator==(const AnonymousViewTimeline& o) const { return axis == o.axis && insets == o.insets; }
+    };
+    using Timeline = std::variant<TimelineKeyword, AtomString, AnonymousScrollTimeline, AnonymousViewTimeline>;
 
     Direction direction() const { return static_cast<Direction>(m_direction); }
     bool directionIsForwards() const { return direction() == Direction::Normal || direction() == Direction::Alternate; }
@@ -298,6 +309,8 @@ WTF::TextStream& operator<<(WTF::TextStream&, AnimationPlayState);
 WTF::TextStream& operator<<(WTF::TextStream&, Animation::TransitionProperty);
 WTF::TextStream& operator<<(WTF::TextStream&, Animation::Direction);
 WTF::TextStream& operator<<(WTF::TextStream&, Animation::TimelineKeyword);
+WTF::TextStream& operator<<(WTF::TextStream&, const Animation::AnonymousScrollTimeline&);
+WTF::TextStream& operator<<(WTF::TextStream&, const Animation::AnonymousViewTimeline&);
 WTF::TextStream& operator<<(WTF::TextStream&, const Animation::Timeline&);
 WTF::TextStream& operator<<(WTF::TextStream&, const Animation&);
 


### PR DESCRIPTION
#### 319e2fc273efed67ae7e06d3daf850fbaef86e5d
<pre>
[scroll-animations] <a href="https://scroll-driven-animations.style/demos/parallax-carousel/css/">https://scroll-driven-animations.style/demos/parallax-carousel/css/</a> does not work
<a href="https://bugs.webkit.org/show_bug.cgi?id=284534">https://bugs.webkit.org/show_bug.cgi?id=284534</a>
<a href="https://rdar.apple.com/141356306">rdar://141356306</a>

Reviewed by Antti Koivisto.

The Scroll-driven Animations demo at <a href="https://scroll-driven-animations.style/demos/parallax-carousel/css/">https://scroll-driven-animations.style/demos/parallax-carousel/css/</a> uses
an `animation-timeline: view()` property set via a CSS rule on a number of sibling `&lt;img&gt;` elements. In WebKit,
these elements share style.

However, the anonymous `ViewTimeline` created by `animation-timeline: view()` is stored on an `Animation` object
owned by `RenderStyle` through its `AnimationList` for CSS Animations accessed via `RenderStyle::animations()`.
If elements that are using an anonymous timeline share style, then they&apos;ll share their timeline even though those
need to be unique to each element.

To address this, we no longer create a `ScrollTimeline` or `ViewTimeline` when finding an anonymous timeline set
for the `animation-timeline` property and instead use a dedicated small struct for each type which we add to the
`std::variant&lt;&gt;` used to represent timelines on `Animation`. Then, when we deal with a style change on the associated
`CSSAnimation`, we create a new `ScrollTimeline` or `ViewTimeline` using the struct hosted on `Animation`.

This change yields a fair bit of refactoring to deal with the expanded variant but yields some WPT progressions as
well as fixing the demo.

We also add a new WPT test specifically testing timeline uniqueness for this case.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-nearest-dirty-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-root-dirty-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/siblings-with-anonymous-timelines-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/siblings-with-anonymous-timelines.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/contain-alignment-expected.txt:
* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::syncPropertiesWithBackingAnimation):
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::create):
(WebCore::operator&lt;&lt;):
(WebCore::ScrollTimeline::createFromCSSValue): Deleted.
(WebCore::ScrollTimeline::dump const): Deleted.
(WebCore::ScrollTimeline::toCSSValue const): Deleted.
* Source/WebCore/animation/ScrollTimeline.h:
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::createFromCSSValue): Deleted.
(WebCore::ViewTimeline::dump const): Deleted.
(WebCore::ViewTimeline::toCSSValue const): Deleted.
* Source/WebCore/animation/ViewTimeline.h:
* Source/WebCore/css/CSSScrollValue.h:
* Source/WebCore/css/CSSToStyleMap.cpp:
(WebCore::CSSToStyleMap::mapAnimationTimeline const):
* Source/WebCore/css/CSSViewValue.h:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::valueForAnimationTimeline):
* Source/WebCore/platform/animation/Animation.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/animation/Animation.h:
(WebCore::Animation::AnonymousScrollTimeline::operator== const):
(WebCore::Animation::AnonymousViewTimeline::operator== const):

Canonical link: <a href="https://commits.webkit.org/287836@main">https://commits.webkit.org/287836@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0116a161e54f8cbdc0509caeab697571f15a9730

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81050 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/575 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34993 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85579 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32036 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83160 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/593 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8377 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63267 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/21032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84119 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/353 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73767 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43565 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/250 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27928 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30494 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/71795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28482 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87014 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8280 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71570 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8457 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69602 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70806 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14851 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/13775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12567 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8241 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/13764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8078 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11598 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9886 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->