### PR TITLE
[Win Skia] Loading tests fonts for WebKitTestRunner

### DIFF
--- a/Source/WebCore/PlatformWin.cmake
+++ b/Source/WebCore/PlatformWin.cmake
@@ -219,6 +219,10 @@ if (USE_CAIRO)
 
         platform/win/cairo/DragImageWinCairo.cpp
     )
+elseif (USE_SKIA)
+    list(APPEND WebCore_SOURCES
+        platform/graphics/win/FontCacheSkiaWin.cpp
+    )
 endif ()
 
 if (USE_WOFF2)

--- a/Source/WebCore/platform/graphics/FontCache.h
+++ b/Source/WebCore/platform/graphics/FontCache.h
@@ -72,6 +72,7 @@
 #include <objidl.h>
 #include <mlang.h>
 struct IDWriteFactory;
+struct IDWriteFontCollection;
 #endif
 
 #if USE(FREETYPE)
@@ -283,7 +284,11 @@ private:
 #endif
 
 #if PLATFORM(WIN) && USE(SKIA)
-    COMPtr<IDWriteFactory> m_DWFactory;
+    struct CreateDWriteFactoryResult {
+        COMPtr<IDWriteFactory> factory;
+        COMPtr<IDWriteFontCollection> fontCollection;
+    };
+    static CreateDWriteFactoryResult createDWriteFactory();
 #endif
 
     friend class Font;

--- a/Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp
@@ -53,10 +53,6 @@ namespace WebCore {
 
 void FontCache::platformInit()
 {
-#if PLATFORM(WIN)
-    HRESULT hr = DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory), reinterpret_cast<IUnknown**>(&m_DWFactory));
-    RELEASE_ASSERT(SUCCEEDED(hr));
-#endif
 }
 
 SkFontMgr& FontCache::fontManager() const
@@ -65,7 +61,8 @@ SkFontMgr& FontCache::fontManager() const
 #if defined(__ANDROID__) || defined(ANDROID)
         m_fontManager = SkFontMgr_New_Android(nullptr);
 #elif OS(WINDOWS)
-        m_fontManager = SkFontMgr_New_DirectWrite(m_DWFactory.get(), nullptr);
+        auto result = createDWriteFactory();
+        m_fontManager = SkFontMgr_New_DirectWrite(result.factory.get(), result.fontCollection.get());
 #else
         m_fontManager = SkFontMgr_New_FontConfig(FcConfigReference(nullptr));
 #endif

--- a/Source/WebCore/platform/graphics/win/FontCacheSkiaWin.cpp
+++ b/Source/WebCore/platform/graphics/win/FontCacheSkiaWin.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2024 Sony Interactive Entertainment Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FontCache.h"
+
+#include <dwrite_3.h>
+#include <wtf/FileSystem.h>
+#include <wtf/text/win/WCharStringExtras.h>
+
+namespace WebCore {
+
+static String fontsPath()
+{
+    const wchar_t* fontsEnvironmentVariable = L"WEBKIT_TESTFONTS";
+    // <https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-getenvironmentvariable>
+    // The return size includes the terminating null character.
+    DWORD size = GetEnvironmentVariable(fontsEnvironmentVariable, nullptr, 0);
+    if (!size)
+        return { };
+    Vector<UChar> buffer(size);
+    // The return size doesn't include the terminating null character.
+    if (GetEnvironmentVariable(fontsEnvironmentVariable, wcharFrom(buffer.data()), size) != size - 1)
+        return { };
+    return buffer.span().first(size - 1);
+}
+
+FontCache::CreateDWriteFactoryResult FontCache::createDWriteFactory()
+{
+    CreateDWriteFactoryResult result;
+    COMPtr<IDWriteFactory> factory;
+    HRESULT hr = DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory), reinterpret_cast<IUnknown**>(&result.factory));
+    if (FAILED(hr))
+        return result;
+
+    COMPtr<IDWriteFactory5> factory5(Query, result.factory);
+    if (!factory5)
+        return result;
+
+    COMPtr<IDWriteFontSetBuilder1> builder;
+    hr = factory5->CreateFontSetBuilder(&builder);
+    if (FAILED(hr))
+        return result;
+
+    COMPtr<IDWriteFontSet> systemFontSet;
+    hr = factory5->GetSystemFontSet(&systemFontSet);
+    if (FAILED(hr))
+        return result;
+
+    builder->AddFontSet(systemFontSet.get());
+
+    String baseFontPath = fontsPath();
+    if (baseFontPath.isEmpty())
+        return result;
+
+    const std::span<const LChar> fontFilenames[] = {
+        "AHEM____.TTF"_span,
+        "WebKitWeightWatcher100.ttf"_span,
+        "WebKitWeightWatcher200.ttf"_span,
+        "WebKitWeightWatcher300.ttf"_span,
+        "WebKitWeightWatcher400.ttf"_span,
+        "WebKitWeightWatcher500.ttf"_span,
+        "WebKitWeightWatcher600.ttf"_span,
+        "WebKitWeightWatcher700.ttf"_span,
+        "WebKitWeightWatcher800.ttf"_span,
+        "WebKitWeightWatcher900.ttf"_span,
+    };
+
+    for (auto filename : fontFilenames) {
+        String path = FileSystem::pathByAppendingComponent(baseFontPath, filename);
+        COMPtr<IDWriteFontFile> file;
+        hr = factory5->CreateFontFileReference(path.wideCharacters().data(), nullptr, &file);
+        if (FAILED(hr))
+            return result;
+        builder->AddFontFile(file.get());
+    }
+    COMPtr<IDWriteFontSet> fontSet;
+    hr = builder->CreateFontSet(&fontSet);
+    if (FAILED(hr))
+        return result;
+    COMPtr<IDWriteFontCollection1> collection1;
+    hr = factory5->CreateFontCollectionFromFontSet(fontSet.get(), &collection1);
+    if (FAILED(hr))
+        return result;
+    result.fontCollection.query(collection1);
+    return result;
+}
+
+} // namespace WebCore

--- a/Tools/WebKitTestRunner/InjectedBundle/win/ActivateFontsWin.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/win/ActivateFontsWin.cpp
@@ -26,12 +26,15 @@
 #include "config.h"
 #include "ActivateFonts.h"
 
+#if USE(CAIRO)
 #include <string>
 #include <vector>
 #include <windows.h>
+#endif
 
 namespace WTR {
 
+#if USE(CAIRO)
 static const wchar_t* fontsEnvironmentVariable = L"WEBKIT_TESTFONTS";
 
 static const std::wstring& fontsPath()
@@ -78,6 +81,12 @@ void activateFonts()
         }
     }
 }
+#else
+void activateFonts()
+{
+    // Load the test fonts in WebCore::FontCache::createDWriteFactory()
+}
+#endif
 
 void installFakeHelvetica(WKStringRef)
 {


### PR DESCRIPTION
#### 1dda088dce596bde633affd7263c10d19facc044
<pre>
[Win Skia] Loading tests fonts for WebKitTestRunner
<a href="https://bugs.webkit.org/show_bug.cgi?id=284575">https://bugs.webkit.org/show_bug.cgi?id=284575</a>

Reviewed by Don Olmstead.

A lot of layout tests were failing for Windows Skia port because the
bundled Ahem font wasn&apos;t loaded for WebKitTestRunner.

Windows Cairo port is using a Windows GDI API AddFontResourceExW to
load tests fonts for WebKitTestRunner in web process. However, this
doesn&apos;t work for Windows Skia port because it is using DirectWrite to
find a font. It should create an IDWriteFontCollection which contains
the test fonts.

Windows Cairo port is using the injected bundle to load the test fonts
in web process. However, this is a problem for GPU process mode. They
should be loaded in GPU process. That&apos;s the reason why it still
disables DOM rendering in GPU process. &lt;<a href="https://webkit.org/b/278895">https://webkit.org/b/278895</a>&gt;

In this change, WebCore::FontCache loads the test fonts if
&quot;WEBKIT_TESTFONTS&quot; environment variable is specified. I confirmed this
approach works as expected even after enabling DOM rendering in GPU
process for WebKitTestRunner.

* Source/WebCore/PlatformWin.cmake:
* Source/WebCore/platform/graphics/FontCache.h:
* Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp:
(WebCore::FontCache::platformInit):
(WebCore::FontCache::fontManager const):
* Source/WebCore/platform/graphics/win/FontCacheSkiaWin.cpp: Added.
(WebCore::fontsPath):
(WebCore::FontCache::createDWriteFactory):
* Tools/WebKitTestRunner/InjectedBundle/win/ActivateFontsWin.cpp:
(WTR::activateFonts):

Canonical link: <a href="https://commits.webkit.org/287769@main">https://commits.webkit.org/287769@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d198241c0160cc6e82473b2e5efa5f4944be19bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80740 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/262 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34676 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85267 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31724 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82851 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/279 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8059 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63057 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20848 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83809 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/114 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73493 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43359 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/46 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27653 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30181 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/71609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28182 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86699 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7967 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5629 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/71357 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8144 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69329 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70593 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14617 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13558 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12523 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7929 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/13450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7768 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11287 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9574 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->