### PR TITLE
[UnifiedPDF] [iOS] Support text selection adjustment with selection handles

### DIFF
--- a/Source/WebKit/Shared/ios/GestureTypes.h
+++ b/Source/WebKit/Shared/ios/GestureTypes.h
@@ -79,4 +79,7 @@ enum class TextInteractionSource : uint8_t {
     Mouse = 1 << 1,
 };
 
+enum class SelectionEndpoint : bool { Start, End };
+enum class SelectionWasFlipped : bool { No, Yes };
+
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -84,6 +84,8 @@ class WebFrame;
 class WebKeyboardEvent;
 class WebMouseEvent;
 class WebWheelEvent;
+enum class SelectionEndpoint : bool;
+enum class SelectionWasFlipped : bool;
 struct EditorState;
 struct WebHitTestResultData;
 
@@ -313,6 +315,7 @@ public:
 
 #if PLATFORM(IOS_FAMILY)
     virtual void setSelectionRange(WebCore::FloatPoint /* pointInRootView */, WebCore::TextGranularity) { }
+    virtual SelectionWasFlipped moveSelectionEndpoint(WebCore::FloatPoint /* pointInRootView */, SelectionEndpoint);
 #endif
 
     bool populateEditorStateIfNeeded(EditorState&) const;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -29,6 +29,7 @@
 #if ENABLE(PDF_PLUGIN)
 
 #import "EditorState.h"
+#import "GestureTypes.h"
 #import "Logging.h"
 #import "MessageSenderInlines.h"
 #import "PDFIncrementalLoader.h"
@@ -1190,6 +1191,15 @@ bool PDFPluginBase::populateEditorStateIfNeeded(EditorState& state) const
 #endif
     return true;
 }
+
+#if PLATFORM(IOS_FAMILY)
+
+SelectionWasFlipped PDFPluginBase::moveSelectionEndpoint(FloatPoint, SelectionEndpoint)
+{
+    return SelectionWasFlipped::No;
+}
+
+#endif
 
 #if !LOG_DISABLED
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -574,10 +574,17 @@ private:
 
     WebCore::FloatRect pageBoundsInContentsSpace(PDFDocumentLayout::PageIndex) const;
 
+    using PageAndPoint = std::pair<RetainPtr<PDFPage>, WebCore::FloatPoint>;
+    PageAndPoint rootViewToPage(WebCore::FloatPoint) const;
+
 #if PLATFORM(IOS_FAMILY)
     void setSelectionRange(WebCore::FloatPoint pointInRootView, WebCore::TextGranularity) final;
+    SelectionWasFlipped moveSelectionEndpoint(WebCore::FloatPoint pointInRootView, SelectionEndpoint) final;
     bool platformPopulateEditorStateIfNeeded(EditorState&) const final;
-#endif
+
+    static std::optional<PageAndPoint> selectionCaretPointInPage(PDFSelection *, SelectionEndpoint);
+    std::optional<PageAndPoint> selectionCaretPointInPage(SelectionEndpoint) const;
+#endif // PLATFORM(IOS_FAMILY)
 
     RefPtr<PDFPresentationController> m_presentationController;
 

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -1121,6 +1121,11 @@ void PluginView::setSelectionRange(FloatPoint pointInRootView, TextGranularity g
     protectedPlugin()->setSelectionRange(pointInRootView, granularity);
 }
 
+SelectionWasFlipped PluginView::moveSelectionEndpoint(WebCore::FloatPoint pointInRootView, SelectionEndpoint endpoint)
+{
+    return protectedPlugin()->moveSelectionEndpoint(pointInRootView, endpoint);
+}
+
 #endif // PLATFORM(IOS_FAMILY)
 
 bool PluginView::populateEditorStateIfNeeded(EditorState& state) const

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -57,6 +57,8 @@ namespace WebKit {
 class PDFPluginBase;
 class WebFrame;
 class WebPage;
+enum class SelectionEndpoint : bool;
+enum class SelectionWasFlipped : bool;
 struct EditorState;
 struct FrameInfoData;
 struct WebHitTestResultData;
@@ -95,6 +97,7 @@ public:
 #if PLATFORM(IOS_FAMILY)
     void pluginDidInstallPDFDocument(double initialScaleFactor);
     void setSelectionRange(WebCore::FloatPoint pointInRootView, WebCore::TextGranularity);
+    SelectionWasFlipped moveSelectionEndpoint(WebCore::FloatPoint pointInRootView, SelectionEndpoint);
 #endif
 
     bool populateEditorStateIfNeeded(EditorState&) const;


### PR DESCRIPTION
#### fc167fd5d50cfa0a26daf54b11a68055355d85d5
<pre>
[UnifiedPDF] [iOS] Support text selection adjustment with selection handles
<a href="https://bugs.webkit.org/show_bug.cgi?id=284582">https://bugs.webkit.org/show_bug.cgi?id=284582</a>
<a href="https://rdar.apple.com/141324936">rdar://141324936</a>

Reviewed by Abrar Rahman Protyasha.

Add support for range adjustment text interactions (i.e. dragging selection handles to select text)
when using unified PDF on iOS. See below for more details.

* Source/WebKit/Shared/ios/GestureTypes.h:

Add a couple new selection-related enum types to help clarify the parameter/return type in the new
`moveSelectionEndpoint` method (see below).

* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::moveSelectionEndpoint):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::setSelectionRange):

Adopt the new `rootViewToPage` helper below.

(WebKit::UnifiedPDFPlugin::moveSelectionEndpoint):

Add a new helper method to handle selection changes triggered by the user moving one of the
selection endpoints with a loupe gesture on iOS. This handles selection flipping by detecting when
the location of the selection base (i.e. the stationary selection range endpoint) has moved, and
surfaces `SelectionWasFlipped::Yes` back to UIKit in order to allow the system text interaction UI
to swap the selection start and end handles on the fly.

(WebKit::UnifiedPDFPlugin::selectionCaretPointInPage):
(WebKit::UnifiedPDFPlugin::selectionCaretPointInPage const):

Add a couple of helper methods to compute the selection start/end points, relative to page
coordinates. Returns both a point, and a `PDFPage` that is the the point&apos;s coordinate space.

(WebKit::UnifiedPDFPlugin::rootViewToPage const):

Pull out some existing code to map a point from root view coordinates to a PDF page out into a
separate helper. This returns both the new mapped point, as well as the `PDFPage` that the point is
relative to.

* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::moveSelectionEndpoint):
* Source/WebKit/WebProcess/Plugins/PluginView.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::updateSelectionWithTouches):

Add a hook to defer to the PDF plugin, if present.

Canonical link: <a href="https://commits.webkit.org/287780@main">https://commits.webkit.org/287780@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd5e278a254e7053104fd62a95accb6a753678c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80782 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/304 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34718 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85309 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31766 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/321 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8102 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63086 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20875 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83851 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/149 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73527 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43388 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/75 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30223 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/71641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28219 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86741 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8009 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5660 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71382 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8186 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69363 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70621 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17594 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14648 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/13586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7971 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/13492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7810 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11329 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9616 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->