### PR TITLE
[ iOS18 ] 3x TestWebKitAPI.WebKit.ScrollTo* (api-tests) are constant timeouts

### DIFF
--- a/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
+++ b/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
@@ -255,6 +255,7 @@ typedef NS_ENUM(NSInteger, UIWKGestureType) {
 @end
 
 @interface UIScreen ()
+- (BOOL)_isEmbeddedScreen;
 @property (nonatomic, readonly) CGRect _referenceBounds;
 @end
 


### PR DESCRIPTION
#### 586aa00275b46a60eca5c692d81de42e51882171
<pre>
[ iOS18 ] 3x TestWebKitAPI.WebKit.ScrollTo* (api-tests) are constant timeouts
<a href="https://bugs.webkit.org/show_bug.cgi?id=284410">https://bugs.webkit.org/show_bug.cgi?id=284410</a>
<a href="https://rdar.apple.com/141248187">rdar://141248187</a>

Reviewed by Wenson Hsieh.

Since TestWebKitAPI is not a real `UIApplication`, UIKit gets into a state
where its own update cycle is enabled (which is not runtime configurable), but
not started (which is done in `UIApplicationMain()`).

This means that `UIAnimation`-driven animations (like scroll view animations)
will never reach completion, and `scrollViewDidEndScrollingAnimation:` will
never be called.

Fix by leveraging the fact that UIKit&apos;s update cycle is not used for
`UIAnimation`s if `-[UIScreen _isEmbeddedScreen]` is false. This will result in
UIKit using a `CADisplayLink` to drive animations, and ensures completion is
reached without needing to be a `UIApplication`.

* Tools/TestRunnerShared/spi/UIKitSPIForTesting.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPage.mm:
(swizzledIsEmbeddedScreen):
(-[TestScrollViewDelegate init]):

Swizzle out `-[UIScreen _isEmbeddedScreen]` to force UIKit to use a
`CADisplayLink` to drive animations.

(TEST(WebKit, ScrollToFoundRangeWithExistingSelection)):
(TEST(WebKit, ScrollToFoundRangeDoesNotFocusElement)):
(TEST(WebKit, ScrollToFoundRangeRepeated)):

Canonical link: <a href="https://commits.webkit.org/287822@main">https://commits.webkit.org/287822@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4cc616cca591f975ddd56169a7a0714a45645144

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80921 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/443 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34857 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85449 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31910 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83032 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/461 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8244 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63195 "Found 1 new test failure: media/modern-media-controls/css/transformed-media-crash.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20967 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83990 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/251 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73651 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43493 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/146 "Build was cancelled. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27811 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30363 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71719 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28350 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86883 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8148 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5763 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71496 "Found 40 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-update-001.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-update-005.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-update-006.html imported/w3c/web-platform-tests/css/css-backgrounds/background-attachment-local/attachment-local-positioning-5.html imported/w3c/web-platform-tests/css/css-backgrounds/background-color-body-propagation-006.html imported/w3c/web-platform-tests/css/css-backgrounds/background-color-root-propagation-002.html imported/w3c/web-platform-tests/css/css-images/object-fit-contain-png-002i.html imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-descendant-text-mutated-001.html imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-position-under-left-001.xht imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-position-under-right-001.xht ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8325 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69487 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70729 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14759 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13690 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12560 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8110 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7949 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11468 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9755 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->