### PR TITLE
Fix missing includes and guards when certain features are disabled

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -7138,6 +7138,8 @@ void Document::privateBrowsingStateDidChange(PAL::SessionID sessionID)
     forEachMediaElement([sessionID] (HTMLMediaElement& element) {
         element.privateBrowsingStateDidChange(sessionID);
     });
+#else
+    UNUSED_PARAM(sessionID);
 #endif
 }
 

--- a/Source/WebCore/loader/LinkLoader.cpp
+++ b/Source/WebCore/loader/LinkLoader.cpp
@@ -186,7 +186,11 @@ std::optional<CachedResource::Type> LinkLoader::resourceTypeFromAsAttribute(cons
     case FetchRequestDestination::Style:
         return CachedResource::Type::CSSStyleSheet;
     case FetchRequestDestination::Track:
+#if ENABLE(VIDEO)
         return CachedResource::Type::TextTrackResource;
+#else
+        return std::nullopt;
+#endif
     case FetchRequestDestination::Video:
         if (document.settings().mediaPreloadingEnabled())
             return CachedResource::Type::MediaResource;
@@ -210,8 +214,10 @@ static std::unique_ptr<LinkPreloadResourceClient> createLinkPreloadResourceClien
         return makeUnique<LinkPreloadStyleResourceClient>(loader, downcast<CachedCSSStyleSheet>(resource));
     case CachedResource::Type::FontResource:
         return makeUnique<LinkPreloadFontResourceClient>(loader, downcast<CachedFont>(resource));
+#if ENABLE(VIDEO)
     case CachedResource::Type::TextTrackResource:
         return makeUnique<LinkPreloadDefaultResourceClient>(loader, downcast<CachedTextTrack>(resource));
+#endif
     case CachedResource::Type::MediaResource:
         ASSERT_UNUSED(document, document.settings().mediaPreloadingEnabled());
         FALLTHROUGH;
@@ -257,8 +263,10 @@ bool LinkLoader::isSupportedType(CachedResource::Type resourceType, const String
         if (!document.settings().mediaPreloadingEnabled())
             ASSERT_NOT_REACHED();
         return MIMETypeRegistry::isSupportedMediaMIMEType(mimeType);
+#if ENABLE(VIDEO)
     case CachedResource::Type::TextTrackResource:
         return MIMETypeRegistry::isSupportedTextTrackMIMEType(mimeType);
+#endif
     case CachedResource::Type::RawResource:
 #if ENABLE(APPLICATION_MANIFEST)
     case CachedResource::Type::ApplicationManifest:

--- a/Source/WebCore/loader/SubresourceLoader.cpp
+++ b/Source/WebCore/loader/SubresourceLoader.cpp
@@ -634,7 +634,9 @@ static void logResourceLoaded(LocalFrame* frame, CachedResource::Type type)
         break;
 #endif
     case CachedResource::Type::LinkPrefetch:
+#if ENABLE(VIDEO)
     case CachedResource::Type::TextTrackResource:
+#endif
         resourceType = DiagnosticLoggingKeys::otherKey();
         break;
     }

--- a/Source/WebCore/loader/cache/CachedResource.h
+++ b/Source/WebCore/loader/cache/CachedResource.h
@@ -103,7 +103,9 @@ public:
         XSLStyleSheet,
 #endif
         LinkPrefetch,
+#if ENABLE(VIDEO)
         TextTrackResource,
+#endif
 #if ENABLE(APPLICATION_MANIFEST)
         ApplicationManifest,
 #endif

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -161,8 +161,10 @@ static CachedResourceHandle<CachedResource> createResource(CachedResource::Type 
 #endif
     case CachedResource::Type::LinkPrefetch:
         return new CachedResource(WTFMove(request), CachedResource::Type::LinkPrefetch, sessionID, cookieJar);
+#if ENABLE(VIDEO)
     case CachedResource::Type::TextTrackResource:
         return new CachedTextTrack(WTFMove(request), sessionID, cookieJar);
+#endif
 #if ENABLE(APPLICATION_MANIFEST)
     case CachedResource::Type::ApplicationManifest:
         return new CachedApplicationManifest(WTFMove(request), sessionID, cookieJar);
@@ -204,8 +206,10 @@ static CachedResourceHandle<CachedResource> createResource(CachedResourceRequest
 #endif
     case CachedResource::Type::LinkPrefetch:
         return new CachedResource(WTFMove(request), CachedResource::Type::LinkPrefetch, resource.sessionID(), resource.cookieJar());
+#if ENABLE(VIDEO)
     case CachedResource::Type::TextTrackResource:
         return new CachedTextTrack(WTFMove(request), resource.sessionID(), resource.cookieJar());
+#endif
 #if ENABLE(APPLICATION_MANIFEST)
     case CachedResource::Type::ApplicationManifest:
         return new CachedApplicationManifest(WTFMove(request), resource.sessionID(), resource.cookieJar());

--- a/Source/WebCore/loader/cache/CachedResourceLoader.h
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.h
@@ -53,7 +53,9 @@ class CachedFont;
 class CachedImage;
 class CachedRawResource;
 class CachedScript;
+#if ENABLE(VIDEO)
 class CachedTextTrack;
+#endif
 class CachedXSLStyleSheet;
 class Document;
 class DocumentLoader;

--- a/Source/WebCore/loader/cache/CachedTextTrack.cpp
+++ b/Source/WebCore/loader/cache/CachedTextTrack.cpp
@@ -33,6 +33,8 @@
 #include "SharedBuffer.h"
 #include "TextResourceDecoder.h"
 
+#if ENABLE(VIDEO)
+
 namespace WebCore {
 
 CachedTextTrack::CachedTextTrack(CachedResourceRequest&& request, PAL::SessionID sessionID, const CookieJar* cookieJar)
@@ -64,3 +66,5 @@ void CachedTextTrack::finishLoading(const FragmentedSharedBuffer* data, const Ne
 }
 
 }
+
+#endif // ENABLE(VIDEO)

--- a/Source/WebCore/loader/cache/CachedTextTrack.h
+++ b/Source/WebCore/loader/cache/CachedTextTrack.h
@@ -27,6 +27,8 @@
 
 #include "CachedResource.h"
 
+#if ENABLE(VIDEO)
+
 namespace WebCore {
 
 class CachedTextTrack final : public CachedResource {
@@ -44,3 +46,5 @@ private:
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_CACHED_RESOURCE(CachedTextTrack, CachedResource::Type::TextTrackResource)
+
+#endif // ENABLE(VIDEO)

--- a/Source/WebCore/platform/audio/PlatformRawAudioData.cpp
+++ b/Source/WebCore/platform/audio/PlatformRawAudioData.cpp
@@ -24,6 +24,8 @@
 #include "NotImplemented.h"
 #include <wtf/RefPtr.h>
 
+#if ENABLE(WEB_CODECS)
+
 namespace WebCore {
 
 #if !USE(GSTREAMER) && !USE(AVFOUNDATION)
@@ -40,3 +42,5 @@ void PlatformRawAudioData::copyTo(std::span<uint8_t>, AudioSampleFormat, size_t,
 #endif
 
 } // namespace WebCore
+
+#endif // ENABLE(WEB_CODECS)

--- a/Source/WebCore/platform/audio/PlatformRawAudioData.h
+++ b/Source/WebCore/platform/audio/PlatformRawAudioData.h
@@ -23,6 +23,8 @@
 #include <span>
 #include <wtf/ThreadSafeRefCounted.h>
 
+#if ENABLE(WEB_CODECS)
+
 namespace WebCore {
 
 enum class AudioSampleFormat;
@@ -49,3 +51,5 @@ public:
 };
 
 } // namespace WebCore
+
+#endif // ENABLE(WEB_CODECS)

--- a/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
+++ b/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
@@ -45,6 +45,7 @@
 
 #if USE(GLIB)
 #include <gio/gio.h>
+#include <wtf/glib/GUniquePtr.h>
 #endif
 
 #if OS(DARWIN)

--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -532,12 +532,16 @@ void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request)
 #if PLATFORM(GTK)
         if (usingDMABufRenderer) {
             addTableRow(hardwareAccelerationObject, "Renderer"_s, dmabufRendererWithSupportedBuffers());
+#if USE(LIBDRM)
             addTableRow(hardwareAccelerationObject, "Buffer format"_s, renderBufferFormat(request));
+#endif
         }
 #elif PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
         if (usingWPEPlatformAPI) {
             addTableRow(hardwareAccelerationObject, "Renderer"_s, dmabufRendererWithSupportedBuffers());
+#if USE(LIBDRM)
             addTableRow(hardwareAccelerationObject, "Buffer format"_s, renderBufferFormat(request));
+#endif
         }
 #endif
         addTableRow(hardwareAccelerationObject, "Native interface"_s, uiProcessContextIsEGL() ? "EGL"_s : "None"_s);

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -4752,6 +4752,7 @@ gboolean webkit_web_view_can_show_mime_type(WebKitWebView* webView, const char* 
     return getPage(webView).canShowMIMEType(String::fromUTF8(mimeType));
 }
 
+#if ENABLE(MHTML)
 struct ViewSaveAsyncData {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
     RefPtr<API::Data> webData;
@@ -4759,7 +4760,6 @@ struct ViewSaveAsyncData {
 };
 WEBKIT_DEFINE_ASYNC_DATA_STRUCT(ViewSaveAsyncData)
 
-#if ENABLE(MHTML)
 static void fileReplaceContentsCallback(GObject* object, GAsyncResult* result, gpointer data)
 {
     GRefPtr<GTask> task = adoptGRef(G_TASK(data));
@@ -4821,13 +4821,16 @@ void webkit_web_view_save(WebKitWebView* webView, WebKitSaveMode saveMode, GCanc
     // We only support MHTML at the moment.
     g_return_if_fail(saveMode == WEBKIT_SAVE_MODE_MHTML);
 
-#if ENABLE(MHTML)
     GTask* task = g_task_new(webView, cancellable, callback, userData);
     g_task_set_source_tag(task, reinterpret_cast<gpointer>(webkit_web_view_save));
+
+#if ENABLE(MHTML)
     g_task_set_task_data(task, createViewSaveAsyncData(), reinterpret_cast<GDestroyNotify>(destroyViewSaveAsyncData));
     getPage(webView).getContentsAsMHTMLData([task](API::Data* data) {
         getContentsAsMHTMLDataCallback(data, task);
     });
+#else
+    g_task_return_new_error_literal(task, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "WebKit was built without MHTML support which this API requires");
 #endif // ENABLE(MHTML)
 }
 
@@ -4851,6 +4854,7 @@ GInputStream* webkit_web_view_save_finish(WebKitWebView* webView, GAsyncResult* 
     if (!g_task_propagate_boolean(task, error))
         return 0;
 
+#if ENABLE(MHTML)
     GInputStream* dataStream = g_memory_input_stream_new();
     ViewSaveAsyncData* data = static_cast<ViewSaveAsyncData*>(g_task_get_task_data(task));
     auto bytes = data->webData->span();
@@ -4858,6 +4862,9 @@ GInputStream* webkit_web_view_save_finish(WebKitWebView* webView, GAsyncResult* 
         g_memory_input_stream_add_data(G_MEMORY_INPUT_STREAM(dataStream), fastMemDup(bytes.data(), bytes.size()), bytes.size(), fastFree);
 
     return dataStream;
+#else
+    return 0;
+#endif
 }
 
 /**
@@ -4887,9 +4894,10 @@ void webkit_web_view_save_to_file(WebKitWebView* webView, GFile* file, WebKitSav
     // We only support MHTML at the moment.
     g_return_if_fail(saveMode == WEBKIT_SAVE_MODE_MHTML);
 
-#if ENABLE(MHTML)
     GTask* task = g_task_new(webView, cancellable, callback, userData);
     g_task_set_source_tag(task, reinterpret_cast<gpointer>(webkit_web_view_save_to_file));
+
+#if ENABLE(MHTML)
     ViewSaveAsyncData* data = createViewSaveAsyncData();
     data->file = file;
     g_task_set_task_data(task, data, reinterpret_cast<GDestroyNotify>(destroyViewSaveAsyncData));
@@ -4897,6 +4905,8 @@ void webkit_web_view_save_to_file(WebKitWebView* webView, GFile* file, WebKitSav
     getPage(webView).getContentsAsMHTMLData([task](API::Data* data) {
         getContentsAsMHTMLDataCallback(data, task);
     });
+#else
+    g_task_return_new_error_literal(task, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "WebKit was built without MHTML support which this API requires");
 #endif // ENABLE(MHTML)
 }
 

--- a/Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionWPE.cpp
+++ b/Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionWPE.cpp
@@ -46,7 +46,7 @@
 
 namespace WebKit {
 
-#if ENABLE(WEBDRIVER)
+#if ENABLE(WEBDRIVER) && (ENABLE(WEBDRIVER_MOUSE_INTERACTIONS) || ENABLE(WEBDRIVER_TOUCH_INTERACTIONS) || ENABLE(WEBDRIVER_WHEEL_INTERACTIONS))
 static WebCore::IntPoint deviceScaleLocationInView(WebPageProxy& page, const WebCore::IntPoint& locationInView)
 {
     WebCore::IntPoint deviceScaleLocationInView(locationInView);

--- a/Source/WebKit/UIProcess/wpe/WebContextMenuProxyWPE.h
+++ b/Source/WebKit/UIProcess/wpe/WebContextMenuProxyWPE.h
@@ -27,6 +27,8 @@
 
 #include "WebContextMenuProxy.h"
 
+#if ENABLE(CONTEXT_MENUS)
+
 namespace WebKit {
 
 class WebContextMenuProxyWPE final : public WebContextMenuProxy {
@@ -46,3 +48,5 @@ private:
 };
 
 } // namespace WebKit
+
+#endif // ENABLE(CONTEXT_MENUS)

--- a/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteBarcodeDetectorProxy.h
+++ b/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteBarcodeDetectorProxy.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#if ENABLE(GPU_PROCESS)
-
 #include "RenderingBackendIdentifier.h"
 #include "ShapeDetectionIdentifier.h"
 #include <WebCore/BarcodeDetectorInterface.h>
@@ -35,6 +33,8 @@
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
+
+#if ENABLE(GPU_PROCESS)
 
 namespace IPC {
 class StreamClientConnection;

--- a/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.h
+++ b/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#if ENABLE(GPU_PROCESS)
-
 #include "RenderingBackendIdentifier.h"
 #include "ShapeDetectionIdentifier.h"
 #include <WebCore/FaceDetectorInterface.h>
@@ -35,6 +33,8 @@
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
+
+#if ENABLE(GPU_PROCESS)
 
 namespace IPC {
 class StreamClientConnection;

--- a/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteTextDetectorProxy.h
+++ b/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteTextDetectorProxy.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#if ENABLE(GPU_PROCESS)
-
 #include "RenderingBackendIdentifier.h"
 #include "ShapeDetectionIdentifier.h"
 #include <WebCore/TextDetectorInterface.h>
@@ -35,6 +33,8 @@
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
+
+#if ENABLE(GPU_PROCESS)
 
 namespace IPC {
 class StreamClientConnection;

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -179,7 +179,9 @@ static Seconds maximumBufferingTime(CachedResource* resource)
     case CachedResource::Type::RawResource:
     case CachedResource::Type::SVGDocumentResource:
     case CachedResource::Type::LinkPrefetch:
+#if ENABLE(VIDEO)
     case CachedResource::Type::TextTrackResource:
+#endif
 #if ENABLE(XSLT)
     case CachedResource::Type::XSLStyleSheet:
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -68,6 +68,7 @@
 #include <WebCore/EventHandler.h>
 #include <WebCore/File.h>
 #include <WebCore/FocusController.h>
+#include <WebCore/FrameLoader.h>
 #include <WebCore/FrameSnapshotting.h>
 #include <WebCore/HTMLFormElement.h>
 #include <WebCore/HTMLFrameOwnerElement.h>

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -50,6 +50,7 @@
 #include <WebCore/PointerCharacteristics.h>
 #include <WebCore/PointerID.h>
 #include <WebCore/RectEdges.h>
+#include <WebCore/RegistrableDomain.h>
 #include <WebCore/SecurityPolicyViolationEvent.h>
 #include <WebCore/ShareData.h>
 #include <WebCore/ShareableBitmap.h>


### PR DESCRIPTION
#### 951a118e17cd92adc3aa31129af7cd348fac91e9
<pre>
Fix missing includes and guards when certain features are disabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=284523">https://bugs.webkit.org/show_bug.cgi?id=284523</a>

Reviewed by Philippe Normand.

When disabling long-standing features such as VIDEO, WEB_AUDIO, WEB_CODECS
and others, WebKit failed to build as some of the symbols were not
properly guarded, or includes were missing (probably because they were
transitively included otherwise).

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::privateBrowsingStateDidChange): Missing UNUSED_PARAM
when VIDEO is not enabled.
* Source/WebCore/loader/LinkLoader.cpp:
(WebCore::LinkLoader::resourceTypeFromAsAttribute): TextTrackResource
can&apos;t be returned with VIDEO not enabled.
(WebCore::createLinkPreloadResourceClient): Skip TextTrackResource with
VIDEO not enabled.
(WebCore::LinkLoader::isSupportedType): ditto.
* Source/WebCore/loader/SubresourceLoader.cpp:
(WebCore::logResourceLoaded): ditto.
* Source/WebCore/loader/cache/CachedResource.h: ditto.
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::createResource): ditto.
* Source/WebCore/loader/cache/CachedResourceLoader.h: Do not expose
  CachedTextTrack if VIDEO is not enabled.
* Source/WebCore/loader/cache/CachedTextTrack.cpp: Do not expose if
  VIDEO is not enabled.
* Source/WebCore/loader/cache/CachedTextTrack.h: Do not expose if VIDEO
  is not enabled.
* Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp:
(WebCore::PlatformMediaSessionManager::endInterruption): Missing
UNUSED_PARAM when VIDEO is not enabled.
(WebCore::PlatformMediaSessionManager::addSession): Protect
Session-specific members when VIDEO and WEB_AUDIO are not enabled.
(WebCore::PlatformMediaSessionManager::removeSession): ditto.
(WebCore::PlatformMediaSessionManager::sessionWillEndPlayback): ditto.
(WebCore::PlatformMediaSessionManager::setCurrentSession): ditto.
(WebCore::PlatformMediaSessionManager::applicationWillBecomeInactive):
ditto.
(WebCore::PlatformMediaSessionManager::applicationDidBecomeActive):
ditto.
(WebCore::PlatformMediaSessionManager::applicationDidEnterBackground):
ditto.
(WebCore::PlatformMediaSessionManager::applicationWillEnterForeground):
ditto.
(WebCore::PlatformMediaSessionManager::processWillSuspend): ditto.
(WebCore::PlatformMediaSessionManager::processDidResume): ditto.
(WebCore::PlatformMediaSessionManager::processDidReceiveRemoteControlCommand): ditto.
(WebCore::PlatformMediaSessionManager::processSystemWillSleep): ditto.
(WebCore::PlatformMediaSessionManager::processSystemDidWake): ditto.
(WebCore::PlatformMediaSessionManager::stopAllMediaPlaybackForProcess):
ditto.
(WebCore::PlatformMediaSessionManager::suspendAllMediaPlaybackForGroup):
ditto.
(WebCore::PlatformMediaSessionManager::resumeAllMediaPlaybackForGroup):
ditto.
(WebCore::PlatformMediaSessionManager::bestEligibleSessionForRemoteControls): ditto.
(WebCore::PlatformMediaSessionManager::hasActiveNowPlayingSessionInGroup): ditto.
(WebCore::PlatformMediaSessionManager::dumpSessionStates): ditto.
* Source/WebCore/platform/audio/PlatformRawAudioData.cpp: Do not expose
  if WEB_CODECS are not enabled.
* Source/WebCore/platform/audio/PlatformRawAudioData.h: ditto.
* Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp: Missing include.
* Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp:
(WebKit::WebKitProtocolHandler::handleGPU): Protected renderMediaBuffer
usage with USE(LIBDRM)
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp: Guard
  MHTML-related logic better, and fail saving if unavailable.
* Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionWPE.cpp:
  Do not expose unused methods when WebDriver&apos;s Mouse, Wheel or Touch
interactions are disabled.
* Source/WebKit/UIProcess/wpe/WebContextMenuProxyWPE.h: Do not expose
  when CONTEXT_MENUS is not enabled.
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteBarcodeDetectorProxy.h:
  Moved the guard after the type is defined
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.h:
  ditto.
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteTextDetectorProxy.h:
  ditto.
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::maximumBufferingTime): Do not expose TextTrackResource if VIDEO
is not enabled.
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp: Missing FrameLoader
  include.
* Source/WebKit/WebProcess/WebPage/WebPage.h: Missing RegistrableDomain
  include.

Canonical link: <a href="https://commits.webkit.org/288522@main">https://commits.webkit.org/288522@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14a18c2cafb34fb3655a909cebb640d4bcae342d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83693 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3310 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37994 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88765 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34701 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85778 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3400 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11268 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65103 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22935 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86739 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2510 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76045 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45391 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/2438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30255 "Found 1 new test failure: fast/editing/recursive-reapply-edit-command-crash.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33750 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31001 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90143 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10958 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7911 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73539 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11182 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71870 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72763 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17990 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17025 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15724 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/2282 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10910 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16382 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10758 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14233 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12530 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->