### PR TITLE
Prepare AVAudioSessionCaptureDeviceManager for speaker selection

### DIFF
--- a/Source/WebCore/platform/audio/ios/AudioSessionIOS.h
+++ b/Source/WebCore/platform/audio/ios/AudioSessionIOS.h
@@ -76,7 +76,7 @@ private:
     void setSoundStageSize(SoundStageSize) final;
     SoundStageSize soundStageSize() const final { return m_soundStageSize; }
 
-    String m_lastSetPreferredAudioDeviceUID;
+    String m_lastSetPreferredMicrophoneID;
     RetainPtr<WebInterruptionObserverHelper> m_interruptionObserverHelper;
     String m_sceneIdentifier;
     SoundStageSize m_soundStageSize { SoundStageSize::Automatic };

--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.h
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.h
@@ -58,6 +58,7 @@ public:
     virtual void stop() = 0;
     virtual void close() { };
     virtual void retrieveFormatDescription(CompletionHandler<void(std::optional<CAAudioStreamDescription>)>&&) = 0;
+    virtual void setLastDeviceUsed(const String&) { }
 };
 
 }

--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.cpp
@@ -44,12 +44,31 @@ AudioMediaStreamTrackRendererUnit& AudioMediaStreamTrackRendererUnit::singleton(
     return *sharedUnit.get();
 }
 
+bool AudioMediaStreamTrackRendererUnit::supportsPerDeviceRendering()
+{
+#if !PLATFORM(IOS_FAMILY)
+    return true;
+#else
+    return false;
+#endif
+}
+
 AudioMediaStreamTrackRendererUnit::AudioMediaStreamTrackRendererUnit()
     : m_deleteUnitsTimer([] { AudioMediaStreamTrackRendererUnit::singleton().deleteUnitsIfPossible(); })
 {
 }
 
 AudioMediaStreamTrackRendererUnit::~AudioMediaStreamTrackRendererUnit() = default;
+
+void AudioMediaStreamTrackRendererUnit::setLastDeviceUsed(const String& deviceID)
+{
+    if (supportsPerDeviceRendering())
+        return;
+
+    UNUSED_PARAM(deviceID);
+    Ref unit = ensureDeviceUnit(AudioMediaStreamTrackRenderer::defaultDeviceID());
+    unit->setLastDeviceUsed(deviceID);
+}
 
 void AudioMediaStreamTrackRendererUnit::deleteUnitsIfPossible()
 {
@@ -65,11 +84,34 @@ void AudioMediaStreamTrackRendererUnit::deleteUnitsIfPossible()
     });
 }
 
-void AudioMediaStreamTrackRendererUnit::addSource(const String& deviceID, Ref<AudioSampleDataSource>&& source)
+Ref<AudioMediaStreamTrackRendererUnit::Unit> AudioMediaStreamTrackRendererUnit::ensureDeviceUnit(const String& identifier)
 {
+    String deviceID = supportsPerDeviceRendering() ? identifier : AudioMediaStreamTrackRenderer::defaultDeviceID();
+
     assertIsMainThread();
 
-    Ref unit = m_units.ensure(deviceID, [&deviceID] { return Unit::create(deviceID); }).iterator->value;
+    return m_units.ensure(deviceID, [&deviceID] {
+        return Unit::create(deviceID);
+    }).iterator->value;
+}
+
+RefPtr<AudioMediaStreamTrackRendererUnit::Unit> AudioMediaStreamTrackRendererUnit::getDeviceUnit(const String& identifier)
+{
+    String deviceID = supportsPerDeviceRendering() ? identifier : AudioMediaStreamTrackRenderer::defaultDeviceID();
+
+    assertIsMainThread();
+
+    auto iterator = m_units.find(deviceID);
+    if (iterator == m_units.end())
+        return { };
+    return iterator->value.ptr();
+}
+
+void AudioMediaStreamTrackRendererUnit::addSource(const String& deviceID, Ref<AudioSampleDataSource>&& source)
+{
+    setLastDeviceUsed(deviceID);
+
+    Ref unit = ensureDeviceUnit(deviceID);
     unit->addSource(WTFMove(source));
 }
 
@@ -77,22 +119,18 @@ void AudioMediaStreamTrackRendererUnit::removeSource(const String& deviceID, Aud
 {
     assertIsMainThread();
 
-    auto iterator = m_units.find(deviceID);
-    if (iterator == m_units.end())
+    RefPtr unit = getDeviceUnit(deviceID);
+    if (!unit)
         return;
 
     static constexpr Seconds deleteUnitDelay = 10_s;
-
-    Ref unit = iterator->value;
     if (unit->removeSource(source) && !unit->isDefault())
         m_deleteUnitsTimer.startOneShot(deleteUnitDelay);
 }
 
 void AudioMediaStreamTrackRendererUnit::addResetObserver(const String& deviceID, ResetObserver& observer)
 {
-    assertIsMainThread();
-
-    Ref unit = m_units.ensure(deviceID, [&deviceID] { return Unit::create(deviceID); }).iterator->value;
+    Ref unit = ensureDeviceUnit(deviceID);
     unit->addResetObserver(observer);
 }
 
@@ -100,8 +138,7 @@ void AudioMediaStreamTrackRendererUnit::retrieveFormatDescription(CompletionHand
 {
     assertIsMainThread();
 
-    auto defaultDeviceID = AudioMediaStreamTrackRenderer::defaultDeviceID();
-    Ref unit = m_units.ensure(defaultDeviceID, [&defaultDeviceID] { return Unit::create(defaultDeviceID); }).iterator->value;
+    Ref unit = ensureDeviceUnit(AudioMediaStreamTrackRenderer::defaultDeviceID());
     unit->retrieveFormatDescription(WTFMove(callback));
 }
 
@@ -169,6 +206,12 @@ void AudioMediaStreamTrackRendererUnit::Unit::addResetObserver(ResetObserver& ob
 {
     assertIsMainThread();
     m_resetObservers.add(observer);
+}
+
+void AudioMediaStreamTrackRendererUnit::Unit::setLastDeviceUsed(const String& deviceID)
+{
+    assertIsMainThread();
+    m_internalUnit->setLastDeviceUsed(deviceID);
 }
 
 void AudioMediaStreamTrackRendererUnit::Unit::retrieveFormatDescription(CompletionHandler<void(std::optional<CAAudioStreamDescription>)>&& callback)

--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.h
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.h
@@ -51,9 +51,11 @@ class AudioMediaStreamTrackRendererUnit : public BaseAudioMediaStreamTrackRender
     WTF_MAKE_FAST_ALLOCATED;
 public:
     WEBCORE_EXPORT static AudioMediaStreamTrackRendererUnit& singleton();
+    static bool supportsPerDeviceRendering();
 
     ~AudioMediaStreamTrackRendererUnit();
 
+    void setLastDeviceUsed(const String&);
     void retrieveFormatDescription(CompletionHandler<void(std::optional<CAAudioStreamDescription>)>&&);
 
     // BaseAudioMediaStreamTrackRendererUnit
@@ -84,6 +86,7 @@ private:
 
         void close();
         void retrieveFormatDescription(CompletionHandler<void(std::optional<CAAudioStreamDescription>)>&&);
+        void setLastDeviceUsed(const String&);
 
     private:
         explicit Unit(const String&);
@@ -107,6 +110,9 @@ private:
         WeakHashSet<ResetObserver> m_resetObservers WTF_GUARDED_BY_CAPABILITY(mainThread);
         const bool m_isDefaultUnit { false };
     };
+
+    Ref<Unit> ensureDeviceUnit(const String&);
+    RefPtr<Unit> getDeviceUnit(const String&);
 
     HashMap<String, Ref<Unit>> m_units WTF_GUARDED_BY_CAPABILITY(mainThread);
     Timer m_deleteUnitsTimer;

--- a/Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(MEDIA_STREAM) && USE(LIBWEBRTC)
 
+#include "AudioMediaStreamTrackRenderer.h"
 #include "AudioMediaStreamTrackRendererUnit.h"
 #include "AudioSampleDataSource.h"
 #include "LibWebRTCAudioFormat.h"
@@ -76,8 +77,12 @@ std::pair<bool, Vector<Ref<AudioSampleDataSource>>> IncomingAudioMediaStreamTrac
     return std::make_pair(shouldStart, copyToVector(mixer.sources));
 }
 
-void IncomingAudioMediaStreamTrackRendererUnit::addSource(const String& deviceID, Ref<AudioSampleDataSource>&& source)
+void IncomingAudioMediaStreamTrackRendererUnit::addSource(const String& identifier, Ref<AudioSampleDataSource>&& source)
 {
+    AudioMediaStreamTrackRendererUnit::singleton().setLastDeviceUsed(identifier);
+
+    String deviceID = AudioMediaStreamTrackRendererUnit::supportsPerDeviceRendering() ? identifier : AudioMediaStreamTrackRenderer::defaultDeviceID();
+
 #if !RELEASE_LOG_DISABLED
     source->logger().logAlways(LogWebRTC, "IncomingAudioMediaStreamTrackRendererUnit::addSource ", source->logIdentifier());
 #endif
@@ -141,8 +146,10 @@ std::pair<bool, Vector<Ref<AudioSampleDataSource>>> IncomingAudioMediaStreamTrac
     return std::make_pair(shouldStop, copyToVector(mixer.sources));
 }
 
-void IncomingAudioMediaStreamTrackRendererUnit::removeSource(const String& deviceID, AudioSampleDataSource& source)
+void IncomingAudioMediaStreamTrackRendererUnit::removeSource(const String& identifier, AudioSampleDataSource& source)
 {
+    String deviceID = AudioMediaStreamTrackRendererUnit::supportsPerDeviceRendering() ? identifier : AudioMediaStreamTrackRenderer::defaultDeviceID();
+
 #if !RELEASE_LOG_DISABLED
     source.logger().logAlways(LogWebRTC, "IncomingAudioMediaStreamTrackRendererUnit::removeSource ", source.logIdentifier());
 #endif

--- a/Source/WebCore/platform/mediastream/ios/AVAudioSessionCaptureDeviceManager.h
+++ b/Source/WebCore/platform/mediastream/ios/AVAudioSessionCaptureDeviceManager.h
@@ -58,9 +58,12 @@ public:
     void enableAllDevicesQuery();
     void disableAllDevicesQuery();
 
-    void setPreferredAudioSessionDeviceUID(const String&);
-    String preferredAudioSessionDeviceUID() const { return m_preferredAudioDeviceUID; }
-    void configurePreferredAudioCaptureDevice();
+    void setPreferredMicrophoneID(const String&);
+    const String& preferredMicrophoneID() const { return m_preferredMicrophoneID; }
+    void configurePreferredMicrophone();
+
+    WEBCORE_EXPORT void setPreferredSpeakerID(const String&);
+    bool isReceiverPreferredSpeaker() const { return m_isReceiverPreferredSpeaker; }
 
 private:
     AVAudioSessionCaptureDeviceManager();
@@ -70,7 +73,7 @@ private:
     void refreshAudioCaptureDevices();
     Vector<AVAudioSessionCaptureDevice> retrieveAudioSessionCaptureDevices() const;
     void setAudioCaptureDevices(Vector<AVAudioSessionCaptureDevice>&&);
-    bool setPreferredAudioSessionDeviceUIDInternal(const String&);
+    bool setPreferredAudioSessionDeviceIDs();
     void notifyNewCurrentMicrophoneDevice(CaptureDevice&&);
 
     enum class AudioSessionState { NotNeeded, Inactive, Active };
@@ -81,7 +84,9 @@ private:
     RetainPtr<WebAVAudioSessionAvailableInputsListener> m_listener;
     RetainPtr<AVAudioSession> m_audioSession;
     Ref<WorkQueue> m_dispatchQueue;
-    String m_preferredAudioDeviceUID;
+    String m_preferredMicrophoneID;
+    String m_preferredSpeakerID;
+    bool m_isReceiverPreferredSpeaker { false };
     bool m_recomputeDevices { true };
     mutable RetainPtr<AVAudioSessionPortDescription> m_lastDefaultMicrophone;
 };

--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
@@ -58,7 +58,7 @@ public:
 
     void startProducingData();
     void stopProducingData();
-    void reconfigure();
+    WEBCORE_EXPORT void reconfigure();
     virtual bool isProducingData() const = 0;
 
     virtual void delaySamples(Seconds) { }

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
@@ -266,7 +266,7 @@ void CoreAudioSharedUnit::captureDeviceChanged()
 #if PLATFORM(MAC)
     reconfigureAudioUnit();
 #else
-    AVAudioSessionCaptureDeviceManager::singleton().setPreferredAudioSessionDeviceUID(isCapturingWithDefaultMicrophone() ? String { } : persistentID());
+    AVAudioSessionCaptureDeviceManager::singleton().setPreferredMicrophoneID(isCapturingWithDefaultMicrophone() ? String { } : persistentID());
 #endif
     updateVoiceActivityDetection();
 }

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -279,6 +279,10 @@ public:
 
     bool isAlwaysOnLoggingAllowed() const;
 
+#if USE(AUDIO_SESSION)
+    RemoteAudioSessionProxy& audioSessionProxy();
+#endif
+
 private:
     GPUConnectionToWebProcess(GPUProcess&, WebCore::ProcessIdentifier, PAL::SessionID, IPC::Connection::Handle&&, GPUProcessConnectionParameters&&);
 
@@ -325,7 +329,6 @@ private:
 #endif
 
 #if USE(AUDIO_SESSION)
-    RemoteAudioSessionProxy& audioSessionProxy();
     Ref<RemoteAudioSessionProxy> protectedAudioSessionProxy();
     using EnsureAudioSessionCompletion = CompletionHandler<void(const RemoteAudioSessionConfiguration&)>;
     void ensureAudioSession(EnsureAudioSessionCompletion&&);

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
@@ -35,6 +35,7 @@
 #include "RemoteAudioSessionProxyManager.h"
 #include "RemoteAudioSessionProxyMessages.h"
 #include <WebCore/AudioSession.h>
+#include <WebCore/AVAudioSessionCaptureDeviceManager.h>
 #include <wtf/TZoneMalloc.h>
 
 #define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, protectedConnection().get())
@@ -46,7 +47,7 @@ using namespace WebCore;
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteAudioSessionProxy);
 
 RemoteAudioSessionProxy::RemoteAudioSessionProxy(GPUConnectionToWebProcess& gpuConnection)
-    : m_gpuConnection(gpuConnection)
+: m_gpuConnection(gpuConnection)
 {
 }
 
@@ -106,6 +107,11 @@ void RemoteAudioSessionProxy::tryToSetActive(bool active, SetActiveCompletion&& 
         m_active = active;
         if (m_active)
             m_isInterrupted = false;
+
+#if ENABLE(MEDIA_STREAM) && PLATFORM(IOS_FAMILY)
+        if (m_active)
+            AVAudioSessionCaptureDeviceManager::singleton().setPreferredSpeakerID(m_speakerID);
+#endif
     }
 
     completion(success);
@@ -194,6 +200,22 @@ std::optional<SharedPreferencesForWebProcess> RemoteAudioSessionProxy::sharedPre
 
     return std::nullopt;
 }
+
+#if PLATFORM(IOS_FAMILY)
+void RemoteAudioSessionProxy::setPreferredSpeakerID(const String& speakerID)
+{
+    if (m_speakerID == speakerID)
+        return;
+    
+    m_speakerID = speakerID;
+    if (!m_active)
+        return;
+
+#if ENABLE(MEDIA_STREAM)
+    AVAudioSessionCaptureDeviceManager::singleton().setPreferredSpeakerID(m_speakerID);
+#endif
+}
+#endif
 
 } // namespace WebKit
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h
@@ -87,6 +87,10 @@ public:
     RefPtr<GPUConnectionToWebProcess> gpuConnectionToWebProcess() const;
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
+#if PLATFORM(IOS_FAMILY)
+    void setPreferredSpeakerID(const String&);
+#endif
+
 private:
     explicit RemoteAudioSessionProxy(GPUConnectionToWebProcess&);
 
@@ -116,6 +120,9 @@ private:
     bool m_active { false };
     bool m_isInterrupted { false };
     bool m_isPlayingToBluetoothOverrideChanged { false };
+#if PLATFORM(IOS_FAMILY)
+    String m_speakerID;
+#endif
 };
 
 }

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -43,6 +43,7 @@
 #include "RemoteMediaResourceIdentifier.h"
 #include "RemoteMediaResourceLoader.h"
 #include "RemoteMediaResourceManager.h"
+#include "RemoteAudioSessionProxy.h"
 #include "RemoteTextTrackProxy.h"
 #include "RemoteVideoFrameObjectHeap.h"
 #include "RemoteVideoFrameProxy.h"
@@ -1326,6 +1327,13 @@ void RemoteMediaPlayerProxy::audioOutputDeviceChanged(String&& deviceId)
     m_configuration.audioOutputDeviceId = WTFMove(deviceId);
     if (RefPtr player = m_player)
         player->audioOutputDeviceChanged();
+
+#if PLATFORM(IOS_FAMILY) && USE(AUDIO_SESSION)
+    RefPtr manager = m_manager.get();
+    RefPtr connection = manager->gpuConnectionToWebProcess();
+    Ref audioSession = connection->audioSessionProxy();
+    audioSession->setPreferredSpeakerID(m_configuration.audioOutputDeviceId);
+#endif
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -33,7 +33,9 @@
 #include "GPUProcessConnectionMessages.h"
 #include "IPCSemaphore.h"
 #include "Logging.h"
+#include "RemoteAudioSessionProxy.h"
 #include "SharedCARingBuffer.h"
+#include <WebCore/AVAudioSessionCaptureDeviceManager.h>
 #include <WebCore/AudioMediaStreamTrackRenderer.h>
 #include <WebCore/AudioMediaStreamTrackRendererInternalUnit.h>
 #include <WebCore/AudioSampleBufferList.h>
@@ -159,6 +161,15 @@ void RemoteAudioMediaStreamTrackRendererInternalUnitManager::notifyLastToCapture
 {
     for (Ref unit : m_units.values())
         unit->updateShouldRegisterAsSpeakerSamplesProducer();
+}
+
+void RemoteAudioMediaStreamTrackRendererInternalUnitManager::setLastDeviceUsed(const String& deviceID)
+{
+#if PLATFORM(IOS_FAMILY) && USE(AUDIO_SESSION)
+    RefPtr connection = m_gpuConnectionToWebProcess.get();
+    Ref audioSession = connection->audioSessionProxy();
+    audioSession->setPreferredSpeakerID(deviceID != AudioMediaStreamTrackRenderer::defaultDeviceID() ? deviceID : emptyString());
+#endif
 }
 
 std::optional<SharedPreferencesForWebProcess> RemoteAudioMediaStreamTrackRendererInternalUnitManager::sharedPreferencesForWebProcess() const

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.h
@@ -74,6 +74,7 @@ private:
     void deleteUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier);
     void startUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier, ConsumerSharedCARingBuffer::Handle&&, IPC::Semaphore&&);
     void stopUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier);
+    void setLastDeviceUsed(const String&);
 
     HashMap<AudioMediaStreamTrackRendererInternalUnitIdentifier, Ref<class RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit>> m_units;
     ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.messages.in
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.messages.in
@@ -34,6 +34,8 @@ messages -> RemoteAudioMediaStreamTrackRendererInternalUnitManager {
 
     StartUnit(WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier identifier, struct WebKit::ConsumerSharedCARingBufferHandle storageHandle, IPC::Semaphore renderSemaphore)
     StopUnit(WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier identifier)
+
+    SetLastDeviceUsed(String deviceID)
 }
 
 #endif

--- a/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -31,6 +31,7 @@
 #include "AudioMediaStreamTrackRendererInternalUnitIdentifier.h"
 #include "GPUProcessConnection.h"
 #include "IPCSemaphore.h"
+#include "Logging.h"
 #include "RemoteAudioMediaStreamTrackRendererInternalUnitManagerMessages.h"
 #include "SharedCARingBuffer.h"
 #include "WebProcess.h"
@@ -73,6 +74,7 @@ private:
     void close() { stopThread(); }
 
     void retrieveFormatDescription(CompletionHandler<void(std::optional<WebCore::CAAudioStreamDescription>)>&&) final;
+    void setLastDeviceUsed(const String&) final;
 
     void initialize(const WebCore::CAAudioStreamDescription&, size_t frameChunkSize);
     void storageChanged(WebCore::SharedMemory*, const WebCore::CAAudioStreamDescription&, size_t);
@@ -221,6 +223,11 @@ void AudioMediaStreamTrackRendererInternalUnitManagerProxy::retrieveFormatDescri
         return;
     }
     callback(m_description);
+}
+
+void AudioMediaStreamTrackRendererInternalUnitManagerProxy::setLastDeviceUsed(const String& deviceID)
+{
+    WebProcess::singleton().ensureGPUProcessConnection().connection().send(Messages::RemoteAudioMediaStreamTrackRendererInternalUnitManager::SetLastDeviceUsed { deviceID }, 0);
 }
 
 void AudioMediaStreamTrackRendererInternalUnitManagerProxy::stopThread()


### PR DESCRIPTION
#### 19888c4fb22381309ac240707969b138b6210b77
<pre>
Prepare AVAudioSessionCaptureDeviceManager for speaker selection
<a href="https://rdar.apple.com/141435061">rdar://141435061</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=284629">https://bugs.webkit.org/show_bug.cgi?id=284629</a>

Reviewed by Eric Carlson.

Update AudioMediaStreamTrackRendererUnit so that we store the last used speaker of a page.
We then use that speaker on iOS for all audio of that page.
We add special support for the receiver speaker since this is handled by category option.

In addition, AVAudioSessionCaptureDeviceManager will be the place to set the preferred speaker.
In GPU process, the various players will all go to the AudioSessionProxy to give their preferred speaker.
The speaker will be used when the AudioSessionProxy gets activated.
This allows several pages to use different speakers without interferring with each other as long as they are not playing audio at the same time.

* Source/WebCore/platform/audio/ios/AudioSessionIOS.h:
* Source/WebCore/platform/audio/ios/AudioSessionIOS.mm:
(WebCore::AudioSessionIOS::setCategory):
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.h:
(WebCore::AudioMediaStreamTrackRendererInternalUnit::setLastDeviceUsed):
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.cpp:
(WebCore::AudioMediaStreamTrackRendererUnit::supportsPerDeviceRendering):
(WebCore::AudioMediaStreamTrackRendererUnit::setLastDeviceUsed):
(WebCore::AudioMediaStreamTrackRendererUnit::ensureDeviceUnit):
(WebCore::AudioMediaStreamTrackRendererUnit::getDeviceUnit):
(WebCore::AudioMediaStreamTrackRendererUnit::addSource):
(WebCore::AudioMediaStreamTrackRendererUnit::removeSource):
(WebCore::AudioMediaStreamTrackRendererUnit::addResetObserver):
(WebCore::AudioMediaStreamTrackRendererUnit::retrieveFormatDescription):
(WebCore::AudioMediaStreamTrackRendererUnit::Unit::setLastDeviceUsed):
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.h:
* Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.cpp:
(WebCore::IncomingAudioMediaStreamTrackRendererUnit::addSource):
(WebCore::IncomingAudioMediaStreamTrackRendererUnit::removeSource):
* Source/WebCore/platform/mediastream/ios/AVAudioSessionCaptureDeviceManager.h:
* Source/WebCore/platform/mediastream/ios/AVAudioSessionCaptureDeviceManager.mm:
(WebCore::AVAudioSessionCaptureDeviceManager::setPreferredMicrophoneID):
(WebCore::AVAudioSessionCaptureDeviceManager::configurePreferredMicrophone):
(WebCore::AVAudioSessionCaptureDeviceManager::setPreferredSpeakerID):
(WebCore::AVAudioSessionCaptureDeviceManager::setPreferredAudioSessionDeviceIDs):
(WebCore::AVAudioSessionCaptureDeviceManager::setPreferredAudioSessionDeviceUID): Deleted.
(WebCore::AVAudioSessionCaptureDeviceManager::configurePreferredAudioCaptureDevice): Deleted.
(WebCore::AVAudioSessionCaptureDeviceManager::setPreferredAudioSessionDeviceUIDInternal): Deleted.
* Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h:
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp:
(WebCore::CoreAudioSharedUnit::captureDeviceChanged):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp:
(WebKit::RemoteAudioSessionProxy::RemoteAudioSessionProxy):
(WebKit::RemoteAudioSessionProxy::setCategory):
(WebKit::RemoteAudioSessionProxy::tryToSetActive):
(WebKit::RemoteAudioSessionProxy::sharedPreferencesForWebProcess const):
(WebKit::RemoteAudioSessionProxy::setPreferredSpeakerID):
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::audioOutputDeviceChanged):
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp:
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManager::setLastDeviceUsed):
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.h:
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.messages.in:
* Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp:
(WebKit::AudioMediaStreamTrackRendererInternalUnitManagerProxy::setLastDeviceUsed):

Canonical link: <a href="https://commits.webkit.org/288010@main">https://commits.webkit.org/288010@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4be68db760dc957bc7ea5e1a10009a0468e33251

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81673 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1198 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35622 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86213 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32663 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83779 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1229 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9017 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63713 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21439 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84743 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/879 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74322 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44005 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/778 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28499 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31118 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29097 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87652 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8910 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72054 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9093 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70147 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71289 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17749 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15365 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14280 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8862 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/14399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8702 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12223 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10511 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->