### PR TITLE
AX: Accessing AXIsolatedTree::rootNode() should not require taking a lock

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -1050,7 +1050,6 @@ RefPtr<AXIsolatedTree> AXObjectCache::getOrCreateIsolatedTree()
             m_buildIsolatedTreeTimer.startOneShot(0_s);
     } else
         tree = AXIsolatedTree::create(*this);
-    setIsolatedTreeRoot(tree->rootNode().get());
 
     initializeAXThreadIfNeeded();
 
@@ -1065,8 +1064,6 @@ void AXObjectCache::buildIsolatedTree()
         return;
 
     auto tree = AXIsolatedTree::create(*this);
-    setIsolatedTreeRoot(tree->rootNode().get());
-
     if (RefPtr webArea = rootWebArea()) {
         postPlatformNotification(*webArea, AXNotification::LoadComplete);
         postPlatformNotification(*webArea, AXNotification::FocusedUIElementChanged);
@@ -1076,7 +1073,7 @@ void AXObjectCache::buildIsolatedTree()
 AXCoreObject* AXObjectCache::isolatedTreeRootObject()
 {
     if (auto tree = getOrCreateIsolatedTree())
-        return tree->rootNode().get();
+        return tree->rootNode();
 
     // Should not get here, couldn't create the IsolatedTree.
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -736,11 +736,13 @@ void AXIsolatedObject::setSelectedChildren(const AccessibilityChildrenVector& se
 
 bool AXIsolatedObject::isDetachedFromParent()
 {
+    ASSERT(!isMainThread());
+
     if (parent())
         return false;
 
     // Check whether this is the root node, in which case we should return false.
-    if (auto root = tree()->rootNode())
+    if (RefPtr root = tree()->rootNode())
         return root->objectID() != objectID();
     return false;
 }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -362,7 +362,7 @@ public:
     AXObjectCache* axObjectCache() const;
     constexpr AXGeometryManager* geometryManager() const { return m_geometryManager.get(); }
 
-    RefPtr<AXIsolatedObject> rootNode();
+    AXIsolatedObject* rootNode() { return m_rootNode.get(); }
     RefPtr<AXIsolatedObject> rootWebArea();
     std::optional<AXID> focusedNodeID();
     WEBCORE_EXPORT RefPtr<AXIsolatedObject> focusedNode();
@@ -449,11 +449,12 @@ public:
 #endif // ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
     }
 
-    // Both setRootNodeID and setFocusedNodeID are called during the generation
+    // Both setPendingRootNodeLocked and setFocusedNodeID are called during the generation
     // of the IsolatedTree.
     // Focused node updates in AXObjectCache use setFocusNodeID.
-    void setRootNode(AXIsolatedObject*) WTF_REQUIRES_LOCK(m_changeLogLock);
+    void setPendingRootNodeLocked(AXIsolatedObject&) WTF_REQUIRES_LOCK(m_changeLogLock);
     void setFocusedNodeID(std::optional<AXID>);
+    void applyPendingRootNode();
 
     // Relationships between objects.
     std::optional<ListHashSet<AXID>> relatedObjectIDsFor(const AXIsolatedObject&, AXRelationType);
@@ -567,11 +568,12 @@ private:
     // 1-based tree level, 0 = not collecting. Only accessed on the main thread.
     unsigned m_collectingNodeChangesAtTreeLevel { 0 };
 
-    // Only accessed on AX thread requesting data.
+    // Only accessed on AX thread.
     UncheckedKeyHashMap<AXID, Ref<AXIsolatedObject>> m_readerThreadNodeMap;
+    RefPtr<AXIsolatedObject> m_rootNode;
 
     // Written to by main thread under lock, accessed and applied by AX thread.
-    RefPtr<AXIsolatedObject> m_rootNode WTF_GUARDED_BY_LOCK(m_changeLogLock);
+    RefPtr<AXIsolatedObject> m_pendingRootNode WTF_GUARDED_BY_LOCK(m_changeLogLock);
     Vector<NodeChange> m_pendingAppends WTF_GUARDED_BY_LOCK(m_changeLogLock); // Nodes to be added to the tree and platform-wrapped.
     Vector<AXPropertyChange> m_pendingPropertyChanges WTF_GUARDED_BY_LOCK(m_changeLogLock);
     Vector<AXID> m_pendingSubtreeRemovals WTF_GUARDED_BY_LOCK(m_changeLogLock); // Nodes whose subtrees are to be removed from the tree.

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
@@ -192,7 +192,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return [self accessibilityChildren];
     }
 
-    // The follwoing attributes have to be retrieved from the main thread. Return nil for any other attribute.
+    // The following attributes have to be retrieved from the main thread. Return nil for any other attribute.
     if (![attribute isEqualToString:NSAccessibilityParentAttribute]
         && ![attribute isEqualToString:NSAccessibilityWindowAttribute]
         && ![attribute isEqualToString:NSAccessibilityTopLevelUIElementAttribute]


### PR DESCRIPTION
#### 36b6519ff89e17bb7a38224b3f1c8403da54c417
<pre>
AX: Accessing AXIsolatedTree::rootNode() should not require taking a lock
<a href="https://bugs.webkit.org/show_bug.cgi?id=284640">https://bugs.webkit.org/show_bug.cgi?id=284640</a>
<a href="https://rdar.apple.com/141445513">rdar://141445513</a>

Reviewed by Chris Fleizach.

rootNode() is called quite frequently (e.g. from screenRelativePosition(), relativeFrame(), isDetachedFromParent(), and more),
so it&apos;s important that it should be consistently fast to access (i.e. not behind m_changeLogLock).

With this commit, we add AXIsolatedTree::m_pendingRootNode, matching the pattern of other state we sync to the AX thread,
e.g. m_pendingFocusedNodeID and m_focusedNodeID. The expectation then becomes that AXIsolatedTree::m_rootNode is only
ever read and written from the AX thread, except when each AXIsolatedTree is first created before it is registered
via AXIsolatedTree::storeTree, as at that point only the main-thread can access the tree.

This commit also fixes a potential thread-safety issue where AXIsolatedTree::updateRootScreenRelativePosition accessed
the root node on the main-thread after the tree was registed via `AXIsolatedTree::storeTree`.

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::getOrCreateIsolatedTree):
(WebCore::AXObjectCache::buildIsolatedTree):
(WebCore::AXObjectCache::isolatedTreeRootObject):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::isDetachedFromParent):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::createEmptyContent):
(WebCore::AXIsolatedTree::create):
(WebCore::AXIsolatedTree::applyPendingRootNode):
(WebCore::AXIsolatedTree::nodeChangeForObject):
(WebCore::AXIsolatedTree::setPendingRootNodeLocked):
(WebCore::AXIsolatedTree::updateRootScreenRelativePosition):
(WebCore::AXIsolatedTree::applyPendingChanges):
(WebCore::AXIsolatedTree::rootNode): Deleted.
(WebCore::AXIsolatedTree::setRootNode): Deleted.
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
(WebCore::AXIsolatedTree::rootNode):
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm:
(-[WKAccessibilityWebPageObject accessibilityAttributeValue:]):

Canonical link: <a href="https://commits.webkit.org/287828@main">https://commits.webkit.org/287828@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3366ffb9d836ccca9659cfbffa4d8ef9076090b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80936 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/458 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34872 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85467 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31924 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83047 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/476 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8259 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63206 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20975 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84005 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/278 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73670 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43504 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/163 "Build was cancelled. Recent messages:OS: Sequoia (15.2), Xcode: 16.2") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27828 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30382 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71735 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28374 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86902 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8168 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5776 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71506 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8345 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69500 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70740 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17616 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14768 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13700 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8133 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13652 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7966 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11486 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9774 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->