### PR TITLE
getUserMedia video track getSettings() returns stale value for torch and whiteBalanceMode constraints

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
@@ -201,6 +201,7 @@ private:
     uint64_t m_framesCount { 0 };
     uint64_t m_lastFramesCount { 0 };
     int64_t m_defaultTorchMode { 0 };
+    OptionSet<RealtimeMediaSourceSettings::Flag> m_pendingSettingsChanges;
     bool m_useSensorAndDeviceOrientation { true };
 };
 


### PR DESCRIPTION
#### 46a4e69cafac4513de5b44023e0e9084f15c5c14
<pre>
getUserMedia video track getSettings() returns stale value for torch and whiteBalanceMode constraints
<a href="https://bugs.webkit.org/show_bug.cgi?id=280970">https://bugs.webkit.org/show_bug.cgi?id=280970</a>
<a href="https://rdar.apple.com/137870391">rdar://137870391</a>

Reviewed by Youenn Fablet.

Torch and whiteBalanceMode changes are applied asynchronously so `track.settings` will
return the incorrect value if read after constraints are applied but before the device
setting is applied. To fix this, we return the most recent value set if track.settings
is requested while an update is pending, and return the actual device settings otherwise.

Tested manually.

* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::settingsDidChange): Set `m_settingsChangesPending` before
calling `scheduleDeferredTask`, clear it after changing device settings.
(WebCore::AVVideoCaptureSource::settings): Return the currently cached value for torch
and/or whiteBalanceMode if a change is pending, return the device setting otherwise.
(WebCore::AVVideoCaptureSource::applyFrameRateAndZoomWithPreset): Set `m_settingsChangesPending`
before calling `scheduleDeferredTask`, clear it after changing device settings.
(WebCore::AVVideoCaptureSource::updateWhiteBalanceMode): Clear m_currentSettings after
changing device settings to force a refresh the next time settings are queried.
(WebCore::AVVideoCaptureSource::updateTorch): Ditto.

Canonical link: <a href="https://commits.webkit.org/287845@main">https://commits.webkit.org/287845@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa5e96f628749973a602dcd8d90eaa9851817f33

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80932 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34868 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85463 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31920 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83043 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/472 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8350 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63202 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20971 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84001 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/269 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73652 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43500 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/155 "Build was cancelled. Recent messages:OS: Sequoia (15.2), Xcode: 16.2") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27812 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30378 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71728 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28351 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86898 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8164 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5825 "Found 60 new test failures: fast/selectors/selection-window-inactive-stroke-color.html http/tests/eventsource/eventsource-reconnect.html http/wpt/opener/parent-access-child-via-windowproxy.html imported/w3c/web-platform-tests/content-security-policy/frame-ancestors/frame-ancestors-none-block.html imported/w3c/web-platform-tests/css/css-contain/contain-layout-020.html imported/w3c/web-platform-tests/css/css-contain/contain-size-scrollbars-001.html imported/w3c/web-platform-tests/css/css-contain/contain-size-scrollbars-002.html imported/w3c/web-platform-tests/css/css-contain/contain-size-scrollbars-003.html imported/w3c/web-platform-tests/css/css-ruby/interlinear-block-margin-box.html imported/w3c/web-platform-tests/css/css-ruby/ruby-reflow-001-opaqueruby.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71503 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8341 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69488 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70737 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17631 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14767 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13691 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8121 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13648 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7962 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11482 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9770 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->