### PR TITLE
[css-masonry] Definite items are no longer placed first by default

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001-auto-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001-auto-expected.html
@@ -46,7 +46,7 @@ grid {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="width:2ch; grid-area:1/2">5</item>
+  <item style="width:2ch; grid-column: 2;">5</item>
 </grid>
 
 <grid>
@@ -54,28 +54,25 @@ grid {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="width:4ch; grid-area:1/2/2/4">5</item>
+  <item style="width:4ch; grid-column:2/span 2">5</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="grid-area: 1/2/2/span 2">5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
+  <item style="grid-column:2/span 2">5</item>
+  <item style="width:5ch; grid-column:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="width:3ch; grid-area:1/2/2/4">5</item>
-  <item style="width:5ch; grid-area:2/1/3/4">6</item>
+  <item style="width:3ch; grid-column:span 2/4">5</item>
+  <item style="width:5ch; grid-column:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001-auto-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001-auto-ref.html
@@ -46,7 +46,7 @@ grid {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="width:2ch; grid-area:1/2">5</item>
+  <item style="width:2ch; grid-column: 2;">5</item>
 </grid>
 
 <grid>
@@ -54,28 +54,25 @@ grid {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="width:4ch; grid-area:1/2/2/4">5</item>
+  <item style="width:4ch; grid-column:2/span 2">5</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="grid-area: 1/2/2/span 2">5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
+  <item style="grid-column:2/span 2">5</item>
+  <item style="width:5ch; grid-column:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="width:3ch; grid-area:1/2/2/4">5</item>
-  <item style="width:5ch; grid-area:2/1/3/4">6</item>
+  <item style="width:3ch; grid-column:span 2/4">5</item>
+  <item style="width:5ch; grid-column:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001-fr-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001-fr-expected.html
@@ -46,7 +46,7 @@ grid {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="width:2ch; grid-area: 1/2">5</item>
+  <item style="width:2ch; grid-column:2">5</item>
 </grid>
 
 <grid>
@@ -54,27 +54,25 @@ grid {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="width:4ch; grid-area: 1/2/2/4">5</item>
+  <item style="width:4ch; grid-column:2/span 2">5</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="grid-area: 1/2/2/span 2">5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
+  <item style="grid-column:2/span 2">5</item>
+  <item style="width:5ch; grid-column:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="width:3ch; grid-area:1/2/2/4">5</item>
-  <item style="width:5ch; grid-area:2/1/3/4">6</item>
+  <item style="width:3ch; grid-column:span 2/4">5</item>
+  <item style="width:5ch; grid-column:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001-fr-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001-fr-ref.html
@@ -46,7 +46,7 @@ grid {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="width:2ch; grid-area: 1/2">5</item>
+  <item style="width:2ch; grid-column:2">5</item>
 </grid>
 
 <grid>
@@ -54,27 +54,25 @@ grid {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="width:4ch; grid-area: 1/2/2/4">5</item>
+  <item style="width:4ch; grid-column:2/span 2">5</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="grid-area: 1/2/2/span 2">5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
+  <item style="grid-column:2/span 2">5</item>
+  <item style="width:5ch; grid-column:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="width:3ch; grid-area:1/2/2/4">5</item>
-  <item style="width:5ch; grid-area:2/1/3/4">6</item>
+  <item style="width:3ch; grid-column:span 2/4">5</item>
+  <item style="width:5ch; grid-column:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001-mix1-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001-mix1-expected.html
@@ -47,7 +47,7 @@ grid {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="width:2ch; grid-area: 1/2">5</item>
+  <item style="width:2ch; grid-column:2">5</item>
 </grid>
 
 <grid>
@@ -55,28 +55,25 @@ grid {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="width:4ch; grid-area: 1/2/2/4">5</item>
+  <item style="width:4ch; grid-column:2/span 2">5</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="grid-area: 1/2/2/span 2">5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
+  <item style="grid-column:2/span 2">5</item>
+  <item style="width:5ch; grid-column:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="width:3ch; grid-area:1/2/2/4">5</item>
-  <item style="width:5ch; grid-area:2/1/3/4">6</item>
+  <item style="width:3ch; grid-column:span 2/4">5</item>
+  <item style="width:5ch; grid-column:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001-mix1-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001-mix1-ref.html
@@ -47,7 +47,7 @@ grid {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="width:2ch; grid-area: 1/2">5</item>
+  <item style="width:2ch; grid-column:2">5</item>
 </grid>
 
 <grid>
@@ -55,28 +55,25 @@ grid {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="width:4ch; grid-area: 1/2/2/4">5</item>
+  <item style="width:4ch; grid-column:2/span 2">5</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="grid-area: 1/2/2/span 2">5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
+  <item style="grid-column:2/span 2">5</item>
+  <item style="width:5ch; grid-column:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="width:3ch; grid-area:1/2/2/4">5</item>
-  <item style="width:5ch; grid-area:2/1/3/4">6</item>
+  <item style="width:3ch; grid-column:span 2/4">5</item>
+  <item style="width:5ch; grid-column:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001-mix2-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001-mix2-expected.html
@@ -46,7 +46,7 @@ grid {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="width:2ch; grid-area: 1/2">5</item>
+  <item style="width:2ch; grid-column:2">5</item>
 </grid>
 
 <grid>
@@ -54,26 +54,25 @@ grid {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="width:4ch; grid-area: 1/2/2/4">5</item>
+  <item style="width:4ch; grid-column:2/span 2">5</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="grid-area: 1/2/2/span 2">5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
+  <item style="grid-column:2/span 2">5</item>
+  <item style="width:5ch; grid-column:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="width:3ch; grid-area:1/2/2/4">5</item>
-  <item style="width:5ch; grid-area:2/1/3/4">6</item>
+  <item style="width:3ch; grid-column:span 2/4">5</item>
+  <item style="width:5ch; grid-column:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001-mix2-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001-mix2-ref.html
@@ -46,7 +46,7 @@ grid {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="width:2ch; grid-area: 1/2">5</item>
+  <item style="width:2ch; grid-column:2">5</item>
 </grid>
 
 <grid>
@@ -54,26 +54,25 @@ grid {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="width:4ch; grid-area: 1/2/2/4">5</item>
+  <item style="width:4ch; grid-column:2/span 2">5</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="grid-area: 1/2/2/span 2">5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
+  <item style="grid-column:2/span 2">5</item>
+  <item style="width:5ch; grid-column:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="width:3ch; grid-area:1/2/2/4">5</item>
-  <item style="width:5ch; grid-area:2/1/3/4">6</item>
+  <item style="width:3ch; grid-column:span 2/4">5</item>
+  <item style="width:5ch; grid-column:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-auto-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-auto-expected.html
@@ -47,7 +47,7 @@ grid {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="width:2ch; grid-area:1/2">5</item>
+  <item style="width:2ch; grid-column:2">5</item>
 </grid>
 
 <grid>
@@ -55,28 +55,25 @@ grid {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="width:4ch; grid-area:1/2/2/4">5</item>
+  <item style="width:4ch; grid-column:2/span 2">5</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="grid-area: 1/2/2/span 2">5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
+  <item style="grid-column:2/span 2">5</item>
+  <item style="width:5ch; grid-column:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="width:3ch; grid-area:1/2/2/4">5</item>
-  <item style="width:5ch; grid-area:2/1/3/4">6</item>
+  <item style="width:3ch; grid-column:span 2/4">5</item>
+  <item style="width:5ch; grid-column:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-auto-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-auto-ref.html
@@ -47,7 +47,7 @@ grid {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="width:2ch; grid-area:1/2">5</item>
+  <item style="width:2ch; grid-column:2">5</item>
 </grid>
 
 <grid>
@@ -55,28 +55,25 @@ grid {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="width:4ch; grid-area:1/2/2/4">5</item>
+  <item style="width:4ch; grid-column:2/span 2">5</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="grid-area: 1/2/2/span 2">5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
+  <item style="grid-column:2/span 2">5</item>
+  <item style="width:5ch; grid-column:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="width:3ch; grid-area:1/2/2/4">5</item>
-  <item style="width:5ch; grid-area:2/1/3/4">6</item>
+  <item style="width:3ch; grid-column:span 2/4">5</item>
+  <item style="width:5ch; grid-column:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-fr-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-fr-expected.html
@@ -47,7 +47,7 @@ grid {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="width:2ch; grid-area: 1/2">5</item>
+  <item style="width:2ch; grid-column:2">5</item>
 </grid>
 
 <grid>
@@ -55,27 +55,25 @@ grid {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="width:4ch; grid-area: 1/2/2/4">5</item>
+  <item style="width:4ch; grid-column:2/span 2">5</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="grid-area: 1/2/2/span 2">5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
+  <item style="grid-column:2/span 2">5</item>
+  <item style="width:5ch; grid-column:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="width:3ch; grid-area:1/2/2/4">5</item>
-  <item style="width:5ch; grid-area:2/1/3/4">6</item>
+  <item style="width:3ch; grid-column:span 2/4">5</item>
+  <item style="width:5ch; grid-column:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-fr-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-fr-ref.html
@@ -47,7 +47,7 @@ grid {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="width:2ch; grid-area: 1/2">5</item>
+  <item style="width:2ch; grid-column:2">5</item>
 </grid>
 
 <grid>
@@ -55,27 +55,25 @@ grid {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="width:4ch; grid-area: 1/2/2/4">5</item>
+  <item style="width:4ch; grid-column:2/span 2">5</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="grid-area: 1/2/2/span 2">5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
+  <item style="grid-column:2/span 2">5</item>
+  <item style="width:5ch; grid-column:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="width:3ch; grid-area:1/2/2/4">5</item>
-  <item style="width:5ch; grid-area:2/1/3/4">6</item>
+  <item style="width:3ch; grid-column:span 2/4">5</item>
+  <item style="width:5ch; grid-column:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-mix1-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-mix1-expected.html
@@ -47,7 +47,7 @@ grid {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="width:2ch; grid-area: 1/2">5</item>
+  <item style="width:2ch; grid-column:2">5</item>
 </grid>
 
 <grid>
@@ -55,28 +55,25 @@ grid {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="width:4ch; grid-area: 1/2/2/4">5</item>
+  <item style="width:4ch; grid-column:2/span 2">5</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="grid-area: 1/2/2/span 2">5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
+  <item style="grid-column:2/span 2">5</item>
+  <item style="width:5ch; grid-column:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="width:3ch; grid-area:1/2/2/4">5</item>
-  <item style="width:5ch; grid-area:2/1/3/4">6</item>
+  <item style="width:3ch; grid-column:span 2/4">5</item>
+  <item style="width:5ch; grid-column:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-mix1-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-mix1-ref.html
@@ -47,7 +47,7 @@ grid {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="width:2ch; grid-area: 1/2">5</item>
+  <item style="width:2ch; grid-column:2">5</item>
 </grid>
 
 <grid>
@@ -55,28 +55,25 @@ grid {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="width:4ch; grid-area: 1/2/2/4">5</item>
+  <item style="width:4ch; grid-column:2/span 2">5</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="grid-area: 1/2/2/span 2">5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
+  <item style="grid-column:2/span 2">5</item>
+  <item style="width:5ch; grid-column:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="width:3ch; grid-area:1/2/2/4">5</item>
-  <item style="width:5ch; grid-area:2/1/3/4">6</item>
+  <item style="width:3ch; grid-column:span 2/4">5</item>
+  <item style="width:5ch; grid-column:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-mix2-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-mix2-expected.html
@@ -48,7 +48,7 @@ grid {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="width:2ch; grid-area: 1/2">5</item>
+  <item style="width:2ch; grid-column:2">5</item>
 </grid>
 
 <grid>
@@ -56,26 +56,25 @@ grid {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="width:4ch; grid-area: 1/2/2/4">5</item>
+  <item style="width:4ch; grid-column:2/span 2">5</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="grid-area: 1/2/2/span 2">5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
+  <item style="grid-column:2/span 2">5</item>
+  <item style="width:5ch; grid-column:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="width:3ch; grid-area:1/2/2/4">5</item>
-  <item style="width:5ch; grid-area:2/1/3/4">6</item>
+  <item style="width:3ch; grid-column:span 2/4">5</item>
+  <item style="width:5ch; grid-column:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-mix2-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-mix2-ref.html
@@ -48,7 +48,7 @@ grid {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="width:2ch; grid-area: 1/2">5</item>
+  <item style="width:2ch; grid-column:2">5</item>
 </grid>
 
 <grid>
@@ -56,26 +56,25 @@ grid {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="width:4ch; grid-area: 1/2/2/4">5</item>
+  <item style="width:4ch; grid-column:2/span 2">5</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="grid-area: 1/2/2/span 2">5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
+  <item style="grid-column:2/span 2">5</item>
+  <item style="width:5ch; grid-column:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="width:3ch; grid-area:1/2/2/4">5</item>
-  <item style="width:5ch; grid-area:2/1/3/4">6</item>
+  <item style="width:3ch; grid-column:span 2/4">5</item>
+  <item style="width:5ch; grid-column:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-auto-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-auto-expected.html
@@ -52,46 +52,38 @@ item {
 
 <grid>
   <item>1</item>
-  <item style="grid-row: span 2">2 2</item>
-  <item style="grid-row: span 2">3 3</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="width:2ch; grid-area: 1/2/3">5 5</item>
+  <item style="width:2ch; grid-column:2">5 5</item>
 </grid>
 
 <grid>
   <item>1</item>
-  <item style="grid-row: span 2">2 2</item>
-  <item style="grid-row: span 2">3 3</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="width:4ch; grid-area: 1/2/auto/4">5 5</item>
-
-  <item class="hidden">0</item>
+  <item style="width:4ch; grid-column:2/span 2">5 5</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
-  <item style="grid-row: span 2">2 2</item>
-  <item style="grid-row: span 2">3 3</item>
+  <item>1</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="grid-area: 1/2/2/4">5 5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
-
-  <item class="hidden">0</item>
-  <item class="hidden">0 0</item>
-  <item class="hidden">0 0</item>
+  <item style="grid-column: 1; grid-row: 2;" class="hidden">0 0</item>
+  <item style="grid-column:2/span 2">5 5</item>
+  <item style="width:5ch; grid-column:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
-  <item style="grid-row: span 2">2 2</item>
-  <item style="grid-row: span 2">3 3</item>
+  <item>1</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="width:3ch; grid-area: 1/2/2/4">5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
-
-  <item class="hidden">0</item>
-  <item class="hidden">0 0</item>
-  <item class="hidden">0 0</item>
+  <item style="grid-column: 1; grid-row: 2;" class="hidden">0 0</item>
+  <item style="width:3ch; grid-column:span 2/4">5</item>
+  <item style="width:5ch; grid-column:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-auto-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-auto-ref.html
@@ -52,46 +52,38 @@ item {
 
 <grid>
   <item>1</item>
-  <item style="grid-row: span 2">2 2</item>
-  <item style="grid-row: span 2">3 3</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="width:2ch; grid-area: 1/2/3">5 5</item>
+  <item style="width:2ch; grid-column:2">5 5</item>
 </grid>
 
 <grid>
   <item>1</item>
-  <item style="grid-row: span 2">2 2</item>
-  <item style="grid-row: span 2">3 3</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="width:4ch; grid-area: 1/2/auto/4">5 5</item>
-
-  <item class="hidden">0</item>
+  <item style="width:4ch; grid-column:2/span 2">5 5</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
-  <item style="grid-row: span 2">2 2</item>
-  <item style="grid-row: span 2">3 3</item>
+  <item>1</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="grid-area: 1/2/2/4">5 5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
-
-  <item class="hidden">0</item>
-  <item class="hidden">0 0</item>
-  <item class="hidden">0 0</item>
+  <item style="grid-column: 1; grid-row: 2;" class="hidden">0 0</item>
+  <item style="grid-column:2/span 2">5 5</item>
+  <item style="width:5ch; grid-column:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
-  <item style="grid-row: span 2">2 2</item>
-  <item style="grid-row: span 2">3 3</item>
+  <item>1</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="width:3ch; grid-area: 1/2/2/4">5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
-
-  <item class="hidden">0</item>
-  <item class="hidden">0 0</item>
-  <item class="hidden">0 0</item>
+  <item style="grid-column: 1; grid-row: 2;" class="hidden">0 0</item>
+  <item style="width:3ch; grid-column:span 2/4">5</item>
+  <item style="width:5ch; grid-column:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-fr-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-fr-expected.html
@@ -52,44 +52,38 @@ item {
 
 <grid>
   <item>1</item>
-  <item style="grid-row: span 2">2 2</item>
-  <item style="grid-row: span 2">3 3</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="width:2ch; grid-area: 1/2/3">5 5</item>
+  <item style="width:2ch; grid-column:2">5 5</item>
 </grid>
 
 <grid>
   <item>1</item>
-  <item style="grid-row: span 2">2 2</item>
-  <item style="grid-row: span 2">3 3</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="width:4ch; grid-area: 1/2/auto/4">5 5</item>
-  <item class="hidden">0</item>
+  <item style="width:4ch; grid-column:2/span 2">5 5</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
-  <item style="grid-row: span 2">2 2</item>
-  <item style="grid-row: span 2">3 3</item>
+  <item>1</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="grid-area: 1/2/2/4">5 5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
-  <item class="hidden">0</item>
-  <item class="hidden">0 0</item>
-  <item class="hidden">0 0</item>
+  <item style="grid-column: 1; grid-row: 2;" class="hidden">0 0</item>
+  <item style="grid-column:2/span 2">5 5</item>
+  <item style="width:5ch; grid-column:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
-  <item style="grid-row: span 2">2 2</item>
-  <item style="grid-row: span 2">3 3</item>
+  <item>1</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="width:3ch; grid-area: 1/2/2/4">5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
-
-  <item class="hidden">0</item>
-  <item class="hidden">0 0</item>
-  <item class="hidden">0 0</item>
+  <item style="grid-column: 1; grid-row: 2;" class="hidden">0 0</item>
+  <item style="width:3ch; grid-column:span 2/4">5</item>
+  <item style="width:5ch; grid-column:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-fr-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-fr-ref.html
@@ -52,44 +52,38 @@ item {
 
 <grid>
   <item>1</item>
-  <item style="grid-row: span 2">2 2</item>
-  <item style="grid-row: span 2">3 3</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="width:2ch; grid-area: 1/2/3">5 5</item>
+  <item style="width:2ch; grid-column:2">5 5</item>
 </grid>
 
 <grid>
   <item>1</item>
-  <item style="grid-row: span 2">2 2</item>
-  <item style="grid-row: span 2">3 3</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="width:4ch; grid-area: 1/2/auto/4">5 5</item>
-  <item class="hidden">0</item>
+  <item style="width:4ch; grid-column:2/span 2">5 5</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
-  <item style="grid-row: span 2">2 2</item>
-  <item style="grid-row: span 2">3 3</item>
+  <item>1</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="grid-area: 1/2/2/4">5 5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
-  <item class="hidden">0</item>
-  <item class="hidden">0 0</item>
-  <item class="hidden">0 0</item>
+  <item style="grid-column: 1; grid-row: 2;" class="hidden">0 0</item>
+  <item style="grid-column:2/span 2">5 5</item>
+  <item style="width:5ch; grid-column:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
-  <item style="grid-row: span 2">2 2</item>
-  <item style="grid-row: span 2">3 3</item>
+  <item>1</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="width:3ch; grid-area: 1/2/2/4">5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
-
-  <item class="hidden">0</item>
-  <item class="hidden">0 0</item>
-  <item class="hidden">0 0</item>
+  <item style="grid-column: 1; grid-row: 2;" class="hidden">0 0</item>
+  <item style="width:3ch; grid-column:span 2/4">5</item>
+  <item style="width:5ch; grid-column:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-mix1-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-mix1-expected.html
@@ -54,44 +54,44 @@ item {
 
 <grid>
   <item>1</item>
-  <item style="grid-row: span 2">2 2</item>
+  <item>2 2</item>
   <item style="grid-row: span 2">3 3</item>
   <item>4</item>
-  <item style="width:2ch; grid-area: 1/2/3">5 5</item>
+  <item style="width:2ch; grid-column:2">5 5</item>
+
+  <item class="hidden" style="grid-column: 4; grid-row: 2;">0 0</item>
 </grid>
 
 <grid>
   <item>1</item>
-  <item style="grid-row: span 2">2 2</item>
-  <item style="grid-row: span 2">3 3</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="width:4ch; grid-area: 1/2/auto/4">5 5</item>
-  <item class="hidden">0</item>
+  <item style="width:4ch; grid-column:2/span 2">5 5</item>
+
+  <item class="hidden" style="grid-column: 4; grid-row: 2;">0 0</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
-  <item style="grid-row: span 2">2 2</item>
-  <item style="grid-row: span 2">3 3</item>
+  <item>1</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="grid-area: 1/2/2/4">5 5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
-  <item class="hidden">0</item>
-  <item class="hidden">0 0</item>
-  <item class="hidden">0 0</item>
+  <item style="grid-column:2/span 2">5 5</item>
+  <item style="width:5ch; grid-column:span 3/4">6</item>
+
+  <item class="hidden" style="grid-column: 4; grid-row: 2;">0 0</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
-  <item style="grid-row: span 2">2 2</item>
-  <item style="grid-row: span 2">3 3</item>
+  <item>1</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="width:3ch; grid-area: 1/2/2/4">5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
+  <item style="width:3ch; grid-column:span 2/4">5</item>
+  <item style="width:5ch; grid-column:1/span 3">6</item>
 
-  <item class="hidden">0</item>
-  <item class="hidden">0 0</item>
-  <item class="hidden">0 0</item>
+  <item class="hidden" style="grid-column: 4; grid-row: 2;">0 0</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-mix1-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-mix1-ref.html
@@ -54,44 +54,44 @@ item {
 
 <grid>
   <item>1</item>
-  <item style="grid-row: span 2">2 2</item>
+  <item>2 2</item>
   <item style="grid-row: span 2">3 3</item>
   <item>4</item>
-  <item style="width:2ch; grid-area: 1/2/3">5 5</item>
+  <item style="width:2ch; grid-column:2">5 5</item>
+
+  <item class="hidden" style="grid-column: 4; grid-row: 2;">0 0</item>
 </grid>
 
 <grid>
   <item>1</item>
-  <item style="grid-row: span 2">2 2</item>
-  <item style="grid-row: span 2">3 3</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="width:4ch; grid-area: 1/2/auto/4">5 5</item>
-  <item class="hidden">0</item>
+  <item style="width:4ch; grid-column:2/span 2">5 5</item>
+
+  <item class="hidden" style="grid-column: 4; grid-row: 2;">0 0</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
-  <item style="grid-row: span 2">2 2</item>
-  <item style="grid-row: span 2">3 3</item>
+  <item>1</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="grid-area: 1/2/2/4">5 5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
-  <item class="hidden">0</item>
-  <item class="hidden">0 0</item>
-  <item class="hidden">0 0</item>
+  <item style="grid-column:2/span 2">5 5</item>
+  <item style="width:5ch; grid-column:span 3/4">6</item>
+
+  <item class="hidden" style="grid-column: 4; grid-row: 2;">0 0</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
-  <item style="grid-row: span 2">2 2</item>
-  <item style="grid-row: span 2">3 3</item>
+  <item>1</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="width:3ch; grid-area: 1/2/2/4">5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
+  <item style="width:3ch; grid-column:span 2/4">5</item>
+  <item style="width:5ch; grid-column:1/span 3">6</item>
 
-  <item class="hidden">0</item>
-  <item class="hidden">0 0</item>
-  <item class="hidden">0 0</item>
+  <item class="hidden" style="grid-column: 4; grid-row: 2;">0 0</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-mix2-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-mix2-expected.html
@@ -55,44 +55,36 @@ item {
 
 <grid>
   <item>1</item>
-  <item style="grid-row: span 2">2 2</item>
+  <item>2 2</item>
   <item style="grid-row: span 2">3 3</item>
   <item>4</item>
-  <item style="width:2ch; grid-area: 1/2/3">5 5</item>
+  <item style="width:2ch; grid-column:2">5 5</item>
 </grid>
 
 <grid>
   <item>1</item>
-  <item style="grid-row: span 2">2 2</item>
-  <item style="grid-row: span 2">3 3</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="width:4ch; grid-area: 1/2/auto/4">5 5</item>
-  <item class="hidden">0</item>
+  <item style="width:4ch; grid-column:2/span 2">5 5</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
-  <item style="grid-row: span 2">2 2</item>
-  <item style="grid-row: span 2">3 3</item>
+  <item>1</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="grid-area: 1/2/2/4">5 5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
-  <item class="hidden">0</item>
-  <item class="hidden">0 0</item>
-  <item class="hidden">0 0</item>
+  <item style="grid-column:2/span 2">5 5</item>
+  <item style="width:5ch; grid-column:1/span 3">6</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
-  <item style="grid-row: span 2">2 2</item>
-  <item style="grid-row: span 2">3 3</item>
+  <item>1</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="width:3ch; grid-area: 1/2/2/4">5 5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
-
-  <item class="hidden">0</item>
-  <item class="hidden">0 0</item>
-  <item class="hidden">0 0</item>
+  <item style="width:3ch; grid-column:2/span 2">5 5</item>
+  <item style="width:5ch; grid-column:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-mix2-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-mix2-ref.html
@@ -55,44 +55,36 @@ item {
 
 <grid>
   <item>1</item>
-  <item style="grid-row: span 2">2 2</item>
+  <item>2 2</item>
   <item style="grid-row: span 2">3 3</item>
   <item>4</item>
-  <item style="width:2ch; grid-area: 1/2/3">5 5</item>
+  <item style="width:2ch; grid-column:2">5 5</item>
 </grid>
 
 <grid>
   <item>1</item>
-  <item style="grid-row: span 2">2 2</item>
-  <item style="grid-row: span 2">3 3</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="width:4ch; grid-area: 1/2/auto/4">5 5</item>
-  <item class="hidden">0</item>
+  <item style="width:4ch; grid-column:2/span 2">5 5</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
-  <item style="grid-row: span 2">2 2</item>
-  <item style="grid-row: span 2">3 3</item>
+  <item>1</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="grid-area: 1/2/2/4">5 5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
-  <item class="hidden">0</item>
-  <item class="hidden">0 0</item>
-  <item class="hidden">0 0</item>
+  <item style="grid-column:2/span 2">5 5</item>
+  <item style="width:5ch; grid-column:1/span 3">6</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
-  <item style="grid-row: span 2">2 2</item>
-  <item style="grid-row: span 2">3 3</item>
+  <item>1</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="width:3ch; grid-area: 1/2/2/4">5 5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
-
-  <item class="hidden">0</item>
-  <item class="hidden">0 0</item>
-  <item class="hidden">0 0</item>
+  <item style="width:3ch; grid-column:2/span 2">5 5</item>
+  <item style="width:5ch; grid-column:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-auto-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-auto-expected.html
@@ -60,50 +60,46 @@ item {
   <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
-  <item style="grid-area: 2/1">4</item>
-  <item style="width:2ch; grid-area: 1/2/3">5 5</item>
+  <item>4</item>
+  <item style="width:2ch; grid-column: 2">5 5</item>
 
   <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 2/2">0 0</item>
+  <item class="hidden" style="grid-area: 2/4">0 0</item>
 </grid>
 
 <grid>
   <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
-  <item style="grid-area: 2/2">4</item>
-  <item style="width:4ch; grid-area: 1/2/auto/4">5 5</item>
+  <item>4</item>
+  <item style="width:4ch; grid-column:2/span 2">5 5</item>
 
-  <item class="hidden" style="grid-area: 2/2">0 0</item>
-  <item class="hidden" style="grid-area: 2/3">0 0</item>
+  <item class="hidden" style="grid-area: 2/1">0 0</item>
+  <item class="hidden" style="grid-area: 2/4">0 0</item>
 </grid>
 
 <grid>
-  <item style="grid-area: 1/4">1</item>
+  <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="grid-area: 1/2/2/4">5 5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
+  <item style="grid-column:2/span 2">5 5</item>
+  <item style="width:5ch; grid-column:span 3/4">6</item>
 
-  <item class="hidden" style="grid-area: 1/1">0</item>
-  <item class="hidden" style="grid-area: 2/2">0 0</item>
-  <item class="hidden" style="grid-area: 2/3">0 0</item>
-  <item class="hidden" style="grid-area: 1/4">0 0</item>
+  <item class="hidden" style="grid-area: 2/1">0 0</item>
+  <item class="hidden" style="grid-area: 2/4">0 0</item>
 </grid>
 
 <grid>
-  <item style="grid-area: 1/4">1</item>
+  <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="width:3ch; grid-area: 1/2/2/4">5 5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
+  <item style="width:3ch; grid-column:span 2/4">5 5</item>
+  <item style="width:5ch; grid-column:1/span 3">6</item>
 
-  <item class="hidden" style="grid-area: 1/1">0</item>
-  <item class="hidden" style="grid-area: 2/2">0 0</item>
-  <item class="hidden" style="grid-area: 2/3">0 0</item>
-  <item class="hidden" style="grid-area: 1/4">0 0</item>
+  <item class="hidden" style="grid-area: 2/1">0 0</item>
+  <item class="hidden" style="grid-area: 2/4">0 0</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-auto-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-auto-ref.html
@@ -60,50 +60,46 @@ item {
   <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
-  <item style="grid-area: 2/1">4</item>
-  <item style="width:2ch; grid-area: 1/2/3">5 5</item>
+  <item>4</item>
+  <item style="width:2ch; grid-column: 2">5 5</item>
 
   <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 2/2">0 0</item>
+  <item class="hidden" style="grid-area: 2/4">0 0</item>
 </grid>
 
 <grid>
   <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
-  <item style="grid-area: 2/2">4</item>
-  <item style="width:4ch; grid-area: 1/2/auto/4">5 5</item>
+  <item>4</item>
+  <item style="width:4ch; grid-column:2/span 2">5 5</item>
 
-  <item class="hidden" style="grid-area: 2/2">0 0</item>
-  <item class="hidden" style="grid-area: 2/3">0 0</item>
+  <item class="hidden" style="grid-area: 2/1">0 0</item>
+  <item class="hidden" style="grid-area: 2/4">0 0</item>
 </grid>
 
 <grid>
-  <item style="grid-area: 1/4">1</item>
+  <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="grid-area: 1/2/2/4">5 5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
+  <item style="grid-column:2/span 2">5 5</item>
+  <item style="width:5ch; grid-column:span 3/4">6</item>
 
-  <item class="hidden" style="grid-area: 1/1">0</item>
-  <item class="hidden" style="grid-area: 2/2">0 0</item>
-  <item class="hidden" style="grid-area: 2/3">0 0</item>
-  <item class="hidden" style="grid-area: 1/4">0 0</item>
+  <item class="hidden" style="grid-area: 2/1">0 0</item>
+  <item class="hidden" style="grid-area: 2/4">0 0</item>
 </grid>
 
 <grid>
-  <item style="grid-area: 1/4">1</item>
+  <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="width:3ch; grid-area: 1/2/2/4">5 5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
+  <item style="width:3ch; grid-column:span 2/4">5 5</item>
+  <item style="width:5ch; grid-column:1/span 3">6</item>
 
-  <item class="hidden" style="grid-area: 1/1">0</item>
-  <item class="hidden" style="grid-area: 2/2">0 0</item>
-  <item class="hidden" style="grid-area: 2/3">0 0</item>
-  <item class="hidden" style="grid-area: 1/4">0 0</item>
+  <item class="hidden" style="grid-area: 2/1">0 0</item>
+  <item class="hidden" style="grid-area: 2/4">0 0</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-fr-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-fr-expected.html
@@ -57,7 +57,7 @@ item {
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="width:2ch; grid-area: 1/2/3">5 5</item>
+  <item style="width:2ch; grid-column:2">5 5</item>
 </grid>
 
 <grid>
@@ -65,36 +65,31 @@ item {
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="width:4ch; grid-area: 1/2/auto/4">5 5</item>
-  <item class="hidden">0</item>
+  <item style="width:4ch; grid-column:2/span 2">5 5</item>
 </grid>
 
 <grid>
-  <item style="grid-area: 1/4">1</item>
+  <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="grid-area: 1/2/2/4">5 5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
+  <item style="grid-column:2/span 2">5 5</item>
+  <item style="width:5ch; grid-column:span 3/4">6</item>
 
-  <item class="hidden" style="grid-area: 1/1">0</item>
-  <item class="hidden" style="grid-area: 2/2">0 0</item>
-  <item class="hidden" style="grid-area: 2/3">0 0</item>
-  <item class="hidden" style="grid-area: 1/4">0 0</item>
+  <item class="hidden" style="grid-area: 2/1">0 0</item>
+  <item class="hidden" style="grid-area: 2/4">0 0</item>
 </grid>
 
 <grid>
-  <item style="grid-area: 1/4">1</item>
+  <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="width:3ch; grid-area: 1/2/2/4">5 5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
+  <item style="width:3ch; grid-column:span 2/4">5 5</item>
+  <item style="width:5ch; grid-column:1/span 3">6</item>
 
-  <item class="hidden" style="grid-area: 1/1">0</item>
-  <item class="hidden" style="grid-area: 2/2">0 0</item>
-  <item class="hidden" style="grid-area: 2/3">0 0</item>
-  <item class="hidden" style="grid-area: 1/4">0 0</item>
+  <item class="hidden" style="grid-area: 2/1">0 0</item>
+  <item class="hidden" style="grid-area: 2/4">0 0</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-fr-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-fr-ref.html
@@ -41,7 +41,6 @@ item {
   <item>3 3</item>
   <item>4</item>
   <item>5 5</item>
-  <item class="hidden" style="grid-area: 2/4/4">0 0</item>
 </grid>
 
 <grid>
@@ -58,7 +57,7 @@ item {
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="width:2ch; grid-area: 1/2/3">5 5</item>
+  <item style="width:2ch; grid-column:2">5 5</item>
 </grid>
 
 <grid>
@@ -66,36 +65,31 @@ item {
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="width:4ch; grid-area: 1/2/auto/4">5 5</item>
-  <item class="hidden">0</item>
+  <item style="width:4ch; grid-column:2/span 2">5 5</item>
 </grid>
 
 <grid>
-  <item style="grid-area: 1/4">1</item>
+  <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="grid-area: 1/2/2/4">5 5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
+  <item style="grid-column:2/span 2">5 5</item>
+  <item style="width:5ch; grid-column:span 3/4">6</item>
 
-  <item class="hidden" style="grid-area: 1/1">0</item>
-  <item class="hidden" style="grid-area: 2/2">0 0</item>
-  <item class="hidden" style="grid-area: 2/3">0 0</item>
-  <item class="hidden" style="grid-area: 1/4">0 0</item>
+  <item class="hidden" style="grid-area: 2/1">0 0</item>
+  <item class="hidden" style="grid-area: 2/4">0 0</item>
 </grid>
 
 <grid>
-  <item style="grid-area: 1/4">1</item>
+  <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="width:3ch; grid-area: 1/2/2/4">5 5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
+  <item style="width:3ch; grid-column:span 2/4">5 5</item>
+  <item style="width:5ch; grid-column:1/span 3">6</item>
 
-  <item class="hidden" style="grid-area: 1/1">0</item>
-  <item class="hidden" style="grid-area: 2/2">0 0</item>
-  <item class="hidden" style="grid-area: 2/3">0 0</item>
-  <item class="hidden" style="grid-area: 1/4">0 0</item>
+  <item class="hidden" style="grid-area: 2/1">0 0</item>
+  <item class="hidden" style="grid-area: 2/4">0 0</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-mix1-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-mix1-expected.html
@@ -60,12 +60,13 @@ item {
 
 <grid>
   <item>1</item>
-  <item style="grid-row: span 2">2 2</item>
+  <item>2 2</item>
   <item style="grid-row: span 2">3 3</item>
-  <item style="grid-area: 2/1">4</item>
-  <item style="width:2ch; grid-area: 1/2/3">5 5</item>
+  <item>4</item>
+  <item style="width:2ch; grid-column:2">5 5</item>
 
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
+  <item class="hidden" style="grid-column: 1; grid-row: 2;">0 0</item>
+  <item class="hidden" style="grid-column: 4; grid-row: 2;">0 0</item>
 </grid>
 
 <grid>
@@ -73,32 +74,34 @@ item {
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="width:4ch; grid-area: 1/2/auto/4">5 5</item>
+  <item style="width:4ch; grid-column:2/span 2">5 5</item>
 
-  <item class="hidden">0</item>
+  <item class="hidden" style="grid-column: 1; grid-row: 2;">0 0</item>
+  <item class="hidden" style="grid-column: 4; grid-row: 2;">0 0</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="grid-area: 1/2/2/4">5 5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
+  <item style="grid-column:2/span 2">5 5</item>
+  <item style="width:5ch; grid-column:span 3/4">6</item>
 
-  <item class="hidden">0 0</item>
-  <item class="hidden" style="grid-area: 2/2">0 0</item>
+  <item class="hidden" style="grid-column: 1; grid-row: 2;">0 0</item>
+  <item class="hidden" style="grid-column: 4; grid-row: 2;">0 0</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="width:3ch; grid-area: 1/2/2/4">5 5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
+  <item style="width:3ch; grid-column:span 2/4">5 5</item>
+  <item style="width:5ch; grid-column:1/span 3">6</item>
 
-  <item class="hidden" style="grid-area: 2/3">0 0</item>
+  <item class="hidden" style="grid-column: 1; grid-row: 2;">0 0</item>
+  <item class="hidden" style="grid-column: 4; grid-row: 2;">0 0</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-mix1-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-mix1-ref.html
@@ -60,12 +60,13 @@ item {
 
 <grid>
   <item>1</item>
-  <item style="grid-row: span 2">2 2</item>
-  <item style="grid-row: span 2">3 3</item>
-  <item style="grid-area: 2/1">4</item>
-  <item style="width:2ch; grid-area: 1/2/3">5 5</item>
+  <item>2 2</item>
+  <item style="grid-row: span 2;">3 3</item>
+  <item>4</item>
+  <item style="width:2ch; grid-column:2">5 5</item>
 
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
+  <item class="hidden" style="grid-column: 1; grid-row: 2;">0 0</item>
+  <item class="hidden" style="grid-column: 4; grid-row: 2;">0 0</item>
 </grid>
 
 <grid>
@@ -73,32 +74,34 @@ item {
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="width:4ch; grid-area: 1/2/auto/4">5 5</item>
+  <item style="width:4ch; grid-column:2/span 2">5 5</item>
 
-  <item class="hidden">0</item>
+  <item class="hidden" style="grid-column: 1; grid-row: 2;">0 0</item>
+  <item class="hidden" style="grid-column: 4; grid-row: 2;">0 0</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="grid-area: 1/2/2/4">5 5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
+  <item style="grid-column:2/span 2">5 5</item>
+  <item style="width:5ch; grid-column:span 3/4">6</item>
 
-  <item class="hidden">0 0</item>
-  <item class="hidden" style="grid-area: 2/2">0 0</item>
+  <item class="hidden" style="grid-column: 1; grid-row: 2;">0 0</item>
+  <item class="hidden" style="grid-column: 4; grid-row: 2;">0 0</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="width:3ch; grid-area: 1/2/2/4">5 5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
+  <item style="width:3ch; grid-column:span 2/4">5 5</item>
+  <item style="width:5ch; grid-column:1/span 3">6</item>
 
-  <item class="hidden" style="grid-area: 2/3">0 0</item>
+  <item class="hidden" style="grid-column: 1; grid-row: 2;">0 0</item>
+  <item class="hidden" style="grid-column: 4; grid-row: 2;">0 0</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-mix2-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-mix2-expected.html
@@ -60,12 +60,12 @@ item {
 
 <grid>
   <item>1</item>
-  <item style="grid-row: span 2">2 2</item>
+  <item>2 2</item>
   <item style="grid-row: span 2">3 3</item>
-  <item style="grid-area: 2/1">4</item>
-  <item style="width:2ch; grid-area: 1/2/3">5 5</item>
+  <item>4</item>
+  <item style="width:2ch; grid-column:2">5 5</item>
 
-  <item class="hidden" style="grid-area: 2/2">0 0</item>
+  <item class="hidden" style="grid-column: 4; grid-row: 2;">0 0</item>
 </grid>
 
 <grid>
@@ -73,32 +73,31 @@ item {
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="width:4ch; grid-area: 1/2/auto/4">5 5</item>
+  <item style="width:4ch; grid-column:2/span 2">5 5</item>
 
-  <item class="hidden" style="grid-area: 1/2">0 0</item>
+  <item class="hidden" style="grid-column: 4; grid-row: 2;">0 0</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="grid-area: 1/2/2/4">5 5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
+  <item style="grid-column:2/span 2">5 5</item>
+  <item style="width:5ch; grid-column:1/span 3">6</item>
 
-  <item class="hidden" style="grid-area: 1/2">0 0</item>
+  <item class="hidden" style="grid-column: 4; grid-row: 2;">0 0</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="width:3ch; grid-area: 1/2/2/4">5 5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
+  <item style="width:3ch; grid-column:2/span 2">5 5</item>
+  <item style="width:5ch; grid-column:1/span 3">6</item>
 
-  <item class="hidden" style="grid-area: 1/2">0 0</item>
-  <item class="hidden" style="grid-area: 3/4">0 0</item>
+  <item class="hidden" style="grid-column: 4; grid-row: 2;">0 0</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-mix2-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-mix2-ref.html
@@ -60,12 +60,12 @@ item {
 
 <grid>
   <item>1</item>
-  <item style="grid-row: span 2">2 2</item>
+  <item>2 2</item>
   <item style="grid-row: span 2">3 3</item>
-  <item style="grid-area: 2/1">4</item>
-  <item style="width:2ch; grid-area: 1/2/3">5 5</item>
+  <item>4</item>
+  <item style="width:2ch; grid-column:2">5 5</item>
 
-  <item class="hidden" style="grid-area: 2/2">0 0</item>
+  <item class="hidden" style="grid-column: 4; grid-row: 2;">0 0</item>
 </grid>
 
 <grid>
@@ -73,32 +73,31 @@ item {
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="width:4ch; grid-area: 1/2/auto/4">5 5</item>
+  <item style="width:4ch; grid-column:2/span 2">5 5</item>
 
-  <item class="hidden" style="grid-area: 1/2">0 0</item>
+  <item class="hidden" style="grid-column: 4; grid-row: 2;">0 0</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="grid-area: 1/2/2/4">5 5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
+  <item style="grid-column:2/span 2">5 5</item>
+  <item style="width:5ch; grid-column:1/span 3">6</item>
 
-  <item class="hidden" style="grid-area: 1/2">0 0</item>
+  <item class="hidden" style="grid-column: 4; grid-row: 2;">0 0</item>
 </grid>
 
 <grid>
-  <item style="grid-column: 4">1</item>
+  <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="width:3ch; grid-area: 1/2/2/4">5 5</item>
-  <item style="width:5ch; grid-area: 2/1/3/4">6</item>
+  <item style="width:3ch; grid-column:2/span 2">5 5</item>
+  <item style="width:5ch; grid-column:1/span 3">6</item>
 
-  <item class="hidden" style="grid-area: 1/2">0 0</item>
-  <item class="hidden" style="grid-area: 3/4">0 0</item>
+  <item class="hidden" style="grid-column: 4; grid-row: 2;">0 0</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-005-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-005-expected.html
@@ -55,11 +55,11 @@ item {
 </grid>
 
 <grid style="grid-template-columns: 3ch 15px 15px 15px">
-  <item style="grid-column:1; grid-row: span 3;">5 5</item>
   <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
+  <item style="grid-column:1; grid-row: span 2;">5 5</item>
   <item>6</item>
   <item>7</item>
   <item>8</item>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-005-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-005-ref.html
@@ -55,11 +55,11 @@ item {
 </grid>
 
 <grid style="grid-template-columns: 3ch 15px 15px 15px">
-  <item style="grid-column:1; grid-row: span 3;">5 5</item>
   <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
+  <item style="grid-column:1; grid-row: span 2;">5 5</item>
   <item>6</item>
   <item>7</item>
   <item>8</item>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001-auto-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001-auto-expected.html
@@ -52,7 +52,7 @@ item {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="height:2ch; grid-area: 2/1">5</item>
+  <item style="height:2ch; grid-row:2">5</item>
 </grid>
 
 <grid>
@@ -60,28 +60,25 @@ item {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="height:4ch; grid-area:2/1/4/2">5</item>
+  <item style="height:4ch; grid-row:2/span 2">5</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="grid-area: 2/1/span 2/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="grid-row:2/span 2">5</item>
+  <item style="height:5ch; grid-row:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="height:3ch; grid-row:span 2/4">5</item>
+  <item style="height:5ch; grid-row:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001-auto-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001-auto-ref.html
@@ -52,7 +52,7 @@ item {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="height:2ch; grid-area: 2/1">5</item>
+  <item style="height:2ch; grid-row:2">5</item>
 </grid>
 
 <grid>
@@ -60,28 +60,25 @@ item {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="height:4ch; grid-area:2/1/4/2">5</item>
+  <item style="height:4ch; grid-row:2/span 2">5</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="grid-area: 2/1/span 2/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="grid-row:2/span 2">5</item>
+  <item style="height:5ch; grid-row:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="height:3ch; grid-row:span 2/4">5</item>
+  <item style="height:5ch; grid-row:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001-fr-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001-fr-expected.html
@@ -52,7 +52,7 @@ item {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="height:2ch; grid-area: 2/1">5</item>
+  <item style="height:2ch; grid-row:2">5</item>
 </grid>
 
 <grid>
@@ -60,27 +60,25 @@ item {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="height:4ch; grid-area: 2/1/4/2">5</item>
+  <item style="height:4ch; grid-row:2/span 2">5</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="grid-area: 2/1/span 2/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="grid-row:2/span 2">5</item>
+  <item style="height:5ch; grid-row:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="height:3ch; grid-row:span 2/4">5</item>
+  <item style="height:5ch; grid-row:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001-fr-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001-fr-ref.html
@@ -52,7 +52,7 @@ item {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="height:2ch; grid-area: 2/1">5</item>
+  <item style="height:2ch; grid-row:2">5</item>
 </grid>
 
 <grid>
@@ -60,27 +60,25 @@ item {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="height:4ch; grid-area: 2/1/4/2">5</item>
+  <item style="height:4ch; grid-row:2/span 2">5</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="grid-area: 2/1/span 2/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="grid-row:2/span 2">5</item>
+  <item style="height:5ch; grid-row:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="height:3ch; grid-row:span 2/4">5</item>
+  <item style="height:5ch; grid-row:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001-mix1-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001-mix1-expected.html
@@ -52,7 +52,7 @@ item {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="height:2ch; grid-area: 2/1">5</item>
+  <item style="height:2ch; grid-row:2">5</item>
 </grid>
 
 <grid>
@@ -60,28 +60,25 @@ item {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="height:4ch; grid-area: 2/1/4/2">5</item>
+  <item style="height:4ch; grid-row:2/span 2">5</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="grid-area: 2/1/span 2/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="grid-row:2/span 2">5</item>
+  <item style="height:5ch; grid-row:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="height:3ch; grid-row:span 2/4">5</item>
+  <item style="height:5ch; grid-row:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001-mix1-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001-mix1-ref.html
@@ -52,7 +52,7 @@ item {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="height:2ch; grid-area: 2/1">5</item>
+  <item style="height:2ch; grid-row:2">5</item>
 </grid>
 
 <grid>
@@ -60,28 +60,25 @@ item {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="height:4ch; grid-area: 2/1/4/2">5</item>
+  <item style="height:4ch; grid-row:2/span 2">5</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="grid-area: 2/1/span 2/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="grid-row:2/span 2">5</item>
+  <item style="height:5ch; grid-row:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="height:3ch; grid-row:span 2/4">5</item>
+  <item style="height:5ch; grid-row:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001-mix2-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001-mix2-expected.html
@@ -53,7 +53,7 @@ item {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="height:2ch; grid-area: 2/1">5</item>
+  <item style="height:2ch; grid-row:2">5</item>
 </grid>
 
 <grid>
@@ -61,26 +61,25 @@ item {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="height:4ch; grid-area: 2/1/4/2">5</item>
+  <item style="height:4ch; grid-row:2/span 2">5</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="grid-area: 2/1/span 2/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="grid-row:2/span 2">5</item>
+  <item style="height:5ch; grid-row:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="height:3ch; grid-row:span 2/4">5</item>
+  <item style="height:5ch; grid-row:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001-mix2-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001-mix2-ref.html
@@ -53,7 +53,7 @@ item {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="height:2ch; grid-area: 2/1">5</item>
+  <item style="height:2ch; grid-row:2">5</item>
 </grid>
 
 <grid>
@@ -61,26 +61,25 @@ item {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="height:4ch; grid-area: 2/1/4/2">5</item>
+  <item style="height:4ch; grid-row:2/span 2">5</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="grid-area: 2/1/span 2/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="grid-row:2/span 2">5</item>
+  <item style="height:5ch; grid-row:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="height:3ch; grid-row:span 2/4">5</item>
+  <item style="height:5ch; grid-row:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-auto-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-auto-expected.html
@@ -53,7 +53,7 @@ item {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="height:2ch; grid-area:2/1">5</item>
+  <item style="height:2ch; grid-row:2">5</item>
 </grid>
 
 <grid>
@@ -61,28 +61,25 @@ item {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="height:4ch; grid-area:2/1/4/2">5</item>
+  <item style="height:4ch; grid-row:2/span 2">5</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="grid-area: 2/1/span 2/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="grid-row:2/span 2">5</item>
+  <item style="height:5ch; grid-row:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="height:3ch; grid-row:span 2/4">5</item>
+  <item style="height:5ch; grid-row:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-auto-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-auto-ref.html
@@ -53,7 +53,7 @@ item {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="height:2ch; grid-area:2/1">5</item>
+  <item style="height:2ch; grid-row:2">5</item>
 </grid>
 
 <grid>
@@ -61,28 +61,25 @@ item {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="height:4ch; grid-area:2/1/4/2">5</item>
+  <item style="height:4ch; grid-row:2/span 2">5</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="grid-area: 2/1/span 2/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="grid-row:2/span 2">5</item>
+  <item style="height:5ch; grid-row:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="height:3ch; grid-row:span 2/4">5</item>
+  <item style="height:5ch; grid-row:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-fr-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-fr-expected.html
@@ -53,7 +53,7 @@ item {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="height:2ch; grid-area: 2/1">5</item>
+  <item style="height:2ch; grid-row:2">5</item>
 </grid>
 
 <grid>
@@ -61,27 +61,25 @@ item {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="height:4ch; grid-area: 2/1/4/2">5</item>
+  <item style="height:4ch; grid-row:2/span 2">5</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="grid-area: 2/1/span 2/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="grid-row:2/span 2">5</item>
+  <item style="height:5ch; grid-row:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="height:3ch; grid-row:span 2/4">5</item>
+  <item style="height:5ch; grid-row:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-fr-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-fr-ref.html
@@ -53,7 +53,7 @@ item {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="height:2ch; grid-area: 2/1">5</item>
+  <item style="height:2ch; grid-row:2">5</item>
 </grid>
 
 <grid>
@@ -61,27 +61,25 @@ item {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="height:4ch; grid-area: 2/1/4/2">5</item>
+  <item style="height:4ch; grid-row:2/span 2">5</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="grid-area: 2/1/span 2/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="grid-row:2/span 2">5</item>
+  <item style="height:5ch; grid-row:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="height:3ch; grid-row:span 2/4">5</item>
+  <item style="height:5ch; grid-row:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-mix1-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-mix1-expected.html
@@ -53,7 +53,7 @@ item {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="height:2ch; grid-area: 2/1">5</item>
+  <item style="height:2ch; grid-row:2">5</item>
 </grid>
 
 <grid>
@@ -61,28 +61,25 @@ item {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="height:4ch; grid-area: 2/1/4/2">5</item>
+  <item style="height:4ch; grid-row:2/span 2">5</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="grid-area: 2/1/span 2/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="grid-row:2/span 2">5</item>
+  <item style="height:5ch; grid-row:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="height:3ch; grid-row:span 2/4">5</item>
+  <item style="height:5ch; grid-row:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-mix1-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-mix1-ref.html
@@ -53,7 +53,7 @@ item {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="height:2ch; grid-area: 2/1">5</item>
+  <item style="height:2ch; grid-row:2">5</item>
 </grid>
 
 <grid>
@@ -61,28 +61,25 @@ item {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="height:4ch; grid-area: 2/1/4/2">5</item>
+  <item style="height:4ch; grid-row:2/span 2">5</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="grid-area: 2/1/span 2/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="grid-row:2/span 2">5</item>
+  <item style="height:5ch; grid-row:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="height:3ch; grid-row:span 2/4">5</item>
+  <item style="height:5ch; grid-row:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-mix2-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-mix2-expected.html
@@ -54,7 +54,7 @@ item {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="height:2ch; grid-area: 2/1">5</item>
+  <item style="height:2ch; grid-row:2">5</item>
 </grid>
 
 <grid>
@@ -62,26 +62,25 @@ item {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="height:4ch; grid-column: 1; grid-row: 2 / span 2;">5</item>
+  <item style="height:4ch; grid-row:2/span 2">5</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="grid-area: 2/1/span 2/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="grid-row:2/span 2">5</item>
+  <item style="height:5ch; grid-row:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="height:3ch; grid-row:span 2/4">5</item>
+  <item style="height:5ch; grid-row:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-mix2-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-mix2-ref.html
@@ -54,7 +54,7 @@ item {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="height:2ch; grid-area: 2/1">5</item>
+  <item style="height:2ch; grid-row:2">5</item>
 </grid>
 
 <grid>
@@ -62,26 +62,25 @@ item {
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="visibility: hidden">4</item>
-  <item style="height:4ch; grid-column: 1; grid-row: 2 / span 2;">5</item>
+  <item style="height:4ch; grid-row:2/span 2">5</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="grid-area: 2/1/span 2/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="grid-row:2/span 2">5</item>
+  <item style="height:5ch; grid-row:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="height:3ch; grid-row:span 2/4">5</item>
+  <item style="height:5ch; grid-row:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-auto-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-auto-expected.html
@@ -85,49 +85,48 @@ grid > item:nth-child(6) {
 
 <grid>
   <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
+  <item>2 2</item>
   <item style="grid-column: span 2">3 3</item>
-  <item style="grid-area: 1/2">4</item>
-  <item style="height:2ch; grid-area: 2/1/3/3">5 5</item>
+  <item>4</item>
+  <item style="height:2ch; grid-row:2">5 5</item>
 
-  <item class="hidden" style="grid-area: 1/2">0 0</item>
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
+  <item class="hidden" style="grid-column: 2; grid-row: 1">0 0</item>
+  <item class="hidden" style="grid-column: 2; grid-row: 4">0 0</item>
 </grid>
 
 <grid>
   <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
+  <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="height:4ch; grid-area: 2/1/4/auto">5 5</item>
+  <item style="height:4ch; grid-row:2/span 2">5 5</item>
 
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/2">0 0</item>
+  <item class="hidden" style="grid-column: 2; grid-row: 1">0 0</item>
+  <item class="hidden" style="grid-column: 2; grid-row: 4">0 0</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
-  <item style="grid-column: span 2">2 2</item>
+  <item>1</item>
+  <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="grid-area: 2/1/4/2">5 5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="grid-row:2/span 2">5 5</item>
+  <item style="height:5ch; grid-row:span 3/4">6</item>
 
-  <item class="hidden" style="grid-area: 3/3">0</item>
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/1">0 0</item>
+  <item class="hidden" style="grid-column: 2; grid-row: 1">0 0</item>
+  <item class="hidden" style="grid-column: 2; grid-row: 4">0 0</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
-  <item style="grid-column: span 2">2 2</item>
+  <item>1</item>
+  <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="height:3ch; grid-row:span 2/4">5</item>
+  <item style="height:5ch; grid-row:1/span 3">6</item>
 
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/1">0 0</item>
+  <item class="hidden" style="grid-column: 2; grid-row: 1">0 0</item>
+  <item class="hidden" style="grid-column: 2; grid-row: 4">0 0</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-auto-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-auto-ref.html
@@ -5,155 +5,154 @@
 -->
 <!-- WARNING: The interaction of writing-mode and min-content sizing seems to be a bit hazy. It's not clear if this is a correct reference. -->
 <html>
-<meta charset="utf-8">
-<title>Reference: Masonry layout min-content sizing</title>
-<link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
-<style>
+  <meta charset="utf-8">
+  <title>Reference: Masonry layout min-content sizing</title>
+  <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+  <style>
 
-  @import "support/masonry-intrinsic-sizing-visual.css";
+@import "support/masonry-intrinsic-sizing-visual.css";
 
-  grid {
-    display: inline-grid;
-    gap: 1px 2px;
-    grid-template-rows: repeat(4,auto);
-    grid-auto-flow: column;
-    border: 1px solid;
-    padding: 1px 0 2px 0;
-    vertical-align: top;
-    font-family: Ahem;
-    height: min-content;
-  }
+grid {
+  display: inline-grid;
+  gap: 1px 2px;
+  grid-template-rows: repeat(4,auto);
+  grid-auto-flow: column;
+  border: 1px solid;
+  padding: 1px 0 2px 0;
+  vertical-align: top;
+  font-family: Ahem;
+  height: min-content;
+}
 
-  item {
-    justify-self: start;
-    writing-mode: vertical-rl;
-    text-orientation: sideways;
-  }
-  .hidden {
-    visibility: hidden;
-    width: 0;
-  }
+item {
+  justify-self: start;
+  writing-mode: vertical-rl;
+  text-orientation: sideways;
+}
+.hidden {
+  visibility: hidden;
+  width: 0;
+}
 
-  grid > item:nth-child(1) {
-    background-color: #89CFF0;
-  }
+grid > item:nth-child(1) {
+  background-color: #89CFF0;
+}
 
-  grid > item:nth-child(2) {
-    background-color: #FF6F61;
-  }
+grid > item:nth-child(2) {
+  background-color: #FF6F61;
+}
 
-  grid > item:nth-child(3) {
-    background-color: #FDF3E7;
-  }
+grid > item:nth-child(3) {
+  background-color: #FDF3E7;
+}
 
-  grid > item:nth-child(4) {
-    background-color: #F4C542;
-  }
+grid > item:nth-child(4) {
+  background-color: #F4C542;
+}
 
-  grid > item:nth-child(5) {
-    background-color: #333333;
-  }
+grid > item:nth-child(5) {
+  background-color: #333333;
+}
 
-  grid > item:nth-child(6) {
-    background-color: #B2C8A5;
-  }
+grid > item:nth-child(6) {
+  background-color: #B2C8A5;
+}
 </style>
 
 <body>
 
 <section>
-  <grid>
-    <item style="height:2ch">1</item>
-    <item style="grid-column: span 2">2 2</item>
-    <item style="grid-column: span 2">3 3</item>
-    <item>4</item>
-    <item style="grid-column: span 2">5 5</item>
+<grid>
+  <item style="height:2ch">1</item>
+  <item style="grid-column: span 2">2 2</item>
+  <item style="grid-column: span 2">3 3</item>
+  <item>4</item>
+  <item style="grid-column: span 2">5 5</item>
 
-    <item class="hidden" style="grid-area: 4/2">0 0</item>
-  </grid>
+  <item class="hidden" style="grid-area: 4/2">0 0</item>
+</grid>
 
-  <grid>
-    <item style="height: 3ch">1</item>
-    <item style="grid-column: span 2">2 2</item>
-    <item style="grid-column: span 2">3 3</item>
-    <item>4</item>
-    <item style="height: 2ch">5 5</item>
+<grid>
+  <item style="height: 3ch">1</item>
+  <item style="grid-column: span 2">2 2</item>
+  <item style="grid-column: span 2">3 3</item>
+  <item>4</item>
+  <item style="height: 2ch">5 5</item>
 
-    <item class="hidden" style="grid-area: 4/2">0 0</item>
-  </grid>
+  <item class="hidden" style="grid-area: 4/2">0 0</item>
+</grid>
 
-  <grid>
-    <item>1</item>
-    <item style="grid-column: span 2">2 2</item>
-    <item style="grid-column: span 2">3 3</item>
-    <item style="grid-area: 1/2">4</item>
-    <item style="height:2ch; grid-area: 2/1/3/3">5 5</item>
+<grid>
+  <item>1</item>
+  <item>2 2</item>
+  <item style="grid-column: span 2">3 3</item>
+  <item>4</item>
+  <item style="height:2ch; grid-row:2">5 5</item>
 
-    <item class="hidden" style="grid-area: 1/2">0 0</item>
-    <item class="hidden" style="grid-area: 2/1">0 0</item>
-  </grid>
+  <item class="hidden" style="grid-column: 2; grid-row: 1">0 0</item>
+  <item class="hidden" style="grid-column: 2; grid-row: 4">0 0</item>
+</grid>
 
-  <grid>
-    <item>1</item>
-    <item style="grid-column: span 2">2 2</item>
-    <item>3 3</item>
-    <item>4</item>
-    <item style="height:4ch; grid-area: 2/1/4/auto">5 5</item>
+<grid>
+  <item>1</item>
+  <item>2 2</item>
+  <item>3 3</item>
+  <item>4</item>
+  <item style="height:4ch; grid-row:2/span 2">5 5</item>
 
-    <item class="hidden" style="grid-area: 2/1">0 0</item>
-    <item class="hidden" style="grid-area: 3/2">0 0</item>
-  </grid>
+  <item class="hidden" style="grid-column: 2; grid-row: 1">0 0</item>
+  <item class="hidden" style="grid-column: 2; grid-row: 4">0 0</item>
+</grid>
 
-  <grid>
-    <item style="grid-row: 4">1</item>
-    <item style="grid-column: span 2">2 2</item>
-    <item>3 3</item>
-    <item>4</item>
-    <item style="grid-area: 2/1/4/2">5 5</item>
-    <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+<grid>
+  <item>1</item>
+  <item>2 2</item>
+  <item>3 3</item>
+  <item>4</item>
+  <item style="grid-row:2/span 2">5 5</item>
+  <item style="height:5ch; grid-row:span 3/4">6</item>
 
-    <item class="hidden" style="grid-area: 3/3">0</item>
-    <item class="hidden" style="grid-area: 2/1">0 0</item>
-    <item class="hidden" style="grid-area: 3/1">0 0</item>
-  </grid>
+  <item class="hidden" style="grid-column: 2; grid-row: 1">0 0</item>
+  <item class="hidden" style="grid-column: 2; grid-row: 4">0 0</item>
+</grid>
 
-  <grid>
-    <item style="grid-row: 4">1</item>
-    <item style="grid-column: span 2">2 2</item>
-    <item>3 3</item>
-    <item>4</item>
-    <item style="height:3ch; grid-area: 2/1/4/2">5</item>
-    <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+<grid>
+  <item>1</item>
+  <item>2 2</item>
+  <item>3 3</item>
+  <item>4</item>
+  <item style="height:3ch; grid-row:span 2/4">5</item>
+  <item style="height:5ch; grid-row:1/span 3">6</item>
 
-    <item class="hidden" style="grid-area: 2/1">0 0</item>
-    <item class="hidden" style="grid-area: 3/1">0 0</item>
-  </grid>
+  <item class="hidden" style="grid-column: 2; grid-row: 1">0 0</item>
+  <item class="hidden" style="grid-column: 2; grid-row: 4">0 0</item>
+</grid>
 
-  <grid>
-    <item style="height: 3ch">1</item>
-    <item>2 2</item>
-    <item>3 3</item>
-    <item style="height: 3ch">4</item>
-    <item style="grid-column: 2; grid-row: span 4;">5 5</item>
-  </grid>
+<grid>
+  <item style="height: 3ch">1</item>
+  <item>2 2</item>
+  <item>3 3</item>
+  <item style="height: 3ch">4</item>
+  <item style="grid-column: 2; grid-row: span 4;">5 5</item>
+</grid>
 
-  <grid>
-    <item style="height: 3ch">1</item>
-    <item>2 2</item>
-    <item>3 3</item>
-    <item style="height: 3ch">4</item>
-    <item style="grid-column: 2; grid-row: span 4; height: 6ch">5 5</item>
+<grid>
+  <item style="height: 3ch">1</item>
+  <item>2 2</item>
+  <item>3 3</item>
+  <item style="height: 3ch">4</item>
+  <item style="grid-column: 2; grid-row: span 4; height: 6ch">5 5</item>
 
-  </grid>
+</grid>
 
-  <grid>
-    <item style="height: 3ch">1</item>
-    <item>2 2</item>
-    <item>3 3</item>
-    <item style="height: 3ch">4</item>
-    <item style="grid-column: 2; grid-row: span 3; height: 6ch">5 5</item>
+<grid>
+  <item style="height: 3ch">1</item>
+  <item>2 2</item>
+  <item>3 3</item>
+  <item style="height: 3ch">4</item>
+  <item style="grid-column: 2; grid-row: span 3; height: 6ch">5 5</item>
 
-  </grid>
+</grid>
 </section>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-fr-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-fr-expected.html
@@ -85,46 +85,48 @@ grid > item:nth-child(6) {
 
 <grid>
   <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
+  <item>2 2</item>
   <item style="grid-column: span 2">3 3</item>
-  <item style="grid-area: 1/2">4</item>
-  <item style="height:2ch; grid-area: 2/1/3/3">5 5</item>
+  <item>4</item>
+  <item style="height:2ch; grid-row:2">5 5</item>
 
-  <item class="hidden" style="grid-area: 1/2">0 0</item>
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
+  <item class="hidden" style="grid-column: 2; grid-row: 1">0 0</item>
+  <item class="hidden" style="grid-column: 2; grid-row: 4">0 0</item>
 </grid>
 
 <grid>
   <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item>3 3</item>
-  <item>4</item>
-  <item style="height:4ch; grid-area: 2/1/4/auto">5 5</item>
-
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/2">0 0</item>
-</grid>
-
-<grid>
-  <item style="grid-row: 4">1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item>3 3</item>
-  <item>4</item>
-  <item style="grid-area: 2/1/4/2">5 5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
-
-  <item class="hidden" style="grid-area: 3/3">0</item>
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/1">0 0</item>
-</grid>
-
-<grid>
-  <item style="grid-row: 4">1</item>
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="height:4ch; grid-row:2/span 2">5 5</item>
+
+  <item class="hidden" style="grid-column: 2; grid-row: 1">0 0</item>
+  <item class="hidden" style="grid-column: 2; grid-row: 4">0 0</item>
+</grid>
+
+<grid>
+  <item>1</item>
+  <item>2 2</item>
+  <item>3 3</item>
+  <item>4</item>
+  <item style="grid-row:2/span 2">5 5</item>
+  <item style="height:5ch; grid-row:span 3/4">6</item>
+
+  <item class="hidden" style="grid-column: 2; grid-row: 1">0 0</item>
+  <item class="hidden" style="grid-column: 2; grid-row: 4">0 0</item>
+</grid>
+
+<grid>
+  <item>1</item>
+  <item>2 2</item>
+  <item>3 3</item>
+  <item>4</item>
+  <item style="height:3ch; grid-row:span 2/4">5</item>
+  <item style="height:5ch; grid-row:1/span 3">6</item>
+
+  <item class="hidden" style="grid-column: 2; grid-row: 1">0 0</item>
+  <item class="hidden" style="grid-column: 2; grid-row: 4">0 0</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-fr-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-fr-ref.html
@@ -83,49 +83,51 @@ grid > item:nth-child(6) {
   <item class="hidden" style="grid-area: 4/2">0 0</item>
 </grid>
 
-<grid>
-  <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
-  <item style="grid-area: 1/2">4</item>
-  <item style="height:2ch; grid-area: 2/1/3/3">5 5</item>
+  <grid>
+    <item>1</item>
+    <item>2 2</item>
+    <item style="grid-column: span 2">3 3</item>
+    <item>4</item>
+    <item style="height:2ch; grid-row:2">5 5</item>
 
-  <item class="hidden" style="grid-area: 1/2">0 0</item>
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-</grid>
+    <item class="hidden" style="grid-column: 2; grid-row: 1">0 0</item>
+    <item class="hidden" style="grid-column: 2; grid-row: 4">0 0</item>
+  </grid>
 
-<grid>
-  <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item>3 3</item>
-  <item>4</item>
-  <item style="height:4ch; grid-area: 2/1/4/auto">5 5</item>
+  <grid>
+    <item>1</item>
+    <item>2 2</item>
+    <item>3 3</item>
+    <item>4</item>
+    <item style="height:4ch; grid-row:2/span 2">5 5</item>
 
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/2">0 0</item>
-</grid>
+    <item class="hidden" style="grid-column: 2; grid-row: 1">0 0</item>
+    <item class="hidden" style="grid-column: 2; grid-row: 4">0 0</item>
+  </grid>
 
-<grid>
-  <item style="grid-row: 4">1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item>3 3</item>
-  <item>4</item>
-  <item style="grid-area: 2/1/4/2">5 5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <grid>
+    <item>1</item>
+    <item>2 2</item>
+    <item>3 3</item>
+    <item>4</item>
+    <item style="grid-row:2/span 2">5 5</item>
+    <item style="height:5ch; grid-row:span 3/4">6</item>
 
-  <item class="hidden" style="grid-area: 3/3">0</item>
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/1">0 0</item>
-</grid>
+    <item class="hidden" style="grid-column: 2; grid-row: 1">0 0</item>
+    <item class="hidden" style="grid-column: 2; grid-row: 4">0 0</item>
+  </grid>
 
-<grid>
-  <item style="grid-row: 4">1</item>
-  <item>2 2</item>
-  <item>3 3</item>
-  <item>4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
-</grid>
+  <grid>
+    <item>1</item>
+    <item>2 2</item>
+    <item>3 3</item>
+    <item>4</item>
+    <item style="height:3ch; grid-row:span 2/4">5</item>
+    <item style="height:5ch; grid-row:1/span 3">6</item>
+
+    <item class="hidden" style="grid-column: 2; grid-row: 1">0 0</item>
+    <item class="hidden" style="grid-column: 2; grid-row: 4">0 0</item>
+  </grid>
 
 <grid>
   <item>1</item>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-mix1-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-mix1-expected.html
@@ -87,48 +87,48 @@ grid > item:nth-child(6) {
 
 <grid>
   <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
+  <item>2 2</item>
   <item style="grid-column: span 2">3 3</item>
-  <item style="grid-area: 1/2">4</item>
-  <item style="height:2ch; grid-area: 2/1/3/3">5 5</item>
+  <item>4</item>
+  <item style="height:2ch; grid-row:2">5 5</item>
 
-  <item class="hidden" style="grid-area: 1/2">0 0</item>
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
+  <item class="hidden" style="grid-row: 1; grid-column: 2;">0 0</item>
+  <item class="hidden" style="grid-row: 4; grid-column: 2;">0 0</item>
 </grid>
 
-<grid>
+<grid style="grid-template-columns: 30px auto">
   <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="height:4ch; grid-area: 2/1/4/auto">5 5</item>
+  <item style="height:4ch; grid-column: 2; grid-row:2/span 2">5 5</item>
 
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/2">0 0</item>
+  <item class="hidden" style="grid-row: 1; grid-column: 2;">0 0</item>
+  <item class="hidden" style="grid-row: 4; grid-column: 2;">0 0</item>
 </grid>
 
-<grid>
-  <item style="grid-row: 4">1</item>
+<grid style="grid-template-columns: 30px auto auto">
+  <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="grid-area: 2/1/4/2">5 5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="grid-row:2/span 2">5 5</item>
+  <item style="height:5ch; grid-row:span 3/4">6</item>
 
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/1">0 0</item>
+  <item class="hidden" style="grid-row: 1; grid-column: 2;">0 0</item>
+  <item class="hidden" style="grid-row: 4; grid-column: 2;">0 0</item>
 </grid>
 
-<grid>
-  <item style="grid-row: 4">1</item>
+<grid style="grid-template-columns: 30px auto auto">
+  <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="height:3ch; grid-row:span 2/4">5</item>
+  <item style="height:5ch; grid-row:1/span 3">6</item>
 
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/1">0 0</item>
+  <item class="hidden" style="grid-row: 1; grid-column: 2;">0 0</item>
+  <item class="hidden" style="grid-row: 4; grid-column: 2;">0 0</item>
 </grid>
 
 <grid style="grid-template-columns: 30px auto">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-mix1-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-mix1-ref.html
@@ -87,48 +87,48 @@ grid > item:nth-child(6) {
 
 <grid>
   <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
+  <item>2 2</item>
   <item style="grid-column: span 2">3 3</item>
-  <item style="grid-area: 1/2">4</item>
-  <item style="height:2ch; grid-area: 2/1/3/3">5 5</item>
+  <item>4</item>
+  <item style="height:2ch; grid-row:2">5 5</item>
 
-  <item class="hidden" style="grid-area: 1/2">0 0</item>
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
+  <item class="hidden" style="grid-row: 1; grid-column: 2;">0 0</item>
+  <item class="hidden" style="grid-row: 4; grid-column: 2;">0 0</item>
 </grid>
 
-<grid>
+<grid style="grid-template-columns: 30px auto">
   <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="height:4ch; grid-area: 2/1/4/auto">5 5</item>
+  <item style="height:4ch; grid-column: 2; grid-row:2/span 2">5 5</item>
 
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/2">0 0</item>
+  <item class="hidden" style="grid-row: 1; grid-column: 2;">0 0</item>
+  <item class="hidden" style="grid-row: 4; grid-column: 2;">0 0</item>
 </grid>
 
-<grid>
-  <item style="grid-row: 4">1</item>
+<grid style="grid-template-columns: 30px auto auto">
+  <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="grid-area: 2/1/4/2">5 5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="grid-row:2/span 2">5 5</item>
+  <item style="height:5ch; grid-row:span 3/4">6</item>
 
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/1">0 0</item>
+  <item class="hidden" style="grid-row: 1; grid-column: 2;">0 0</item>
+  <item class="hidden" style="grid-row: 4; grid-column: 2;">0 0</item>
 </grid>
 
-<grid>
-  <item style="grid-row: 4">1</item>
+<grid style="grid-template-columns: 30px auto auto">
+  <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="height:3ch; grid-row:span 2/4">5</item>
+  <item style="height:5ch; grid-row:1/span 3">6</item>
 
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/1">0 0</item>
+  <item class="hidden" style="grid-row: 1; grid-column: 2;">0 0</item>
+  <item class="hidden" style="grid-row: 4; grid-column: 2;">0 0</item>
 </grid>
 
 <grid style="grid-template-columns: 30px auto">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-mix2-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-mix2-expected.html
@@ -60,47 +60,44 @@ item {
 
 <grid>
   <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
+  <item>2 2</item>
   <item style="grid-column: span 2">3 3</item>
-  <item style="grid-area: 1/2">4</item>
-  <item style="height:2ch; grid-area: 2/1/3/3">5 5</item>
+  <item>4</item>
+  <item style="height:2ch; grid-row:2">5 5</item>
 
-  <item class="hidden" style="grid-area: 1/2">0 0</item>
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
+  <item class="hidden" style="grid-area: 4/2">0 0</item>
 </grid>
 
 <grid>
   <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="height:4ch; grid-area: 2/1/4/auto">5 5</item>
+  <item style="height:4ch; grid-row:2/span 2">5 5</item>
 
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/2">0 0</item>
+  <item class="hidden" style="grid-area: 4/2">0 0</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
+  <item>1</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="grid-area: 2/1/4/2">5 5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="grid-row:2/span 2">5 5</item>
+  <item style="height:5ch; grid-row:1/span 3">6</item>
 
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/1">0 0</item>
+  <item class="hidden" style="grid-area: 4/2">0 0</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
+  <item>1</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5 5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="height:3ch; grid-row:2/span 2">5 5</item>
+  <item style="height:5ch; grid-row:1/span 3">6</item>
 
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
+  <item class="hidden" style="grid-area: 4/2">0 0</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-mix2-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-mix2-ref.html
@@ -60,47 +60,44 @@ item {
 
 <grid>
   <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
+  <item>2 2</item>
   <item style="grid-column: span 2">3 3</item>
-  <item style="grid-area: 1/2">4</item>
-  <item style="height:2ch; grid-area: 2/1/3/3">5 5</item>
+  <item>4</item>
+  <item style="height:2ch; grid-row:2">5 5</item>
 
-  <item class="hidden" style="grid-area: 1/2">0 0</item>
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
+  <item class="hidden" style="grid-area: 4/2">0 0</item>
 </grid>
 
 <grid>
   <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="height:4ch; grid-area: 2/1/4/auto">5 5</item>
+  <item style="height:4ch; grid-row:2/span 2">5 5</item>
 
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/2">0 0</item>
+  <item class="hidden" style="grid-area: 4/2">0 0</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
+  <item>1</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="grid-area: 2/1/4/2">5 5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="grid-row:2/span 2">5 5</item>
+  <item style="height:5ch; grid-row:1/span 3">6</item>
 
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/1">0 0</item>
+  <item class="hidden" style="grid-area: 4/2">0 0</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
+  <item>1</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5 5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="height:3ch; grid-row:2/span 2">5 5</item>
+  <item style="height:5ch; grid-row:1/span 3">6</item>
 
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
+  <item class="hidden" style="grid-area: 4/2">0 0</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-auto-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-auto-expected.html
@@ -88,11 +88,11 @@ grid > item:nth-child(6) {
   <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
-  <item style="grid-area: 1/2">4</item>
-  <item style="height:2ch; grid-area: 2/1/3/3">5 5</item>
+  <item>4</item>
+  <item style="height:2ch; grid-row:2">5 5</item>
 
-  <item class="hidden" style="grid-area: 1/2">0 0</item>
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
+  <item class="hidden" style="grid-row: 1; grid-column: 2;">0 0</item>
+  <item class="hidden" style="grid-row: 4; grid-column: 2;">0 0</item>
 </grid>
 
 <grid>
@@ -100,35 +100,34 @@ grid > item:nth-child(6) {
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="height:4ch; grid-area: 2/1/4/auto">5 5</item>
+  <item style="height:4ch; grid-row:2/span 2">5 5</item>
 
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/2">0 0</item>
+  <item class="hidden" style="grid-row: 1; grid-column: 2;">0 0</item>
+  <item class="hidden" style="grid-row: 4; grid-column: 2;">0 0</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="grid-area: 2/1/4/2">5 5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="grid-row:2/span 2">5 5</item>
+  <item style="height:5ch; grid-row:span 3/4">6</item>
 
-  <item class="hidden" style="grid-area: 3/3">0</item>
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/1">0 0</item>
+  <item class="hidden" style="grid-row: 1; grid-column: 2;">0 0</item>
+  <item class="hidden" style="grid-row: 4; grid-column: 2;">0 0</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="height:3ch; grid-row:span 2/4">5</item>
+  <item style="height:5ch; grid-row:1/span 3">6</item>
 
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/1">0 0</item>
+  <item class="hidden" style="grid-row: 1; grid-column: 2;">0 0</item>
+  <item class="hidden" style="grid-row: 4; grid-column: 2;">0 0</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-auto-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-auto-ref.html
@@ -4,162 +4,161 @@
      http://creativecommons.org/publicdomain/zero/1.0/
 -->
 <html>
-<meta charset="utf-8">
-<title>Reference: Masonry layout max-content sizing</title>
-<link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
-<style>
+  <meta charset="utf-8">
+  <title>Reference: Masonry layout max-content sizing</title>
+  <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+  <style>
 
-  @import "support/masonry-intrinsic-sizing-visual.css";
+@import "support/masonry-intrinsic-sizing-visual.css";
 
-  grid {
-    display: inline-grid;
-    gap: 1px 2px;
-    grid-template-rows: repeat(4, auto);
-    grid-auto-flow: column;
-    border: 1px solid;
-    padding: 1px 0 2px 0;
-    vertical-align: top;
-    height: max-content;
-    font-family: Ahem;
-  }
+grid {
+  display: inline-grid;
+  gap: 1px 2px;
+  grid-template-rows: repeat(4, auto);
+  grid-auto-flow: column;
+  border: 1px solid;
+  padding: 1px 0 2px 0;
+  vertical-align: top;
+  height: max-content;
+  font-family: Ahem;
+}
 
-  item {
-    justify-self: start;
-    writing-mode: vertical-rl;
-    text-orientation: sideways;
-  }
+item {
+  justify-self: start;
+  writing-mode: vertical-rl;
+  text-orientation: sideways;
+}
 
-  grid > item:nth-child(1) {
-    background-color: #89CFF0;
-  }
+grid > item:nth-child(1) {
+  background-color: #89CFF0;
+}
 
-  grid > item:nth-child(2) {
-    background-color: #FF6F61;
-  }
+grid > item:nth-child(2) {
+  background-color: #FF6F61;
+}
 
-  grid > item:nth-child(3) {
-    background-color: #FDF3E7;
-  }
+grid > item:nth-child(3) {
+  background-color: #FDF3E7;
+}
 
-  grid > item:nth-child(4) {
-    background-color: #F4C542;
-  }
+grid > item:nth-child(4) {
+  background-color: #F4C542;
+}
 
-  grid > item:nth-child(5) {
-    background-color: #333333;
-  }
+grid > item:nth-child(5) {
+  background-color: #333333;
+}
 
-  grid > item:nth-child(6) {
-    background-color: #B2C8A5;
-  }
+grid > item:nth-child(6) {
+  background-color: #B2C8A5;
+}
 
-  .hidden {
-    visibility: hidden;
-    opacity: 0.5;
-    width: 1em;
-  }
+.hidden {
+  visibility: hidden;
+  opacity: 0.5;
+  width: 1em;
+}
 </style>
 
 <body>
 
 <section>
-  <grid>
-    <item style="height:2ch">1</item>
-    <item>2 2</item>
-    <item>3 3</item>
-    <item>4</item>
-    <item>5 5</item>
+<grid>
+  <item style="height:2ch">1</item>
+  <item>2 2</item>
+  <item>3 3</item>
+  <item>4</item>
+  <item>5 5</item>
 
-    <item class="hidden" style="grid-area: 4/2">0 0</item>
-  </grid>
+  <item class="hidden" style="grid-area: 4/2">0 0</item>
+</grid>
 
-  <grid>
-    <item style="height: 3ch">1</item>
-    <item>2 2</item>
-    <item>3 3</item>
-    <item style="height: 3ch">4</item>
-    <item style="height:2ch">5 5</item>
+<grid>
+  <item style="height: 3ch">1</item>
+  <item>2 2</item>
+  <item>3 3</item>
+  <item style="height: 3ch">4</item>
+  <item style="height:2ch">5 5</item>
 
-    <item class="hidden" style="grid-area: 4/2">0 0</item>
-  </grid>
+  <item class="hidden" style="grid-area: 4/2">0 0</item>
+</grid>
 
-  <grid>
-    <item>1</item>
-    <item>2 2</item>
-    <item>3 3</item>
-    <item style="grid-area: 1/2">4</item>
-    <item style="height:2ch; grid-area: 2/1/3/3">5 5</item>
+<grid>
+  <item>1</item>
+  <item>2 2</item>
+  <item>3 3</item>
+  <item>4</item>
+  <item style="height:2ch; grid-row:2">5 5</item>
 
-    <item class="hidden" style="grid-area: 1/2">0 0</item>
-    <item class="hidden" style="grid-area: 2/1">0 0</item>
-  </grid>
+  <item class="hidden" style="grid-row: 1; grid-column: 2;">0 0</item>
+  <item class="hidden" style="grid-row: 4; grid-column: 2;">0 0</item>
+</grid>
 
-  <grid>
-    <item>1</item>
-    <item>2 2</item>
-    <item>3 3</item>
-    <item>4</item>
-    <item style="height:4ch; grid-area: 2/1/4/auto">5 5</item>
+<grid>
+  <item>1</item>
+  <item>2 2</item>
+  <item>3 3</item>
+  <item>4</item>
+  <item style="height:4ch; grid-row:2/span 2">5 5</item>
 
-    <item class="hidden" style="grid-area: 2/1">0 0</item>
-    <item class="hidden" style="grid-area: 3/2">0 0</item>
-  </grid>
+  <item class="hidden" style="grid-row: 1; grid-column: 2;">0 0</item>
+  <item class="hidden" style="grid-row: 4; grid-column: 2;">0 0</item>
+</grid>
 
-  <grid>
-    <item style="grid-row: 4">1</item>
-    <item>2 2</item>
-    <item>3 3</item>
-    <item>4</item>
-    <item style="grid-area: 2/1/4/2">5 5</item>
-    <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+<grid>
+  <item>1</item>
+  <item>2 2</item>
+  <item>3 3</item>
+  <item>4</item>
+  <item style="grid-row:2/span 2">5 5</item>
+  <item style="height:5ch; grid-row:span 3/4">6</item>
 
-    <item class="hidden" style="grid-area: 3/3">0</item>
-    <item class="hidden" style="grid-area: 2/1">0 0</item>
-    <item class="hidden" style="grid-area: 3/1">0 0</item>
-  </grid>
+  <item class="hidden" style="grid-row: 1; grid-column: 2;">0 0</item>
+  <item class="hidden" style="grid-row: 4; grid-column: 2;">0 0</item>
+</grid>
 
-  <grid>
-    <item style="grid-row: 4">1</item>
-    <item>2 2</item>
-    <item>3 3</item>
-    <item>4</item>
-    <item style="height:3ch; grid-area: 2/1/4/2">5</item>
-    <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+<grid>
+  <item>1</item>
+  <item>2 2</item>
+  <item>3 3</item>
+  <item>4</item>
+  <item style="height:3ch; grid-row:span 2/4">5</item>
+  <item style="height:5ch; grid-row:1/span 3">6</item>
 
-    <item class="hidden" style="grid-area: 2/1">0 0</item>
-    <item class="hidden" style="grid-area: 3/1">0 0</item>
-  </grid>
+  <item class="hidden" style="grid-row: 1; grid-column: 2;">0 0</item>
+  <item class="hidden" style="grid-row: 4; grid-column: 2;">0 0</item>
+</grid>
 
-  <grid>
-    <item style="height: 3ch">1</item>
-    <item>2 2</item>
-    <item>3 3</item>
-    <item style="height: 3ch">4</item>
-    <item style="grid-area: 1/2/5/3">5 5</item>
-  </grid>
+<grid>
+  <item style="height: 3ch">1</item>
+  <item>2 2</item>
+  <item>3 3</item>
+  <item style="height: 3ch">4</item>
+  <item style="grid-area: 1/2/5/3">5 5</item>
+</grid>
 
-  <grid>
-    <item>1</item>
-    <item>2 2</item>
-    <item>3 3</item>
-    <item>4</item>
-    <item style="height:6ch; grid-area: 1/2/5/3">5 5</item>
+<grid>
+  <item>1</item>
+  <item>2 2</item>
+  <item>3 3</item>
+  <item>4</item>
+  <item style="height:6ch; grid-area: 1/2/5/3">5 5</item>
 
-    <item class="hidden" style="grid-area: 1/2">0 0</item>
-    <item class="hidden" style="grid-area: 4/2">0 0</item>
-  </grid>
+  <item class="hidden" style="grid-area: 1/2">0 0</item>
+  <item class="hidden" style="grid-area: 4/2">0 0</item>
+</grid>
 
-  <grid>
-    <item>1</item>
-    <item>2 2</item>
-    <item>3 3</item>
-    <item>4</item>
-    <item style="height:6ch; grid-area: 1/2/4/3">5 5</item>
+<grid>
+  <item>1</item>
+  <item>2 2</item>
+  <item>3 3</item>
+  <item>4</item>
+  <item style="height:6ch; grid-area: 1/2/4/3">5 5</item>
 
-    <item class="hidden" style="grid-area: 1/2">0 0</item>
-    <item class="hidden" style="grid-area: 4/2">0 0</item>
-    <item class="hidden" style="height:6ch; grid-area: 2/2/5/3">0 0</item>
-  </grid>
+  <item class="hidden" style="grid-area: 1/2">0 0</item>
+  <item class="hidden" style="grid-area: 4/2">0 0</item>
+  <item class="hidden" style="height:6ch; grid-area: 2/2/5/3">0 0</item>
+</grid>
 </section>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-fr-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-fr-expected.html
@@ -62,11 +62,8 @@ item {
   <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
-  <item style="grid-area: 1/2">4</item>
-  <item style="height:2ch; grid-area: 2/1/3/3">5 5</item>
-
-  <item class="hidden" style="grid-area: 1/2">0 0</item>
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
+  <item>4</item>
+  <item style="height:2ch; grid-row:2">5 5</item>
 </grid>
 
 <grid>
@@ -74,35 +71,25 @@ item {
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="height:4ch; grid-area: 2/1/4/auto">5 5</item>
-
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/2">0 0</item>
+  <item style="height:4ch; grid-row:2/span 2">5 5</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="grid-area: 2/1/4/2">5 5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
-
-  <item class="hidden" style="grid-area: 3/3">0</item>
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/1">0 0</item>
+  <item style="grid-row:2/span 2">5 5</item>
+  <item style="height:5ch; grid-row:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
-
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/1">0 0</item>
+  <item style="height:3ch; grid-row:span 2/4">5</item>
+  <item style="height:5ch; grid-row:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-fr-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-fr-ref.html
@@ -62,11 +62,8 @@ item {
   <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
-  <item style="grid-area: 1/2">4</item>
-  <item style="height:2ch; grid-area: 2/1/3/3">5 5</item>
-
-  <item class="hidden" style="grid-area: 1/2">0 0</item>
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
+  <item>4</item>
+  <item style="height:2ch; grid-row:2">5 5</item>
 </grid>
 
 <grid>
@@ -74,35 +71,25 @@ item {
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="height:4ch; grid-area: 2/1/4/auto">5 5</item>
-
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/2">0 0</item>
+  <item style="height:4ch; grid-row:2/span 2">5 5</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="grid-area: 2/1/4/2">5 5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
-
-  <item class="hidden" style="grid-area: 3/3">0</item>
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/1">0 0</item>
+  <item style="grid-row:2/span 2">5 5</item>
+  <item style="height:5ch; grid-row:span 3/4">6</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
+  <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
-
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/1">0 0</item>
+  <item style="height:3ch; grid-row:span 2/4">5</item>
+  <item style="height:5ch; grid-row:1/span 3">6</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-mix1-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-mix1-expected.html
@@ -86,48 +86,48 @@ grid > item:nth-child(6) {
 
 <grid>
   <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item>3 3</item>
-  <item style="grid-area: 1/2">4</item>
-  <item style="height:2ch; grid-area: 2/1/3/3">5 5</item>
+  <item>2 2</item>
+  <item style="grid-column: span 2">3 3</item>
+  <item>4</item>
+  <item style="height:2ch; grid-row:2">5 5</item>
 
   <item class="hidden" style="grid-area: 1/2">0 0</item>
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
+  <item class="hidden" style="grid-area: 4/2">0 0</item>
 </grid>
 
-<grid>
+<grid style="grid-template-columns: 30px auto;">
   <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="height:4ch; grid-area: 2/1/4/auto">5 5</item>
+  <item style="height:4ch; grid-row:2/span 2">5 5</item>
 
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/2">0 0</item>
+  <item class="hidden" style="grid-area: 1/2">0 0</item>
+  <item class="hidden" style="grid-area: 4/2">0 0</item>
 </grid>
 
-<grid>
-  <item style="grid-row: 4">1</item>
+<grid style="grid-template-columns: 30px auto;">
+  <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="grid-area: 2/1/4/2">5 5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="grid-row:2/span 2">5 5</item>
+  <item style="height:5ch; grid-row:span 3/4">6</item>
 
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/1">0 0</item>
+  <item class="hidden" style="grid-area: 1/2">0 0</item>
+  <item class="hidden" style="grid-area: 4/2">0 0</item>
 </grid>
 
-<grid>
-  <item style="grid-row: 4">1</item>
+<grid style="grid-template-columns: 30px auto;">
+  <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="height:3ch; grid-row:span 2/4">5</item>
+  <item style="height:5ch; grid-row:1/span 3">6</item>
 
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/1">0 0</item>
+  <item class="hidden" style="grid-area: 1/2">0 0</item>
+  <item class="hidden" style="grid-area: 4/2">0 0</item>
 </grid>
 
 <grid style="grid-template-columns: 30px auto;">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-mix1-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-mix1-ref.html
@@ -86,48 +86,48 @@ grid > item:nth-child(6) {
 
 <grid>
   <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item>3 3</item>
-  <item style="grid-area: 1/2">4</item>
-  <item style="height:2ch; grid-area: 2/1/3/3">5 5</item>
+  <item>2 2</item>
+  <item style="grid-column: span 2">3 3</item>
+  <item>4</item>
+  <item style="height:2ch; grid-row:2">5 5</item>
 
   <item class="hidden" style="grid-area: 1/2">0 0</item>
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
+  <item class="hidden" style="grid-area: 4/2">0 0</item>
 </grid>
 
-<grid>
+<grid style="grid-template-columns: 30px auto;">
   <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="height:4ch; grid-area: 2/1/4/auto">5 5</item>
+  <item style="height:4ch; grid-row:2/span 2">5 5</item>
 
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/2">0 0</item>
+  <item class="hidden" style="grid-area: 1/2">0 0</item>
+  <item class="hidden" style="grid-area: 4/2">0 0</item>
 </grid>
 
-<grid>
-  <item style="grid-row: 4">1</item>
+<grid style="grid-template-columns: 30px auto;">
+  <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="grid-area: 2/1/4/2">5 5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="grid-row:2/span 2">5 5</item>
+  <item style="height:5ch; grid-row:span 3/4">6</item>
 
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/1">0 0</item>
+  <item class="hidden" style="grid-area: 1/2">0 0</item>
+  <item class="hidden" style="grid-area: 4/2">0 0</item>
 </grid>
 
-<grid>
-  <item style="grid-row: 4">1</item>
+<grid style="grid-template-columns: 30px auto;">
+  <item>1</item>
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="height:3ch; grid-row:span 2/4">5</item>
+  <item style="height:5ch; grid-row:1/span 3">6</item>
 
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/1">0 0</item>
+  <item class="hidden" style="grid-area: 1/2">0 0</item>
+  <item class="hidden" style="grid-area: 4/2">0 0</item>
 </grid>
 
 <grid style="grid-template-columns: 30px auto;">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-mix2-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-mix2-expected.html
@@ -61,46 +61,44 @@ item {
 
 <grid>
   <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item>3 3</item>
-  <item style="grid-area: 1/2">4</item>
-  <item style="height:2ch; grid-area: 2/1/3/3">5 5</item>
+  <item>2 2</item>
+  <item style="grid-column: span 2">3 3</item>
+  <item>4</item>
+  <item style="height:2ch; grid-row:2">5 5</item>
 
-  <item class="hidden" style="grid-area: 1/2">0 0</item>
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
+  <item class="hidden" style="grid-area: 4/2">0 0</item>
 </grid>
 
 <grid>
   <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="height:4ch; grid-area: 2/1/4/auto">5 5</item>
+  <item style="height:4ch; grid-row:2/span 2">5 5</item>
 
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/2">0 0</item>
+  <item class="hidden" style="grid-area: 4/2">0 0</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
+  <item>1</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="grid-area: 2/1/4/2">5 5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="grid-row:2/span 2">5 5</item>
+  <item style="height:5ch; grid-row:1/span 3">6</item>
 
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
+  <item class="hidden" style="grid-area: 4/2">0 0</item>
 </grid>
 
 <grid>
-  <item style="grid-row: 4">1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
+  <item>1</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5 5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <item style="height:3ch; grid-row:2/span 2">5 5</item>
+  <item style="height:5ch; grid-row:1/span 3">6</item>
 
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
+  <item class="hidden" style="grid-area: 4/2">0 0</item>
 </grid>
 
 <grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-mix2-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-mix2-ref.html
@@ -39,79 +39,77 @@
 <body>
 
 <section>
-  <grid>
-    <item style="height:2ch">1</item>
-    <item>2 2</item>
-    <item style="grid-column: span 2">3 3</item>
-    <item>4</item>
-    <item style="grid-column: span 2">5 5</item>
+<grid>
+  <item style="height:2ch">1</item>
+  <item>2 2</item>
+  <item style="grid-column: span 2">3 3</item>
+  <item>4</item>
+  <item style="grid-column: span 2">5 5</item>
 
-    <item class="hidden" style="grid-area: 4/2">0 0</item>
-  </grid>
+  <item class="hidden" style="grid-area: 4/2">0 0</item>
+</grid>
 
-  <grid>
-    <item>1</item>
-    <item>2 2</item>
-    <item style="grid-column: span 2">3 3</item>
-    <item>4</item>
-    <item style="height: 2ch;">5 5</item>
+<grid>
+  <item>1</item>
+  <item>2 2</item>
+  <item style="grid-column: span 2">3 3</item>
+  <item>4</item>
+  <item style="height: 2ch;">5 5</item>
 
-    <item class="hidden" style="grid-area: 4/2">0 0</item>
-  </grid>
+  <item class="hidden" style="grid-area: 4/2">0 0</item>
+</grid>
 
-  <grid>
-    <item>1</item>
-    <item style="grid-column: span 2">2 2</item>
-    <item>3 3</item>
-    <item style="grid-area: 1/2">4</item>
-    <item style="height:2ch; grid-area: 2/1/3/3">5 5</item>
+<grid>
+  <item>1</item>
+  <item>2 2</item>
+  <item style="grid-column: span 2">3 3</item>
+  <item>4</item>
+  <item style="height:2ch; grid-row:2">5 5</item>
 
-    <item class="hidden" style="grid-area: 1/2">0 0</item>
-    <item class="hidden" style="grid-area: 2/1">0 0</item>
-  </grid>
+  <item class="hidden" style="grid-area: 4/2">0 0</item>
+</grid>
 
-  <grid>
-    <item>1</item>
-    <item style="grid-column: span 2">2 2</item>
-    <item style="grid-column: span 2">3 3</item>
-    <item>4</item>
-    <item style="height:4ch; grid-area: 2/1/4/auto">5 5</item>
+<grid>
+  <item>1</item>
+  <item>2 2</item>
+  <item>3 3</item>
+  <item>4</item>
+  <item style="height:4ch; grid-row:2/span 2">5 5</item>
 
-    <item class="hidden" style="grid-area: 2/1">0 0</item>
-    <item class="hidden" style="grid-area: 3/2">0 0</item>
-  </grid>
+  <item class="hidden" style="grid-area: 4/2">0 0</item>
+</grid>
 
-  <grid>
-    <item style="grid-row: 4">1</item>
-    <item style="grid-column: span 2">2 2</item>
-    <item style="grid-column: span 2">3 3</item>
-    <item>4</item>
-    <item style="grid-area: 2/1/4/2">5 5</item>
-    <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+<grid>
+  <item>1</item>
+  <item>2 2</item>
+  <item>3 3</item>
+  <item>4</item>
+  <item style="grid-row:2/span 2">5 5</item>
+  <item style="height:5ch; grid-row:1/span 3">6</item>
 
-    <item class="hidden" style="grid-area: 2/1">0 0</item>
-  </grid>
+  <item class="hidden" style="grid-area: 4/2">0 0</item>
+</grid>
 
-  <grid>
-    <item style="grid-row: 4">1</item>
-    <item style="grid-column: span 2">2 2</item>
-    <item style="grid-column: span 2">3 3</item>
-    <item>4</item>
-    <item style="height:3ch; grid-area: 2/1/4/2">5 5</item>
-    <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+<grid>
+  <item>1</item>
+  <item>2 2</item>
+  <item>3 3</item>
+  <item>4</item>
+  <item style="height:3ch; grid-row:2/span 2">5 5</item>
+  <item style="height:5ch; grid-row:1/span 3">6</item>
 
-    <item class="hidden" style="grid-area: 2/1">0 0</item>
-  </grid>
+  <item class="hidden" style="grid-area: 4/2">0 0</item>
+</grid>
 
-  <grid>
-    <item>1</item>
-    <item style="grid-column: span 2">2 2</item>
-    <item style="grid-column: span 2">3 3</item>
-    <item>4</item>
-    <item style="grid-area: 1/3/5/4">5 5</item>
+<grid>
+  <item>1</item>
+  <item style="grid-column: span 2">2 2</item>
+  <item style="grid-column: span 2">3 3</item>
+  <item>4</item>
+  <item style="grid-area: 1/3/5/4">5 5</item>
 
-    <item class="hidden" style="grid-area: 4/3">0 0</item>
-  </grid>
+  <item class="hidden" style="grid-area: 4/3">0 0</item>
+</grid>
 
   <grid>
     <item>1</item>
@@ -120,18 +118,18 @@
     <item>4</item>
     <item style="height:6ch; grid-area: 1/3/5/4">5 5</item>
 
-    <item class="hidden" style="grid-area: 4/3">0 0</item>
-  </grid>
+  <item class="hidden" style="grid-area: 4/3">0 0</item>
+</grid>
 
-  <grid>
-    <item>1</item>
-    <item>2 2</item>
-    <item style="grid-column: span 2">3 3</item>
-    <item>4</item>
-    <item style="height:6ch; grid-area: 1/3/4/4">5 5</item>
+<grid>
+  <item>1</item>
+  <item>2 2</item>
+  <item style="grid-column: span 2">3 3</item>
+  <item>4</item>
+  <item style="height:6ch; grid-area: 1/3/4/4">5 5</item>
 
-    <item class="hidden" style="grid-area: 4/3">0 0</item>
-    <item class="hidden" style="height:6ch; grid-area: 2/3/5/4">0 0</item>
-  </grid>
+  <item class="hidden" style="grid-area: 4/3">0 0</item>
+  <item class="hidden" style="height:6ch; grid-area: 2/3/5/4">0 0</item>
+</grid>
 </section>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-001-expected.html
@@ -35,11 +35,11 @@
 
 <grid>
   <item style="grid-column:1">6</item>
-  <item style="grid-column:2">5</item>
-  <item style="grid-column:span 2">4</item>
+  <item>5</item>
   <item style="margin-top:10px">3</item>
   <item style="grid-column:span 2">1</item>
   <item>2</item>
+  <item style="grid-column:3/span 2">4</item>
 </grid>
 
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-001-ref.html
@@ -35,11 +35,11 @@
 
 <grid>
   <item style="grid-column:1">6</item>
-  <item style="grid-column:2">5</item>
-  <item style="grid-column:span 2">4</item>
+  <item>5</item>
   <item style="margin-top:10px">3</item>
   <item style="grid-column:span 2">1</item>
   <item>2</item>
+  <item style="grid-column:3/span 2">4</item>
 </grid>
 
 </body>

--- a/Source/WebCore/rendering/GridMasonryLayout.cpp
+++ b/Source/WebCore/rendering/GridMasonryLayout.cpp
@@ -64,12 +64,7 @@ void GridMasonryLayout::performMasonryPlacement(const GridTrackSizingAlgorithm& 
     // the insertIntoGridAndLayoutItem() will modify the m_autoFlowNextCursor, so m_autoFlowNextCursor needs to be reset.
     m_autoFlowNextCursor = 0;
 
-    if (m_renderGrid.style().masonryAutoFlow().placementOrder == MasonryAutoFlowPlacementOrder::Ordered)
-        placeItemsUsingOrderModifiedDocumentOrder(algorithm, layoutPhase);
-    else {
-        placeItemsWithDefiniteGridAxisPosition(algorithm, layoutPhase);
-        placeItemsWithIndefiniteGridAxisPosition(algorithm, layoutPhase);
-    }
+    placeItemsUsingOrderModifiedDocumentOrder(algorithm, layoutPhase);
 }
 
 void GridMasonryLayout::collectMasonryItems()
@@ -84,14 +79,7 @@ void GridMasonryLayout::collectMasonryItems()
         if (grid.orderIterator().shouldSkipChild(*gridItem))
             continue;
 
-        if (m_renderGrid.style().masonryAutoFlow().placementOrder == MasonryAutoFlowPlacementOrder::Ordered)
-            m_itemsWithDefiniteGridAxisPosition.append(gridItem);
-        else if (m_renderGrid.style().masonryAutoFlow().placementOrder == MasonryAutoFlowPlacementOrder::DefiniteFirst) {
-            if (hasDefiniteGridAxisPosition(*gridItem, gridAxisDirection()))
-                m_itemsWithDefiniteGridAxisPosition.append(gridItem);
-            else
-                m_itemsWithIndefiniteGridAxisPosition.append(gridItem);
-        }
+        m_itemsWithDefiniteGridAxisPosition.append(gridItem);
     }
 }
 


### PR DESCRIPTION
#### 504067dd96c0341a41afd7330cf7e5265d51903f
<pre>
[css-masonry] Definite items are no longer placed first by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=284622">https://bugs.webkit.org/show_bug.cgi?id=284622</a>
<a href="https://rdar.apple.com/134949237">rdar://134949237</a>

Reviewed by Sammy Gill.

In CSS Masonry, definite items are no longer automatically placed first
based on spec chages.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001-auto-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001-auto-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001-fr-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001-fr-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001-mix1-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001-mix1-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001-mix2-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001-mix2-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-auto-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-auto-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-fr-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-fr-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-mix1-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-mix1-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-mix2-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-mix2-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-auto-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-auto-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-fr-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-fr-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-mix1-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-mix1-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-mix2-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-mix2-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-auto-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-auto-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-fr-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-fr-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-mix1-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-mix1-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-mix2-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-mix2-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-005-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-005-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001-auto-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001-auto-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001-fr-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001-fr-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001-mix1-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001-mix1-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001-mix2-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001-mix2-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-auto-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-auto-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-fr-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-fr-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-mix1-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-mix1-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-mix2-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-mix2-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-auto-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-auto-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-fr-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-fr-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-mix1-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-mix1-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-mix2-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-mix2-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-auto-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-auto-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-fr-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-fr-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-mix1-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-mix1-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-mix2-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-mix2-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-001-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-001-ref.html:
* Source/WebCore/rendering/GridMasonryLayout.cpp:
(WebCore::GridMasonryLayout::performMasonryPlacement):
(WebCore::GridMasonryLayout::collectMasonryItems):

Canonical link: <a href="https://commits.webkit.org/288003@main">https://commits.webkit.org/288003@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0180ddc10e22aca32e907ca367c36bebdd2f71b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81624 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1149 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35573 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86160 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32614 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83730 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1180 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8967 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63679 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21409 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84694 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/877 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74276 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43968 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/734 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28454 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31069 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29053 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87603 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8861 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6278 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72006 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9044 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70102 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71241 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17743 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15322 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14235 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8813 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14341 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8653 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12174 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10461 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->