### PR TITLE
Deduplicate RenderStyle data structures

### DIFF
--- a/Source/WTF/wtf/DataRef.h
+++ b/Source/WTF/wtf/DataRef.h
@@ -120,6 +120,22 @@ template<typename T> struct HashTraits<DataRef<T>> : SimpleClassHashTraits<DataR
     static bool isEmptyValue(const DataRef<T>& value) { return value.isHashTableEmptyValue(); }
 };
 
+enum class DataAreDifferent : bool { No, Yes };
+
+template <typename T>
+DataAreDifferent deduplicateData(const DataRef<T>& dataRef, const DataRef<T>& otherData)
+{
+    if (dataRef.ptr() == otherData.ptr())
+        return DataAreDifferent::No;
+
+    if (*dataRef != *otherData)
+        return DataAreDifferent::Yes;
+
+    const_cast<DataRef<T>&>(dataRef) = otherData;
+    return DataAreDifferent::No;
+}
+
 } // namespace WTF
 
 using WTF::DataRef;
+using WTF::DataAreDifferent;

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -3509,18 +3509,12 @@ void RenderStyle::setColumnStylesFromPaginationMode(PaginationMode paginationMod
     }
 }
 
-void RenderStyle::deduplicateCustomProperties(const RenderStyle& other)
+void RenderStyle::deduplicate(const RenderStyle& other)
 {
-    auto deduplicate = [&] <typename T> (const DataRef<T>& data, const DataRef<T>& otherData) {
-        auto& properties = const_cast<DataRef<StyleCustomPropertyData>&>(data->customProperties);
-        auto& otherProperties = otherData->customProperties;
-        if (properties.ptr() == otherProperties.ptr() || *properties != *otherProperties)
-            return;
-        properties = otherProperties;
-    };
-
-    deduplicate(m_rareInheritedData, other.m_rareInheritedData);
-    deduplicate(m_nonInheritedData->rareData, other.m_nonInheritedData->rareData);
+    deduplicateData(m_inheritedData, other.m_inheritedData);
+    deduplicateData(m_nonInheritedData, other.m_nonInheritedData);
+    deduplicateData(m_rareInheritedData, other.m_rareInheritedData);
+    deduplicateData(m_svgStyle, other.m_svgStyle);
 }
 
 void RenderStyle::setCustomPropertyValue(Ref<const CSSCustomPropertyValue>&& value, bool isInherited)

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -344,6 +344,8 @@ public:
 
     bool operator==(const RenderStyle&) const;
 
+    void deduplicate(const RenderStyle&);
+
     void inheritFrom(const RenderStyle&);
     void inheritIgnoringCustomPropertiesFrom(const RenderStyle&);
     void fastPathInheritFrom(const RenderStyle&);
@@ -378,7 +380,6 @@ public:
     const CSSCustomPropertyValue* customPropertyValue(const AtomString&) const;
     bool customPropertyValueEqual(const RenderStyle&, const AtomString&) const;
 
-    void deduplicateCustomProperties(const RenderStyle&);
     void setCustomPropertyValue(Ref<const CSSCustomPropertyValue>&&, bool isInherited);
     bool customPropertiesEqual(const RenderStyle&) const;
 

--- a/Source/WebCore/rendering/style/SVGRenderStyle.h
+++ b/Source/WebCore/rendering/style/SVGRenderStyle.h
@@ -53,6 +53,8 @@ public:
 
     bool operator==(const SVGRenderStyle&) const;
 
+    DataAreDifferent deduplicate(const SVGRenderStyle&);
+
 #if !LOG_DISABLED
     void dumpDifferences(TextStream&, const SVGRenderStyle&) const;
 #endif
@@ -496,5 +498,7 @@ inline void SVGRenderStyle::setBitDefaults()
     m_nonInheritedFlags.flagBits.bufferedRendering = static_cast<unsigned>(initialBufferedRendering());
     m_nonInheritedFlags.flagBits.maskType = static_cast<unsigned>(initialMaskType());
 }
+
+DataAreDifferent deduplicateData(DataRef<SVGRenderStyle>&, const DataRef<SVGRenderStyle>&);
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleInheritedData.cpp
@@ -93,6 +93,26 @@ void StyleInheritedData::fastPathInheritFrom(const StyleInheritedData& inheritPa
     visitedLinkColor = inheritParent.visitedLinkColor;
 }
 
+DataAreDifferent deduplicateData(DataRef<StyleInheritedData>& data, const DataRef<StyleInheritedData>& otherData)
+{
+    if (data.ptr() == otherData.ptr())
+        return DataAreDifferent::No;
+
+    bool haveDataDifferences = false;
+
+    if (deduplicateData(data->fontData, otherData->fontData) == DataAreDifferent::Yes)
+        haveDataDifferences = true;
+
+    if (haveDataDifferences)
+        return DataAreDifferent::Yes;
+
+    if (*data != *otherData)
+        return DataAreDifferent::Yes;
+
+    data = otherData;
+    return DataAreDifferent::No;
+}
+
 #if !LOG_DISABLED
 void StyleInheritedData::dumpDifferences(TextStream& ts, const StyleInheritedData& other) const
 {

--- a/Source/WebCore/rendering/style/StyleInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleInheritedData.h
@@ -71,4 +71,6 @@ private:
     void operator=(const StyleInheritedData&) = delete;
 };
 
+DataAreDifferent deduplicateData(DataRef<StyleInheritedData>&, const DataRef<StyleInheritedData>&);
+
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleNonInheritedData.cpp
@@ -76,6 +76,37 @@ bool StyleNonInheritedData::operator==(const StyleNonInheritedData& other) const
         && rareData == other.rareData;
 }
 
+DataAreDifferent deduplicateData(DataRef<StyleNonInheritedData>& data, const DataRef<StyleNonInheritedData>& otherData)
+{
+    if (data.ptr() == otherData.ptr())
+        return DataAreDifferent::No;
+
+    bool haveDataDifferences = false;
+    if (deduplicateData(data->boxData, otherData->boxData) == DataAreDifferent::Yes)
+        haveDataDifferences = true;
+
+    if (deduplicateData(data->backgroundData, otherData->backgroundData) == DataAreDifferent::Yes)
+        haveDataDifferences = true;
+
+    if (deduplicateData(data->surroundData, otherData->surroundData) == DataAreDifferent::Yes)
+        haveDataDifferences = true;
+
+    if (deduplicateData(data->miscData, otherData->miscData) == DataAreDifferent::Yes) // We could also deduplicate more inside here.
+        haveDataDifferences = true;
+
+    if (deduplicateData(data->rareData, otherData->rareData) == DataAreDifferent::Yes)
+        haveDataDifferences = true;
+
+    if (haveDataDifferences)
+        return DataAreDifferent::Yes;
+
+    // If this class gains any non-DataRef numbers, we will need to compare them here.
+    ASSERT(*data == *otherData);
+
+    data = otherData;
+    return DataAreDifferent::No;
+}
+
 #if !LOG_DISABLED
 void StyleNonInheritedData::dumpDifferences(TextStream& ts, const StyleNonInheritedData& other) const
 {

--- a/Source/WebCore/rendering/style/StyleNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleNonInheritedData.h
@@ -65,4 +65,6 @@ private:
     StyleNonInheritedData(const StyleNonInheritedData&);
 };
 
+DataAreDifferent deduplicateData(DataRef<StyleNonInheritedData>&, const DataRef<StyleNonInheritedData>&);
+
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
@@ -384,6 +384,28 @@ bool StyleRareInheritedData::hasColorFilters() const
     return !appleColorFilter->operations.isEmpty();
 }
 
+DataAreDifferent deduplicateData(DataRef<StyleRareInheritedData>& data, const DataRef<StyleRareInheritedData>& otherData)
+{
+    if (data.ptr() == otherData.ptr())
+        return DataAreDifferent::No;
+
+    bool haveDataDifferences = false;
+    if (deduplicateData(data->customProperties, otherData->customProperties) == DataAreDifferent::Yes)
+        haveDataDifferences = true;
+
+    if (deduplicateData(data->appleColorFilter, otherData->appleColorFilter) == DataAreDifferent::Yes)
+        haveDataDifferences = true;
+
+    if (haveDataDifferences)
+        return DataAreDifferent::Yes;
+
+    if (*data != *otherData)
+        return DataAreDifferent::Yes;
+
+    data = otherData;
+    return DataAreDifferent::No;
+}
+
 #if !LOG_DISABLED
 void StyleRareInheritedData::dumpDifferences(TextStream& ts, const StyleRareInheritedData& other) const
 {

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.h
@@ -221,4 +221,6 @@ private:
     StyleRareInheritedData(const StyleRareInheritedData&);
 };
 
+DataAreDifferent deduplicateData(DataRef<StyleRareInheritedData>&, const DataRef<StyleRareInheritedData>&);
+
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
@@ -365,6 +365,38 @@ bool StyleRareNonInheritedData::hasBackdropFilters() const
     return !backdropFilter->operations.isEmpty();
 }
 
+DataAreDifferent deduplicateData(DataRef<StyleRareNonInheritedData>& data, const DataRef<StyleRareNonInheritedData>& otherData)
+{
+    if (data.ptr() == otherData.ptr())
+        return DataAreDifferent::No;
+
+    bool haveDataDifferences = false;
+
+    if (deduplicateData(data->marquee, otherData->marquee) == DataAreDifferent::Yes)
+        haveDataDifferences = true;
+
+    if (deduplicateData(data->backdropFilter, otherData->backdropFilter) == DataAreDifferent::Yes)
+        haveDataDifferences = true;
+
+    if (deduplicateData(data->grid, otherData->grid) == DataAreDifferent::Yes)
+        haveDataDifferences = true;
+
+    if (deduplicateData(data->gridItem, otherData->gridItem) == DataAreDifferent::Yes)
+        haveDataDifferences = true;
+
+    if (deduplicateData(data->customProperties, otherData->customProperties) == DataAreDifferent::Yes)
+        haveDataDifferences = true;
+
+    if (haveDataDifferences)
+        return DataAreDifferent::Yes;
+
+    if (*data != *otherData)
+        return DataAreDifferent::Yes;
+
+    data = otherData;
+    return DataAreDifferent::No;
+}
+
 #if !LOG_DISABLED
 void StyleRareNonInheritedData::dumpDifferences(TextStream& ts, const StyleRareNonInheritedData& other) const
 {

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -269,4 +269,6 @@ private:
     StyleRareNonInheritedData(const StyleRareNonInheritedData&);
 };
 
+DataAreDifferent deduplicateData(DataRef<StyleRareNonInheritedData>&, const DataRef<StyleRareNonInheritedData>&);
+
 } // namespace WebCore

--- a/Source/WebCore/style/CustomPropertyRegistry.cpp
+++ b/Source/WebCore/style/CustomPropertyRegistry.cpp
@@ -159,7 +159,7 @@ const RenderStyle& CustomPropertyRegistry::initialValuePrototypeStyle() const
         initializeToStyle(m_propertiesFromStylesheet);
         initializeToStyle(m_propertiesFromAPI);
 
-        m_initialValuePrototypeStyle->deduplicateCustomProperties(*oldStyle);
+        m_initialValuePrototypeStyle->deduplicate(*oldStyle);
     }
 
     return *m_initialValuePrototypeStyle;

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -739,10 +739,9 @@ ElementUpdate TreeResolver::createAnimatedElementUpdate(ResolvedStyle&& resolved
     // as animations created via the JS API.
     auto [newStyle, animationImpact] = applyAnimations();
 
-    // Deduplication speeds up equality comparisons as the properties inherit to descendants.
-    // FIXME: There should be a more general mechanism for this.
+    // Deduplication speeds up equality comparisons between old and new styles as the properties inherit to descendants.
     if (currentStyle)
-        newStyle->deduplicateCustomProperties(*currentStyle);
+        newStyle->deduplicate(*currentStyle);
 
     auto change = currentStyle ? determineChange(*currentStyle, *newStyle) : Change::Renderer;
 


### PR DESCRIPTION
#### 0a33707ee495109ad3fd9617d524233a9d11496b
<pre>
Deduplicate RenderStyle data structures
<a href="https://bugs.webkit.org/show_bug.cgi?id=284585">https://bugs.webkit.org/show_bug.cgi?id=284585</a>
<a href="https://rdar.apple.com/141401865">rdar://141401865</a>

Reviewed by NOBODY (OOPS!).

When Style::TreeResolver builds up a RenderStyle, the new style is built from scratch, and
doesn&apos;t share any DataRef&lt;&gt; objects with the old style. This means that when we compare
old and new styles in `RenderStyle::diff()`, the StyleMumbleData pointer equality tests
always fail, and we go down the more expensive value comparison branches.

We can offset this cost by doing an up-front deduplication of the DataRef&lt;&gt;-held members
of the old and new styles with an explicit deduplication step. This is a generalization of
the existing `deduplicateCustomProperties()` function.

We add `deduplicateData(const DataRef&lt;T&gt;&amp; dataRef, const DataRef&lt;T&gt;&amp; otherData)` which
is the generic implementation for classes that don&apos;t need to deduplicate members; the
first argument is `const` because DataRef only has a `const T&amp;` getter (we want to avoid
calling `access()` which clones).

Classes that need to deduplicate their data members specialize this template.

* Source/WTF/wtf/DataRef.h:
(WTF::deduplicateData):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::deduplicate):
(WebCore::RenderStyle::deduplicateCustomProperties): Deleted.
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/SVGRenderStyle.cpp:
(WebCore::SVGRenderStyle::deduplicate):
(WebCore::deduplicateData):
* Source/WebCore/rendering/style/SVGRenderStyle.h:
* Source/WebCore/rendering/style/StyleInheritedData.cpp:
(WebCore::deduplicateData):
* Source/WebCore/rendering/style/StyleInheritedData.h:
* Source/WebCore/rendering/style/StyleNonInheritedData.cpp:
(WebCore::deduplicateData):
* Source/WebCore/rendering/style/StyleNonInheritedData.h:
* Source/WebCore/rendering/style/StyleRareInheritedData.cpp:
(WebCore::deduplicateData):
* Source/WebCore/rendering/style/StyleRareInheritedData.h:
* Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp:
(WebCore::deduplicateData):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:
* Source/WebCore/style/CustomPropertyRegistry.cpp:
(WebCore::Style::CustomPropertyRegistry::initialValuePrototypeStyle const):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::createAnimatedElementUpdate):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a33707ee495109ad3fd9617d524233a9d11496b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80769 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/291 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34705 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85296 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31753 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82880 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/308 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8089 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63082 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20867 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83838 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/141 "Found 1 new test failure: fast/forms/ios/file-upload-panel.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73520 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43384 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/67 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27680 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30210 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/73749 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71633 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28211 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86728 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/79828 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7996 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5652 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71376 "Found 1 new test failure: imported/blink/compositing/animation/hidden-animated-layer-should-not-have-scrollbars.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8173 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69356 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70615 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14638 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13580 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/102235 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7958 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13479 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/24868 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/struct-new_default-small-members.js.wasm-collect-continuously (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7797 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11316 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9603 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->