### PR TITLE
[JSC] Add `"never"` and `"formalSymbol"` to `currencyDisplay` option for `Intl.NumberFormat`

### DIFF
--- a/JSTests/stress/intl-numberformat-currencyDisplay-formalSymbol.js
+++ b/JSTests/stress/intl-numberformat-currencyDisplay-formalSymbol.js
@@ -1,0 +1,19 @@
+//@ requireOptions("--useMoreCurrencyDisplayChoices=1")
+
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+
+// TODO: We need to add more tests but but CLDR is not for ready
+// https://github.com/tc39/proposal-intl-currency-display-choices/issues/3
+{
+    const nf = new Intl.NumberFormat("zh-TW", {
+        style: "currency",
+        currency: "TWD",
+        currencyDisplay: "formalSymbol",
+    });
+    shouldBe(nf.format(42), "NT$42.00");
+}
+

--- a/JSTests/stress/intl-numberformat-currencyDisplay-never.js
+++ b/JSTests/stress/intl-numberformat-currencyDisplay-never.js
@@ -1,0 +1,34 @@
+//@ requireOptions("--useMoreCurrencyDisplayChoices=1")
+
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+{
+    const nf = new Intl.NumberFormat("zh-TW", {
+        style: "currency",
+        currency: "TWD",
+        currencyDisplay: "never",
+    });
+    shouldBe(nf.format(42), "42.00");
+}
+
+{
+    const nf = new Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency: "USD",
+        currencyDisplay: "never",
+    });
+    shouldBe(nf.format(42), "42.00");
+}
+
+{
+    const nf = new Intl.NumberFormat("ja-JP", {
+        style: "currency",
+        currency: "JPY",
+        currencyDisplay: "never",
+    });
+    shouldBe(nf.format(42), "42");
+}
+

--- a/Source/JavaScriptCore/runtime/IntlNumberFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormat.h
@@ -195,7 +195,7 @@ private:
 
     static Vector<String> localeData(const String&, RelevantExtensionKey);
 
-    enum class CurrencyDisplay : uint8_t { Code, Symbol, NarrowSymbol, Name };
+    enum class CurrencyDisplay : uint8_t { Code, Symbol, FormalSymbol, NarrowSymbol, Name, Never };
     enum class CurrencySign : uint8_t { Standard, Accounting };
     enum class UnitDisplay : uint8_t { Short, Narrow, Long };
     enum class CompactDisplay : uint8_t { Short, Long };

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -603,6 +603,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useIteratorSequencing, false, Normal, "Expose the Iterator.concat method."_s) \
     v(Bool, useMapGetOrInsert, false, Normal, "Expose the Map.prototype.getOrInsert family of methods."_s) \
     v(Bool, useMathSumPreciseMethod, false, Normal, "Expose the Math.sumPrecise() method."_s) \
+    v(Bool, useMoreCurrencyDisplayChoices, false, Normal, "Enable more currencyDisplay choices for Intl.NumberFormat"_s) \
     v(Bool, usePromiseTryMethod, true, Normal, "Expose the Promise.try() method."_s) \
     v(Bool, useRegExpEscape, true, Normal, "Expose RegExp.escape feature."_s) \
     v(Bool, useSharedArrayBuffer, false, Normal, nullptr) \


### PR DESCRIPTION
#### 8e35dc0335a2dae0574990ba5469788ddbe86fd6
<pre>
[JSC] Add `&quot;never&quot;` and `&quot;formalSymbol&quot;` to `currencyDisplay` option for `Intl.NumberFormat`
<a href="https://bugs.webkit.org/show_bug.cgi?id=284613">https://bugs.webkit.org/show_bug.cgi?id=284613</a>

Reviewed by Yusuke Suzuki.

This patch adds support for More Currency Display Choices stage2
proposal[1]. This proposal adds `&quot;formalSymbol&quot;` and `&quot;never&quot;`
to `currencyDisplay` option for `Intl.NumberFormat`.

[1]: <a href="https://github.com/tc39/proposal-intl-currency-display-choices">https://github.com/tc39/proposal-intl-currency-display-choices</a>

* JSTests/stress/intl-numberformat-currencyDisplay-formalSymbol.js: Added.
(shouldBe):
(throw.new.Error):
* JSTests/stress/intl-numberformat-currencyDisplay-never.js: Added.
(shouldBe):
(throw.new.Error):
* Source/JavaScriptCore/runtime/IntlNumberFormat.cpp:
(JSC::IntlNumberFormat::initializeNumberFormat):
(JSC::IntlNumberFormat::currencyDisplayString):
* Source/JavaScriptCore/runtime/IntlNumberFormat.h:
* Source/JavaScriptCore/runtime/OptionsList.h:

Canonical link: <a href="https://commits.webkit.org/287849@main">https://commits.webkit.org/287849@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3d643549d6fd367ea6f39b0259f5c4ab4b7617d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80841 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/363 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34777 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85368 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31825 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/380 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8162 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63125 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20905 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83910 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/189 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73577 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43429 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/105 "Build was cancelled. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27737 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-child-with-border.html imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30282 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/73821 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71668 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28273 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86800 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/79900 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8068 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5692 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71421 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8245 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69413 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70662 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17637 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14691 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13626 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/102307 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8030 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/24878 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/struct-new_default-small-members.js.wasm-collect-continuously (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7869 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11388 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9675 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->