### PR TITLE
Null-check baseURL parameter when it is provided with an input URLPatternInit

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
@@ -8,8 +8,8 @@ FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] 
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}]
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}]
@@ -24,11 +24,11 @@ FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"]
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}]
 PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}]
@@ -168,12 +168,12 @@ FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] assert
 FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] assert_equals: test() result expected true but got false
 PASS Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}]
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: test() result expected true but got false
 PASS Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}]
 FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "./foo/bar"
 FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/" but got ""
-FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}]
+PASS Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}]
 FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/b" but got "b"
 PASS Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"]
 FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
@@ -198,7 +198,7 @@ FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs:
 PASS Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}]
 FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: test() result expected true but got false
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" did not throw
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"]
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Not implemented.
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
 FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
@@ -314,7 +314,7 @@ PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_object_equals: exec() result for protocol property "0" expected "https" got ""
 FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
 FAIL Pattern: [] Inputs: [{}] Not implemented.
 FAIL Pattern: [] Inputs: [] Not implemented.
@@ -355,8 +355,8 @@ PASS Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Not implemented.
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Type error
 PASS Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
-FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}]
+PASS Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}]
 FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Type error
 PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}]
 PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
@@ -8,8 +8,8 @@ FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] 
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}]
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}]
@@ -24,11 +24,11 @@ FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"]
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}]
 PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}]
@@ -168,12 +168,12 @@ FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] assert
 FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] assert_equals: test() result expected true but got false
 PASS Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}]
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: test() result expected true but got false
 PASS Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}]
 FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "./foo/bar"
 FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/" but got ""
-FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}]
+PASS Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}]
 FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/b" but got "b"
 PASS Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"]
 FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
@@ -198,7 +198,7 @@ FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs:
 PASS Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}]
 FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: test() result expected true but got false
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" did not throw
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"]
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Not implemented.
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
 FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
@@ -314,7 +314,7 @@ PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_object_equals: exec() result for protocol property "0" expected "https" got ""
 FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
 FAIL Pattern: [] Inputs: [{}] Not implemented.
 FAIL Pattern: [] Inputs: [] Not implemented.
@@ -355,8 +355,8 @@ PASS Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Not implemented.
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Type error
 PASS Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
-FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}]
+PASS Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}]
 FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Type error
 PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}]
 PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
@@ -8,8 +8,8 @@ FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] 
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}]
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}]
@@ -24,11 +24,11 @@ FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"]
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}]
 PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}]
@@ -168,12 +168,12 @@ FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] assert
 FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] assert_equals: test() result expected true but got false
 PASS Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}]
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: test() result expected true but got false
 PASS Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}]
 FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "./foo/bar"
 FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/" but got ""
-FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}]
+PASS Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}]
 FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/b" but got "b"
 PASS Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"]
 FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
@@ -198,7 +198,7 @@ FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs:
 PASS Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}]
 FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: test() result expected true but got false
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" did not throw
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"]
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Not implemented.
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
 FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
@@ -314,7 +314,7 @@ PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_object_equals: exec() result for protocol property "0" expected "https" got ""
 FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
 FAIL Pattern: [] Inputs: [{}] Not implemented.
 FAIL Pattern: [] Inputs: [] Not implemented.
@@ -355,8 +355,8 @@ PASS Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Not implemented.
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Type error
 PASS Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
-FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}]
+PASS Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}]
 FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Type error
 PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}]
 PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
@@ -8,8 +8,8 @@ FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] 
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}]
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}]
@@ -24,11 +24,11 @@ FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"]
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}]
 PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}]
@@ -168,12 +168,12 @@ FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] assert
 FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] assert_equals: test() result expected true but got false
 PASS Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}]
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: test() result expected true but got false
 PASS Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}]
 FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "./foo/bar"
 FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/" but got ""
-FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}]
+PASS Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}]
 FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/b" but got "b"
 PASS Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"]
 FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
@@ -198,7 +198,7 @@ FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs:
 PASS Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}]
 FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: test() result expected true but got false
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" did not throw
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"]
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Not implemented.
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
 FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
@@ -314,7 +314,7 @@ PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_object_equals: exec() result for protocol property "0" expected "https" got ""
 FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
 FAIL Pattern: [] Inputs: [{}] Not implemented.
 FAIL Pattern: [] Inputs: [] Not implemented.
@@ -355,8 +355,8 @@ PASS Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Not implemented.
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Type error
 PASS Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
-FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}]
+PASS Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}]
 FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Type error
 PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}]
 PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
@@ -8,8 +8,8 @@ FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] 
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}]
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}]
@@ -24,11 +24,11 @@ FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"]
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}]
 PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}]
@@ -168,12 +168,12 @@ FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] assert
 FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] assert_equals: test() result expected true but got false
 PASS Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}]
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: test() result expected true but got false
 PASS Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}]
 FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "./foo/bar"
 FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/" but got ""
-FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}]
+PASS Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}]
 FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/b" but got "b"
 PASS Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"]
 FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
@@ -198,7 +198,7 @@ FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs:
 PASS Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}]
 FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: test() result expected true but got false
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" did not throw
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"]
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Not implemented.
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
 FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
@@ -314,7 +314,7 @@ PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_object_equals: exec() result for protocol property "0" expected "https" got ""
 FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
 FAIL Pattern: [] Inputs: [{}] Not implemented.
 FAIL Pattern: [] Inputs: [] Not implemented.
@@ -355,8 +355,8 @@ PASS Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Not implemented.
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Type error
 PASS Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
-FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}]
+PASS Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}]
 FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Type error
 PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}]
 PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
@@ -8,8 +8,8 @@ FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] 
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}]
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}]
@@ -24,11 +24,11 @@ FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"]
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}]
 PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}]
@@ -168,12 +168,12 @@ FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] assert
 FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] assert_equals: test() result expected true but got false
 PASS Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}]
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: test() result expected true but got false
 PASS Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}]
 FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "./foo/bar"
 FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/" but got ""
-FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}]
+PASS Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}]
 FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/b" but got "b"
 PASS Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"]
 FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
@@ -198,7 +198,7 @@ FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs:
 PASS Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}]
 FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: test() result expected true but got false
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" did not throw
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"]
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Not implemented.
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
 FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
@@ -314,7 +314,7 @@ PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_object_equals: exec() result for protocol property "0" expected "https" got ""
 FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
 FAIL Pattern: [] Inputs: [{}] Not implemented.
 FAIL Pattern: [] Inputs: [] Not implemented.
@@ -355,8 +355,8 @@ PASS Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Not implemented.
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Type error
 PASS Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
-FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}]
+PASS Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}]
 FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Type error
 PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}]
 PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
@@ -8,8 +8,8 @@ FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] 
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}]
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}]
@@ -24,11 +24,11 @@ FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"]
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}]
 PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}]
@@ -168,12 +168,12 @@ FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] assert
 FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] assert_equals: test() result expected true but got false
 PASS Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}]
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: test() result expected true but got false
 PASS Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}]
 FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "./foo/bar"
 FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/" but got ""
-FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}]
+PASS Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}]
 FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/b" but got "b"
 PASS Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"]
 FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
@@ -198,7 +198,7 @@ FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs:
 PASS Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}]
 FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: test() result expected true but got false
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" did not throw
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"]
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Not implemented.
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
 FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
@@ -314,7 +314,7 @@ PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_object_equals: exec() result for protocol property "0" expected "https" got ""
 FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
 FAIL Pattern: [] Inputs: [{}] Not implemented.
 FAIL Pattern: [] Inputs: [] Not implemented.
@@ -355,8 +355,8 @@ PASS Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Not implemented.
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Type error
 PASS Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
-FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}]
+PASS Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}]
 FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Type error
 PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}]
 PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
@@ -8,8 +8,8 @@ FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] 
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}]
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}]
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}]
@@ -24,11 +24,11 @@ FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"]
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}]
 PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}]
@@ -168,12 +168,12 @@ FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] assert
 FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] assert_equals: test() result expected true but got false
 PASS Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}]
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Initial URLPatternInit input should not contain a base URL string.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: test() result expected true but got false
 PASS Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}]
 FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "./foo/bar"
 FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/" but got ""
-FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}]
+PASS Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}]
 FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/b" but got "b"
 PASS Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"]
 FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
@@ -198,7 +198,7 @@ FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs:
 PASS Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}]
 FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: test() result expected true but got false
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" did not throw
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"]
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Not implemented.
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
 FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
@@ -314,7 +314,7 @@ PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_equals: test() result expected true but got false
+FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_object_equals: exec() result for protocol property "0" expected "https" got ""
 FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
 FAIL Pattern: [] Inputs: [{}] Not implemented.
 FAIL Pattern: [] Inputs: [] Not implemented.
@@ -355,8 +355,8 @@ PASS Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Not implemented.
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Type error
 PASS Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
-FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Initial URLPatternInit input should not contain a base URL string.
-FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Initial URLPatternInit input should not contain a base URL string.
+PASS Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}]
+PASS Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}]
 FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Type error
 PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}]
 PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}]

--- a/Source/WebCore/Modules/url-pattern/URLPattern.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.cpp
@@ -356,7 +356,7 @@ static inline void matchHelperAssignInputsFromInit(const URLPatternInit& input, 
 }
 
 // https://urlpattern.spec.whatwg.org/#url-pattern-match
-ExceptionOr<std::optional<URLPatternResult>> URLPattern::match(ScriptExecutionContext& context, std::variant<URL, URLPatternInput>&& input, std::optional<String>&& baseURLString) const
+ExceptionOr<std::optional<URLPatternResult>> URLPattern::match(ScriptExecutionContext& context, std::variant<URL, URLPatternInput>&& input, String&& baseURLString) const
 {
     URLPatternResult result;
     String protocol, username, password, hostname, port, pathname, search, hash;
@@ -371,8 +371,8 @@ ExceptionOr<std::optional<URLPatternResult>> URLPattern::match(ScriptExecutionCo
 
         WTF::switchOn(*inputPattern,
             [&] (const URLPatternInit& value) {
-                if (!value.baseURL.isEmpty())
-                    hasError = Exception { ExceptionCode::TypeError, "Initial URLPatternInit input should not contain a base URL string."_s };
+                if (!baseURLString.isNull())
+                    hasError = Exception { ExceptionCode::TypeError, "Base URL string is provided with a URLPatternInit. If URLPatternInit is provided, please use URLPatternInit.baseURL property instead"_s };
 
                 URLPatternInit initCopy = value;
                 auto maybeResult = processInit(WTFMove(initCopy), BaseURLStringType::URL);
@@ -383,8 +383,8 @@ ExceptionOr<std::optional<URLPatternResult>> URLPattern::match(ScriptExecutionCo
                     matchHelperAssignInputsFromInit(processedInit, protocol, username, password, hostname, port, pathname, search, hash);
                 }
             }, [&] (const String& value) {
-                if (baseURLString) {
-                    auto baseURL = URL(*baseURLString);
+                if (!baseURLString.isNull()) {
+                    auto baseURL = URL(baseURLString);
                     if (!baseURL.isValid())
                         hasError = true;
                     else

--- a/Source/WebCore/Modules/url-pattern/URLPattern.h
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.h
@@ -72,7 +72,7 @@ public:
 private:
     URLPattern();
     ExceptionOr<void> compileAllComponents(ScriptExecutionContext&, URLPatternInit&&, const URLPatternOptions&);
-    ExceptionOr<std::optional<URLPatternResult>> match(ScriptExecutionContext&, std::variant<URL, URLPatternInput>&&, std::optional<String>&& baseURLString) const;
+    ExceptionOr<std::optional<URLPatternResult>> match(ScriptExecutionContext&, std::variant<URL, URLPatternInput>&&, String&& baseURLString) const;
 
     URLPatternUtilities::URLPatternComponent m_protocolComponent;
     URLPatternUtilities::URLPatternComponent m_usernameComponent;


### PR DESCRIPTION
#### c1be3898e16f9441a71fa05e697ae20ef701d713
<pre>
Null-check baseURL parameter when it is provided with an input URLPatternInit
<a href="https://bugs.webkit.org/show_bug.cgi?id=284588">https://bugs.webkit.org/show_bug.cgi?id=284588</a>
<a href="https://rdar.apple.com/141422060">rdar://141422060</a>

Reviewed by Chris Dumez.

Currently, implementation is checking to see if the input URLPatternInit&apos;s baseURL field has a value. This is incorrect. The spec actually states that we should be checking the baseURLString parameter of the match() function.

* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt:
* Source/WebCore/Modules/url-pattern/URLPattern.cpp:
(WebCore::URLPattern::test const):
(WebCore::URLPattern::exec const):
(WebCore::URLPattern::match const):
* Source/WebCore/Modules/url-pattern/URLPattern.h:

Canonical link: <a href="https://commits.webkit.org/287815@main">https://commits.webkit.org/287815@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a789b29de2643b493cf2e142c169179cbb76d23

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80954 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/479 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34897 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/85483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/31940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83064 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/491 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8279 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/85483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/31940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84023 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/283 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73676 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/85483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/169 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27833 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30398 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/71739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28382 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/86918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8184 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/86918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8361 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69508 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/86918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17608 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14778 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/13705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8145 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/13668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7982 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11502 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9790 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->