### PR TITLE
[iOS18] 2 tests in TestWebKitAPI.WebKit.SystemPreview are a constant crash(failure in EWS)

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SystemPreview.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SystemPreview.mm
@@ -121,7 +121,12 @@ TEST(WebKit, SystemPreviewLoad)
     Util::run(&wasTriggered);
 }
 
+// FIXME when rdar://141378456 is resolved.
+#if PLATFORM(IOS)
+TEST(WebKit, DISABLED_SystemPreviewFail)
+#else
 TEST(WebKit, SystemPreviewFail)
+#endif
 {
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
     [configuration _setSystemPreviewEnabled:YES];
@@ -185,7 +190,12 @@ TEST(WebKit, SystemPreviewBlobRevokedImmediately)
     Util::run(&wasTriggered);
 }
 
+// FIXME when rdar://141378456 is resolved.
+#if PLATFORM(IOS)
+TEST(WebKit, DISABLED_SystemPreviewBlob)
+#else
 TEST(WebKit, SystemPreviewBlob)
+#endif
 {
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
     [configuration _setSystemPreviewEnabled:YES];


### PR DESCRIPTION
#### 7bc94d88c9c3806292c441cca88d9891742a956b
<pre>
[iOS18] 2 tests in TestWebKitAPI.WebKit.SystemPreview are a constant crash(failure in EWS)
<a href="https://bugs.webkit.org/show_bug.cgi?id=284572">https://bugs.webkit.org/show_bug.cgi?id=284572</a>
<a href="https://rdar.apple.com/141378456">rdar://141378456</a>

Unreviewed test gardening

Disabling the tests as the failure slows EWS runtime

* Tools/TestWebKitAPI/Tests/WebKitCocoa/SystemPreview.mm:
(TestWebKitAPI::TEST(WebKit, SystemPreviewFail)):
(TestWebKitAPI::TEST(WebKit, SystemPreviewBlob)):

Canonical link: <a href="https://commits.webkit.org/287768@main">https://commits.webkit.org/287768@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5cd842e5918e86cb3c37d201b3256684ea06d20b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80748 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/270 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34684 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85275 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31732 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82859 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/287 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8067 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/63061 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/20854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83817 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73499 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43363 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/54 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27659 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30189 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/71618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28190 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86707 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7975 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/71355 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8152 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69335 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70596 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/17587 "The change is no longer eligible for processing.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14624 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/13564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12522 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7937 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7776 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11295 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9582 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->