### PR TITLE
[UnifiedPDF] [iOS] Support tap-and-drag and tap-and-half for text selections

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -317,6 +317,7 @@ public:
     virtual void setSelectionRange(WebCore::FloatPoint /* pointInRootView */, WebCore::TextGranularity) { }
     virtual void clearSelection() { }
     virtual SelectionWasFlipped moveSelectionEndpoint(WebCore::FloatPoint /* pointInRootView */, SelectionEndpoint);
+    virtual SelectionEndpoint extendInitialSelection(WebCore::FloatPoint /* pointInRootView */, WebCore::TextGranularity);
 #endif
 
     bool populateEditorStateIfNeeded(EditorState&) const;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -1199,7 +1199,12 @@ SelectionWasFlipped PDFPluginBase::moveSelectionEndpoint(FloatPoint, SelectionEn
     return SelectionWasFlipped::No;
 }
 
-#endif
+SelectionEndpoint PDFPluginBase::extendInitialSelection(FloatPoint pointInRootView, TextGranularity)
+{
+    return SelectionEndpoint::Start;
+}
+
+#endif // PLATFORM(IOS_FAMILY)
 
 #if !LOG_DISABLED
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -581,10 +581,17 @@ private:
     void setSelectionRange(WebCore::FloatPoint pointInRootView, WebCore::TextGranularity) final;
     void clearSelection() final;
     SelectionWasFlipped moveSelectionEndpoint(WebCore::FloatPoint pointInRootView, SelectionEndpoint) final;
+    SelectionEndpoint extendInitialSelection(WebCore::FloatPoint pointInRootView, WebCore::TextGranularity) final;
     bool platformPopulateEditorStateIfNeeded(EditorState&) const final;
 
-    static std::optional<PageAndPoint> selectionCaretPointInPage(PDFSelection *, SelectionEndpoint);
-    std::optional<PageAndPoint> selectionCaretPointInPage(SelectionEndpoint) const;
+#if HAVE(PDFDOCUMENT_SELECTION_WITH_GRANULARITY)
+    PDFSelection *selectionAtPoint(WebCore::FloatPoint pointInPage, PDFPage *, WebCore::TextGranularity) const;
+    PDFSelection *selectionBetweenPoints(WebCore::FloatPoint fromPoint, PDFPage *fromPage, WebCore::FloatPoint toPoint, PDFPage *toPage) const;
+#endif
+
+    static PageAndPoint selectionCaretPointInPage(PDFSelection *, SelectionEndpoint);
+    PageAndPoint selectionCaretPointInPage(SelectionEndpoint) const;
+    void resetInitialSelection();
 #endif // PLATFORM(IOS_FAMILY)
 
     RefPtr<PDFPresentationController> m_presentationController;
@@ -644,6 +651,11 @@ private:
 
 #if ENABLE(UNIFIED_PDF_DATA_DETECTION)
     std::unique_ptr<PDFDataDetectorOverlayController> m_dataDetectorOverlayController;
+#endif
+
+#if PLATFORM(IOS_FAMILY)
+    RetainPtr<PDFSelection> m_initialSelection;
+    PageAndPoint m_initialSelectionStart;
 #endif
 
     RefPtr<WebCore::ShadowRoot> m_shadowRoot;

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -1121,9 +1121,14 @@ void PluginView::setSelectionRange(FloatPoint pointInRootView, TextGranularity g
     protectedPlugin()->setSelectionRange(pointInRootView, granularity);
 }
 
-SelectionWasFlipped PluginView::moveSelectionEndpoint(WebCore::FloatPoint pointInRootView, SelectionEndpoint endpoint)
+SelectionWasFlipped PluginView::moveSelectionEndpoint(FloatPoint pointInRootView, SelectionEndpoint endpoint)
 {
     return protectedPlugin()->moveSelectionEndpoint(pointInRootView, endpoint);
+}
+
+SelectionEndpoint PluginView::extendInitialSelection(FloatPoint pointInRootView, TextGranularity granularity)
+{
+    return protectedPlugin()->extendInitialSelection(pointInRootView, granularity);
 }
 
 void PluginView::clearSelection()

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -99,6 +99,7 @@ public:
     void setSelectionRange(WebCore::FloatPoint pointInRootView, WebCore::TextGranularity);
     void clearSelection();
     SelectionWasFlipped moveSelectionEndpoint(WebCore::FloatPoint pointInRootView, SelectionEndpoint);
+    SelectionEndpoint extendInitialSelection(WebCore::FloatPoint pointInRootView, WebCore::TextGranularity);
 #endif
 
     bool populateEditorStateIfNeeded(EditorState&) const;

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -2682,6 +2682,13 @@ void WebPage::updateSelectionWithExtentPointAndBoundary(const WebCore::IntPoint&
     if (!frame)
         return callback(false);
 
+#if ENABLE(PDF_PLUGIN)
+    if (RefPtr pluginView = pluginViewForFrame(frame.get())) {
+        auto movedEndpoint = pluginView->extendInitialSelection(point, granularity);
+        return callback(movedEndpoint == SelectionEndpoint::End);
+    }
+#endif
+
     auto position = visiblePositionInFocusedNodeForPoint(*frame, point, isInteractingWithFocusedElement);
     auto newRange = rangeForGranularityAtPoint(*frame, point, granularity, isInteractingWithFocusedElement);
     


### PR DESCRIPTION
#### 70f0749b52792ef31ff7de092be021912fce330e
<pre>
[UnifiedPDF] [iOS] Support tap-and-drag and tap-and-half for text selections
<a href="https://bugs.webkit.org/show_bug.cgi?id=284641">https://bugs.webkit.org/show_bug.cgi?id=284641</a>
<a href="https://rdar.apple.com/141324790">rdar://141324790</a>

Reviewed by Abrar Rahman Protyasha.

Add support for additional text interaction gestures when selecting text on iOS with unified PDF
enabled: tap-and-a-half, and tap-and-drag. See below for more details.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::extendInitialSelection):

Add more plumbing through `PluginView` → `PDFPluginBase` → `UnifiedPDFPlugin` to handle this new
selection extent update.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::areVisuallyDistinct):
(WebKit::UnifiedPDFPlugin::clearSelection):
(WebKit::UnifiedPDFPlugin::setSelectionRange):

Teach `UnifiedPDFPlugin` to keep track of the initial selection when using `setSelectionRange` to
select text, so that we can use it in `extendInitialSelection` for these new text interactions.

(WebKit::isEmpty):
(WebKit::UnifiedPDFPlugin::moveSelectionEndpoint):

Adopt the new `selectionBetweenPoints` helper below.

(WebKit::UnifiedPDFPlugin::resetInitialSelection):

Reset the initial selection, along with the initial selection start info.

(WebKit::UnifiedPDFPlugin::selectionBetweenPoints const):

Add a new helper method to obtain a selection at the given point relative to the given page&apos;s
coordinate space, with the given granularity.

(WebKit::UnifiedPDFPlugin::selectionAtPoint const):

Add a new helper method to obtain a selection between two points in the document (at character
granularity).

(WebKit::UnifiedPDFPlugin::extendInitialSelection):

Add support for extending the selection to the given point here. This method works by:

1.  Mapping the given point in root view coordinates to a point in a PDF page.

2.  Getting the PDF selection (with the given granularity) at that point.

3.  Expanding and canonicalizing the selection from (2) to include the initial selection range as
    well (note that this does not include any text in between).

4.  Setting the current selection to a new selection that encompasses all selectable text in between
    the extent point, and the initial selection.

5.  Returning the selection endpoint that moved as a result of running the above steps (by checking
    whether or not the start position has changed).

(WebKit::UnifiedPDFPlugin::selectionCaretPointInPage):
(WebKit::UnifiedPDFPlugin::selectionCaretPointInPage const):

Drive-by refactoring: adjust these helpers to just return a `PageAndPoint` rather than
`optional&lt;PageAndPoint&gt;`. In the case where the result is invalid, the page is `nil` anyways, and
all call sites check for this; as such, the optional wrapping is unnecessary, and makes the code
slightly more difficult to read because the call site can&apos;t directly use destructuring assignment.

* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::moveSelectionEndpoint):
(WebKit::PluginView::extendInitialSelection):

Plumb over to the PDF plugin.

* Source/WebKit/WebProcess/Plugins/PluginView.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::updateSelectionWithExtentPointAndBoundary):

Defer to the PDF plugin if needed (see above).

Canonical link: <a href="https://commits.webkit.org/287816@main">https://commits.webkit.org/287816@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db4b17715f7ad28e5c215d3977b7e01e38c7caaf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80949 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/474 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34892 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/85478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/31935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8274 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/85478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/31935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84018 "Passed tests") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73680 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/85478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30393 "Built successfully") | 
| | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28386 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86913 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8179 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/71510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8356 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69512 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70744 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17609 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14773 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/13708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8140 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/13663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7977 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11497 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9785 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->