### PR TITLE
Reduce calls to AffineTransform::multiply()

### DIFF
--- a/Source/WebCore/platform/graphics/transforms/AffineTransform.cpp
+++ b/Source/WebCore/platform/graphics/transforms/AffineTransform.cpp
@@ -42,6 +42,26 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(AffineTransform);
 
+AffineTransform AffineTransform::makeRotation(double angleInDegrees, FloatPoint center)
+{
+    if (center.isZero())
+        return makeRotation(angleInDegrees);
+
+    auto centerSize = toFloatSize(center);
+    auto matrix = makeTranslation(centerSize);
+    matrix.rotate(angleInDegrees);
+    matrix.translate(-centerSize);
+    return matrix;
+}
+
+AffineTransform AffineTransform::makeRotation(double angleInDegrees)
+{
+    auto angleInRadians = deg2rad(angleInDegrees);
+    double cosAngle = cos(angleInRadians);
+    double sinAngle = sin(angleInRadians);
+    return AffineTransform { cosAngle, sinAngle, -sinAngle, cosAngle, 0, 0 };
+}
+
 void AffineTransform::makeIdentity()
 {
     setMatrix(1, 0, 0, 1, 0, 0);

--- a/Source/WebCore/platform/graphics/transforms/AffineTransform.h
+++ b/Source/WebCore/platform/graphics/transforms/AffineTransform.h
@@ -207,13 +207,8 @@ public:
         return AffineTransform(scale.width(), 0, 0, scale.height(), 0, 0);
     }
 
-    static AffineTransform makeRotation(double angleInDegrees, FloatPoint center = { })
-    {
-        auto matrix = makeTranslation(toFloatSize(center));
-        matrix.rotate(angleInDegrees);
-        matrix.translate(-toFloatSize(center));
-        return matrix;
-    }
+    WEBCORE_EXPORT static AffineTransform makeRotation(double angleInDegrees, FloatPoint center);
+    WEBCORE_EXPORT static AffineTransform makeRotation(double angleInDegrees);
 
     // decompose the matrix into its component parts
     typedef struct {

--- a/Source/WebCore/svg/SVGGraphicsElement.cpp
+++ b/Source/WebCore/svg/SVGGraphicsElement.cpp
@@ -112,7 +112,7 @@ AffineTransform SVGGraphicsElement::animatedLocalTransform() const
     }
 
     // If we didn't have the CSS "transform" property set, we must account for the "transform" attribute.
-    if (!hasSpecifiedTransform && style) {
+    if (!hasSpecifiedTransform && style && !transform().isEmpty()) {
         auto t = style->computeTransformOrigin(renderer->transformReferenceBoxRect()).xy();
         matrix.translate(t);
         matrix *= transform().concatenate();


### PR DESCRIPTION
#### e1e511077e89c748d975eae1d1637e110fa805d8
<pre>
Reduce calls to AffineTransform::multiply()
<a href="https://bugs.webkit.org/show_bug.cgi?id=284596">https://bugs.webkit.org/show_bug.cgi?id=284596</a>
<a href="https://rdar.apple.com/141404759">rdar://141404759</a>

Reviewed by Abrar Rahman Protyasha.

In SVGGraphicsElement::animatedLocalTransform() we can avoid the `matrix *= transform().concatenate()`
if the transform list is empty.

We can also avoid the multiply in `AffineTransform::makeRotation()` if the center is zero.

* Source/WebCore/platform/graphics/transforms/AffineTransform.cpp:
(WebCore::AffineTransform::makeRotation):
* Source/WebCore/platform/graphics/transforms/AffineTransform.h:
(WebCore::AffineTransform::makeRotation): Deleted.
* Source/WebCore/svg/SVGGraphicsElement.cpp:
(WebCore::SVGGraphicsElement::animatedLocalTransform const):

Canonical link: <a href="https://commits.webkit.org/287799@main">https://commits.webkit.org/287799@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f44e949df9aba38b4bd02fb405be3adaa0ca593

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80776 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/298 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34712 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85303 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31760 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82887 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/315 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8096 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63091 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20872 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83845 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/145 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73525 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43394 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/71 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27685 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30217 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71637 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28217 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86735 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8003 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5658 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71378 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8180 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69361 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70617 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17605 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14649 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13584 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7965 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13486 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7804 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11323 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9610 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->