### PR TITLE
Partial sync `bidirectional text` UA stylesheet rules as per Web Specification

### DIFF
--- a/LayoutTests/fast/css/all-keyword-direction-expected.html
+++ b/LayoutTests/fast/css/all-keyword-direction-expected.html
@@ -10,4 +10,4 @@ span { direction:rtl; }
 </style>
 </head>
 <body>
-<span id="quote">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</span> Phasellus eget velit sagittis.
+<span id="quote">.Lorem ipsum dolor sit amet, consectetur adipiscing elit</span> Phasellus eget velit sagittis.

--- a/LayoutTests/fast/css/all-keyword-direction.html
+++ b/LayoutTests/fast/css/all-keyword-direction.html
@@ -1,3 +1,4 @@
+<meta name="fuzzy" content="maxDifference=111; totalPixels=3" />
 <head>
 <style>
 html {

--- a/LayoutTests/fast/css/default-bidi-css-rules-expected.txt
+++ b/LayoutTests/fast/css/default-bidi-css-rules-expected.txt
@@ -1,7 +1,7 @@
 This test checks the default rules for direction and unicode-bidi CSS properties.
 
 PASS styleOf("div", {}).direction is "ltr"
-FAIL styleOf("div", {}).unicodeBidi should be isolate. Was normal.
+PASS styleOf("div", {}).unicodeBidi is "isolate"
 PASS styleOf("div", {"dir":"ltr"}).direction is "ltr"
 PASS styleOf("div", {"dir":"ltr"}).unicodeBidi is "isolate"
 PASS styleOf("div", {"dir":"rtl"}).direction is "rtl"
@@ -9,7 +9,7 @@ PASS styleOf("div", {"dir":"rtl"}).unicodeBidi is "isolate"
 PASS styleOf("div", {"dir":"auto"}).direction is "ltr"
 PASS styleOf("div", {"dir":"auto"}).unicodeBidi is "isolate"
 PASS styleOf("div", {"dir":""}).direction is "ltr"
-PASS styleOf("div", {"dir":""}).unicodeBidi is "normal"
+PASS styleOf("div", {"dir":""}).unicodeBidi is "isolate"
 PASS styleOf("span", {}).direction is "ltr"
 PASS styleOf("span", {}).unicodeBidi is "normal"
 PASS styleOf("span", {"dir":"ltr"}).direction is "ltr"
@@ -61,7 +61,7 @@ PASS styleOf("textarea", {"dir":"auto"}).unicodeBidi is "plaintext"
 PASS styleOf("textarea", {"dir":""}).direction is "ltr"
 PASS styleOf("textarea", {"dir":""}).unicodeBidi is "normal"
 PASS styleOf("pre", {}).direction is "ltr"
-PASS styleOf("pre", {}).unicodeBidi is "normal"
+PASS styleOf("pre", {}).unicodeBidi is "isolate"
 PASS styleOf("pre", {"dir":"ltr"}).direction is "ltr"
 PASS styleOf("pre", {"dir":"ltr"}).unicodeBidi is "isolate"
 PASS styleOf("pre", {"dir":"rtl"}).direction is "rtl"
@@ -69,7 +69,7 @@ PASS styleOf("pre", {"dir":"rtl"}).unicodeBidi is "isolate"
 PASS styleOf("pre", {"dir":"auto"}).direction is "ltr"
 PASS styleOf("pre", {"dir":"auto"}).unicodeBidi is "plaintext"
 PASS styleOf("pre", {"dir":""}).direction is "ltr"
-PASS styleOf("pre", {"dir":""}).unicodeBidi is "normal"
+PASS styleOf("pre", {"dir":""}).unicodeBidi is "isolate"
 PASS successfullyParsed is true
 Some tests failed.
 

--- a/LayoutTests/fast/css/default-bidi-css-rules.html
+++ b/LayoutTests/fast/css/default-bidi-css-rules.html
@@ -24,7 +24,7 @@ var tests = [
     ['div', {'dir': 'ltr'}, 'ltr', 'isolate'],
     ['div', {'dir': 'rtl'}, 'rtl', 'isolate'],
     ['div', {'dir': 'auto'}, 'ltr', 'isolate'],
-    ['div', {'dir': ''}, 'ltr', 'normal'],
+    ['div', {'dir': ''}, 'ltr', 'isolate'],
 
     ['span', {}, 'ltr', 'normal'],
     ['span', {'dir': 'ltr'}, 'ltr', 'isolate'],
@@ -44,6 +44,7 @@ var tests = [
     ['output', {'dir': 'auto'}, 'ltr', 'isolate'],
     ['output', {'dir': ''}, 'ltr', 'isolate'],
 
+    // https://html.spec.whatwg.org/multipage/rendering.html#bidi-rendering
     ['bdo', {}, 'ltr', 'isolate-override'],
     ['bdo', {'dir': 'ltr'}, 'ltr', 'isolate-override'],
     ['bdo', {'dir': 'rtl'}, 'rtl', 'isolate-override'],
@@ -56,11 +57,11 @@ var tests = [
     ['textarea', {'dir': 'auto'}, 'ltr', 'plaintext'],
     ['textarea', {'dir': ''}, 'ltr', 'normal'],
 
-    ['pre', {}, 'ltr', 'normal'],
+    ['pre', {}, 'ltr', 'isolate'],
     ['pre', {'dir': 'ltr'}, 'ltr', 'isolate'],
     ['pre', {'dir': 'rtl'}, 'rtl', 'isolate'],
     ['pre', {'dir': 'auto'}, 'ltr', 'plaintext'],
-    ['pre', {'dir': ''}, 'ltr', 'normal'],
+    ['pre', {'dir': ''}, 'ltr', 'isolate'],
 ].forEach(function (test) {
     shouldBe('styleOf("' + test[0] + '", ' + JSON.stringify(test[1]) + ').direction', '"' + test[2] + '"');
     container.innerHTML = '';

--- a/LayoutTests/fast/css/getComputedStyle/computed-style-without-renderer-expected.txt
+++ b/LayoutTests/fast/css/getComputedStyle/computed-style-without-renderer-expected.txt
@@ -196,7 +196,7 @@ transition-delay: 0s
 transition-duration: 0s
 transition-property: all
 transition-timing-function: ease
-unicode-bidi: normal
+unicode-bidi: isolate
 vector-effect: none
 vertical-align: baseline
 visibility: visible

--- a/LayoutTests/fast/css/unicode-bidi-computed-value-expected.txt
+++ b/LayoutTests/fast/css/unicode-bidi-computed-value-expected.txt
@@ -7,7 +7,7 @@ PASS styleOf("span", {"style":"unicode-bidi: bidi-override;"}).unicodeBidi is "b
 PASS styleOf("span", {"style":"unicode-bidi: plaintext;"}).unicodeBidi is "plaintext"
 PASS styleOf("span", {"style":"unicode-bidi: bad-value;"}).unicodeBidi is "normal"
 PASS styleOf("span", {"style":"unicode-bidi: embed embed;"}).unicodeBidi is "normal"
-PASS styleOf("span", {"style":"unicode-bidi: embed -webkit-plain-text;"}).unicodeBidi is "normal"
+PASS styleOf("span", {"style":"unicode-bidi: embed plain-text;"}).unicodeBidi is "normal"
 PASS styleOf("span", {"style":"unicode-bidi: bidi-override isolate;"}).unicodeBidi is "normal"
 PASS styleOf("span", {"style":"unicode-bidi: isolate bidi-override;"}).unicodeBidi is "normal"
 PASS styleOf("span", {"style":"unicode-bidi: isolate-override;"}).unicodeBidi is "isolate-override"
@@ -15,4 +15,7 @@ PASS styleOf("span", {"style":"unicode-bidi: bidi-override isolate bidi-override
 PASS styleOf("span", {"style":"unicode-bidi: bidi-override isolate isolate;"}).unicodeBidi is "normal"
 PASS styleOf("span", {"style":"unicode-bidi: bidi-override bad-value;"}).unicodeBidi is "normal"
 PASS styleOf("span", {"style":"unicode-bidi: bidi-override embed;"}).unicodeBidi is "normal"
+PASS successfullyParsed is true
+
+TEST COMPLETE
 

--- a/LayoutTests/fast/css/unicode-bidi-computed-value.html
+++ b/LayoutTests/fast/css/unicode-bidi-computed-value.html
@@ -1,7 +1,7 @@
 ﻿<!DOCTYPE html>
 <html>
 <body>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 <p id="description">This tests the computed value of unicode-bidi property.</p>
 <div id="container"></div>
 <div id="console"></div>
@@ -10,10 +10,10 @@
 var container = document.getElementById('container');
 
 function styleOf(name, attributes) {
-    var element = document.createElement('div');
-    for (var name in attributes) {
-        var value = attributes[name];
-        element.setAttribute(name, value);
+    var element = document.createElement(name);
+    for (var attr in attributes) {
+        var value = attributes[attr];
+        element.setAttribute(attr, value);
     }
     container.appendChild(element);
     return getComputedStyle(element);
@@ -27,7 +27,7 @@ var tests = [
     ['span', {'style': 'unicode-bidi: plaintext;'}, 'plaintext'],
     ['span', {'style': 'unicode-bidi: bad-value;'}, 'normal'],
     ['span', {'style': 'unicode-bidi: embed embed;'}, 'normal'],
-    ['span', {'style': 'unicode-bidi: embed -webkit-plain-text;'}, 'normal'],
+    ['span', {'style': 'unicode-bidi: embed plain-text;'}, 'normal'],
     ['span', {'style': 'unicode-bidi: bidi-override isolate;'}, 'normal'],
     ['span', {'style': 'unicode-bidi: isolate bidi-override;'}, 'normal'],
     ['span', {'style': 'unicode-bidi: isolate-override;'}, 'isolate-override'],

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/unicode-bidi-parsing-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/unicode-bidi-parsing-001.html
@@ -8,8 +8,8 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 
-<div title="Initial value of unicode-bidi"
-  data-expected="normal"></div>
+<span title="Initial value of unicode-bidi"
+  data-expected="normal"></span>
 
 <div style="unicode-bidi: embed; unicode-bidi: normal"
   data-expected="normal"></div>
@@ -19,8 +19,8 @@
   data-expected="bidi-override"></div>
 
 <div style="unicode-bidi: embed">
-  <div title="unicode-bidi should not inherit"
-    data-expected="normal"></div>
+  <span title="unicode-bidi should not inherit"
+    data-expected="normal"></span>
 </div>
 
 <script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/bidi-rendering/unicode-bidi-ua-rules-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/bidi-rendering/unicode-bidi-ua-rules-expected.txt
@@ -1,52 +1,52 @@
 
-FAIL UA stylesheet rule for unicode-bidi, for <address> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <blockquote> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <center> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <div> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <figure> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <figcaption> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <footer> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <form> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <header> assert_equals: expected "isolate" but got "normal"
+PASS UA stylesheet rule for unicode-bidi, for <address>
+PASS UA stylesheet rule for unicode-bidi, for <blockquote>
+PASS UA stylesheet rule for unicode-bidi, for <center>
+PASS UA stylesheet rule for unicode-bidi, for <div>
+PASS UA stylesheet rule for unicode-bidi, for <figure>
+PASS UA stylesheet rule for unicode-bidi, for <figcaption>
+PASS UA stylesheet rule for unicode-bidi, for <footer>
+PASS UA stylesheet rule for unicode-bidi, for <form>
+PASS UA stylesheet rule for unicode-bidi, for <header>
 PASS UA stylesheet rule for unicode-bidi, for <hr>
-FAIL UA stylesheet rule for unicode-bidi, for <legend> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <listing> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <main> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <p> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <plaintext> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <pre> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <summary> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <xmp> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <article> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <aside> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <h1> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <h2> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <h3> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <h4> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <h5> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <h6> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <hgroup> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <nav> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <section> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <search> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <table> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <caption> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <colgroup> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <col> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <thead> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <tbody> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <tfoot> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <tr> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <td> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <th> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <dir> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <dd> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <dl> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <dt> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <menu> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <ol> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <ul> assert_equals: expected "isolate" but got "normal"
-FAIL UA stylesheet rule for unicode-bidi, for <li> assert_equals: expected "isolate" but got "normal"
+PASS UA stylesheet rule for unicode-bidi, for <legend>
+PASS UA stylesheet rule for unicode-bidi, for <listing>
+PASS UA stylesheet rule for unicode-bidi, for <main>
+PASS UA stylesheet rule for unicode-bidi, for <p>
+PASS UA stylesheet rule for unicode-bidi, for <plaintext>
+PASS UA stylesheet rule for unicode-bidi, for <pre>
+PASS UA stylesheet rule for unicode-bidi, for <summary>
+PASS UA stylesheet rule for unicode-bidi, for <xmp>
+PASS UA stylesheet rule for unicode-bidi, for <article>
+PASS UA stylesheet rule for unicode-bidi, for <aside>
+PASS UA stylesheet rule for unicode-bidi, for <h1>
+PASS UA stylesheet rule for unicode-bidi, for <h2>
+PASS UA stylesheet rule for unicode-bidi, for <h3>
+PASS UA stylesheet rule for unicode-bidi, for <h4>
+PASS UA stylesheet rule for unicode-bidi, for <h5>
+PASS UA stylesheet rule for unicode-bidi, for <h6>
+PASS UA stylesheet rule for unicode-bidi, for <hgroup>
+PASS UA stylesheet rule for unicode-bidi, for <nav>
+PASS UA stylesheet rule for unicode-bidi, for <section>
+PASS UA stylesheet rule for unicode-bidi, for <search>
+PASS UA stylesheet rule for unicode-bidi, for <table>
+PASS UA stylesheet rule for unicode-bidi, for <caption>
+PASS UA stylesheet rule for unicode-bidi, for <colgroup>
+PASS UA stylesheet rule for unicode-bidi, for <col>
+PASS UA stylesheet rule for unicode-bidi, for <thead>
+PASS UA stylesheet rule for unicode-bidi, for <tbody>
+PASS UA stylesheet rule for unicode-bidi, for <tfoot>
+PASS UA stylesheet rule for unicode-bidi, for <tr>
+PASS UA stylesheet rule for unicode-bidi, for <td>
+PASS UA stylesheet rule for unicode-bidi, for <th>
+PASS UA stylesheet rule for unicode-bidi, for <dir>
+PASS UA stylesheet rule for unicode-bidi, for <dd>
+PASS UA stylesheet rule for unicode-bidi, for <dl>
+PASS UA stylesheet rule for unicode-bidi, for <dt>
+PASS UA stylesheet rule for unicode-bidi, for <menu>
+PASS UA stylesheet rule for unicode-bidi, for <ol>
+PASS UA stylesheet rule for unicode-bidi, for <ul>
+PASS UA stylesheet rule for unicode-bidi, for <li>
 PASS UA stylesheet rule for unicode-bidi, for <bdi>
 PASS UA stylesheet rule for unicode-bidi, for <output>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/search-styles-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/search-styles-expected.txt
@@ -8,5 +8,5 @@ PASS <search> - padding-top
 PASS <search> - padding-right
 PASS <search> - padding-bottom
 PASS <search> - padding-left
-FAIL <search> - unicode-bidi assert_equals: expected "isolate" but got "normal"
+PASS <search> - unicode-bidi
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/search-styles-iso-8859-8-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/search-styles-iso-8859-8-expected.txt
@@ -9,5 +9,5 @@ PASS <search> - padding-top
 PASS <search> - padding-right
 PASS <search> - padding-bottom
 PASS <search> - padding-left
-FAIL <search> - unicode-bidi assert_equals: expected "bidi-override" but got "normal"
+FAIL <search> - unicode-bidi assert_equals: expected "bidi-override" but got "isolate"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/legend-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/legend-expected.txt
@@ -2,7 +2,7 @@
 
 
 PASS in-body: display
-FAIL in-body: unicodeBidi assert_equals: expected "isolate" but got "normal"
+PASS in-body: unicodeBidi
 PASS in-body: marginTop
 PASS in-body: marginRight
 PASS in-body: marginBottom
@@ -16,7 +16,7 @@ PASS in-body: height
 PASS in-body: box-sizing
 FAIL in-body: width assert_not_equals: got disallowed value "0px"
 PASS rendered-legend: display
-FAIL rendered-legend: unicodeBidi assert_equals: expected "isolate" but got "normal"
+PASS rendered-legend: unicodeBidi
 PASS rendered-legend: marginTop
 PASS rendered-legend: marginRight
 PASS rendered-legend: marginBottom
@@ -30,7 +30,7 @@ PASS rendered-legend: height
 PASS rendered-legend: box-sizing
 PASS rendered-legend: width
 PASS in-fieldset-second-child: display
-FAIL in-fieldset-second-child: unicodeBidi assert_equals: expected "isolate" but got "normal"
+PASS in-fieldset-second-child: unicodeBidi
 PASS in-fieldset-second-child: marginTop
 PASS in-fieldset-second-child: marginRight
 PASS in-fieldset-second-child: marginBottom
@@ -44,7 +44,7 @@ PASS in-fieldset-second-child: height
 PASS in-fieldset-second-child: box-sizing
 FAIL in-fieldset-second-child: width assert_not_equals: got disallowed value "0px"
 PASS in-fieldset-descendant: display
-FAIL in-fieldset-descendant: unicodeBidi assert_equals: expected "isolate" but got "normal"
+PASS in-fieldset-descendant: unicodeBidi
 PASS in-fieldset-descendant: marginTop
 PASS in-fieldset-descendant: marginRight
 PASS in-fieldset-descendant: marginBottom

--- a/LayoutTests/inspector/css/shadow-scoped-style-expected.txt
+++ b/LayoutTests/inspector/css/shadow-scoped-style-expected.txt
@@ -19,6 +19,8 @@ STYLES:
 :host {
     padding: 20px;
 }
+address, blockquote, center, div, figure, figcaption, footer, form, header, hr, legend, listing, main, p, plaintext, pre, summary, xmp, article, aside, h1, h2, h3, h4, h5, h6, hgroup, nav, section, search, table, caption, colgroup, col, thead, tbody, tfoot, tr, td, th, dir, dd, dl, dt, menu, ol, ul, li, bdi, output {
+}
 address, article, aside, div, footer, header, hgroup, main, nav, search, section {
 }
 html {
@@ -33,6 +35,8 @@ STYLES:
 }
 div {
     color: blue;
+}
+address, blockquote, center, div, figure, figcaption, footer, form, header, hr, legend, listing, main, p, plaintext, pre, summary, xmp, article, aside, h1, h2, h3, h4, h5, h6, hgroup, nav, section, search, table, caption, colgroup, col, thead, tbody, tfoot, tr, td, th, dir, dd, dl, dt, menu, ol, ul, li, bdi, output {
 }
 address, article, aside, div, footer, header, hgroup, main, nav, search, section {
 }

--- a/LayoutTests/platform/gtk/fast/forms/form-in-malformed-markup-expected.txt
+++ b/LayoutTests/platform/gtk/fast/forms/form-in-malformed-markup-expected.txt
@@ -4,7 +4,7 @@ layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock (anonymous) at (0,0) size 784x0
-        RenderInline {B} at (0,0) size 0x0
+        RenderInline {B} at (0,-14) size 0x17
           RenderInline {FORM} at (0,0) size 0x0
       RenderTable {TABLE} at (0,0) size 230x24
         RenderTableSection {TBODY} at (0,0) size 230x24

--- a/LayoutTests/platform/ios/fast/forms/form-in-malformed-markup-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/form-in-malformed-markup-expected.txt
@@ -4,7 +4,7 @@ layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock (anonymous) at (0,0) size 784x0
-        RenderInline {B} at (0,0) size 0x0
+        RenderInline {B} at (0,-15) size 0x19
           RenderInline {FORM} at (0,0) size 0x0
       RenderTable {TABLE} at (0,0) size 236x26
         RenderTableSection {TBODY} at (0,0) size 236x26

--- a/LayoutTests/platform/mac/fast/forms/form-in-malformed-markup-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/form-in-malformed-markup-expected.txt
@@ -4,7 +4,7 @@ layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock (anonymous) at (0,0) size 784x0
-        RenderInline {B} at (0,0) size 0x0
+        RenderInline {B} at (0,-14) size 0x18
           RenderInline {FORM} at (0,0) size 0x0
       RenderTable {TABLE} at (0,0) size 236x24
         RenderTableSection {TBODY} at (0,0) size 236x24

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -99,7 +99,6 @@ center {
 hr {
     display: block;
     overflow: hidden;
-    unicode-bidi: isolate;
     color: gray;
     margin-block-start: 0.5em;
     margin-block-end: 0.5em;
@@ -1406,8 +1405,11 @@ iframe {
     border: 2px inset;
 }
 
-bdi, output {
-    unicode-bidi: isolate;
+address, blockquote, center, div, figure, figcaption, footer, form, header, hr,
+legend, listing, main, p, plaintext, pre, summary, xmp, article, aside, h1, h2,
+h3, h4, h5, h6, hgroup, nav, section, search, table, caption, colgroup, col,
+thead, tbody, tfoot, tr, td, th, dir, dd, dl, dt, menu, ol, ul, li, bdi, output {
+    unicode-bidi: isolate; 
 }
 
 input[type=tel i]:dir(ltr) { direction: ltr; }

--- a/Source/WebCore/editing/EditingStyle.cpp
+++ b/Source/WebCore/editing/EditingStyle.cpp
@@ -1674,7 +1674,7 @@ WritingDirection EditingStyle::textDirectionForSelection(const VisibleSelection&
         if (unicodeBidiValue == CSSValueBidiOverride)
             return WritingDirection::Natural;
 
-        ASSERT(unicodeBidiValue == CSSValueEmbed);
+        ASSERT(isEmbedOrIsolate(unicodeBidiValue));
         RefPtr<CSSValue> direction = computedStyle.propertyValue(CSSPropertyDirection);
         if (!is<CSSPrimitiveValue>(direction))
             continue;

--- a/Source/WebCore/editing/EditingStyle.h
+++ b/Source/WebCore/editing/EditingStyle.h
@@ -168,6 +168,7 @@ public:
     WEBCORE_EXPORT bool hasStyle(CSSPropertyID, const String& value);
     WEBCORE_EXPORT static RefPtr<EditingStyle> styleAtSelectionStart(const VisibleSelection&, bool shouldUseBackgroundColorInEffect = false);
     static WritingDirection textDirectionForSelection(const VisibleSelection&, EditingStyle* typingStyle, bool& hasNestedOrMultipleEmbeddings);
+    static bool isEmbedOrIsolate(CSSValueID unicodeBidi) { return unicodeBidi == CSSValueID::CSSValueIsolate || unicodeBidi == CSSValueID::CSSValueWebkitIsolate || unicodeBidi == CSSValueID::CSSValueEmbed; }
 
     Ref<EditingStyle> inverseTransformColorIfNeeded(Element&);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEditActions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEditActions.mm
@@ -405,7 +405,7 @@ TEST(WKWebViewEditActions, ModifyTextWritingDirection)
     auto webView = webViewForEditActionTesting(@"<div id='text' style='direction: rtl; unicode-bidi: bidi-override;'>WebKit</div>");
     [webView selectAll:nil];
     [webView makeTextWritingDirectionNatural:nil];
-    EXPECT_WK_STREQ("normal", [webView stringByEvaluatingJavaScript:@"getComputedStyle(text).unicodeBidi"]);
+    EXPECT_WK_STREQ("isolate", [webView stringByEvaluatingJavaScript:@"getComputedStyle(text).unicodeBidi"]);
 }
 
 TEST(WKWebViewEditActions, CopyFontAtCaretSelection)


### PR DESCRIPTION
#### ea2a8afbd89e36c72f4c7785538e206f4778730a
<pre>
Partial sync `bidirectional text` UA stylesheet rules as per Web Specification

<a href="https://bugs.webkit.org/show_bug.cgi?id=284620">https://bugs.webkit.org/show_bug.cgi?id=284620</a>
<a href="https://rdar.apple.com/141426858">rdar://141426858</a>

Reviewed by Tim Nguyen.

This patch is to align WebKit with Web-Specification [1]:

[1] <a href="https://html.spec.whatwg.org/multipage/rendering.html#bidi-rendering">https://html.spec.whatwg.org/multipage/rendering.html#bidi-rendering</a>

It syncs partially bidirectional text user agent stylesheet rules to ensure that
respective HTML elements have respect direction based as per standard.

The WPT test changes are synced as per:

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/e45da1637c6ae670bdc45929905506fca4f6d0bd">https://github.com/web-platform-tests/wpt/commit/e45da1637c6ae670bdc45929905506fca4f6d0bd</a>

* Source/WebCore/css/html.css:
(hr):
(address, blockquote, center, div, figure, figcaption, footer, form, header, hr,):
(bdi, output): Deleted.
* Source/WebCore/editing/EditingStyle.cpp:
(EditingStyle::textDirectionForSelection): textDirection could be `embed` or `isolate` so assert both
* Source/WebCore/editing/EditingStyle.h:

Test Updates (API &amp; Layout):
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/bidi-rendering/unicode-bidi-ua-rules-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/search-styles-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/search-styles-iso-8859-8-expected.txt: Rebaselined
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/legend-expected.txt: Progression
* LayoutTests/fast/css/all-keyword-direction.html: Added `3px` tolerance for Windows Platform
* LayoutTests/fast/css/all-keyword-direction-expected.html: Rebaselined
* LayoutTests/fast/css/default-bidi-css-rules.html: Updated test for new behavior
* LayoutTests/fast/css/default-bidi-css-rules-expected.txt: Rebaselined
* LayoutTests/fast/css/getComputedStyle/computed-style-without-renderer-expected.txt: Rebaseline
* LayoutTests/fast/css/unicode-bidi-computed-value-expected.txt: Rebaselined
* LayoutTests/fast/css/unicode-bidi-computed-value.html: Fixed test based on change done by Blink
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/unicode-bidi-parsing-001.html: Synced from WPT
* LayoutTests/inspector/css/shadow-scoped-style-expected.txt: Rebaselined
* LayoutTests/platform/ios/fast/forms/form-in-malformed-markup-expected.txt: Rebaselined
* LayoutTests/platform/mac/fast/forms/form-in-malformed-markup-expected.txt: Rebaselined
* LayoutTests/platform/gtk/fast/forms/form-in-malformed-markup-expected.txt: Rebaselined
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEditActions.mm:
(ModifyTextWritingDirection): Update Test

Canonical link: <a href="https://commits.webkit.org/287842@main">https://commits.webkit.org/287842@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c99ae2365d03ce3ab9ea9bf06ac4ca5d9bad9ab8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81059 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/584 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35002 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85588 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32045 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83169 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/602 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8389 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63276 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21041 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84128 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/364 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73777 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43574 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/261 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27937 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30503 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71801 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28492 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87023 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8289 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5857 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71579 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8466 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69611 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70815 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17628 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14860 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13784 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8250 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13773 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8087 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11607 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9895 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->