### PR TITLE
The Overlay Regions flag should be on WKPreferences and not WKWebViewConfiguration

### DIFF
--- a/LayoutTests/overlay-region/fixed-node-updates.html
+++ b/LayoutTests/overlay-region/fixed-node-updates.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ OverlayRegionsEnabled=true AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
 <html>
 <head>
     <meta charset="utf-8" />

--- a/LayoutTests/overlay-region/fixed-overlay-drawn-rect.html
+++ b/LayoutTests/overlay-region/fixed-overlay-drawn-rect.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ OverlayRegionsEnabled=true AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
 <html>
 <head>
     <meta charset="utf-8" />

--- a/LayoutTests/overlay-region/many-candidates.html
+++ b/LayoutTests/overlay-region/many-candidates.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ OverlayRegionsEnabled=true AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
 <html>
 <head>
     <meta charset="utf-8" />

--- a/LayoutTests/overlay-region/map.html
+++ b/LayoutTests/overlay-region/map.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ OverlayRegionsEnabled=true AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
 <html>
 <head>
     <meta charset="utf-8" />

--- a/LayoutTests/overlay-region/split-scrollers.html
+++ b/LayoutTests/overlay-region/split-scrollers.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ OverlayRegionsEnabled=true AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
 <html>
 <head>
     <meta charset="utf-8" />

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5590,6 +5590,19 @@ OverlappingBackingStoreProvidersEnabled:
     WebCore:
       default: true
 
+OverlayRegionsEnabled:
+  type: bool
+  status: testable
+  category: dom
+  humanReadableName: "Overlay Regions"
+  humanReadableDescription: "Generate and visualize overlay regions"
+  condition: ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+  webcoreBinding: none
+  exposed: [ WebKit ]
+  defaultValue:
+    WebKit:
+      default: false
+
 OverscrollBehaviorEnabled:
   type: bool
   status: stable

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -451,10 +451,6 @@ public:
     void setGamepadAccessRequiresExplicitConsent(WebCore::ShouldRequireExplicitConsentForGamepadAccess value) { m_data.gamepadAccessRequiresExplicitConsent = value; }
 #endif // ENABLE(GAMEPAD)
 
-#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
-    bool overlayRegionsEnabled() const { return m_data.overlayRegionsEnabled; }
-    void setOverlayRegionsEnabled(bool value) { m_data.overlayRegionsEnabled = value; }
-#endif // ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
     bool cssTransformStyleSeparatedEnabled() const { return m_data.cssTransformStyleSeparatedEnabled; }
     void setCSSTransformStyleSeparatedEnabled(bool value) { m_data.cssTransformStyleSeparatedEnabled = value; }
@@ -635,9 +631,6 @@ private:
         WebCore::ShouldRequireExplicitConsentForGamepadAccess gamepadAccessRequiresExplicitConsent { WebCore::ShouldRequireExplicitConsentForGamepadAccess::No };
 #endif // ENABLE(GAMEPAD)
 
-#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
-        bool overlayRegionsEnabled { false };
-#endif
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
         bool cssTransformStyleSeparatedEnabled { false };
 #endif

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.h
@@ -109,4 +109,8 @@ typedef NS_ENUM(NSInteger, WKInactiveSchedulingPolicy) {
 
 @property (nonatomic) BOOL javaScriptEnabled WK_API_DEPRECATED("Use WKWebpagePreferences.allowsContentJavaScript to disable content JavaScript on a per-navigation basis", macos(10.10, 11.0), ios(8.0, 14.0));
 
+#if 0 // API_WEBKIT_ADDITIONS_REPLACEMENT
+#import <WebKitAdditions/WKPreferencesAdditions.h>
+#endif
+
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
@@ -1672,6 +1672,24 @@ static WebCore::EditableLinkBehavior toEditableLinkBehavior(_WKEditableLinkBehav
     return _preferences->cssTransformStyleSeparatedEnabled();
 }
 
+- (void)_setOverlayRegionsEnabled:(BOOL)enabled
+{
+#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+    _preferences->setOverlayRegionsEnabled(enabled);
+#else
+    UNUSED_PARAM(enabled);
+#endif
+}
+
+- (BOOL)_overlayRegionsEnabled
+{
+#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+    return _preferences->overlayRegionsEnabled();
+#else
+    return NO;
+#endif
+}
+
 - (void)_setSpatialVideoEnabled:(BOOL)enabled
 {
 #if ENABLE(LINEAR_MEDIA_PLAYER)
@@ -1844,5 +1862,9 @@ static WebCore::EditableLinkBehavior toEditableLinkBehavior(_WKEditableLinkBehav
 - (void)_setOfflineApplicationCacheIsEnabled:(BOOL)offlineApplicationCacheIsEnabled
 {
 }
+
+#if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/WKPreferencesAdditions.mm>)
+#import <WebKitAdditions/WKPreferencesAdditions.mm>
+#endif
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
@@ -195,6 +195,7 @@ typedef NS_ENUM(NSInteger, _WKPitchCorrectionAlgorithm) {
 @property (nonatomic, setter=_setAllowPrivacySensitiveOperationsInNonPersistentDataStores:) BOOL _allowPrivacySensitiveOperationsInNonPersistentDataStores WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 @property (nonatomic, setter=_setVideoFullscreenRequiresElementFullscreen:) BOOL _videoFullscreenRequiresElementFullscreen WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 @property (nonatomic, setter=_setCSSTransformStyleSeparatedEnabled:) BOOL _cssTransformStyleSeparatedEnabled WK_API_AVAILABLE(visionos(WK_XROS_TBA));
+@property (nonatomic, setter=_setOverlayRegionsEnabled:) BOOL _overlayRegionsEnabled WK_API_AVAILABLE(visionos(WK_XROS_TBA));
 @property (nonatomic, setter=_setSpatialVideoEnabled:) BOOL _spatialVideoEnabled WK_API_AVAILABLE(visionos(WK_XROS_TBA));
 
 #if !TARGET_OS_IPHONE

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -255,7 +255,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [coder encodeBool:self._multiRepresentationHEICInsertionEnabled forKey:@"multiRepresentationHEICInsertionEnabled"];
 #if PLATFORM(VISION)
     [coder encodeBool:self._gamepadAccessRequiresExplicitConsent forKey:@"gamepadAccessRequiresExplicitConsent"];
-    [coder encodeBool:self._overlayRegionsEnabled forKey:@"overlayRegionsEnabled"];
     [coder encodeBool:self._cssTransformStyleSeparatedEnabled forKey:@"cssTransformStyleSeparatedEnabled"];
 #endif
 }
@@ -307,7 +306,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     self._multiRepresentationHEICInsertionEnabled = [coder decodeBoolForKey:@"multiRepresentationHEICInsertionEnabled"];
 #if PLATFORM(VISION)
     self._gamepadAccessRequiresExplicitConsent = [coder decodeBoolForKey:@"gamepadAccessRequiresExplicitConsent"];
-    self._overlayRegionsEnabled = [coder decodeBoolForKey:@"overlayRegionsEnabled"];
     self._cssTransformStyleSeparatedEnabled = [coder decodeBoolForKey:@"cssTransformStyleSeparatedEnabled"];
 #endif
 
@@ -1533,22 +1531,6 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
 {
 #if ENABLE(GAMEPAD)
     _pageConfiguration->setGamepadAccessRequiresExplicitConsent(gamepadAccessRequiresExplicitConsent ? WebCore::ShouldRequireExplicitConsentForGamepadAccess::Yes : WebCore::ShouldRequireExplicitConsentForGamepadAccess::No);
-#endif
-}
-
-- (BOOL)_overlayRegionsEnabled
-{
-#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
-    return _pageConfiguration->overlayRegionsEnabled();
-#else
-    return NO;
-#endif
-}
-
-- (void)_setOverlayRegionsEnabled:(BOOL)overlayRegionsEnabled
-{
-#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
-    _pageConfiguration->setOverlayRegionsEnabled(overlayRegionsEnabled);
 #endif
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
@@ -177,7 +177,6 @@ typedef NS_ENUM(NSUInteger, _WKContentSecurityPolicyModeForExtension) {
 
 #if defined(TARGET_OS_VISION) && TARGET_OS_VISION
 @property (nonatomic, setter=_setGamepadAccessRequiresExplicitConsent:) BOOL _gamepadAccessRequiresExplicitConsent WK_API_AVAILABLE(visionos(2.0));
-@property (nonatomic, setter=_setOverlayRegionsEnabled:) BOOL _overlayRegionsEnabled WK_API_AVAILABLE(visionos(WK_XROS_TBA));
 @property (nonatomic, setter=_setCSSTransformStyleSeparatedEnabled:) BOOL _cssTransformStyleSeparatedEnabled WK_API_AVAILABLE(visionos(WK_XROS_TBA));
 #endif
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -1143,7 +1143,7 @@ static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, Web
     }
 
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
-    if ([_configuration _overlayRegionsEnabled])
+    if (_page && _page->preferences().overlayRegionsEnabled())
         [self _updateOverlayRegions:layerTreeTransaction.changedLayerProperties() destroyedLayers:layerTreeTransaction.destroyedLayers()];
 #endif
 }
@@ -1368,7 +1368,7 @@ static void configureScrollViewWithOverlayRegionsIDs(WKBaseScrollView* scrollVie
 
 - (void)_updateOverlayRegionsForCustomContentView
 {
-    if (![_configuration _overlayRegionsEnabled])
+    if (!_page || !_page->preferences().overlayRegionsEnabled())
         return;
 
     if (![self _scrollViewCanHaveOverlayRegions:_scrollView.get()]) {

--- a/Source/WebKit/mac/replace-webkit-additions-includes.py
+++ b/Source/WebKit/mac/replace-webkit-additions-includes.py
@@ -30,7 +30,7 @@ import sys
 
 
 # Enable this if `FeatureNeededForHeaderReplacement` should be taken into account.
-should_restrict_header_replacement_based_on_feature = False
+should_restrict_header_replacement_based_on_feature = True
 
 
 def read_content_from_webkit_additions(built_products_directory, sdk_root_directory, filename):

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -175,10 +175,6 @@ void initializeWebViewConfiguration(const char* libraryPath, WKStringRef injecte
         [configuration _setAllowTopNavigationToDataURLs:YES];
         [configuration _setApplePayEnabled:YES];
 
-#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
-        [configuration _setOverlayRegionsEnabled:YES];
-#endif
-
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
         [configuration _setCSSTransformStyleSeparatedEnabled:YES];
 #endif


### PR DESCRIPTION
#### bbc7a0a8ee157e7b65ba8934e94e46669ed09049
<pre>
The Overlay Regions flag should be on WKPreferences and not WKWebViewConfiguration
<a href="https://bugs.webkit.org/show_bug.cgi?id=284574">https://bugs.webkit.org/show_bug.cgi?id=284574</a>
&lt;<a href="https://rdar.apple.com/134291686">rdar://134291686</a>&gt;

Reviewed by Mike Wyrzykowski.

Move from a WKWebViewConfiguration flag to a (testable) preference.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/UIProcess/API/Cocoa/WKPreferences.h:
* Source/WebKit/mac/replace-webkit-additions-includes.py:
* Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm:
(-[WKPreferences _setOverlayRegionsEnabled:]):
(-[WKPreferences _overlayRegionsEnabled]):
* Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h:
Add the new preference and a WKA extension point.

* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
(API::PageConfiguration::overlayRegionsEnabled const): Deleted.
(API::PageConfiguration::setOverlayRegionsEnabled): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration encodeWithCoder:]):
(-[WKWebViewConfiguration initWithCoder:]):
(-[WKWebViewConfiguration _overlayRegionsEnabled]): Deleted.
(-[WKWebViewConfiguration _setOverlayRegionsEnabled:]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h:
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::initializeWebViewConfiguration):
Remove the WKWebViewConfiguration flag.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _didCommitLayerTree:]):
(-[WKWebView _updateOverlayRegionsForCustomContentView]):
Switch from checking the Configuration to checking the Preference.

* LayoutTests/overlay-region/fixed-node-updates.html:
* LayoutTests/overlay-region/fixed-overlay-drawn-rect.html:
* LayoutTests/overlay-region/many-candidates.html:
* LayoutTests/overlay-region/map.html:
* LayoutTests/overlay-region/split-scrollers.html:
Prepare the tests for when we&apos;ll turn the compile time flag on.

Canonical link: <a href="https://commits.webkit.org/288012@main">https://commits.webkit.org/288012@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31f49c1619924ba1e5d8b5c54cc4cd66e8fec625

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81679 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1204 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35628 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86219 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32669 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83785 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1235 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9023 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63718 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21446 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84749 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/885 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74327 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44010 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/784 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28504 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31124 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/74658 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29103 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87658 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/80733 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8916 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72053 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9099 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70152 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71288 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17751 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15371 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14285 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/103144 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8868 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/14403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25054 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8708 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12229 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10517 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->