### PR TITLE
Drop CString::mutableData(), in favor of mutableSpan()

### DIFF
--- a/Source/JavaScriptCore/runtime/IntlDisplayNames.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDisplayNames.cpp
@@ -156,19 +156,19 @@ JSValue IntlDisplayNames::of(JSGlobalObject* globalObject, JSValue codeValue) co
         case Type::Region: {
             // Let code be the result of mapping code to upper case as described in 6.1.
             auto result = code.ascii();
-            char* mutableData = result.mutableData();
-            for (unsigned index = 0; index < result.length(); ++index)
-                mutableData[index] = toASCIIUpper(mutableData[index]);
+            for (auto& character : result.mutableSpan())
+                character = toASCIIUpper(character);
             return result;
         }
         case Type::Script: {
             // Let code be the result of mapping the first character in code to upper case, and mapping the second, third and fourth character in code to lower case, as described in 6.1.
             auto result = code.ascii();
-            char* mutableData = result.mutableData();
-            if (result.length() >= 1)
+            auto mutableData = result.mutableSpan();
+            if (mutableData.size() >= 1) {
                 mutableData[0] = toASCIIUpper(mutableData[0]);
-            for (unsigned index = 1; index < result.length(); ++index)
-                mutableData[index] = toASCIILower(mutableData[index]);
+                for (auto& character : mutableData.subspan(1))
+                    character = toASCIILower(character);
+            }
             return result;
         }
         case Type::Currency:

--- a/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
+++ b/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
@@ -76,7 +76,7 @@ String createTemporaryZipArchive(const String& path)
     RetainPtr coordinator = adoptNS([[NSFileCoordinator alloc] initWithFilePresenter:nil]);
     [coordinator coordinateReadingItemAtURL:[NSURL fileURLWithPath:path] options:NSFileCoordinatorReadingWithoutChanges error:nullptr byAccessor:[&](NSURL *newURL) mutable {
         CString archivePath([NSTemporaryDirectory() stringByAppendingPathComponent:@"WebKitGeneratedFileXXXXXX"].fileSystemRepresentation);
-        int fd = mkostemp(archivePath.mutableData(), O_CLOEXEC);
+        int fd = mkostemp(archivePath.mutableSpanIncludingNullTerminator().data(), O_CLOEXEC);
         if (fd == -1)
             return;
         close(fd);

--- a/Source/WTF/wtf/darwin/OSLogPrintStream.mm
+++ b/Source/WTF/wtf/darwin/OSLogPrintStream.mm
@@ -58,12 +58,12 @@ void OSLogPrintStream::vprintf(const char* format, va_list argList)
     va_list backup;
     va_copy(backup, argList);
 ALLOW_NONLITERAL_FORMAT_BEGIN
-    size_t bytesWritten = vsnprintf(m_string.mutableData() + offset, freeBytes, format, argList);
+    size_t bytesWritten = vsnprintf(m_string.mutableSpanIncludingNullTerminator().subspan(offset).data(), freeBytes, format, argList);
     if (UNLIKELY(bytesWritten >= freeBytes)) {
         size_t newLength = std::max(bytesWritten + m_string.length(), m_string.length() * 2);
         m_string.grow(newLength);
         freeBytes = newLength - offset;
-        bytesWritten = vsnprintf(m_string.mutableData() + offset, freeBytes, format, backup);
+        bytesWritten = vsnprintf(m_string.mutableSpanIncludingNullTerminator().subspan(offset).data(), freeBytes, format, backup);
         ASSERT(bytesWritten < freeBytes);
     }
 ALLOW_NONLITERAL_FORMAT_END

--- a/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
+++ b/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
@@ -327,17 +327,17 @@ bool makeAllDirectories(const String& path)
     if (!access(fullPath.data(), F_OK))
         return true;
 
-    char* p = fullPath.mutableData() + 1;
+    auto p = fullPath.mutableSpanIncludingNullTerminator().subspan(1);
     if (p[length - 1] == '/')
         p[length - 1] = '\0';
-    for (; *p; ++p) {
-        if (*p == '/') {
-            *p = '\0';
+    for (; p[0]; p = p.subspan(1)) {
+        if (p[0] == '/') {
+            p[0] = '\0';
             if (access(fullPath.data(), F_OK)) {
                 if (mkdir(fullPath.data(), S_IRWXU))
                     return false;
             }
-            *p = '/';
+            p[0] = '/';
         }
     }
     if (access(fullPath.data(), F_OK)) {

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -496,7 +496,7 @@ static NSString *temporaryPDFDirectoryPath()
     static NeverDestroyed path = [] {
         auto temporaryDirectoryTemplate = [NSTemporaryDirectory() stringByAppendingPathComponent:@"WebKitPDFs-XXXXXX"];
         CString templateRepresentation = [temporaryDirectoryTemplate fileSystemRepresentation];
-        if (mkdtemp(templateRepresentation.mutableData()))
+        if (mkdtemp(templateRepresentation.mutableSpanIncludingNullTerminator().data()))
             return adoptNS([[[NSFileManager defaultManager] stringWithFileSystemRepresentation:templateRepresentation.data() length:templateRepresentation.length()] copy]);
         return RetainPtr<id> { };
     }();
@@ -521,7 +521,7 @@ static NSString *pathToPDFOnDisk(const String& suggestedFilename)
         NSString *pathTemplate = [pathTemplatePrefix stringByAppendingString:suggestedFilename];
         CString pathTemplateRepresentation = [pathTemplate fileSystemRepresentation];
 
-        int fd = mkstemps(pathTemplateRepresentation.mutableData(), pathTemplateRepresentation.length() - strlen([pathTemplatePrefix fileSystemRepresentation]) + 1);
+        int fd = mkstemps(pathTemplateRepresentation.mutableSpanIncludingNullTerminator().data(), pathTemplateRepresentation.length() - strlen([pathTemplatePrefix fileSystemRepresentation]) + 1);
         if (fd < 0) {
             WTFLogAlways("Cannot create PDF file in the temporary directory (%s).", suggestedFilename.utf8().data());
             return nil;

--- a/Tools/TestWebKitAPI/Tests/WTF/CString.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CString.cpp
@@ -103,7 +103,7 @@ TEST(WTF, CStringCopyOnWrite)
     CString string(initialString);
     CString copy = string;
 
-    string.mutableData()[3] = 'K';
+    string.mutableSpan()[3] = 'K';
     ASSERT_TRUE(string != copy);
     ASSERT_STREQ(string.data(), "WebKit");
     ASSERT_STREQ(copy.data(), initialString);

--- a/Tools/TestWebKitAPI/Tests/WTF/SynchronizedFixedQueue.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/SynchronizedFixedQueue.cpp
@@ -45,10 +45,8 @@ static char const* textItem(size_t index)
 static CString toUpper(const CString& lower)
 {
     CString upper = lower;
-
-    for (char* buffer = upper.mutableData(); *buffer; ++buffer)
-        *buffer = toASCIIUpper(*buffer);
-
+    for (auto& character : upper.mutableSpan())
+        character = toASCIIUpper(character);
     return upper;
 }
 


### PR DESCRIPTION
#### 837e13b4365be7092a7f31e63e271ebf4beeb608
<pre>
Drop CString::mutableData(), in favor of mutableSpan()
<a href="https://bugs.webkit.org/show_bug.cgi?id=284580">https://bugs.webkit.org/show_bug.cgi?id=284580</a>

Reviewed by Darin Adler.

* Source/JavaScriptCore/runtime/IntlDisplayNames.cpp:
(JSC::IntlDisplayNames::of const):
* Source/WTF/wtf/cocoa/FileSystemCocoa.mm:
(WTF::FileSystemImpl::createTemporaryZipArchive):
* Source/WTF/wtf/darwin/OSLogPrintStream.mm:
(WTF::OSLogPrintStream::vprintf):
* Source/WTF/wtf/posix/FileSystemPOSIX.cpp:
(WTF::FileSystemImpl::makeAllDirectories):
* Source/WTF/wtf/text/CString.cpp:
(WTF::CStringBuffer::createUninitialized):
(WTF::CString::copyBufferIfNeeded):
(WTF::CString::grow):
(WTF::CString::mutableData): Deleted.
* Source/WTF/wtf/text/CString.h:
(WTF::CString::data const):
(WTF::CString::spanIncludingNullTerminator const):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::temporaryPDFDirectoryPath):
(WebKit::pathToPDFOnDisk):
* Tools/TestWebKitAPI/Tests/WTF/CString.cpp:
(TEST(WTF, CStringCopyOnWrite)):
* Tools/TestWebKitAPI/Tests/WTF/SynchronizedFixedQueue.cpp:
(TestWebKitAPI::toUpper):

Canonical link: <a href="https://commits.webkit.org/287795@main">https://commits.webkit.org/287795@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ed6ac510053b63a1416fb05d53f4a15e1556c50

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80823 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/345 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34759 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85350 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31807 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82934 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/362 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8144 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63112 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20893 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83892 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/173 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73564 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43416 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/95 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27724 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30264 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/73803 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71656 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28258 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86782 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/79882 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8050 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5679 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71419 "Found 15 new test failures: imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-scale.html imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-translate-em.html imported/w3c/web-platform-tests/css/css-transforms/animation/translate-percent-with-width-and-height-separate.html imported/w3c/web-platform-tests/css/css-transitions/pseudo-element-transform.html imported/w3c/web-platform-tests/css/css-values/vh-interpolate-pct.html imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html imported/w3c/web-platform-tests/css/css-view-transitions/animating-new-content.html imported/w3c/web-platform-tests/css/css-view-transitions/auto-name.html imported/w3c/web-platform-tests/css/css-view-transitions/old-content-with-overflow.html imported/w3c/web-platform-tests/web-animations/timing-model/animations/infinite-duration-animation.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8227 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69400 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70660 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14677 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13616 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/102289 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12539 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8012 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13533 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/24872 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7851 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11370 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9657 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->