### PR TITLE
Main frame PDFs served with CSP sandbox header do not load

### DIFF
--- a/Source/WebCore/html/HTMLPlugInImageElement.h
+++ b/Source/WebCore/html/HTMLPlugInImageElement.h
@@ -45,6 +45,8 @@ public:
 
     bool needsWidgetUpdate() const { return m_needsWidgetUpdate; }
     void setNeedsWidgetUpdate(bool needsWidgetUpdate) { m_needsWidgetUpdate = needsWidgetUpdate; }
+
+    bool shouldBypassCSPForPDFPlugin(const String& contentType) const;
     
 protected:
     HTMLPlugInImageElement(const QualifiedName& tagName, Document&);
@@ -68,7 +70,6 @@ protected:
 private:
     bool isPlugInImageElement() const final { return true; }
 
-    bool shouldBypassCSPForPDFPlugin(const String&) const;
     bool canLoadPlugInContent(const String& relativeURL, const String& mimeType) const;
     bool canLoadURL(const URL&) const;
 

--- a/Source/WebCore/loader/SubframeLoader.h
+++ b/Source/WebCore/loader/SubframeLoader.h
@@ -67,7 +67,7 @@ private:
     bool loadPlugin(HTMLPlugInImageElement&, const URL&, const String& mimeType, const Vector<AtomString>& paramNames, const Vector<AtomString>& paramValues, bool useFallback);
 
     bool shouldUsePlugin(const URL&, const String& mimeType, bool hasFallback, bool& useFallback);
-    bool pluginIsLoadable(const URL&);
+    bool pluginIsLoadable(const URL&, const HTMLPlugInImageElement&, const String& mimeType) const;
 
     URL completeURL(const String&) const;
 

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -86,6 +86,7 @@ Tests/WebKitCocoa/ConsoleMessageWithDetails.mm
 Tests/WebKitCocoa/ContentFiltering.mm
 Tests/WebKitCocoa/ContentRuleListNotification.mm
 Tests/WebKitCocoa/ContentSecurityPolicy.mm
+Tests/WebKitCocoa/ContentSecurityPolicyTestHelpers.mm
 Tests/WebKitCocoa/ContextMenus.mm
 Tests/WebKitCocoa/CookieAcceptPolicy.mm
 Tests/WebKitCocoa/CookiePrivateBrowsing.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -2436,6 +2436,8 @@
 		33BE5AF8137B5AAE00705813 /* MouseMoveAfterCrash_Bundle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MouseMoveAfterCrash_Bundle.cpp; sourceTree = "<group>"; };
 		33C2C9C02651F5B900E407F6 /* SmallSet.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SmallSet.cpp; sourceTree = "<group>"; };
 		33C39CFF2B07D4B9008FA14B /* WKWebExtensionAPIDeclarativeNetRequest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionAPIDeclarativeNetRequest.mm; sourceTree = "<group>"; };
+		33D799652D0BBC3500B63ED5 /* ContentSecurityPolicyTestHelpers.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ContentSecurityPolicyTestHelpers.mm; sourceTree = "<group>"; };
+		33D799662D0BBC3500B63ED5 /* ContentSecurityPolicyTestHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ContentSecurityPolicyTestHelpers.h; sourceTree = "<group>"; };
 		33DB57422CFD46700045C37C /* metalSpecTOC.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = metalSpecTOC.pdf; sourceTree = "<group>"; };
 		33DB57442CFD9D100045C37C /* WKWebViewForTestingImmediateActions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKWebViewForTestingImmediateActions.h; sourceTree = "<group>"; };
 		33DB57452CFD9D100045C37C /* WKWebViewForTestingImmediateActions.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewForTestingImmediateActions.mm; sourceTree = "<group>"; };
@@ -4285,6 +4287,8 @@
 				A14FC5891B89927100D107EB /* ContentFilteringPlugIn.mm */,
 				5CA1DED81F74A87100E71BD3 /* ContentRuleListNotification.mm */,
 				CEBCA12E1E3A660100C73293 /* ContentSecurityPolicy.mm */,
+				33D799662D0BBC3500B63ED5 /* ContentSecurityPolicyTestHelpers.h */,
+				33D799652D0BBC3500B63ED5 /* ContentSecurityPolicyTestHelpers.mm */,
 				5C121E8C2410703200486F9B /* ContentWorldPlugIn.mm */,
 				5C3B1D2522A74EA400BCF4D0 /* ContextMenus.mm */,
 				5C2936911D5BF63E00DEAB1E /* CookieAcceptPolicy.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKThumbnailView.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKThumbnailView.mm
@@ -35,6 +35,7 @@
 #import "TestWKWebView.h"
 #import "UISideCompositingScope.h"
 #import "WKWebViewConfigurationExtras.h"
+#import <WebCore/Color.h>
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/_WKThumbnailView.h>
 #import <wtf/RetainPtr.h>

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentSecurityPolicy.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentSecurityPolicy.mm
@@ -25,6 +25,7 @@
 
 #import "config.h"
 
+#import "ContentSecurityPolicyTestHelpers.h"
 #import "HTTPServer.h"
 #import "TestNavigationDelegate.h"
 #import "TestWKWebView.h"
@@ -125,4 +126,9 @@ TEST(ContentSecurityPolicy, InvalidRequireTrustedTypesFor)
     auto webView = adoptNS([WKWebView new]);
     [webView loadRequest:server.request()];
     [webView _test_waitForDidFinishNavigation];
+}
+
+TEST(ContentSecurityPolicy, LoadPDFWithSandboxCSPDirective)
+{
+    TestWebKitAPI::runLoadPDFWithSandboxCSPDirectiveTest([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentSecurityPolicyTestHelpers.h
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentSecurityPolicyTestHelpers.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,35 +25,10 @@
 
 #pragma once
 
-#include <CoreGraphics/CoreGraphics.h>
-#include <wtf/Forward.h>
-#include <wtf/RetainPtr.h>
-
-namespace WebCore {
-class Color;
-}
+OBJC_CLASS TestWKWebView;
 
 namespace TestWebKitAPI {
 
-// FIXME: We can unify most of this helper class with the logic in `TestPDFPage::colorAtPoint`, and deploy this
-// helper class in several other tests that read pixel data from CGImages.
-class CGImagePixelReader {
-    WTF_MAKE_FAST_ALLOCATED; WTF_MAKE_NONCOPYABLE(CGImagePixelReader);
-public:
-    CGImagePixelReader(CGImageRef);
+void runLoadPDFWithSandboxCSPDirectiveTest(TestWKWebView *);
 
-    bool isTransparentBlack(unsigned x, unsigned y) const;
-    WebCore::Color at(unsigned x, unsigned y) const;
-
-    unsigned width() const { return m_width; }
-    unsigned height() const { return m_height; }
-
-    static constexpr auto defaultWebViewSamplingInterval { 100 };
-
-private:
-    unsigned m_width { 0 };
-    unsigned m_height { 0 };
-    RetainPtr<CGContextRef> m_context;
-};
-
-} // namespace TestWebKitAPI
+}

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CookieAcceptPolicy.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CookieAcceptPolicy.mm
@@ -26,11 +26,18 @@
 #import "config.h"
 
 #import "DeprecatedGlobalValues.h"
+#import "HTTPServer.h"
 #import "PlatformUtilities.h"
+#import "TestNavigationDelegate.h"
+#import "TestUIDelegate.h"
+#import "TestWKWebView.h"
 #import <WebKit/WKHTTPCookieStorePrivate.h>
 #import <WebKit/WKProcessPoolPrivate.h>
 #import <WebKit/WKWebView.h>
 #import <WebKit/WKWebViewConfiguration.h>
+#import <WebKit/WKWebViewConfigurationPrivate.h>
+#import <WebKit/WKWebsiteDataStorePrivate.h>
+#import <WebKit/_WKWebsiteDataStoreConfiguration.h>
 #import <pal/spi/cf/CFNetworkSPI.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/text/MakeString.h>

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EditorStateTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EditorStateTests.mm
@@ -432,11 +432,15 @@ TEST(EditorStateTests, SelectedText)
     EXPECT_GT([[webView textInputContentView] selectedText].length, 0U);
 }
 
+namespace EditorStateTests {
+
 constexpr unsigned glyphWidth { 25 }; // pixels
 
-static NSString *applyAhemStyle(NSString *htmlString)
+NSString *applyAhemStyle(NSString *htmlString)
 {
-    return [NSString stringWithFormat:@"<style>@font-face { font-family: Ahem; src: url(Ahem.ttf); } body { margin: 0; } * { font: %upx/1 Ahem; -webkit-text-size-adjust: none; }</style><meta name='viewport' content='width=980, initial-scale=1.0'>%@", glyphWidth, htmlString];
+    return [NSString stringWithFormat:@"<style>@font-face { font-family: Ahem; src: url(Ahem.ttf); } body { margin: 0; } * { font: %upx/1 Ahem; -webkit-text-size-adjust: none; }</style><meta name='viewport' content='width=980, initial-scale=1.0'>%@", EditorStateTests::glyphWidth, htmlString];
+}
+
 }
 
 TEST(EditorStateTests, MarkedTextRange_HorizontalCaretSelection)
@@ -444,7 +448,7 @@ TEST(EditorStateTests, MarkedTextRange_HorizontalCaretSelection)
     IPhoneUserInterfaceSwizzler userInterfaceSwizzler;
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
-    [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:applyAhemStyle(@"<body contenteditable='true'>.</body>")]; // . is dummy to force Ahem to load
+    [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:EditorStateTests::applyAhemStyle(@"<body contenteditable='true'>.</body>")]; // . is dummy to force Ahem to load
     [webView stringByEvaluatingJavaScript:@"document.body.focus()"];
 
     auto *contentView = [webView textInputContentView];
@@ -454,9 +458,9 @@ TEST(EditorStateTests, MarkedTextRange_HorizontalCaretSelection)
     UITextRange *markedTextRange = [contentView markedTextRange];
     NSArray<UITextSelectionRect *> *rects = [contentView selectionRectsForRange:markedTextRange];
     EXPECT_EQ(1U, rects.count);
-    EXPECT_EQ(CGRectMake(0, 0, 5 * glyphWidth, glyphWidth), rects[0].rect);
-    EXPECT_EQ(CGRectMake(0, 0, 2, glyphWidth), [contentView caretRectForPosition:markedTextRange.start]);
-    EXPECT_EQ(CGRectMake(124, 0, 2, glyphWidth), [contentView caretRectForPosition:markedTextRange.end]);
+    EXPECT_EQ(CGRectMake(0, 0, 5 * EditorStateTests::glyphWidth, EditorStateTests::glyphWidth), rects[0].rect);
+    EXPECT_EQ(CGRectMake(0, 0, 2, EditorStateTests::glyphWidth), [contentView caretRectForPosition:markedTextRange.start]);
+    EXPECT_EQ(CGRectMake(124, 0, 2, EditorStateTests::glyphWidth), [contentView caretRectForPosition:markedTextRange.end]);
     EXPECT_FALSE(rects[0].isVertical);
 }
 
@@ -465,7 +469,7 @@ TEST(EditorStateTests, MarkedTextRange_HorizontalRangeSelection)
     IPhoneUserInterfaceSwizzler userInterfaceSwizzler;
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
-    [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:applyAhemStyle(@"<body contenteditable='true'>.</body>")]; // . is dummy to force Ahem to load
+    [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:EditorStateTests::applyAhemStyle(@"<body contenteditable='true'>.</body>")]; // . is dummy to force Ahem to load
     [webView stringByEvaluatingJavaScript:@"document.body.focus()"];
     [webView _synchronouslyExecuteEditCommand:@"InsertText" argument:@"Hello world"];
 
@@ -477,9 +481,9 @@ TEST(EditorStateTests, MarkedTextRange_HorizontalRangeSelection)
     UITextRange *markedTextRange = [contentView markedTextRange];
     NSArray<UITextSelectionRect *> *rects = [contentView selectionRectsForRange:markedTextRange];
     EXPECT_EQ(1U, rects.count);
-    EXPECT_EQ(CGRectMake(150, 0, 5 * glyphWidth, glyphWidth), rects[0].rect);
-    EXPECT_EQ(CGRectMake(149, 0, 2, glyphWidth), [contentView caretRectForPosition:markedTextRange.start]);
-    EXPECT_EQ(CGRectMake(274, 0, 2, glyphWidth), [contentView caretRectForPosition:markedTextRange.end]);
+    EXPECT_EQ(CGRectMake(150, 0, 5 * EditorStateTests::glyphWidth, EditorStateTests::glyphWidth), rects[0].rect);
+    EXPECT_EQ(CGRectMake(149, 0, 2, EditorStateTests::glyphWidth), [contentView caretRectForPosition:markedTextRange.start]);
+    EXPECT_EQ(CGRectMake(274, 0, 2, EditorStateTests::glyphWidth), [contentView caretRectForPosition:markedTextRange.end]);
     EXPECT_FALSE(rects[0].isVertical);
 }
 
@@ -488,7 +492,7 @@ TEST(EditorStateTests, MarkedTextRange_VerticalCaretSelection)
     IPhoneUserInterfaceSwizzler userInterfaceSwizzler;
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
-    [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:applyAhemStyle(@"<body style='writing-mode: vertical-lr' contenteditable='true'>.</body>")]; // . is dummy to force Ahem to load
+    [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:EditorStateTests::applyAhemStyle(@"<body style='writing-mode: vertical-lr' contenteditable='true'>.</body>")]; // . is dummy to force Ahem to load
     [webView stringByEvaluatingJavaScript:@"document.body.focus()"];
 
     auto *contentView = [webView textInputContentView];
@@ -498,9 +502,9 @@ TEST(EditorStateTests, MarkedTextRange_VerticalCaretSelection)
     UITextRange *markedTextRange = [contentView markedTextRange];
     NSArray<UITextSelectionRect *> *rects = [contentView selectionRectsForRange:markedTextRange];
     EXPECT_EQ(1U, rects.count);
-    EXPECT_EQ(CGRectMake(0, 0, glyphWidth, 5 * glyphWidth), rects[0].rect);
-    EXPECT_EQ(CGRectMake(0, 0, glyphWidth, 2), [contentView caretRectForPosition:markedTextRange.start]);
-    EXPECT_EQ(CGRectMake(0, 124, glyphWidth, 2), [contentView caretRectForPosition:markedTextRange.end]);
+    EXPECT_EQ(CGRectMake(0, 0, EditorStateTests::glyphWidth, 5 * EditorStateTests::glyphWidth), rects[0].rect);
+    EXPECT_EQ(CGRectMake(0, 0, EditorStateTests::glyphWidth, 2), [contentView caretRectForPosition:markedTextRange.start]);
+    EXPECT_EQ(CGRectMake(0, 124, EditorStateTests::glyphWidth, 2), [contentView caretRectForPosition:markedTextRange.end]);
     EXPECT_TRUE(rects[0].isVertical);
 }
 
@@ -509,7 +513,7 @@ TEST(EditorStateTests, MarkedTextRange_VerticalRangeSelection)
     IPhoneUserInterfaceSwizzler userInterfaceSwizzler;
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
-    [webView synchronouslyLoadHTMLString:applyAhemStyle(@"<body style='writing-mode: vertical-lr' contenteditable='true'>.</body>")]; // . is dummy to force Ahem to load
+    [webView synchronouslyLoadHTMLString:EditorStateTests::applyAhemStyle(@"<body style='writing-mode: vertical-lr' contenteditable='true'>.</body>")]; // . is dummy to force Ahem to load
     [webView stringByEvaluatingJavaScript:@"document.body.focus()"];
     [webView _synchronouslyExecuteEditCommand:@"InsertText" argument:@"Hello world"];
 
@@ -521,9 +525,9 @@ TEST(EditorStateTests, MarkedTextRange_VerticalRangeSelection)
     UITextRange *markedTextRange = [contentView markedTextRange];
     NSArray<UITextSelectionRect *> *rects = [contentView selectionRectsForRange:markedTextRange];
     EXPECT_EQ(1U, rects.count);
-    EXPECT_EQ(CGRectMake(0, 150, glyphWidth, 5 * glyphWidth), rects[0].rect);
-    EXPECT_EQ(CGRectMake(0, 149, glyphWidth, 2), [contentView caretRectForPosition:markedTextRange.start]);
-    EXPECT_EQ(CGRectMake(0, 274, glyphWidth, 2), [contentView caretRectForPosition:markedTextRange.end]);
+    EXPECT_EQ(CGRectMake(0, 150, EditorStateTests::glyphWidth, 5 * EditorStateTests::glyphWidth), rects[0].rect);
+    EXPECT_EQ(CGRectMake(0, 149, EditorStateTests::glyphWidth, 2), [contentView caretRectForPosition:markedTextRange.start]);
+    EXPECT_EQ(CGRectMake(0, 274, EditorStateTests::glyphWidth, 2), [contentView caretRectForPosition:markedTextRange.end]);
     EXPECT_TRUE(rects[0].isVertical);
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm
@@ -29,6 +29,7 @@
 #import "PlatformUtilities.h"
 #import "TestUIDelegate.h"
 #import "TestWKWebView.h"
+#import <WebCore/Color.h>
 #import <WebKit/WKFrameInfoPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/_WKFrameTreeNode.h>

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FileSystemAccess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FileSystemAccess.mm
@@ -422,37 +422,37 @@ TEST(FileSystemAccess, RemoveDataByModificationTime)
     TestWebKitAPI::Util::run(&done);
 }
 
-static NSString *mainFrameString = @"<script> \
-    function postResult(event) \
-    { \
-        window.webkit.messageHandlers.testHandler.postMessage(event.data); \
-    } \
-    addEventListener('message', postResult, false); \
-    </script> \
-    <iframe src='https://127.0.0.1:9091/'>";
-
-static constexpr auto frameBytes = R"TESTRESOURCE(
-<script>
-function postMessage(message)
-{
-    parent.postMessage(message, '*');
-}
-async function open()
-{
-    try {
-        var rootHandle = await navigator.storage.getDirectory();
-        var fileHandle = await rootHandle.getFileHandle('file-system-access.txt', { 'create' : true });
-        postMessage('file is opened');
-    } catch(err) {
-        postMessage('error: ' + err.name + ' - ' + err.message);
-    }
-}
-open();
-</script>
-)TESTRESOURCE"_s;
-
 TEST(FileSystemAccess, FetchDataForThirdParty)
 {
+    static NSString *mainFrameString = @"<script> \
+        function postResult(event) \
+        { \
+            window.webkit.messageHandlers.testHandler.postMessage(event.data); \
+        } \
+        addEventListener('message', postResult, false); \
+        </script> \
+        <iframe src='https://127.0.0.1:9091/'>";
+
+    static constexpr auto frameBytes = R"TESTRESOURCE(
+    <script>
+    function postMessage(message)
+    {
+        parent.postMessage(message, '*');
+    }
+    async function open()
+    {
+        try {
+            var rootHandle = await navigator.storage.getDirectory();
+            var fileHandle = await rootHandle.getFileHandle('file-system-access.txt', { 'create' : true });
+            postMessage('file is opened');
+        } catch(err) {
+            postMessage('error: ' + err.name + ' - ' + err.message);
+        }
+    }
+    open();
+    </script>
+    )TESTRESOURCE"_s;
+
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { frameBytes } },
     }, TestWebKitAPI::HTTPServer::Protocol::Https, nullptr, nullptr, 9091);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBSuspendImminently.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBSuspendImminently.mm
@@ -94,53 +94,53 @@ TEST(IndexedDB, IndexedDBSuspendImminently)
     runUntilMessageReceived(@"Expected Success After Resume");
 }
 
-static NSString *mainFrameString = @"<script> \
-    function postResult(event) { \
-        window.webkit.messageHandlers.testHandler.postMessage(event.data); \
-    } \
-    addEventListener('message', postResult, false); \
-    </script> \
-    <iframe src='iframe://'>";
-
-static const char* iframeBytes = R"TESTRESOURCE(
-<script>
-function postResult(result) {
-    if (window.parent != window.top) {
-        parent.postMessage(result, '*');
-    } else {
-        window.webkit.messageHandlers.testHandler.postMessage(result);
-    }
-}
-
-try {
-    var request = window.indexedDB.open('IndexedDBSuspendImminentlyForThirdPartyDatabases');
-    request.onupgradeneeded = function(event) {
-        var db = event.target.result;
-        var os = db.createObjectStore('TestObjectStore');
-        var transaction = event.target.transaction;
-        transaction.onabort = function(event) {
-            postResult('transaction is aborted');
-        }
-        transaction.oncomplete = function(event) {
-            postResult('transaction is completed');
-        }
-
-        postResult('database is created');
-
-        for (let i = 0; i < 1000; i ++)
-            os.put('TestValue', 'TestKey');
-    }
-    request.onerror = function(event) {
-        postResult('database error: ' + event.target.error.name + ' - ' + event.target.error.message);
-    }
-} catch(err) {
-    postResult('database error: ' + err.name + ' - ' + err.message);
-}
-</script>
-)TESTRESOURCE";
-
 TEST(IndexedDB, SuspendImminentlyForThirdPartyDatabases)
 {
+    static NSString *mainFrameString = @"<script> \
+        function postResult(event) { \
+            window.webkit.messageHandlers.testHandler.postMessage(event.data); \
+        } \
+        addEventListener('message', postResult, false); \
+        </script> \
+        <iframe src='iframe://'>";
+
+    static const char* iframeBytes = R"TESTRESOURCE(
+    <script>
+    function postResult(result) {
+        if (window.parent != window.top) {
+            parent.postMessage(result, '*');
+        } else {
+            window.webkit.messageHandlers.testHandler.postMessage(result);
+        }
+    }
+
+    try {
+        var request = window.indexedDB.open('IndexedDBSuspendImminentlyForThirdPartyDatabases');
+        request.onupgradeneeded = function(event) {
+            var db = event.target.result;
+            var os = db.createObjectStore('TestObjectStore');
+            var transaction = event.target.transaction;
+            transaction.onabort = function(event) {
+                postResult('transaction is aborted');
+            }
+            transaction.oncomplete = function(event) {
+                postResult('transaction is completed');
+            }
+
+            postResult('database is created');
+
+            for (let i = 0; i < 1000; i ++)
+                os.put('TestValue', 'TestKey');
+        }
+        request.onerror = function(event) {
+            postResult('database error: ' + event.target.error.name + ' - ' + event.target.error.message);
+        }
+    } catch(err) {
+        postResult('database error: ' + err.name + ' - ' + err.message);
+    }
+    </script>
+    )TESTRESOURCE";
+
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto handler = adoptNS([[IndexedDBSuspendImminentlyMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/NavigationAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/NavigationAction.mm
@@ -30,6 +30,7 @@
 #import "PlatformUtilities.h"
 #import "Test.h"
 #import "TestNavigationDelegate.h"
+#import "TestUIDelegate.h"
 #import "TestWKWebView.h"
 #import <WebKit/WKNavigationActionPrivate.h>
 #import <wtf/RetainPtr.h>

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/RestoreLocalStorage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/RestoreLocalStorage.mm
@@ -138,36 +138,36 @@ TEST(WebKit, RestoreLocalStorageFromEphemeralDataStore)
 
 @end
 
-static NSString *mainFrameString = @"<script> \
-    function postResult(event) \
-    { \
-        window.webkit.messageHandlers.testHandler.postMessage(event.data); \
-    } \
-    addEventListener('message', postResult, false); \
-    </script> \
-    <iframe src='https://127.0.0.1:9091/'>";
-
-static constexpr auto frameBytes = R"TESTRESOURCE(
-<script>
-function postMessage(message)
-{
-    parent.postMessage(message, '*');
-}
-function item()
-{
-    result = localStorage.getItem('key');
-    if (!result) {
-        localStorage.setItem('key', 'value');
-        postMessage('Item is set');
-    } else
-        postMessage(result);
-}
-item();
-</script>
-)TESTRESOURCE"_s;
-
 static void testRestoreLocalStorageThirdPartyIFrame(RetainPtr<WKWebsiteDataStore> websiteDataStore)
 {
+    static NSString *mainFrameString = @"<script> \
+        function postResult(event) \
+        { \
+            window.webkit.messageHandlers.testHandler.postMessage(event.data); \
+        } \
+        addEventListener('message', postResult, false); \
+        </script> \
+        <iframe src='https://127.0.0.1:9091/'>";
+
+    static constexpr auto frameBytes = R"TESTRESOURCE(
+    <script>
+    function postMessage(message)
+    {
+        parent.postMessage(message, '*');
+    }
+    function item()
+    {
+        result = localStorage.getItem('key');
+        if (!result) {
+            localStorage.setItem('key', 'value');
+            postMessage('Item is set');
+        } else
+            postMessage(result);
+    }
+    item();
+    </script>
+    )TESTRESOURCE"_s;
+
     // Fetch Local Storage.
 
     // Clear the data store.

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/RestoreSessionStorage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/RestoreSessionStorage.mm
@@ -136,36 +136,36 @@ TEST(WebKit, RestoreSessionStorageFromEphemeralDataStore)
 
 @end
 
-static NSString *mainFrameString = @"<script> \
-    function postResult(event) \
-    { \
-        window.webkit.messageHandlers.testHandler.postMessage(event.data); \
-    } \
-    addEventListener('message', postResult, false); \
-    </script> \
-    <iframe src='https://127.0.0.1:9091/'>";
-
-static constexpr auto frameBytes = R"TESTRESOURCE(
-<script>
-function postMessage(message)
-{
-    parent.postMessage(message, '*');
-}
-function item()
-{
-    result = sessionStorage.getItem('key');
-    if (!result) {
-        sessionStorage.setItem('key', 'value');
-        postMessage('Item is set');
-    } else
-        postMessage(result);
-}
-item();
-</script>
-)TESTRESOURCE"_s;
-
 static void testRestoreSessionStorageThirdPartyIFrame(RetainPtr<WKWebsiteDataStore> websiteDataStore)
 {
+    static NSString *mainFrameString = @"<script> \
+        function postResult(event) \
+        { \
+            window.webkit.messageHandlers.testHandler.postMessage(event.data); \
+        } \
+        addEventListener('message', postResult, false); \
+        </script> \
+        <iframe src='https://127.0.0.1:9091/'>";
+
+    static constexpr auto frameBytes = R"TESTRESOURCE(
+    <script>
+    function postMessage(message)
+    {
+        parent.postMessage(message, '*');
+    }
+    function item()
+    {
+        result = sessionStorage.getItem('key');
+        if (!result) {
+            sessionStorage.setItem('key', 'value');
+            postMessage('Item is set');
+        } else
+            postMessage(result);
+    }
+    item();
+    </script>
+    )TESTRESOURCE"_s;
+
     // Fetch Session Storage.
 
     // Clear the data store.

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SystemPreview.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SystemPreview.mm
@@ -27,6 +27,7 @@
 
 #if (PLATFORM(IOS) || PLATFORM(VISION)) && USE(SYSTEM_PREVIEW)
 
+#import "PlatformUtilities.h"
 #import "TestUIDelegate.h"
 #import "TestWKWebViewController.h"
 #import "Utilities.h"

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextWidth.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextWidth.mm
@@ -25,7 +25,7 @@
 
 #import "config.h"
 
-#import "TestNSBundleExtras.h"
+#import "PlatformUtilities.h"
 #import "TestNavigationDelegate.h"
 #import "Utilities.h"
 #import <CoreText/CoreText.h>

--- a/Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm
@@ -39,6 +39,7 @@
 #import "UIKitSPIForTesting.h"
 #import "UserInterfaceSwizzler.h"
 #import "WKWebViewConfigurationExtras.h"
+#import <WebCore/Color.h>
 #import <WebKit/WKProcessPoolPrivate.h>
 #import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>

--- a/Tools/TestWebKitAPI/Tests/mac/WKWebViewMacEditingTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/WKWebViewMacEditingTests.mm
@@ -34,6 +34,7 @@
 #import "TestProtocol.h"
 #import "TestWKWebView.h"
 #import "WKWebViewConfigurationExtras.h"
+#import <WebCore/Color.h>
 #import <WebKit/WKProcessPoolPrivate.h>
 #import <WebKit/WKWebViewPrivateForTesting.h>
 #import <WebKit/_WKProcessPoolConfiguration.h>

--- a/Tools/TestWebKitAPI/cocoa/CGImagePixelReader.cpp
+++ b/Tools/TestWebKitAPI/cocoa/CGImagePixelReader.cpp
@@ -26,6 +26,9 @@
 #include "config.h"
 #include "CGImagePixelReader.h"
 
+#include <WebCore/Color.h>
+#include <wtf/Vector.h>
+
 namespace TestWebKitAPI {
 using namespace WebCore;
 

--- a/Tools/TestWebKitAPI/cocoa/HTTPServer.h
+++ b/Tools/TestWebKitAPI/cocoa/HTTPServer.h
@@ -30,6 +30,7 @@
 #import <wtf/Forward.h>
 #import <wtf/HashMap.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/text/StringHash.h>
 
 OBJC_CLASS NSURLRequest;
@@ -101,6 +102,8 @@ struct HTTPResponse {
         , body(bodyFromString(body)) { }
     HTTPResponse(Behavior behavior)
         : behavior(behavior) { }
+    HTTPResponse(NSData *data)
+        : body(makeVector(data)) { }
 
     HTTPResponse(const HTTPResponse&) = default;
     HTTPResponse(HTTPResponse&&) = default;

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
@@ -24,6 +24,7 @@
  */
 
 #import <WebKit/WebKit.h>
+#import <wtf/Forward.h>
 #import <wtf/RetainPtr.h>
 
 @class _WKFrameTreeNode;
@@ -65,6 +66,10 @@ struct AutocorrectionContext {
 };
 
 } // namespace TestWebKitAPI
+
+namespace WebCore {
+class Color;
+}
 
 @interface WKWebView (TestWebKitAPI)
 #if PLATFORM(IOS_FAMILY)
@@ -165,6 +170,8 @@ struct AutocorrectionContext {
 - (void)waitForPendingMouseEvents;
 - (void)focus;
 - (std::optional<CGPoint>)getElementMidpoint:(NSString *)selector;
+- (Vector<WebCore::Color>)sampleColors;
+- (Vector<WebCore::Color>)sampleColorsWithInterval:(unsigned)interval;
 @end
 
 #if PLATFORM(IOS_FAMILY)

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -26,6 +26,7 @@
 #import "config.h"
 #import "TestWKWebView.h"
 
+#import "CGImagePixelReader.h"
 #import "ClassMethodSwizzler.h"
 #import "InstanceMethodSwizzler.h"
 #import "PlatformUtilities.h"
@@ -33,6 +34,7 @@
 #import "TestNavigationDelegate.h"
 #import "Utilities.h"
 
+#import <WebCore/Color.h>
 #import <WebKit/WKContentWorld.h>
 #import <WebKit/WKUIDelegate.h>
 #import <WebKit/WKWebViewConfigurationPrivate.h>
@@ -47,6 +49,7 @@
 #import <wtf/BlockPtr.h>
 #import <wtf/Deque.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/Vector.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 
 #if PLATFORM(MAC)
@@ -1128,6 +1131,23 @@ static InputSessionChangeCount nextInputSessionChangeCount()
     if (midpoint.count != 2)
         return std::nullopt;
     return CGPointMake(midpoint.firstObject.doubleValue, midpoint.lastObject.doubleValue);
+}
+
+- (Vector<WebCore::Color>)sampleColors
+{
+    return [self sampleColorsWithInterval:TestWebKitAPI::CGImagePixelReader::defaultWebViewSamplingInterval];
+}
+
+- (Vector<WebCore::Color>)sampleColorsWithInterval:(unsigned)interval
+{
+    [self waitForNextPresentationUpdate];
+    Vector<WebCore::Color> samples;
+    TestWebKitAPI::CGImagePixelReader reader { [self snapshotAfterScreenUpdates] };
+    for (unsigned x = interval; x < reader.width() - interval; x += interval) {
+        for (unsigned y = interval; y < reader.height() - interval; y += interval)
+            samples.append(reader.at(x, y));
+    }
+    return samples;
 }
 
 #if PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### cf8519d4c46735412bfd7e9b52b8208810c6d3be
<pre>
Main frame PDFs served with CSP sandbox header do not load
<a href="https://bugs.webkit.org/show_bug.cgi?id=284594">https://bugs.webkit.org/show_bug.cgi?id=284594</a>
<a href="https://rdar.apple.com/141166987">rdar://141166987</a>

Reviewed by Wenson Hsieh.

The PDF plugin is an internal WebKit implementation detail, and thus
should not be subjected to the CSP sandbox. This patch makes sure we
bypass the sandbox in SubframeLoader::pluginIsLoadable(). Note that we
only do so for main frame PDFs. The embedded PDF case&apos;s behavior is
directed by <a href="https://github.com/whatwg/html/issues/3958">https://github.com/whatwg/html/issues/3958</a>, and the WPT
`html/semantics/embedded-content/the-iframe-element/sandbox_004.htm`.

Also, add two new API tests that assert correct loading behavior. The
latter enables UnifiedPDFPlugin while the former tests legacy PDF
plugin.

- ContentSecurityPolicy.LoadPDFWithSandboxCSPDirective
- UnifiedPDF.LoadPDFWithSandboxCSPDirective

The rest of the change involves adding new test helpers to facilitate
the API tests, TestWKWebView interface to sample colors (which, by the
way, should be adopted by many tests), and the fallout unified source
build fixes required for a clean build.

* Source/WebCore/html/HTMLPlugInImageElement.h:
* Source/WebCore/loader/SubframeLoader.cpp:
(WebCore::FrameLoader::SubframeLoader::pluginIsLoadable const):
(WebCore::FrameLoader::SubframeLoader::requestPlugin):
(WebCore::FrameLoader::SubframeLoader::pluginIsLoadable): Deleted.
* Source/WebCore/loader/SubframeLoader.h:
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/WKThumbnailView.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentSecurityPolicy.mm:
(TEST(ContentSecurityPolicy, LoadPDFWithSandboxCSPDirective)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentSecurityPolicyTestHelpers.h: Copied from Tools/TestWebKitAPI/cocoa/CGImagePixelReader.h.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentSecurityPolicyTestHelpers.mm: Copied from Tools/TestWebKitAPI/cocoa/CGImagePixelReader.h.
(TestWebKitAPI::runLoadPDFWithSandboxCSPDirectiveTest):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CookieAcceptPolicy.mm:

* Tools/TestWebKitAPI/Tests/WebKitCocoa/DocumentEditingContext.mm:
(applyStyle): Deleted.
(applyAhemStyle): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EditorStateTests.mm:
(): Deleted.
(TestWebKitAPI::applyAhemStyle): Deleted.

Fix ODR violation by pushing applyAhemStyle into specific namespaces.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/NavigationAction.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextWidth.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm:
(TestWebKitAPI::UNIFIED_PDF_TEST):
(TestWebKitAPI::sampleColorsInWebView): Deleted.
* Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm:
* Tools/TestWebKitAPI/Tests/mac/WKWebViewMacEditingTests.mm:
* Tools/TestWebKitAPI/cocoa/CGImagePixelReader.cpp:
* Tools/TestWebKitAPI/cocoa/CGImagePixelReader.h:
* Tools/TestWebKitAPI/cocoa/HTTPServer.h:
(TestWebKitAPI::HTTPResponse::HTTPResponse):
* Tools/TestWebKitAPI/cocoa/TestWKWebView.h:
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[TestWKWebView sampleColors]):
(-[TestWKWebView sampleColorsWithInterval:]):

Canonical link: <a href="https://commits.webkit.org/288060@main">https://commits.webkit.org/288060@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1bf319676a4989d7ae74a376368a6409cdfc42c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81775 "29 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1301 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35729 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/86322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32771 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83881 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1334 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9121 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/86322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21513 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84845 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/968 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74419 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/86322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/868 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28593 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31224 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29196 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87758 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9015 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72130 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9200 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70238 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71360 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17777 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15455 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14371 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8966 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/14498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8807 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12330 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10615 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->