### PR TITLE
Extend PublicSuffix List with convenience method to access URL domain without the public suffix

### DIFF
--- a/Source/WebCore/platform/PublicSuffixStore.cpp
+++ b/Source/WebCore/platform/PublicSuffixStore.cpp
@@ -96,4 +96,32 @@ String PublicSuffixStore::topPrivatelyControlledDomain(StringView host) const
     return result;
 }
 
+String PublicSuffixStore::topPrivatelyControlledDomainWithoutPublicSuffix(StringView host) const
+{
+    auto topPrivatelyControlledDomain = this->topPrivatelyControlledDomain(host);
+    if (topPrivatelyControlledDomain.isEmpty())
+        return { };
+
+    return domainWithoutPublicSuffix(topPrivatelyControlledDomain);
+}
+
+String PublicSuffixStore::domainWithoutPublicSuffix(StringView domain) const
+{
+    if (URL::hostIsIPAddress(domain))
+        return domain.toString();
+
+    size_t separatorPosition;
+    for (unsigned labelStart = 0; (separatorPosition = domain.find('.', labelStart)) != notFound; labelStart = separatorPosition + 1) {
+        auto candidate = domain.substring(separatorPosition + 1);
+        if (isPublicSuffix(candidate)) {
+            if (separatorPosition > 0 && domain.length() > separatorPosition) {
+                auto domainWithoutSuffix = domain.substring(0, separatorPosition);
+                return domainWithoutSuffix.toString();
+            }
+        }
+    }
+
+    return domain.toString();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/platform/PublicSuffixStore.h
+++ b/Source/WebCore/platform/PublicSuffixStore.h
@@ -42,6 +42,8 @@ public:
     WEBCORE_EXPORT PublicSuffix publicSuffix(const URL&) const;
     WEBCORE_EXPORT String topPrivatelyControlledDomain(StringView host) const;
     WEBCORE_EXPORT void clearHostTopPrivatelyControlledDomainCache();
+    WEBCORE_EXPORT String topPrivatelyControlledDomainWithoutPublicSuffix(StringView host) const;
+    WEBCORE_EXPORT String domainWithoutPublicSuffix(StringView domain) const;
 
 #if PLATFORM(COCOA)
     WEBCORE_EXPORT void enablePublicSuffixCache();

--- a/Tools/TestWebKitAPI/Tests/WebCore/PublicSuffix.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PublicSuffix.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -184,6 +184,39 @@ TEST_F(PublicSuffix, TopPrivatelyControlledDomain)
     EXPECT_EQ(String::fromUTF8("ÅÄÖ"), publicSuffixStore.topPrivatelyControlledDomain(String::fromUTF8("ÅÄÖ")));
     EXPECT_EQ(String("test.com"_s), publicSuffixStore.topPrivatelyControlledDomain(".test.com"_s));
     EXPECT_EQ(String(), publicSuffixStore.topPrivatelyControlledDomain("...."_s));
+}
+
+TEST_F(PublicSuffix, topPrivatelyControlledDomainWithoutPublicSuffix)
+{
+    auto& publicSuffixStore = PublicSuffixStore::singleton();
+    EXPECT_EQ(String(utf16String(u"example")), publicSuffixStore.topPrivatelyControlledDomainWithoutPublicSuffix(utf16String(u"example.\u6803\u6728.jp")));
+    EXPECT_EQ(String(), publicSuffixStore.topPrivatelyControlledDomainWithoutPublicSuffix(String()));
+    EXPECT_EQ(String(), publicSuffixStore.topPrivatelyControlledDomainWithoutPublicSuffix(""_s));
+    EXPECT_EQ(String("test"_s), publicSuffixStore.topPrivatelyControlledDomainWithoutPublicSuffix("test.com"_s));
+    EXPECT_EQ(String("test"_s), publicSuffixStore.topPrivatelyControlledDomainWithoutPublicSuffix("com.test.com"_s));
+    EXPECT_EQ(String("test"_s), publicSuffixStore.topPrivatelyControlledDomainWithoutPublicSuffix("subdomain.test.com"_s));
+    EXPECT_EQ(String("com"_s), publicSuffixStore.topPrivatelyControlledDomainWithoutPublicSuffix("www.com.com"_s));
+    EXPECT_EQ(String("test"_s), publicSuffixStore.topPrivatelyControlledDomainWithoutPublicSuffix("test.co.uk"_s));
+    EXPECT_EQ(String("test"_s), publicSuffixStore.topPrivatelyControlledDomainWithoutPublicSuffix("subdomain.test.co.uk"_s));
+    EXPECT_EQ(String("bl"_s), publicSuffixStore.topPrivatelyControlledDomainWithoutPublicSuffix("bl.uk"_s));
+    EXPECT_EQ(String("bl"_s), publicSuffixStore.topPrivatelyControlledDomainWithoutPublicSuffix("subdomain.bl.uk"_s));
+    EXPECT_EQ(String("test"_s), publicSuffixStore.topPrivatelyControlledDomainWithoutPublicSuffix("test.xn--zf0ao64a.tw"_s));
+    EXPECT_EQ(String("test"_s), publicSuffixStore.topPrivatelyControlledDomainWithoutPublicSuffix("www.test.xn--zf0ao64a.tw"_s));
+    EXPECT_EQ(String("127.0.0.1"_s), publicSuffixStore.topPrivatelyControlledDomainWithoutPublicSuffix("127.0.0.1"_s));
+    EXPECT_EQ(String(), publicSuffixStore.topPrivatelyControlledDomainWithoutPublicSuffix("1"_s));
+    EXPECT_EQ(String(), publicSuffixStore.topPrivatelyControlledDomainWithoutPublicSuffix("com"_s));
+    EXPECT_EQ(String("test"_s), publicSuffixStore.topPrivatelyControlledDomainWithoutPublicSuffix("r4---asdf.test.com"_s));
+    EXPECT_EQ(String("r4---asdf"_s), publicSuffixStore.topPrivatelyControlledDomainWithoutPublicSuffix("r4---asdf.com"_s));
+    EXPECT_EQ(String(), publicSuffixStore.topPrivatelyControlledDomainWithoutPublicSuffix("r4---asdf"_s));
+    EXPECT_EQ(utf16String(bidirectionalDomain), utf16String(bidirectionalDomain));
+    EXPECT_EQ(String("example"_s), publicSuffixStore.topPrivatelyControlledDomainWithoutPublicSuffix("ExamPle.com"_s));
+    EXPECT_EQ(String("example"_s), publicSuffixStore.topPrivatelyControlledDomainWithoutPublicSuffix("SUB.dOmain.ExamPle.com"_s));
+    EXPECT_EQ(String("localhost"_s), publicSuffixStore.topPrivatelyControlledDomainWithoutPublicSuffix("localhost"_s));
+    EXPECT_EQ(String("localhost"_s), publicSuffixStore.topPrivatelyControlledDomainWithoutPublicSuffix("LocalHost"_s));
+    EXPECT_EQ(String::fromUTF8("åäö"), publicSuffixStore.topPrivatelyControlledDomainWithoutPublicSuffix(String::fromUTF8("åäö")));
+    EXPECT_EQ(String::fromUTF8("ÅÄÖ"), publicSuffixStore.topPrivatelyControlledDomainWithoutPublicSuffix(String::fromUTF8("ÅÄÖ")));
+    EXPECT_EQ(String("test"_s), publicSuffixStore.topPrivatelyControlledDomainWithoutPublicSuffix(".test.com"_s));
+    EXPECT_EQ(String(), publicSuffixStore.topPrivatelyControlledDomainWithoutPublicSuffix("...."_s));
 }
 
 #if PLATFORM(COCOA)


### PR DESCRIPTION
#### 72e7d13f0b054ebe4abf9e8f7a5bdfc404f89a53
<pre>
Extend PublicSuffix List with convenience method to access URL domain without the public suffix
<a href="https://bugs.webkit.org/show_bug.cgi?id=284650">https://bugs.webkit.org/show_bug.cgi?id=284650</a>
&lt;<a href="https://rdar.apple.com/problem/141452522">rdar://problem/141452522</a>&gt;

Reviewed by Matthew Finkel.

Add two new convenience methods to the PublicSuffixStore that allow a StringView to be passed, returning a String that is the passed domain with any Public Suffix removed.

This will be used for future Quirk pattern matching.

Tested by new API tests.

* Source/WebCore/platform/PublicSuffixStore.cpp:
(WebCore::PublicSuffixStore::topPrivatelyControlledDomainWithoutPublicSuffix const):
(WebCore::PublicSuffixStore::domainWithoutPublicSuffix const):
* Source/WebCore/platform/PublicSuffixStore.h:
* Tools/TestWebKitAPI/Tests/WebCore/PublicSuffix.cpp:
(TestWebKitAPI::TEST_F(PublicSuffix, topPrivatelyControlledDomainWithoutPublicSuffix)):

Canonical link: <a href="https://commits.webkit.org/287886@main">https://commits.webkit.org/287886@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1663f1ccb6fd6288bfd2dbf9bbaa1c2b8f69acf3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80996 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/521 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34939 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85525 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31982 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83106 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/538 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8322 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63239 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21004 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84065 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73718 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43537 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27876 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30440 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28427 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86960 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8226 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5807 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71542 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8403 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69551 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70777 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14813 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13735 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12586 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8187 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13710 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8024 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11544 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9832 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->