### PR TITLE
[UnifiedPDF] [visionOS] PDF opening as thumbnail and pushed to the corner of Safari

### DIFF
--- a/Source/WebCore/page/ViewportConfiguration.h
+++ b/Source/WebCore/page/ViewportConfiguration.h
@@ -61,6 +61,8 @@ public:
 
         bool ignoreInitialScaleForLayoutWidth { false };
 
+        bool shouldHonorMinimumEffectiveDeviceWidthFromClient { true };
+
         friend bool operator==(const Parameters&, const Parameters&) = default;
     };
 
@@ -215,6 +217,7 @@ private:
     bool m_isKnownToLayOutWiderThanViewport { false };
     bool m_prefersHorizontalScrollingBelowDesktopViewportWidths { false };
     bool m_canIgnoreViewportArgumentsToAvoidExcessiveZoom { false };
+    bool m_minimumEffectiveDeviceWidthWasSetByClient { false };
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, const ViewportConfiguration::Parameters&);


### PR DESCRIPTION
#### a8debe65e40785cdfd2088195409132d66021e9d
<pre>
[UnifiedPDF] [visionOS] PDF opening as thumbnail and pushed to the corner of Safari
<a href="https://bugs.webkit.org/show_bug.cgi?id=284479">https://bugs.webkit.org/show_bug.cgi?id=284479</a>
<a href="https://rdar.apple.com/140186673">rdar://140186673</a>

Reviewed by Wenson Hsieh.

Safari on visionOS applies a minimum effective device width (mEDW) on
the web view. This makes for a very odd layout size, which results in
the PDF plugin being displayed in a tiny rect.

Unlike regular web content, PDF content does not reflow, and hence does
not require laying out a page at a given minimum width. As such, this
patch chooses to disregard the mEDW when the viewport is configured for
a plugin document.

We do so by adding `shouldHonorMinimumEffectiveDeviceWidthFromClient` to
ViewportConfigration::Parameters, and only setting that to false for
plugin document parameters. This option is consulted when we consider
the new effective width when the view layout size is updated (as part of
mEDW application), and is also consulted during regular viewport
configuration updates where we reset mEDW to 0 if the option is set.

* Source/WebCore/page/ViewportConfiguration.cpp:
(WebCore::ViewportConfiguration::setViewLayoutSize):
(WebCore::ViewportConfiguration::pluginDocumentParameters):
(WebCore::ViewportConfiguration::updateConfiguration):
(WebCore::operator&lt;&lt;):

Add a couple of missing flags in text stream dumping output.

* Source/WebCore/page/ViewportConfiguration.h:

Canonical link: <a href="https://commits.webkit.org/287797@main">https://commits.webkit.org/287797@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/233b4a9aab50bff7079d2940ccfe4609325452f6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80843 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/365 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34779 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85370 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31827 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82954 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/382 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8164 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63131 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20906 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83912 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/191 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73581 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43427 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27741 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30284 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71670 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28278 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86802 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8070 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5695 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71432 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8247 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69417 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70664 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17603 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14695 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13628 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8032 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13553 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7871 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11390 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9677 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->