### PR TITLE
[UnifiedPDF] [iOS] Text selection should clear when tapping outside of the selection

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -315,6 +315,7 @@ public:
 
 #if PLATFORM(IOS_FAMILY)
     virtual void setSelectionRange(WebCore::FloatPoint /* pointInRootView */, WebCore::TextGranularity) { }
+    virtual void clearSelection() { }
     virtual SelectionWasFlipped moveSelectionEndpoint(WebCore::FloatPoint /* pointInRootView */, SelectionEndpoint);
 #endif
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -579,6 +579,7 @@ private:
 
 #if PLATFORM(IOS_FAMILY)
     void setSelectionRange(WebCore::FloatPoint pointInRootView, WebCore::TextGranularity) final;
+    void clearSelection() final;
     SelectionWasFlipped moveSelectionEndpoint(WebCore::FloatPoint pointInRootView, SelectionEndpoint) final;
     bool platformPopulateEditorStateIfNeeded(EditorState&) const final;
 

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -1126,6 +1126,11 @@ SelectionWasFlipped PluginView::moveSelectionEndpoint(WebCore::FloatPoint pointI
     return protectedPlugin()->moveSelectionEndpoint(pointInRootView, endpoint);
 }
 
+void PluginView::clearSelection()
+{
+    protectedPlugin()->clearSelection();
+}
+
 #endif // PLATFORM(IOS_FAMILY)
 
 bool PluginView::populateEditorStateIfNeeded(EditorState& state) const

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -97,6 +97,7 @@ public:
 #if PLATFORM(IOS_FAMILY)
     void pluginDidInstallPDFDocument(double initialScaleFactor);
     void setSelectionRange(WebCore::FloatPoint pointInRootView, WebCore::TextGranularity);
+    void clearSelection();
     SelectionWasFlipped moveSelectionEndpoint(WebCore::FloatPoint pointInRootView, SelectionEndpoint);
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -981,6 +981,11 @@ void WebPage::completeSyntheticClick(Node& nodeRespondingToClick, const WebCore:
     if (m_isClosed)
         return;
 
+#if ENABLE(PDF_PLUGIN)
+    if (RefPtr pluginView = pluginViewForFrame(newFocusedFrame.get()))
+        pluginView->clearSelection();
+#endif
+
     invokePendingSyntheticClickCallback(SyntheticClickResult::Click);
 
     if ((!handledPress && !handledRelease) || !nodeRespondingToClick.isElementNode())
@@ -1353,6 +1358,13 @@ void WebPage::clearSelectionAfterTapIfNeeded()
     RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
     if (!frame)
         return;
+
+#if ENABLE(PDF_PLUGIN)
+    if (RefPtr pluginView = pluginViewForFrame(frame.get())) {
+        pluginView->clearSelection();
+        return;
+    }
+#endif
 
     if (frame->selection().selection().isContentEditable())
         return;
@@ -1898,6 +1910,10 @@ void WebPage::clearSelection()
     m_startingGestureRange = std::nullopt;
     RefPtr focusedOrMainFrame = m_page->checkedFocusController()->focusedOrMainFrame();
     focusedOrMainFrame->selection().clear();
+#if ENABLE(PDF_PLUGIN)
+    if (RefPtr pluginView = pluginViewForFrame(focusedOrMainFrame.get()))
+        pluginView->clearSelection();
+#endif
 }
 
 void WebPage::dispatchSyntheticMouseEventsForSelectionGesture(SelectionTouch touch, const IntPoint& point)


### PR DESCRIPTION
#### 4f4133c103f56f6f60b2e5f3ddcd29711ebde341
<pre>
[UnifiedPDF] [iOS] Text selection should clear when tapping outside of the selection
<a href="https://bugs.webkit.org/show_bug.cgi?id=284604">https://bugs.webkit.org/show_bug.cgi?id=284604</a>
<a href="https://rdar.apple.com/141325055">rdar://141325055</a>

Reviewed by Abrar Rahman Protyasha.

Clear the selection when tapping outside of the current selection, when unified PDF is enabled. The
way this works in normal web content is that we&apos;ll clear the selection by default if the synthetic
tap gesture is not handled — however, on iOS, tapping over the full-document `embed` (i.e. a
platform `Widget`) causes us to always handle the mouse press event resulting from the synthetic
click. Account for this by adding logic to call into the plugin view to dismiss the selection, when
this happens.

When tapping over the selection highlight, existing logic inside `-_shouldToggleEditMenuAfterTapAt:`
will prevent the synthetic click from committing altogether, thereby allowing the system text
interaction to toggle the edit menu.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::clearSelection):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::setCurrentSelection):
(WebKit::UnifiedPDFPlugin::clearSelection):

Add plumbing to clear the selection on the PDF plugin.

(WebKit::UnifiedPDFPlugin::platformPopulateEditorStateIfNeeded const):

Make a small adjustment here to ensure that when the selection is null, we still send a valid
(i.e. &quot;post-layout&quot;) editor state. This is necessary to ensure that we&apos;ll actually tell UIKit to
update the selection, rather than wait for the next editor state with post-layout data.

* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::clearSelection):
* Source/WebKit/WebProcess/Plugins/PluginView.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::commitPotentialTap):
(WebKit::WebPage::clearSelectionAfterTapIfNeeded):
(WebKit::WebPage::clearSelection):

Defer to the focused frame&apos;s plugin in several places, to clear the PDF&apos;s text selection.

Canonical link: <a href="https://commits.webkit.org/287791@main">https://commits.webkit.org/287791@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34062f8dedd2573f5192e8e776ba69db4a5a0078

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80829 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/351 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34765 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85356 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31813 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/368 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8150 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63115 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20895 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83898 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/175 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73569 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43419 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/97 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30270 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71658 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28263 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86788 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8056 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5687 "Found 1 new test failure: media/video-canvas-createPattern.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71409 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8233 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69405 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70650 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17601 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14680 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13620 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8018 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13539 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7857 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11376 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9663 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->