### PR TITLE
[css-anchor-position-1] Fix anchor-center alignment corner case

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-003-expected.txt
@@ -1,0 +1,3 @@
+
+PASS .target 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-003.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#anchor-center">
+<link rel="author" href="mailto:plampe@igalia.com">
+<title>Tests the position and available-size of 'anchor-center' alignment with target width: auto.</title>
+<style>
+.container {
+  width: 100px;
+  height: 100px;
+  border: solid 3px;
+  position: relative;
+  margin: 50px;
+}
+
+.anchor {
+  anchor-name: --anchor;
+  position: relative;
+  width: 50px;
+  height: 50px;
+  left: 40px;
+  top: 5px;
+  background: lime;
+}
+
+.target {
+  position-anchor: --anchor;
+  position: fixed;
+  background: cyan;
+  justify-self: anchor-center;
+  top: anchor(bottom);
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+
+<body onload="checkLayout('.target')">
+
+<div class="container">
+  <div class="anchor"></div>
+  <div class="target" data-expected-width="30" data-offset-x="111">
+    <div style="width:30px;height:20px;"></div>
+  </div>
+</div>

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -720,8 +720,7 @@ private:
 
     struct PositionedLayoutConstraints;
     void computePositionedLogicalHeight(LogicalExtentComputedValues&) const;
-    void computePositionedLogicalWidthUsing(SizeType, Length logicalWidth, const PositionedLayoutConstraints&,
-                                            LogicalExtentComputedValues&) const;
+    void computePositionedLogicalWidthUsing(SizeType, Length logicalWidth, const PositionedLayoutConstraints&, LogicalExtentComputedValues&, bool anchorCenterForcesShrinkToFit = false) const;
     void computePositionedLogicalHeightUsing(SizeType, Length logicalHeightLength, LayoutUnit computedHeight, const PositionedLayoutConstraints&,
                                              LogicalExtentComputedValues&) const;
 


### PR DESCRIPTION
#### ad9f857c5b6b0fc36e7a6a7fda714ead29bec547
<pre>
[css-anchor-position-1] Fix anchor-center alignment corner case
<a href="https://bugs.webkit.org/show_bug.cgi?id=284619">https://bugs.webkit.org/show_bug.cgi?id=284619</a>

Reviewed by NOBODY (OOPS!).

This change fixes the anchor-center behavior when anchor target has width: auto.

As anchor positioning (in case of anchor-center) forces inset properties to
resolve to 0, in case of width: auto, the wrong sizing algorithm was used and
effectively width was calculated to take maximum possible size.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-003-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-003.html: Added.
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::computePositionedLogicalWidth const):
(WebCore::RenderBox::computePositionedLogicalWidthUsing const):
* Source/WebCore/rendering/RenderBox.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad9f857c5b6b0fc36e7a6a7fda714ead29bec547

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92389 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11930 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/1519 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97373 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42896 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94439 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12208 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20391 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70812 "Found 6 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/position-area-abs-inline-container.html imported/w3c/web-platform-tests/css/css-anchor-position/position-area-anchor-outside.html imported/w3c/web-platform-tests/css/css-anchor-position/position-area-anchor-partially-outside.html imported/w3c/web-platform-tests/css/css-anchor-position/position-area-basic.html imported/w3c/web-platform-tests/css/css-anchor-position/position-area-with-insets.html imported/w3c/web-platform-tests/css/css-anchor-position/position-area-wm-dir.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28268 "Found 6 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/position-area-abs-inline-container.html imported/w3c/web-platform-tests/css/css-anchor-position/position-area-anchor-outside.html imported/w3c/web-platform-tests/css/css-anchor-position/position-area-anchor-partially-outside.html imported/w3c/web-platform-tests/css/css-anchor-position/position-area-basic.html imported/w3c/web-platform-tests/css/css-anchor-position/position-area-with-insets.html imported/w3c/web-platform-tests/css/css-anchor-position/position-area-wm-dir.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95391 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9282 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83673 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51130 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8989 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1301 "Found 6 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/position-area-abs-inline-container.html imported/w3c/web-platform-tests/css/css-anchor-position/position-area-anchor-outside.html imported/w3c/web-platform-tests/css/css-anchor-position/position-area-anchor-partially-outside.html imported/w3c/web-platform-tests/css/css-anchor-position/position-area-basic.html imported/w3c/web-platform-tests/css/css-anchor-position/position-area-with-insets.html imported/w3c/web-platform-tests/css/css-anchor-position/position-area-wm-dir.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42226 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79316 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1252 "Found 6 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/position-area-abs-inline-container.html imported/w3c/web-platform-tests/css/css-anchor-position/position-area-anchor-outside.html imported/w3c/web-platform-tests/css/css-anchor-position/position-area-anchor-partially-outside.html imported/w3c/web-platform-tests/css/css-anchor-position/position-area-basic.html imported/w3c/web-platform-tests/css/css-anchor-position/position-area-with-insets.html imported/w3c/web-platform-tests/css/css-anchor-position/position-area-wm-dir.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99399 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19440 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14373 "Found 8 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/position-area-abs-inline-container.html imported/w3c/web-platform-tests/css/css-anchor-position/position-area-anchor-outside.html imported/w3c/web-platform-tests/css/css-anchor-position/position-area-anchor-partially-outside.html imported/w3c/web-platform-tests/css/css-anchor-position/position-area-basic.html imported/w3c/web-platform-tests/css/css-anchor-position/position-area-with-insets.html imported/w3c/web-platform-tests/css/css-anchor-position/position-area-wm-dir.html imported/w3c/web-platform-tests/fullscreen/rendering/backdrop-object.html ipc/media-player-invalid-test.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79823 "Found 6 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/position-area-abs-inline-container.html imported/w3c/web-platform-tests/css/css-anchor-position/position-area-anchor-outside.html imported/w3c/web-platform-tests/css/css-anchor-position/position-area-anchor-partially-outside.html imported/w3c/web-platform-tests/css/css-anchor-position/position-area-basic.html imported/w3c/web-platform-tests/css/css-anchor-position/position-area-with-insets.html imported/w3c/web-platform-tests/css/css-anchor-position/position-area-wm-dir.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19690 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79546 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79079 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23620 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/924 "Found 6 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/position-area-abs-inline-container.html imported/w3c/web-platform-tests/css/css-anchor-position/position-area-anchor-outside.html imported/w3c/web-platform-tests/css/css-anchor-position/position-area-anchor-partially-outside.html imported/w3c/web-platform-tests/css/css-anchor-position/position-area-basic.html imported/w3c/web-platform-tests/css/css-anchor-position/position-area-with-insets.html imported/w3c/web-platform-tests/css/css-anchor-position/position-area-wm-dir.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12441 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19424 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24596 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19111 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22570 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20851 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->