### PR TITLE
[iOS18] TestWebKitAPI.ResourceLoadDelegate.LoadInfo is a constant failure

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadDelegate.mm
@@ -203,12 +203,7 @@ TEST(ResourceLoadDelegate, ResourceType)
         EXPECT_EQ(loadInfos[i].get().resourceType, expectedTypes[i]);
 }
 
-// rdar://136524076
-#if PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 150000
-TEST(ResourceLoadDelegate, DISABLED_LoadInfo)
-#else
 TEST(ResourceLoadDelegate, LoadInfo)
-#endif
 {
     __block bool clearedStore = false;
     [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] modifiedSince:[NSDate distantPast] completionHandler:^() {
@@ -312,8 +307,10 @@ TEST(ResourceLoadDelegate, LoadInfo)
     checkFrames(7, sub, main, _WKResourceLoadInfoResourceTypeFetch);
     checkFrames(8, sub, main, _WKResourceLoadInfoResourceTypeFetch);
 
+    String requestClass = NSStringFromClass([otherParameters[0] class]);
+
     EXPECT_EQ(otherParameters.size(), 12ull);
-    EXPECT_WK_STREQ(NSStringFromClass([otherParameters[0] class]), "NSMutableURLRequest");
+    EXPECT_TRUE(requestClass == "NSURLRequest"_s || requestClass == "NSMutableURLRequest"_s);
     EXPECT_WK_STREQ([otherParameters[0] URL].path, "/");
     EXPECT_WK_STREQ(NSStringFromClass([otherParameters[1] class]), "NSHTTPURLResponse");
     EXPECT_WK_STREQ([otherParameters[1] URL].path, "/");


### PR DESCRIPTION
#### f666714ff2ed2a7a55935937adf7b31402e34653
<pre>
[iOS18] TestWebKitAPI.ResourceLoadDelegate.LoadInfo is a constant failure
<a href="https://rdar.apple.com/141403212">rdar://141403212</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=284591">https://bugs.webkit.org/show_bug.cgi?id=284591</a>

Unreviewed.

We partiall revert the revert which removed the fix for one of the test.
After applying this patch and the previous revert, we are back to disabling StorageAccessOnRedirectSitesWithQuirk and StorageAccessGrantMultipleSubFrameDomains on macOS, but ResourceLoadDelegate.LoadInfo  is now enabled and runs fine..

* Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadDelegate.mm:
(LoadInfo)):

Canonical link: <a href="https://commits.webkit.org/287792@main">https://commits.webkit.org/287792@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/202f1b06d9da80afbb3abfb07d60114070a5ab54

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80871 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/393 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34807 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85399 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31855 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82982 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/411 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8193 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63150 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/20924 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83940 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/217 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73606 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43453 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27766 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30313 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/71686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28304 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86833 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8098 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5718 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71450 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8275 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69442 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70690 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17602 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14722 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13647 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8060 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7899 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11418 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9705 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->