### PR TITLE
[iOS] Do not set a microphone as preferred if getUserMedia is not asking for a specific device

### DIFF
--- a/Source/WebCore/platform/mediastream/ios/AVAudioSessionCaptureDeviceManager.mm
+++ b/Source/WebCore/platform/mediastream/ios/AVAudioSessionCaptureDeviceManager.mm
@@ -170,18 +170,22 @@ void AVAudioSessionCaptureDeviceManager::configurePreferredAudioCaptureDevice()
 bool AVAudioSessionCaptureDeviceManager::setPreferredAudioSessionDeviceUIDInternal(const String& deviceUID)
 {
     AVAudioSessionPortDescription *preferredPort = nil;
-    NSString *nsDeviceUID = deviceUID;
-    for (AVAudioSessionPortDescription *portDescription in [m_audioSession availableInputs]) {
-        if ([portDescription.UID isEqualToString:nsDeviceUID]) {
-            preferredPort = portDescription;
-            break;
+    if (!deviceUID.isNull()) {
+        NSString *nsDeviceUID = deviceUID;
+        for (AVAudioSessionPortDescription *portDescription in [m_audioSession availableInputs]) {
+            if ([portDescription.UID isEqualToString:nsDeviceUID]) {
+                preferredPort = portDescription;
+                break;
+            }
+        }
+
+        if (!preferredPort) {
+            RELEASE_LOG_ERROR(WebRTC, "failed to find preferred input '%{public}s'", deviceUID.ascii().data());
+            return false;
         }
     }
 
-    if (!preferredPort) {
-        RELEASE_LOG_ERROR(WebRTC, "failed to find preferred input '%{public}s'", deviceUID.ascii().data());
-        return false;
-    }
+    RELEASE_LOG_INFO(WebRTC, "AVAudioSessionCaptureDeviceManager setting preferred input to '%{public}s'", deviceUID.ascii().data());
 
     NSError *error = nil;
     if (![[PAL::getAVAudioSessionClass() sharedInstance] setPreferredInput:preferredPort error:&error]) {

--- a/Source/WebCore/platform/mediastream/ios/CoreAudioCaptureSourceIOS.h
+++ b/Source/WebCore/platform/mediastream/ios/CoreAudioCaptureSourceIOS.h
@@ -40,8 +40,6 @@ public:
     ~CoreAudioCaptureSourceFactoryIOS();
 
 private:
-    CaptureSourceOrError createAudioCaptureSource(const CaptureDevice&, MediaDeviceHashSalts&&, const MediaConstraints*, std::optional<PageIdentifier>) final;
-
     RetainPtr<WebCoreAudioCaptureSourceIOSListener> m_listener;
 };
 

--- a/Source/WebCore/platform/mediastream/ios/CoreAudioCaptureSourceIOS.mm
+++ b/Source/WebCore/platform/mediastream/ios/CoreAudioCaptureSourceIOS.mm
@@ -101,11 +101,6 @@ CoreAudioCaptureSourceFactory& CoreAudioCaptureSourceFactory::singleton()
     return factory.get();
 }
 
-CaptureSourceOrError CoreAudioCaptureSourceFactoryIOS::createAudioCaptureSource(const CaptureDevice& device, MediaDeviceHashSalts&& hashSalts, const MediaConstraints* constraints, std::optional<PageIdentifier> pageIdentifier)
-{
-    return CoreAudioCaptureSource::create(String { device.persistentId() }, WTFMove(hashSalts), constraints, pageIdentifier);
-}
-
 }
 
 #endif // ENABLE(MEDIA_STREAM) && PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp
@@ -165,16 +165,14 @@ void BaseAudioSharedUnit::prepareForNewCapture()
     captureFailed();
 }
 
-void BaseAudioSharedUnit::setCaptureDevice(String&& persistentID, uint32_t captureDeviceID)
+void BaseAudioSharedUnit::setCaptureDevice(String&& persistentID, uint32_t captureDeviceID, bool isDefault)
 {
-    bool hasChanged = this->persistentID() != persistentID || this->captureDeviceID() != captureDeviceID;
+    bool hasChanged = this->persistentID() != persistentID || this->captureDeviceID() != captureDeviceID || m_isCapturingWithDefaultMicrophone != isDefault;
     if (hasChanged)
         willChangeCaptureDevice();
 
     m_capturingDevice = { WTFMove(persistentID), captureDeviceID };
-
-    auto devices = RealtimeMediaSourceCenter::singleton().audioCaptureFactory().audioCaptureDeviceManager().captureDevices();
-    m_isCapturingWithDefaultMicrophone = devices.size() && devices[0].persistentId() == m_capturingDevice->first;
+    m_isCapturingWithDefaultMicrophone = isDefault;
 
     if (hasChanged)
         captureDeviceChanged();

--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
@@ -84,7 +84,7 @@ public:
     void clearClients();
 
     virtual bool hasAudioUnit() const = 0;
-    void setCaptureDevice(String&&, uint32_t);
+    void setCaptureDevice(String&&, uint32_t, bool isDefault);
 
     virtual LongCapabilityRange sampleRateCapacities() const = 0;
     virtual int actualSampleRate() const { return sampleRate(); }
@@ -135,6 +135,8 @@ protected:
 
     void disableVoiceActivityThrottleTimerForTesting() { m_voiceActivityThrottleTimer.stop(); }
     void stopRunning();
+
+    bool isCapturingWithDefaultMicrophone() const { return m_isCapturingWithDefaultMicrophone; }
 
 private:
     OSStatus startUnit();

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDevice.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDevice.cpp
@@ -31,7 +31,6 @@
 #include "CaptureDeviceManager.h"
 #include "Logging.h"
 #include <AudioUnit/AudioUnit.h>
-#include <CoreMedia/CMSync.h>
 
 #import <pal/cf/CoreMediaSoftLink.h>
 
@@ -154,23 +153,6 @@ Vector<AudioDeviceID> CoreAudioCaptureDevice::relatedAudioDeviceIDs(AudioDeviceI
     if (error)
         return { };
     return devices;
-}
-
-RetainPtr<CMClockRef> CoreAudioCaptureDevice::deviceClock()
-{
-    if (m_deviceClock)
-        return m_deviceClock;
-
-    CMClockRef clock;
-    auto err = PAL::CMAudioDeviceClockCreate(kCFAllocatorDefault, persistentId().createCFString().get(), &clock);
-    if (err) {
-        RELEASE_LOG_ERROR(WebRTC, "CoreAudioCaptureDevice::CMAudioDeviceClockCreate(%p) CMAudioDeviceClockCreate failed with error %d (%.4s)", this, (int)err, (char*)&err);
-        return nullptr;
-    }
-
-    m_deviceClock = adoptCF(clock);
-
-    return m_deviceClock;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDevice.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDevice.h
@@ -42,7 +42,6 @@ public:
     virtual ~CoreAudioCaptureDevice() = default;
 
     uint32_t deviceID() const { return m_deviceID; }
-    RetainPtr<CMClockRef> deviceClock();
 
     static Vector<AudioDeviceID> relatedAudioDeviceIDs(AudioDeviceID);
 
@@ -50,7 +49,6 @@ private:
     CoreAudioCaptureDevice(uint32_t, const String& persistentID, DeviceType, const String& label, const String& groupID);
 
     uint32_t m_deviceID { 0 };
-    RetainPtr<CMClockRef> m_deviceClock;
 };
 
 

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
@@ -53,7 +53,7 @@ class WebAudioSourceProviderAVFObjC;
 
 class CoreAudioCaptureSource : public RealtimeMediaSource, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<CoreAudioCaptureSource, WTF::DestructionThread::MainRunLoop> {
 public:
-    WEBCORE_EXPORT static CaptureSourceOrError create(String&& deviceID, MediaDeviceHashSalts&&, const MediaConstraints*, std::optional<PageIdentifier>);
+    WEBCORE_EXPORT static CaptureSourceOrError create(const CaptureDevice&, MediaDeviceHashSalts&&, const MediaConstraints*, std::optional<PageIdentifier>);
     static CaptureSourceOrError createForTesting(String&& deviceID, AtomString&& label, MediaDeviceHashSalts&&, const MediaConstraints*, std::optional<PageIdentifier>);
 
     WEBCORE_EXPORT static AudioCaptureFactory& factory();
@@ -156,7 +156,7 @@ private:
 
 inline CaptureSourceOrError CoreAudioCaptureSourceFactory::createAudioCaptureSource(const CaptureDevice& device, MediaDeviceHashSalts&& hashSalts, const MediaConstraints* constraints, std::optional<PageIdentifier> pageIdentifier)
 {
-    return CoreAudioCaptureSource::create(String { device.persistentId() }, WTFMove(hashSalts), constraints, pageIdentifier);
+    return CoreAudioCaptureSource::create(device, WTFMove(hashSalts), constraints, pageIdentifier);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
@@ -266,7 +266,7 @@ void CoreAudioSharedUnit::captureDeviceChanged()
 #if PLATFORM(MAC)
     reconfigureAudioUnit();
 #else
-    AVAudioSessionCaptureDeviceManager::singleton().setPreferredAudioSessionDeviceUID(persistentID());
+    AVAudioSessionCaptureDeviceManager::singleton().setPreferredAudioSessionDeviceUID(isCapturingWithDefaultMicrophone() ? String { } : persistentID());
 #endif
     updateVoiceActivityDetection();
 }
@@ -725,7 +725,7 @@ bool CoreAudioSharedUnit::migrateToNewDefaultDevice(const CaptureDevice& capture
         return false;
 
     // We were capturing with the default device which disappeared, let's move capture to the new default device.
-    setCaptureDevice(WTFMove(newDefaultDevicePersistentId), device->deviceID());
+    setCaptureDevice(WTFMove(newDefaultDevicePersistentId), device->deviceID(), true);
     handleNewCurrentMicrophoneDevice(WTFMove(*device));
     return true;
 }


### PR DESCRIPTION
#### 8bc8b76f63733d530c74a3cb99090bed2a014720
<pre>
[iOS] Do not set a microphone as preferred if getUserMedia is not asking for a specific device
<a href="https://rdar.apple.com/140384961">rdar://140384961</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=284617">https://bugs.webkit.org/show_bug.cgi?id=284617</a>

Reviewed by Eric Carlson.

When capturing microphone on iOS, we were setting preferred microphone on the AudioSession.
This sometimes seems to interfere with smart routing, in particular with AirPods.

To prevent this, in UIProcess, we are checking the constraints to see whether the web page asked for a specific device.
If not, we are marking the CaptureDevice as &apos;default&apos;.

We send the CaptureDevice to GPUProcess and CoreAudioCaptureSource will let know CoreAudioSharedUnit whether the device to use is the default one.
If it is not the default, we continue setting the preferred microphone on the AudioSession.
Otherwise, we set it to nil so that the OS is free to select whichever microphone is best suited.

Manually tested on <a href="https://webrtc.github.io/samples/src/content/devices/input-output/">https://webrtc.github.io/samples/src/content/devices/input-output/</a> in a setup with AirPods.
AirPods would be initially selected as the page is requesting any microphone.
Then, within the page, by selecting either built-in microphone or AirPods, the microphone (and speaker route) should follow.

We do a minor refactoring to CoreAudioCaptureDevice by removing the unused deviceClock method and related member.
We do a minor refactoring of CoreAudioCaptureSourceFactoryIOS since its createAudioCaptureSource method is the same as the base one.

We update CoreAudioCaptureSourceFactory::createAudioCaptureSource and CoreAudioCaptureSource::create so that CoreAudioCaptureSource constructor gets the device sent from UIProcess.
This ensures that we keep whether the device to be used is the default or not.

* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp:
(WebCore::RealtimeMediaSourceCenter::getUserMediaDevices):
* Source/WebCore/platform/mediastream/ios/AVAudioSessionCaptureDeviceManager.mm:
(WebCore::AVAudioSessionCaptureDeviceManager::setPreferredAudioSessionDeviceUIDInternal):
* Source/WebCore/platform/mediastream/ios/CoreAudioCaptureSourceIOS.h:
* Source/WebCore/platform/mediastream/ios/CoreAudioCaptureSourceIOS.mm:
(WebCore::CoreAudioCaptureSourceFactoryIOS::createAudioCaptureSource): Deleted.
* Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp:
(WebCore::BaseAudioSharedUnit::setCaptureDevice):
* Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h:
(WebCore::BaseAudioSharedUnit::isCapturingWithDefaultMicrophone const):
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDevice.cpp:
(WebCore::CoreAudioCaptureDevice::deviceClock): Deleted.
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDevice.h:
(WebCore::CoreAudioCaptureDevice::deviceID const):
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp:
(WebCore::CoreAudioCaptureSource::create):
(WebCore::CoreAudioCaptureSource::initializeToStartProducingData):
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h:
(WebCore::CoreAudioCaptureSourceFactory::createAudioCaptureSource):
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp:
(WebCore::CoreAudioSharedUnit::captureDeviceChanged):
(WebCore::CoreAudioSharedUnit::migrateToNewDefaultDevice):

Canonical link: <a href="https://commits.webkit.org/287834@main">https://commits.webkit.org/287834@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e91f274638428c54bd7fad946a3bafbc442b667

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80852 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/374 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34788 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85380 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31836 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82963 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/391 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8174 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63134 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20909 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83921 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/198 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73588 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43437 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/110 "Build was cancelled. Recent messages:OS: Sequoia (15.2), Xcode: 16.2") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27748 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30293 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71673 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28285 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86812 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8079 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5702 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71433 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8256 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69424 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70673 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17621 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14702 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13632 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8041 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13562 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7880 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11399 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9686 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->