### PR TITLE
Unreviewed, reverting 287764@main (21002ccbaf1f), 287744@main (61eddb55b6d2), and 287716@main (501409200944)

### DIFF
--- a/Tools/Scripts/webkitpy/xcode/simulated_device.py
+++ b/Tools/Scripts/webkitpy/xcode/simulated_device.py
@@ -28,8 +28,6 @@ import pathlib
 import re
 import time
 
-from typing import List
-
 from webkitcorepy import Version, Timeout
 
 from webkitpy.common.memoized import memoized
@@ -59,26 +57,15 @@ class DeviceRequest(object):
 
 class SimulatedDeviceManager(object):
     class Runtime(object):
-        def __init__(self, runtime_dict: dict):
-            self.root: str = runtime_dict['runtimeRoot']
-            self.bundle_path: str = runtime_dict['bundlePath']
-            self.build_version: str = runtime_dict['buildversion']
-            self.os_variant: str = runtime_dict['name'].split(' ')[0]  # webkitpy doesn't know what xrOS is, so we can't use runtime_dict['platform'] here
-            self.version: str = Version.from_string(runtime_dict['version'])
-            self.identifier: str = runtime_dict['identifier']
-            self.name: str = runtime_dict['name']
-            self.has_rebuilt_cache: bool = False
+        def __init__(self, runtime_dict):
+            self.root = runtime_dict['runtimeRoot']
+            self.build_version = runtime_dict['buildversion']
+            self.os_variant = runtime_dict['name'].split(' ')[0]
+            self.version = Version.from_string(runtime_dict['version'])
+            self.identifier = runtime_dict['identifier']
+            self.name = runtime_dict['name']
 
-        def rebuild_dyld_shared_cache(self, host):
-            host = host or SystemHost.get_default()
-            if not self.has_rebuilt_cache:
-                _log.debug(f'Rebuilding dyld cache for {self.name} ({self.build_version}) simulator runtime...')
-                host.executive.run_command([
-                    SimulatedDeviceManager.xcrun, 'simctl', 'legacyruntime', 'update_dyld_shared_cache', self.bundle_path
-                ])
-                self.has_rebuilt_cache = True
-
-    AVAILABLE_RUNTIMES: List[Runtime] = []
+    AVAILABLE_RUNTIMES = []
     AVAILABLE_DEVICES = []
     INITIALIZED_DEVICES = None
 
@@ -485,16 +472,6 @@ class SimulatedDeviceManager(object):
 
         if len(requests):
             _log.debug(f'Running{"/specified" if udids else ""} simulators did not satisfy request. Finding matching non-booted ones, and/or creating new ones to satisfy the request.')
-
-            # New simulators will load all system frameworks into memory if the dyld shared cache doesn't exist.
-            # To avoid the immense strain this causes on the host's memory usage, we rebuild the cache here.
-            if len(SimulatedDeviceManager.INITIALIZED_DEVICES) == 0:
-                platforms_requested = []
-                for request in requests:
-                    platforms_requested.append(request.device_type.software_variant)
-                for runtime in SimulatedDeviceManager.AVAILABLE_RUNTIMES:
-                    if runtime.os_variant in platforms_requested:
-                        runtime.rebuild_dyld_shared_cache(host)
 
         # Check for any other matching simulators that can satisfy the request.
         # If none are found, we create and boot new ones.

--- a/Tools/Scripts/webkitpy/xcode/simulated_device_unittest.py
+++ b/Tools/Scripts/webkitpy/xcode/simulated_device_unittest.py
@@ -164,51 +164,41 @@ simctl_json_output = """{
  ],
  "runtimes" : [
    {
-     "runtimeRoot" : "/path/to/bundle.simruntime/path/to/RuntimeRoot",
-     "bundlePath" : "/path/to/bundle.simruntime",
+     "runtimeRoot" : "/path/to/RuntimeRoot",
      "buildversion" : "13E233",
      "availability" : "(available)",
-     "platform" : "iOS",
      "name" : "iOS 9.3",
      "identifier" : "com.apple.CoreSimulator.SimRuntime.iOS-9-3",
      "version" : "9.3"
    },
    {
-     "runtimeRoot" : "/path/to/bundle.simruntime/path/to/RuntimeRoot",
-     "bundlePath" : "/path/to/bundle.simruntime",
+     "runtimeRoot" : "/path/to/RuntimeRoot",
      "buildversion" : "15A8401",
      "availability" : "(available)",
-     "platform" : "iOS",
      "name" : "iOS 11.0",
      "identifier" : "com.apple.CoreSimulator.SimRuntime.iOS-11-0",
      "version" : "11.0.1"
    },
    {
-     "runtimeRoot" : "/path/to/bundle.simruntime/path/to/RuntimeRoot",
-     "bundlePath" : "/path/to/bundle.simruntime",
+     "runtimeRoot" : "/path/to/RuntimeRoot",
      "buildversion" : "15J380",
      "availability" : "(available)",
-     "platform" : "tvOS",
      "name" : "tvOS 11.0",
      "identifier" : "com.apple.CoreSimulator.SimRuntime.tvOS-11-0",
      "version" : "11.0"
    },
    {
-     "runtimeRoot" : "/path/to/bundle.simruntime/path/to/RuntimeRoot",
-     "bundlePath" : "/path/to/bundle.simruntime",
+     "runtimeRoot" : "/path/to/RuntimeRoot",
      "buildversion" : "15R372",
      "availability" : "(available)",
-     "platform" : "watchOS",
      "name" : "watchOS 4.0",
      "identifier" : "com.apple.CoreSimulator.SimRuntime.watchOS-4-0",
      "version" : "4.0"
    },
    {
-     "runtimeRoot" : "/path/to/bundle.simruntime/path/to/RuntimeRoot",
-     "bundlePath" : "/path/to/bundle.simruntime",
+     "runtimeRoot" : "/path/to/RuntimeRoot",
      "buildversion" : "16A367",
      "isAvailable" : "YES",
-     "platform" : "iOS",
      "name" : "iOS 12.0",
      "identifier" : "com.apple.CoreSimulator.SimRuntime.iOS-12-0",
      "version" : "12.0"


### PR DESCRIPTION
#### 62136b2711034efc8c8caa007332c3bd9416a589
<pre>
Unreviewed, reverting 287764@main (21002ccbaf1f), 287744@main (61eddb55b6d2), and 287716@main (501409200944)
<a href="https://bugs.webkit.org/show_bug.cgi?id=284642">https://bugs.webkit.org/show_bug.cgi?id=284642</a>
<a href="https://rdar.apple.com/141446200">rdar://141446200</a>

[webkitpy] Remove dyld shared cache rebuild in SimulatedDeviceManager.initialize_devices.

Reverted changes:

    [webkitpy] Only rebuild dyld cache for requested platform(s) in SimulatedDeviceManager.initialize_devices.
    <a href="https://bugs.webkit.org/show_bug.cgi?id=284576">https://bugs.webkit.org/show_bug.cgi?id=284576</a>
    <a href="https://rdar.apple.com/141393593">rdar://141393593</a>
    287764@main (21002ccbaf1f)

    REGRESSION (287716@main): [visionOS] Test runs exiting on EWS/post-commit with exceptions.
    <a href="https://bugs.webkit.org/show_bug.cgi?id=284555">https://bugs.webkit.org/show_bug.cgi?id=284555</a>
    <a href="https://rdar.apple.com/141360856">rdar://141360856</a>
    287744@main (61eddb55b6d2)

    [webkitpy] SimulatedDeviceManager.initialize_devices should rebuild the dyld shared cache before booting simulators with none already booted.
    <a href="https://bugs.webkit.org/show_bug.cgi?id=284494">https://bugs.webkit.org/show_bug.cgi?id=284494</a>
    <a href="https://rdar.apple.com/141316056">rdar://141316056</a>
    287716@main (501409200944)

Canonical link: <a href="https://commits.webkit.org/287800@main">https://commits.webkit.org/287800@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d058935a58a14d2ae57c2965cf0f0a8e926f0b27

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80915 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34851 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/85443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/31899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83026 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8238 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/85443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/31899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83984 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/73643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/85443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/80373 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/27803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/30357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/28342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/86877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/8142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/86877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/8319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/69479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/86877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/13679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12541 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8104 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/7943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/11462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/9749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->