### PR TITLE
[Screen Time Refactoring] iOS support for URL donations

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -355,14 +355,13 @@ static uint32_t convertSystemLayoutDirection(NSUserInterfaceLayoutDirection dire
     if (!PAL::isScreenTimeFrameworkAvailable())
         return;
 
-    if (!_page->preferences().screenTimeEnabled())
+    if (_page && !_page->preferences().screenTimeEnabled())
         return;
 
     if (!_screenTimeWebpageController) {
         _screenTimeWebpageController = adoptNS([PAL::allocSTWebpageControllerInstance() init]);
-        [_screenTimeWebpageController addObserver:self forKeyPath:@"URLIsBlocked" options:(NSKeyValueObservingOptionOld | NSKeyValueObservingOptionNew) context:screenTimeWebpageControllerBlockedKVOContext];
+        [_screenTimeWebpageController addObserver:self forKeyPath:@"URLIsBlocked" options:(NSKeyValueObservingOptionOld | NSKeyValueObservingOptionNew) context:&screenTimeWebpageControllerBlockedKVOContext];
 
-#if PLATFORM(MAC)
         RetainPtr screenTimeView = [_screenTimeWebpageController view];
         [screenTimeView setTranslatesAutoresizingMaskIntoConstraints:NO];
         [self addSubview:screenTimeView.get()];
@@ -372,7 +371,6 @@ static uint32_t convertSystemLayoutDirection(NSUserInterfaceLayoutDirection dire
             [[screenTimeView leadingAnchor] constraintEqualToAnchor:self.leadingAnchor],
             [[screenTimeView topAnchor] constraintEqualToAnchor:self.topAnchor]
         ]];
-#endif // PLATFORM(MAC)
     }
 }
 
@@ -385,7 +383,7 @@ static uint32_t convertSystemLayoutDirection(NSUserInterfaceLayoutDirection dire
         return;
 
     [[_screenTimeWebpageController view] removeFromSuperview];
-    [_screenTimeWebpageController removeObserver:self forKeyPath:@"URLIsBlocked" context:screenTimeWebpageControllerBlockedKVOContext];
+    [_screenTimeWebpageController removeObserver:self forKeyPath:@"URLIsBlocked" context:&screenTimeWebpageControllerBlockedKVOContext];
     _screenTimeWebpageController = nil;
 }
 #endif // ENABLE(SCREEN_TIME)

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
@@ -128,6 +128,11 @@ public:
     void removeTextAnimationForAnimationID(const WTF::UUID&) final;
 #endif
 
+#if ENABLE(SCREEN_TIME)
+    void installScreenTimeWebpageController() final;
+    void updateScreenTimeWebpageControllerURL(WKWebView *);
+#endif
+
 #if ENABLE(GAMEPAD)
     void setGamepadsRecentlyAccessed(GamepadsRecentlyAccessed) final;
 #if PLATFORM(VISION)

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -39,6 +39,10 @@
 #import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/text/WTFString.h>
 
+#if ENABLE(SCREEN_TIME)
+#import <pal/cocoa/ScreenTimeSoftLink.h>
+#endif
+
 namespace WebKit {
 
 PageClientImplCocoa::PageClientImplCocoa(WKWebView *webView)
@@ -319,6 +323,30 @@ void PageClientImplCocoa::removeTextAnimationForAnimationID(const WTF::UUID& uui
     [m_webView _removeTextAnimationForAnimationID:uuid];
 }
 
+#endif
+
+#if ENABLE(SCREEN_TIME)
+void PageClientImplCocoa::installScreenTimeWebpageController()
+{
+    [m_webView _installScreenTimeWebpageController];
+}
+
+void PageClientImplCocoa::updateScreenTimeWebpageControllerURL(WKWebView *webView)
+{
+    if (!PAL::isScreenTimeFrameworkAvailable())
+        return;
+
+    RetainPtr screenTimeWebpageController = [webView _screenTimeWebpageController];
+    if (!screenTimeWebpageController)
+        return;
+
+    NakedPtr<WebKit::WebPageProxy> pageProxy = [webView _page];
+    if (pageProxy && !pageProxy->preferences().screenTimeEnabled()) {
+        [webView _uninstallScreenTimeWebpageController];
+        return;
+    }
+    [screenTimeWebpageController setURL:[webView _mainFrameURL]];
+}
 #endif
 
 #if ENABLE(GAMEPAD)

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -315,6 +315,9 @@ void PageClientImpl::didCommitLoadForMainFrame(const String& mimeType, bool useC
     [webView _hidePasswordView];
     [webView _setHasCustomContentView:useCustomContentProvider loadedMIMEType:mimeType];
     [contentView() _didCommitLoadForMainFrame];
+#if ENABLE(SCREEN_TIME)
+    updateScreenTimeWebpageControllerURL(webView.get());
+#endif // ENABLE(SCREEN_TIME)
 }
 
 void PageClientImpl::didChangeContentSize(const WebCore::IntSize&)

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -325,10 +325,6 @@ private:
         
     void requestScrollToRect(const WebCore::FloatRect& targetRect, const WebCore::FloatPoint& origin) override;
 
-#if ENABLE(SCREEN_TIME)
-    void installScreenTimeWebpageController() override;
-#endif
-
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     void didEnterFullscreen() final { }
     void didExitFullscreen() final { }

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -92,10 +92,6 @@
 #import <WebCore/WebMediaSessionManager.h>
 #endif
 
-#if ENABLE(SCREEN_TIME)
-#import <pal/cocoa/ScreenTimeSoftLink.h>
-#endif
-
 #import <pal/cocoa/WritingToolsUISoftLink.h>
 
 static NSString * const kAXLoadCompleteNotification = @"AXLoadComplete";
@@ -287,30 +283,6 @@ void PageClientImpl::toolTipChanged(const String& oldToolTip, const String& newT
 {
     m_impl->toolTipChanged(oldToolTip, newToolTip);
 }
-
-#if ENABLE(SCREEN_TIME)
-void PageClientImpl::installScreenTimeWebpageController()
-{
-    [webView() _installScreenTimeWebpageController];
-}
-
-static void updateScreenTimeWebpageControllerURL(WKWebView *webView)
-{
-    if (!PAL::isScreenTimeFrameworkAvailable())
-        return;
-
-    RetainPtr screenTimeWebpageController = [webView _screenTimeWebpageController];
-    if (!screenTimeWebpageController)
-        return;
-
-    NakedPtr<WebKit::WebPageProxy> pageProxy = [webView _page];
-    if (pageProxy && !pageProxy->preferences().screenTimeEnabled()) {
-        [webView _uninstallScreenTimeWebpageController];
-        return;
-    }
-    [screenTimeWebpageController setURL:[webView _mainFrameURL]];
-}
-#endif
 
 void PageClientImpl::didCommitLoadForMainFrame(const String&, bool)
 {


### PR DESCRIPTION
#### a733f9fa61f55450eac6e28714112c5317bf8d62
<pre>
[Screen Time Refactoring] iOS support for URL donations
<a href="https://bugs.webkit.org/show_bug.cgi?id=284316">https://bugs.webkit.org/show_bug.cgi?id=284316</a>
<a href="https://rdar.apple.com/140438859">rdar://140438859</a>

Reviewed by Aditya Keerthi and Richard Robinson.

Added Screen Time shield to show for iOS.
Mirrored macOS Screen Time donation for loaded pages, but for iOS as well.
Changed screenTimeWebpageControllerBlockedKVOContext to use
&amp;screenTimeWebpageControllerBlockedKVOContext.
Consolidated `installScreenTimeWebpageController` and `updateScreenTimeWebpageControllerURL`
to be on `PageClientImplCocoa` since the logic is now the same for macOS and iOS.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _installScreenTimeWebpageController]):
(-[WKWebView _uninstallScreenTimeWebpageController]):
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::installScreenTimeWebpageController):
(WebKit::PageClientImplCocoa::updateScreenTimeWebpageControllerURL):
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::didCommitLoadForMainFrame):
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::installScreenTimeWebpageController): Deleted.
(WebKit::updateScreenTimeWebpageControllerURL): Deleted.

Canonical link: <a href="https://commits.webkit.org/287810@main">https://commits.webkit.org/287810@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b10a72e228d916acb577b00c84d9bc84f639619f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80821 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/343 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34757 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85348 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31805 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/360 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8142 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63110 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20889 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83890 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/169 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73559 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43414 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/93 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30262 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71654 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28253 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86780 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8048 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5678 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71405 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8225 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69395 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70646 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14672 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13611 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12551 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8010 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13531 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7849 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11368 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9655 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->