### PR TITLE
Convert aborted to an enum class

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -383,6 +383,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/filesystemaccess/FileSystemSyncAccessHandleIdentifier.h
     Modules/filesystemaccess/FileSystemWritableFileStream.h
     Modules/filesystemaccess/FileSystemWritableFileStreamSink.h
+    Modules/filesystemaccess/FileSystemWriteCloseReason.h
     Modules/filesystemaccess/FileSystemWriteCommandType.h
     Modules/filesystemaccess/StorageManagerFileSystemAccess.h
     Modules/filesystemaccess/WorkerFileSystemStorageConnection.h

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemFileHandle.cpp
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemFileHandle.cpp
@@ -140,19 +140,19 @@ void FileSystemFileHandle::createWritable(const CreateWritableOptions& options, 
 
         RefPtr context = protectedThis->scriptExecutionContext();
         if (!context) {
-            closeWritable(true);
+            closeWritable(FileSystemWriteCloseReason::Aborted);
             return promise.reject(Exception { ExceptionCode::InvalidStateError, "Context has stopped"_s });
         }
 
         auto* globalObject = JSC::jsCast<JSDOMGlobalObject*>(context->globalObject());
         if (!globalObject) {
-            closeWritable(true);
+            closeWritable(FileSystemWriteCloseReason::Aborted);
             return promise.reject(Exception { ExceptionCode::InvalidStateError, "Global object is invalid"_s });
         }
 
         auto sink = FileSystemWritableFileStreamSink::create(*this);
         if (sink.hasException()) {
-            closeWritable(true);
+            closeWritable(FileSystemWriteCloseReason::Aborted);
             return promise.reject(sink.releaseException());
         }
 
@@ -167,10 +167,10 @@ void FileSystemFileHandle::createWritable(const CreateWritableOptions& options, 
     });
 }
 
-void FileSystemFileHandle::closeWritable(bool aborted)
+void FileSystemFileHandle::closeWritable(FileSystemWriteCloseReason reason)
 {
     if (!isClosed())
-        connection().closeWritable(identifier(), aborted, [](auto) { });
+        connection().closeWritable(identifier(), reason, [](auto) { });
 }
 
 void FileSystemFileHandle::executeCommandForWritable(FileSystemWriteCommandType type, std::optional<uint64_t> position, std::optional<uint64_t> size, std::span<const uint8_t> dataBytes, bool hasDataError, DOMPromiseDeferred<void>&& promise)

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemFileHandle.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemFileHandle.h
@@ -33,6 +33,7 @@ namespace WebCore {
 class File;
 class FileSystemSyncAccessHandle;
 class FileSystemWritableFileStream;
+enum class FileSystemWriteCloseReason : bool;
 enum class FileSystemWriteCommandType : uint8_t;
 template<typename> class ExceptionOr;
 
@@ -52,7 +53,8 @@ public:
         bool keepExistingData { false };
     };
     void createWritable(const CreateWritableOptions&, DOMPromiseDeferred<IDLInterface<FileSystemWritableFileStream>>&&);
-    void closeWritable(bool aborted);
+
+    void closeWritable(FileSystemWriteCloseReason);
     void executeCommandForWritable(FileSystemWriteCommandType, std::optional<uint64_t> position, std::optional<uint64_t> size, std::span<const uint8_t> dataBytes, bool hasDataError, DOMPromiseDeferred<void>&&);
 
 private:

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemStorageConnection.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemStorageConnection.h
@@ -28,6 +28,7 @@
 #include "FileHandle.h"
 #include "FileSystemHandleIdentifier.h"
 #include "FileSystemSyncAccessHandleIdentifier.h"
+#include "FileSystemWriteCloseReason.h"
 #include "FileSystemWriteCommandType.h"
 #include "ProcessQualified.h"
 #include "ScriptExecutionContextIdentifier.h"
@@ -79,7 +80,7 @@ public:
     virtual void unregisterSyncAccessHandle(FileSystemSyncAccessHandleIdentifier) = 0;
     virtual void invalidateAccessHandle(WebCore::FileSystemSyncAccessHandleIdentifier) = 0;
     virtual void createWritable(FileSystemHandleIdentifier, bool keepExistingData, VoidCallback&&) = 0;
-    virtual void closeWritable(FileSystemHandleIdentifier, bool aborted, VoidCallback&&) = 0;
+    virtual void closeWritable(FileSystemHandleIdentifier, FileSystemWriteCloseReason, VoidCallback&&) = 0;
     virtual void executeCommandForWritable(FileSystemHandleIdentifier, FileSystemWriteCommandType, std::optional<uint64_t> position, std::optional<uint64_t> size, std::span<const uint8_t> dataBytes, bool hasDataError, VoidCallback&&) = 0;
     virtual void getHandleNames(FileSystemHandleIdentifier, GetHandleNamesCallback&&) = 0;
     virtual void getHandle(FileSystemHandleIdentifier, const String& name, GetHandleCallback&&) = 0;

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStreamSink.cpp
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStreamSink.cpp
@@ -28,6 +28,7 @@
 
 #include "FileSystemFileHandle.h"
 #include "FileSystemWritableFileStream.h"
+#include "FileSystemWriteCloseReason.h"
 #include "JSBlob.h"
 #include <JavaScriptCore/ArrayBufferView.h>
 #include <JavaScriptCore/JSArrayBuffer.h>
@@ -104,7 +105,7 @@ FileSystemWritableFileStreamSink::FileSystemWritableFileStreamSink(FileSystemFil
 FileSystemWritableFileStreamSink::~FileSystemWritableFileStreamSink()
 {
     if (!m_isClosed)
-        protectedSource()->closeWritable(false);
+        protectedSource()->closeWritable(FileSystemWriteCloseReason::Completed);
 }
 
 // https://fs.spec.whatwg.org/#write-a-chunk
@@ -140,7 +141,7 @@ void FileSystemWritableFileStreamSink::close()
     ASSERT(!m_isClosed);
 
     m_isClosed = true;
-    protectedSource()->closeWritable(false);
+    protectedSource()->closeWritable(FileSystemWriteCloseReason::Completed);
 }
 
 void FileSystemWritableFileStreamSink::error(String&&)
@@ -148,7 +149,7 @@ void FileSystemWritableFileStreamSink::error(String&&)
     ASSERT(!m_isClosed);
 
     m_isClosed = true;
-    protectedSource()->closeWritable(true);
+    protectedSource()->closeWritable(FileSystemWriteCloseReason::Aborted);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemWriteCloseReason.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemWriteCloseReason.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+enum class FileSystemWriteCloseReason : bool {
+    Aborted,
+    Completed
+};
+
+} // namespace WebCore
+

--- a/Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnection.h
+++ b/Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnection.h
@@ -80,7 +80,7 @@ private:
     void invalidateAccessHandle(FileSystemSyncAccessHandleIdentifier) final;
     void requestNewCapacityForSyncAccessHandle(FileSystemHandleIdentifier, FileSystemSyncAccessHandleIdentifier, uint64_t, RequestCapacityCallback&&) final;
     void createWritable(FileSystemHandleIdentifier, bool keepExistingData, VoidCallback&&) final;
-    void closeWritable(FileSystemHandleIdentifier, bool aborted, VoidCallback&&) final;
+    void closeWritable(FileSystemHandleIdentifier, FileSystemWriteCloseReason, VoidCallback&&) final;
     void executeCommandForWritable(FileSystemHandleIdentifier, FileSystemWriteCommandType, std::optional<uint64_t> position, std::optional<uint64_t> size, std::span<const uint8_t> dataBytes, bool hasDataError, VoidCallback&&) final;
 
     WeakPtr<WorkerGlobalScope, WeakPtrImplWithEventTargetData> m_scope;

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.h
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.h
@@ -39,6 +39,7 @@ class SharedFileHandle;
 }
 
 namespace WebCore {
+enum class FileSystemWriteCloseReason : bool;
 enum class FileSystemWriteCommandType : uint8_t;
 }
 
@@ -73,7 +74,7 @@ public:
     std::optional<WebCore::FileSystemSyncAccessHandleIdentifier> activeSyncAccessHandle();
 
     std::optional<FileSystemStorageError> createWritable(bool keepExistingData);
-    std::optional<FileSystemStorageError> closeWritable(bool aborted);
+    std::optional<FileSystemStorageError> closeWritable(WebCore::FileSystemWriteCloseReason);
     std::optional<FileSystemStorageError> executeCommandForWritable(WebCore::FileSystemWriteCommandType, std::optional<uint64_t> position, std::optional<uint64_t> size, std::span<const uint8_t> dataBytes, bool hasDataError);
 
 private:

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -1033,7 +1033,7 @@ void NetworkStorageManager::createWritable(WebCore::FileSystemHandleIdentifier i
     completionHandler(handle->createWritable(keepExistingData));
 }
 
-void NetworkStorageManager::closeWritable(WebCore::FileSystemHandleIdentifier identifier, bool aborted, CompletionHandler<void(std::optional<FileSystemStorageError>)>&& completionHandler)
+void NetworkStorageManager::closeWritable(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemWriteCloseReason reason, CompletionHandler<void(std::optional<FileSystemStorageError>)>&& completionHandler)
 {
     ASSERT(!RunLoop::isMain());
 
@@ -1041,7 +1041,7 @@ void NetworkStorageManager::closeWritable(WebCore::FileSystemHandleIdentifier id
     if (!handle)
         return completionHandler(FileSystemStorageError::Unknown);
 
-    completionHandler(handle->closeWritable(aborted));
+    completionHandler(handle->closeWritable(reason));
 }
 
 void NetworkStorageManager::executeCommandForWritable(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemWriteCommandType type, std::optional<uint64_t> position, std::optional<uint64_t> size, std::span<const uint8_t> dataBytes, bool hasDataError, CompletionHandler<void(std::optional<FileSystemStorageError>)>&& completionHandler)

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -79,6 +79,7 @@ struct IDBIterateCursorData;
 struct IDBKeyRangeData;
 struct RetrieveRecordsOptions;
 struct ServiceWorkerContextData;
+enum class FileSystemWriteCloseReason : bool;
 enum class FileSystemWriteCommandType : uint8_t;
 enum class StorageType : uint8_t;
 }
@@ -189,7 +190,7 @@ private:
     void closeSyncAccessHandle(WebCore::FileSystemHandleIdentifier, WebCore::FileSystemSyncAccessHandleIdentifier, CompletionHandler<void()>&&);
     void requestNewCapacityForSyncAccessHandle(WebCore::FileSystemHandleIdentifier, WebCore::FileSystemSyncAccessHandleIdentifier, uint64_t newCapacity, CompletionHandler<void(std::optional<uint64_t>)>&&);
     void createWritable(WebCore::FileSystemHandleIdentifier, bool keepExistingData, CompletionHandler<void(std::optional<FileSystemStorageError>)>&&);
-    void closeWritable(WebCore::FileSystemHandleIdentifier, bool aborted, CompletionHandler<void(std::optional<FileSystemStorageError>)>&&);
+    void closeWritable(WebCore::FileSystemHandleIdentifier, WebCore::FileSystemWriteCloseReason, CompletionHandler<void(std::optional<FileSystemStorageError>)>&&);
     void executeCommandForWritable(WebCore::FileSystemHandleIdentifier, WebCore::FileSystemWriteCommandType, std::optional<uint64_t> position, std::optional<uint64_t> size, std::span<const uint8_t> dataBytes, bool hasDataError, CompletionHandler<void(std::optional<FileSystemStorageError>)>&&);
     void getHandleNames(WebCore::FileSystemHandleIdentifier, CompletionHandler<void(Expected<Vector<String>, FileSystemStorageError>)>&&);
     void getHandle(IPC::Connection&, WebCore::FileSystemHandleIdentifier, String&& name, CompletionHandler<void(Expected<std::optional<std::pair<WebCore::FileSystemHandleIdentifier, bool>>, FileSystemStorageError>)>&&);

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
@@ -45,7 +45,7 @@
     CloseSyncAccessHandle(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemSyncAccessHandleIdentifier accessHandleIdentifier) -> ()
     RequestNewCapacityForSyncAccessHandle(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemSyncAccessHandleIdentifier accessHandleIdentifier, uint64_t newCapacity) -> (std::optional<uint64_t> result)
     [EnabledBy=FileSystemWritableStreamEnabled] CreateWritable(WebCore::FileSystemHandleIdentifier identifier, bool keepExistingData) -> (std::optional<WebKit::FileSystemStorageError> result)
-    [EnabledBy=FileSystemWritableStreamEnabled] CloseWritable(WebCore::FileSystemHandleIdentifier identifier, bool aborted) -> (std::optional<WebKit::FileSystemStorageError> result)
+    [EnabledBy=FileSystemWritableStreamEnabled] CloseWritable(WebCore::FileSystemHandleIdentifier identifier, enum:bool WebCore::FileSystemWriteCloseReason reason) -> (std::optional<WebKit::FileSystemStorageError> result)
     [EnabledBy=FileSystemWritableStreamEnabled] ExecuteCommandForWritable(WebCore::FileSystemHandleIdentifier identifier, enum:uint8_t WebCore::FileSystemWriteCommandType type, std::optional<uint64_t> position, std::optional<uint64_t> size, std::span<const uint8_t> dataBytes, bool hasDataError) ->  (std::optional<WebKit::FileSystemStorageError> result)
     GetHandleNames(WebCore::FileSystemHandleIdentifier identifier) -> (Expected<Vector<String>, WebKit::FileSystemStorageError> result)
     GetHandle(WebCore::FileSystemHandleIdentifier identifier, String name) -> (Expected<std::optional<std::pair<WebCore::FileSystemHandleIdentifier, bool>>, WebKit::FileSystemStorageError> result)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8723,6 +8723,8 @@ enum class WebCore::FileSystemWriteCommandType : uint8_t {
     Truncate
 };
 
+enum class WebCore::FileSystemWriteCloseReason : bool;
+
 [Nested] enum class WebCore::ResourceError::IsSanitized : bool
 
 #if ENABLE(DOM_AUDIO_SESSION)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp
@@ -226,10 +226,10 @@ void WebFileSystemStorageConnection::createWritable(WebCore::FileSystemHandleIde
     completionHandler(WebCore::Exception { WebCore::ExceptionCode::UnknownError, "Connection is lost"_s });
 }
 
-void WebFileSystemStorageConnection::closeWritable(WebCore::FileSystemHandleIdentifier identifier, bool aborted, WebCore::FileSystemStorageConnection::VoidCallback&& completionHandler)
+void WebFileSystemStorageConnection::closeWritable(WebCore::FileSystemHandleIdentifier identifier, FileSystemWriteCloseReason reason, WebCore::FileSystemStorageConnection::VoidCallback&& completionHandler)
 {
     if (RefPtr connection = m_connection) {
-        connection->sendWithAsyncReply(Messages::NetworkStorageManager::CloseWritable(identifier, aborted), [completionHandler = WTFMove(completionHandler)](auto error) mutable {
+        connection->sendWithAsyncReply(Messages::NetworkStorageManager::CloseWritable(identifier, reason), [completionHandler = WTFMove(completionHandler)](auto error) mutable {
             completionHandler(convertToExceptionOr(error));
         });
         return;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.h
@@ -91,7 +91,7 @@ private:
     void unregisterSyncAccessHandle(WebCore::FileSystemSyncAccessHandleIdentifier) final;
     void invalidateAccessHandle(WebCore::FileSystemSyncAccessHandleIdentifier) final;
     void createWritable(WebCore::FileSystemHandleIdentifier, bool keepExistingData, WebCore::FileSystemStorageConnection::VoidCallback&&) final;
-    void closeWritable(WebCore::FileSystemHandleIdentifier, bool aborted, WebCore::FileSystemStorageConnection::VoidCallback&&) final;
+    void closeWritable(WebCore::FileSystemHandleIdentifier, WebCore::FileSystemWriteCloseReason, WebCore::FileSystemStorageConnection::VoidCallback&&) final;
     void executeCommandForWritable(WebCore::FileSystemHandleIdentifier, WebCore::FileSystemWriteCommandType, std::optional<uint64_t> position, std::optional<uint64_t> size, std::span<const uint8_t> dataBytes, bool hasDataError, WebCore::FileSystemStorageConnection::VoidCallback&&) final;
 
     HashMap<WebCore::FileSystemSyncAccessHandleIdentifier, WebCore::ScriptExecutionContextIdentifier> m_syncAccessHandles;


### PR DESCRIPTION
#### c608c4b79459ad05610f783ae4fa0e5ea6212bb9
<pre>
Convert aborted to an enum class
<a href="https://bugs.webkit.org/show_bug.cgi?id=284571">https://bugs.webkit.org/show_bug.cgi?id=284571</a>
<a href="https://rdar.apple.com/141375932">rdar://141375932</a>

Reviewed by Chris Dumez.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/filesystemaccess/FileSystemFileHandle.cpp:
(WebCore::FileSystemFileHandle::createWritable):
(WebCore::FileSystemFileHandle::closeWritable):
* Source/WebCore/Modules/filesystemaccess/FileSystemFileHandle.h:
* Source/WebCore/Modules/filesystemaccess/FileSystemStorageConnection.h:
* Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStreamSink.cpp:
(WebCore::FileSystemWritableFileStreamSink::~FileSystemWritableFileStreamSink):
(WebCore::FileSystemWritableFileStreamSink::close):
(WebCore::FileSystemWritableFileStreamSink::error):
* Source/WebCore/Modules/filesystemaccess/FileSystemWriteCloseReason.h: Added.
* Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnection.cpp:
(WebCore::WorkerFileSystemStorageConnection::closeWritable):
* Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnection.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp:
(WebKit::FileSystemStorageHandle::close):
(WebKit::FileSystemStorageHandle::closeWritable):
(WebKit::FileSystemStorageHandle::executeCommandForWritable):
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::closeWritable):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp:
(WebKit::WebFileSystemStorageConnection::closeWritable):
* Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.h:

Canonical link: <a href="https://commits.webkit.org/287779@main">https://commits.webkit.org/287779@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d403aaf37a0fd795e5f76427ad809bcef7059035

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80731 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/253 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34667 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85258 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31715 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82842 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/270 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8050 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63050 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20846 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83800 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/110 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73486 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43352 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/42 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27646 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30172 "Built successfully") | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71605 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; 10 api tests failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28174 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86690 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7958 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5623 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71342 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8135 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69322 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70583 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17592 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14609 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13553 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7920 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13441 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7759 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11278 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9565 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->