### PR TITLE
Further reduce use of memset()

### DIFF
--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -932,6 +932,20 @@ void memsetSpan(std::span<T, Extent> destination, uint8_t byte)
 }
 
 template<typename T, std::size_t Extent>
+void zeroSpan(std::span<T, Extent> destination)
+{
+    static_assert(std::is_trivially_copyable_v<T>);
+    memset(destination.data(), 0, destination.size_bytes());
+}
+
+template<typename T>
+void zeroBytes(T& object)
+{
+    static_assert(std::is_trivially_copyable_v<T>);
+    zeroSpan(asMutableByteSpan(object));
+}
+
+template<typename T, std::size_t Extent>
 void secureMemsetSpan(std::span<T, Extent> destination, uint8_t byte)
 {
     static_assert(std::is_trivially_copyable_v<T>);
@@ -1223,6 +1237,8 @@ using WTF::tryBinarySearch;
 using WTF::unsafeMakeSpan;
 using WTF::valueOrCompute;
 using WTF::valueOrDefault;
+using WTF::zeroBytes;
+using WTF::zeroSpan;
 using WTF::Invocable;
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/text/icu/TextBreakIteratorICU.h
+++ b/Source/WTF/wtf/text/icu/TextBreakIteratorICU.h
@@ -182,7 +182,7 @@ private:
             return AtomString::fromUTF8(scratchBuffer.subspan(0, lengthNeeded));
         if (needsToGrowToProduceBuffer(status)) {
             scratchBuffer.grow(lengthNeeded + 1);
-            memsetSpan(scratchBuffer.mutableSpan().subspan(utf8Locale.length()), 0);
+            zeroSpan(scratchBuffer.mutableSpan().subspan(utf8Locale.length()));
             status = U_ZERO_ERROR;
             int32_t lengthNeeded2 = uloc_setKeywordValue("lb", keywordValue, scratchBuffer.data(), scratchBuffer.size(), &status);
             if (!U_SUCCESS(status) || lengthNeeded != lengthNeeded2)

--- a/Source/WebCore/Modules/compression/CompressionStream.cpp
+++ b/Source/WebCore/Modules/compression/CompressionStream.cpp
@@ -32,7 +32,7 @@ namespace WebCore {
 CompressionStream::CompressionStream()
 {
 #if PLATFORM(COCOA)
-    memsetSpan(asMutableByteSpan(m_stream), 0);
+    zeroBytes(m_stream);
 #endif
 }
 

--- a/Source/WebCore/Modules/compression/ZStream.cpp
+++ b/Source/WebCore/Modules/compression/ZStream.cpp
@@ -74,7 +74,7 @@ bool ZStream::initializeIfNecessary(Algorithm algorithm, Operation operation)
 
 ZStream::ZStream()
 {
-    memsetSpan(asMutableByteSpan(m_stream), 0);
+    zeroBytes(m_stream);
 }
 
 ZStream::~ZStream()

--- a/Source/WebCore/Modules/webaudio/AudioScheduledSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioScheduledSourceNode.cpp
@@ -118,7 +118,7 @@ void AudioScheduledSourceNode::updateSchedulingInfo(size_t quantumFrameSize, Aud
     // Zero any initial frames representing silence leading up to a rendering start time in the middle of the quantum.
     if (quantumFrameOffset) {
         for (unsigned i = 0; i < outputBus.numberOfChannels(); ++i)
-            memsetSpan(outputBus.channel(i)->mutableSpan().first(quantumFrameOffset), 0);
+            zeroSpan(outputBus.channel(i)->mutableSpan().first(quantumFrameOffset));
     }
 
     // Handle silence after we're done playing.
@@ -140,7 +140,7 @@ void AudioScheduledSourceNode::updateSchedulingInfo(size_t quantumFrameSize, Aud
                 nonSilentFramesToProcess -= framesToZero;
 
             for (unsigned i = 0; i < outputBus.numberOfChannels(); ++i)
-                memsetSpan(outputBus.channel(i)->mutableSpan().subspan(zeroStartFrame, framesToZero), 0);
+                zeroSpan(outputBus.channel(i)->mutableSpan().subspan(zeroStartFrame, framesToZero));
         }
 
         finish();

--- a/Source/WebCore/Modules/webaudio/PeriodicWave.cpp
+++ b/Source/WebCore/Modules/webaudio/PeriodicWave.cpp
@@ -220,8 +220,8 @@ void PeriodicWave::createBandLimitedTables(const float* realData, const float* i
         unsigned clampedNumberOfComponents = std::min(numberOfComponents, numberOfPartials + 1);
         if (clampedNumberOfComponents < halfSize) {
             size_t numValues = halfSize - clampedNumberOfComponents;
-            memsetSpan(realP.span().subspan(clampedNumberOfComponents, numValues), 0);
-            memsetSpan(imagP.span().subspan(clampedNumberOfComponents, numValues), 0);
+            zeroSpan(realP.span().subspan(clampedNumberOfComponents, numValues));
+            zeroSpan(imagP.span().subspan(clampedNumberOfComponents, numValues));
         }
 
         // Clear packed-nyquist and any DC-offset.

--- a/Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp
+++ b/Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp
@@ -143,7 +143,7 @@ cbor::CBORValue::MapValue buildAttestationMap(Vector<uint8_t>&& authData, String
     if (attestation == AttestationConveyancePreference::None) {
         const size_t aaguidOffset = rpIdHashLength + flagsLength + signCounterLength;
         if (authData.size() >= aaguidOffset + aaguidLength && shouldZero == ShouldZeroAAGUID::Yes)
-            memsetSpan(authData.mutableSpan().subspan(aaguidOffset, aaguidLength), 0);
+            zeroSpan(authData.mutableSpan().subspan(aaguidOffset, aaguidLength));
         format = String::fromLatin1(noneAttestationValue);
         statementMap.clear();
     }

--- a/Source/WebCore/Modules/webauthn/fido/FidoHidPacket.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/FidoHidPacket.cpp
@@ -107,7 +107,7 @@ Vector<uint8_t> FidoHidInitPacket::getSerializedData() const
     serialized.appendVector(m_data);
     auto offset = serialized.size();
     serialized.grow(kHidPacketSize);
-    memsetSpan(serialized.mutableSpan().subspan(offset, kHidPacketSize - offset), 0);
+    zeroSpan(serialized.mutableSpan().subspan(offset, kHidPacketSize - offset));
 
     return serialized;
 }
@@ -155,7 +155,7 @@ Vector<uint8_t> FidoHidContinuationPacket::getSerializedData() const
     serialized.appendVector(m_data);
     auto offset = serialized.size();
     serialized.grow(kHidPacketSize);
-    memsetSpan(serialized.mutableSpan().subspan(offset, kHidPacketSize - offset), 0);
+    zeroSpan(serialized.mutableSpan().subspan(offset, kHidPacketSize - offset));
 
     return serialized;
 }

--- a/Source/WebCore/Modules/websockets/WebSocketDeflater.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketDeflater.cpp
@@ -52,7 +52,7 @@ WebSocketDeflater::WebSocketDeflater(int windowBits, ContextTakeOverMode context
     ASSERT(m_windowBits >= 8);
     ASSERT(m_windowBits <= 15);
     m_stream = makeUniqueWithoutFastMallocCheck<z_stream>();
-    memsetSpan(asMutableByteSpan(*m_stream), 0);
+    zeroBytes(*m_stream);
 }
 
 bool WebSocketDeflater::initialize()
@@ -138,7 +138,7 @@ WebSocketInflater::WebSocketInflater(int windowBits)
     : m_windowBits(windowBits)
     , m_stream(makeUniqueWithoutFastMallocCheck<z_stream>())
 {
-    memsetSpan(asMutableByteSpan(*m_stream), 0);
+    zeroBytes(*m_stream);
 }
 
 bool WebSocketInflater::initialize()

--- a/Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp
@@ -215,7 +215,7 @@ bool TextCodecUTF8::handlePartialSequence(LChar*& destination, std::span<const u
         bool partialSequenceIsTooShort = false;
         if (count > m_partialSequenceSize) {
             partialSequenceIsTooShort = true;
-            memsetSpan(std::span { m_partialSequence }.subspan(m_partialSequenceSize, count - m_partialSequenceSize), 0);
+            zeroSpan(std::span { m_partialSequence }.subspan(m_partialSequenceSize, count - m_partialSequenceSize));
         }
 
         int character = decodeNonASCIISequence(std::span { m_partialSequence }, count);
@@ -272,7 +272,7 @@ void TextCodecUTF8::handlePartialSequence(UChar*& destination, std::span<const u
         bool partialSequenceIsTooShort = false;
         if (count > m_partialSequenceSize) {
             partialSequenceIsTooShort = true;
-            memsetSpan(std::span { m_partialSequence }.subspan(m_partialSequenceSize, count - m_partialSequenceSize), 0);
+            zeroSpan(std::span { m_partialSequence }.subspan(m_partialSequenceSize, count - m_partialSequenceSize));
         }
 
         int character = decodeNonASCIISequence(std::span { m_partialSequence }, count);

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -56,7 +56,7 @@ TextMarkerData::TextMarkerData(AXObjectCache& cache, const VisiblePosition& visi
 {
     ASSERT(isMainThread());
 
-    memsetSpan(asMutableByteSpan(*this), 0);
+    zeroBytes(*this);
     treeID = cache.treeID().toUInt64();
     auto position = visiblePosition.deepEquivalent();
     auto optionalObjectID = nodeID(cache, position.anchorNode());
@@ -73,7 +73,7 @@ TextMarkerData::TextMarkerData(AXObjectCache& cache, const CharacterOffset& char
 {
     ASSERT(isMainThread());
 
-    memsetSpan(asMutableByteSpan(*this), 0);
+    zeroBytes(*this);
     treeID = cache.treeID().toUInt64();
     auto optionalObjectID = nodeID(cache, characterOffsetParam.node.get());
     objectID = optionalObjectID ? optionalObjectID->toUInt64() : 0;

--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -81,7 +81,7 @@ struct TextMarkerData {
     // For an example of such byte-comparison, see the TestRunner WTR::AccessibilityTextMarker::isEqual.
     TextMarkerData()
     {
-        memsetSpan(asMutableByteSpan(*this), 0);
+        zeroBytes(*this);
     }
 
     TextMarkerData(std::optional<AXID> axTreeID, std::optional<AXID> axObjectID,
@@ -90,7 +90,7 @@ struct TextMarkerData {
         Affinity affinityParam = Affinity::Downstream,
         unsigned charStart = 0, unsigned charOffset = 0, bool ignoredParam = false)
     {
-        memsetSpan(asMutableByteSpan(*this), 0);
+        zeroBytes(*this);
         treeID = axTreeID ? axTreeID->toUInt64() : 0;
         objectID = axObjectID ? axObjectID->toUInt64() : 0;
         offset = offsetParam;

--- a/Source/WebCore/loader/FTPDirectoryParser.h
+++ b/Source/WebCore/loader/FTPDirectoryParser.h
@@ -98,7 +98,7 @@ struct ListState {
         , carryBufferLength(0)
         , numLines(0)
     { 
-        memsetSpan(asMutableByteSpan(nowFTPTime), 0);
+        zeroBytes(nowFTPTime);
     }
     
     double      now;               /* needed for year determination */
@@ -135,7 +135,7 @@ struct ListResult
         linknameLength = 0;
         fileSize = { };
         caseSensitive = false;
-        memsetSpan(asMutableByteSpan(modifiedTime), 0);
+        zeroBytes(modifiedTime);
     }
 
     std::span<const char> filenameSpan() const { return { filename, filenameLength }; }

--- a/Source/WebCore/platform/audio/AudioArray.h
+++ b/Source/WebCore/platform/audio/AudioArray.h
@@ -102,23 +102,23 @@ public:
     T& operator[](size_t i) { return at(i); }
     const T& operator[](size_t i) const { return at(i); }
 
-    void zero() { memsetSpan(this->span(), 0); }
+    void zero() { zeroSpan(span()); }
 
     void zeroRange(unsigned start, unsigned end)
     {
-        bool isSafe = (start <= end) && (end <= this->size());
+        bool isSafe = (start <= end) && (end <= size());
         ASSERT(isSafe);
         if (!isSafe)
             return;
 
         // This expression cannot overflow because end - start cannot be
         // greater than m_size, which is safe due to the check in resize().
-        memsetSpan(this->span().subspan(start, end - start), 0);
+        zeroSpan(span().subspan(start, end - start));
     }
 
     void copyToRange(const T* sourceData, unsigned start, unsigned end)
     {
-        bool isSafe = (start <= end) && (end <= this->size());
+        bool isSafe = (start <= end) && (end <= size());
         ASSERT(isSafe);
         if (!isSafe)
             return;

--- a/Source/WebCore/platform/audio/AudioBus.cpp
+++ b/Source/WebCore/platform/audio/AudioBus.cpp
@@ -465,7 +465,7 @@ void AudioBus::copyWithGainFrom(const AudioBus& sourceBus, float gain)
             memcpySpan(destinations[channelIndex], sources[channelIndex].first(framesToProcess));
     } else if (!gain) {
         for (unsigned channelIndex = 0; channelIndex < numberOfChannels; ++channelIndex)
-            memsetSpan(destinations[channelIndex].first(framesToProcess), 0);
+            zeroSpan(destinations[channelIndex].first(framesToProcess));
     } else {
         for (unsigned channelIndex = 0; channelIndex < numberOfChannels; ++channelIndex)
             VectorMath::multiplyByScalar(sources[channelIndex].data(), gain, destinations[channelIndex].data(), framesToProcess);

--- a/Source/WebCore/platform/audio/AudioChannel.cpp
+++ b/Source/WebCore/platform/audio/AudioChannel.cpp
@@ -88,7 +88,7 @@ void AudioChannel::copyFromRange(const AudioChannel* sourceChannel, unsigned sta
         if (rangeLength == length())
             zero();
         else
-            memsetSpan(destination.first(rangeLength), 0);
+            zeroSpan(destination.first(rangeLength));
     } else
         memcpySpan(destination, source.subspan(startFrame, rangeLength));
 }

--- a/Source/WebCore/platform/audio/AudioChannel.h
+++ b/Source/WebCore/platform/audio/AudioChannel.h
@@ -108,7 +108,7 @@ public:
         if (m_memBuffer)
             m_memBuffer->zero();
         else
-            memsetSpan(mutableSpan(), 0);
+            zeroSpan(mutableSpan());
     }
 
     // Clears the silent flag.

--- a/Source/WebCore/platform/audio/DenormalDisabler.h
+++ b/Source/WebCore/platform/audio/DenormalDisabler.h
@@ -104,7 +104,7 @@ private:
         } __attribute__ ((aligned (16)));
 
         fxsaveResult registerData;
-        memsetSpan(asMutableByteSpan(registerData), 0);
+        zeroBytes(registerData);
         asm volatile("fxsave %0" : "=m" (registerData));
         s_isSupported = registerData.CSRMask & 0x0040;
         s_isInited = true;

--- a/Source/WebCore/platform/audio/PushPullFIFO.cpp
+++ b/Source/WebCore/platform/audio/PushPullFIFO.cpp
@@ -110,7 +110,7 @@ size_t PushPullFIFO::pull(AudioBus* outputBus, size_t framesRequested)
         // The frames available was not enough to fulfill the requested frames. Fill
         // the rest of the channel with silence.
         if (framesRequested > framesToFill)
-            memsetSpan(outputBusChannel.subspan(framesToFill, framesRequested - framesToFill), 0);
+            zeroSpan(outputBusChannel.subspan(framesToFill, framesRequested - framesToFill));
     }
 
     // Update the read index; wrap it around if necessary.

--- a/Source/WebCore/platform/audio/ReverbAccumulationBuffer.cpp
+++ b/Source/WebCore/platform/audio/ReverbAccumulationBuffer.cpp
@@ -64,12 +64,12 @@ void ReverbAccumulationBuffer::readAndClear(std::span<float> destination, size_t
 
     auto source = m_buffer.span();
     memcpySpan(destination, source.subspan(m_readIndex).first(numberOfFrames1));
-    memsetSpan(source.subspan(m_readIndex, numberOfFrames1), 0);
+    zeroSpan(source.subspan(m_readIndex, numberOfFrames1));
 
     // Handle wrap-around if necessary
     if (numberOfFrames2 > 0) {
         memcpySpan(destination.subspan(numberOfFrames1), source.first(numberOfFrames2));
-        memsetSpan(source.first(numberOfFrames2), 0);
+        zeroSpan(source.first(numberOfFrames2));
     }
 
     m_readIndex = (m_readIndex + numberOfFrames) % bufferLength;

--- a/Source/WebCore/platform/audio/SincResampler.cpp
+++ b/Source/WebCore/platform/audio/SincResampler.cpp
@@ -217,7 +217,7 @@ void SincResampler::processBuffer(std::span<const float> source, std::span<float
 
         // Zero-pad if necessary.
         if (framesToCopy < framesToProcess)
-            memsetSpan(buffer.subspan(framesToCopy, framesToProcess - framesToCopy), 0);
+            zeroSpan(buffer.subspan(framesToCopy, framesToProcess - framesToCopy));
 
         source = source.subspan(framesToCopy);
     });

--- a/Source/WebCore/platform/audio/cocoa/WebAudioBufferList.cpp
+++ b/Source/WebCore/platform/audio/cocoa/WebAudioBufferList.cpp
@@ -152,7 +152,7 @@ RetainPtr<CMBlockBufferRef> WebAudioBufferList::setSampleCountWithBlockBuffer(si
 
 void WebAudioBufferList::initializeList(std::span<uint8_t> buffer, size_t channelLength)
 {
-    memsetSpan(buffer, 0);
+    zeroSpan(buffer);
 
     for (uint32_t index = 0; index < m_canonicalList->mNumberBuffers; ++index) {
         m_canonicalList->mBuffers[index].mData = buffer.data() + channelLength * index;

--- a/Source/WebCore/platform/graphics/PixelBuffer.cpp
+++ b/Source/WebCore/platform/graphics/PixelBuffer.cpp
@@ -118,7 +118,7 @@ bool PixelBuffer::zeroRange(size_t byteOffset, size_t rangeByteLength)
     if (!isSumSmallerThanOrEqual(byteOffset, rangeByteLength, m_bytes.size()))
         return false;
 
-    memsetSpan(m_bytes.subspan(byteOffset, rangeByteLength), 0);
+    zeroSpan(m_bytes.subspan(byteOffset, rangeByteLength));
     return true;
 }
 

--- a/Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp
+++ b/Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp
@@ -1782,7 +1782,7 @@ void TransformationMatrix::blend(const TransformationMatrix& from, double progre
 bool TransformationMatrix::decompose2(Decomposed2Type& decomp) const
 {
     if (isIdentity()) {
-        memsetSpan(asMutableByteSpan(decomp), 0);
+        zeroBytes(decomp);
         decomp.scaleX = 1;
         decomp.scaleY = 1;
         decomp.m11 = 1;
@@ -1796,7 +1796,7 @@ bool TransformationMatrix::decompose2(Decomposed2Type& decomp) const
 bool TransformationMatrix::decompose4(Decomposed4Type& decomp) const
 {
     if (isIdentity()) {
-        memsetSpan(asMutableByteSpan(decomp), 0);
+        zeroBytes(decomp);
         decomp.perspectiveW = 1;
         decomp.scaleX = 1;
         decomp.scaleY = 1;

--- a/Source/WebCore/platform/image-decoders/bmp/BMPImageReader.cpp
+++ b/Source/WebCore/platform/image-decoders/bmp/BMPImageReader.cpp
@@ -54,7 +54,7 @@ BMPImageReader::BMPImageReader(ScalableImageDecoder* parent, size_t decodedAndHe
     , m_andMaskState(usesAndMask ? NotYetDecoded : None)
 {
     // Clue-in decodeBMP() that we need to detect the correct info header size.
-    memsetSpan(asMutableByteSpan(m_infoHeader), 0);
+    zeroBytes(m_infoHeader);
 }
 
 bool BMPImageReader::decodeBMP(bool onlySize)

--- a/Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.cpp
@@ -260,7 +260,7 @@ public:
         , m_state(JPEG_HEADER)
         , m_samples(0)
     {
-        memsetSpan(asMutableByteSpan(m_info), 0);
+        zeroBytes(m_info);
 
         // We set up the normal JPEG error routines, then override error_exit.
         m_info.err = jpeg_std_error(&m_err.pub);

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCDav1dDecoder.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCDav1dDecoder.cpp
@@ -174,7 +174,7 @@ int32_t Dav1dDecoder::Decode(const webrtc::EncodedImage& encodedImage, bool /*mi
 
     ScopedDav1dData scopedDav1dData;
     Dav1dData& dav1dData = scopedDav1dData.Data();
-    memsetSpan(asMutableByteSpan(dav1dData), 0);
+    zeroBytes(dav1dData);
     auto* data = encodedImage.data();
     auto size = encodedImage.size();
     if (!data || !size) {
@@ -190,7 +190,7 @@ int32_t Dav1dDecoder::Decode(const webrtc::EncodedImage& encodedImage, bool /*mi
 
     ScopedDav1dPicture scopedDav1dPicture;
     Dav1dPicture& dav1dPicture = scopedDav1dPicture.Picture();
-    memsetSpan(asMutableByteSpan(dav1dPicture), 0);
+    zeroBytes(dav1dPicture);
 
     if (int res = dav1d_get_picture(m_context, &dav1dPicture)) {
         RELEASE_LOG_ERROR(WebRTC, "Dav1dDecoder::Decode getting picture failed with error code %d", res);

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDeviceManager.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDeviceManager.cpp
@@ -38,6 +38,7 @@
 #include <wtf/Assertions.h>
 #include <wtf/MainThread.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/StdLibExtras.h>
 
 #import <pal/cf/CoreMediaSoftLink.h>
 
@@ -77,7 +78,7 @@ static bool deviceHasStreams(AudioObjectID deviceID, const AudioObjectPropertyAd
         return false;
 
     auto bufferList = std::unique_ptr<AudioBufferList>((AudioBufferList*) ::operator new (dataSize));
-    memset(bufferList.get(), 0, dataSize);
+    zeroSpan(unsafeMakeSpan(bufferList.get(), dataSize));
     err = AudioObjectGetPropertyData(deviceID, &address, 0, nullptr, &dataSize, bufferList.get());
 
     return !err && bufferList->mNumberBuffers;

--- a/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm
+++ b/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm
@@ -328,7 +328,7 @@ void MockAudioSharedInternalUnit::emitSampleBuffers(uint32_t frameCount)
     AudioUnitRenderActionFlags ioActionFlags = 0;
     
     AudioTimeStamp timeStamp;
-    memsetSpan(asMutableByteSpan(timeStamp), 0);
+    zeroBytes(timeStamp);
     timeStamp.mSampleTime = sampleTime;
     timeStamp.mHostTime = static_cast<UInt64>(sampleTime);
 

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -1287,7 +1287,7 @@ static void ignorableWhitespaceHandler(void*, const xmlChar*, int)
 void XMLDocumentParser::initializeParserContext(const CString& chunk)
 {
     xmlSAXHandler sax;
-    memsetSpan(asMutableByteSpan(sax), 0);
+    zeroBytes(sax);
 
     sax.error = normalErrorHandler;
     sax.fatalError = fatalErrorHandler;
@@ -1502,7 +1502,7 @@ std::optional<HashMap<String, String>> parseAttributes(CachedResourceLoader& cac
     AttributeParseState attributes;
 
     xmlSAXHandler sax;
-    memsetSpan(asMutableByteSpan(sax), 0);
+    zeroBytes(sax);
     sax.startElementNs = attributesStartElementNsHandler;
     sax.initialized = XML_SAX2_MAGIC;
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
@@ -97,7 +97,7 @@ void RemoteImageBuffer::getPixelBuffer(WebCore::PixelBufferFormat destinationFor
         MESSAGE_CHECK(pixelBuffer->bytes().size() <= memory->size(), "Shmem for return of getPixelBuffer is too small");
         memcpySpan(memory->mutableSpan(), pixelBuffer->bytes());
     } else
-        memsetSpan(memory->mutableSpan(), 0);
+        zeroSpan(memory->mutableSpan());
     completionHandler();
 }
 

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp
@@ -229,7 +229,7 @@ static bool connectToRemoteAddress(int socket, bool useIPv4)
     const int publicPort = 53;
 
     sockaddr_storage remoteAddressStorage;
-    memsetSpan(asMutableByteSpan(remoteAddressStorage), 0);
+    zeroBytes(remoteAddressStorage);
     size_t remoteAddressStorageLength = 0;
     if (useIPv4) {
         auto& remoteAddress = *reinterpret_cast<sockaddr_in*>(&remoteAddressStorage);
@@ -267,7 +267,7 @@ static bool connectToRemoteAddress(int socket, bool useIPv4)
 static std::optional<RTCNetwork::IPAddress> getSocketLocalAddress(int socket, bool useIPv4)
 {
     sockaddr_storage localAddressStorage;
-    memsetSpan(asMutableByteSpan(localAddressStorage), 0);
+    zeroBytes(localAddressStorage);
     socklen_t localAddressStorageLength = sizeof(sockaddr_storage);
     if (::getsockname(socket, reinterpret_cast<sockaddr*>(&localAddressStorage), &localAddressStorageLength) < 0) {
         RELEASE_LOG_ERROR(WebRTC, "getDefaultIPAddress getsockname failed, useIPv4=%d", useIPv4);

--- a/Source/WebKit/Platform/IPC/Encoder.cpp
+++ b/Source/WebKit/Platform/IPC/Encoder.cpp
@@ -162,7 +162,7 @@ std::span<uint8_t> Encoder::grow(size_t alignment, size_t size)
     reserve(alignedSize + size);
 
     auto capacityBuffer = this->capacityBuffer();
-    memsetSpan(capacityBuffer.subspan(m_bufferSize, alignedSize - m_bufferSize), 0);
+    zeroSpan(capacityBuffer.subspan(m_bufferSize, alignedSize - m_bufferSize));
 
     m_bufferSize = alignedSize + size;
 

--- a/Source/WebKit/Platform/IPC/darwin/IPCEventDarwin.cpp
+++ b/Source/WebKit/Platform/IPC/darwin/IPCEventDarwin.cpp
@@ -63,7 +63,7 @@ static void clearNoSenderNotifications(mach_port_t port)
 void Signal::signal()
 {
     mach_msg_header_t message;
-    memsetSpan(asMutableByteSpan(message), 0);
+    zeroBytes(message);
     message.msgh_remote_port = m_sendRight.sendRight();
     message.msgh_local_port = MACH_PORT_NULL;
     message.msgh_bits = MACH_MSGH_BITS(MACH_MSG_TYPE_COPY_SEND, 0);
@@ -111,7 +111,7 @@ typedef struct {
 bool Event::wait()
 {
     ReceiveMessage receiveMessage;
-    memsetSpan(asMutableByteSpan(receiveMessage), 0);
+    zeroBytes(receiveMessage);
     mach_msg_return_t ret = mach_msg(&receiveMessage.header, MACH_RCV_MSG, 0, sizeof(receiveMessage), m_receiveRight, MACH_MSG_TIMEOUT_NONE, MACH_PORT_NULL);
     if (ret != MACH_MSG_SUCCESS)
         return false;
@@ -123,7 +123,7 @@ bool Event::wait()
 bool Event::waitFor(Timeout timeout)
 {
     ReceiveMessage receiveMessage;
-    memsetSpan(asMutableByteSpan(receiveMessage), 0);
+    zeroBytes(receiveMessage);
     mach_msg_return_t ret = mach_msg(&receiveMessage.header, MACH_RCV_MSG | MACH_RCV_TIMEOUT, 0, sizeof(receiveMessage), m_receiveRight, timeout.secondsUntilDeadline().milliseconds(), MACH_PORT_NULL);
     if (ret != MACH_MSG_SUCCESS)
         return false;

--- a/Source/WebKit/Shared/API/APIClient.h
+++ b/Source/WebKit/Shared/API/APIClient.h
@@ -67,7 +67,7 @@ public:
             return;
         }
 
-        memsetSpan(asMutableByteSpan(m_client), 0);
+        zeroBytes(m_client);
 
         if (client && client->version < latestClientVersion) {
             auto interfaceSizes = InterfaceSizes<ClientVersions>::sizes();

--- a/Source/WebKit/Shared/SharedStringHashStore.cpp
+++ b/Source/WebKit/Shared/SharedStringHashStore.cpp
@@ -124,7 +124,7 @@ void SharedStringHashStore::resizeTable(unsigned newTableLength)
         return;
     }
 
-    memsetSpan(newTableMemory->mutableSpan(), 0);
+    zeroSpan(newTableMemory->mutableSpan());
 
     RefPtr<SharedMemory> currentTableMemory = m_table.sharedMemory();
     unsigned currentTableLength = m_tableLength;

--- a/Source/WebKit/Shared/SharedStringHashTable.cpp
+++ b/Source/WebKit/Shared/SharedStringHashTable.cpp
@@ -69,7 +69,7 @@ void SharedStringHashTable::clear()
     if (!m_sharedMemory)
         return;
 
-    memsetSpan(m_sharedMemory->mutableSpan(), 0);
+    zeroSpan(m_sharedMemory->mutableSpan());
     setSharedMemory(nullptr);
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm
@@ -439,7 +439,7 @@ static void setUpPageLoaderClient(WKBrowsingContextController *browsingContext, 
 ALLOW_DEPRECATED_DECLARATIONS_END
 {
     WKPageNavigationClientV0 loaderClient;
-    memsetSpan(asMutableByteSpan(loaderClient), 0);
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 0;
     loaderClient.base.clientInfo = (__bridge void*)browsingContext;
@@ -478,7 +478,7 @@ static void setUpPagePolicyClient(WKBrowsingContextController *browsingContext, 
 ALLOW_DEPRECATED_DECLARATIONS_END
 {
     WKPagePolicyClientInternal policyClient;
-    memsetSpan(asMutableByteSpan(policyClient), 0);
+    zeroBytes(policyClient);
 
     policyClient.base.version = 2;
     policyClient.base.clientInfo = (__bridge void*)browsingContext;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessGroup.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessGroup.mm
@@ -63,7 +63,7 @@ static void setUpInjectedBundleClient(WKProcessGroup *processGroup, WKContextRef
 ALLOW_DEPRECATED_DECLARATIONS_END
 {
     WKContextInjectedBundleClientV1 injectedBundleClient;
-    memsetSpan(asMutableByteSpan(injectedBundleClient), 0);
+    zeroBytes(injectedBundleClient);
 
     injectedBundleClient.base.version = 1;
     injectedBundleClient.base.clientInfo = (__bridge void*)processGroup;
@@ -132,7 +132,7 @@ static void setUpHistoryClient(WKProcessGroup *processGroup, WKContextRef contex
 ALLOW_DEPRECATED_DECLARATIONS_END
 {
     WKContextHistoryClientV0 historyClient;
-    memsetSpan(asMutableByteSpan(historyClient), 0);
+    zeroBytes(historyClient);
 
     historyClient.base.version = 0;
     historyClient.base.clientInfo = (__bridge CFTypeRef)processGroup;

--- a/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
+++ b/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
@@ -232,7 +232,7 @@ private:
 
         growCapacity(bufferSize.value());
 
-        memsetSpan(mutableBuffer().subspan(m_bufferSize, alignedSize - m_bufferSize), 0);
+        zeroSpan(mutableBuffer().subspan(m_bufferSize, alignedSize - m_bufferSize));
 
         m_bufferSize = bufferSize.value();
         m_bufferPointer = mutableBuffer().subspan(m_bufferSize).data();

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugIn.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugIn.mm
@@ -75,7 +75,7 @@ static void willDestroyPage(WKBundleRef bundle, WKBundlePageRef page, const void
 static void setUpBundleClient(WKWebProcessPlugInController *plugInController, WebKit::InjectedBundle& bundle)
 {
     WKBundleClientV1 bundleClient;
-    memsetSpan(asMutableByteSpan(bundleClient), 0);
+    zeroBytes(bundleClient);
 
     bundleClient.base.version = 1;
     bundleClient.base.clientInfo = (__bridge void*)plugInController;

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
@@ -255,7 +255,7 @@ static void didHandleOnloadEventsForFrame(WKBundlePageRef page, WKBundleFrameRef
 static void setUpPageLoaderClient(WKWebProcessPlugInBrowserContextController *contextController, WebKit::WebPage& page)
 {
     WKBundlePageLoaderClientV11 client;
-    memsetSpan(asMutableByteSpan(client), 0);
+    zeroBytes(client);
 
     client.base.version = 11;
     client.base.clientInfo = (__bridge void*)contextController;
@@ -352,7 +352,7 @@ static void didFailLoadForResource(WKBundlePageRef, WKBundleFrameRef frame, uint
 static void setUpResourceLoadClient(WKWebProcessPlugInBrowserContextController *contextController, WebKit::WebPage& page)
 {
     WKBundlePageResourceLoadClientV1 client;
-    memsetSpan(asMutableByteSpan(client), 0);
+    zeroBytes(client);
 
     client.base.version = 1;
     client.base.clientInfo = (__bridge void*) contextController;

--- a/Source/WebKitLegacy/mac/WebView/WebDynamicScrollBarsView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebDynamicScrollBarsView.mm
@@ -33,6 +33,7 @@
 #import <WebCore/LocalFrame.h>
 #import <WebCore/LocalFrameView.h>
 #import <WebCore/PlatformEventFactoryMac.h>
+#import <wtf/StdLibExtras.h>
 
 using namespace WebCore;
 
@@ -109,7 +110,7 @@ static Class customScrollerClass;
         return nil;
 
     _private = new WebDynamicScrollBarsViewPrivate;
-    memset(_private, 0, sizeof(WebDynamicScrollBarsViewPrivate));
+    zeroBytes(*_private);
     return self;
 }
 
@@ -119,7 +120,7 @@ static Class customScrollerClass;
         return nil;
 
     _private = new WebDynamicScrollBarsViewPrivate;
-    memset(_private, 0, sizeof(WebDynamicScrollBarsViewPrivate));
+    zeroBytes(*_private);
     return self;
 }
 

--- a/Tools/TestRunnerShared/IOSLayoutTestCommunication.cpp
+++ b/Tools/TestRunnerShared/IOSLayoutTestCommunication.cpp
@@ -32,6 +32,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <wtf/Assertions.h>
+#include <wtf/StdLibExtras.h>
 
 static int stdinSocket;
 static int stdoutSocket;
@@ -57,7 +58,7 @@ void setUpIOSLayoutTestCommunication()
 
     struct hostent* host = gethostbyname("127.0.0.1");
     struct sockaddr_in serverAddress;
-    memset((char*) &serverAddress, 0, sizeof(serverAddress));
+    zeroBytes(serverAddress);
     serverAddress.sin_family = AF_INET;
     memcpy(
         (char*)&serverAddress.sin_addr.s_addr,

--- a/Tools/TestWebKitAPI/Tests/InjectInternals_Bundle.cpp
+++ b/Tools/TestWebKitAPI/Tests/InjectInternals_Bundle.cpp
@@ -52,7 +52,7 @@ private:
     virtual void didCreatePage(WKBundleRef, WKBundlePageRef page)
     {
         WKBundlePageLoaderClientV0 loaderClient;
-        memset(&loaderClient, 0, sizeof(loaderClient));
+        zeroBytes(loaderClient);
 
         loaderClient.base.version = 0;
         loaderClient.base.clientInfo = this;

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
@@ -27,6 +27,7 @@
 
 #import "Test.h"
 #import "WTFTestUtilities.h"
+#import <wtf/StdLibExtras.h>
 #import <wtf/URL.h>
 #import <wtf/Vector.h>
 #import <wtf/cocoa/NSURLExtras.h>
@@ -312,11 +313,10 @@ TEST(WTF_URLExtras, URLExtras_ParsingError)
     EXPECT_TRUE(url4.string().is8Bit());
     EXPECT_STREQ([[url4 absoluteString] UTF8String], "%C3%82%C2%B6");
 
-    char buffer[100];
-    memset(buffer, 0, sizeof(buffer));
+    std::array<char, 100> buffer = { };
     WTF::URL url5 { "file:///A%C3%A7%C3%A3o.html"_str };
-    CFURLGetFileSystemRepresentation(url5.createCFURL().get(), false, reinterpret_cast<UInt8*>(buffer), sizeof(buffer));
-    EXPECT_STREQ(buffer, "/Ação.html");
+    CFURLGetFileSystemRepresentation(url5.createCFURL().get(), false, byteCast<UInt8>(buffer.data()), buffer.size());
+    EXPECT_STREQ(buffer.data(), "/Ação.html");
 }
 
 TEST(WTF_URLExtras, URLExtras_Nil)

--- a/Tools/TestWebKitAPI/Tests/WebKit/AboutBlankLoad.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/AboutBlankLoad.cpp
@@ -47,7 +47,7 @@ TEST(WebKit, AboutBlankLoad)
     PlatformWebView webView(context.get());
 
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 0;
     loaderClient.didFinishNavigation = didFinishNavigation;

--- a/Tools/TestWebKitAPI/Tests/WebKit/CanHandleRequest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/CanHandleRequest.cpp
@@ -49,7 +49,7 @@ static void didReceiveMessageFromInjectedBundle(WKContextRef, WKStringRef messag
 static void setInjectedBundleClient(WKContextRef context)
 {
     WKContextInjectedBundleClientV0 injectedBundleClient;
-    memset(&injectedBundleClient, 0, sizeof(injectedBundleClient));
+    zeroBytes(injectedBundleClient);
 
     injectedBundleClient.base.version = 0;
     injectedBundleClient.didReceiveMessageFromInjectedBundle = didReceiveMessageFromInjectedBundle;

--- a/Tools/TestWebKitAPI/Tests/WebKit/CloseFromWithinCreatePage.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/CloseFromWithinCreatePage.cpp
@@ -50,7 +50,7 @@ static WKPageRef createNewPageThenClose(WKPageRef page, WKPageConfigurationRef c
     openedWebView = makeUnique<PlatformWebView>(configuration);
 
     WKPageUIClientV6 uiClient;
-    memset(&uiClient, 0, sizeof(uiClient));
+    zeroBytes(uiClient);
 
     uiClient.base.version = 6;
     uiClient.runJavaScriptAlert = runJavaScriptAlert;
@@ -69,7 +69,7 @@ TEST(WebKit, CloseFromWithinCreatePage)
     PlatformWebView webView(context.get());
 
     WKPageUIClientV6 uiClient;
-    memset(&uiClient, 0, sizeof(uiClient));
+    zeroBytes(uiClient);
 
     uiClient.base.version = 6;
     uiClient.createNewPage = createNewPageThenClose;
@@ -96,7 +96,7 @@ static WKPageRef createNewPage(WKPageRef page, WKPageConfigurationRef configurat
     openedWebView = makeUnique<PlatformWebView>(configuration);
 
     WKPageUIClientV6 uiClient;
-    memset(&uiClient, 0, sizeof(uiClient));
+    zeroBytes(uiClient);
 
     uiClient.base.version = 6;
     uiClient.runJavaScriptAlert = runJavaScriptAlert;
@@ -113,7 +113,7 @@ TEST(WebKit, CreatePageThenDocumentOpenMIMEType)
     PlatformWebView webView(context.get());
 
     WKPageUIClientV6 uiClient;
-    memset(&uiClient, 0, sizeof(uiClient));
+    zeroBytes(uiClient);
 
     uiClient.base.version = 6;
     uiClient.createNewPage = createNewPage;

--- a/Tools/TestWebKitAPI/Tests/WebKit/CloseThenTerminate.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/CloseThenTerminate.cpp
@@ -48,7 +48,7 @@ TEST(WebKit, CloseThenTerminate)
     PlatformWebView webView(context.get());
 
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0 , sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 0;
     loaderClient.didFinishNavigation = didFinishNavigation;

--- a/Tools/TestWebKitAPI/Tests/WebKit/DOMWindowExtensionBasic.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/DOMWindowExtensionBasic.cpp
@@ -85,7 +85,7 @@ TEST(WebKit, DISABLED_DOMWindowExtensionBasic)
     WKRetainPtr<WKContextRef> context = adoptWK(Util::createContextForInjectedBundleTest("DOMWindowExtensionBasic"));
 
     WKContextInjectedBundleClientV0 injectedBundleClient;
-    memset(&injectedBundleClient, 0, sizeof(injectedBundleClient));
+    zeroBytes(injectedBundleClient);
 
     injectedBundleClient.base.version = 0;
     injectedBundleClient.didReceiveMessageFromInjectedBundle = didReceiveMessageFromInjectedBundle;
@@ -138,7 +138,7 @@ TEST(WebKit, DOMWindowExtensionCrashOnReload)
     WKRetainPtr<WKContextRef> context = adoptWK(Util::createContextForInjectedBundleTest("DOMWindowExtensionBasic"));
 
     WKContextInjectedBundleClientV0 injectedBundleClient;
-    memset(&injectedBundleClient, 0, sizeof(injectedBundleClient));
+    zeroBytes(injectedBundleClient);
 
     injectedBundleClient.base.version = 0;
     injectedBundleClient.didReceiveMessageFromInjectedBundle = didReceiveMessageFromInjectedBundle;

--- a/Tools/TestWebKitAPI/Tests/WebKit/DOMWindowExtensionBasic_Bundle.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/DOMWindowExtensionBasic_Bundle.cpp
@@ -151,7 +151,7 @@ void DOMWindowExtensionBasic::didCreatePage(WKBundleRef bundle, WKBundlePageRef 
     WKBundlePageAddUserScriptInWorld(page, source.get(), WKBundleScriptWorldCreateWorld(), kWKInjectAtDocumentStart, kWKInjectInAllFrames);
     
     WKBundlePageLoaderClientV1 pageLoaderClient;
-    memset(&pageLoaderClient, 0, sizeof(pageLoaderClient));
+    zeroBytes(pageLoaderClient);
     
     pageLoaderClient.base.version = 1;
     pageLoaderClient.base.clientInfo = this;

--- a/Tools/TestWebKitAPI/Tests/WebKit/DOMWindowExtensionNoCache.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/DOMWindowExtensionNoCache.cpp
@@ -86,7 +86,7 @@ TEST(WebKit, DISABLED_DOMWindowExtensionNoCache)
     WKRetainPtr<WKContextRef> context = adoptWK(Util::createContextForInjectedBundleTest("DOMWindowExtensionNoCache"));
 
     WKContextInjectedBundleClientV1 injectedBundleClient;
-    memset(&injectedBundleClient, 0, sizeof(injectedBundleClient));
+    zeroBytes(injectedBundleClient);
 
     injectedBundleClient.base.version = 1;
     injectedBundleClient.didReceiveMessageFromInjectedBundle = didReceiveMessageFromInjectedBundle;

--- a/Tools/TestWebKitAPI/Tests/WebKit/DOMWindowExtensionNoCache_Bundle.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/DOMWindowExtensionNoCache_Bundle.cpp
@@ -158,7 +158,7 @@ void DOMWindowExtensionNoCache::didCreatePage(WKBundleRef bundle, WKBundlePageRe
     WKBundlePageAddUserScriptInWorld(page, source.get(), WKBundleScriptWorldCreateWorld(), kWKInjectAtDocumentStart, kWKInjectInAllFrames);
 
     WKBundlePageLoaderClientV7 pageLoaderClient;
-    memset(&pageLoaderClient, 0, sizeof(pageLoaderClient));
+    zeroBytes(pageLoaderClient);
 
     pageLoaderClient.base.version = 7;
     pageLoaderClient.base.clientInfo = this;

--- a/Tools/TestWebKitAPI/Tests/WebKit/DeferredViewInWindowStateChange.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/DeferredViewInWindowStateChange.mm
@@ -44,7 +44,7 @@ static void didFinishNavigation(WKPageRef, WKNavigationRef, WKTypeRef, const voi
 static void setPageLoaderClient(WKPageRef page)
 {
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 0;
     loaderClient.didFinishNavigation = didFinishNavigation;

--- a/Tools/TestWebKitAPI/Tests/WebKit/DidAssociateFormControls.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/DidAssociateFormControls.cpp
@@ -63,7 +63,7 @@ static void didReceiveMessageFromInjectedBundle(WKContextRef, WKStringRef messag
 static void setInjectedBundleClient(WKContextRef context)
 {
     WKContextInjectedBundleClientV0 injectedBundleClient;
-    memset(&injectedBundleClient, 0, sizeof(injectedBundleClient));
+    zeroBytes(injectedBundleClient);
 
     injectedBundleClient.base.version = 0;
     injectedBundleClient.didReceiveMessageFromInjectedBundle = didReceiveMessageFromInjectedBundle;

--- a/Tools/TestWebKitAPI/Tests/WebKit/DidAssociateFormControls_Bundle.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/DidAssociateFormControls_Bundle.cpp
@@ -68,7 +68,7 @@ DidAssociateFormControlsTest::DidAssociateFormControlsTest(const std::string& id
 void DidAssociateFormControlsTest::didCreatePage(WKBundleRef bundle, WKBundlePageRef page)
 {
     WKBundlePageFormClientV2 formClient;
-    memset(&formClient, 0, sizeof(formClient));
+    zeroBytes(formClient);
 
     formClient.base.version = 2;
     formClient.base.clientInfo = this;

--- a/Tools/TestWebKitAPI/Tests/WebKit/DidNotHandleKeyDown.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/DidNotHandleKeyDown.cpp
@@ -51,7 +51,7 @@ TEST(WebKit, DidNotHandleKeyDown)
     PlatformWebView webView(context.get());
 
     WKPageUIClientV0 uiClient;
-    memset(&uiClient, 0, sizeof(uiClient));
+    zeroBytes(uiClient);
 
     uiClient.base.version = 0;
     uiClient.didNotHandleKeyEvent = didNotHandleKeyEventCallback;

--- a/Tools/TestWebKitAPI/Tests/WebKit/DidRemoveFrameFromHiearchyInPageCache.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/DidRemoveFrameFromHiearchyInPageCache.cpp
@@ -45,7 +45,7 @@ static void didFinishNavigation(WKPageRef, WKNavigationRef, WKTypeRef, const voi
 static void setPageLoaderClient(WKPageRef page)
 {
     WKPageNavigationClientV1 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 1;
     loaderClient.didFinishNavigation = didFinishNavigation;

--- a/Tools/TestWebKitAPI/Tests/WebKit/DidRemoveFrameFromHiearchyInPageCache_Bundle.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/DidRemoveFrameFromHiearchyInPageCache_Bundle.cpp
@@ -66,7 +66,7 @@ DidRemoveFrameFromHiearchyInBackForwardCacheTest::DidRemoveFrameFromHiearchyInBa
 void DidRemoveFrameFromHiearchyInBackForwardCacheTest::didCreatePage(WKBundleRef bundle, WKBundlePageRef page)
 {
     WKBundlePageLoaderClientV8 pageLoaderClient;
-    memset(&pageLoaderClient, 0, sizeof(pageLoaderClient));
+    zeroBytes(pageLoaderClient);
 
     pageLoaderClient.base.version = 8;
     pageLoaderClient.base.clientInfo = this;

--- a/Tools/TestWebKitAPI/Tests/WebKit/DocumentStartUserScriptAlertCrash.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/DocumentStartUserScriptAlertCrash.cpp
@@ -52,7 +52,7 @@ TEST(WebKit, DocumentStartUserScriptAlertCrashTest)
     PlatformWebView webView(context.get());
 
     WKPageUIClientV0 uiClient;
-    memset(&uiClient, 0, sizeof(uiClient));
+    zeroBytes(uiClient);
 
     uiClient.base.version = 0;
     uiClient.runJavaScriptAlert = runJavaScriptAlert;

--- a/Tools/TestWebKitAPI/Tests/WebKit/DownloadDecideDestinationCrash.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/DownloadDecideDestinationCrash.cpp
@@ -51,7 +51,7 @@ static WKStringRef decideDestinationWithSuggestedFilename(WKDownloadRef download
 static void navigationResponseDidBecomeDownload(WKPageRef page, WKNavigationResponseRef navigationResponse, WKDownloadRef download, const void* clientInfo)
 {
     WKDownloadClientV0 client;
-    memsetSpan(asMutableByteSpan(client), 0);
+    zeroBytes(client);
     client.base.version = 0;
     client.decideDestinationWithResponse = decideDestinationWithSuggestedFilename;
     WKDownloadSetClient(download, &client.base);
@@ -60,7 +60,7 @@ static void navigationResponseDidBecomeDownload(WKPageRef page, WKNavigationResp
 static void setPagePolicyClient(WKPageRef page)
 {
     WKPageNavigationClientV3 navigationClient;
-    memset(&navigationClient, 0, sizeof(navigationClient));
+    zeroBytes(navigationClient);
 
     navigationClient.base.version = 3;
     navigationClient.decidePolicyForNavigationResponse = decidePolicyForNavigationResponse;

--- a/Tools/TestWebKitAPI/Tests/WebKit/EnumerateMediaDevices.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/EnumerateMediaDevices.cpp
@@ -52,7 +52,7 @@ TEST(WebKit, EnumerateDevices)
     auto context = adoptWK(WKContextCreateWithConfiguration(nullptr));
 
     WKPageUIClientV6 uiClient;
-    memset(&uiClient, 0, sizeof(uiClient));
+    zeroBytes(uiClient);
     uiClient.base.version = 6;
     uiClient.checkUserMediaPermissionForOrigin = checkUserMediaPermissionCallback;
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/EphemeralSessionPushStateNoHistoryCallback.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/EphemeralSessionPushStateNoHistoryCallback.cpp
@@ -62,7 +62,7 @@ TEST(WebKit, EphemeralSessionPushStateNoHistoryCallback)
     WKPageConfigurationSetWebsiteDataStore(configuration.get(), websiteDataStore.get());
 
     WKContextHistoryClientV0 historyClient;
-    memset(&historyClient, 0, sizeof(historyClient));
+    zeroBytes(historyClient);
 
     historyClient.base.version = 0;
     historyClient.didNavigateWithNavigationData = didNavigateWithNavigationData;
@@ -72,7 +72,7 @@ TEST(WebKit, EphemeralSessionPushStateNoHistoryCallback)
     PlatformWebView webView(configuration.get());
 
     WKPageNavigationClientV0 pageLoaderClient;
-    memset(&pageLoaderClient, 0, sizeof(pageLoaderClient));
+    zeroBytes(pageLoaderClient);
 
     pageLoaderClient.base.version = 0;
     pageLoaderClient.didSameDocumentNavigation = didSameDocumentNavigation;

--- a/Tools/TestWebKitAPI/Tests/WebKit/EventModifiers.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/EventModifiers.cpp
@@ -50,13 +50,13 @@ static void mouseDidMoveOverElement(WKPageRef, WKHitTestResultRef, WKEventModifi
 static void setClients(WKPageRef page)
 {
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
     loaderClient.base.version = 0;
     loaderClient.didFinishNavigation = didFinishNavigation;
     WKPageSetPageNavigationClient(page, &loaderClient.base);
     
     WKPageUIClientV1 uiClient;
-    memset(&uiClient, 0, sizeof(uiClient));
+    zeroBytes(uiClient);
     uiClient.base.version = 1;
     uiClient.mouseDidMoveOverElement = mouseDidMoveOverElement;
     WKPageSetPageUIClient(page, &uiClient.base);

--- a/Tools/TestWebKitAPI/Tests/WebKit/FailedLoad.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/FailedLoad.cpp
@@ -55,7 +55,7 @@ TEST(WebKit, FailedLoad)
     PlatformWebView webView(context.get());
 
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 0;
     loaderClient.didFailProvisionalNavigation = didFailProvisionalNavigation;

--- a/Tools/TestWebKitAPI/Tests/WebKit/Find.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/Find.cpp
@@ -55,7 +55,7 @@ TEST(WebKit, Find)
     PlatformWebView webView(context.get());
     
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
     
     loaderClient.base.version = 0;
     loaderClient.didFinishNavigation = didFinishNavigation;
@@ -63,7 +63,7 @@ TEST(WebKit, Find)
     WKPageSetPageNavigationClient(webView.page(), &loaderClient.base);
 
     WKPageFindClientV0 findClient;
-    memset(&findClient, 0, sizeof(findClient));
+    zeroBytes(findClient);
 
     findClient.base.version = 0;
     findClient.didCountStringMatches = didCountStringMatches;

--- a/Tools/TestWebKitAPI/Tests/WebKit/FindMatches.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/FindMatches.mm
@@ -122,7 +122,7 @@ TEST(WebKit, FindMatches)
     PlatformWebView webView(context.get());
     
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
     
     loaderClient.base.version = 0;
     loaderClient.didFinishNavigation = didFinishNavigation;
@@ -130,7 +130,7 @@ TEST(WebKit, FindMatches)
     WKPageSetPageNavigationClient(webView.page(), &loaderClient.base);
 
     WKPageFindMatchesClientV0 findMatchesClient;
-    memset(&findMatchesClient, 0, sizeof(findMatchesClient));
+    zeroBytes(findMatchesClient);
 
     findMatchesClient.base.version = 0;
     findMatchesClient.didFindStringMatches = didFindStringMatches;

--- a/Tools/TestWebKitAPI/Tests/WebKit/FirstMeaningfulPaintMilestone.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/FirstMeaningfulPaintMilestone.cpp
@@ -44,7 +44,7 @@ static void didReachMilestone(WKPageRef, WKPageRenderingProgressEvents type, WKT
 static void setPageLoaderClient(WKPageRef page)
 {
     WKPageNavigationClientV3 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 3;
     loaderClient.renderingProgressDidChange = didReachMilestone;

--- a/Tools/TestWebKitAPI/Tests/WebKit/ForceRepaint.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/ForceRepaint.cpp
@@ -55,7 +55,7 @@ TEST(WebKit, ForceRepaint)
     PlatformWebView webView(context.get());
 
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 0;
     loaderClient.didFinishNavigation = didFinishNavigation;

--- a/Tools/TestWebKitAPI/Tests/WebKit/FrameMIMETypeHTML.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/FrameMIMETypeHTML.cpp
@@ -62,7 +62,7 @@ TEST(WebKit, FrameMIMETypeHTML)
     PlatformWebView webView(context.get());
 
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 0;
     loaderClient.didStartProvisionalNavigation = didStartProvisionalNavigation;

--- a/Tools/TestWebKitAPI/Tests/WebKit/FrameMIMETypePNG.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/FrameMIMETypePNG.cpp
@@ -61,7 +61,7 @@ TEST(WebKit, FrameMIMETypePNG)
     PlatformWebView webView(context.get());
 
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 0;
     loaderClient.didStartProvisionalNavigation = didStartProvisionalNavigation;

--- a/Tools/TestWebKitAPI/Tests/WebKit/Geolocation.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/Geolocation.cpp
@@ -105,7 +105,7 @@ void decidePolicyForGeolocationPermissionRequestCallBack(WKPageRef page, WKFrame
 void setupGeolocationProvider(WKContextRef context, void* clientInfo)
 {
     WKGeolocationProviderV1 providerCallback;
-    memset(&providerCallback, 0, sizeof(WKGeolocationProviderV1));
+    zeroBytes(providerCallback);
 
     providerCallback.base.version = 1;
     providerCallback.base.clientInfo = clientInfo;
@@ -124,7 +124,7 @@ void clearGeolocationProvider(WKContextRef context)
 void setupView(PlatformWebView& webView)
 {
     WKPageUIClientV2 uiClient;
-    memset(&uiClient, 0, sizeof(uiClient));
+    zeroBytes(uiClient);
 
     uiClient.base.version = 2;
     uiClient.decidePolicyForGeolocationPermissionRequest = decidePolicyForGeolocationPermissionRequestCallBack;
@@ -344,7 +344,7 @@ TEST(WebKit, GeolocationTransitionToLowAccuracy)
     JavaScriptAlertContext secondStepContext;
 
     WKPageUIClientV2 uiClient;
-    memset(&uiClient, 0, sizeof(uiClient));
+    zeroBytes(uiClient);
     uiClient.base.version = 2;
     uiClient.base.clientInfo = &secondStepContext;
     uiClient.decidePolicyForGeolocationPermissionRequest = decidePolicyForGeolocationPermissionRequestCallBack;
@@ -377,7 +377,7 @@ TEST(WebKit, GeolocationWatchMultiprocess)
     JavaScriptAlertContext testContext;
 
     WKPageUIClientV2 uiClient;
-    memset(&uiClient, 0, sizeof(uiClient));
+    zeroBytes(uiClient);
     uiClient.base.version = 2;
     uiClient.base.clientInfo = &testContext;
     uiClient.decidePolicyForGeolocationPermissionRequest = decidePolicyForGeolocationPermissionRequestCallBack;

--- a/Tools/TestWebKitAPI/Tests/WebKit/GetInjectedBundleInitializationUserDataCallback.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/GetInjectedBundleInitializationUserDataCallback.cpp
@@ -51,7 +51,7 @@ TEST(WebKit, GetInjectedBundleInitializationUserDataCallback)
     WKRetainPtr<WKContextRef> context = adoptWK(Util::createContextWithInjectedBundle());
 
     WKContextInjectedBundleClientV1 injectedBundleClient;
-    memset(&injectedBundleClient, 0, sizeof(injectedBundleClient));
+    zeroBytes(injectedBundleClient);
 
     injectedBundleClient.base.version = 1;
     injectedBundleClient.didReceiveMessageFromInjectedBundle = didReceiveMessageFromInjectedBundle;

--- a/Tools/TestWebKitAPI/Tests/WebKit/HitTestResultNodeHandle.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/HitTestResultNodeHandle.cpp
@@ -54,7 +54,7 @@ static void didReceiveMessageFromInjectedBundle(WKContextRef context, WKStringRe
 static void setPageLoaderClient(WKPageRef page)
 {
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 0;
     loaderClient.didFinishNavigation = didFinishNavigation;
@@ -65,7 +65,7 @@ static void setPageLoaderClient(WKPageRef page)
 static void setInjectedBundleClient(WKContextRef context)
 {
     WKContextInjectedBundleClientV0 injectedBundleClient;
-    memset(&injectedBundleClient, 0, sizeof(injectedBundleClient));
+    zeroBytes(injectedBundleClient);
 
     injectedBundleClient.base.version = 0;
     injectedBundleClient.didReceiveMessageFromInjectedBundle = didReceiveMessageFromInjectedBundle;

--- a/Tools/TestWebKitAPI/Tests/WebKit/HitTestResultNodeHandle_Bundle.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/HitTestResultNodeHandle_Bundle.cpp
@@ -57,7 +57,7 @@ public:
     virtual void didCreatePage(WKBundleRef bundle, WKBundlePageRef page)
     {
         WKBundlePageContextMenuClientV0 contextMenuClient;
-        memset(&contextMenuClient, 0, sizeof(contextMenuClient));
+        zeroBytes(contextMenuClient);
 
         contextMenuClient.base.version = 0;
         contextMenuClient.getContextMenuFromDefaultMenu = getContextMenuFromDefaultMenu;

--- a/Tools/TestWebKitAPI/Tests/WebKit/InjectedBundleBasic.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/InjectedBundleBasic.cpp
@@ -56,7 +56,7 @@ TEST(WebKit, InjectedBundleBasic)
     WKRetainPtr<WKContextRef> context = adoptWK(Util::createContextForInjectedBundleTest("InjectedBundleBasicTest"));
 
     WKContextInjectedBundleClientV0 injectedBundleClient;
-    memset(&injectedBundleClient, 0, sizeof(injectedBundleClient));
+    zeroBytes(injectedBundleClient);
 
     injectedBundleClient.base.version = 0;
     injectedBundleClient.didReceiveMessageFromInjectedBundle = didReceiveMessageFromInjectedBundle;
@@ -66,7 +66,7 @@ TEST(WebKit, InjectedBundleBasic)
     PlatformWebView webView(context.get());
 
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 0;
     loaderClient.didFinishNavigation = didFinishNavigation;

--- a/Tools/TestWebKitAPI/Tests/WebKit/InjectedBundleDisableOverrideBuiltinsBehavior.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/InjectedBundleDisableOverrideBuiltinsBehavior.cpp
@@ -54,7 +54,7 @@ TEST(WebKit, InjectedBundleNoDisableOverrideBuiltinsBehaviorTest)
     PlatformWebView webView(context.get());
 
     WKPageUIClientV0 uiClient;
-    memset(&uiClient, 0, sizeof(uiClient));
+    zeroBytes(uiClient);
 
     uiClient.base.version = 0;
     uiClient.runJavaScriptAlert = runJavaScriptAlertEnabled;
@@ -86,7 +86,7 @@ TEST(WebKit, InjectedBundleDisableOverrideBuiltinsBehaviorTest)
     PlatformWebView webView(context.get());
 
     WKPageUIClientV0 uiClient;
-    memset(&uiClient, 0, sizeof(uiClient));
+    zeroBytes(uiClient);
 
     uiClient.base.version = 0;
     uiClient.runJavaScriptAlert = runJavaScriptAlertDisabled;

--- a/Tools/TestWebKitAPI/Tests/WebKit/InjectedBundleFrameHitTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/InjectedBundleFrameHitTest.cpp
@@ -47,7 +47,7 @@ static void didReceiveMessageFromInjectedBundle(WKContextRef context, WKStringRe
 static void setInjectedBundleClient(WKContextRef context)
 {
     WKContextInjectedBundleClientV0 injectedBundleClient;
-    memset(&injectedBundleClient, 0, sizeof(injectedBundleClient));
+    zeroBytes(injectedBundleClient);
 
     injectedBundleClient.base.version = 0;
     injectedBundleClient.didReceiveMessageFromInjectedBundle = didReceiveMessageFromInjectedBundle;

--- a/Tools/TestWebKitAPI/Tests/WebKit/InjectedBundleFrameHitTest_Bundle.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/InjectedBundleFrameHitTest_Bundle.cpp
@@ -62,7 +62,7 @@ void InjectedBundleFrameHitTestTest::didCreatePage(WKBundleRef bundle, WKBundleP
     m_bundle = bundle;
 
     WKBundlePageLoaderClientV1 pageLoaderClient;
-    memset(&pageLoaderClient, 0, sizeof(pageLoaderClient));
+    zeroBytes(pageLoaderClient);
     
     pageLoaderClient.base.version = 1;
     pageLoaderClient.base.clientInfo = this;

--- a/Tools/TestWebKitAPI/Tests/WebKit/InjectedBundleInitializationUserDataCallbackWins.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/InjectedBundleInitializationUserDataCallbackWins.cpp
@@ -53,7 +53,7 @@ TEST(WebKit, InjectedBundleInitializationUserDataCallbackWins)
     WKContextSetInitializationUserDataForInjectedBundle(context.get(), initializationDictionary.get());
 
     WKContextInjectedBundleClientV1 injectedBundleClient;
-    memset(&injectedBundleClient, 0, sizeof(injectedBundleClient));
+    zeroBytes(injectedBundleClient);
 
     injectedBundleClient.base.version = 1;
     injectedBundleClient.didReceiveMessageFromInjectedBundle = didReceiveMessageFromInjectedBundle;

--- a/Tools/TestWebKitAPI/Tests/WebKit/InjectedBundleMakeAllShadowRootsOpen.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/InjectedBundleMakeAllShadowRootsOpen.cpp
@@ -89,7 +89,7 @@ TEST(WebKit, InjectedBundleMakeAllShadowRootOpenTest)
     PlatformWebView webView(context.get());
 
     WKPageUIClientV0 uiClient;
-    memset(&uiClient, 0, sizeof(uiClient));
+    zeroBytes(uiClient);
 
     uiClient.base.version = 0;
     uiClient.runJavaScriptAlert = runJavaScriptAlert;

--- a/Tools/TestWebKitAPI/Tests/WebKit/LayoutMilestonesWithAllContentInFrame.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/LayoutMilestonesWithAllContentInFrame.cpp
@@ -57,7 +57,7 @@ TEST(WebKit, LayoutMilestonesWithAllContentInFrame)
     PlatformWebView webView(context.get());
 
     WKPageNavigationClientV3 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 3;
     loaderClient.base.clientInfo = &webView;
@@ -81,7 +81,7 @@ TEST(WebKit, FirstVisuallyNonEmptyLayoutAfterPageCacheRestore)
     PlatformWebView webView(context.get());
 
     WKPageNavigationClientV3 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 3;
     loaderClient.base.clientInfo = &webView;
@@ -123,7 +123,7 @@ TEST(WebKit, FirstVisuallyNonEmptyMilestoneWithLoadComplete)
     PlatformWebView webView(context.get());
 
     WKPageNavigationClientV3 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 3;
     loaderClient.base.clientInfo = &webView;

--- a/Tools/TestWebKitAPI/Tests/WebKit/LoadAlternateHTMLStringWithNonDirectoryURL.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/LoadAlternateHTMLStringWithNonDirectoryURL.cpp
@@ -51,7 +51,7 @@ static void loadAlternateHTMLString(WKURLRef baseURL, WKURLRef unreachableURL)
     PlatformWebView webView(context.get());
 
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
     
     loaderClient.base.version = 0;
     loaderClient.didFinishNavigation = didFinishNavigation;

--- a/Tools/TestWebKitAPI/Tests/WebKit/LoadCanceledNoServerRedirectCallback.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/LoadCanceledNoServerRedirectCallback.cpp
@@ -56,7 +56,7 @@ TEST(WebKit, LoadCanceledNoServerRedirectCallback)
     WKRetainPtr<WKContextRef> context = adoptWK(Util::createContextForInjectedBundleTest("LoadCanceledNoServerRedirectCallbackTest"));
     
     WKContextInjectedBundleClientV0 injectedBundleClient;
-    memset(&injectedBundleClient, 0, sizeof(injectedBundleClient));
+    zeroBytes(injectedBundleClient);
 
     injectedBundleClient.base.version = 0;
 
@@ -65,7 +65,7 @@ TEST(WebKit, LoadCanceledNoServerRedirectCallback)
     PlatformWebView webView(context.get());
 
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
     
     loaderClient.base.version = 0;
     loaderClient.didFinishNavigation = didFinishNavigation;
@@ -73,7 +73,7 @@ TEST(WebKit, LoadCanceledNoServerRedirectCallback)
     WKPageSetPageNavigationClient(webView.page(), &loaderClient.base);
     
     WKContextHistoryClientV0 historyClient;
-    memset(&historyClient, 0, sizeof(historyClient));
+    zeroBytes(historyClient);
     
     historyClient.base.version = 0;
     historyClient.didPerformServerRedirect = didPerformServerRedirect;

--- a/Tools/TestWebKitAPI/Tests/WebKit/LoadCanceledNoServerRedirectCallback_Bundle.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/LoadCanceledNoServerRedirectCallback_Bundle.cpp
@@ -59,7 +59,7 @@ public:
     virtual void didCreatePage(WKBundleRef bundle, WKBundlePageRef page)
     {
         WKBundlePageResourceLoadClientV0 resourceLoadClient;
-        memset(&resourceLoadClient, 0, sizeof(resourceLoadClient));
+        zeroBytes(resourceLoadClient);
         
         resourceLoadClient.base.version = 0;
         resourceLoadClient.willSendRequestForFrame = willSendRequestForFrame;

--- a/Tools/TestWebKitAPI/Tests/WebKit/LoadPageOnCrash.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/LoadPageOnCrash.cpp
@@ -45,7 +45,7 @@ public:
         , firstSuccessfulLoad(false)
         , secondSuccessfulLoad(false)
     {
-        memset(&loaderClient, 0, sizeof(loaderClient));
+        zeroBytes(loaderClient);
 
         loaderClient.base.version = 0;
         loaderClient.base.clientInfo = this;

--- a/Tools/TestWebKitAPI/Tests/WebKit/MenuTypesForMouseEvents.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/MenuTypesForMouseEvents.cpp
@@ -43,7 +43,7 @@ static void didFinishNavigation(WKPageRef, WKNavigationRef, WKTypeRef, const voi
 static void setPageLoaderClient(WKPageRef page)
 {
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 0;
     loaderClient.didFinishNavigation = didFinishNavigation;

--- a/Tools/TestWebKitAPI/Tests/WebKit/ModalAlertsSPI.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/ModalAlertsSPI.cpp
@@ -107,7 +107,7 @@ static WKPageRef createNewPage(WKPageRef page, WKPageConfigurationRef configurat
     openedWebView = makeUnique<PlatformWebView>(configuration);
 
     WKPageUIClientV6 uiClient;
-    memset(&uiClient, 0, sizeof(uiClient));
+    zeroBytes(uiClient);
 
     uiClient.base.version = 6;
     uiClient.runJavaScriptAlert = runJavaScriptAlert;
@@ -127,7 +127,7 @@ TEST(WebKit, ModalAlertsSPI)
     PlatformWebView webView(context.get());
 
     WKPageUIClientV6 uiClient;
-    memset(&uiClient, 0, sizeof(uiClient));
+    zeroBytes(uiClient);
 
     uiClient.base.version = 6;
     uiClient.createNewPage = createNewPage;
@@ -158,7 +158,7 @@ TEST(WebKit, CreateNewPageDelegateFrameLoadState)
         PlatformWebView webView(context.get());
 
         WKPageUIClientV6 uiClient;
-        memset(&uiClient, 0, sizeof(uiClient));
+        zeroBytes(uiClient);
         uiClient.base.version = 6;
         uiClient.createNewPage = checkFrameLoadStateAndCreateNewPage;
         WKPageSetPageUIClient(webView.page(), &uiClient.base);

--- a/Tools/TestWebKitAPI/Tests/WebKit/MouseMoveAfterCrash.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/MouseMoveAfterCrash.cpp
@@ -43,7 +43,7 @@ static void didFinishNavigation(WKPageRef, WKNavigationRef, WKTypeRef, const voi
 static void setPageLoaderClient(WKPageRef page)
 {
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 0;
     loaderClient.didFinishNavigation = didFinishNavigation;

--- a/Tools/TestWebKitAPI/Tests/WebKit/NavigationClientDefaultCrypto.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/NavigationClientDefaultCrypto.cpp
@@ -62,7 +62,7 @@ TEST(WebKit, NavigationClientDefaultCrypto)
     // The navigationClient quite explicitly does *not* have a copyWebCryptoMasterKey callback,
     // which allows this test to make sure that WebKit2 instead creates a default crypto master key.
     WKPageNavigationClientV0 navigationClient;
-    memset(&navigationClient, 0, sizeof(navigationClient));
+    zeroBytes(navigationClient);
     navigationClient.base.version = 0;
     navigationClient.decidePolicyForNavigationAction = decidePolicyForNavigationAction;
     navigationClient.decidePolicyForNavigationResponse = decidePolicyForNavigationResponse;
@@ -70,7 +70,7 @@ TEST(WebKit, NavigationClientDefaultCrypto)
     WKPageSetPageNavigationClient(webView.page(), &navigationClient.base);
 
     WKPageUIClientV5 uiClient;
-    memset(&uiClient, 0, sizeof(uiClient));
+    zeroBytes(uiClient);
     uiClient.base.version = 5;
     uiClient.runJavaScriptAlert = runJavaScriptAlert;
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/NetworkProcessCrashWithPendingConnection.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/NetworkProcessCrashWithPendingConnection.mm
@@ -70,7 +70,7 @@ TEST(WebKit, NetworkProcessCrashWithPendingConnection)
 
     // FIXME: Adopt the new API once it's added in webkit.org/b/174061.
     WKContextClientV0 client;
-    memsetSpan(asMutableByteSpan(client), 0);
+    zeroBytes(client);
     client.networkProcessDidCrash = [](WKContextRef context, const void* clientInfo) {
         networkProcessCrashed = true;
     };
@@ -137,7 +137,7 @@ TEST(WebKit, NetworkProcessRelaunchOnLaunchFailure)
     networkProcessCrashed = false;
 
     WKContextClientV0 client;
-    memsetSpan(asMutableByteSpan(client), 0);
+    zeroBytes(client);
     client.networkProcessDidCrash = [](WKContextRef context, const void* clientInfo) {
         networkProcessCrashed = true;
     };

--- a/Tools/TestWebKitAPI/Tests/WebKit/NewFirstVisuallyNonEmptyLayout.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/NewFirstVisuallyNonEmptyLayout.cpp
@@ -61,7 +61,7 @@ static void didLayout(WKPageRef, WKPageRenderingProgressEvents type, WKTypeRef, 
 static void setPageLoaderClient(WKPageRef page)
 {
     WKPageNavigationClientV3 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 3;
     loaderClient.renderingProgressDidChange = didLayout;

--- a/Tools/TestWebKitAPI/Tests/WebKit/NewFirstVisuallyNonEmptyLayoutFails.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/NewFirstVisuallyNonEmptyLayoutFails.cpp
@@ -60,7 +60,7 @@ static void didLayout(WKPageRef, WKPageRenderingProgressEvents type, WKTypeRef, 
 static void setPageLoaderClient(WKPageRef page)
 {
     WKPageNavigationClientV3 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 3;
     loaderClient.didFinishNavigation = didFinishNavigation;

--- a/Tools/TestWebKitAPI/Tests/WebKit/NewFirstVisuallyNonEmptyLayoutForImages.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/NewFirstVisuallyNonEmptyLayoutForImages.cpp
@@ -61,7 +61,7 @@ static void didLayout(WKPageRef, WKPageRenderingProgressEvents type, WKTypeRef, 
 static void setPageLoaderClient(WKPageRef page)
 {
     WKPageNavigationClientV3 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 3;
     loaderClient.renderingProgressDidChange = didLayout;

--- a/Tools/TestWebKitAPI/Tests/WebKit/NewFirstVisuallyNonEmptyLayoutFrames.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/NewFirstVisuallyNonEmptyLayoutFrames.cpp
@@ -65,7 +65,7 @@ static void renderingProgressDidChange(WKPageRef, WKPageRenderingProgressEvents 
 static void setPageLoaderClient(WKPageRef page)
 {
     WKPageNavigationClientV3 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 3;
     loaderClient.didFinishNavigation = didFinishNavigation;

--- a/Tools/TestWebKitAPI/Tests/WebKit/PageLoadBasic.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/PageLoadBasic.cpp
@@ -112,7 +112,7 @@ TEST(WebKit, PageLoadBasic)
     PlatformWebView webView(context.get());
 
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 0;
     loaderClient.base.clientInfo = &state;
@@ -167,7 +167,7 @@ TEST(WebKit, PageLoadTwiceAndReload)
     static unsigned loadsCount = 0;
 
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
     loaderClient.base.version = 0;
     loaderClient.base.clientInfo = nullptr;
     loaderClient.didFailProvisionalNavigation = [](WKPageRef page, WKNavigationRef, WKErrorRef error, WKTypeRef userData, const void *clientInfo) {

--- a/Tools/TestWebKitAPI/Tests/WebKit/PageLoadDidChangeLocationWithinPageForFrame.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/PageLoadDidChangeLocationWithinPageForFrame.cpp
@@ -56,7 +56,7 @@ TEST(WebKit, PageLoadDidChangeLocationWithinPage)
     PlatformWebView webView(context.get());
 
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 0;
     loaderClient.didFinishNavigation = [] (WKPageRef, WKNavigationRef, WKTypeRef, const void*) {

--- a/Tools/TestWebKitAPI/Tests/WebKit/ParentFrame.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/ParentFrame.cpp
@@ -49,7 +49,7 @@ static void didReceiveMessageFromInjectedBundle(WKContextRef, WKStringRef messag
 static void setInjectedBundleClient(WKContextRef context)
 {
     WKContextInjectedBundleClientV0 injectedBundleClient;
-    memset(&injectedBundleClient, 0, sizeof(injectedBundleClient));
+    zeroBytes(injectedBundleClient);
 
     injectedBundleClient.base.version = 0;
     injectedBundleClient.didReceiveMessageFromInjectedBundle = didReceiveMessageFromInjectedBundle;

--- a/Tools/TestWebKitAPI/Tests/WebKit/ParentFrame_Bundle.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/ParentFrame_Bundle.cpp
@@ -73,7 +73,7 @@ void ParentFrameTest::didCreatePage(WKBundleRef bundle, WKBundlePageRef page)
     testBundle = bundle;
     
     WKBundlePageLoaderClientV1 pageLoaderClient;
-    memset(&pageLoaderClient, 0, sizeof(pageLoaderClient));
+    zeroBytes(pageLoaderClient);
     
     pageLoaderClient.base.version = 1;
     pageLoaderClient.didFinishLoadForFrame = didFinishLoadForFrame;

--- a/Tools/TestWebKitAPI/Tests/WebKit/PasteboardNotifications.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/PasteboardNotifications.mm
@@ -50,7 +50,7 @@ static void didReceiveMessageFromInjectedBundle(WKContextRef context, WKStringRe
 static void setInjectedBundleClient(WKContextRef context)
 {
     WKContextInjectedBundleClientV0 injectedBundleClient;
-    memset(&injectedBundleClient, 0, sizeof(injectedBundleClient));
+    zeroBytes(injectedBundleClient);
 
     injectedBundleClient.base.version = 0;
     injectedBundleClient.didReceiveMessageFromInjectedBundle = didReceiveMessageFromInjectedBundle;

--- a/Tools/TestWebKitAPI/Tests/WebKit/PasteboardNotifications_Bundle.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/PasteboardNotifications_Bundle.cpp
@@ -73,7 +73,7 @@ PasteboardNotificationsTest::PasteboardNotificationsTest(const std::string& iden
 void PasteboardNotificationsTest::didCreatePage(WKBundleRef bundle, WKBundlePageRef page)
 {    
     WKBundlePageEditorClientV1 pageEditorClient;
-    memset(&pageEditorClient, 0, sizeof(pageEditorClient));
+    zeroBytes(pageEditorClient);
 
     pageEditorClient.base.version = 1;
     pageEditorClient.base.clientInfo = this;

--- a/Tools/TestWebKitAPI/Tests/WebKit/PendingAPIRequestURL.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/PendingAPIRequestURL.cpp
@@ -42,7 +42,7 @@ TEST(WebKit, PendingAPIRequestURL)
     PlatformWebView webView(context.get());
 
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
     loaderClient.base.version = 0;
     loaderClient.didFinishNavigation = [](WKPageRef, WKNavigationRef, WKTypeRef, const void*) {
         done = true;

--- a/Tools/TestWebKitAPI/Tests/WebKit/PrivateBrowsingPushStateNoHistoryCallback.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/PrivateBrowsingPushStateNoHistoryCallback.cpp
@@ -62,7 +62,7 @@ TEST(WebKit, PrivateBrowsingPushStateNoHistoryCallback)
     WKPageConfigurationSetWebsiteDataStore(pageConfiguration.get(), ephemeralStore.get());
 
     WKContextHistoryClientV0 historyClient;
-    memset(&historyClient, 0, sizeof(historyClient));
+    zeroBytes(historyClient);
 
     historyClient.base.version = 0;
     historyClient.didNavigateWithNavigationData = didNavigateWithoutNavigationData;
@@ -72,7 +72,7 @@ TEST(WebKit, PrivateBrowsingPushStateNoHistoryCallback)
     PlatformWebView webView(pageConfiguration.get());
 
     WKPageNavigationClientV0 pageLoaderClient;
-    memset(&pageLoaderClient, 0, sizeof(pageLoaderClient));
+    zeroBytes(pageLoaderClient);
 
     pageLoaderClient.base.version = 0;
     pageLoaderClient.didSameDocumentNavigation = [] (WKPageRef, WKNavigationRef, WKSameDocumentNavigationType, WKTypeRef, const void *) {

--- a/Tools/TestWebKitAPI/Tests/WebKit/ProcessDidTerminate.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/ProcessDidTerminate.cpp
@@ -82,7 +82,7 @@ TEST(WebKit, ProcessDidTerminateRequestedByClient)
     PlatformWebView webView(context.get());
 
     WKPageNavigationClientV1 navigationClient;
-    memset(&navigationClient, 0, sizeof(navigationClient));
+    zeroBytes(navigationClient);
     navigationClient.base.version = 1;
     navigationClient.didFinishNavigation = didFinishNavigation;
     navigationClient.webProcessDidTerminate = webProcessWasTerminatedByClient;
@@ -106,7 +106,7 @@ TEST(WebKit, ProcessDidTerminateWithReasonCrash)
     PlatformWebView webView(context.get());
 
     WKPageNavigationClientV1 navigationClient;
-    memset(&navigationClient, 0, sizeof(navigationClient));
+    zeroBytes(navigationClient);
     navigationClient.base.version = 1;
     navigationClient.didFinishNavigation = didFinishNavigation;
     navigationClient.webProcessDidTerminate = webProcessCrashed;

--- a/Tools/TestWebKitAPI/Tests/WebKit/ProvisionalURLAfterWillSendRequestCallback.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/ProvisionalURLAfterWillSendRequestCallback.cpp
@@ -67,14 +67,14 @@ TEST(WebKit2, ProvisionalURLAfterWillSendRequestCallback)
     WKRetainPtr<WKContextRef> context = adoptWK(Util::createContextForInjectedBundleTest("ProvisionalURLAfterWillSendRequestCallbackTest"));
 
     WKContextInjectedBundleClientV0 injectedBundleClient;
-    memset(&injectedBundleClient, 0, sizeof(injectedBundleClient));
+    zeroBytes(injectedBundleClient);
     injectedBundleClient.base.version = 0;
     WKContextSetInjectedBundleClient(context.get(), &injectedBundleClient.base);
 
     PlatformWebView webView(context.get());
 
     WKPageNavigationClientV0 navigationClient;
-    memset(&navigationClient, 0, sizeof(navigationClient));
+    zeroBytes(navigationClient);
 
     navigationClient.base.version = 0;
     navigationClient.didCommitNavigation = didCommitNavigationCallback;

--- a/Tools/TestWebKitAPI/Tests/WebKit/ProvisionalURLAfterWillSendRequestCallback_Bundle.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/ProvisionalURLAfterWillSendRequestCallback_Bundle.cpp
@@ -67,13 +67,13 @@ public:
     void didCreatePage(WKBundleRef bundle, WKBundlePageRef page) override
     {
         WKBundlePageResourceLoadClientV0 resourceLoadClient;
-        memset(&resourceLoadClient, 0, sizeof(resourceLoadClient));
+        zeroBytes(resourceLoadClient);
         resourceLoadClient.base.version = 0;
         resourceLoadClient.willSendRequestForFrame = willSendRequestForFrame;
         WKBundlePageSetResourceLoadClient(page, &resourceLoadClient.base);
 
         WKBundlePageLoaderClientV0 pageLoaderClient;
-        memset(&pageLoaderClient, 0, sizeof(pageLoaderClient));
+        zeroBytes(pageLoaderClient);
         pageLoaderClient.base.version = 0;
         pageLoaderClient.didCommitLoadForFrame = didCommitLoadForFrame;
         WKBundlePageSetPageLoaderClient(page, &pageLoaderClient.base);

--- a/Tools/TestWebKitAPI/Tests/WebKit/ReloadPageAfterCrash.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/ReloadPageAfterCrash.cpp
@@ -78,7 +78,7 @@ TEST(WebKit, ReloadPageAfterCrash)
     PlatformWebView webView(context.get());
 
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 0;
     loaderClient.didFinishNavigation = didFinishLoad;
@@ -121,7 +121,7 @@ TEST(WebKit, FocusedFrameAfterCrash)
     PlatformWebView webView(context.get());
 
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 0;
     loaderClient.didFinishNavigation = didFinishLoad;

--- a/Tools/TestWebKitAPI/Tests/WebKit/ResizeReversePaginatedWebView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/ResizeReversePaginatedWebView.cpp
@@ -64,7 +64,7 @@ TEST(WebKit, ResizeReversePaginatedWebView)
     PlatformWebView webView(context.get());
 
     WKPageNavigationClientV3 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 3;
     loaderClient.base.clientInfo = &webView;

--- a/Tools/TestWebKitAPI/Tests/WebKit/ResizeWindowAfterCrash.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/ResizeWindowAfterCrash.cpp
@@ -79,7 +79,7 @@ TEST(WebKit, ResizeWindowAfterCrash)
     TestStatesData states(context.get());
 
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 0;
     loaderClient.base.clientInfo = &states;

--- a/Tools/TestWebKitAPI/Tests/WebKit/RestoreSessionState.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/RestoreSessionState.cpp
@@ -74,7 +74,7 @@ static void decidePolicyForResponse(WKPageRef page, WKFrameRef frame, WKURLRespo
 static void setPageLoaderClient(WKPageRef page)
 {
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 0;
     loaderClient.didFinishNavigation = didFinishNavigation;
@@ -121,7 +121,7 @@ TEST(WebKit, RestoreSessionStateContainingScrollRestorationDefaultWithAsyncPolic
     setPageLoaderClient(webView.page());
 
     WKPagePolicyClientV1 policyClient;
-    memset(&policyClient, 0, sizeof(policyClient));
+    zeroBytes(policyClient);
     policyClient.base.version = 1;
     policyClient.decidePolicyForNavigationAction = decidePolicyForNavigationAction;
     policyClient.decidePolicyForResponse = decidePolicyForResponse;
@@ -175,7 +175,7 @@ TEST(WebKit, ClearedPendingURLAfterCancelingRestoreSessionState)
     setPageLoaderClient(webView.page());
 
     WKPagePolicyClientV1 policyClient;
-    memset(&policyClient, 0, sizeof(policyClient));
+    zeroBytes(policyClient);
     policyClient.base.version = 1;
     policyClient.decidePolicyForNavigationAction = decidePolicyForNavigationActionIgnore;
     WKPageSetPagePolicyClient(webView.page(), &policyClient.base);

--- a/Tools/TestWebKitAPI/Tests/WebKit/RestoreSessionStateContainingFormData.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/RestoreSessionStateContainingFormData.cpp
@@ -45,7 +45,7 @@ static void didFinishNavigation(WKPageRef, WKNavigationRef, WKTypeRef, const voi
 static void setPageLoaderClient(WKPageRef page)
 {
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 0;
     loaderClient.didFinishNavigation = didFinishNavigation;

--- a/Tools/TestWebKitAPI/Tests/WebKit/ScrollPinningBehaviors.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/ScrollPinningBehaviors.mm
@@ -61,7 +61,7 @@ TEST(WebKit, ScrollPinningBehaviors)
     PlatformWebView webView(configuration.get());
 
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 0;
     loaderClient.base.clientInfo = &webView;

--- a/Tools/TestWebKitAPI/Tests/WebKit/ShouldKeepCurrentBackForwardListItemInList.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/ShouldKeepCurrentBackForwardListItemInList.cpp
@@ -112,7 +112,7 @@ static bool shouldKeepCurrentBackForwardListItemInList(WKPageRef page, WKBackFor
 static void setPageLoaderClient(WKPageRef page)
 {
     WKPageLoaderClientV5 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 5;
     loaderClient.didFinishLoadForFrame = didFinishLoadForFrame;

--- a/Tools/TestWebKitAPI/Tests/WebKit/SpacebarScrolling.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/SpacebarScrolling.cpp
@@ -73,7 +73,7 @@ TEST(WebKit, SpacebarScrolling)
     PlatformWebView webView(configuration.get());
 
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 0;
     loaderClient.didFinishNavigation = didFinishNavigation;
@@ -81,7 +81,7 @@ TEST(WebKit, SpacebarScrolling)
     WKPageSetPageNavigationClient(webView.page(), &loaderClient.base);
 
     WKPageUIClientV0 uiClient;
-    memset(&uiClient, 0, sizeof(uiClient));
+    zeroBytes(uiClient);
 
     uiClient.base.version = 0;
     uiClient.didNotHandleKeyEvent = didNotHandleKeyEventCallback;

--- a/Tools/TestWebKitAPI/Tests/WebKit/TerminateTwice.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/TerminateTwice.cpp
@@ -45,7 +45,7 @@ TEST(WebKit, TerminateTwice)
     PlatformWebView webView(context.get());
 
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 0;
     loaderClient.didFinishNavigation = didFinishNavigation;

--- a/Tools/TestWebKitAPI/Tests/WebKit/TextFieldDidBeginAndEndEditing.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/TextFieldDidBeginAndEndEditing.cpp
@@ -58,7 +58,7 @@ struct WebKit2TextFieldBeginAndEditEditingTest : public ::testing::Test {
     static void setInjectedBundleClient(WKContextRef context, const void* clientInfo)
     {
         WKContextInjectedBundleClientV1 injectedBundleClient;
-        memset(&injectedBundleClient, 0, sizeof(injectedBundleClient));
+        zeroBytes(injectedBundleClient);
 
         injectedBundleClient.base.version = 1;
         injectedBundleClient.base.clientInfo = clientInfo;
@@ -70,7 +70,7 @@ struct WebKit2TextFieldBeginAndEditEditingTest : public ::testing::Test {
     static void setPageLoaderClient(WKPageRef page, const void* clientInfo)
     {
         WKPageNavigationClientV0 loaderClient;
-        memset(&loaderClient, 0, sizeof(loaderClient));
+        zeroBytes(loaderClient);
 
         loaderClient.base.version = 0;
         loaderClient.base.clientInfo = clientInfo;

--- a/Tools/TestWebKitAPI/Tests/WebKit/TextFieldDidBeginAndEndEditing_Bundle.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/TextFieldDidBeginAndEndEditing_Bundle.cpp
@@ -61,7 +61,7 @@ TextFieldDidBeginAndEndEditingEventsTest::TextFieldDidBeginAndEndEditingEventsTe
 void TextFieldDidBeginAndEndEditingEventsTest::didCreatePage(WKBundleRef bundle, WKBundlePageRef page)
 {
     WKBundlePageFormClientV2 formClient;
-    memset(&formClient, 0, sizeof(formClient));
+    zeroBytes(formClient);
 
     formClient.base.version = 2;
     formClient.base.clientInfo = this;

--- a/Tools/TestWebKitAPI/Tests/WebKit/UserMedia.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/UserMedia.cpp
@@ -72,7 +72,7 @@ TEST(WebKit, UserMediaBasic)
     auto context = adoptWK(WKContextCreateWithConfiguration(nullptr));
 
     WKPageUIClientV6 uiClient;
-    memset(&uiClient, 0, sizeof(uiClient));
+    zeroBytes(uiClient);
     uiClient.base.version = 6;
     uiClient.decidePolicyForUserMediaPermissionRequest = decidePolicyForUserMediaPermissionRequestCallBack;
     uiClient.checkUserMediaPermissionForOrigin = checkUserMediaPermissionCallback;
@@ -116,7 +116,7 @@ TEST(WebKit, OnDeviceChangeCrash)
     WKPageConfigurationSetPreferences(configuration.get(), preferences.get());
 
     WKPageUIClientV6 uiClient;
-    memset(&uiClient, 0, sizeof(uiClient));
+    zeroBytes(uiClient);
     uiClient.base.version = 6;
     uiClient.decidePolicyForUserMediaPermissionRequest = decidePolicyForUserMediaPermissionRequestCallBack;
     uiClient.checkUserMediaPermissionForOrigin = checkUserMediaPermissionCallback;
@@ -134,7 +134,7 @@ TEST(WebKit, OnDeviceChangeCrash)
     PlatformWebView webView2(webView.page());
     WKPageSetPageUIClient(webView2.page(), &uiClient.base);
     WKPageNavigationClientV0 navigationClient;
-    memset(&navigationClient, 0, sizeof(navigationClient));
+    zeroBytes(navigationClient);
     navigationClient.base.version = 0;
     navigationClient.webProcessDidCrash = didCrashCallback;
     WKPageSetPageNavigationClient(webView2.page(), &navigationClient.base);
@@ -178,11 +178,11 @@ TEST(WebKit, EnumerateDevicesCrash)
 
     WKPageUIClientV6 uiClient;
     // We want uiClient.checkUserMediaPermissionForOrigin to be null.
-    memset(&uiClient, 0, sizeof(uiClient));
+    zeroBytes(uiClient);
     uiClient.base.version = 6;
 
     WKPageNavigationClientV3 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
     loaderClient.base.version = 3;
     loaderClient.didFinishNavigation = didFinishNavigation;
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/UserMessage.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/UserMessage.cpp
@@ -66,7 +66,7 @@ public:
     static void setInjectedBundleClient(WKContextRef context, const void* clientInfo)
     {
         WKContextInjectedBundleClientV1 injectedBundleClient;
-        memset(&injectedBundleClient, 0, sizeof(injectedBundleClient));
+        zeroBytes(injectedBundleClient);
 
         injectedBundleClient.base.version = 1;
         injectedBundleClient.base.clientInfo = clientInfo;
@@ -78,7 +78,7 @@ public:
     static void setPageLoaderClient(WKPageRef page, const void* clientInfo)
     {
         WKPageNavigationClientV3 loaderClient;
-        memset(&loaderClient, 0, sizeof(loaderClient));
+        zeroBytes(loaderClient);
 
         loaderClient.base.version = 3;
         loaderClient.base.clientInfo = clientInfo;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPageConfiguration.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPageConfiguration.cpp
@@ -56,7 +56,7 @@ static void didFinishNavigation(WKPageRef, WKNavigationRef, WKTypeRef, const voi
 static void setPageLoaderClient(WKPageRef page)
 {
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 0;
     loaderClient.didFinishNavigation = didFinishNavigation;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPageCopySessionStateWithFiltering.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPageCopySessionStateWithFiltering.cpp
@@ -45,7 +45,7 @@ static void didFinishNavigation(WKPageRef, WKNavigationRef, WKTypeRef, const voi
 static void setPageLoaderClient(WKPageRef page)
 {
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 0;
     loaderClient.didFinishNavigation = didFinishNavigation;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPageGetScaleFactorNotZero.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPageGetScaleFactorNotZero.cpp
@@ -43,7 +43,7 @@ static void didFinishNavigation(WKPageRef, WKNavigationRef, WKTypeRef, const voi
 static void setPageLoaderClient(WKPageRef page)
 {
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 0;
     loaderClient.didFinishNavigation = didFinishNavigation;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPageIsPlayingAudio.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPageIsPlayingAudio.cpp
@@ -68,7 +68,7 @@ static void isPlayingAudioDidChangeCallback(WKPageRef page, const void*)
 static void setUpClients(WKPageRef page)
 {
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 0;
     loaderClient.didFinishNavigation = didFinishNavigation;
@@ -76,7 +76,7 @@ static void setUpClients(WKPageRef page)
     WKPageSetPageNavigationClient(page, &loaderClient.base);
 
     WKPageUIClientV5 uiClient;
-    memset(&uiClient, 0, sizeof(uiClient));
+    zeroBytes(uiClient);
 
     uiClient.base.version = 5;
     uiClient.isPlayingAudioDidChange = isPlayingAudioDidChangeCallback;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKThumbnailView.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKThumbnailView.mm
@@ -95,7 +95,7 @@ static void didFinishNavigation(WKPageRef, WKNavigationRef, WKTypeRef, const voi
 static void setPageLoaderClient(WKPageRef page)
 {
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 0;
     loaderClient.didFinishNavigation = didFinishNavigation;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebArchive.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebArchive.cpp
@@ -91,7 +91,7 @@ static void didReceiveMessageFromInjectedBundle(WKContextRef, WKStringRef messag
 static void setInjectedBundleClient(WKContextRef context)
 {
     WKContextInjectedBundleClientV0 injectedBundleClient;
-    memset(&injectedBundleClient, 0, sizeof(injectedBundleClient));
+    zeroBytes(injectedBundleClient);
 
     injectedBundleClient.base.version = 0;
     injectedBundleClient.didReceiveMessageFromInjectedBundle = didReceiveMessageFromInjectedBundle;
@@ -112,7 +112,7 @@ TEST(WebKit, WebArchive)
     PlatformWebView webView(context.get());
 
     WKPageNavigationClientV3 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
     
     loaderClient.base.version = 3;
     loaderClient.didFinishNavigation = didFinishNavigation;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WillLoad.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WillLoad.cpp
@@ -57,7 +57,7 @@ public:
     static void setInjectedBundleClient(WKContextRef context, const void* clientInfo)
     {
         WKContextInjectedBundleClientV1 injectedBundleClient;
-        memset(&injectedBundleClient, 0, sizeof(injectedBundleClient));
+        zeroBytes(injectedBundleClient);
 
         injectedBundleClient.base.version = 1;
         injectedBundleClient.base.clientInfo = clientInfo;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WillLoad_Bundle.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WillLoad_Bundle.cpp
@@ -71,7 +71,7 @@ private:
     void didCreatePage(WKBundleRef, WKBundlePageRef bundlePage) override
     {
         WKBundlePageLoaderClientV6 pageLoaderClient;
-        memset(&pageLoaderClient, 0, sizeof(pageLoaderClient));
+        zeroBytes(pageLoaderClient);
         
         pageLoaderClient.base.version = 6;
         pageLoaderClient.base.clientInfo = this;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WillSendSubmitEvent.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WillSendSubmitEvent.cpp
@@ -69,7 +69,7 @@ static void didReceiveMessageFromInjectedBundle(WKContextRef, WKStringRef messag
 static void setInjectedBundleClient(WKContextRef context)
 {
     WKContextInjectedBundleClientV0 injectedBundleClient;
-    memset(&injectedBundleClient, 0, sizeof(injectedBundleClient));
+    zeroBytes(injectedBundleClient);
 
     injectedBundleClient.base.version = 0;
     injectedBundleClient.didReceiveMessageFromInjectedBundle = didReceiveMessageFromInjectedBundle;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WillSendSubmitEvent_Bundle.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WillSendSubmitEvent_Bundle.cpp
@@ -67,7 +67,7 @@ WillSendSubmitEventTest::WillSendSubmitEventTest(const std::string& identifier)
 void WillSendSubmitEventTest::didCreatePage(WKBundleRef bundle, WKBundlePageRef page)
 {
     WKBundlePageFormClientV1 formClient;
-    memset(&formClient, 0, sizeof(formClient));
+    zeroBytes(formClient);
     
     formClient.base.version = 1;
     formClient.base.clientInfo = this;

--- a/Tools/TestWebKitAPI/Tests/WebKit/mac/AttributedSubstringForProposedRangeWithImage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/mac/AttributedSubstringForProposedRangeWithImage.mm
@@ -61,7 +61,7 @@ TEST(WebKit, AttributedSubstringForProposedRangeWithImage)
     PlatformWebView webView(context.get());
 
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
     loaderClient.base.version = 0;
     loaderClient.didFinishNavigation = didFinishNavigation;
     loaderClient.webProcessDidCrash = processDidCrash;

--- a/Tools/TestWebKitAPI/Tests/WebKit/mac/ContextMenuDownload.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/mac/ContextMenuDownload.mm
@@ -81,7 +81,7 @@ static WKStringRef decideDestinationWithSuggestedFilename(WKDownloadRef download
 static void contextMenuDidCreateDownload(WKPageRef page, WKDownloadRef download, const void* clientInfo)
 {
     WKDownloadClientV0 client;
-    memsetSpan(asMutableByteSpan(client), 0);
+    zeroBytes(client);
     client.base.version = 0;
     client.decideDestinationWithResponse = decideDestinationWithSuggestedFilename;
     WKDownloadSetClient(download, &client.base);
@@ -96,14 +96,14 @@ TEST(WebKit, ContextMenuDownloadHTMLDownloadAttribute)
     PlatformWebView webView(context.get());
 
     WKPageNavigationClientV3 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
     loaderClient.base.version = 3;
     loaderClient.didFinishNavigation = didFinishNavigation;
     loaderClient.contextMenuDidCreateDownload = contextMenuDidCreateDownload;
     WKPageSetPageNavigationClient(webView.page(), &loaderClient.base);
 
     WKPageContextMenuClientV3 contextMenuClient;
-    memset(&contextMenuClient, 0, sizeof(contextMenuClient));
+    zeroBytes(contextMenuClient);
     contextMenuClient.base.version = 3;
     contextMenuClient.getContextMenuFromProposedMenu = getContextMenuFromProposedMenu;
     WKPageSetPageContextMenuClient(webView.page(), &contextMenuClient.base);
@@ -133,7 +133,7 @@ static WKStringRef decideDestinationWithSuggestedFilenameContainingSlashes(WKDow
 static void contextMenuDidCreateDownloadWithSuggestedFilenameContainingSlashes(WKPageRef page, WKDownloadRef download, const void* clientInfo)
 {
     WKDownloadClientV0 client;
-    memsetSpan(asMutableByteSpan(client), 0);
+    zeroBytes(client);
     client.base.version = 0;
     client.decideDestinationWithResponse = decideDestinationWithSuggestedFilenameContainingSlashes;
     WKDownloadSetClient(download, &client.base);
@@ -146,14 +146,14 @@ TEST(WebKit, ContextMenuDownloadHTMLDownloadAttributeWithSlashes)
     PlatformWebView webView(context.get());
 
     WKPageNavigationClientV3 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
     loaderClient.base.version = 3;
     loaderClient.didFinishNavigation = didFinishNavigation;
     loaderClient.contextMenuDidCreateDownload = contextMenuDidCreateDownloadWithSuggestedFilenameContainingSlashes;
     WKPageSetPageNavigationClient(webView.page(), &loaderClient.base);
 
     WKPageContextMenuClientV3 contextMenuClient;
-    memset(&contextMenuClient, 0, sizeof(contextMenuClient));
+    zeroBytes(contextMenuClient);
     contextMenuClient.base.version = 3;
     contextMenuClient.getContextMenuFromProposedMenu = getContextMenuFromProposedMenu;
     WKPageSetPageContextMenuClient(webView.page(), &contextMenuClient.base);

--- a/Tools/TestWebKitAPI/Tests/WebKit/mac/CustomBundleParameter.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/mac/CustomBundleParameter.mm
@@ -79,7 +79,7 @@ TEST(WebKit, CustomBundleParameter)
     WKRetainPtr<WKContextRef> context = adoptWK(Util::createContextForInjectedBundleTest("CustomBundleParameterTest"));
     
     WKContextInjectedBundleClientV0 injectedBundleClient;
-    memset(&injectedBundleClient, 0, sizeof(injectedBundleClient));
+    zeroBytes(injectedBundleClient);
     
     injectedBundleClient.base.version = 0;
     injectedBundleClient.didReceiveMessageFromInjectedBundle = didReceiveMessageFromInjectedBundle;
@@ -89,7 +89,7 @@ TEST(WebKit, CustomBundleParameter)
     PlatformWebView webView(context.get());
     
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
     
     loaderClient.base.version = 0;
     loaderClient.didFinishNavigation = didFinishNavigation;

--- a/Tools/TestWebKitAPI/Tests/WebKit/mac/EditorCommands.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/mac/EditorCommands.mm
@@ -57,7 +57,7 @@ TEST(WebKit, ScrollByLineCommands)
     PlatformWebView webView(configuration.get());
 
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 0;
     loaderClient.didFinishNavigation = didFinishNavigation;

--- a/Tools/TestWebKitAPI/Tests/WebKit/mac/ForceLightAppearanceInBundle.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/mac/ForceLightAppearanceInBundle.mm
@@ -64,7 +64,7 @@ TEST(WebKit, ForceLightAppearanceInBundle)
     [webView.platformView() setAppearance:[NSAppearance appearanceNamed:NSAppearanceNameDarkAqua]];
 
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 0;
     loaderClient.didFinishNavigation = didFinishNavigation;
@@ -72,7 +72,7 @@ TEST(WebKit, ForceLightAppearanceInBundle)
     WKPageSetPageNavigationClient(webView.page(), &loaderClient.base);
 
     WKContextInjectedBundleClientV0 injectedBundleClient;
-    memset(&injectedBundleClient, 0, sizeof(injectedBundleClient));
+    zeroBytes(injectedBundleClient);
 
     injectedBundleClient.base.version = 0;
     injectedBundleClient.didReceiveMessageFromInjectedBundle = didReceiveMessageFromInjectedBundle;

--- a/Tools/TestWebKitAPI/Tests/WebKit/mac/GetBackingScaleFactor.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/mac/GetBackingScaleFactor.mm
@@ -49,7 +49,7 @@ static void didReceiveMessageFromInjectedBundle(WKContextRef context, WKStringRe
 static void setInjectedBundleClient(WKContextRef context)
 {
     WKContextInjectedBundleClientV0 injectedBundleClient;
-    memset(&injectedBundleClient, 0, sizeof(injectedBundleClient));
+    zeroBytes(injectedBundleClient);
 
     injectedBundleClient.base.version = 0;
     injectedBundleClient.didReceiveMessageFromInjectedBundle = didReceiveMessageFromInjectedBundle;

--- a/Tools/TestWebKitAPI/Tests/WebKit/mac/GetPIDAfterAbortedProcessLaunch.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/mac/GetPIDAfterAbortedProcessLaunch.cpp
@@ -47,7 +47,7 @@ TEST(WebKit, GetPIDAfterAbortedProcessLaunch)
     PlatformWebView webView(context.get());
 
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 0;
     loaderClient.didFinishNavigation = didFinishNavigation;

--- a/Tools/TestWebKitAPI/Tests/WebKit/mac/InjectedBundleAppleEvent.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/mac/InjectedBundleAppleEvent.cpp
@@ -70,7 +70,7 @@ TEST(WebKit, InjectedBundleAppleEvent)
     WKRetainPtr<WKContextRef> context = adoptWK(Util::createContextForInjectedBundleTest("InjectedBundleAppleEventTest"));
 
     WKContextInjectedBundleClientV0 injectedBundleClient;
-    memset(&injectedBundleClient, 0, sizeof(injectedBundleClient));
+    zeroBytes(injectedBundleClient);
 
     injectedBundleClient.base.version = 0;
     injectedBundleClient.didReceiveMessageFromInjectedBundle = didReceiveMessageFromInjectedBundle;
@@ -80,7 +80,7 @@ TEST(WebKit, InjectedBundleAppleEvent)
     PlatformWebView webView(context.get());
 
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 0;
     loaderClient.didFinishNavigation = didFinishNavigation;

--- a/Tools/TestWebKitAPI/Tests/WebKit/mac/RestoreStateAfterTermination.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/mac/RestoreStateAfterTermination.mm
@@ -79,14 +79,14 @@ TEST(WebKit, RestoreStateAfterTermination)
     [window.get().contentView addSubview:webView.platformView()];
 
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
     loaderClient.base.version = 0;
     loaderClient.didFinishNavigation = didFinishLoad;
     loaderClient.webProcessDidCrash = didCrash;
     WKPageSetPageNavigationClient(webView.page(), &loaderClient.base);
 
     WKPageUIClientV0 uiClient;
-    memset(&uiClient, 0, sizeof(uiClient));
+    zeroBytes(uiClient);
     uiClient.base.version = 0;
     uiClient.runJavaScriptAlert = runJavaScriptAlert;
     WKPageSetPageUIClient(webView.page(), &uiClient.base);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/BasicProposedCredentialPlugIn.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/BasicProposedCredentialPlugIn.mm
@@ -39,7 +39,7 @@
 - (void)webProcessPlugIn:(WKWebProcessPlugInController *)plugInController didCreateBrowserContextController:(WKWebProcessPlugInBrowserContextController *)browserContextController
 {
     WKBundlePageResourceLoadClientV1 client;
-    memsetSpan(asMutableByteSpan(client), 0);
+    zeroBytes(client);
     client.base.version = 1;
     client.shouldUseCredentialStorage = [](auto...) {
         static size_t queries { 0 };

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/BundlePageConsoleMessage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/BundlePageConsoleMessage.mm
@@ -48,7 +48,7 @@ void willAddMessageToConsoleCallback(WKBundlePageRef page, WKStringRef message, 
 - (void)webProcessPlugIn:(WKWebProcessPlugInController *)plugInController didCreateBrowserContextController:(WKWebProcessPlugInBrowserContextController *)browserContextController
 {
     WKBundlePageUIClientV4 client;
-    memsetSpan(asMutableByteSpan(client), 0);
+    zeroBytes(client);
     client.base.version = 4;
     client.willAddMessageToConsole = willAddMessageToConsoleCallback;
     WKBundlePageSetUIClient([browserContextController _bundlePageRef], &client.base);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/BundlePageConsoleMessageWithDetails.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/BundlePageConsoleMessageWithDetails.mm
@@ -70,7 +70,7 @@ static void willAddMessageWithDetailsToConsoleCallback(WKBundlePageRef page, WKS
 - (void)webProcessPlugIn:(WKWebProcessPlugInController *)plugInController didCreateBrowserContextController:(WKWebProcessPlugInBrowserContextController *)browserContextController
 {
     WKBundlePageUIClientV5 client;
-    memsetSpan(asMutableByteSpan(client), 0);
+    zeroBytes(client);
     client.base.version = 5;
     client.willAddMessageWithDetailsToConsole = willAddMessageWithDetailsToConsoleCallback;
     WKBundlePageSetUIClient([browserContextController _bundlePageRef], &client.base);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ClickAutoFillButton.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ClickAutoFillButton.mm
@@ -52,7 +52,7 @@ void didClickAutoFillButton(WKBundlePageRef, WKBundleNodeHandleRef, WKTypeRef* u
 - (void)webProcessPlugIn:(WKWebProcessPlugInController *)plugInController didCreateBrowserContextController:(WKWebProcessPlugInBrowserContextController *)browserContextController
 {
     WKBundlePageUIClientV3 client;
-    memsetSpan(asMutableByteSpan(client), 0);
+    zeroBytes(client);
     client.base.version = 3;
     client.didClickAutoFillButton = didClickAutoFillButton;
     WKBundlePageSetUIClient([browserContextController _bundlePageRef], &client.base);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CommandBackForward.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CommandBackForward.mm
@@ -100,7 +100,7 @@ public:
         webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100)]);
 
         WKPageNavigationClientV0 loaderClient;
-        memset(&loaderClient, 0, sizeof(loaderClient));
+        zeroBytes(loaderClient);
 
         loaderClient.base.version = 0;
         loaderClient.didFinishNavigation = [] (WKPageRef, WKNavigationRef, WKTypeRef, const void* clientInfo) {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/DecidePolicyForNavigationAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/DecidePolicyForNavigationAction.mm
@@ -300,7 +300,7 @@ TEST(WebKit, DecidePolicyForNewWindowAction)
     TestWebKitAPI::PlatformWebView webView(context.get());
 
     WKPagePolicyClientV1 policyClient;
-    memset(&policyClient, 0, sizeof(policyClient));
+    zeroBytes(policyClient);
     policyClient.base.version = 1;
     policyClient.decidePolicyForNewWindowAction = [] (WKPageRef page, WKFrameRef frame, WKFrameNavigationType navigationType, WKEventModifiers modifiers, WKEventMouseButton mouseButton, WKURLRequestRef request, WKStringRef frameName, WKFramePolicyListenerRef listener, WKTypeRef userData, const void* clientInfo) {
         EXPECT_TRUE(WKStringIsEqualToUTF8CString(adoptWK(WKURLCopyString(adoptWK(WKURLRequestCopyURL(request)).get())).get(), "https://webkit.org/"));

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/DidResignInputElementStrongPasswordAppearance.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/DidResignInputElementStrongPasswordAppearance.mm
@@ -52,7 +52,7 @@ void didResignInputElementStrongPasswordAppearance(WKBundlePageRef, WKBundleNode
 - (void)webProcessPlugIn:(WKWebProcessPlugInController *)plugInController didCreateBrowserContextController:(WKWebProcessPlugInBrowserContextController *)browserContextController
 {
     WKBundlePageUIClientV4 client;
-    memsetSpan(asMutableByteSpan(client), 0);
+    zeroBytes(client);
     client.base.version = 4;
     client.didResignInputElementStrongPasswordAppearance = didResignInputElementStrongPasswordAppearance;
     WKBundlePageSetUIClient([browserContextController _bundlePageRef], &client.base);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FrameHandleSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FrameHandleSerialization.mm
@@ -44,7 +44,7 @@ void mouseDidMoveOverElement(WKBundlePageRef page, WKBundleHitTestResultRef hitT
 - (void)webProcessPlugIn:(WKWebProcessPlugInController *)plugInController didCreateBrowserContextController:(WKWebProcessPlugInBrowserContextController *)browserContextController
 {
     WKBundlePageUIClientV0 client;
-    memsetSpan(asMutableByteSpan(client), 0);
+    zeroBytes(client);
     client.mouseDidMoveOverElement = mouseDidMoveOverElement;
     WKBundlePageSetUIClient([browserContextController _bundlePageRef], &client.base);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PictureInPictureDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PictureInPictureDelegate.mm
@@ -202,14 +202,14 @@ TEST(PictureInPicture, WKPageUIClient)
     WKPreferencesSetAllowsPictureInPictureMediaPlayback(preferences, true);
 
     WKPageUIClientV10 uiClient;
-    memset(&uiClient, 0, sizeof(uiClient));
+    zeroBytes(uiClient);
     uiClient.base.version = 10;
     uiClient.base.clientInfo = NULL;
     uiClient.hasVideoInPictureInPictureDidChange = hasVideoInPictureInPictureDidChange;
     WKPageSetPageUIClient(webView.page(), &uiClient.base);
     
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0 , sizeof(loaderClient));
+    zeroBytes(loaderClient);
     loaderClient.base.version = 0;
     loaderClient.didFinishNavigation = didFinishNavigation;
     WKPageSetPageNavigationClient(webView.page(), &loaderClient.base);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResponsivenessTimerDoesntFireEarly.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResponsivenessTimerDoesntFireEarly.mm
@@ -44,7 +44,7 @@ static void didReceiveMessageFromInjectedBundle(WKContextRef, WKStringRef messag
 static void setInjectedBundleClient(WKContextRef context)
 {
     WKContextInjectedBundleClientV0 injectedBundleClient;
-    memset(&injectedBundleClient, 0, sizeof(injectedBundleClient));
+    zeroBytes(injectedBundleClient);
 
     injectedBundleClient.base.version = 0;
     injectedBundleClient.didReceiveMessageFromInjectedBundle = didReceiveMessageFromInjectedBundle;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
@@ -163,7 +163,7 @@ TEST(WebKit, GeolocationPermission)
     auto pool = adoptNS([[WKProcessPool alloc] init]);
     
     WKGeolocationProviderV1 providerCallback;
-    memset(&providerCallback, 0, sizeof(WKGeolocationProviderV1));
+    zeroBytes(providerCallback);
     providerCallback.base.version = 1;
     providerCallback.startUpdating = [] (WKGeolocationManagerRef manager, const void*) {
         WKGeolocationManagerProviderDidChangePosition(manager, adoptWK(WKGeolocationPositionCreate(0, 50.644358, 3.345453, 2.53)).get());
@@ -278,7 +278,7 @@ TEST(WebKit, GeolocationPermissionInIFrame)
     auto pool = adoptNS([[WKProcessPool alloc] init]);
 
     WKGeolocationProviderV1 providerCallback;
-    memset(&providerCallback, 0, sizeof(WKGeolocationProviderV1));
+    zeroBytes(providerCallback);
     providerCallback.base.version = 1;
     providerCallback.startUpdating = [] (WKGeolocationManagerRef manager, const void*) {
         WKGeolocationManagerProviderDidChangePosition(manager, adoptWK(WKGeolocationPositionCreate(0, 50.644358, 3.345453, 2.53)).get());
@@ -341,7 +341,7 @@ TEST(WebKit, GeolocationPermissionInDisallowedIFrame)
     auto pool = adoptNS([[WKProcessPool alloc] init]);
 
     WKGeolocationProviderV1 providerCallback;
-    memset(&providerCallback, 0, sizeof(WKGeolocationProviderV1));
+    zeroBytes(providerCallback);
     providerCallback.base.version = 1;
     providerCallback.startUpdating = [] (WKGeolocationManagerRef manager, const void*) {
         WKGeolocationManagerProviderDidChangePosition(manager, adoptWK(WKGeolocationPositionCreate(0, 50.644358, 3.345453, 2.53)).get());

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm
@@ -735,11 +735,10 @@ TEST(URLSchemeHandler, XHRPost)
             EXPECT_TRUE(!!stream);
             [stream open];
             EXPECT_TRUE(stream.hasBytesAvailable);
-            uint8_t buffer[9];
-            memset(buffer, 0, 9);
-            auto length = [stream read:buffer maxLength:9];
+            std::array<uint8_t, 9> buffer = { };
+            auto length = [stream read:buffer.data() maxLength:buffer.size()];
             EXPECT_EQ(length, 8);
-            EXPECT_STREQ(reinterpret_cast<const char*>(buffer), "foo=bar2");
+            EXPECT_STREQ(reinterpret_cast<const char*>(buffer.data()), "foo=bar2");
             EXPECT_FALSE(stream.hasBytesAvailable);
             [stream close];
         } else if ([task.request.URL.absoluteString isEqualToString:@"xhrpost://example/arraybuffer"]) {

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestUIClient.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestUIClient.cpp
@@ -23,6 +23,7 @@
 #include <WebKitSettingsPrivate.h>
 #include <wtf/HashSet.h>
 #include <wtf/RunLoop.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/text/StringHash.h>
 
@@ -56,7 +57,7 @@ public:
             , m_fullscreen(false)
         {
 #if PLATFORM(GTK)
-            memset(&m_geometry, 0, sizeof(GdkRectangle));
+            zeroBytes(m_geometry);
 #endif
         }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitObjC/CustomProtocolsTest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitObjC/CustomProtocolsTest.mm
@@ -86,7 +86,7 @@ static RetainPtr<WKWebView> wkView;
 {
     dispatch_async(dispatch_get_main_queue(), ^ {
         WKContextClientV0 client;
-        memsetSpan(asMutableByteSpan(client), 0);
+        zeroBytes(client);
         client.base.clientInfo = self;
         client.networkProcessDidCrash = [](WKContextRef context, const void* clientInfo) {
             auto protocol = (CloseWhileStartingProtocol *)clientInfo;

--- a/Tools/TestWebKitAPI/Tests/WebKitObjC/PreventImageLoadWithAutoResizing_Bundle.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitObjC/PreventImageLoadWithAutoResizing_Bundle.cpp
@@ -50,7 +50,7 @@ public:
     virtual void didCreatePage(WKBundleRef bundle, WKBundlePageRef page)
     {
         WKBundlePageResourceLoadClientV0 resourceLoadClient;
-        memset(&resourceLoadClient, 0, sizeof(resourceLoadClient));
+        zeroBytes(resourceLoadClient);
         
         resourceLoadClient.base.version = 0;
         resourceLoadClient.willSendRequestForFrame = willSendRequestForFrame;

--- a/Tools/TestWebKitAPI/Tests/mac/FirstResponderScrollingPosition.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/FirstResponderScrollingPosition.mm
@@ -62,7 +62,7 @@ TEST(WebKit, DISABLED_FirstResponderScrollingPosition)
     PlatformWebView webView(configuration.get());
 
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
     loaderClient.base.version = 0;
     loaderClient.didFinishNavigation = didFinishNavigation;
     WKPageSetPageNavigationClient(webView.page(), &loaderClient.base);

--- a/Tools/TestWebKitAPI/Tests/mac/FullscreenZoomInitialFrame.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/FullscreenZoomInitialFrame.mm
@@ -112,7 +112,7 @@ void FullscreenZoomInitialFrame::teardownView(WebView *webView)
 void FullscreenZoomInitialFrame::initializeView(WKWebView *wkView)
 {
     WKPageUIClientV0 uiClient;
-    memset(&uiClient, 0, sizeof(uiClient));
+    zeroBytes(uiClient);
 
     uiClient.base.version = 0;
     uiClient.runJavaScriptAlert = runJavaScriptAlert;

--- a/Tools/TestWebKitAPI/Tests/mac/PageVisibilityStateWithWindowChanges.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/PageVisibilityStateWithWindowChanges.mm
@@ -101,7 +101,7 @@ void PageVisibilityStateWithWindowChanges::teardownView(WebView *webView)
 void PageVisibilityStateWithWindowChanges::initializeView(WKWebView *wkView)
 {
     WKPageUIClientV0 uiClient;
-    memset(&uiClient, 0, sizeof(uiClient));
+    zeroBytes(uiClient);
 
     uiClient.base.version = 0;
     uiClient.runJavaScriptAlert = runJavaScriptAlert;

--- a/Tools/TestWebKitAPI/mac/WebKitAgnosticTest.mm
+++ b/Tools/TestWebKitAPI/mac/WebKitAgnosticTest.mm
@@ -68,7 +68,7 @@ static void didFinishNavigation(WKPageRef, WKNavigationRef, WKTypeRef, const voi
 static void setPageLoaderClient(WKPageRef page, bool* didFinishLoad)
 {
     WKPageNavigationClientV0 loaderClient;
-    memset(&loaderClient, 0, sizeof(loaderClient));
+    zeroBytes(loaderClient);
 
     loaderClient.base.version = 0;
     loaderClient.base.clientInfo = didFinishLoad;

--- a/Tools/WebKitTestRunner/GeolocationProviderMock.cpp
+++ b/Tools/WebKitTestRunner/GeolocationProviderMock.cpp
@@ -29,6 +29,7 @@
 #include <WebKit/WKGeolocationManager.h>
 #include <string.h>
 #include <wtf/Assertions.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/WallTime.h>
 
 namespace WTR {
@@ -50,7 +51,7 @@ GeolocationProviderMock::GeolocationProviderMock(WKContextRef context)
     , m_geolocationManager(WKContextGetGeolocationManager(context))
 {
     WKGeolocationProviderV1 providerCallback;
-    memset(&providerCallback, 0, sizeof(WKGeolocationProviderV1));
+    zeroBytes(providerCallback);
     providerCallback.base.version = 1;
     providerCallback.base.clientInfo = this;
     providerCallback.startUpdating = startUpdatingCallback;


### PR DESCRIPTION
#### 98af39ad6c25944145ada5d30f5c1f1db2e9d35c
<pre>
Further reduce use of memset()
<a href="https://bugs.webkit.org/show_bug.cgi?id=284605">https://bugs.webkit.org/show_bug.cgi?id=284605</a>

Reviewed by Darin Adler.

* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDeviceManager.cpp:
(WebCore::deviceHasStreams):
* Source/WebKitLegacy/mac/WebView/WebDynamicScrollBarsView.mm:
(-[WebDynamicScrollBarsView initWithFrame:]):
(-[WebDynamicScrollBarsView initWithCoder:]):
* Tools/TestRunnerShared/IOSLayoutTestCommunication.cpp:
(setUpIOSLayoutTestCommunication):
* Tools/TestWebKitAPI/Tests/InjectInternals_Bundle.cpp:
(TestWebKitAPI::InternalsInjectedBundleTest::didCreatePage):
* Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm:
(TestWebKitAPI::TEST(WTF_URLExtras, URLExtras_ParsingError)):
* Tools/TestWebKitAPI/Tests/WebCore/CARingBufferTest.cpp:
(TestWebKitAPI::TEST_F(CARingBufferTest, Basics)):
(TestWebKitAPI::MixingTest::run):
* Tools/TestWebKitAPI/Tests/WebCore/LineBreaking.mm:
(breakingLocationsFromICU):
* Tools/TestWebKitAPI/Tests/WebKit/AboutBlankLoad.cpp:
(TestWebKitAPI::TEST(WebKit, AboutBlankLoad)):
* Tools/TestWebKitAPI/Tests/WebKit/CanHandleRequest.cpp:
(TestWebKitAPI::setInjectedBundleClient):
* Tools/TestWebKitAPI/Tests/WebKit/CloseFromWithinCreatePage.cpp:
(TestWebKitAPI::createNewPageThenClose):
(TestWebKitAPI::TEST(WebKit, CloseFromWithinCreatePage)):
(TestWebKitAPI::createNewPage):
(TestWebKitAPI::TEST(WebKit, CreatePageThenDocumentOpenMIMEType)):
* Tools/TestWebKitAPI/Tests/WebKit/CloseThenTerminate.cpp:
(TestWebKitAPI::TEST(WebKit, CloseThenTerminate)):
* Tools/TestWebKitAPI/Tests/WebKit/DOMWindowExtensionBasic.cpp:
(TestWebKitAPI::TEST(WebKit, DISABLED_DOMWindowExtensionBasic)):
(TestWebKitAPI::TEST(WebKit, DOMWindowExtensionCrashOnReload)):
* Tools/TestWebKitAPI/Tests/WebKit/DOMWindowExtensionBasic_Bundle.cpp:
(TestWebKitAPI::DOMWindowExtensionBasic::didCreatePage):
* Tools/TestWebKitAPI/Tests/WebKit/DOMWindowExtensionNoCache.cpp:
(TestWebKitAPI::TEST(WebKit, DISABLED_DOMWindowExtensionNoCache)):
* Tools/TestWebKitAPI/Tests/WebKit/DOMWindowExtensionNoCache_Bundle.cpp:
(TestWebKitAPI::DOMWindowExtensionNoCache::didCreatePage):
* Tools/TestWebKitAPI/Tests/WebKit/DeferredViewInWindowStateChange.mm:
(TestWebKitAPI::setPageLoaderClient):
* Tools/TestWebKitAPI/Tests/WebKit/DidAssociateFormControls.cpp:
(TestWebKitAPI::setInjectedBundleClient):
* Tools/TestWebKitAPI/Tests/WebKit/DidAssociateFormControls_Bundle.cpp:
(TestWebKitAPI::DidAssociateFormControlsTest::didCreatePage):
* Tools/TestWebKitAPI/Tests/WebKit/DidNotHandleKeyDown.cpp:
(TestWebKitAPI::TEST(WebKit, DidNotHandleKeyDown)):
* Tools/TestWebKitAPI/Tests/WebKit/DidRemoveFrameFromHiearchyInPageCache.cpp:
(TestWebKitAPI::setPageLoaderClient):
* Tools/TestWebKitAPI/Tests/WebKit/DidRemoveFrameFromHiearchyInPageCache_Bundle.cpp:
(TestWebKitAPI::DidRemoveFrameFromHiearchyInBackForwardCacheTest::didCreatePage):
* Tools/TestWebKitAPI/Tests/WebKit/DocumentStartUserScriptAlertCrash.cpp:
(TestWebKitAPI::TEST(WebKit, DocumentStartUserScriptAlertCrashTest)):
* Tools/TestWebKitAPI/Tests/WebKit/DownloadDecideDestinationCrash.cpp:
(TestWebKitAPI::setPagePolicyClient):
* Tools/TestWebKitAPI/Tests/WebKit/EnumerateMediaDevices.cpp:
(TestWebKitAPI::TEST(WebKit, EnumerateDevices)):
* Tools/TestWebKitAPI/Tests/WebKit/EphemeralSessionPushStateNoHistoryCallback.cpp:
(TestWebKitAPI::TEST(WebKit, EphemeralSessionPushStateNoHistoryCallback)):
* Tools/TestWebKitAPI/Tests/WebKit/EventModifiers.cpp:
(TestWebKitAPI::setClients):
* Tools/TestWebKitAPI/Tests/WebKit/FailedLoad.cpp:
(TestWebKitAPI::TEST(WebKit, FailedLoad)):
* Tools/TestWebKitAPI/Tests/WebKit/Find.cpp:
(TestWebKitAPI::TEST(WebKit, Find)):
* Tools/TestWebKitAPI/Tests/WebKit/FindMatches.mm:
(TestWebKitAPI::TEST(WebKit, FindMatches)):
* Tools/TestWebKitAPI/Tests/WebKit/FirstMeaningfulPaintMilestone.cpp:
(TestWebKitAPI::setPageLoaderClient):
* Tools/TestWebKitAPI/Tests/WebKit/ForceRepaint.cpp:
(TestWebKitAPI::TEST(WebKit, ForceRepaint)):
* Tools/TestWebKitAPI/Tests/WebKit/FrameMIMETypeHTML.cpp:
(TestWebKitAPI::TEST(WebKit, FrameMIMETypeHTML)):
* Tools/TestWebKitAPI/Tests/WebKit/FrameMIMETypePNG.cpp:
(TestWebKitAPI::TEST(WebKit, FrameMIMETypePNG)):
* Tools/TestWebKitAPI/Tests/WebKit/Geolocation.cpp:
(TestWebKitAPI::setupGeolocationProvider):
(TestWebKitAPI::setupView):
(TestWebKitAPI::TEST(WebKit, GeolocationTransitionToLowAccuracy)):
(TestWebKitAPI::TEST(WebKit, GeolocationWatchMultiprocess)):
* Tools/TestWebKitAPI/Tests/WebKit/GetInjectedBundleInitializationUserDataCallback.cpp:
(TestWebKitAPI::TEST(WebKit, GetInjectedBundleInitializationUserDataCallback)):
* Tools/TestWebKitAPI/Tests/WebKit/HitTestResultNodeHandle.cpp:
(TestWebKitAPI::setPageLoaderClient):
(TestWebKitAPI::setInjectedBundleClient):
* Tools/TestWebKitAPI/Tests/WebKit/HitTestResultNodeHandle_Bundle.cpp:
(TestWebKitAPI::HitTestResultNodeHandleTest::didCreatePage):
* Tools/TestWebKitAPI/Tests/WebKit/InjectedBundleBasic.cpp:
(TestWebKitAPI::TEST(WebKit, InjectedBundleBasic)):
* Tools/TestWebKitAPI/Tests/WebKit/InjectedBundleDisableOverrideBuiltinsBehavior.cpp:
(TestWebKitAPI::TEST(WebKit, InjectedBundleNoDisableOverrideBuiltinsBehaviorTest)):
(TestWebKitAPI::TEST(WebKit, InjectedBundleDisableOverrideBuiltinsBehaviorTest)):
* Tools/TestWebKitAPI/Tests/WebKit/InjectedBundleFrameHitTest.cpp:
(TestWebKitAPI::setInjectedBundleClient):
* Tools/TestWebKitAPI/Tests/WebKit/InjectedBundleFrameHitTest_Bundle.cpp:
(TestWebKitAPI::InjectedBundleFrameHitTestTest::didCreatePage):
* Tools/TestWebKitAPI/Tests/WebKit/InjectedBundleInitializationUserDataCallbackWins.cpp:
(TestWebKitAPI::TEST(WebKit, InjectedBundleInitializationUserDataCallbackWins)):
* Tools/TestWebKitAPI/Tests/WebKit/InjectedBundleMakeAllShadowRootsOpen.cpp:
(TestWebKitAPI::TEST(WebKit, InjectedBundleMakeAllShadowRootOpenTest)):
* Tools/TestWebKitAPI/Tests/WebKit/LayoutMilestonesWithAllContentInFrame.cpp:
(TestWebKitAPI::TEST(WebKit, LayoutMilestonesWithAllContentInFrame)):
(TestWebKitAPI::TEST(WebKit, FirstVisuallyNonEmptyLayoutAfterPageCacheRestore)):
(TestWebKitAPI::TEST(WebKit, FirstVisuallyNonEmptyMilestoneWithLoadComplete)):
* Tools/TestWebKitAPI/Tests/WebKit/LoadAlternateHTMLStringWithNonDirectoryURL.cpp:
(TestWebKitAPI::loadAlternateHTMLString):
* Tools/TestWebKitAPI/Tests/WebKit/LoadCanceledNoServerRedirectCallback.cpp:
(TestWebKitAPI::TEST(WebKit, LoadCanceledNoServerRedirectCallback)):
* Tools/TestWebKitAPI/Tests/WebKit/LoadCanceledNoServerRedirectCallback_Bundle.cpp:
(TestWebKitAPI::LoadCanceledNoServerRedirectCallbackTest::didCreatePage):
* Tools/TestWebKitAPI/Tests/WebKit/LoadPageOnCrash.cpp:
(TestWebKitAPI::WebKit2CrashLoader::WebKit2CrashLoader):
* Tools/TestWebKitAPI/Tests/WebKit/MenuTypesForMouseEvents.cpp:
(TestWebKitAPI::setPageLoaderClient):
* Tools/TestWebKitAPI/Tests/WebKit/ModalAlertsSPI.cpp:
(TestWebKitAPI::createNewPage):
(TestWebKitAPI::TEST(WebKit, ModalAlertsSPI)):
(TestWebKitAPI::TEST(WebKit, CreateNewPageDelegateFrameLoadState)):
* Tools/TestWebKitAPI/Tests/WebKit/MouseMoveAfterCrash.cpp:
(TestWebKitAPI::setPageLoaderClient):
* Tools/TestWebKitAPI/Tests/WebKit/NavigationClientDefaultCrypto.cpp:
(TestWebKitAPI::TEST(WebKit, NavigationClientDefaultCrypto)):
* Tools/TestWebKitAPI/Tests/WebKit/NewFirstVisuallyNonEmptyLayout.cpp:
(TestWebKitAPI::setPageLoaderClient):
* Tools/TestWebKitAPI/Tests/WebKit/NewFirstVisuallyNonEmptyLayoutFails.cpp:
(TestWebKitAPI::setPageLoaderClient):
* Tools/TestWebKitAPI/Tests/WebKit/NewFirstVisuallyNonEmptyLayoutForImages.cpp:
(TestWebKitAPI::setPageLoaderClient):
* Tools/TestWebKitAPI/Tests/WebKit/NewFirstVisuallyNonEmptyLayoutFrames.cpp:
(TestWebKitAPI::setPageLoaderClient):
* Tools/TestWebKitAPI/Tests/WebKit/PageLoadBasic.cpp:
(TestWebKitAPI::TEST(WebKit, PageLoadBasic)):
(TestWebKitAPI::TEST(WebKit, PageLoadTwiceAndReload)):
* Tools/TestWebKitAPI/Tests/WebKit/PageLoadDidChangeLocationWithinPageForFrame.cpp:
(TestWebKitAPI::TEST(WebKit, PageLoadDidChangeLocationWithinPage)):
* Tools/TestWebKitAPI/Tests/WebKit/ParentFrame.cpp:
(TestWebKitAPI::setInjectedBundleClient):
* Tools/TestWebKitAPI/Tests/WebKit/ParentFrame_Bundle.cpp:
(TestWebKitAPI::ParentFrameTest::didCreatePage):
* Tools/TestWebKitAPI/Tests/WebKit/PasteboardNotifications.mm:
(TestWebKitAPI::setInjectedBundleClient):
* Tools/TestWebKitAPI/Tests/WebKit/PasteboardNotifications_Bundle.cpp:
(TestWebKitAPI::PasteboardNotificationsTest::didCreatePage):
* Tools/TestWebKitAPI/Tests/WebKit/PendingAPIRequestURL.cpp:
(TestWebKitAPI::TEST(WebKit, PendingAPIRequestURL)):
* Tools/TestWebKitAPI/Tests/WebKit/PrivateBrowsingPushStateNoHistoryCallback.cpp:
(TestWebKitAPI::TEST(WebKit, PrivateBrowsingPushStateNoHistoryCallback)):
* Tools/TestWebKitAPI/Tests/WebKit/ProcessDidTerminate.cpp:
(TestWebKitAPI::TEST(WebKit, ProcessDidTerminateRequestedByClient)):
(TestWebKitAPI::TEST(WebKit, ProcessDidTerminateWithReasonCrash)):
* Tools/TestWebKitAPI/Tests/WebKit/ProvisionalURLAfterWillSendRequestCallback.cpp:
(TestWebKitAPI::TEST(WebKit2, ProvisionalURLAfterWillSendRequestCallback)):
* Tools/TestWebKitAPI/Tests/WebKit/ProvisionalURLAfterWillSendRequestCallback_Bundle.cpp:
* Tools/TestWebKitAPI/Tests/WebKit/ReloadPageAfterCrash.cpp:
(TestWebKitAPI::TEST(WebKit, ReloadPageAfterCrash)):
(TestWebKitAPI::TEST(WebKit, FocusedFrameAfterCrash)):
* Tools/TestWebKitAPI/Tests/WebKit/ResizeReversePaginatedWebView.cpp:
(TestWebKitAPI::TEST(WebKit, ResizeReversePaginatedWebView)):
* Tools/TestWebKitAPI/Tests/WebKit/ResizeWindowAfterCrash.cpp:
(TestWebKitAPI::TEST(WebKit, ResizeWindowAfterCrash)):
* Tools/TestWebKitAPI/Tests/WebKit/RestoreSessionState.cpp:
(TestWebKitAPI::setPageLoaderClient):
(TestWebKitAPI::TEST(WebKit, RestoreSessionStateContainingScrollRestorationDefaultWithAsyncPolicyDelegates)):
(TestWebKitAPI::TEST(WebKit, ClearedPendingURLAfterCancelingRestoreSessionState)):
* Tools/TestWebKitAPI/Tests/WebKit/RestoreSessionStateContainingFormData.cpp:
(TestWebKitAPI::setPageLoaderClient):
* Tools/TestWebKitAPI/Tests/WebKit/ScrollPinningBehaviors.mm:
(TestWebKitAPI::TEST(WebKit, ScrollPinningBehaviors)):
* Tools/TestWebKitAPI/Tests/WebKit/ShouldKeepCurrentBackForwardListItemInList.cpp:
(TestWebKitAPI::setPageLoaderClient):
* Tools/TestWebKitAPI/Tests/WebKit/SpacebarScrolling.cpp:
(TestWebKitAPI::TEST(WebKit, SpacebarScrolling)):
* Tools/TestWebKitAPI/Tests/WebKit/TerminateTwice.cpp:
(TestWebKitAPI::TEST(WebKit, TerminateTwice)):
* Tools/TestWebKitAPI/Tests/WebKit/TextFieldDidBeginAndEndEditing.cpp:
(TestWebKitAPI::WebKit2TextFieldBeginAndEditEditingTest::setInjectedBundleClient):
(TestWebKitAPI::WebKit2TextFieldBeginAndEditEditingTest::setPageLoaderClient):
* Tools/TestWebKitAPI/Tests/WebKit/TextFieldDidBeginAndEndEditing_Bundle.cpp:
(TestWebKitAPI::TextFieldDidBeginAndEndEditingEventsTest::didCreatePage):
* Tools/TestWebKitAPI/Tests/WebKit/UserMedia.cpp:
(TestWebKitAPI::TEST(WebKit, UserMediaBasic)):
(TestWebKitAPI::TEST(WebKit, OnDeviceChangeCrash)):
(TestWebKitAPI::TEST(WebKit, EnumerateDevicesCrash)):
* Tools/TestWebKitAPI/Tests/WebKit/UserMessage.cpp:
(TestWebKitAPI::WebKit2UserMessageRoundTripTest::setInjectedBundleClient):
(TestWebKitAPI::WebKit2UserMessageRoundTripTest::setPageLoaderClient):
* Tools/TestWebKitAPI/Tests/WebKit/WKPageConfiguration.cpp:
(TestWebKitAPI::setPageLoaderClient):
* Tools/TestWebKitAPI/Tests/WebKit/WKPageCopySessionStateWithFiltering.cpp:
(TestWebKitAPI::setPageLoaderClient):
* Tools/TestWebKitAPI/Tests/WebKit/WKPageGetScaleFactorNotZero.cpp:
(TestWebKitAPI::setPageLoaderClient):
* Tools/TestWebKitAPI/Tests/WebKit/WKPageIsPlayingAudio.cpp:
(TestWebKitAPI::setUpClients):
* Tools/TestWebKitAPI/Tests/WebKit/WKThumbnailView.mm:
(TestWebKitAPI::setPageLoaderClient):
* Tools/TestWebKitAPI/Tests/WebKit/WebArchive.cpp:
(TestWebKitAPI::setInjectedBundleClient):
(TestWebKitAPI::TEST(WebKit, WebArchive)):
* Tools/TestWebKitAPI/Tests/WebKit/WillLoad.cpp:
(TestWebKitAPI::WebKit2WillLoadTest::setInjectedBundleClient):
* Tools/TestWebKitAPI/Tests/WebKit/WillLoad_Bundle.cpp:
* Tools/TestWebKitAPI/Tests/WebKit/WillSendSubmitEvent.cpp:
(TestWebKitAPI::setInjectedBundleClient):
* Tools/TestWebKitAPI/Tests/WebKit/WillSendSubmitEvent_Bundle.cpp:
(TestWebKitAPI::WillSendSubmitEventTest::didCreatePage):
* Tools/TestWebKitAPI/Tests/WebKit/mac/AttributedSubstringForProposedRangeWithImage.mm:
(TestWebKitAPI::TEST(WebKit, AttributedSubstringForProposedRangeWithImage)):
* Tools/TestWebKitAPI/Tests/WebKit/mac/ContextMenuDownload.mm:
(TestWebKitAPI::TEST(WebKit, ContextMenuDownloadHTMLDownloadAttribute)):
(TestWebKitAPI::TEST(WebKit, ContextMenuDownloadHTMLDownloadAttributeWithSlashes)):
* Tools/TestWebKitAPI/Tests/WebKit/mac/CustomBundleParameter.mm:
(TestWebKitAPI::TEST(WebKit, CustomBundleParameter)):
* Tools/TestWebKitAPI/Tests/WebKit/mac/EditorCommands.mm:
(TestWebKitAPI::TEST(WebKit, ScrollByLineCommands)):
* Tools/TestWebKitAPI/Tests/WebKit/mac/ForceLightAppearanceInBundle.mm:
(TestWebKitAPI::TEST(WebKit, ForceLightAppearanceInBundle)):
* Tools/TestWebKitAPI/Tests/WebKit/mac/GetBackingScaleFactor.mm:
(TestWebKitAPI::setInjectedBundleClient):
* Tools/TestWebKitAPI/Tests/WebKit/mac/GetPIDAfterAbortedProcessLaunch.cpp:
(TestWebKitAPI::TEST(WebKit, GetPIDAfterAbortedProcessLaunch)):
* Tools/TestWebKitAPI/Tests/WebKit/mac/InjectedBundleAppleEvent.cpp:
(TestWebKitAPI::TEST(WebKit, InjectedBundleAppleEvent)):
* Tools/TestWebKitAPI/Tests/WebKit/mac/RestoreStateAfterTermination.mm:
(TestWebKitAPI::TEST(WebKit, RestoreStateAfterTermination)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CommandBackForward.mm:
(WebKit2_CommandBackForwardTestWKView::SetUp):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DecidePolicyForNavigationAction.mm:
(TEST(WebKit, DecidePolicyForNewWindowAction)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PictureInPictureDelegate.mm:
(TestWebKitAPI::TEST(PictureInPicture, WKPageUIClient)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ResponsivenessTimerDoesntFireEarly.mm:
(setInjectedBundleClient):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm:
(TEST(WebKit, GeolocationPermission)):
((WebKit, GeolocationPermissionInIFrame)):
((WebKit, GeolocationPermissionInDisallowedIFrame)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm:
((URLSchemeHandler, XHRPost)):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestUIClient.cpp:
* Tools/TestWebKitAPI/Tests/WebKitObjC/PreventImageLoadWithAutoResizing_Bundle.cpp:
(TestWebKitAPI::DenyWillSendRequestTest::didCreatePage):
* Tools/TestWebKitAPI/Tests/mac/FirstResponderScrollingPosition.mm:
(TestWebKitAPI::TEST(WebKit, DISABLED_FirstResponderScrollingPosition)):
* Tools/TestWebKitAPI/Tests/mac/FullscreenZoomInitialFrame.mm:
(TestWebKitAPI::FullscreenZoomInitialFrame::initializeView):
* Tools/TestWebKitAPI/Tests/mac/PageVisibilityStateWithWindowChanges.mm:
(TestWebKitAPI::PageVisibilityStateWithWindowChanges::initializeView):
* Tools/TestWebKitAPI/mac/WebKitAgnosticTest.mm:
(TestWebKitAPI::setPageLoaderClient):
* Tools/WebKitTestRunner/GeolocationProviderMock.cpp:
(WTR::GeolocationProviderMock::GeolocationProviderMock):

Canonical link: <a href="https://commits.webkit.org/287824@main">https://commits.webkit.org/287824@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b14f8cd4dd85e988ccc376637963aaf9e6d0e83

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80938 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/466 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34883 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85469 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31926 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83049 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/478 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8261 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63209 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20980 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84007 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/279 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73679 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43507 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/209 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27836 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30384 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/73927 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71736 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28385 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86904 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/80006 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8170 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5778 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71519 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8347 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69511 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70753 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14777 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13707 "Found 1 new test failure: fast/mediastream/device-change-event-2.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/102404 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12562 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8134 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13654 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/24886 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Found 3 jsc stress test failures: stress/json-stringify-inspector-check.js.no-llint, wasm.yaml/wasm/stress/cc-int-to-int-cross-module-with-exception.js.default-wasm, wasm.yaml/wasm/stress/struct-new_default-small-members.js.wasm-eager-jettison; Compiled JSC; jscore-tests; Running analyze-jsc-tests-results") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7968 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11488 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9776 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->