### PR TITLE
Annotate RemoteVideoFrameObjectHeap endpoints

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -1313,6 +1313,9 @@ void GPUConnectionToWebProcess::updateSharedPreferencesForWebProcess(SharedPrefe
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
     protectedSampleBufferDisplayLayerManager()->updateSharedPreferencesForWebProcess(m_sharedPreferencesForWebProcess);
 #endif
+#if ENABLE(VIDEO)
+    protectedVideoFrameObjectHeap()->updateSharedPreferencesForWebProcess(m_sharedPreferencesForWebProcess);
+#endif
 
     enableMediaPlaybackIfNecessary();
 }

--- a/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.cpp
@@ -206,6 +206,13 @@ void RemoteVideoFrameObjectHeap::lowMemoryHandler()
 #endif
 }
 
+void RemoteVideoFrameObjectHeap::updateSharedPreferencesForWebProcess(SharedPreferencesForWebProcess sharedPreferencesForWebProcess)
+{
+    remoteVideoFrameObjectHeapQueueSingleton().dispatch([this, protectedThis = Ref { *this }, sharedPreferencesForWebProcess = WTFMove(sharedPreferencesForWebProcess)] {
+        m_sharedPreferencesForWebProcess = sharedPreferencesForWebProcess;
+    });
+}
+
 }
 
 #endif

--- a/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.h
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.h
@@ -28,6 +28,7 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(VIDEO)
 #include "Connection.h"
 #include "RemoteVideoFrameProxy.h"
+#include "SharedPreferencesForWebProcess.h"
 #include "ThreadSafeObjectHeap.h"
 #include "WorkQueueMessageReceiver.h"
 
@@ -59,6 +60,9 @@ public:
     void stopListeningForIPC(Ref<RemoteVideoFrameObjectHeap>&&) { close(); }
     void lowMemoryHandler();
 
+    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_sharedPreferencesForWebProcess; }
+    void updateSharedPreferencesForWebProcess(SharedPreferencesForWebProcess);
+
 private:
     explicit RemoteVideoFrameObjectHeap(Ref<IPC::Connection>&&);
 
@@ -89,6 +93,7 @@ private:
     std::unique_ptr<WebCore::PixelBufferConformerCV> m_pixelBufferConformer WTF_GUARDED_BY_LOCK(m_pixelBufferConformerLock);
 #endif
     bool m_isClosed { false };
+    SharedPreferencesForWebProcess m_sharedPreferencesForWebProcess;
 };
 
 }

--- a/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.messages.in
@@ -23,7 +23,7 @@
 
 #if ENABLE(GPU_PROCESS) && ENABLE(VIDEO)
 [
-    ExceptionForEnabledBy,
+    EnabledBy=UseGPUProcessForMediaEnabled,
     DispatchedFrom=WebContent,
     DispatchedTo=GPU
 ]


### PR DESCRIPTION
#### ed1c53aac1de7687275065532cf2ce7668c2022a
<pre>
Annotate RemoteVideoFrameObjectHeap endpoints
<a href="https://bugs.webkit.org/show_bug.cgi?id=286361">https://bugs.webkit.org/show_bug.cgi?id=286361</a>
<a href="https://rdar.apple.com/143396324">rdar://143396324</a>

Reviewed by NOBODY (OOPS!).

Annotate RemoteVideoFrameObjectHeap endpoints using UseGPUProcessForMediaEnabled

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::updateSharedPreferencesForWebProcess):
* Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.cpp:
(WebKit::RemoteVideoFrameObjectHeap::updateSharedPreferencesForWebProcess):
* Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.h:
* Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.messages.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed1c53aac1de7687275065532cf2ce7668c2022a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92805 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12356 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2088 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97801 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43316 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12636 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20808 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71015 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28445 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95807 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9543 "Found 60 new test failures: compositing/contents-format/deep-color-backing-store.html compositing/tiling/tiled-reflection-inwindow.html compositing/video/video-border-radius.html editing/caret/caret-position-vertical-rl.html fast/canvas/webgl/tex-image-and-sub-image-2d-with-video-rgb565.html fast/canvas/webgl/tex-image-and-sub-image-2d-with-video-rgba4444.html fast/canvas/webgl/tex-image-and-sub-image-2d-with-video-rgba5551.html fast/forms/ios/focus-input-in-fixed.html fast/media/update-media-query-css-parser.html fast/mediacapturefromelement/CanvasCaptureMediaStream-capture-out-of-DOM-canvas-webgl.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84021 "Found 14 new API test failures: TestWebKitAPI.WebKit.InterruptionBetweenGetDisplayMediaAndGetUserMedia, TestWebKitAPI.GPUProcess.ExitsUnderMemoryPressureWebRTCCase, TestWebKitAPI.GetUserMedia.ClearRemoteVideoFrameObjectHeapPixelConformerUnderMemoryPressure, TestWebKitAPI.GPUProcess.ExitsUnderMemoryPressureGetUserMediaAudioCase, TestWebKitAPI.ContextMenuTests.HitTestResultNonFullscreenMedia, TestWebKitAPI.ContextMenuTests.HitTestResultElementTypeVideo, TestWebKitAPI.WebKit2.CrashGPUProcessWhileCapturingAndCalling, TestWebKitAPI.WKWebExtensionAPIMenus.MacVideoContextMenuItems, TestWebKitAPI.WebKit2.CrashGPUProcessWhileCapturing, TestWebKitAPI.ContextMenuTests.HitTestResultMediaDownloadable ... (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51344 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9233 "Found 46 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-006.html imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-timing.https.sub.html imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/canvas-createImageBitmap-video-resize.html imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-origin.sub.html imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-sizeOverflow.html imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/imageBitmap-from-imageData-no-image-rotation.html imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled-keyboard.tentative.html imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-with-window-tracks.https.html imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-blob-timecode.https.html imported/w3c/web-platform-tests/mediacapture-streams/GUM-required-constraint-with-ideal-value.https.html ... (failure)") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42644 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79540 "Found 4 new API test failures: TestWebKitAPI.WebKit2.CrashGPUProcessWhileCapturing, TestWebKitAPI.WebKit.InterruptionBetweenSameProcessPages, TestWebKitAPI.GetUserMedia.ClearRemoteVideoFrameObjectHeapPixelConformerUnderMemoryPressure, TestWebKitAPI.WebKit2.CrashGPUProcessWhileCapturingAndCalling (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1629 "Found 60 new test failures: compositing/video/video-border-radius.html compositing/video/video-object-fit.html fast/canvas/canvas-createPattern-video-loading.html fast/canvas/canvas-createPattern-video-modify.html fast/canvas/webgl/tex-image-and-sub-image-2d-with-video-rgb565.html fast/canvas/webgl/tex-image-and-sub-image-2d-with-video-rgba4444.html fast/canvas/webgl/tex-image-and-sub-image-2d-with-video-rgba5551.html fast/canvas/webgl/tex-image-and-sub-image-2d-with-video.html fast/canvas/webgl/texImage2D-mse-flipY-false.html fast/canvas/webgl/texImage2D-mse-flipY-true.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99823 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19857 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14586 "Found 60 new test failures: compositing/video/video-border-radius.html fast/canvas/canvas-createPattern-video-loading.html fast/canvas/canvas-createPattern-video-modify.html fast/canvas/canvas-drawImage-incomplete.html fast/canvas/webgl/tex-image-and-sub-image-2d-with-video-rgb565.html fast/canvas/webgl/tex-image-and-sub-image-2d-with-video-rgba4444.html fast/canvas/webgl/tex-image-and-sub-image-2d-with-video-rgba5551.html fast/canvas/webgl/tex-image-and-sub-image-2d-with-video.html fast/canvas/webgl/texImage2D-mse-flipY-false.html fast/canvas/webgl/texImage2D-mse-flipY-true.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80029 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20108 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79919 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79331 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23862 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1163 "Found 60 new test failures: compositing/video/video-border-radius.html css3/blending/background-blend-mode-background-position-percentage.html css3/filters/backdrop/dynamic-with-clip-path.html css3/font-feature-settings-calc.html css3/masking/clip-path-border-radius-content-box-000.html fast/canvas/canvas-createPattern-video-loading.html fast/canvas/canvas-createPattern-video-modify.html fast/canvas/webgl/tex-image-and-sub-image-2d-with-video-rgb565.html fast/canvas/webgl/tex-image-and-sub-image-2d-with-video-rgba4444.html fast/canvas/webgl/tex-image-and-sub-image-2d-with-video-rgba5551.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12893 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19841 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25017 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19528 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22988 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21269 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->