### PR TITLE
Introduce ModelPresentationManagerProxy that manages the remote model views on the page

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -47,6 +47,7 @@ namespace WebCore {
 class DOMMatrixReadOnly;
 class DOMPointReadOnly;
 class Event;
+class GraphicsLayer;
 class LayoutSize;
 class Model;
 class ModelPlayer;
@@ -57,6 +58,7 @@ template<typename IDLType> class DOMPromiseProxyWithResolveCallback;
 
 #if ENABLE(MODEL_PROCESS)
 template<typename IDLType> class DOMPromiseProxy;
+class ModelContext;
 #endif
 
 class HTMLModelElement final : public HTMLElement, private CachedRawResourceClient, public ModelPlayerClient, public ActiveDOMObject {
@@ -91,6 +93,8 @@ public:
     void applyBackgroundColor(Color);
 
 #if ENABLE(MODEL_PROCESS)
+    RefPtr<ModelContext> modelContext() const;
+
     const DOMMatrixReadOnly& entityTransform() const;
     ExceptionOr<void> setEntityTransform(const DOMMatrixReadOnly&);
 
@@ -167,6 +171,9 @@ private:
     void createModelPlayer();
     void deleteModelPlayer();
 
+    RefPtr<GraphicsLayer> graphicsLayer() const;
+    std::optional<PlatformLayerIdentifier> layerID() const;
+
     HTMLModelElement& readyPromiseResolve();
 
     // ActiveDOMObject.
@@ -199,7 +206,7 @@ private:
     void didUpdateBoundingBox(ModelPlayer&, const FloatPoint3D&, const FloatPoint3D&) final;
     void didFinishEnvironmentMapLoading(bool succeeded) final;
 #endif
-    std::optional<PlatformLayerIdentifier> platformLayerID() final;
+    std::optional<PlatformLayerIdentifier> modelContentsLayerID() const final;
 
     void defaultEventHandler(Event&) final;
     void dragDidStart(MouseEvent&);

--- a/Source/WebCore/Modules/model-element/ModelPlayerClient.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayerClient.h
@@ -58,7 +58,7 @@ public:
     virtual void didUpdateBoundingBox(ModelPlayer&, const FloatPoint3D&, const FloatPoint3D&) = 0;
     virtual void didFinishEnvironmentMapLoading(bool succeeded) = 0;
 #endif
-    virtual std::optional<PlatformLayerIdentifier> platformLayerID() = 0;
+    virtual std::optional<PlatformLayerIdentifier> modelContentsLayerID() const = 0;
 };
 
 }

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2522,6 +2522,7 @@ platform/graphics/MediaPlayerPrivate.cpp
 platform/graphics/MediaResourceSniffer.cpp
 platform/graphics/MediaSourcePrivate.cpp
 platform/graphics/Model.cpp
+platform/graphics/ModelContext.cpp
 platform/graphics/NamedImageGeneratedImage.cpp
 platform/graphics/NullImageBufferBackend.cpp
 platform/graphics/NativeImage.cpp

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -83,6 +83,10 @@ class TransformationMatrix;
 
 typedef unsigned TileCoverage;
 
+#if ENABLE(MODEL_PROCESS)
+class ModelContext;
+#endif
+
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
 struct AcceleratedEffectValues;
 String acceleratedEffectPropertyIDAsString(AcceleratedEffectProperty);
@@ -569,7 +573,9 @@ public:
     virtual void setContentsToSolidColor(const Color&) { }
     virtual void setContentsToPlatformLayer(PlatformLayer*, ContentsLayerPurpose) { }
     virtual void setContentsToPlatformLayerHost(LayerHostingContextIdentifier) { }
-    virtual void setContentsToRemotePlatformContext(LayerHostingContextIdentifier, ContentsLayerPurpose) { }
+#if ENABLE(MODEL_PROCESS)
+    virtual void setContentsToModelContext(Ref<ModelContext>, ContentsLayerPurpose) { }
+#endif
     virtual void setContentsToVideoElement(HTMLVideoElement&, ContentsLayerPurpose) { }
     virtual void setContentsDisplayDelegate(RefPtr<GraphicsLayerContentsDisplayDelegate>&&, ContentsLayerPurpose);
     WEBCORE_EXPORT virtual RefPtr<GraphicsLayerAsyncContentsDisplayDelegate> createAsyncContentsDisplayDelegate(GraphicsLayerAsyncContentsDisplayDelegate* existing);

--- a/Source/WebCore/platform/graphics/ModelContext.cpp
+++ b/Source/WebCore/platform/graphics/ModelContext.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ModelContext.h"
+
+namespace WebCore {
+
+Ref<ModelContext> ModelContext::create(const PlatformLayerIdentifier& modelLayerIdentifier, const LayerHostingContextIdentifier& modelContentsLayerHostingContextIdentifier)
+{
+    return adoptRef(*new ModelContext(modelLayerIdentifier, modelContentsLayerHostingContextIdentifier));
+}
+
+ModelContext::ModelContext(const PlatformLayerIdentifier& modelLayerIdentifier, const LayerHostingContextIdentifier& modelContentsLayerHostingContextIdentifier)
+    : m_modelLayerIdentifier(modelLayerIdentifier)
+    , m_modelContentsLayerHostingContextIdentifier(modelContentsLayerHostingContextIdentifier)
+{
+}
+
+ModelContext::~ModelContext() = default;
+
+}

--- a/Source/WebCore/platform/graphics/ModelContext.h
+++ b/Source/WebCore/platform/graphics/ModelContext.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "LayerHostingContextIdentifier.h"
+#include "PlatformLayerIdentifier.h"
+#include <wtf/RefCounted.h>
+
+namespace WebCore {
+
+class ModelContext final : public RefCounted<ModelContext> {
+public:
+    WEBCORE_EXPORT static Ref<ModelContext> create(const PlatformLayerIdentifier&, const LayerHostingContextIdentifier&);
+    WEBCORE_EXPORT ~ModelContext();
+
+    PlatformLayerIdentifier modelLayerIdentifier() const { return m_modelLayerIdentifier; }
+    LayerHostingContextIdentifier modelContentsLayerHostingContextIdentifier() const { return m_modelContentsLayerHostingContextIdentifier; }
+
+private:
+    explicit ModelContext(const PlatformLayerIdentifier&, const LayerHostingContextIdentifier&);
+
+    PlatformLayerIdentifier m_modelLayerIdentifier;
+    LayerHostingContextIdentifier m_modelContentsLayerHostingContextIdentifier;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -79,6 +79,10 @@
 #include "AcceleratedEffectStack.h"
 #endif
 
+#if ENABLE(MODEL_PROCESS)
+#include "ModelContext.h"
+#endif
+
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(GraphicsLayerCA);
@@ -344,11 +348,13 @@ Ref<PlatformCALayer> GraphicsLayerCA::createPlatformCALayer(PlatformLayer* platf
     return PlatformCALayerCocoa::create(platformLayer, owner);
 }
 
-Ref<PlatformCALayer> GraphicsLayerCA::createPlatformCALayer(LayerHostingContextIdentifier, PlatformCALayerClient* owner)
+#if ENABLE(MODEL_PROCESS)
+Ref<PlatformCALayer> GraphicsLayerCA::createPlatformCALayer(Ref<ModelContext>, PlatformCALayerClient* owner)
 {
     ASSERT_NOT_REACHED_WITH_MESSAGE("GraphicsLayerCARemote::createPlatformCALayer should always be called instead of this, but this symbol is needed to compile WebKitLegacy.");
     return GraphicsLayerCA::createPlatformCALayer(PlatformCALayer::LayerType::LayerTypeLayer, owner);
 }
+#endif
 
 #if ENABLE(MODEL_ELEMENT)
 Ref<PlatformCALayer> GraphicsLayerCA::createPlatformCALayer(Ref<WebCore::Model>, PlatformCALayerClient* owner)
@@ -1371,17 +1377,19 @@ void GraphicsLayerCA::setContentsToPlatformLayerHost(LayerHostingContextIdentifi
     noteLayerPropertyChanged(ContentsPlatformLayerChanged);
 }
 
-void GraphicsLayerCA::setContentsToRemotePlatformContext(LayerHostingContextIdentifier identifier, ContentsLayerPurpose purpose)
+#if ENABLE(MODEL_PROCESS)
+void GraphicsLayerCA::setContentsToModelContext(Ref<ModelContext> modelContext, ContentsLayerPurpose purpose)
 {
-    if (m_contentsLayer && m_contentsLayer->hostingContextIdentifier() == identifier)
+    if (m_contentsLayer && m_contentsLayer->hostingContextIdentifier() == modelContext->modelContentsLayerHostingContextIdentifier())
         return;
 
-    m_contentsLayer = createPlatformCALayer(identifier, this);
+    m_contentsLayer = createPlatformCALayer(modelContext, this);
     m_contentsLayerPurpose = purpose;
     m_contentsDisplayDelegate = nullptr;
     noteSublayersChanged();
     noteLayerPropertyChanged(ContentsPlatformLayerChanged);
 }
+#endif
 
 void GraphicsLayerCA::setContentsToVideoElement(HTMLVideoElement& videoElement, ContentsLayerPurpose purpose)
 {

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -52,6 +52,10 @@ class Image;
 class NativeImage;
 class TransformState;
 
+#if ENABLE(MODEL_PROCESS)
+class ModelContext;
+#endif
+
 class GraphicsLayerCA : public GraphicsLayer, public PlatformCALayerClient {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(GraphicsLayerCA, WEBCORE_EXPORT);
 public:
@@ -160,7 +164,9 @@ public:
 #endif
     WEBCORE_EXPORT void setContentsToPlatformLayer(PlatformLayer*, ContentsLayerPurpose) override;
     WEBCORE_EXPORT void setContentsToPlatformLayerHost(LayerHostingContextIdentifier) override;
-    WEBCORE_EXPORT void setContentsToRemotePlatformContext(LayerHostingContextIdentifier, ContentsLayerPurpose) override;
+#if ENABLE(MODEL_PROCESS)
+    WEBCORE_EXPORT void setContentsToModelContext(Ref<ModelContext>, ContentsLayerPurpose) override;
+#endif
     WEBCORE_EXPORT void setContentsToVideoElement(HTMLVideoElement&, ContentsLayerPurpose) override;
     WEBCORE_EXPORT void setContentsDisplayDelegate(RefPtr<GraphicsLayerContentsDisplayDelegate>&&, ContentsLayerPurpose) override;
     WEBCORE_EXPORT PlatformLayerIdentifier setContentsToAsyncDisplayDelegate(RefPtr<GraphicsLayerContentsDisplayDelegate>, ContentsLayerPurpose);
@@ -286,7 +292,9 @@ private:
 
     virtual Ref<PlatformCALayer> createPlatformCALayer(PlatformCALayer::LayerType, PlatformCALayerClient* owner);
     virtual Ref<PlatformCALayer> createPlatformCALayer(PlatformLayer*, PlatformCALayerClient* owner);
-    virtual Ref<PlatformCALayer> createPlatformCALayer(LayerHostingContextIdentifier, PlatformCALayerClient*);
+#if ENABLE(MODEL_PROCESS)
+    virtual Ref<PlatformCALayer> createPlatformCALayer(Ref<ModelContext>, PlatformCALayerClient*);
+#endif
 #if ENABLE(MODEL_ELEMENT)
     virtual Ref<PlatformCALayer> createPlatformCALayer(Ref<WebCore::Model>, PlatformCALayerClient* owner);
 #endif

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -110,6 +110,10 @@
 #include <wtf/WeakListHashSet.h>
 #endif
 
+#if ENABLE(MODEL_PROCESS)
+#include "ModelContext.h"
+#endif
+
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderLayerBacking);
@@ -1233,8 +1237,8 @@ bool RenderLayerBacking::updateConfiguration(const RenderLayer* compositingAnces
         if (element->usesPlatformLayer())
             m_graphicsLayer->setContentsToPlatformLayer(element->platformLayer(), GraphicsLayer::ContentsLayerPurpose::Model);
 #if ENABLE(MODEL_PROCESS)
-        else if (auto contextID = element->layerHostingContextIdentifier(); contextID && element->document().settings().modelProcessEnabled()) {
-            m_graphicsLayer->setContentsToRemotePlatformContext(contextID.value(), GraphicsLayer::ContentsLayerPurpose::HostedModel);
+        else if (auto modelContext = element->modelContext(); modelContext && element->document().settings().modelProcessEnabled()) {
+            m_graphicsLayer->setContentsToModelContext(*modelContext, GraphicsLayer::ContentsLayerPurpose::HostedModel);
             element->applyBackgroundColor(rendererBackgroundColor());
         }
 #endif

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -194,10 +194,13 @@ headers: "LayerProperties.h" "PlatformCALayerRemote.h"
     Markable<WebCore::PlatformLayerIdentifier> layerID;
     WebCore::PlatformCALayerLayerType type;
     std::optional<WebKit::RemoteLayerTreeTransaction::LayerCreationProperties::VideoElementData> videoElementData;
-#if ENABLE(MODEL_ELEMENT)
+#if ENABLE(MODEL_ELEMENT) && ENABLE(MODEL_PROCESS)
+    std::variant<WebKit::RemoteLayerTreeTransaction::LayerCreationProperties::NoAdditionalData, WebKit::RemoteLayerTreeTransaction::LayerCreationProperties::CustomData, Ref<WebCore::Model>, Ref<WebCore::ModelContext>, WebCore::LayerHostingContextIdentifier> additionalData;
+#endif
+#if ENABLE(MODEL_ELEMENT) && !ENABLE(MODEL_PROCESS)
     std::variant<WebKit::RemoteLayerTreeTransaction::LayerCreationProperties::NoAdditionalData, WebKit::RemoteLayerTreeTransaction::LayerCreationProperties::CustomData, Ref<WebCore::Model>, WebCore::LayerHostingContextIdentifier> additionalData;
 #endif
-#if !ENABLE(MODEL_ELEMENT)
+#if !ENABLE(MODEL_PROCESS) && !ENABLE(MODEL_ELEMENT)
     std::variant<WebKit::RemoteLayerTreeTransaction::LayerCreationProperties::NoAdditionalData, WebKit::RemoteLayerTreeTransaction::LayerCreationProperties::CustomData, WebCore::LayerHostingContextIdentifier> additionalData;
 #endif
 };

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -60,6 +60,10 @@
 #include <WebCore/Model.h>
 #endif
 
+#if ENABLE(MODEL_PROCESS)
+#include <WebCore/ModelContext.h>
+#endif
+
 namespace WebKit {
 
 struct LayerProperties;
@@ -97,6 +101,9 @@ public:
             CustomData, // PlatformCALayerRemoteCustom
 #if ENABLE(MODEL_ELEMENT)
             Ref<WebCore::Model>, // PlatformCALayerRemoteModelHosting
+#if ENABLE(MODEL_PROCESS)
+            Ref<WebCore::ModelContext>, // PlatformCALayerRemoteCustom
+#endif
 #endif
             WebCore::LayerHostingContextIdentifier // PlatformCALayerRemoteHost
         >;
@@ -115,6 +122,10 @@ public:
         uint32_t hostingContextID() const;
         bool preservesFlip() const;
         float hostingDeviceScaleFactor() const;
+
+#if ENABLE(MODEL_PROCESS)
+        RefPtr<WebCore::ModelContext> modelContext() const;
+#endif
     };
 
     explicit RemoteLayerTreeTransaction();

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
@@ -40,6 +40,10 @@
 #import <wtf/text/MakeString.h>
 #import <wtf/text/TextStream.h>
 
+#if ENABLE(MODEL_PROCESS)
+#import <WebCore/ModelContext.h>
+#endif
+
 namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteLayerTreeTransaction);
@@ -396,6 +400,11 @@ std::optional<WebCore::LayerHostingContextIdentifier> RemoteLayerTreeTransaction
 
 uint32_t RemoteLayerTreeTransaction::LayerCreationProperties::hostingContextID() const
 {
+#if ENABLE(MODEL_PROCESS)
+    if (auto* modelContext = std::get_if<Ref<WebCore::ModelContext>>(&additionalData))
+        return (*modelContext)->modelContentsLayerHostingContextIdentifier().toRawValue();
+#endif
+
     if (auto* customData = std::get_if<CustomData>(&additionalData))
         return customData->hostingContextID;
     return 0;
@@ -414,6 +423,16 @@ float RemoteLayerTreeTransaction::LayerCreationProperties::hostingDeviceScaleFac
         return customData->hostingDeviceScaleFactor;
     return 1;
 }
+
+#if ENABLE(MODEL_PROCESS)
+RefPtr<WebCore::ModelContext> RemoteLayerTreeTransaction::LayerCreationProperties::modelContext() const
+{
+    auto* modelContext = std::get_if<Ref<WebCore::ModelContext>>(&additionalData);
+    if (!modelContext)
+        return nullptr;
+    return modelContext->ptr();
+}
+#endif
 
 } // namespace WebKit
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7017,6 +7017,13 @@ struct WebCore::CookieChangeSubscription {
     URL url()
 }
 
+#if ENABLE(MODEL_PROCESS)
+[RefCounted] class WebCore::ModelContext {
+    WebCore::PlatformLayerIdentifier modelLayerIdentifier()
+    WebCore::LayerHostingContextIdentifier modelContentsLayerHostingContextIdentifier()
+};
+#endif
+
 #if PLATFORM(IOS_FAMILY)
 [Nested] enum class WebCore::InspectorOverlayLabel::Arrow::Direction : uint8_t {
     None,

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -528,6 +528,7 @@ UIProcess/ios/WKModelInteractionGestureRecognizer.mm
 UIProcess/ios/WKModelView.mm
 UIProcess/ios/WKMouseDeviceObserver.mm
 UIProcess/ios/WKMouseInteraction.mm
+UIProcess/ios/WKPageHostedModelView.mm
 UIProcess/ios/WKPasswordView.mm
 UIProcess/ios/WKPDFView.mm
 UIProcess/ios/WKScrollView.mm
@@ -582,6 +583,8 @@ UIProcess/mac/WebViewImpl.mm
 
 UIProcess/Media/cocoa/AudioSessionRoutingArbitratorProxyCocoa.mm
 UIProcess/Media/cocoa/MediaUsageManagerCocoa.mm
+
+UIProcess/Model/ModelPresentationManagerProxy.mm
 
 UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.cpp
 

--- a/Source/WebKit/UIProcess/Model/ModelPresentationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Model/ModelPresentationManagerProxy.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(IOS_FAMILY) && ENABLE(MODEL_PROCESS)
+
+#import <WebCore/ModelContext.h>
+#import <wtf/RefCounted.h>
+#import <wtf/TZoneMalloc.h>
+#import <wtf/UniqueRef.h>
+
+OBJC_CLASS WKPageHostedModelView;
+OBJC_CLASS UIView;
+OBJC_CLASS _UIRemoteView;
+
+namespace WebKit {
+
+class WebPageProxy;
+
+class ModelPresentationManagerProxy : public RefCounted<ModelPresentationManagerProxy> {
+    WTF_MAKE_TZONE_ALLOCATED(ModelPresentationManagerProxy);
+public:
+    static Ref<ModelPresentationManagerProxy> create(WebPageProxy& page)
+    {
+        return adoptRef(*new ModelPresentationManagerProxy(page));
+    }
+
+    virtual ~ModelPresentationManagerProxy();
+
+    RetainPtr<WKPageHostedModelView> setUpModelView(Ref<WebCore::ModelContext>);
+    void invalidateModel(const WebCore::PlatformLayerIdentifier&);
+    void invalidateAllModels();
+
+private:
+    explicit ModelPresentationManagerProxy(WebPageProxy&);
+
+    struct ModelPresentation {
+        WTF_MAKE_FAST_ALLOCATED;
+
+    public:
+        Ref<WebCore::ModelContext> modelContext;
+        RetainPtr<_UIRemoteView> remoteModelView;
+        RetainPtr<WKPageHostedModelView> pageHostedModelView;
+    };
+
+    ModelPresentation& ensureModelPresentation(Ref<WebCore::ModelContext>, const WebPageProxy&);
+
+    HashMap<WebCore::PlatformLayerIdentifier, UniqueRef<ModelPresentation>> m_modelPresentations;
+    WeakPtr<WebPageProxy> m_page;
+};
+
+}
+
+#endif // PLATFORM(IOS_FAMILY) && ENABLE(MODEL_PROCESS)

--- a/Source/WebKit/UIProcess/Model/ModelPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Model/ModelPresentationManagerProxy.mm
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "ModelPresentationManagerProxy.h"
+
+#if PLATFORM(IOS_FAMILY) && ENABLE(MODEL_PROCESS)
+
+#import "UIKitSPI.h"
+#import "WKPageHostedModelView.h"
+#import "WebPageProxy.h"
+#import <wtf/RefPtr.h>
+#import <wtf/TZoneMallocInlines.h>
+
+namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ModelPresentationManagerProxy);
+
+ModelPresentationManagerProxy::ModelPresentationManagerProxy(WebPageProxy& page)
+    : m_page(page)
+{
+}
+
+ModelPresentationManagerProxy::~ModelPresentationManagerProxy() = default;
+
+RetainPtr<WKPageHostedModelView> ModelPresentationManagerProxy::setUpModelView(Ref<WebCore::ModelContext> modelContext)
+{
+    RefPtr webPageProxy = m_page.get();
+    if (!webPageProxy)
+        return nil;
+
+    auto& modelPresentation = ensureModelPresentation(modelContext, *webPageProxy);
+    return modelPresentation.pageHostedModelView;
+}
+
+void ModelPresentationManagerProxy::invalidateModel(const WebCore::PlatformLayerIdentifier& layerIdentifier)
+{
+    m_modelPresentations.remove(layerIdentifier);
+    RELEASE_LOG_INFO(ModelElement, "%p - ModelPresentationManagerProxy removed model presentation for layer ID: %" PRIu64, this, layerIdentifier.object().toRawValue());
+}
+
+void ModelPresentationManagerProxy::invalidateAllModels()
+{
+    m_modelPresentations.clear();
+    RELEASE_LOG_INFO(ModelElement, "%p - ModelPresentationManagerProxy removed all model presentations", this);
+}
+
+ModelPresentationManagerProxy::ModelPresentation& ModelPresentationManagerProxy::ensureModelPresentation(Ref<WebCore::ModelContext> modelContext, const WebPageProxy& webPageProxy)
+{
+    auto layerIdentifier = modelContext->modelLayerIdentifier();
+    if (m_modelPresentations.contains(layerIdentifier)) {
+        // Update the existing ModelPresentation
+        ModelPresentation& modelPresentation = *(m_modelPresentations.get(layerIdentifier));
+        if (modelPresentation.modelContext->modelContentsLayerHostingContextIdentifier() != modelContext->modelContentsLayerHostingContextIdentifier()) {
+            modelPresentation.remoteModelView = adoptNS([[_UIRemoteView alloc] initWithFrame:CGRectZero pid:webPageProxy.legacyMainFrameProcessID() contextID:modelContext->modelContentsLayerHostingContextIdentifier().toRawValue()]);
+            [modelPresentation.pageHostedModelView setRemoteModelView:modelPresentation.remoteModelView.get()];
+            RELEASE_LOG_INFO(ModelElement, "%p - ModelPresentationManagerProxy updated model view for element: %" PRIu64, this, layerIdentifier.object().toRawValue());
+        }
+        modelPresentation.modelContext = modelContext;
+    } else {
+        auto pageHostedModelView = adoptNS([[WKPageHostedModelView alloc] init]);
+        auto remoteModelView = adoptNS([[_UIRemoteView alloc] initWithFrame:CGRectZero pid:webPageProxy.legacyMainFrameProcessID() contextID:modelContext->modelContentsLayerHostingContextIdentifier().toRawValue()]);
+        [pageHostedModelView setRemoteModelView:remoteModelView.get()];
+        auto modelPresentation = ModelPresentation {
+            .modelContext = modelContext,
+            .remoteModelView = remoteModelView,
+            .pageHostedModelView = pageHostedModelView,
+        };
+        m_modelPresentations.add(layerIdentifier, makeUniqueRef<ModelPresentationManagerProxy::ModelPresentation>(WTFMove(modelPresentation)));
+        RELEASE_LOG_INFO(ModelElement, "%p - ModelPresentationManagerProxy created new model presentation for element: %" PRIu64, this, layerIdentifier.object().toRawValue());
+    }
+
+    return *(m_modelPresentations.get(layerIdentifier));
+}
+
+}
+
+#endif // PLATFORM(IOS_FAMILY) && ENABLE(MODEL_PROCESS)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
@@ -34,6 +34,10 @@
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
 
+#if PLATFORM(IOS_FAMILY) && ENABLE(MODEL_PROCESS)
+#include <WebCore/ElementIdentifier.h>
+#endif
+
 OBJC_CLASS CAAnimation;
 OBJC_CLASS WKAnimationDelegate;
 
@@ -125,6 +129,9 @@ private:
 #endif
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
     HashSet<WebCore::PlatformLayerIdentifier> m_overlayRegionIDs;
+#endif
+#if PLATFORM(IOS_FAMILY) && ENABLE(MODEL_PROCESS)
+    HashSet<WebCore::PlatformLayerIdentifier> m_modelLayers;
 #endif
     bool m_isDebugLayerTreeHost { false };
 };

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -47,12 +47,16 @@
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
-#import <pal/cocoa/CoreMaterialSoftLink.h>
-#import <pal/cocoa/QuartzCoreSoftLink.h>
 
 #if PLATFORM(IOS_FAMILY)
 #import <UIKit/UIView.h>
+#if ENABLE(MODEL_PROCESS)
+#import "ModelPresentationManagerProxy.h"
 #endif
+#endif
+
+#import <pal/cocoa/CoreMaterialSoftLink.h>
+#import <pal/cocoa/QuartzCoreSoftLink.h>
 
 namespace WebKit {
 using namespace WebCore;
@@ -302,6 +306,14 @@ void RemoteLayerTreeHost::layerWillBeRemoved(WebCore::ProcessIdentifier processI
         if (auto videoManager = m_drawingArea->page() ? m_drawingArea->page()->videoPresentationManager() : nullptr)
             videoManager->willRemoveLayerForID(videoLayerIter->value);
         m_videoLayers.remove(videoLayerIter);
+    }
+#endif
+
+#if PLATFORM(IOS_FAMILY) && ENABLE(MODEL_PROCESS)
+    if (m_modelLayers.contains(layerID)) {
+        if (auto modelPresentationManager = m_drawingArea->page() ? m_drawingArea->page()->modelPresentationManagerProxy() : nullptr)
+            modelPresentationManager->invalidateModel(layerID);
+        m_modelLayers.remove(layerID);
     }
 #endif
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeHostIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeHostIOS.mm
@@ -42,6 +42,11 @@
 #import "WKModelView.h"
 #endif
 
+#if ENABLE(MODEL_PROCESS)
+#import "ModelPresentationManagerProxy.h"
+#import "WKPageHostedModelView.h"
+#endif
+
 namespace WebKit {
 using namespace WebCore;
 
@@ -92,6 +97,17 @@ RefPtr<RemoteLayerTreeNode> RemoteLayerTreeHost::makeNode(const RemoteLayerTreeT
 
         if (!m_drawingArea->page())
             return nullptr;
+
+#if ENABLE(MODEL_PROCESS)
+        if (auto modelContext = properties.modelContext()) {
+            if (auto modelPresentationManager = m_drawingArea->page() ? m_drawingArea->page()->modelPresentationManagerProxy() : nullptr) {
+                if (auto view = modelPresentationManager->setUpModelView(*modelContext)) {
+                    m_modelLayers.add(modelContext->modelLayerIdentifier());
+                    return makeWithView(WTFMove(view));
+                }
+            }
+        }
+#endif
 
         auto view = adoptNS([[WKUIRemoteView alloc] initWithFrame:CGRectZero pid:m_drawingArea->page()->legacyMainFrameProcessID() contextID:properties.hostingContextID()]);
         return makeWithView(WTFMove(view));

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -427,6 +427,10 @@
 #include <wtf/glib/RunLoopSourcePriority.h>
 #endif
 
+#if PLATFORM(IOS_FAMILY) && ENABLE(MODEL_PROCESS)
+#include "ModelPresentationManagerProxy.h"
+#endif
+
 #define MESSAGE_CHECK(process, assertion) MESSAGE_CHECK_BASE(assertion, process->connection())
 #define MESSAGE_CHECK_URL(process, url) MESSAGE_CHECK_BASE(checkURLReceivedFromCurrentOrPreviousWebProcess(process, url), process->connection())
 #define MESSAGE_CHECK_URL_COROUTINE(process, url) MESSAGE_CHECK_BASE_COROUTINE(checkURLReceivedFromCurrentOrPreviousWebProcess(process, url), process->connection())
@@ -1566,6 +1570,10 @@ void WebPageProxy::didAttachToRunningProcess()
 #if ENABLE(WEBXR) && !USE(OPENXR)
     ASSERT(!internals().xrSystem);
     internals().xrSystem = PlatformXRSystem::create(*this);
+#endif
+
+#if PLATFORM(IOS_FAMILY) && ENABLE(MODEL_PROCESS)
+    internals().modelPresentationManagerProxy = ModelPresentationManagerProxy::create(*this);
 #endif
 }
 
@@ -11015,6 +11023,11 @@ void WebPageProxy::resetState(ResetStateReason resetStateReason)
 
     if (RefPtr pageClient = this->pageClient())
         pageClient->hasActiveNowPlayingSessionChanged(false);
+
+#if PLATFORM(IOS_FAMILY) && ENABLE(MODEL_PROCESS)
+    if (auto modelPresentationManager = modelPresentationManagerProxy())
+        modelPresentationManager->invalidateAllModels();
+#endif
 }
 
 void WebPageProxy::resetStateAfterProcessExited(ProcessTerminationReason terminationReason)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -498,6 +498,10 @@ class WebWheelEvent;
 class WebWheelEventCoalescer;
 class WebsiteDataStore;
 
+#if PLATFORM(IOS_FAMILY) && ENABLE(MODEL_PROCESS)
+class ModelPresentationManagerProxy;
+#endif
+
 struct AppPrivacyReportTestingData;
 struct DataDetectionResult;
 struct DocumentEditingContext;
@@ -2630,6 +2634,10 @@ public:
 #if HAVE(AUDIT_TOKEN)
     const std::optional<audit_token_t>& presentingApplicationAuditToken() const;
     void setPresentingApplicationAuditToken(const audit_token_t&);
+#endif
+
+#if PLATFORM(IOS_FAMILY) && ENABLE(MODEL_PROCESS)
+    RefPtr<ModelPresentationManagerProxy> modelPresentationManagerProxy() const;
 #endif
 
 private:

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -95,6 +95,10 @@
 #include "CocoaWindow.h"
 #endif
 
+#if PLATFORM(IOS_FAMILY) && ENABLE(MODEL_PROCESS)
+#include "ModelPresentationManagerProxy.h"
+#endif
+
 namespace WebKit {
 
 #if ENABLE(WINDOW_PROXY_PROPERTY_ACCESS_NOTIFICATION)
@@ -448,6 +452,10 @@ public:
 
 #if PLATFORM(MAC)
     WebCore::FloatPoint scrollPositionDuringLastEditorStateUpdate;
+#endif
+
+#if PLATFORM(IOS_FAMILY) && ENABLE(MODEL_PROCESS)
+    RefPtr<ModelPresentationManagerProxy> modelPresentationManagerProxy;
 #endif
 
     bool allowsLayoutViewportHeightExpansion { true };

--- a/Source/WebKit/UIProcess/ios/WKPageHostedModelView.h
+++ b/Source/WebKit/UIProcess/ios/WKPageHostedModelView.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if PLATFORM(IOS_FAMILY) && ENABLE(MODEL_PROCESS)
+
+#import "RemoteLayerTreeViews.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface WKPageHostedModelView : WKCompositingView
+
+@property (nonatomic, retain) UIView *remoteModelView;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif // PLATFORM(IOS_FAMILY) && ENABLE(MODEL_PROCESS)

--- a/Source/WebKit/UIProcess/ios/WKPageHostedModelView.mm
+++ b/Source/WebKit/UIProcess/ios/WKPageHostedModelView.mm
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "WKPageHostedModelView.h"
+
+#if PLATFORM(IOS_FAMILY) && ENABLE(MODEL_PROCESS)
+
+#import <wtf/RetainPtr.h>
+
+@implementation WKPageHostedModelView {
+    RetainPtr<UIView> _remoteModelView;
+}
+
+- (UIView *)remoteModelView
+{
+    return _remoteModelView.get();
+}
+
+- (void)setRemoteModelView:(UIView *)remoteModelView
+{
+    if (_remoteModelView.get() == remoteModelView)
+        return;
+
+    [_remoteModelView removeFromSuperview];
+
+    _remoteModelView = remoteModelView;
+    CGRect bounds = self.bounds;
+    [_remoteModelView setFrame:bounds];
+    [_remoteModelView setAutoresizingMask:(UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight)];
+    [self addSubview:_remoteModelView.get()];
+}
+
+@end
+
+#endif // PLATFORM(IOS_FAMILY) && ENABLE(MODEL_PROCESS)

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1748,6 +1748,13 @@ void WebPageProxy::isPotentialTapInProgress(CompletionHandler<void(bool)>&& comp
 
 #endif // PLATFORM(IOS_FAMILY)
 
+#if PLATFORM(IOS_FAMILY) && ENABLE(MODEL_PROCESS)
+RefPtr<ModelPresentationManagerProxy> WebPageProxy::modelPresentationManagerProxy() const
+{
+    return internals().modelPresentationManagerProxy;
+}
+#endif
+
 } // namespace WebKit
 
 #undef WEBPAGEPROXY_RELEASE_LOG

--- a/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.h
+++ b/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.h
@@ -26,6 +26,7 @@
 #if PLATFORM(IOS_FAMILY)
 
 #import <UIKit/UIViewController.h>
+#import <wtf/RetainPtr.h>
 
 @class WKContentView;
 @protocol WKFileUploadPanelDelegate;

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -50,6 +50,7 @@
 #import <WebCore/IntRect.h>
 #import <WebCore/LocalizedStrings.h>
 #import <WebCore/VideoPresentationInterfaceAVKitLegacy.h>
+#import <WebCore/VideoPresentationInterfaceTVOS.h>
 #import <WebCore/VideoPresentationModel.h>
 #import <WebCore/ViewportArguments.h>
 #import <objc/runtime.h>

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5800,6 +5800,10 @@
 		52B060F82B745E00009B1666 /* CoreIPCCVPixelBufferRef.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCCVPixelBufferRef.mm; sourceTree = "<group>"; };
 		52C05BA72874996C00D80C59 /* MockCcidService.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MockCcidService.h; sourceTree = "<group>"; };
 		52C05BA82874996C00D80C59 /* MockCcidService.mm */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; path = MockCcidService.mm; sourceTree = "<group>"; };
+		52C25B422D0C12F700A26AB8 /* ModelPresentationManagerProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ModelPresentationManagerProxy.h; sourceTree = "<group>"; };
+		52C25B432D0C12F700A26AB8 /* ModelPresentationManagerProxy.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ModelPresentationManagerProxy.mm; sourceTree = "<group>"; };
+		52C25B442D0C1B9100A26AB8 /* WKPageHostedModelView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKPageHostedModelView.h; path = ios/WKPageHostedModelView.h; sourceTree = "<group>"; };
+		52C25B452D0C1B9100A26AB8 /* WKPageHostedModelView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKPageHostedModelView.mm; path = ios/WKPageHostedModelView.mm; sourceTree = "<group>"; };
 		52C3C26428651F860005BE6E /* WKBrowsingContextHandlePrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKBrowsingContextHandlePrivate.h; sourceTree = "<group>"; };
 		52CDC5BD2731DA0C00A3E3EB /* VirtualAuthenticatorConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VirtualAuthenticatorConfiguration.h; sourceTree = "<group>"; };
 		52CDC5BE2731DA0C00A3E3EB /* VirtualService.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = VirtualService.mm; sourceTree = "<group>"; };
@@ -11119,6 +11123,8 @@
 		2DA8153428A4939700CF811C /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				52C25B422D0C12F700A26AB8 /* ModelPresentationManagerProxy.h */,
+				52C25B432D0C12F700A26AB8 /* ModelPresentationManagerProxy.mm */,
 				2DA8153628A4939700CF811C /* ModelProcessProxy.cpp */,
 				2DA8153528A4939700CF811C /* ModelProcessProxy.h */,
 				2DA8153728A4939700CF811C /* ModelProcessProxy.messages.in */,
@@ -11243,6 +11249,8 @@
 				950F287F252414EA00B74F1C /* WKMouseDeviceObserver.mm */,
 				F4C627E62A7AC17400F546BF /* WKMouseInteraction.h */,
 				F4C627E52A7AC17300F546BF /* WKMouseInteraction.mm */,
+				52C25B442D0C1B9100A26AB8 /* WKPageHostedModelView.h */,
+				52C25B452D0C1B9100A26AB8 /* WKPageHostedModelView.mm */,
 				A15EEDE41E301CEE000069B0 /* WKPasswordView.h */,
 				A15EEDE31E301CEE000069B0 /* WKPasswordView.mm */,
 				A1046E9F2079263100F0C5D8 /* WKPDFView.h */,

--- a/Source/WebKit/WebProcess/Model/ios/ARKitInlinePreviewModelPlayerIOS.mm
+++ b/Source/WebKit/WebProcess/Model/ios/ARKitInlinePreviewModelPlayerIOS.mm
@@ -66,7 +66,7 @@ ARKitInlinePreviewModelPlayerIOS* ARKitInlinePreviewModelPlayerIOS::modelPlayerF
         if (&page != modelPlayer.page())
             continue;
 
-        if (modelPlayer.client()->platformLayerID() != layerID)
+        if (modelPlayer.client()->modelContentsLayerID() != layerID)
             continue;
 
         return &modelPlayer;
@@ -92,7 +92,7 @@ std::optional<ModelIdentifier> ARKitInlinePreviewModelPlayerIOS::modelIdentifier
     if (!client())
         return { };
 
-    if (auto layerId = client()->platformLayerID())
+    if (auto layerId = client()->modelContentsLayerID())
         return { { *layerId } };
 
     return { };

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.h
@@ -30,6 +30,12 @@
 #include <WebCore/PlatformLayer.h>
 #include <wtf/TZoneMalloc.h>
 
+#if ENABLE(MODEL_PROCESS)
+namespace WebCore {
+class ModelContext;
+}
+#endif
+
 namespace WebKit {
 
 class RemoteLayerTreeContext;
@@ -50,7 +56,9 @@ private:
 
     Ref<WebCore::PlatformCALayer> createPlatformCALayer(WebCore::PlatformCALayer::LayerType, WebCore::PlatformCALayerClient* owner) override;
     Ref<WebCore::PlatformCALayer> createPlatformCALayer(PlatformLayer*, WebCore::PlatformCALayerClient* owner) override;
-    Ref<WebCore::PlatformCALayer> createPlatformCALayer(WebCore::LayerHostingContextIdentifier, WebCore::PlatformCALayerClient* owner) override;
+#if ENABLE(MODEL_PROCESS)
+    Ref<WebCore::PlatformCALayer> createPlatformCALayer(Ref<WebCore::ModelContext>, WebCore::PlatformCALayerClient* owner) override;
+#endif
 #if ENABLE(MODEL_ELEMENT)
     Ref<WebCore::PlatformCALayer> createPlatformCALayer(Ref<WebCore::Model>, WebCore::PlatformCALayerClient* owner) override;
 #endif

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
@@ -41,6 +41,10 @@
 #include <WebCore/RemoteFrame.h>
 #include <wtf/TZoneMallocInlines.h>
 
+#if ENABLE(MODEL_PROCESS)
+#include <WebCore/ModelContext.h>
+#endif
+
 namespace WebKit {
 using namespace WebCore;
 
@@ -83,11 +87,13 @@ Ref<PlatformCALayer> GraphicsLayerCARemote::createPlatformCALayer(PlatformLayer*
     return PlatformCALayerRemote::create(platformLayer, owner, *m_context);
 }
 
-Ref<PlatformCALayer> GraphicsLayerCARemote::createPlatformCALayer(WebCore::LayerHostingContextIdentifier layerHostingContextIdentifier, PlatformCALayerClient* owner)
+#if ENABLE(MODEL_PROCESS)
+Ref<PlatformCALayer> GraphicsLayerCARemote::createPlatformCALayer(Ref<WebCore::ModelContext> modelContext, PlatformCALayerClient* owner)
 {
     RELEASE_ASSERT(m_context.get());
-    return PlatformCALayerRemote::create(layerHostingContextIdentifier.toUInt64(), owner, *m_context);
+    return PlatformCALayerRemote::create(modelContext, owner, *m_context);
 }
+#endif
 
 #if ENABLE(MODEL_ELEMENT)
 Ref<PlatformCALayer> GraphicsLayerCARemote::createPlatformCALayer(Ref<WebCore::Model> model, PlatformCALayerClient* owner)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
@@ -40,6 +40,9 @@ class LayerPool;
 class AcceleratedEffect;
 struct AcceleratedEffectValues;
 #endif
+#if ENABLE(MODEL_PROCESS)
+class ModelContext;
+#endif
 }
 
 namespace WebKit {
@@ -57,7 +60,9 @@ class PlatformCALayerRemote : public WebCore::PlatformCALayer, public CanMakeWea
 public:
     static Ref<PlatformCALayerRemote> create(WebCore::PlatformCALayer::LayerType, WebCore::PlatformCALayerClient*, RemoteLayerTreeContext&);
     static Ref<PlatformCALayerRemote> create(PlatformLayer *, WebCore::PlatformCALayerClient*, RemoteLayerTreeContext&);
-    static Ref<PlatformCALayerRemote> create(LayerHostingContextID, WebCore::PlatformCALayerClient* owner, RemoteLayerTreeContext&);
+#if ENABLE(MODEL_PROCESS)
+    static Ref<PlatformCALayerRemote> create(Ref<WebCore::ModelContext>, WebCore::PlatformCALayerClient* owner, RemoteLayerTreeContext&);
+#endif
 #if ENABLE(MODEL_ELEMENT)
     static Ref<PlatformCALayerRemote> create(Ref<WebCore::Model>, WebCore::PlatformCALayerClient*, RemoteLayerTreeContext&);
 #endif

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
@@ -50,6 +50,10 @@
 #import <WebCore/AcceleratedEffectValues.h>
 #endif
 
+#if ENABLE(MODEL_PROCESS)
+#import <WebCore/ModelContext.h>
+#endif
+
 namespace WebKit {
 using namespace WebCore;
 
@@ -72,10 +76,12 @@ Ref<PlatformCALayerRemote> PlatformCALayerRemote::create(PlatformLayer *platform
     return PlatformCALayerRemoteCustom::create(platformLayer, owner, context);
 }
 
-Ref<PlatformCALayerRemote> PlatformCALayerRemote::create(LayerHostingContextID contextID, WebCore::PlatformCALayerClient* owner, RemoteLayerTreeContext& context)
+#if ENABLE(MODEL_PROCESS)
+Ref<PlatformCALayerRemote> PlatformCALayerRemote::create(Ref<WebCore::ModelContext> modelContext, WebCore::PlatformCALayerClient* owner, RemoteLayerTreeContext& context)
 {
-    return PlatformCALayerRemoteCustom::create(contextID, owner, context);
+    return PlatformCALayerRemoteCustom::create(modelContext, owner, context);
 }
+#endif
 
 #if ENABLE(MODEL_ELEMENT)
 Ref<PlatformCALayerRemote> PlatformCALayerRemote::create(Ref<WebCore::Model> model, WebCore::PlatformCALayerClient* owner, RemoteLayerTreeContext& context)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.h
@@ -29,6 +29,10 @@
 
 namespace WebCore {
 class PlatformCALayerClient;
+
+#if ENABLE(MODEL_PROCESS)
+class ModelContext;
+#endif
 }
 
 namespace WebKit {
@@ -40,7 +44,9 @@ class PlatformCALayerRemoteCustom final : public PlatformCALayerRemote {
     friend class PlatformCALayerRemote;
 public:
     static Ref<PlatformCALayerRemote> create(PlatformLayer *, WebCore::PlatformCALayerClient*, RemoteLayerTreeContext&);
-    static Ref<PlatformCALayerRemote> create(LayerHostingContextID, WebCore::PlatformCALayerClient*, RemoteLayerTreeContext&);
+#if ENABLE(MODEL_PROCESS)
+    static Ref<PlatformCALayerRemote> create(Ref<WebCore::ModelContext>, WebCore::PlatformCALayerClient*, RemoteLayerTreeContext&);
+#endif
 #if HAVE(AVKIT)
     static Ref<PlatformCALayerRemote> create(WebCore::HTMLVideoElement&, WebCore::PlatformCALayerClient* owner, RemoteLayerTreeContext&);
 #endif
@@ -60,6 +66,9 @@ private:
     PlatformCALayerRemoteCustom(WebCore::PlatformCALayer::LayerType, PlatformLayer *, WebCore::PlatformCALayerClient* owner, RemoteLayerTreeContext&);
     PlatformCALayerRemoteCustom(WebCore::PlatformCALayer::LayerType, LayerHostingContextID, WebCore::PlatformCALayerClient* owner, RemoteLayerTreeContext&);
     PlatformCALayerRemoteCustom(WebCore::HTMLVideoElement&, WebCore::PlatformCALayerClient* owner, RemoteLayerTreeContext&);
+#if ENABLE(MODEL_PROCESS)
+    PlatformCALayerRemoteCustom(WebCore::PlatformCALayer::LayerType, Ref<WebCore::ModelContext>, WebCore::PlatformCALayerClient* owner, RemoteLayerTreeContext&);
+#endif
 
     Ref<WebCore::PlatformCALayer> clone(WebCore::PlatformCALayerClient* owner) const override;
     
@@ -73,6 +82,9 @@ private:
     bool m_hasVideo { false };
     std::unique_ptr<LayerHostingContext> m_layerHostingContext;
     RetainPtr<PlatformLayer> m_platformLayer;
+#if ENABLE(MODEL_PROCESS)
+    RefPtr<WebCore::ModelContext> m_modelContext;
+#endif
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### fce7a7280e2c1e0812936efc57be17d806d49591
<pre>
Introduce ModelPresentationManagerProxy that manages the remote model views on the page
<a href="https://bugs.webkit.org/show_bug.cgi?id=284649">https://bugs.webkit.org/show_bug.cgi?id=284649</a>
<a href="https://rdar.apple.com/141450845">rdar://141450845</a>

Reviewed by Simon Fraser.

Add a new ModelPresentationManagerProxy to manage the presentations of remotely
hosted model contents on the page. ModelPresentationManagerProxy has a map of
model layer identifiers to ModelPresentation objects, which contains info
about the model being hosted (ModelContext), the remote view hosting the model layer,
and the new WKPageHostedModelView which is a WKCompositingView subclass used
in the layer tree node for the model contents. ModelContext is passed
down with the LayerCreationProperties. When setting up the view for the model
contents layer tree node, instead of creating a new WKUIRemoteView with the
layer hosting context ID, it’ll ask ModelPresentationManagerProxy for the view.

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::graphicsLayer const):
(WebCore::HTMLModelElement::layerID const):
Helper method to get the PlatformLayerID of the primary layer of the model
element.
(WebCore::HTMLModelElement::modelContentsLayerID const):
Renamed from platformLayerID() so it&apos;s clear which layer it&apos;s for.
(WebCore::HTMLModelElement::modelContext const):
(WebCore::HTMLModelElement::platformLayerID): Deleted.
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/Modules/model-element/ModelPlayerClient.h:
* Source/WebCore/Sources.txt
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::GraphicsLayer::setContentsToModelContext):
Make this a method dedicated for setting model contents which takes in
a ModelContext.
(WebCore::GraphicsLayer::setContentsToRemotePlatformContext): Deleted.
* Source/WebCore/platform/graphics/ModelContext.cpp
* Source/WebCore/platform/graphics/ModelContext.h
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::createPlatformCALayer):
(WebCore::GraphicsLayerCA::setContentsToModelContext):
(WebCore::GraphicsLayerCA::setContentsToRemotePlatformContext): Deleted.
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateConfiguration):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h:
Adding ModelContext in the AdditionalData.
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm:
(WebKit::RemoteLayerTreeTransaction::LayerCreationProperties::hostingContextID const):
Updated to handle the new ModelContext additional data.
(WebKit::RemoteLayerTreeTransaction::LayerCreationProperties::modelContext const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/Model/ModelPresentationManagerProxy.h: Added.
* Source/WebKit/UIProcess/Model/ModelPresentationManagerProxy.mm: Added.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::layerWillBeRemoved):
If the model element&apos;s layer is being removed, remove the corresponding
ModelPresentation from ModelPresentationManagerProxy.
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeHostIOS.mm:
(WebKit::RemoteLayerTreeHost::makeNode):
Instead of always creating a new WKUIRemoteView, get the model view from ModelPresentationManagerProxy.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didAttachToRunningProcess):
Set up ModelPresentationManagerProxy.
(WebKit::WebPageProxy::resetState):
Invalidate all model presentations on that page.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Source/WebKit/UIProcess/ios/WKPageHostedModelView.h: Copied from Source/WebCore/Modules/model-element/ModelPlayerClient.h.
* Source/WebKit/UIProcess/ios/WKPageHostedModelView.mm: Copied from Source/WebCore/Modules/model-element/ModelPlayerClient.h.
(-[WKPage:WKPageHostedModelView setRemoteModelView:]):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::modelPresentationManagerProxy const):
* Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm:
(WebKit::GraphicsLayerCARemote::createPlatformCALayer):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm:
(WebKit::PlatformCALayerRemote::create):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm:
(WebKit::PlatformCALayerRemoteCustom::create):
(WebKit::PlatformCALayerRemoteCustom::PlatformCALayerRemoteCustom):
(WebKit::PlatformCALayerRemoteCustom::populateCreationProperties):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm:
(WebKit::RemoteLayerTreeContext::layerDidEnterContext):

Canonical link: <a href="https://commits.webkit.org/288141@main">https://commits.webkit.org/288141@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b22ba4909e610415b594c8faa46944c6f95d2b5c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81953 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1480 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35910 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86510 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32985 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84059 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1515 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9303 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63904 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21630 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85023 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1125 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74574 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44187 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1027 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28751 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31404 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29362 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87941 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9195 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6555 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72272 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9380 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70393 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71494 "Found 1 new API test failure: /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/cut-copy-paste/non-editable (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17826 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15600 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14519 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9146 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14682 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8986 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12511 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10794 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->