### PR TITLE
Autogenerate syncing of `IsAutofocusProcessed` and `UserDidInteractWithPage` data.

### DIFF
--- a/Source/WebCore/Scripts/generate-process-sync-data.py
+++ b/Source/WebCore/Scripts/generate-process-sync-data.py
@@ -58,6 +58,7 @@ class SyncedData(object):
         self.automatic_location = None
         self.conditional = None
         self.header = None
+        self.variant_index = None
 
         if options is not None:
             option_list = options.split()
@@ -160,7 +161,7 @@ def generate_process_sync_client_header(synched_datas):
 
     result.append(_process_sync_client_header_prefix)
 
-    for data in sorted(synched_datas, key=lambda data: data.name):
+    for data in synched_datas:
         if data.conditional is not None:
             result.append('#if %s' % data.conditional)
         result.append('    void broadcast%sToOtherProcesses(const %s&);' % (data.name, data.fully_qualified_type))
@@ -186,12 +187,14 @@ def generate_process_sync_client_impl(synched_datas):
     result.append(_header_license)
     result.append(_process_sync_client_impl_prefix)
 
-    for data in sorted(synched_datas, key=lambda data: data.name):
+    for data in synched_datas:
         if data.conditional is not None:
             result.append('#if %s' % data.conditional)
         result.append('void ProcessSyncClient::broadcast%sToOtherProcesses(const %s& data)' % (data.name, data.fully_qualified_type))
         result.append('{')
-        result.append('    broadcastProcessSyncDataToOtherProcesses({ ProcessSyncDataType::%s, { data }});' % data.name)
+        result.append('    ProcessSyncDataVariant dataVariant;')
+        result.append('    dataVariant.emplace<enumToUnderlyingType(ProcessSyncDataType::%s)>(data);' % data.name)
+        result.append('    broadcastProcessSyncDataToOtherProcesses({ ProcessSyncDataType::%s, WTFMove(dataVariant)});' % data.name)
         result.append('}')
         if data.conditional is not None:
             result.append('#endif')
@@ -210,25 +213,6 @@ struct ProcessSyncData {
 """
 
 
-def sorted_qualified_types(synched_datas):
-    type_set = set()
-    conditional_type_set = set()
-
-    for data in synched_datas:
-        if data.conditional is None:
-            type_set.add(data)
-        else:
-            conditional_type_set.add(data)
-
-    type_list = sorted(list(type_set), key=lambda data: data.fully_qualified_type)
-    conditional_type_list = sorted(list(conditional_type_set), key=lambda data: data.fully_qualified_type)
-
-    if not type_list:
-        raise Exception("Surprisingly, no unconditional types found (this will make it hard to construct the variant in a way that will compile)")
-
-    return conditional_type_list + type_list
-
-
 def generate_process_sync_data_header(synched_datas):
     result = []
     result.append(_header_license)
@@ -241,18 +225,17 @@ def generate_process_sync_data_header(synched_datas):
 
     result.append('\nnamespace WebCore {\n')
     result.append("enum class ProcessSyncDataType : uint8_t {")
-    for data in sorted(synched_datas, key=lambda data: data.name):
+    for data in synched_datas:
         if data.conditional is not None:
             result.append('#if %s' % data.conditional)
-        result.append('    %s,' % data.name)
+        result.append('    %s = %s,' % (data.name, data.variant_index))
         if data.conditional is not None:
             result.append('#endif')
 
     result.append("};")
     result.append(" ")
 
-    sorted_variant_types = sorted_qualified_types(synched_datas)
-    for data in sorted_variant_types:
+    for data in synched_datas:
         if data.conditional is not None:
             result.append('#if !%s' % data.conditional)
             result.append('using %s = bool;' % data.underlying_type)
@@ -260,10 +243,10 @@ def generate_process_sync_data_header(synched_datas):
     
     result.append("")
     result.append("using ProcessSyncDataVariant = std::variant<")
-    for data in sorted_variant_types[:-1]:
+    for data in synched_datas[:-1]:
         result.append('    %s,' % data.fully_qualified_type)
 
-    data = sorted_variant_types[-1]
+    data = synched_datas[-1]
     result.append('    %s' % data.fully_qualified_type)
 
     result.append(">;")
@@ -305,7 +288,7 @@ def generate_document_synched_data_header(synched_datas):
 
     result.append(_document_synced_data_header_midfix)
 
-    for data in sorted(synched_datas, key=lambda data: data.name):
+    for data in synched_datas:
         if data.automatic_location != 'DocumentSyncData':
             continue
         if data.conditional is not None:
@@ -327,8 +310,6 @@ _document_synched_data_impl_prefix = """
 
 namespace WebCore {
 
-// FIXME: Remove this once the update() function definitely always handles at least one case.
-IGNORE_WARNINGS_BEGIN("missing-noreturn")
 void DocumentSyncData::update(const ProcessSyncData& data)
 {
     switch (data.type) {"""
@@ -337,7 +318,6 @@ _document_synched_data_impl_suffix = """    default:
         RELEASE_ASSERT_NOT_REACHED();
     }
 }
-IGNORE_WARNINGS_END
 
 } //namespace WebCore
 """
@@ -348,7 +328,7 @@ def generate_document_synched_data_impl(synched_datas):
     result.append(_header_license)
     result.append(_document_synched_data_impl_prefix)
 
-    for data in sorted(synched_datas, key=lambda data: data.name):
+    for data in synched_datas:
         if data.automatic_location != 'DocumentSyncData':
             continue
         if data.conditional is not None:
@@ -356,7 +336,7 @@ def generate_document_synched_data_impl(synched_datas):
 
         lowercase_name = data.name[0].lower() + data.name[1:]
         result.append('    case ProcessSyncDataType::%s:' % data.name)
-        result.append('        %s = std::get<%s>(data.value);' % (lowercase_name, data.fully_qualified_type))
+        result.append('        %s = std::get<enumToUnderlyingType(ProcessSyncDataType::%s)>(data.value);' % (lowercase_name, data.name))
         result.append('        break;')
 
         if data.conditional is not None:
@@ -407,7 +387,7 @@ def generate_process_sync_data_serialiation_in(synched_datas):
     result.append(_process_sync_data_serialiation_in_prefix)
 
     result.append("enum class WebCore::ProcessSyncDataType : uint8_t {")
-    for data in sorted(synched_datas, key=lambda data: data.name):
+    for data in synched_datas:
         if data.conditional is not None:
             result.append('#if %s' % data.conditional)
         result.append('    %s,' % data.name)
@@ -417,8 +397,7 @@ def generate_process_sync_data_serialiation_in(synched_datas):
     result.append("};")
     result.append(" ")
 
-    sorted_variant_types = sorted_qualified_types(synched_datas)
-    for data in sorted_variant_types:
+    for data in synched_datas:
         if data.conditional is not None:
             result.append('#if !%s' % data.conditional)
             result.append('using %s = bool;' % data.fully_qualified_type)
@@ -426,13 +405,38 @@ def generate_process_sync_data_serialiation_in(synched_datas):
     
     result.append("")
     variant_string = "using WebCore::ProcessSyncDataVariant = std::variant<"
-    for data in sorted_variant_types[:-1]:
+    for data in synched_datas[:-1]:
         variant_string += data.fully_qualified_type + ', '
-    variant_string += sorted_variant_types[-1].fully_qualified_type + '>;'
+    variant_string += synched_datas[-1].fully_qualified_type + '>;'
     result.append(variant_string)
 
     result.append(_process_sync_data_serialiation_in_suffix)
     return '\n'.join(result)
+
+
+def sort_datas_for_variant_order(synched_datas):
+    type_set = set()
+    conditional_type_set = set()
+
+    for data in synched_datas:
+        if data.conditional is None:
+            type_set.add(data)
+        else:
+            conditional_type_set.add(data)
+
+    type_list = sorted(list(type_set), key=lambda data: data.fully_qualified_type)
+    conditional_type_list = sorted(list(conditional_type_set), key=lambda data: data.fully_qualified_type)
+
+    if not type_list:
+        raise Exception("Surprisingly, no unconditional types found (this will make it hard to construct the variant in a way that will compile)")
+
+    full_list = conditional_type_list + type_list
+    current_variant_index = 0
+    for data in full_list:
+        data.variant_index = current_variant_index
+        current_variant_index += 1
+
+    return full_list
 
 
 def main(argv):
@@ -450,6 +454,8 @@ def main(argv):
         new_synched_datas = parse_process_sync_data(file)
         for synched_data in new_synched_datas:
             synched_datas.append(synched_data)
+
+    synched_datas = sort_datas_for_variant_order(synched_datas)
 
     with open(output_directory + 'ProcessSyncClient.h', "w+") as output:
         output.write(generate_process_sync_client_header(synched_datas))

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -5346,7 +5346,9 @@ void Document::noteUserInteractionWithMediaElement()
     if (m_userHasInteractedWithMediaElement)
         return;
 
-    if (!protectedTopDocument()->userDidInteractWithPage())
+    RefPtr page = protectedPage();
+
+    if (!page || page->userDidInteractWithPage())
         return;
 
     m_userHasInteractedWithMediaElement = true;
@@ -5639,7 +5641,12 @@ void Document::adjustFocusedNodeOnNodeRemoval(Node& node, NodeRemoval nodeRemova
 void Document::appendAutofocusCandidate(Element& candidate)
 {
     ASSERT(isTopDocument());
-    ASSERT(!m_isAutofocusProcessed);
+
+    RefPtr page = protectedPage();
+    if (!page)
+        return;
+    ASSERT(!page->autofocusProcessed());
+
     auto it = m_autofocusCandidates.findIf([&candidate](auto& c) {
         return c == &candidate;
     });
@@ -5657,7 +5664,8 @@ void Document::clearAutofocusCandidates()
 void Document::flushAutofocusCandidates()
 {
     ASSERT(isTopDocument());
-    if (m_isAutofocusProcessed)
+    RefPtr page = protectedPage();
+    if (!page || page->autofocusProcessed())
         return;
 
     if (m_autofocusCandidates.isEmpty())
@@ -5665,7 +5673,7 @@ void Document::flushAutofocusCandidates()
 
     if (cssTarget()) {
         m_autofocusCandidates.clear();
-        setAutofocusProcessed();
+        page->setAutofocusProcessed();
         return;
     }
 
@@ -5694,7 +5702,7 @@ void Document::flushAutofocusCandidates()
         // FIXME: Use the result of getting the focusable area for element if element is not focusable.
         if (element->isFocusable()) {
             clearAutofocusCandidates();
-            setAutofocusProcessed();
+            page->setAutofocusProcessed();
             element->runFocusingStepsForAutofocus();
             return;
         }

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -951,9 +951,6 @@ public:
     void adjustFocusedNodeOnNodeRemoval(Node&, NodeRemoval = NodeRemoval::Node);
     void adjustFocusNavigationNodeOnNodeRemoval(Node&, NodeRemoval = NodeRemoval::Node);
 
-    bool isAutofocusProcessed() const { return m_isAutofocusProcessed; }
-    void setAutofocusProcessed() { m_isAutofocusProcessed = true; }
-
     void appendAutofocusCandidate(Element&);
     void clearAutofocusCandidates();
     void flushAutofocusCandidates();
@@ -1477,9 +1474,6 @@ public:
     bool processingUserGestureForMedia() const;
     bool hasRecentUserInteractionForNavigationFromJS() const;
     void userActivatedMediaFinishedPlaying() { m_userActivatedMediaFinishedPlayingTimestamp = MonotonicTime::now(); }
-
-    void setUserDidInteractWithPage(bool userDidInteractWithPage) { ASSERT(isTopDocumentLegacy()); m_userDidInteractWithPage = userDidInteractWithPage; }
-    bool userDidInteractWithPage() const { ASSERT(isTopDocumentLegacy()); return m_userDidInteractWithPage; }
 
     // Used for testing. Count handlers in the main document, and one per frame which contains handlers.
     WEBCORE_EXPORT unsigned wheelEventHandlerCount() const;
@@ -2607,8 +2601,6 @@ private:
     bool m_isSynthesized { false };
     bool m_isNonRenderedPlaceholder { false };
 
-    bool m_isAutofocusProcessed { false };
-
     bool m_sawElementsInKnownNamespaces { false };
     bool m_isSrcdocDocument { false };
 
@@ -2628,7 +2620,6 @@ private:
     bool m_scheduledTasksAreSuspended { false };
 
     bool m_areDeviceMotionAndOrientationUpdatesSuspended { false };
-    bool m_userDidInteractWithPage { false };
 
     bool m_didEnqueueFirstContentfulPaint { false };
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -230,10 +230,14 @@ static Attr* findAttrNodeInList(Vector<RefPtr<Attr>>& attrNodeList, const Qualif
 
 static bool shouldAutofocus(const Element& element)
 {
+    Ref document = element.document();
+    RefPtr page = document->protectedPage();
+    if (!page || page->autofocusProcessed())
+        return false;
+
     if (!element.hasAttributeWithoutSynchronization(HTMLNames::autofocusAttr))
         return false;
 
-    Ref document = element.document();
     if (!element.isInDocumentTree() || !document->hasBrowsingContext())
         return false;
 
@@ -242,13 +246,11 @@ static bool shouldAutofocus(const Element& element)
         document->addConsoleMessage(MessageSource::Security, MessageLevel::Error, "Blocked autofocusing on a form control because the form's frame is sandboxed and the 'allow-scripts' permission is not set."_s);
         return false;
     }
+
     if (!document->frame()->isMainFrame() && !document->topOrigin().isSameOriginDomain(document->securityOrigin())) {
         document->addConsoleMessage(MessageSource::Security, MessageLevel::Error, "Blocked autofocusing on a form control in a cross-origin subframe."_s);
         return false;
     }
-
-    if (document->topDocument().isAutofocusProcessed())
-        return false;
 
     return true;
 }

--- a/Source/WebCore/dom/UserGestureIndicator.cpp
+++ b/Source/WebCore/dom/UserGestureIndicator.cpp
@@ -30,6 +30,7 @@
 #include "FrameDestructionObserverInlines.h"
 #include "LocalDOMWindow.h"
 #include "LocalFrame.h"
+#include "Page.h"
 #include "ResourceLoadObserver.h"
 #include "SecurityOrigin.h"
 #include <wtf/MainThread.h>
@@ -123,7 +124,8 @@ UserGestureIndicator::UserGestureIndicator(std::optional<IsProcessingUserGesture
         document->updateLastHandledUserGestureTimestamp(currentToken()->startTime());
         if (processInteractionStyle == ProcessInteractionStyle::Immediate)
             ResourceLoadObserver::shared().logUserInteractionWithReducedTimeResolution(document->topDocument());
-        document->topDocument().setUserDidInteractWithPage(true);
+        if (RefPtr page = document->protectedPage())
+            page->setUserDidInteractWithPage(true);
         if (RefPtr frame = document->frame(); frame && !frame->hasHadUserInteraction()) {
             for (RefPtr<Frame> ancestor = WTFMove(frame); ancestor; ancestor = ancestor->tree().parent()) {
                 if (RefPtr localAncestor = dynamicDowncast<LocalFrame>(ancestor))

--- a/Source/WebCore/html/HTMLDialogElement.cpp
+++ b/Source/WebCore/html/HTMLDialogElement.cpp
@@ -193,6 +193,10 @@ void HTMLDialogElement::runFocusingSteps()
     if (!control)
         control = this;
 
+    RefPtr page = control->document().protectedPage();
+    if (!page)
+        return;
+
     if (control->isFocusable())
         control->runFocusingStepsForAutofocus();
     else if (m_isModal)
@@ -203,7 +207,7 @@ void HTMLDialogElement::runFocusingSteps()
 
     Ref topDocument = control->document().topDocument();
     topDocument->clearAutofocusCandidates();
-    topDocument->setAutofocusProcessed();
+    page->setAutofocusProcessed();
 }
 
 bool HTMLDialogElement::supportsFocus() const

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -1058,8 +1058,11 @@ static void runPopoverFocusingSteps(HTMLElement& popover)
     }
 
     RefPtr control = popover.hasAttribute(autofocusAttr) ? &popover : popover.findAutofocusDelegate();
-
     if (!control)
+        return;
+
+    RefPtr page = control->document().protectedPage();
+    if (!page)
         return;
 
     control->runFocusingStepsForAutofocus();
@@ -1069,7 +1072,7 @@ static void runPopoverFocusingSteps(HTMLElement& popover)
 
     Ref topDocument = control->document().topDocument();
     topDocument->clearAutofocusCandidates();
-    topDocument->setAutofocusProcessed();
+    page->setAutofocusProcessed();
 }
 
 void HTMLElement::queuePopoverToggleEventTask(ToggleState oldState, ToggleState newState)

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3833,7 +3833,9 @@ static bool shouldAskForNavigationConfirmation(Document& document, const BeforeU
     if (document.isSandboxed(SandboxFlag::Modals))
         return false;
 
-    bool userDidInteractWithPage = document.topDocument().userDidInteractWithPage();
+    RefPtr page = document.protectedPage();
+    bool userDidInteractWithPage = page ? page->userDidInteractWithPage() : false;
+
     // Web pages can request we ask for confirmation before navigating by:
     // - Cancelling the BeforeUnloadEvent (modern way)
     // - Setting the returnValue attribute on the BeforeUnloadEvent to a non-empty string.

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -3794,9 +3794,10 @@ bool EventHandler::isKeyEventAllowedInFullScreen(const PlatformKeyboardEvent& ke
 bool EventHandler::keyEvent(const PlatformKeyboardEvent& keyEvent)
 {
     Ref frame = m_frame.get();
+    RefPtr page = frame->protectedPage();
     RefPtr topDocument = frame->document() ? &frame->document()->topDocument() : nullptr;
     MonotonicTime savedLastHandledUserGestureTimestamp;
-    bool savedUserDidInteractWithPage = topDocument ? topDocument->userDidInteractWithPage() : false;
+    bool savedUserDidInteractWithPage = page ? page->userDidInteractWithPage() : false;
 
     if (RefPtr document = frame->document())
         savedLastHandledUserGestureTimestamp = document->lastHandledUserGestureTimestamp();
@@ -3805,9 +3806,10 @@ bool EventHandler::keyEvent(const PlatformKeyboardEvent& keyEvent)
 
     // If the key event was not handled, do not treat it as user interaction with the page.
     if (topDocument) {
-        if (!wasHandled)
-            topDocument->setUserDidInteractWithPage(savedUserDidInteractWithPage);
-        else
+        if (!wasHandled) {
+            if (page)
+                page->setUserDidInteractWithPage(savedUserDidInteractWithPage);
+        } else
             ResourceLoadObserver::shared().logUserInteractionWithReducedTimeResolution(*topDocument);
     }
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -817,11 +817,43 @@ DOMAudioSessionType Page::audioSessionType() const
 }
 #endif
 
+void Page::setUserDidInteractWithPage(bool didInteract)
+{
+    if (m_documentSyncData->userDidInteractWithPage == didInteract)
+        return;
+    m_documentSyncData->userDidInteractWithPage = didInteract;
+    processSyncClient().broadcastUserDidInteractWithPageToOtherProcesses(didInteract);
+}
+
+bool Page::userDidInteractWithPage() const
+{
+    return m_documentSyncData->userDidInteractWithPage;
+}
+
+void Page::setAutofocusProcessed()
+{
+    if (m_documentSyncData->isAutofocusProcessed)
+        return;
+    m_documentSyncData->isAutofocusProcessed = true;
+    processSyncClient().broadcastIsAutofocusProcessedToOtherProcesses(true);
+}
+
+bool Page::autofocusProcessed() const
+{
+    return m_documentSyncData->isAutofocusProcessed;
+}
+
 void Page::updateProcessSyncData(const ProcessSyncData& data)
 {
     switch (data.type) {
     case ProcessSyncDataType::MainFrameURLChange:
-        setMainFrameURL(std::get<URL>(data.value));
+        setMainFrameURL(std::get<enumToUnderlyingType(ProcessSyncDataType::MainFrameURLChange)>(data.value));
+        break;
+    case ProcessSyncDataType::IsAutofocusProcessed:
+        m_documentSyncData->update(data);
+        break;
+    case ProcessSyncDataType::UserDidInteractWithPage:
+        m_documentSyncData->update(data);
         break;
 #if ENABLE(DOM_AUDIO_SESSION)
     case ProcessSyncDataType::AudioSessionType:

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -385,6 +385,10 @@ public:
     void setAudioSessionType(DOMAudioSessionType);
     DOMAudioSessionType audioSessionType() const;
 #endif
+    void setUserDidInteractWithPage(bool);
+    bool userDidInteractWithPage() const;
+    void setAutofocusProcessed();
+    bool autofocusProcessed() const;
 
     WEBCORE_EXPORT void updateProcessSyncData(const ProcessSyncData&);
     WEBCORE_EXPORT void setMainFrameURLFragment(String&&);

--- a/Source/WebCore/page/ProcessSyncData.in
+++ b/Source/WebCore/page/ProcessSyncData.in
@@ -58,3 +58,5 @@
 
 MainFrameURLChange : URL [Header=<wtf/URL.h>]
 AudioSessionType : WebCore::DOMAudioSessionType [DocumentSyncData Conditional=ENABLE(DOM_AUDIO_SESSION) Header="DOMAudioSession.h"]
+IsAutofocusProcessed : bool [DocumentSyncData]
+UserDidInteractWithPage : bool [DocumentSyncData]


### PR DESCRIPTION
#### f1675e8e351c325d218676866def2e91f3738f45
<pre>
Autogenerate syncing of `IsAutofocusProcessed` and `UserDidInteractWithPage` data.
<a href="https://bugs.webkit.org/show_bug.cgi?id=284573">https://bugs.webkit.org/show_bug.cgi?id=284573</a>
<a href="https://rdar.apple.com/141378639">rdar://141378639</a>

Reviewed by Alex Christensen.

Adding these two types at the same time exposed the next issue that needed to be solved
in the generator script - having multiple copies of the same type in the variant.

We handle this by:
1 - Switching from direct initialization of the variant to using emplace() with an index
2 - Switching from std::get&lt;type&gt; to std::get&lt;(integer index&gt;)
3 - Giving explicit integer values to the `enum class` member that aligns with the type&apos;s index

* Source/WebCore/Scripts/generate-process-sync-data.py:
(SyncedData.__init__):
(generate_process_sync_client_header):
(generate_process_sync_client_impl):
(generate_process_sync_data_header):
(generate_document_synched_data_header):
(generate_document_synched_data_impl):
(generate_process_sync_data_serialiation_in):
(sort_datas_for_variant_order):
(main):
(sorted_qualified_types): Deleted.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::noteUserInteractionWithMediaElement):
(WebCore::Document::appendAutofocusCandidate):
(WebCore::Document::flushAutofocusCandidates):
* Source/WebCore/dom/Document.h:
(WebCore::Document::isAutofocusProcessed const): Deleted.
(WebCore::Document::setAutofocusProcessed): Deleted.
(WebCore::Document::setUserDidInteractWithPage): Deleted.
(WebCore::Document::userDidInteractWithPage const): Deleted.
* Source/WebCore/dom/Element.cpp:
(WebCore::shouldAutofocus):
* Source/WebCore/dom/UserGestureIndicator.cpp:
* Source/WebCore/html/HTMLDialogElement.cpp:
(WebCore::HTMLDialogElement::runFocusingSteps):
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::runPopoverFocusingSteps):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::shouldAskForNavigationConfirmation):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::keyEvent):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::setUserDidInteractWithPage):
(WebCore::Page::userDidInteractWithPage const):
(WebCore::Page::setAutofocusProcessed):
(WebCore::Page::autofocusProcessed const):
(WebCore::Page::updateProcessSyncData):
* Source/WebCore/page/Page.h:
* Source/WebCore/page/ProcessSyncData.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1675e8e351c325d218676866def2e91f3738f45

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80741 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/263 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34677 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85268 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/31725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82852 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/280 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8060 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/63058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/31725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83810 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/73495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/43360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/49 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/27655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30182 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/71612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/28184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86700 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7968 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/71353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8145 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/69331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/70594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/14619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/13560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7930 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/13451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7769 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11288 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9575 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->