### PR TITLE
Implement multiple import maps

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6187,13 +6187,7 @@ imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/js
 imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload.html [ Skip ]
 imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload-link-header.html [ Skip ]
 
-imported/w3c/web-platform-tests/import-maps/dynamic-integrity.html [ DumpJSConsoleLogInStdErr ]
-imported/w3c/web-platform-tests/import-maps/static-integrity.html [ DumpJSConsoleLogInStdErr ]
-imported/w3c/web-platform-tests/import-maps/no-referencing-script-integrity.html [ DumpJSConsoleLogInStdErr ]
-imported/w3c/web-platform-tests/import-maps/nonimport-integrity.html [ DumpJSConsoleLogInStdErr ]
-
-# These tests have been timing out since their import.
-imported/w3c/web-platform-tests/import-maps/data-driven [ Skip ]
+imported/w3c/web-platform-tests/import-maps/ [ DumpJSConsoleLogInStdErr ]
 
 # Imported tests that are timing out because the feature is not yet implemented.
 imported/w3c/web-platform-tests/content-security-policy/report-hash [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/dynamic-import-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/dynamic-import-expected.txt
@@ -1,4 +1,4 @@
 
 PASS A dynamic import succeeds
-FAIL After a dynamic import(), import maps work fine assert_array_equals: expected property 0 to be "log:B" but got "log:A" (expected array ["log:B"] got ["log:A"])
+PASS After a dynamic import(), import maps work fine
 

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/script-tag-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/script-tag-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL After <script type="module"> import maps work fine assert_array_equals: expected property 0 to be "log:B" but got "log:A" (expected array ["log:B"] got ["log:A"])
+PASS After <script type="module"> import maps work fine
 

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/script-tag-inline-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/script-tag-inline-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL After inline <script type="module"> import maps work fine assert_array_equals: expected property 0 to be "log:B" but got "log:A" (expected array ["log:B"] got ["log:A"])
+PASS After inline <script type="module"> import maps work fine
 

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/bare-specifiers.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/bare-specifiers.sub-expected.txt
@@ -1,27 +1,6 @@
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
 Blocked access to external URL https://www1.localhost:9443/import-maps/resources/log.js?pipe=sub&name=cross-origin-bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
 Blocked access to external URL https://www1.localhost:9443/import-maps/resources/log.js?pipe=sub&name=cross-origin-bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
 Blocked access to external URL https://www1.localhost:9443/import-maps/resources/log.js?pipe=sub&name=cross-origin-bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: TypeError: Module name, 'bare/to-bare' does not resolve to a valid URL.
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
 
 
 PASS bare/bare: <script src type=module>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target-dynamic.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target-dynamic.sub-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: Refused to load https://www1.localhost:9443/import-maps/resources/log.js?pipe=sub&name=B because it does not appear in the script-src directive of the Content Security Policy.
 
 PASS The URL after mapping violates CSP (but not the URL before mapping)
 PASS The URL before mapping violates CSP (but not the URL after mapping)

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target.sub-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: Refused to load https://www1.localhost:9443/import-maps/resources/log.js?pipe=sub&name=B because it does not appear in the script-src directive of the Content Security Policy.
 
 PASS The URL after mapping violates CSP (but not the URL before mapping)
 PASS The URL before mapping violates CSP (but not the URL after mapping)

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/hash-failure-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/hash-failure-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: Refused to execute a script because its hash, its nonce, or 'unsafe-inline' does not appear in the script-src directive of the Content Security Policy.
 
 PASS Importmap should not be accepted due to wrong hash
 

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/nonce-failure-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/nonce-failure-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: Refused to execute a script because its hash, its nonce, or 'unsafe-inline' does not appear in the script-src directive of the Content Security Policy.
 
 PASS Importmap should be rejected due to nonce
 

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resolving_data-url-prefix.json-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resolving_data-url-prefix.json-expected.txt
@@ -1,8 +1,5 @@
-CONSOLE MESSAGE: Error: assert_unreached: Invalid message: FetchError Reached unreachable code
 
-
-Harness Error (TIMEOUT), message = null
 
 PASS Test helper: fetching and sanity checking test JSON: data-url-prefix.json
-TIMEOUT data: URL prefix: should not resolve since you can't resolve relative to a data: URL: foo/bar Test timed out
+PASS data: URL prefix: should not resolve since you can't resolve relative to a data: URL: foo/bar
 

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resolving_empty-import-map.json-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resolving_empty-import-map.json-expected.txt
@@ -1,37 +1,34 @@
-CONSOLE MESSAGE: Error: assert_unreached: Invalid message: FetchError Reached unreachable code
 
-
-Harness Error (TIMEOUT), message = null
 
 PASS Test helper: fetching and sanity checking test JSON: empty-import-map.json
-TIMEOUT valid relative specifiers: ./foo Test timed out
-NOTRUN valid relative specifiers: ./foo/bar
-NOTRUN valid relative specifiers: ./foo/../bar
-NOTRUN valid relative specifiers: ./foo/../../bar
-NOTRUN valid relative specifiers: ../foo
-NOTRUN valid relative specifiers: ../foo/bar
-NOTRUN valid relative specifiers: ../../../foo/bar
-NOTRUN valid relative specifiers: /foo
-NOTRUN valid relative specifiers: /foo/bar
-NOTRUN valid relative specifiers: /../../foo/bar
-NOTRUN valid relative specifiers: /../foo/../bar
-NOTRUN HTTPS scheme absolute URLs: https://fetch-scheme.net
-NOTRUN HTTPS scheme absolute URLs: https:fetch-scheme.org
-NOTRUN HTTPS scheme absolute URLs: https://fetch%2Dscheme.com/
-NOTRUN HTTPS scheme absolute URLs: https://///fetch-scheme.com///
-NOTRUN valid relative URLs that are invalid as specifiers should fail: invalid-specifier
-NOTRUN valid relative URLs that are invalid as specifiers should fail: \invalid-specifier
-NOTRUN valid relative URLs that are invalid as specifiers should fail: :invalid-specifier
-NOTRUN valid relative URLs that are invalid as specifiers should fail: @invalid-specifier
-NOTRUN valid relative URLs that are invalid as specifiers should fail: %2E/invalid-specifier
-NOTRUN valid relative URLs that are invalid as specifiers should fail: %2E%2E/invalid-specifier
-NOTRUN valid relative URLs that are invalid as specifiers should fail: .%2Finvalid-specifier
-NOTRUN invalid absolute URLs should fail: https://invalid-url.com:demo
-NOTRUN invalid absolute URLs should fail: http://[invalid-url.com]/
-NOTRUN non-HTTPS fetch scheme absolute URLs: about:fetch-scheme
-NOTRUN non-fetch scheme absolute URLs: about:fetch-scheme
-NOTRUN non-fetch scheme absolute URLs: mailto:non-fetch-scheme
-NOTRUN non-fetch scheme absolute URLs: import:non-fetch-scheme
-NOTRUN non-fetch scheme absolute URLs: javascript:non-fetch-scheme
-NOTRUN non-fetch scheme absolute URLs: wss:non-fetch-scheme
+PASS valid relative specifiers: ./foo
+PASS valid relative specifiers: ./foo/bar
+PASS valid relative specifiers: ./foo/../bar
+PASS valid relative specifiers: ./foo/../../bar
+PASS valid relative specifiers: ../foo
+PASS valid relative specifiers: ../foo/bar
+PASS valid relative specifiers: ../../../foo/bar
+PASS valid relative specifiers: /foo
+PASS valid relative specifiers: /foo/bar
+PASS valid relative specifiers: /../../foo/bar
+PASS valid relative specifiers: /../foo/../bar
+PASS HTTPS scheme absolute URLs: https://fetch-scheme.net
+PASS HTTPS scheme absolute URLs: https:fetch-scheme.org
+PASS HTTPS scheme absolute URLs: https://fetch%2Dscheme.com/
+PASS HTTPS scheme absolute URLs: https://///fetch-scheme.com///
+PASS valid relative URLs that are invalid as specifiers should fail: invalid-specifier
+PASS valid relative URLs that are invalid as specifiers should fail: \invalid-specifier
+PASS valid relative URLs that are invalid as specifiers should fail: :invalid-specifier
+PASS valid relative URLs that are invalid as specifiers should fail: @invalid-specifier
+PASS valid relative URLs that are invalid as specifiers should fail: %2E/invalid-specifier
+PASS valid relative URLs that are invalid as specifiers should fail: %2E%2E/invalid-specifier
+PASS valid relative URLs that are invalid as specifiers should fail: .%2Finvalid-specifier
+PASS invalid absolute URLs should fail: https://invalid-url.com:demo
+PASS invalid absolute URLs should fail: http://[invalid-url.com]/
+PASS non-HTTPS fetch scheme absolute URLs: about:fetch-scheme
+PASS non-fetch scheme absolute URLs: about:fetch-scheme
+PASS non-fetch scheme absolute URLs: mailto:non-fetch-scheme
+PASS non-fetch scheme absolute URLs: import:non-fetch-scheme
+PASS non-fetch scheme absolute URLs: javascript:non-fetch-scheme
+PASS non-fetch scheme absolute URLs: wss:non-fetch-scheme
 

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resolving_overlapping-entries.json-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resolving_overlapping-entries.json-expected.txt
@@ -1,13 +1,10 @@
-CONSOLE MESSAGE: Error: assert_unreached: Invalid message: FetchError Reached unreachable code
 
-
-Harness Error (TIMEOUT), message = null
 
 PASS Test helper: fetching and sanity checking test JSON: overlapping-entries.json
-TIMEOUT should favor the most-specific key: Overlapping entries with trailing slashes: a Test timed out
-NOTRUN should favor the most-specific key: Overlapping entries with trailing slashes: a/
-NOTRUN should favor the most-specific key: Overlapping entries with trailing slashes: a/x
-NOTRUN should favor the most-specific key: Overlapping entries with trailing slashes: a/b
-NOTRUN should favor the most-specific key: Overlapping entries with trailing slashes: a/b/
-NOTRUN should favor the most-specific key: Overlapping entries with trailing slashes: a/b/c
+PASS should favor the most-specific key: Overlapping entries with trailing slashes: a
+PASS should favor the most-specific key: Overlapping entries with trailing slashes: a/
+PASS should favor the most-specific key: Overlapping entries with trailing slashes: a/x
+PASS should favor the most-specific key: Overlapping entries with trailing slashes: a/b
+PASS should favor the most-specific key: Overlapping entries with trailing slashes: a/b/
+PASS should favor the most-specific key: Overlapping entries with trailing slashes: a/b/c
 

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resolving_packages-via-trailing-slashes.json-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resolving_packages-via-trailing-slashes.json-expected.txt
@@ -1,39 +1,36 @@
-CONSOLE MESSAGE: Error: assert_unreached: Invalid message: FetchError Reached unreachable code
 
-
-Harness Error (TIMEOUT), message = null
 
 PASS Test helper: fetching and sanity checking test JSON: packages-via-trailing-slashes.json
-TIMEOUT Package-like scenarios: package main modules: moment Test timed out
-NOTRUN Package-like scenarios: package main modules: lodash-dot
-NOTRUN Package-like scenarios: package main modules: lodash-dotdot
-NOTRUN Package-like scenarios: package submodules: moment/foo
-NOTRUN Package-like scenarios: package submodules: moment/foo?query
-NOTRUN Package-like scenarios: package submodules: moment/foo#fragment
-NOTRUN Package-like scenarios: package submodules: moment/foo?query#fragment
-NOTRUN Package-like scenarios: package submodules: lodash-dot/foo
-NOTRUN Package-like scenarios: package submodules: lodash-dotdot/foo
-NOTRUN Package-like scenarios: package names that end in a slash should just pass through: moment/
-NOTRUN Package-like scenarios: package modules that are not declared should fail: underscore/
-NOTRUN Package-like scenarios: package modules that are not declared should fail: underscore/foo
-NOTRUN Package-like scenarios: backtracking via ..: mapped/path
-NOTRUN Package-like scenarios: backtracking via ..: mapped/path/
-NOTRUN Package-like scenarios: backtracking via ..: mapped/path/..
-NOTRUN Package-like scenarios: backtracking via ..: mapped/path/../path/
-NOTRUN Package-like scenarios: backtracking via ..: mapped/path/../207
-NOTRUN Package-like scenarios: backtracking via ..: mapped/path/../207/
-NOTRUN Package-like scenarios: backtracking via ..: mapped/path//
-NOTRUN Package-like scenarios: backtracking via ..: mapped/path/WICG/import-maps/issues/207/
-NOTRUN Package-like scenarios: backtracking via ..: mapped/path//WICG/import-maps/issues/207/
-NOTRUN Package-like scenarios: backtracking via ..: mapped/path/../backtrack
-NOTRUN Package-like scenarios: backtracking via ..: mapped/path/../../backtrack
-NOTRUN Package-like scenarios: backtracking via ..: mapped/path/../../../backtrack
-NOTRUN Package-like scenarios: backtracking via ..: moment/../backtrack
-NOTRUN Package-like scenarios: backtracking via ..: moment/..
-NOTRUN Package-like scenarios: backtracking via ..: mapped/non-ascii-1/
-NOTRUN Package-like scenarios: backtracking via ..: mapped/non-ascii-1/../%E3%81%8D%E3%81%A4%E3%81%AD/
-NOTRUN Package-like scenarios: backtracking via ..: mapped/non-ascii-1/../きつね/
-NOTRUN Package-like scenarios: backtracking via ..: mapped/non-ascii-2/
-NOTRUN Package-like scenarios: backtracking via ..: mapped/non-ascii-2/../%E3%81%8D%E3%81%A4%E3%81%AD/
-NOTRUN Package-like scenarios: backtracking via ..: mapped/non-ascii-2/../きつね/
+PASS Package-like scenarios: package main modules: moment
+PASS Package-like scenarios: package main modules: lodash-dot
+PASS Package-like scenarios: package main modules: lodash-dotdot
+PASS Package-like scenarios: package submodules: moment/foo
+PASS Package-like scenarios: package submodules: moment/foo?query
+PASS Package-like scenarios: package submodules: moment/foo#fragment
+PASS Package-like scenarios: package submodules: moment/foo?query#fragment
+PASS Package-like scenarios: package submodules: lodash-dot/foo
+PASS Package-like scenarios: package submodules: lodash-dotdot/foo
+PASS Package-like scenarios: package names that end in a slash should just pass through: moment/
+PASS Package-like scenarios: package modules that are not declared should fail: underscore/
+PASS Package-like scenarios: package modules that are not declared should fail: underscore/foo
+PASS Package-like scenarios: backtracking via ..: mapped/path
+PASS Package-like scenarios: backtracking via ..: mapped/path/
+PASS Package-like scenarios: backtracking via ..: mapped/path/..
+PASS Package-like scenarios: backtracking via ..: mapped/path/../path/
+PASS Package-like scenarios: backtracking via ..: mapped/path/../207
+PASS Package-like scenarios: backtracking via ..: mapped/path/../207/
+PASS Package-like scenarios: backtracking via ..: mapped/path//
+PASS Package-like scenarios: backtracking via ..: mapped/path/WICG/import-maps/issues/207/
+PASS Package-like scenarios: backtracking via ..: mapped/path//WICG/import-maps/issues/207/
+PASS Package-like scenarios: backtracking via ..: mapped/path/../backtrack
+PASS Package-like scenarios: backtracking via ..: mapped/path/../../backtrack
+PASS Package-like scenarios: backtracking via ..: mapped/path/../../../backtrack
+PASS Package-like scenarios: backtracking via ..: moment/../backtrack
+PASS Package-like scenarios: backtracking via ..: moment/..
+PASS Package-like scenarios: backtracking via ..: mapped/non-ascii-1/
+PASS Package-like scenarios: backtracking via ..: mapped/non-ascii-1/../%E3%81%8D%E3%81%A4%E3%81%AD/
+PASS Package-like scenarios: backtracking via ..: mapped/non-ascii-1/../きつね/
+PASS Package-like scenarios: backtracking via ..: mapped/non-ascii-2/
+PASS Package-like scenarios: backtracking via ..: mapped/non-ascii-2/../%E3%81%8D%E3%81%A4%E3%81%AD/
+PASS Package-like scenarios: backtracking via ..: mapped/non-ascii-2/../きつね/
 

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resolving_resolving-null.json-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resolving_resolving-null.json-expected.txt
@@ -1,25 +1,24 @@
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL https://:invalid-url:/
-CONSOLE MESSAGE: value in specifier map needs to be a string
-CONSOLE MESSAGE: address https://example.com/x does not end with '/' while key without-trailing-slashes/b/ ends with '/'
-CONSOLE MESSAGE: value in specifier map needs to be a string
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL https://:invalid-url:/
-CONSOLE MESSAGE: address https://example.com/x does not end with '/' while key without-trailing-slashes/ ends with '/'
-CONSOLE MESSAGE: Error: assert_unreached: Invalid message: Success Reached unreachable code
 
 
-Harness Error (TIMEOUT), message = null
-
-FAIL Test helper: fetching and sanity checking test JSON: resolving-null.json assert_equals: Import map registration should be successful for resolution tests expected "Success" but got "FetchError"
-TIMEOUT Entries with errors shouldn't allow fallback: No fallback to less-specific prefixes: null/x Test timed out
-NOTRUN Entries with errors shouldn't allow fallback: No fallback to less-specific prefixes: null/b/x
-NOTRUN Entries with errors shouldn't allow fallback: No fallback to less-specific prefixes: null/b/c/x
-NOTRUN Entries with errors shouldn't allow fallback: No fallback to less-specific prefixes: invalid-url/x
-NOTRUN Entries with errors shouldn't allow fallback: No fallback to less-specific prefixes: invalid-url/b/x
-NOTRUN Entries with errors shouldn't allow fallback: No fallback to less-specific prefixes: invalid-url/b/c/x
-NOTRUN Entries with errors shouldn't allow fallback: No fallback to less-specific prefixes: without-trailing-slashes/x
-NOTRUN Entries with errors shouldn't allow fallback: No fallback to less-specific prefixes: without-trailing-slashes/b/x
-NOTRUN Entries with errors shouldn't allow fallback: No fallback to less-specific prefixes: without-trailing-slashes/b/c/x
-NOTRUN Entries with errors shouldn't allow fallback: No fallback to less-specific prefixes: prefix-resolution-error/x
-NOTRUN Entries with errors shouldn't allow fallback: No fallback to less-specific prefixes: prefix-resolution-error/b/x
-NOTRUN Entries with errors shouldn't allow fallback: No fallback to less-specific prefixes: prefix-resolution-error/b/c/x
+PASS Test helper: fetching and sanity checking test JSON: resolving-null.json
+PASS Entries with errors shouldn't allow fallback: No fallback to less-specific prefixes: null/x
+PASS Entries with errors shouldn't allow fallback: No fallback to less-specific prefixes: null/b/x
+PASS Entries with errors shouldn't allow fallback: No fallback to less-specific prefixes: null/b/c/x
+PASS Entries with errors shouldn't allow fallback: No fallback to less-specific prefixes: invalid-url/x
+PASS Entries with errors shouldn't allow fallback: No fallback to less-specific prefixes: invalid-url/b/x
+PASS Entries with errors shouldn't allow fallback: No fallback to less-specific prefixes: invalid-url/b/c/x
+PASS Entries with errors shouldn't allow fallback: No fallback to less-specific prefixes: without-trailing-slashes/x
+PASS Entries with errors shouldn't allow fallback: No fallback to less-specific prefixes: without-trailing-slashes/b/x
+PASS Entries with errors shouldn't allow fallback: No fallback to less-specific prefixes: without-trailing-slashes/b/c/x
+PASS Entries with errors shouldn't allow fallback: No fallback to less-specific prefixes: prefix-resolution-error/x
+PASS Entries with errors shouldn't allow fallback: No fallback to less-specific prefixes: prefix-resolution-error/b/x
+PASS Entries with errors shouldn't allow fallback: No fallback to less-specific prefixes: prefix-resolution-error/b/c/x
+PASS Entries with errors shouldn't allow fallback: No fallback to less-specific scopes: null
+PASS Entries with errors shouldn't allow fallback: No fallback to less-specific scopes: invalid-url
+PASS Entries with errors shouldn't allow fallback: No fallback to less-specific scopes: without-trailing-slashes/x
+PASS Entries with errors shouldn't allow fallback: No fallback to less-specific scopes: prefix-resolution-error/x
+PASS Entries with errors shouldn't allow fallback: No fallback to absolute URL parsing: https://example.com/null
+PASS Entries with errors shouldn't allow fallback: No fallback to absolute URL parsing: https://example.com/invalid-url
+PASS Entries with errors shouldn't allow fallback: No fallback to absolute URL parsing: https://example.com/without-trailing-slashes/x
+PASS Entries with errors shouldn't allow fallback: No fallback to absolute URL parsing: https://example.com/prefix-resolution-error/x
 

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resolving_scopes-exact-vs-prefix.json-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resolving_scopes-exact-vs-prefix.json-expected.txt
@@ -1,15 +1,28 @@
-CONSOLE MESSAGE: Error: assert_unreached: Invalid message: Success Reached unreachable code
 
 
-Harness Error (TIMEOUT), message = null
-
-FAIL Test helper: fetching and sanity checking test JSON: scopes-exact-vs-prefix.json assert_equals: Import map registration should be successful for resolution tests expected "Success" but got "FetchError"
-TIMEOUT Exact vs. prefix based matching: Scope without trailing slash only: Non-trailing-slash base URL (exact match): moment Test timed out
-NOTRUN Exact vs. prefix based matching: Scope without trailing slash only: Non-trailing-slash base URL (exact match): moment/foo
-NOTRUN Exact vs. prefix based matching: Scope without trailing slash only: Trailing-slash base URL (fail): moment
-NOTRUN Exact vs. prefix based matching: Scope without trailing slash only: Trailing-slash base URL (fail): moment/foo
-NOTRUN Exact vs. prefix based matching: Scope without trailing slash only: Subpath base URL (fail): moment
-NOTRUN Exact vs. prefix based matching: Scope without trailing slash only: Subpath base URL (fail): moment/foo
-NOTRUN Exact vs. prefix based matching: Scope without trailing slash only: Non-subpath base URL (fail): moment
-NOTRUN Exact vs. prefix based matching: Scope without trailing slash only: Non-subpath base URL (fail): moment/foo
+PASS Test helper: fetching and sanity checking test JSON: scopes-exact-vs-prefix.json
+PASS Exact vs. prefix based matching: Scope without trailing slash only: Non-trailing-slash base URL (exact match): moment
+PASS Exact vs. prefix based matching: Scope without trailing slash only: Non-trailing-slash base URL (exact match): moment/foo
+PASS Exact vs. prefix based matching: Scope without trailing slash only: Trailing-slash base URL (fail): moment
+PASS Exact vs. prefix based matching: Scope without trailing slash only: Trailing-slash base URL (fail): moment/foo
+PASS Exact vs. prefix based matching: Scope without trailing slash only: Subpath base URL (fail): moment
+PASS Exact vs. prefix based matching: Scope without trailing slash only: Subpath base URL (fail): moment/foo
+PASS Exact vs. prefix based matching: Scope without trailing slash only: Non-subpath base URL (fail): moment
+PASS Exact vs. prefix based matching: Scope without trailing slash only: Non-subpath base URL (fail): moment/foo
+PASS Exact vs. prefix based matching: Scope with trailing slash only: Non-trailing-slash base URL (fail): moment
+PASS Exact vs. prefix based matching: Scope with trailing slash only: Non-trailing-slash base URL (fail): moment/foo
+PASS Exact vs. prefix based matching: Scope with trailing slash only: Trailing-slash base URL (exact match): moment
+PASS Exact vs. prefix based matching: Scope with trailing slash only: Trailing-slash base URL (exact match): moment/foo
+PASS Exact vs. prefix based matching: Scope with trailing slash only: Subpath base URL (prefix match): moment
+PASS Exact vs. prefix based matching: Scope with trailing slash only: Subpath base URL (prefix match): moment/foo
+PASS Exact vs. prefix based matching: Scope with trailing slash only: Non-subpath base URL (fail): moment
+PASS Exact vs. prefix based matching: Scope with trailing slash only: Non-subpath base URL (fail): moment/foo
+PASS Exact vs. prefix based matching: Scopes with and without trailing slash: Non-trailing-slash base URL (exact match): moment
+PASS Exact vs. prefix based matching: Scopes with and without trailing slash: Non-trailing-slash base URL (exact match): moment/foo
+PASS Exact vs. prefix based matching: Scopes with and without trailing slash: Trailing-slash base URL (exact match): moment
+PASS Exact vs. prefix based matching: Scopes with and without trailing slash: Trailing-slash base URL (exact match): moment/foo
+PASS Exact vs. prefix based matching: Scopes with and without trailing slash: Subpath base URL (prefix match): moment
+PASS Exact vs. prefix based matching: Scopes with and without trailing slash: Subpath base URL (prefix match): moment/foo
+PASS Exact vs. prefix based matching: Scopes with and without trailing slash: Non-subpath base URL (fail): moment
+PASS Exact vs. prefix based matching: Scopes with and without trailing slash: Non-subpath base URL (fail): moment/foo
 

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resolving_scopes.json-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resolving_scopes.json-expected.txt
@@ -1,19 +1,40 @@
-CONSOLE MESSAGE: Error: assert_unreached: Invalid message: Success Reached unreachable code
 
 
-Harness Error (TIMEOUT), message = null
-
-FAIL Test helper: fetching and sanity checking test JSON: scopes.json assert_equals: Import map registration should be successful for resolution tests expected "Success" but got "FetchError"
-TIMEOUT Fallback to toplevel and between scopes: should fall back to `imports` when no scopes match: a Test timed out
-NOTRUN Fallback to toplevel and between scopes: should fall back to `imports` when no scopes match: b
-NOTRUN Fallback to toplevel and between scopes: should fall back to `imports` when no scopes match: c
-NOTRUN Fallback to toplevel and between scopes: should fall back to `imports` when no scopes match: d
-NOTRUN Fallback to toplevel and between scopes: should use a direct scope override: a
-NOTRUN Fallback to toplevel and between scopes: should use a direct scope override: b
-NOTRUN Fallback to toplevel and between scopes: should use a direct scope override: c
-NOTRUN Fallback to toplevel and between scopes: should use a direct scope override: d
-NOTRUN Fallback to toplevel and between scopes: should use an indirect scope override: a
-NOTRUN Fallback to toplevel and between scopes: should use an indirect scope override: b
-NOTRUN Fallback to toplevel and between scopes: should use an indirect scope override: c
-NOTRUN Fallback to toplevel and between scopes: should use an indirect scope override: d
+PASS Test helper: fetching and sanity checking test JSON: scopes.json
+PASS Fallback to toplevel and between scopes: should fall back to `imports` when no scopes match: a
+PASS Fallback to toplevel and between scopes: should fall back to `imports` when no scopes match: b
+PASS Fallback to toplevel and between scopes: should fall back to `imports` when no scopes match: c
+PASS Fallback to toplevel and between scopes: should fall back to `imports` when no scopes match: d
+PASS Fallback to toplevel and between scopes: should use a direct scope override: a
+PASS Fallback to toplevel and between scopes: should use a direct scope override: b
+PASS Fallback to toplevel and between scopes: should use a direct scope override: c
+PASS Fallback to toplevel and between scopes: should use a direct scope override: d
+PASS Fallback to toplevel and between scopes: should use an indirect scope override: a
+PASS Fallback to toplevel and between scopes: should use an indirect scope override: b
+PASS Fallback to toplevel and between scopes: should use an indirect scope override: c
+PASS Fallback to toplevel and between scopes: should use an indirect scope override: d
+PASS Relative URL scope keys: An empty string scope is a scope with import map base URL: a
+PASS Relative URL scope keys: An empty string scope is a scope with import map base URL: b
+PASS Relative URL scope keys: An empty string scope is a scope with import map base URL: c
+PASS Relative URL scope keys: './' scope is a scope with import map base URL's directory: a
+PASS Relative URL scope keys: './' scope is a scope with import map base URL's directory: b
+PASS Relative URL scope keys: './' scope is a scope with import map base URL's directory: c
+PASS Relative URL scope keys: '../' scope is a scope with import map base URL's parent directory: a
+PASS Relative URL scope keys: '../' scope is a scope with import map base URL's parent directory: b
+PASS Relative URL scope keys: '../' scope is a scope with import map base URL's parent directory: c
+PASS Package-like scenarios: Base URLs inside the scope should use the scope if the scope has matching keys: lodash-dot
+PASS Package-like scenarios: Base URLs inside the scope should use the scope if the scope has matching keys: lodash-dot/foo
+PASS Package-like scenarios: Base URLs inside the scope should use the scope if the scope has matching keys: lodash-dotdot
+PASS Package-like scenarios: Base URLs inside the scope should use the scope if the scope has matching keys: lodash-dotdot/foo
+PASS Package-like scenarios: Base URLs inside the scope fallback to less specific scope: moment
+PASS Package-like scenarios: Base URLs inside the scope fallback to less specific scope: vue
+PASS Package-like scenarios: Base URLs inside the scope fallback to toplevel: moment/foo
+PASS Package-like scenarios: Base URLs outside a scope shouldn't use the scope even if the scope has matching keys: lodash-dot
+PASS Package-like scenarios: Base URLs outside a scope shouldn't use the scope even if the scope has matching keys: lodash-dotdot
+PASS Package-like scenarios: Base URLs outside a scope shouldn't use the scope even if the scope has matching keys: lodash-dot/foo
+PASS Package-like scenarios: Base URLs outside a scope shouldn't use the scope even if the scope has matching keys: lodash-dotdot/foo
+PASS Package-like scenarios: Fallback to toplevel or not, depending on trailing slash match: moment
+PASS Package-like scenarios: Fallback to toplevel or not, depending on trailing slash match: moment/foo
+PASS Package-like scenarios: should still fail for package-like specifiers that are not declared: underscore/
+PASS Package-like scenarios: should still fail for package-like specifiers that are not declared: underscore/foo
 

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resolving_tricky-specifiers.json-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resolving_tricky-specifiers.json-expected.txt
@@ -1,31 +1,28 @@
-CONSOLE MESSAGE: Error: assert_unreached: Invalid message: FetchError Reached unreachable code
 
-
-Harness Error (TIMEOUT), message = null
 
 PASS Test helper: fetching and sanity checking test JSON: tricky-specifiers.json
-TIMEOUT Tricky specifiers: explicitly-mapped specifiers that happen to have a slash: package/withslash Test timed out
-NOTRUN Tricky specifiers: specifier with punctuation: .
-NOTRUN Tricky specifiers: specifier with punctuation: ..
-NOTRUN Tricky specifiers: specifier with punctuation: ..\
-NOTRUN Tricky specifiers: specifier with punctuation: %2E
-NOTRUN Tricky specifiers: specifier with punctuation: %2F
-NOTRUN Tricky specifiers: submodule of something not declared with a trailing slash should fail: not-a-package/foo
-NOTRUN Tricky specifiers: module for which only a trailing-slash version is present should fail: only-slash
-NOTRUN Tricky specifiers: URL-like specifiers are normalized: https://map.example/%E3%81%8D%E3%81%A4%E3%81%AD/
-NOTRUN Tricky specifiers: URL-like specifiers are normalized: https://map.example/%E3%81%8D%E3%81%A4%E3%81%AD/bar
-NOTRUN Tricky specifiers: URL-like specifiers are normalized: https://map.example/%E3%81%8D%E3%81%A4%E3%81%AD/fox/
-NOTRUN Tricky specifiers: URL-like specifiers are normalized: https://map.example/%E3%81%8D%E3%81%A4%E3%81%AD/fox/bar
-NOTRUN Tricky specifiers: URL-like specifiers are normalized: https://map.example/きつね/
-NOTRUN Tricky specifiers: URL-like specifiers are normalized: https://map.example/きつね/bar
-NOTRUN Tricky specifiers: URL-like specifiers are normalized: https://map.example/きつね/fox/
-NOTRUN Tricky specifiers: URL-like specifiers are normalized: https://map.example/きつね/fox/bar
-NOTRUN Tricky specifiers: Bare specifiers are not normalized: %E3%81%8D%E3%81%A4%E3%81%AD/
-NOTRUN Tricky specifiers: Bare specifiers are not normalized: %E3%81%8D%E3%81%A4%E3%81%AD/bar
-NOTRUN Tricky specifiers: Bare specifiers are not normalized: %E3%81%8D%E3%81%A4%E3%81%AD/fox/
-NOTRUN Tricky specifiers: Bare specifiers are not normalized: %E3%81%8D%E3%81%A4%E3%81%AD/fox/bar
-NOTRUN Tricky specifiers: Bare specifiers are not normalized: きつね/
-NOTRUN Tricky specifiers: Bare specifiers are not normalized: きつね/bar
-NOTRUN Tricky specifiers: Bare specifiers are not normalized: きつね/fox/
-NOTRUN Tricky specifiers: Bare specifiers are not normalized: きつね/fox/bar
+PASS Tricky specifiers: explicitly-mapped specifiers that happen to have a slash: package/withslash
+PASS Tricky specifiers: specifier with punctuation: .
+PASS Tricky specifiers: specifier with punctuation: ..
+PASS Tricky specifiers: specifier with punctuation: ..\
+PASS Tricky specifiers: specifier with punctuation: %2E
+PASS Tricky specifiers: specifier with punctuation: %2F
+PASS Tricky specifiers: submodule of something not declared with a trailing slash should fail: not-a-package/foo
+PASS Tricky specifiers: module for which only a trailing-slash version is present should fail: only-slash
+PASS Tricky specifiers: URL-like specifiers are normalized: https://map.example/%E3%81%8D%E3%81%A4%E3%81%AD/
+PASS Tricky specifiers: URL-like specifiers are normalized: https://map.example/%E3%81%8D%E3%81%A4%E3%81%AD/bar
+PASS Tricky specifiers: URL-like specifiers are normalized: https://map.example/%E3%81%8D%E3%81%A4%E3%81%AD/fox/
+PASS Tricky specifiers: URL-like specifiers are normalized: https://map.example/%E3%81%8D%E3%81%A4%E3%81%AD/fox/bar
+PASS Tricky specifiers: URL-like specifiers are normalized: https://map.example/きつね/
+PASS Tricky specifiers: URL-like specifiers are normalized: https://map.example/きつね/bar
+PASS Tricky specifiers: URL-like specifiers are normalized: https://map.example/きつね/fox/
+PASS Tricky specifiers: URL-like specifiers are normalized: https://map.example/きつね/fox/bar
+PASS Tricky specifiers: Bare specifiers are not normalized: %E3%81%8D%E3%81%A4%E3%81%AD/
+PASS Tricky specifiers: Bare specifiers are not normalized: %E3%81%8D%E3%81%A4%E3%81%AD/bar
+PASS Tricky specifiers: Bare specifiers are not normalized: %E3%81%8D%E3%81%A4%E3%81%AD/fox/
+PASS Tricky specifiers: Bare specifiers are not normalized: %E3%81%8D%E3%81%A4%E3%81%AD/fox/bar
+PASS Tricky specifiers: Bare specifiers are not normalized: きつね/
+PASS Tricky specifiers: Bare specifiers are not normalized: きつね/bar
+PASS Tricky specifiers: Bare specifiers are not normalized: きつね/fox/
+PASS Tricky specifiers: Bare specifiers are not normalized: きつね/fox/bar
 

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resolving_url-specifiers-schemes.json-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resolving_url-specifiers-schemes.json-expected.txt
@@ -1,27 +1,24 @@
-CONSOLE MESSAGE: Error: assert_unreached: Invalid message: FetchError Reached unreachable code
 
-
-Harness Error (TIMEOUT), message = null
 
 PASS Test helper: fetching and sanity checking test JSON: url-specifiers-schemes.json
-TIMEOUT URL-like specifiers: Non-special vs. special schemes: data:text/javascript,console.log('foo') Test timed out
-NOTRUN URL-like specifiers: Non-special vs. special schemes: data:text/
-NOTRUN URL-like specifiers: Non-special vs. special schemes: about:text/foo
-NOTRUN URL-like specifiers: Non-special vs. special schemes: about:text/
-NOTRUN URL-like specifiers: Non-special vs. special schemes: blob:text/foo
-NOTRUN URL-like specifiers: Non-special vs. special schemes: blob:text/
-NOTRUN URL-like specifiers: Non-special vs. special schemes: blah:text/foo
-NOTRUN URL-like specifiers: Non-special vs. special schemes: blah:text/
-NOTRUN URL-like specifiers: Non-special vs. special schemes: http:text/foo
-NOTRUN URL-like specifiers: Non-special vs. special schemes: http:text/
-NOTRUN URL-like specifiers: Non-special vs. special schemes: https:text/foo
-NOTRUN URL-like specifiers: Non-special vs. special schemes: https:text/
-NOTRUN URL-like specifiers: Non-special vs. special schemes: ftp:text/foo
-NOTRUN URL-like specifiers: Non-special vs. special schemes: ftp:text/
-NOTRUN URL-like specifiers: Non-special vs. special schemes: file:text/foo
-NOTRUN URL-like specifiers: Non-special vs. special schemes: file:text/
-NOTRUN URL-like specifiers: Non-special vs. special schemes: ws:text/foo
-NOTRUN URL-like specifiers: Non-special vs. special schemes: ws:text/
-NOTRUN URL-like specifiers: Non-special vs. special schemes: wss:text/foo
-NOTRUN URL-like specifiers: Non-special vs. special schemes: wss:text/
+PASS URL-like specifiers: Non-special vs. special schemes: data:text/javascript,console.log('foo')
+PASS URL-like specifiers: Non-special vs. special schemes: data:text/
+PASS URL-like specifiers: Non-special vs. special schemes: about:text/foo
+PASS URL-like specifiers: Non-special vs. special schemes: about:text/
+PASS URL-like specifiers: Non-special vs. special schemes: blob:text/foo
+PASS URL-like specifiers: Non-special vs. special schemes: blob:text/
+PASS URL-like specifiers: Non-special vs. special schemes: blah:text/foo
+PASS URL-like specifiers: Non-special vs. special schemes: blah:text/
+PASS URL-like specifiers: Non-special vs. special schemes: http:text/foo
+PASS URL-like specifiers: Non-special vs. special schemes: http:text/
+PASS URL-like specifiers: Non-special vs. special schemes: https:text/foo
+PASS URL-like specifiers: Non-special vs. special schemes: https:text/
+PASS URL-like specifiers: Non-special vs. special schemes: ftp:text/foo
+PASS URL-like specifiers: Non-special vs. special schemes: ftp:text/
+PASS URL-like specifiers: Non-special vs. special schemes: file:text/foo
+PASS URL-like specifiers: Non-special vs. special schemes: file:text/
+PASS URL-like specifiers: Non-special vs. special schemes: ws:text/foo
+PASS URL-like specifiers: Non-special vs. special schemes: ws:text/
+PASS URL-like specifiers: Non-special vs. special schemes: wss:text/foo
+PASS URL-like specifiers: Non-special vs. special schemes: wss:text/
 

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resolving_url-specifiers.json-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resolving_url-specifiers.json-expected.txt
@@ -1,31 +1,28 @@
-CONSOLE MESSAGE: Error: assert_unreached: Invalid message: FetchError Reached unreachable code
 
-
-Harness Error (TIMEOUT), message = null
 
 PASS Test helper: fetching and sanity checking test JSON: url-specifiers.json
-TIMEOUT URL-like specifiers: Ordinary URL-like specifiers: https://example.com/lib/foo.mjs Test timed out
-NOTRUN URL-like specifiers: Ordinary URL-like specifiers: https://///example.com/lib/foo.mjs
-NOTRUN URL-like specifiers: Ordinary URL-like specifiers: /lib/foo.mjs
-NOTRUN URL-like specifiers: Ordinary URL-like specifiers: https://example.com/app/dotrelative/foo.mjs
-NOTRUN URL-like specifiers: Ordinary URL-like specifiers: ../app/dotrelative/foo.mjs
-NOTRUN URL-like specifiers: Ordinary URL-like specifiers: https://example.com/dotdotrelative/foo.mjs
-NOTRUN URL-like specifiers: Ordinary URL-like specifiers: ../dotdotrelative/foo.mjs
-NOTRUN URL-like specifiers: Import map entries just composed from / and .: https://example.com/
-NOTRUN URL-like specifiers: Import map entries just composed from / and .: /
-NOTRUN URL-like specifiers: Import map entries just composed from / and .: ../
-NOTRUN URL-like specifiers: Import map entries just composed from / and .: https://example.com/app/
-NOTRUN URL-like specifiers: Import map entries just composed from / and .: /app/
-NOTRUN URL-like specifiers: Import map entries just composed from / and .: ../app/
-NOTRUN URL-like specifiers: prefix-matched by keys with trailing slashes: /test/foo.mjs
-NOTRUN URL-like specifiers: prefix-matched by keys with trailing slashes: https://example.com/app/test/foo.mjs
-NOTRUN URL-like specifiers: should use the last entry's address when URL-like specifiers parse to the same absolute URL: /test
-NOTRUN URL-like specifiers: backtracking (relative URLs): /test/..
-NOTRUN URL-like specifiers: backtracking (relative URLs): /test/../backtrack
-NOTRUN URL-like specifiers: backtracking (relative URLs): /test/../../backtrack
-NOTRUN URL-like specifiers: backtracking (relative URLs): /test/../../../backtrack
-NOTRUN URL-like specifiers: backtracking (absolute URLs): https://example.com/test/..
-NOTRUN URL-like specifiers: backtracking (absolute URLs): https://example.com/test/../backtrack
-NOTRUN URL-like specifiers: backtracking (absolute URLs): https://example.com/test/../../backtrack
-NOTRUN URL-like specifiers: backtracking (absolute URLs): https://example.com/test/../../../backtrack
+PASS URL-like specifiers: Ordinary URL-like specifiers: https://example.com/lib/foo.mjs
+PASS URL-like specifiers: Ordinary URL-like specifiers: https://///example.com/lib/foo.mjs
+PASS URL-like specifiers: Ordinary URL-like specifiers: /lib/foo.mjs
+PASS URL-like specifiers: Ordinary URL-like specifiers: https://example.com/app/dotrelative/foo.mjs
+PASS URL-like specifiers: Ordinary URL-like specifiers: ../app/dotrelative/foo.mjs
+PASS URL-like specifiers: Ordinary URL-like specifiers: https://example.com/dotdotrelative/foo.mjs
+PASS URL-like specifiers: Ordinary URL-like specifiers: ../dotdotrelative/foo.mjs
+PASS URL-like specifiers: Import map entries just composed from / and .: https://example.com/
+PASS URL-like specifiers: Import map entries just composed from / and .: /
+PASS URL-like specifiers: Import map entries just composed from / and .: ../
+PASS URL-like specifiers: Import map entries just composed from / and .: https://example.com/app/
+PASS URL-like specifiers: Import map entries just composed from / and .: /app/
+PASS URL-like specifiers: Import map entries just composed from / and .: ../app/
+PASS URL-like specifiers: prefix-matched by keys with trailing slashes: /test/foo.mjs
+PASS URL-like specifiers: prefix-matched by keys with trailing slashes: https://example.com/app/test/foo.mjs
+PASS URL-like specifiers: should use the last entry's address when URL-like specifiers parse to the same absolute URL: /test
+PASS URL-like specifiers: backtracking (relative URLs): /test/..
+PASS URL-like specifiers: backtracking (relative URLs): /test/../backtrack
+PASS URL-like specifiers: backtracking (relative URLs): /test/../../backtrack
+PASS URL-like specifiers: backtracking (relative URLs): /test/../../../backtrack
+PASS URL-like specifiers: backtracking (absolute URLs): https://example.com/test/..
+PASS URL-like specifiers: backtracking (absolute URLs): https://example.com/test/../backtrack
+PASS URL-like specifiers: backtracking (absolute URLs): https://example.com/test/../../backtrack
+PASS URL-like specifiers: backtracking (absolute URLs): https://example.com/test/../../../backtrack
 

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-url-specifiers.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-url-specifiers.sub-expected.txt
@@ -1,27 +1,6 @@
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
 Blocked access to external URL https://www1.localhost:9443/import-maps/resources/log.js?pipe=sub&name=cross-origin-foo
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
 Blocked access to external URL https://www1.localhost:9443/import-maps/resources/log.js?pipe=sub&name=cross-origin-foo
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
 Blocked access to external URL https://www1.localhost:9443/import-maps/resources/log.js?pipe=sub&name=cross-origin-foo
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: TypeError: Module name, 'data:text/javascript,log.push('data:to-bare')' does not resolve to a valid URL.
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
 
 
 PASS data:text/javascript,log.push('data:foo'): <script src type=module>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/http-url-like-specifiers.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/http-url-like-specifiers.sub-expected.txt
@@ -1,27 +1,6 @@
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
 Blocked access to external URL https://www1.localhost:9443/import-maps/resources/log.js?pipe=sub&name=cross-origin-bar
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
 Blocked access to external URL https://www1.localhost:9443/import-maps/resources/log.js?pipe=sub&name=cross-origin-bar
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
 Blocked access to external URL https://www1.localhost:9443/import-maps/resources/log.js?pipe=sub&name=cross-origin-bar
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: TypeError: Module name, 'http://localhost:8800/import-maps/resources/log.js?pipe=sub&name=to-bare' does not resolve to a valid URL.
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
 
 
 PASS http://localhost:8800/import-maps/resources/log.js?pipe=sub&name=foo: <script src type=module>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/basic-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Second import map should be used for resolution assert_array_equals: lengths differ, expected array ["log:B1", "log:B2", "log:C3"] length 3, got ["onerror 2", "log:B1", "log:B2", "log:A3"] length 4
+PASS Second import map should be used for resolution
 

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/conflict-first-persists-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/conflict-first-persists-expected.txt
@@ -1,5 +1,5 @@
 
 PASS First defined rule persists in case of conflict
 PASS First defined rule persists in case of conflict - prefixed bare specifiers
-FAIL First defined rule persists in case of conflict - non-prefix bare specifier promise_test: Unhandled rejection with value: object "TypeError: Module name, 'module-b' does not resolve to a valid URL."
+PASS First defined rule persists in case of conflict - non-prefix bare specifier
 

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/resolution-consistency-in-module-tree-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/resolution-consistency-in-module-tree-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Module tree that started to download before a new import map should still take it into account assert_array_equals: Import should use the new import map expected property 0 to be "log:B" but got "log:A" (expected array ["log:B"] got ["log:A"])
+PASS Module tree that started to download before a new import map should still take it into account
 

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/resolution-consistency-in-module-tree-inline-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/resolution-consistency-in-module-tree-inline-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Module tree that started to download before a new import map should still take it into account assert_array_equals: Import should use the new import map expected property 0 to be "log:B" but got "log:A" (expected array ["log:B"] got ["log:A"])
+PASS Module tree that started to download before a new import map should still take it into account
 

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/resolution-consistency-in-module-tree.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/resolution-consistency-in-module-tree.html
@@ -5,7 +5,7 @@
   <script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
-<script type="module" async>
+<script>
 step_timeout(() => {
   const importMapScript = document.createElement('script');
   importMapScript.type = 'importmap';

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/with-errors-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/with-errors-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: ImportMap has invalid JSON
 
-FAIL Second import map should be used for resolution even after an import map with errors assert_array_equals: lengths differ, expected array ["log:C"] length 1, got ["onerror 2", "log:A"] length 2
+PASS Second import map should be used for resolution even after an import map with errors
 

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/external-script-bare-descendent-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/external-script-bare-descendent-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Resolution after import map should not be redefined
 PASS Resolution after import map should not be redefined for bare prefixes or exact matches
-FAIL Resolution after import map should be redefined for non-prefixes Module name, 'foo' does not resolve to a valid URL.
+PASS Resolution after import map should be redefined for non-prefixes
 

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/external-script-descendent-with-scope-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/external-script-descendent-with-scope-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Testing descendent resolution with scopes Test timed out
+PASS Testing descendent resolution with scopes
 

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/failed-resolution-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/failed-resolution-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Resolution after import map should not be redefined Module name, 'a' does not resolve to a valid URL.
+PASS Resolution after import map should not be redefined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/out-of-scope-test.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/out-of-scope-test.js
@@ -1,0 +1,5 @@
+// Testing that the resolution is correct using `resolve`, as you can't import
+// the same module twice.
+window.outscope_test_result = import.meta.resolve("a");
+window.outscope_test_result2 = import.meta.resolve("../resources/log.sub.js?name=E");
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/import-maps/bare-specifiers.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/import-maps/bare-specifiers.sub-expected.txt
@@ -1,24 +1,3 @@
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: TypeError: Module name, 'bare/to-bare' does not resolve to a valid URL.
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
 
 
 PASS bare/bare: <script src type=module>

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target-dynamic.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target-dynamic.sub-expected.txt
@@ -1,5 +1,0 @@
-CONSOLE MESSAGE: Refused to load https://www1.web-platform.test:9443/import-maps/resources/log.js?pipe=sub&name=B because it does not appear in the script-src directive of the Content Security Policy.
-
-PASS The URL after mapping violates CSP (but not the URL before mapping)
-PASS The URL before mapping violates CSP (but not the URL after mapping)
-

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target.sub-expected.txt
@@ -1,5 +1,0 @@
-CONSOLE MESSAGE: Refused to load https://www1.web-platform.test:9443/import-maps/resources/log.js?pipe=sub&name=B because it does not appear in the script-src directive of the Content Security Policy.
-
-PASS The URL after mapping violates CSP (but not the URL before mapping)
-PASS The URL before mapping violates CSP (but not the URL after mapping)
-

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/import-maps/data-url-specifiers.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/import-maps/data-url-specifiers.sub-expected.txt
@@ -1,24 +1,3 @@
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: TypeError: Module name, 'data:text/javascript,log.push('data:to-bare')' does not resolve to a valid URL.
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
 
 
 PASS data:text/javascript,log.push('data:foo'): <script src type=module>

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/import-maps/http-url-like-specifiers.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/import-maps/http-url-like-specifiers.sub-expected.txt
@@ -1,24 +1,3 @@
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: TypeError: Module name, 'http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=to-bare' does not resolve to a valid URL.
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
 
 
 PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=foo: <script src type=module>

--- a/LayoutTests/platform/win/imported/w3c/web-platform-tests/import-maps/bare-specifiers.sub-expected.txt
+++ b/LayoutTests/platform/win/imported/w3c/web-platform-tests/import-maps/bare-specifiers.sub-expected.txt
@@ -1,24 +1,3 @@
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: TypeError: Module name, 'bare/to-bare' does not resolve to a valid URL.
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
 
 
 PASS bare/bare: <script src type=module>

--- a/LayoutTests/platform/win/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target-dynamic.sub-expected.txt
+++ b/LayoutTests/platform/win/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target-dynamic.sub-expected.txt
@@ -1,5 +1,0 @@
-CONSOLE MESSAGE: Refused to load https://www1.web-platform.test:9443/import-maps/resources/log.js?pipe=sub&name=B because it does not appear in the script-src directive of the Content Security Policy.
-
-PASS The URL after mapping violates CSP (but not the URL before mapping)
-PASS The URL before mapping violates CSP (but not the URL after mapping)
-

--- a/LayoutTests/platform/win/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target.sub-expected.txt
+++ b/LayoutTests/platform/win/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target.sub-expected.txt
@@ -1,5 +1,0 @@
-CONSOLE MESSAGE: Refused to load https://www1.web-platform.test:9443/import-maps/resources/log.js?pipe=sub&name=B because it does not appear in the script-src directive of the Content Security Policy.
-
-PASS The URL after mapping violates CSP (but not the URL before mapping)
-PASS The URL before mapping violates CSP (but not the URL after mapping)
-

--- a/LayoutTests/platform/win/imported/w3c/web-platform-tests/import-maps/data-url-specifiers.sub-expected.txt
+++ b/LayoutTests/platform/win/imported/w3c/web-platform-tests/import-maps/data-url-specifiers.sub-expected.txt
@@ -1,24 +1,3 @@
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: TypeError: Module name, 'data:text/javascript,log.push('data:to-bare')' does not resolve to a valid URL.
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
 
 
 PASS data:text/javascript,log.push('data:foo'): <script src type=module>

--- a/LayoutTests/platform/win/imported/w3c/web-platform-tests/import-maps/http-url-like-specifiers.sub-expected.txt
+++ b/LayoutTests/platform/win/imported/w3c/web-platform-tests/import-maps/http-url-like-specifiers.sub-expected.txt
@@ -1,24 +1,3 @@
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: TypeError: Module name, 'http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=to-bare' does not resolve to a valid URL.
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
-CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
 
 
 PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=foo: <script src type=module>

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -119,7 +119,6 @@ namespace JSC {
     macro(this) \
     macro(toIntegerOrInfinity) \
     macro(toLength) \
-    macro(importMapStatus) \
     macro(importInRealm) \
     macro(evalFunction) \
     macro(evalInRealm) \

--- a/Source/JavaScriptCore/builtins/ModuleLoader.js
+++ b/Source/JavaScriptCore/builtins/ModuleLoader.js
@@ -545,9 +545,6 @@ async function loadModule(key, parameters, fetcher)
 {
     "use strict";
 
-    var importMap = @importMapStatus();
-    if (importMap)
-        await importMap;
     var entry = await this.requestSatisfy(this.ensureRegistered(key), parameters, fetcher, new @Set);
     return entry.key;
 }
@@ -567,9 +564,6 @@ async function loadAndEvaluateModule(moduleName, parameters, fetcher)
 {
     "use strict";
 
-    var importMap = @importMapStatus();
-    if (importMap)
-        await importMap;
     var key = this.resolve(moduleName, @undefined, fetcher);
     key = await this.loadModule(key, parameters, fetcher);
     return await this.linkAndEvaluateModule(key, fetcher);
@@ -580,9 +574,6 @@ async function requestImportModule(moduleName, referrer, parameters, fetcher)
 {
     "use strict";
 
-    var importMap = @importMapStatus();
-    if (importMap)
-        await importMap;
     var key = this.resolve(moduleName, referrer, fetcher);
     var entry = await this.requestSatisfy(this.ensureRegistered(key), parameters, fetcher, new @Set);
     await this.linkAndEvaluateModule(entry.key, fetcher);

--- a/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
+++ b/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
@@ -86,7 +86,6 @@ class JSGlobalObject;
     v(hostPromiseRejectionTracker, nullptr) \
     v(Set, nullptr) \
     v(Map, nullptr) \
-    v(importMapStatus, nullptr) \
     v(importInRealm, nullptr) \
     v(evalFunction, nullptr) \
     v(evalInRealm, nullptr) \

--- a/Source/JavaScriptCore/runtime/ImportMap.cpp
+++ b/Source/JavaScriptCore/runtime/ImportMap.cpp
@@ -34,9 +34,44 @@
 namespace JSC {
 namespace ImportMapInternal {
 static constexpr bool verbose = false;
+
+// https://html.spec.whatwg.org/C#merge-module-specifier-maps
+static void mergeModuleSpecifierMaps(ImportMap::SpecifierMap& oldMap, const ImportMap::SpecifierMap& newMap, const ImportMap::Reporter& reporter)
+{
+    // Instead of copying the maps and returning the copy, we're modifying the
+    // maps in place.
+    // 2. For each specifier → url of newMap:
+    for (auto& [specifier, url] : newMap) {
+        // 2.2. Set mergedMap[specifier] to url.
+        auto iter = oldMap.add(specifier, url);
+        // 2.1. If specifier exists in oldMap, then:
+        if (!iter.isNewEntry) {
+            // 2.1.1. The user agent may report the removed rule as a warning to the
+            // developer console.
+            reporter.reportWarning(makeString("An import map rule for specifier '"_s, specifier, "' was removed, as it conflicted with an existing rule."_s));
+            // 2.1.2. Continue.
+            continue;
+        }
+    }
 }
 
-Expected<URL, String> ImportMap::resolveImportMatch(const String& normalizedSpecifier, const URL& asURL, const SpecifierMap& specifierMap)
+}
+
+ImportMap::ImportMap(SpecifierMap&& imports, ScopesMap&& scopesMap, IntegrityMap&& integrity)
+    : m_imports(imports), m_scopesMap(scopesMap), m_integrity(integrity)
+{
+    // <spec label="sort-and-normalize-scopes" step="3">Return the result of
+    // sorting normalized, with an entry a being less than an entry b if b’s key
+    // is code unit less than a’s key.</spec>
+    ASSERT(m_scopesVector.isEmpty());
+    m_scopesVector = copyToVector(m_scopesMap.keys());
+    std::sort(m_scopesVector.begin(), m_scopesVector.end(),
+        [](const URL& a, const URL& b) {
+            return codePointCompareLessThan(b.string(), a.string());
+        });
+}
+
+Expected<URL, String> ImportMap::resolveImportMatch(const AtomString& normalizedSpecifier, const URL& asURL, const SpecifierMap& specifierMap)
 {
     // https://html.spec.whatwg.org/C#resolving-an-imports-match
 
@@ -67,7 +102,7 @@ Expected<URL, String> ImportMap::resolveImportMatch(const String& normalizedSpec
         if (matched) {
             if (matched->isNull())
                 return makeUnexpected("specifier is blocked"_s);
-            auto afterPrefix = normalizedSpecifier.substring(length);
+            auto afterPrefix = normalizedSpecifier.string().substring(length);
             ASSERT(matched->string().endsWith('/'));
             URL url { matched.value(), afterPrefix };
             if (!url.isValid())
@@ -91,48 +126,48 @@ static URL parseURLLikeModuleSpecifier(const String& specifier, const URL& baseU
     return URL { specifier };
 }
 
-URL ImportMap::resolve(const String& specifier, const URL& baseURL) const
+URL ImportMap::resolve(const String& specifier, const URL& baseURL)
 {
     // https://html.spec.whatwg.org/C#resolve-a-module-specifier
 
     URL asURL = parseURLLikeModuleSpecifier(specifier, baseURL);
-    String normalizedSpecifier = asURL.isValid() ? asURL.string() : specifier;
+    AtomString normalizedSpecifier = AtomString(asURL.isValid() ? asURL.string() : specifier);
+    URL resolvedURL;
 
     dataLogLnIf(ImportMapInternal::verbose, "Resolve ", specifier, " with ", baseURL);
-    for (auto& entry : m_scopes) {
-        dataLogLnIf(ImportMapInternal::verbose, "    Scope ", entry.m_scope);
-        if (entry.m_scope == baseURL || (entry.m_scope.string().endsWith('/') && baseURL.string().startsWith(entry.m_scope.string()))) {
+    for (auto& scope : m_scopesVector) {
+        dataLogLnIf(ImportMapInternal::verbose, "    Scope ", scope);
+        if (scope == baseURL || (scope.string().endsWith('/') && baseURL.string().startsWith(scope.string()))) {
             dataLogLnIf(ImportMapInternal::verbose, "        Matching");
-            auto result = resolveImportMatch(normalizedSpecifier, asURL, entry.m_map);
+            auto result = resolveImportMatch(normalizedSpecifier, asURL, m_scopesMap.get(scope));
             if (!result)
                 return { };
-            URL scopeImportsMatch = WTFMove(result.value());
-            if (!scopeImportsMatch.isNull())
-                return scopeImportsMatch;
+            if (!result.value().isNull())
+                resolvedURL = WTFMove(result.value());
         }
     }
 
-    dataLogLnIf(ImportMapInternal::verbose, "    Matching with imports");
-    auto result = resolveImportMatch(normalizedSpecifier, asURL, m_imports);
-    if (!result)
-        return { };
-    URL topLevelImportsMatch = WTFMove(result.value());
-    if (!topLevelImportsMatch.isNull())
-        return topLevelImportsMatch;
+    if (resolvedURL.isNull()) {
+        dataLogLnIf(ImportMapInternal::verbose, "    Matching with imports");
+        auto result = resolveImportMatch(normalizedSpecifier, asURL, m_imports);
+        if (!result)
+            return { };
+        resolvedURL = WTFMove(result.value());
+        if (resolvedURL.isNull() && asURL.isValid())
+            resolvedURL = WTFMove(asURL);
+    }
+    if (!resolvedURL.isNull())
+        addModuleToResolvedModuleSet(baseURL.string(), normalizedSpecifier);
 
-    if (asURL.isValid())
-        return asURL;
-
-    return { };
+    return resolvedURL;
 }
 
-static String normalizeSpecifierKey(const String& specifierKey, const URL& baseURL, ImportMap::Reporter* reporter)
+static String normalizeSpecifierKey(const String& specifierKey, const URL& baseURL, const ImportMap::Reporter& reporter)
 {
     // https://html.spec.whatwg.org/C#normalizing-a-specifier-key
 
     if (UNLIKELY(specifierKey.isEmpty())) {
-        if (reporter)
-            reporter->reportWarning("specifier key is empty"_s);
+        reporter.reportWarning("specifier key is empty"_s);
         return nullString();
     }
     URL url = parseURLLikeModuleSpecifier(specifierKey, baseURL);
@@ -141,33 +176,30 @@ static String normalizeSpecifierKey(const String& specifierKey, const URL& baseU
     return specifierKey;
 }
 
-static ImportMap::SpecifierMap sortAndNormalizeSpecifierMap(Ref<JSON::Object> importsMap, const URL& baseURL, ImportMap::Reporter* reporter)
+static ImportMap::SpecifierMap sortAndNormalizeSpecifierMap(Ref<JSON::Object> importsMap, const URL& baseURL, const ImportMap::Reporter& reporter)
 {
     // https://html.spec.whatwg.org/C#sorting-and-normalizing-a-module-specifier-map
 
     ImportMap::SpecifierMap normalized;
     for (auto& [key, value] : importsMap.get()) {
-        String normalizedSpecifierKey = normalizeSpecifierKey(key, baseURL, reporter);
+        AtomString normalizedSpecifierKey = AtomString(normalizeSpecifierKey(key, baseURL, reporter));
         if (normalizedSpecifierKey.isNull())
             continue;
         if (auto valueAsString = value->asString(); LIKELY(!valueAsString.isNull())) {
             URL addressURL = parseURLLikeModuleSpecifier(valueAsString, baseURL);
             if (UNLIKELY(!addressURL.isValid())) {
-                if (reporter)
-                    reporter->reportWarning(makeString("value in specifier map cannot be parsed as URL "_s, valueAsString));
+                reporter.reportWarning(makeString("value in specifier map cannot be parsed as URL "_s, valueAsString));
                 normalized.add(normalizedSpecifierKey, URL { });
                 continue;
             }
             if (UNLIKELY(key.endsWith('/') && !addressURL.string().endsWith('/'))) {
-                if (reporter)
-                    reporter->reportWarning(makeString("address "_s, addressURL.string(), " does not end with '/' while key "_s, key, " ends with '/'"_s));
+                reporter.reportWarning(makeString("address "_s, addressURL.string(), " does not end with '/' while key "_s, key, " ends with '/'"_s));
                 normalized.add(normalizedSpecifierKey, URL { });
                 continue;
             }
             normalized.add(normalizedSpecifierKey, WTFMove(addressURL));
         } else {
-            if (reporter)
-                reporter->reportWarning("value in specifier map needs to be a string"_s);
+            reporter.reportWarning("value in specifier map needs to be a string"_s);
             normalized.add(normalizedSpecifierKey, URL { });
             continue;
         }
@@ -175,66 +207,71 @@ static ImportMap::SpecifierMap sortAndNormalizeSpecifierMap(Ref<JSON::Object> im
     return normalized;
 }
 
-Expected<void, String> ImportMap::registerImportMap(const SourceCode& sourceCode, const URL& baseURL, ImportMap::Reporter* reporter)
+std::optional<Ref<ImportMap>> ImportMap::parseImportMapString(const SourceCode& sourceCode, const URL& baseURL, const ImportMap::Reporter& reporter)
 {
-    // https://html.spec.whatwg.org/C#register-an-import-map
     // https://html.spec.whatwg.org/C#parse-an-import-map-string
 
     auto result = JSON::Value::parseJSON(sourceCode.view());
-    if (!result)
-        return makeUnexpected("ImportMap has invalid JSON"_s);
+    if (!result) {
+        reporter.reportError("ImportMap has invalid JSON"_s);
+        return std::nullopt;
+    }
 
     auto rootMap = result->asObject();
-    if (!rootMap)
-        return makeUnexpected("ImportMap is not a map"_s);
+    if (!rootMap) {
+        reporter.reportError("ImportMap is not a map"_s);
+        return std::nullopt;
+    }
 
     SpecifierMap normalizedImports;
     if (auto importsMapValue = rootMap->getValue("imports"_s)) {
         auto importsMap = importsMapValue->asObject();
-        if (!importsMap)
-            return makeUnexpected("imports is not a map"_s);
+        if (!importsMap) {
+            reporter.reportError("Imports is not a map"_s);
+            return std::nullopt;
+        }
 
         normalizedImports = sortAndNormalizeSpecifierMap(importsMap.releaseNonNull(), baseURL, reporter);
     }
 
-    Scopes scopes;
+    ScopesMap scopesMap;
     if (auto scopesMapValue = rootMap->getValue("scopes"_s)) {
-        auto scopesMap = scopesMapValue->asObject();
-        if (!scopesMap)
-            return makeUnexpected("scopes is not a map"_s);
+        auto scopesMapObject = scopesMapValue->asObject();
+        if (!scopesMapObject) {
+            reporter.reportError("scopes is not a map"_s);
+            return std::nullopt;
+        }
 
         // https://html.spec.whatwg.org/C#sorting-and-normalizing-scopes
-        for (auto& [key, value] : *scopesMap) {
+        for (auto& [key, value] : *scopesMapObject) {
             auto potentialSpecifierMap = value->asObject();
-            if (!potentialSpecifierMap)
-                return makeUnexpected("scopes' value is not a map"_s);
+            if (!potentialSpecifierMap) {
+                reporter.reportError("scopes' value is not a map"_s);
+                return std::nullopt;
+            }
             URL scopePrefixURL { baseURL, key }; // Do not use parseURLLikeModuleSpecifier since we should accept non relative path.
             dataLogLnIf(ImportMapInternal::verbose, "scope key ", key, " and URL ", scopePrefixURL);
             if (UNLIKELY(!scopePrefixURL.isValid())) {
-                if (reporter)
-                    reporter->reportWarning(makeString("scope key"_s, key, " was not parsable"_s));
+                reporter.reportWarning(makeString("scope key"_s, key, " was not parsable"_s));
                 continue;
             }
 
-            scopes.append({ scopePrefixURL, sortAndNormalizeSpecifierMap(potentialSpecifierMap.releaseNonNull(), baseURL, reporter) });
+            scopesMap.set(WTFMove(scopePrefixURL), sortAndNormalizeSpecifierMap(potentialSpecifierMap.releaseNonNull(), baseURL, reporter));
         }
     }
-
-    // Sort to accending order. So, more specific scope will come first.
-    std::sort(scopes.begin(), scopes.end(), [&](const auto& lhs, const auto& rhs) -> bool {
-        return codePointCompareLessThan(rhs.m_scope.string(), lhs.m_scope.string());
-    });
 
     IntegrityMap integrity;
     StringBuilder errorMessage;
     if (auto integrityValue = rootMap->getValue("integrity"_s)) {
         auto integrityMap = integrityValue->asObject();
-        if (!integrityMap)
-            return makeUnexpected("integrity is not a map"_s);
+        if (!integrityMap) {
+            reporter.reportError("integrity is not a map"_s);
+            return std::nullopt;
+        }
 
         // https://html.spec.whatwg.org/C#normalizing-a-module-integrity-map
         for (auto& [key, value] : *integrityMap) {
-            URL integrityURL = resolve(key, baseURL);
+            URL integrityURL = parseURLLikeModuleSpecifier(key, baseURL);
             if (UNLIKELY(integrityURL.isNull())) {
                 errorMessage.append("Integrity URL "_s);
                 errorMessage.append(key);
@@ -254,18 +291,175 @@ Expected<void, String> ImportMap::registerImportMap(const SourceCode& sourceCode
         }
     }
 
-
-    m_imports = WTFMove(normalizedImports);
-    m_scopes = WTFMove(scopes);
-    m_integrity = WTFMove(integrity);
     if (!errorMessage.isEmpty())
-        return makeUnexpected(errorMessage.toString());
-    return { };
+        reporter.reportError(errorMessage.toString());
+
+    return adoptRef(*new ImportMap(WTFMove(normalizedImports), WTFMove(scopesMap), WTFMove(integrity)));
 }
 
 String ImportMap::integrityForURL(const URL& url) const
 {
     return url.isNull() ? String() : m_integrity.get(url);
+}
+
+// https://html.spec.whatwg.org/C/#merge-existing-and-new-import-maps
+void ImportMap::mergeExistingAndNewImportMaps(Ref<ImportMap>&& newImportMap, const ImportMap::Reporter& reporter)
+{
+    // 1. Let newImportMapScopes be a deep copy of newImportMap's scopes.
+    // 2. Let newImportMapImports be a deep copy of newImportMap's imports.
+    //
+    // Instead of copying we have moved the newImportMap here and are performing
+    // the algorithm's mutations directly on them. That's fine because the move
+    // guarantees that no one will use this map for anything else.
+    ImportMap::ScopesMap& newImportMapScopes = newImportMap->m_scopesMap;
+    ImportMap::SpecifierMap& newImportMapImports = newImportMap->m_imports;
+    ImportMap::IntegrityMap& newImportMapIntegrity = newImportMap->m_integrity;
+
+    // 3. For each scopePrefix → scopeImports of newImportMapScopes:
+    for (auto& scope : newImportMapScopes) {
+        auto scopeImports = WTFMove(scope.value);
+        // 3.1. For each pair of global's resolved module set:
+        //
+        // 3.1.1. If pair's referring script does not start with scopePrefix,
+        // continue.
+        //
+        // 3.1.2. For each specifier → url of scopeImports:
+        //
+        // 3.1.2.1. If pair's specifier starts with specifier, then:
+        //
+        //
+        // We are using a different algorithm here, where instead of a resolved
+        // module set, we have a scoped resolved module map. The map's keys are
+        // scope prefixes, and its values are a set of specifier prefixes that
+        // already exist in that scope. We grab the set of specifier prefixes using
+        // the current scope and then iterate over the scope's imports, removing any
+        // specifiers whose prefix is in the set.
+
+        auto iter = m_scopedResolvedModuleMap.find(AtomString(scope.key.string()));
+        if (iter != m_scopedResolvedModuleMap.end()) {
+            auto& currentResolvedSet = iter->value;
+            scopeImports.removeIf([&](const auto& pair) {
+                if (currentResolvedSet.find(pair.key) != currentResolvedSet.end()) {
+                    reporter.reportWarning(makeString("An import map scope rule for specifier '"_s, pair.key, "' was removed, as it conflicted with already resolved module specifiers."_s));
+                    // 3.1.2.1.1. The user agent may report the removed rule as a warning to
+                    // the developer console.
+                    // 3.1.2.1.2. Remove scopeImports[specifier].
+                    return true;
+                }
+                return false;
+            });
+        }
+
+        // 3.2 If scopePrefix exists in oldImportMap's scopes, then set
+        // oldImportMap's scopes[scopePrefix] to the result of merging module
+        // specifier maps, given scopeImports and oldImportMap's
+        // scopes[scopePrefix].
+        const auto oldScopeSpecifierMapIt = m_scopesMap.find(scope.key);
+        if (oldScopeSpecifierMapIt != m_scopesMap.end()) {
+            ImportMap::SpecifierMap& oldScopeSpecifierMap = oldScopeSpecifierMapIt->value;
+            ImportMapInternal::mergeModuleSpecifierMaps(oldScopeSpecifierMap, scopeImports, reporter);
+        } else {
+            // 3.3 Otherwise, set oldImportMap's scopes[scopePrefix] to
+            // scopeImports.
+            m_scopesMap.set(scope.key, WTFMove(scopeImports));
+            m_scopesVector.append(scope.key);
+        }
+    }
+
+    // 4. For each url → integrity of newImportMap's integrity:
+    for (auto& url : newImportMapIntegrity.keys()) {
+        const auto& newIntegrityValue = newImportMapIntegrity.get(url);
+        // 4.2 Set oldImportMap's integrity[url] to integrity.
+        auto iter = m_integrity.add(url, newIntegrityValue);
+        // 4.1 If url exists in oldImportMap's integrity, then:
+        if (!iter.isNewEntry) {
+            // 4.1.1. The user agent may report the removed rule as a warning to the
+            // developer console.
+            reporter.reportWarning(makeString("An import map integrity rule for url '"_s, url.string(), "' was removed, as it conflicted with already defined integrity rules."_s));
+            // 4.1.2 Continue.
+            continue;
+        }
+    }
+    // 5. For each pair of global's resolved module set:
+
+    // 5.1. For each specifier → url of newImportMapImports:
+
+    // 5.1.1. If specifier starts with pair's specifier, then:
+
+    // We're using a different algorithm here where the resolved module set is
+    // replaced with a set of all the prefixes of specifier resolved. For each
+    // such prefix that exists in the new import map's imports section, we remove
+    // it from that section.
+    for (auto& specifier : m_toplevelResolvedModuleSet) {
+        auto iter = newImportMapImports.find(specifier);
+        if (iter == newImportMapImports.end())
+            continue;
+        // 5.1. The user agent may report the removed rule as a warning to the
+        // developer console.
+        reporter.reportWarning(makeString("An import map rule for specifier '"_s, specifier, "' was removed, as it conflicted with already resolved module specifiers."_s));
+        // 5.2. Remove newImportMapImports[specifier].
+        newImportMapImports.remove(iter);
+    }
+    // 6. Set oldImportMap's imports to the result of merge module specifier
+    // maps, given newImportMapImports and oldImportMap's imports.
+    ImportMapInternal::mergeModuleSpecifierMaps(m_imports, newImportMapImports, reporter);
+}
+
+static Vector<AtomString> findURLPrefixes(String specifier)
+{
+    constexpr size_t capacity = 6;
+    Vector<size_t, capacity> positions;
+    constexpr char slash = '/';
+    size_t position = specifier.find(slash);
+
+    while (position != notFound) {
+        positions.append(++position);
+        position = specifier.find(slash, position);
+    }
+
+    Vector<AtomString> result;
+    result.reserveInitialCapacity(positions.size());
+    for (size_t& pos : positions)
+        result.append(AtomString(specifier.substring(0, pos)));
+
+    return result;
+}
+
+// https://html.spec.whatwg.org/C#add-module-to-resolved-module-set
+void ImportMap::addModuleToResolvedModuleSet(String referringScriptURL, AtomString specifier)
+{
+    // 1. Let global be settingsObject's global object.
+
+    // 2. If global does not implement Window, then return.
+
+    // 3. Let pair be a new referring script specifier pair, with referring script
+    // set to referringScriptURL, and specifier set to specifier.
+
+    // 4. Append pair to global's resolved module set.
+
+    // We're using a different algorithm here where we find all the prefixes the
+    // specifier has and add them to the top_level_resolved_module_set. We then
+    // find all the prefixes that the referring script URL has, and add all the
+    // prefixes to the sets of these referring prefixes in the
+    // scoped_resolved_module_map.
+    m_toplevelResolvedModuleSet.add(specifier);
+    Vector<AtomString> specifierPrefixes = findURLPrefixes(specifier);
+    for (auto& specifierPrefix : specifierPrefixes)
+        m_toplevelResolvedModuleSet.add(specifierPrefix);
+
+    Vector<AtomString> referringScriptPrefixes = findURLPrefixes(referringScriptURL);
+    for (AtomString& referringScriptPrefix : referringScriptPrefixes) {
+        const auto& currentSetIt = m_scopedResolvedModuleMap.find(referringScriptPrefix);
+        HashSet<AtomString>* currentSet = nullptr;
+        if (currentSetIt != m_scopedResolvedModuleMap.end())
+            currentSet = &currentSetIt->value;
+        else
+            currentSet = &(m_scopedResolvedModuleMap.set(referringScriptPrefix, HashSet<AtomString>()).iterator->value);
+
+        currentSet->add(specifier);
+        for (AtomString& specifierPrefix : specifierPrefixes)
+            currentSet->add(specifierPrefix);
+    }
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/ImportMap.h
+++ b/Source/JavaScriptCore/runtime/ImportMap.h
@@ -30,6 +30,7 @@
 #include <wtf/URL.h>
 #include <wtf/URLHash.h>
 #include <wtf/Vector.h>
+#include <wtf/text/AtomStringHash.h>
 
 namespace JSC {
 
@@ -37,40 +38,53 @@ class SourceCode;
 
 class ImportMap final : public RefCounted<ImportMap> {
 public:
-    using SpecifierMap = UncheckedKeyHashMap<String, URL>;
-    struct ScopeEntry {
-        URL m_scope;
-        SpecifierMap m_map;
-    };
-    using Scopes = Vector<ScopeEntry>;
+    using SpecifierMap = UncheckedKeyHashMap<AtomString, URL>;
+    using ScopesMap = UncheckedKeyHashMap<URL, SpecifierMap>;
+    using ScopesVector = Vector<URL>;
     using IntegrityMap = UncheckedKeyHashMap<URL, String>;
 
     class Reporter {
     public:
         virtual ~Reporter() = default;
-        virtual void reportWarning(const String&) { };
+        virtual void reportWarning(const String&) const { };
+        virtual void reportError(const String&) const { };
     };
 
     static Ref<ImportMap> create() { return adoptRef(*new ImportMap()); }
 
-    JS_EXPORT_PRIVATE URL resolve(const String& specifier, const URL& baseURL) const;
-    JS_EXPORT_PRIVATE Expected<void, String> registerImportMap(const SourceCode&, const URL& baseURL, ImportMap::Reporter*);
-
-    bool isAcquiringImportMaps() const { return m_isAcquiringImportMaps; }
-    void setAcquiringImportMaps() { m_isAcquiringImportMaps = false; }
+    JS_EXPORT_PRIVATE URL resolve(const String& specifier, const URL& baseURL);
 
     JS_EXPORT_PRIVATE String integrityForURL(const URL&) const;
 
+    // https://html.spec.whatwg.org/C#parse-an-import-map-string
+    JS_EXPORT_PRIVATE static std::optional<Ref<ImportMap>> parseImportMapString(const SourceCode&, const URL& baseURL, const ImportMap::Reporter&);
+
+    // https://html.spec.whatwg.org/C/#merge-existing-and-new-import-maps
+    // `newImportMap` is modified in place here, and should not be used after
+    // this call.
+    JS_EXPORT_PRIVATE void mergeExistingAndNewImportMaps(Ref<ImportMap>&& newImportMap, const ImportMap::Reporter&);
+
+    void addModuleToResolvedModuleSet(String referringScriptURL, AtomString specifier);
 private:
     ImportMap() = default;
+    ImportMap(SpecifierMap&&, ScopesMap&&, IntegrityMap&&);
 
-    static Expected<URL, String> resolveImportMatch(const String&, const URL&, const SpecifierMap&);
+    static Expected<URL, String> resolveImportMatch(const AtomString&, const URL&, const SpecifierMap&);
 
     SpecifierMap m_imports;
-    Scopes m_scopes;
+    ScopesMap m_scopesMap;
+    ScopesVector m_scopesVector;
     IntegrityMap m_integrity;
 
-    bool m_isAcquiringImportMaps : 1 { true };
+    // https://html.spec.whatwg.org/C#resolved-module-set
+    //
+    // We replace the spec's set with two different data structures: a set of all
+    // the prefixes resolved at the top-level scope, and a map of scopes to sets
+    // of prefixes resolved in them. That permits us to reduce the cost of merging
+    // a new map, by performing more work at addModuleToResolvedModuleSet time,
+    // and by keeping more prefixes in memory.
+    HashSet<AtomString> m_toplevelResolvedModuleSet;
+    UncheckedKeyHashMap<AtomString, HashSet<AtomString>> m_scopedResolvedModuleMap;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -428,8 +428,6 @@ public:
     FOR_EACH_TYPED_ARRAY_TYPE(DECLARE_TYPED_ARRAY_TYPE_STRUCTURE)
 #undef DECLARE_TYPED_ARRAY_TYPE_STRUCTURE
 
-    LazyProperty<JSGlobalObject, JSInternalPromise> m_importMapStatusPromise;
-
     FixedVector<LazyProperty<JSGlobalObject, JSCell>> m_linkTimeConstants;
 
     StructureCache m_structureCache;
@@ -1145,16 +1143,6 @@ public:
 
     const ImportMap& importMap() const { return m_importMap.get(); }
     ImportMap& importMap() { return m_importMap.get(); }
-    JSInternalPromise* importMapStatusPromise() const
-    {
-        if (m_importMapStatusPromise.isInitialized())
-            return m_importMapStatusPromise.get(this);
-        return nullptr;
-    }
-    JS_EXPORT_PRIVATE bool isAcquiringImportMaps() const;
-    JS_EXPORT_PRIVATE void setAcquiringImportMaps();
-    JS_EXPORT_PRIVATE void setPendingImportMaps();
-    JS_EXPORT_PRIVATE void clearPendingImportMaps();
 
 protected:
     enum class HasSpeciesProperty : bool { No, Yes };

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
@@ -835,15 +835,6 @@ JSC_DEFINE_HOST_FUNCTION(globalFuncBuiltinDescribe, (JSGlobalObject* globalObjec
     return JSValue::encode(jsString(globalObject->vm(), toString(callFrame->argument(0))));
 }
 
-JSC_DEFINE_HOST_FUNCTION(globalFuncImportMapStatus, (JSGlobalObject* globalObject, CallFrame*))
-{
-    // https://wicg.github.io/import-maps/#integration-wait-for-import-maps
-    globalObject->importMap().setAcquiringImportMaps();
-    if (auto* promise = globalObject->importMapStatusPromise())
-        return JSValue::encode(promise);
-    return JSValue::encode(jsUndefined());
-}
-
 JSC_DEFINE_HOST_FUNCTION(globalFuncImportModule, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.h
@@ -57,7 +57,6 @@ JSC_DECLARE_HOST_FUNCTION(globalFuncSetPrototypeDirectOrThrow);
 JSC_DECLARE_HOST_FUNCTION(globalFuncHostPromiseRejectionTracker);
 JSC_DECLARE_HOST_FUNCTION(globalFuncBuiltinLog);
 JSC_DECLARE_HOST_FUNCTION(globalFuncBuiltinDescribe);
-JSC_DECLARE_HOST_FUNCTION(globalFuncImportMapStatus);
 JSC_DECLARE_HOST_FUNCTION(globalFuncImportModule);
 JSC_DECLARE_HOST_FUNCTION(globalFuncCopyDataProperties);
 JSC_DECLARE_HOST_FUNCTION(globalFuncCloneObject);

--- a/Source/WebCore/bindings/js/ScriptController.h
+++ b/Source/WebCore/bindings/js/ScriptController.h
@@ -174,10 +174,6 @@ public:
     void reportExceptionFromScriptError(LoadableScript::Error, bool);
 
     void registerImportMap(const ScriptSourceCode&, const URL& baseURL);
-    bool isAcquiringImportMaps();
-    void setAcquiringImportMaps();
-    void setPendingImportMaps();
-    void clearPendingImportMaps();
 
 private:
     ValueOrException executeScriptInWorld(DOMWrapperWorld&, RunJavaScriptParameters&&);
@@ -209,6 +205,7 @@ private:
 #if PLATFORM(COCOA)
     RetainPtr<WebScriptObject> m_windowScriptObject;
 #endif
+
 };
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
+++ b/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
@@ -38,7 +38,6 @@
 #include "MIMETypeRegistry.h"
 #include "ModuleFetchFailureKind.h"
 #include "ModuleFetchParameters.h"
-#include "ScriptController.h"
 #include "ScriptSourceCode.h"
 #include "ServiceWorkerGlobalScope.h"
 #include "ShadowRealmGlobalScope.h"

--- a/Source/WebCore/dom/ScriptType.h
+++ b/Source/WebCore/dom/ScriptType.h
@@ -28,7 +28,6 @@
 namespace WebCore {
 
 // https://html.spec.whatwg.org/multipage/scripting.html#concept-script-type
-// https://wicg.github.io/import-maps/#integration-prepare-a-script
 enum class ScriptType : uint8_t { Classic, Module, ImportMap };
 static constexpr unsigned bitWidthOfScriptType = 2;
 static_assert(static_cast<unsigned>(ScriptType::ImportMap) <= ((1U << bitWidthOfScriptType) - 1));


### PR DESCRIPTION
#### c363df60bf5834d874f9830efeebc3892b87ff25
<pre>
Implement multiple import maps

<a href="https://bugs.webkit.org/show_bug.cgi?id=279025">https://bugs.webkit.org/show_bug.cgi?id=279025</a>

Reviewed by Yusuke Suzuki.

This PR enables multiple import maps to co-exist in a single document,
and to be loaded after a module script was loaded.

It also removes some code related to external import maps, which was
removed at <a href="https://github.com/WebKit/WebKit/pull/37629.">https://github.com/WebKit/WebKit/pull/37629.</a>

* LayoutTests/TestExpectations: Remove skip and send console to stderr.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/dynamic-import-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/script-tag-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/script-tag-inline-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/bare-specifiers.sub-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target-dynamic.sub-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target.sub-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/hash-failure-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/nonce-failure-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resolving_data-url-prefix.json-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resolving_empty-import-map.json-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resolving_overlapping-entries.json-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resolving_packages-via-trailing-slashes.json-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resolving_resolving-null.json-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resolving_scopes-exact-vs-prefix.json-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resolving_tricky-specifiers.json-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resolving_url-specifiers-schemes.json-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resolving_url-specifiers.json-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/data-url-specifiers.sub-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/http-url-like-specifiers.sub-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/already-resolved-dropped-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/basic-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/conflict-first-persists-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/resolution-consistency-in-module-tree-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/resolution-consistency-in-module-tree-inline-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/resolution-consistency-in-module-tree.html: Avoid reliance on async inline module timing.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/url-resolution-conflict-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/with-errors-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/not-as-classic-script-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/dynamic-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/external-script-bare-descendent-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/external-script-descendent-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/external-script-descendent-with-scope-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/failed-resolution-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/integrity-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/prefix-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/script-descendent-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/not-overridden/url-resolution-conflict-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/resources/out-of-scope-test.js: Added. Missed during import.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/import-maps/bare-specifiers.sub-expected.txt: progression.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target-dynamic.sub-expected.txt: Removed.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target.sub-expected.txt: Removed.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/import-maps/data-url-specifiers.sub-expected.txt: progression.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/import-maps/http-url-like-specifiers.sub-expected.txt: progression.
* LayoutTests/platform/win/imported/w3c/web-platform-tests/import-maps/bare-specifiers.sub-expected.txt: progression.
* LayoutTests/platform/win/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target-dynamic.sub-expected.txt: Removed.
* LayoutTests/platform/win/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target.sub-expected.txt: Removed.
* LayoutTests/platform/win/imported/w3c/web-platform-tests/import-maps/data-url-specifiers.sub-expected.txt: progression.
* LayoutTests/platform/win/imported/w3c/web-platform-tests/import-maps/http-url-like-specifiers.sub-expected.txt: progression.
* Source/JavaScriptCore/builtins/BuiltinNames.h: remove importMapStatus.
* Source/JavaScriptCore/builtins/ModuleLoader.js: remove
  waiting on importMapStatus.
(visibility.PrivateRecursive.async loadModule):
(visibility.PrivateRecursive.async loadAndEvaluateModule):
(visibility.PrivateRecursive.async requestImportModule):
* Source/JavaScriptCore/bytecode/LinkTimeConstant.h: remove importMapStatus.
* Source/JavaScriptCore/runtime/ImportMap.cpp: Added multiple import map
  logic.
(JSC::ImportMapInternal::mergeModuleSpecifierMaps): <a href="https://html.spec.whatwg.org/C#merge-module-specifier-maps">https://html.spec.whatwg.org/C#merge-module-specifier-maps</a>
(JSC::ImportMap::ImportMap): Constructor to enable creation through
a static function.
(JSC::ImportMap::resolve): refactor and add a call to
addModuleToResolvedModuleSet.
(JSC::normalizeSpecifierKey): Change the reporter to a reference.
(JSC::sortAndNormalizeSpecifierMap): Change the reporter to a reference.
(JSC::ImportMap::parseImportMapString): a static function creating
a new ImportMap from an import map string. Replaces registerImportMap.
(JSC::ImportMap::mergeExistingAndNewImportMaps): <a href="https://html.spec.whatwg.org/C#merge-existing-and-new-import-maps">https://html.spec.whatwg.org/C#merge-existing-and-new-import-maps</a>
the scopes map. The scopes vector is then used to iterate over the
scopes in order.
(JSC::findUrlPrefixes): Find all the prefixes of a URL
(JSC::ImportMap::addModuleToResolvedModuleSet): <a href="https://html.spec.whatwg.org/C#add-module-to-resolved-module-set">https://html.spec.whatwg.org/C#add-module-to-resolved-module-set</a>
(JSC::ImportMap::resolve const): Deleted.
(JSC::ImportMap::registerImportMap): Deleted.
* Source/JavaScriptCore/runtime/ImportMap.h: Replace the previous Scopes
  data structure with a HashMap and a Vector, used for fast retrival and
  in-order iteration.
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp: Remove isAcquiring
  and pendingImportMap logic.
(JSC::JSGlobalObject::init):
(JSC::JSGlobalObject::isAcquiringImportMaps const): Deleted.
(JSC::JSGlobalObject::visitChildrenImpl):
(JSC::JSGlobalObject::setAcquiringImportMaps): Deleted.
(JSC::JSGlobalObject::setPendingImportMaps): Deleted.
(JSC::JSGlobalObject::clearPendingImportMaps): Deleted.
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::importMap):
(JSC::JSGlobalObject::importMapStatusPromise const): Deleted.
* Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp: Remove
  importMapStatus.
* Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.h:
* Source/WebCore/bindings/js/ScriptController.cpp: Remove isAcquiring
  and pendingImportMap logic. Add error reporting to
  ImportMapLogReporter. Call mergeExistingAndNewImportMaps.
(WebCore::ScriptController::isAcquiringImportMaps): Deleted.
(WebCore::ScriptController::registerImportMap):
(WebCore::ScriptController::setAcquiringImportMaps): Deleted.
(WebCore::ScriptController::setPendingImportMaps): Deleted.
(WebCore::ScriptController::clearPendingImportMaps): Deleted.
* Source/WebCore/bindings/js/ScriptController.h:
* Source/WebCore/bindings/js/ScriptModuleLoader.cpp: Remove spurious
  include.
* Source/WebCore/dom/LoadableClassicScript.cpp:
* Source/WebCore/dom/ScriptElement.cpp: Remove logic firing an error
  event related to isAcquiring. Remove pendingImportMap logic.
(WebCore::ScriptElement::determineScriptType):
(WebCore::ScriptElement::prepareScript):
(WebCore::ScriptElement::registerImportMap):
(WebCore::ScriptElement::executePendingScript):
(WebCore::ScriptElement::requestImportMap): Deleted.
* Source/WebCore/dom/ScriptType.h: Fix up spec comments.

Canonical link: <a href="https://commits.webkit.org/288358@main">https://commits.webkit.org/288358@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8abdfb0b428278b7d2bafc9d0110975a9d8f125

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82789 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36993 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87907 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33846 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84882 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2510 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10352 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64506 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22272 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85845 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1863 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75303 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44782 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1742 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29491 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32879 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/75773 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73000 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30163 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89274 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/81836 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10080 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7332 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72922 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10308 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71111 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72137 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16300 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/15140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1468 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12818 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10033 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15554 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/104241 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9907 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25263 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13372 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11676 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->