### PR TITLE
[ResourceMonitor] Add support of monitoring for iframes created by script.

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -11139,20 +11139,29 @@ void Document::securityOriginDidChange()
 
 #if ENABLE(CONTENT_EXTENSIONS)
 
-ResourceMonitor* Document::resourceMonitor()
+ResourceMonitor* Document::resourceMonitorIfExists()
 {
     return m_resourceMonitor.get();
 }
 
-void Document::setResourceMonitor(RefPtr<ResourceMonitor>&& resourceMonitor)
+ResourceMonitor& Document::resourceMonitor()
 {
-    m_resourceMonitor = WTFMove(resourceMonitor);
+    ASSERT(!frame()->isMainFrame());
+
+    if (!m_resourceMonitor)
+        m_resourceMonitor = ResourceMonitor::create(*frame());
+    return *m_resourceMonitor.get();
 }
 
-ResourceMonitor* Document::parentResourceMonitor()
+Ref<ResourceMonitor> Document::protectedResourceMonitor()
+{
+    return resourceMonitor();
+}
+
+ResourceMonitor* Document::parentResourceMonitorIfExists()
 {
     if (RefPtr parent = parentDocument())
-        return parent->resourceMonitor();
+        return parent->resourceMonitorIfExists();
 
     return nullptr;
 }

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1976,9 +1976,10 @@ public:
     unsigned unloadCounter() const { return m_unloadCounter; }
 
 #if ENABLE(CONTENT_EXTENSIONS)
-    ResourceMonitor* resourceMonitor();
-    void setResourceMonitor(RefPtr<ResourceMonitor>&&);
-    ResourceMonitor* parentResourceMonitor();
+    ResourceMonitor* resourceMonitorIfExists();
+    ResourceMonitor& resourceMonitor();
+    Ref<ResourceMonitor> protectedResourceMonitor();
+    ResourceMonitor* parentResourceMonitorIfExists();
 #endif
 
 protected:

--- a/Source/WebCore/html/HTMLIFrameElement.cpp
+++ b/Source/WebCore/html/HTMLIFrameElement.cpp
@@ -55,6 +55,11 @@ inline HTMLIFrameElement::HTMLIFrameElement(const QualifiedName& tagName, Docume
     : HTMLFrameElementBase(tagName, document)
 {
     ASSERT(hasTagName(iframeTag));
+
+#if ENABLE(CONTENT_EXTENSIONS)
+    if (document.settings().iFrameResourceMonitoringEnabled())
+        setInitiatorSourceURL(document.currentSourceURL());
+#endif
 }
 
 HTMLIFrameElement::~HTMLIFrameElement() = default;

--- a/Source/WebCore/html/HTMLIFrameElement.h
+++ b/Source/WebCore/html/HTMLIFrameElement.h
@@ -61,6 +61,11 @@ public:
     void setIFrameFullscreenFlag(bool value) { m_IFrameFullscreenFlag = value; }
 #endif
 
+#if ENABLE(CONTENT_EXTENSIONS)
+    const URL& initiatorSourceURL() const { return m_initiatorSourceURL; }
+    void setInitiatorSourceURL(URL&& url) { m_initiatorSourceURL = WTFMove(url); }
+#endif
+
 private:
     HTMLIFrameElement(const QualifiedName&, Document&);
 
@@ -83,6 +88,9 @@ private:
     bool m_IFrameFullscreenFlag { false };
 #endif
     std::unique_ptr<LazyLoadFrameObserver> m_lazyLoadFrameObserver;
+#if ENABLE(CONTENT_EXTENSIONS)
+    URL m_initiatorSourceURL;
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -1290,8 +1290,12 @@ void DocumentLoader::commitData(const SharedBuffer& data)
         ASSERT(frame);
 
 #if ENABLE(CONTENT_EXTENSIONS)
-        if (shouldEnableResourceMonitor(*frame))
-            document.setResourceMonitor(ResourceMonitor::create(*frame, documentURL()));
+        if (shouldEnableResourceMonitor(*frame)) {
+            URL url = documentURL();
+
+            if (!url.isEmpty() && url.protocolIsInHTTPFamily())
+                document.protectedResourceMonitor()->setDocumentURL(WTFMove(url));
+        }
 #endif
 
         if (SecurityPolicy::allowSubstituteDataAccessToLocal() && m_originalSubstituteDataWasValid) {

--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -610,7 +610,7 @@ void ResourceLoader::didReceiveResponse(const ResourceResponse& r, CompletionHan
         protectedFrameLoader()->notifier().didReceiveResponse(this, m_response);
 
 #if ENABLE(CONTENT_EXTENSIONS)
-    if (RefPtr monitor = resourceMonitor())
+    if (RefPtr monitor = resourceMonitorIfExists())
         monitor->didReceiveResponse(m_response.url(), m_resourceType);
 #endif
 }
@@ -641,7 +641,7 @@ void ResourceLoader::didReceiveBuffer(const FragmentedSharedBuffer& buffer, long
         protectedFrameLoader()->notifier().didReceiveData(this, buffer.makeContiguous(), static_cast<int>(encodedDataLength));
 
 #if ENABLE(CONTENT_EXTENSIONS)
-    if (RefPtr monitor = resourceMonitor())
+    if (RefPtr monitor = resourceMonitorIfExists())
         monitor->addNetworkUsage(encodedDataLength > 0 ? static_cast<size_t>(encodedDataLength) : buffer.size());
 #endif
 }
@@ -964,10 +964,10 @@ RefPtr<LocalFrame> ResourceLoader::protectedFrame() const
 }
 
 #if ENABLE(CONTENT_EXTENSIONS)
-ResourceMonitor* ResourceLoader::resourceMonitor()
+ResourceMonitor* ResourceLoader::resourceMonitorIfExists()
 {
     if (RefPtr document = m_frame ? m_frame->document() : nullptr)
-        return document->resourceMonitor();
+        return document->resourceMonitorIfExists();
     return nullptr;
 }
 #endif

--- a/Source/WebCore/loader/ResourceLoader.h
+++ b/Source/WebCore/loader/ResourceLoader.h
@@ -232,7 +232,7 @@ private:
 #endif
 
 #if ENABLE(CONTENT_EXTENSIONS)
-    ResourceMonitor* resourceMonitor();
+    ResourceMonitor* resourceMonitorIfExists();
 #endif
 
 #if USE(SOUP)

--- a/Source/WebCore/loader/ResourceMonitor.h
+++ b/Source/WebCore/loader/ResourceMonitor.h
@@ -38,20 +38,21 @@ class ResourceMonitor final : public RefCountedAndCanMakeWeakPtr<ResourceMonitor
 public:
     enum class Eligibility : uint8_t { Unsure, NotEligible, Eligible };
 
-    static RefPtr<ResourceMonitor> create(LocalFrame&, URL&&);
+    static Ref<ResourceMonitor> create(LocalFrame&);
 
     Eligibility eligibility() const { return m_eligibility; }
     void setEligibility(Eligibility);
 
+    void setDocumentURL(URL&&);
     void didReceiveResponse(const URL&, OptionSet<ContentExtensions::ResourceType>);
     void addNetworkUsage(size_t);
 
 private:
-    explicit ResourceMonitor(LocalFrame&, URL&&);
+    explicit ResourceMonitor(LocalFrame&);
 
     void checkNetworkUsageExcessIfNecessary();
     Ref<LocalFrame> protectedFrame() const;
-    ResourceMonitor* parentResourceMonitor() const;
+    ResourceMonitor* parentResourceMonitorIfExists() const;
 
     WeakRef<LocalFrame> m_frame;
     URL m_frameURL;


### PR DESCRIPTION
#### 8d3bcb122bc19a1aaa1c15fa1d6b2165d771a669
<pre>
[ResourceMonitor] Add support of monitoring for iframes created by script.
<a href="https://bugs.webkit.org/show_bug.cgi?id=284639">https://bugs.webkit.org/show_bug.cgi?id=284639</a>
<a href="https://rdar.apple.com/137691088">rdar://137691088</a>

Reviewed by Ben Nham.

If the iframe is created runtime, the script URL that creates the element is also the
target of checking the eligibility.

This patch add support for this case by checking the stack trace when iframe is created
and keep the URL of the known source in HTMLIFrameElement object. Then when document of
the frame is created, ResourceMonitor is also checks those URL.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::resourceMonitorIfExists):
(WebCore::Document::resourceMonitor):
(WebCore::Document::protectedResourceMonitor):
(WebCore::Document::parentResourceMonitorIfExists):
(WebCore::Document::setResourceMonitor): Deleted.
(WebCore::Document::parentResourceMonitor): Deleted.
* Source/WebCore/dom/Document.h:
* Source/WebCore/html/HTMLIFrameElement.cpp:
(WebCore::HTMLIFrameElement::HTMLIFrameElement):
* Source/WebCore/html/HTMLIFrameElement.h:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::commitData):
* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::didReceiveResponse):
(WebCore::ResourceLoader::didReceiveBuffer):
(WebCore::ResourceLoader::resourceMonitorIfExists):
(WebCore::ResourceLoader::resourceMonitor): Deleted.
* Source/WebCore/loader/ResourceLoader.h:
* Source/WebCore/loader/ResourceMonitor.cpp:
(WebCore::ResourceMonitor::create):
(WebCore::ResourceMonitor::ResourceMonitor):
(WebCore::ResourceMonitor::setEligibility):
(WebCore::ResourceMonitor::setDocumentURL):
(WebCore::ResourceMonitor::addNetworkUsage):
(WebCore::ResourceMonitor::checkNetworkUsageExcessIfNecessary):
(WebCore::ResourceMonitor::parentResourceMonitorIfExists const):
(WebCore::ResourceMonitor::parentResourceMonitor const): Deleted.
* Source/WebCore/loader/ResourceMonitor.h:

Canonical link: <a href="https://commits.webkit.org/287897@main">https://commits.webkit.org/287897@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0625c9ed9f77cdfd50376455a1ec902f97adb7c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81047 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/572 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34990 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85576 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32033 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83157 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/590 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8384 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63266 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21030 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84116 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/350 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73766 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43564 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/247 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27927 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30491 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71792 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28480 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87011 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8277 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5852 "Found 2 new test failures: http/tests/webgpu/webgpu/api/validation/queue/destroyed/query_set.html storage/indexeddb/modern/workers-enable.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71569 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8454 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69601 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70805 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17672 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14848 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13774 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8238 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13761 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8075 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11595 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9883 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->