### PR TITLE
UnifiedPDF: Page previews are rendered with incorrect scale

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm
@@ -292,7 +292,7 @@ void AsyncPDFRenderer::coverageRectDidChange(TiledBacking& tiledBacking, const F
 
     auto pageCoverage = presentationController->pageCoverageForContentsRect(coverageRect, layoutRow);
 
-    auto pagePreviewScale = presentationController->graphicsLayerClient().customContentsScale(layer.get()).value_or(1);
+    auto pagePreviewScale = presentationController->scaleForPagePreviews();
 
     for (auto& pageInfo : pageCoverage) {
         if (m_pagePreviews.contains(pageInfo.pageIndex))
@@ -721,8 +721,7 @@ void AsyncPDFRenderer::paintPagePreview(GraphicsContext& context, const FloatRec
     Ref image = *preview.image;
     auto imageRect = pageBoundsInPaintingCoordinates;
     imageRect.scale(preview.scale);
-    // FIXME: Cannot use CompositeOperator::Copy because the scale is incorrect.
-    context.drawNativeImage(image, pageBoundsInPaintingCoordinates, imageRect);
+    context.drawNativeImage(image, pageBoundsInPaintingCoordinates, imageRect, { CompositeOperator::Copy });
 }
 
 void AsyncPDFRenderer::invalidateTilesForPaintingRect(float pageScaleFactor, const FloatRect& paintingRect)
@@ -785,7 +784,7 @@ void AsyncPDFRenderer::pdfContentChangedInRect(const GraphicsLayer* layer, const
         enqueueTileRenderIfNecessary(tileInfo, renderInfoForTile(*tiledBacking, tileInfo, tileRect, renderRect, WTFMove(background)));
     }
 
-    auto pagePreviewScale = presentationController->graphicsLayerClient().customContentsScale(layer).value_or(1);
+    auto pagePreviewScale = presentationController->scaleForPagePreviews();
     for (auto& pageInfo : pageCoverage)
         generatePreviewImageForPage(pageInfo.pageIndex, pagePreviewScale);
 }

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm
@@ -1451,7 +1451,7 @@ std::optional<float> PDFDiscretePresentationController::customContentsScale(cons
         return { };
 
     if (rowData->isPageBackgroundLayer(layer))
-        return m_plugin->scaleForPagePreviews();
+        return scaleForPagePreviews();
 
     return { };
 }

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h
@@ -120,6 +120,7 @@ public:
 
     virtual std::optional<WebCore::PlatformLayerIdentifier> contentsLayerIdentifier() const { return std::nullopt; }
 
+    float scaleForPagePreviews() const;
 protected:
     RefPtr<WebCore::GraphicsLayer> createGraphicsLayer(const String&, WebCore::GraphicsLayer::Type);
     RefPtr<WebCore::GraphicsLayer> makePageContainerLayer(PDFDocumentLayout::PageIndex);

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm
@@ -168,6 +168,11 @@ bool PDFPresentationController::pluginShouldCachePagePreviews() const
     return m_plugin->shouldCachePagePreviews();
 }
 
+float PDFPresentationController::scaleForPagePreviews() const
+{
+    return m_plugin->scaleForPagePreviews();
+}
+
 PDFDocumentLayout::PageIndex PDFPresentationController::nearestPageIndexForDocumentPoint(const FloatPoint& point) const
 {
     if (m_plugin->isLocked())

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
@@ -413,7 +413,7 @@ float PDFScrollingPresentationController::deviceScaleFactor() const
 std::optional<float> PDFScrollingPresentationController::customContentsScale(const GraphicsLayer* layer) const
 {
     if (pageIndexForPageBackgroundLayer(layer))
-        return m_plugin->scaleForPagePreviews();
+        return scaleForPagePreviews();
 
     return { };
 }


### PR DESCRIPTION
#### ac461272a92e0d61c043918dfb3fc3378fd0d788
<pre>
UnifiedPDF: Page previews are rendered with incorrect scale
<a href="https://bugs.webkit.org/show_bug.cgi?id=284616">https://bugs.webkit.org/show_bug.cgi?id=284616</a>
<a href="https://rdar.apple.com/141424286">rdar://141424286</a>

Reviewed by Simon Fraser and Abrar Rahman Protyasha.

The cached page previews bitmaps would be rendered with scale 1,
even thougdh the preview layers have content scale of
0.5 * deviceScale * document layout scale.
The code tried to use the custom scale of the graphics layer, but
AsyncPDFRenderer receives invalidation calls with contents layer as the
GraphicsLayer parameter, and asking custom scale from that is
meaningless. The background layer is the one that responds to
the custom scale query.

Fix by resolving the page preview scale by asking from the presentation
controller. Conceptually the AsyncPDFRenderer is oblivious of page
preview layers at the moment. All page preview communication goes via
the presenation controller, and thus it&apos;s at the moment consistent to
ask the preview scale from the controller too.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm:
(WebKit::AsyncPDFRenderer::coverageRectDidChange):
(WebKit::AsyncPDFRenderer::paintPagePreview):
(WebKit::AsyncPDFRenderer::pdfContentChangedInRect):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm:
(WebKit::PDFDiscretePresentationController::customContentsScale const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm:
(WebKit::PDFPresentationController::scaleForPagePreviews const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm:
(WebKit::PDFScrollingPresentationController::customContentsScale const):

Canonical link: <a href="https://commits.webkit.org/287937@main">https://commits.webkit.org/287937@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4ca527bd84b2241512e3b5f9ff7018422f2a4d1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80939 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/467 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34875 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85470 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31927 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/479 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8262 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63207 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20976 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84008 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43505 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30385 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28377 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86905 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8171 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5777 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71507 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8348 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69501 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70741 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17694 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14770 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8128 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13655 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7969 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11489 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9777 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->