### PR TITLE
[iOS] grid-aspect-ratio-align-items-center.html constantly failing (image).

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/grid-aspect-ratio-align-items-center.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/grid-aspect-ratio-align-items-center.html
@@ -3,19 +3,26 @@
 <head>
 <link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
 <link rel="help" href="https://www.w3.org/TR/2021/WD-css-sizing-4-20210520/#aspect-ratio-automatic">
-<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-1977" />
 <meta name="assert" content="Grid has a definite block size computed using the inline size/aspect ratio and item is aligned accordingly (centered vertically).">
 <style>
 .grid {
   display: grid;
   aspect-ratio: 1/1;
   align-items: center;
-  background: linear-gradient(to bottom, green 0, green 25px, red 25px, red 75px, green 75px, green 100px);
+  position: relative;
 }
 .item {
   width: 100px;
   height: 50px;
   background-color: green;
+}
+.abspos {
+  position: absolute;
+  width: 100px;
+  height: 25px;
+  background-color: green;
+  align-self: start;
+  z-index: -1;
 }
 </style>
 </head>
@@ -23,6 +30,9 @@
 <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
 <div style="width: 100px">
   <div class="grid">
+      <div class="abspos"></div>
+      <div class="abspos" style="top: 75px;"></div>
+
       <div class="item"></div>
   </div>
 </div>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7644,9 +7644,7 @@ webkit.org/b/283993 imported/w3c/web-platform-tests/css/css-contain/content-visi
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-animation-and-scroll.html [ Pass ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-nested-scroll.html [ Pass ImageOnlyFailure ]
 
-# webkit.org/b/283995 (New Test (286367@main): [ iOS ] 2 CSS grid sizing tests are constantly failing (image).)
-imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/grid-aspect-ratio-align-items-center.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-005.html [ ImageOnlyFailure ]
+webkit.org/b/284595 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-005.html [ ImageOnlyFailure ]
 
 # webkit.org/b/284096 (REGRESSION (286687@main): [ iOS ] 2 imported scroll-animations tests are consistently failing.)
 imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-responsiveness-from-endpoint.html [ Pass Failure ]


### PR DESCRIPTION
#### d97fff0f2eeb1bb420ac14a607adb3e943f26cbd
<pre>
[iOS] grid-aspect-ratio-align-items-center.html constantly failing (image).
<a href="https://bugs.webkit.org/show_bug.cgi?id=283995">https://bugs.webkit.org/show_bug.cgi?id=283995</a>
<a href="https://rdar.apple.com/140870687">rdar://140870687</a>

Reviewed by Alan Baradlay.

In 286367@main we added a test as part of the bug fix, but it seems like
it has always been failing on iOS since it was added. After taking a
look at the image diff, it seems like the underlying bug that was
addressed in the previous patch is still fixed on iOS, however there is
some sort of discrepancy with the linear-gradient that was used.

This patch slightly modifies the test so that it still verifies that the
underlying bug in the initial patch is fixed and also passes more consistenly
on different platforms. This is done by placing two abs pos divs at the
top and bottom of the div. This then leaves empty space in the middle
which the grid item is supposed to take up. Without the fix in 286367@main
the significant amount of extra space causes the test to fail.

* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/grid-aspect-ratio-align-items-center.html:
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/287802@main">https://commits.webkit.org/287802@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f5f7f128438a28055ebf85abfbc7bf9b8c8e86e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80794 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/316 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34730 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85321 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31778 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/333 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8115 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63090 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83863 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/151 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73536 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43393 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/85 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27696 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30235 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71643 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28229 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86753 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8021 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5663 "Found 1 new test failure: storage/indexeddb/modern/workers-enable.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71389 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8198 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69372 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70628 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17606 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14653 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13592 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7983 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7822 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11341 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9628 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->