### PR TITLE
[SwiftUI] Support media-related API functionality

### DIFF
--- a/Source/WebKit/UIProcess/API/Swift/WKUIDelegateAdapter.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WKUIDelegateAdapter.swift
@@ -35,6 +35,8 @@ final class WKUIDelegateAdapter: NSObject, WKUIDelegate {
         self.dialogPresenter = dialogPresenter ?? DefaultDialogPresenting()
     }
 
+    weak var owner: WebPage_v0? = nil
+
     private let dialogPresenter: any DialogPresenting
 
     // MARK: Dialog presentation
@@ -68,6 +70,24 @@ final class WKUIDelegateAdapter: NSObject, WKUIDelegate {
         case let .ok(value): value
         case .cancel: nil
         }
+    }
+
+    // MARK: Permissions
+
+    func webView(_ webView: WKWebView, requestDeviceOrientationAndMotionPermissionFor origin: WKSecurityOrigin, initiatedByFrame frame: WKFrameInfo) async -> WKPermissionDecision {
+        guard let owner else {
+            return .prompt
+        }
+
+        return await owner.configuration.deviceSensorAuthorization.decisionHandler(.deviceOrientationAndMotion, .init(frame), origin)
+    }
+
+    func webView(_ webView: WKWebView, decideMediaCapturePermissionsFor origin: WKSecurityOrigin, initiatedBy frame: WKFrameInfo, type: WKMediaCaptureType) async -> WKPermissionDecision {
+        guard let owner else {
+            return .prompt
+        }
+
+        return await owner.configuration.deviceSensorAuthorization.decisionHandler(.mediaCapture(type), .init(frame), origin)
     }
 }
 

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift
@@ -43,6 +43,8 @@ extension WebPage_v0 {
 
         public var urlSchemeHandlers: [URLScheme_v0 : any URLSchemeHandler_v0] = [:]
 
+        public var deviceSensorAuthorization: WebPage_v0.DeviceSensorAuthorization = WebPage_v0.DeviceSensorAuthorization(decision: .prompt)
+
         public var applicationNameForUserAgent: String? = nil
 
         public var limitsNavigationsToAppBoundDomains: Bool = false
@@ -60,6 +62,26 @@ extension WebPage_v0 {
 
         public var ignoresViewportScaleLimits: Bool = false
 #endif
+    }
+}
+
+extension WebPage_v0 {
+    @_spi(Private)
+    public struct DeviceSensorAuthorization {
+        public enum Permission: Hashable, Sendable {
+            case deviceOrientationAndMotion
+            case mediaCapture(WKMediaCaptureType)
+        }
+
+        let decisionHandler: (Permission, WebPage_v0.FrameInfo, WKSecurityOrigin) async -> WKPermissionDecision
+
+        public init(decisionHandler: @escaping (Permission, WebPage_v0.FrameInfo, WKSecurityOrigin) async -> WKPermissionDecision) {
+            self.decisionHandler = decisionHandler
+        }
+
+        public init(decision: WKPermissionDecision) {
+            self.init { _, _, _ in decision }
+        }
     }
 }
 

--- a/Tools/SwiftBrowser/Resources/iOS/Info.plist
+++ b/Tools/SwiftBrowser/Resources/iOS/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>This app uses the microphone.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>This app uses the camera.</string>
 	<key>UILaunchScreen</key>
 	<dict/>
 	<key>LSApplicationCategoryType</key>

--- a/Tools/SwiftBrowser/Resources/mac/Info.plist
+++ b/Tools/SwiftBrowser/Resources/mac/Info.plist
@@ -1,48 +1,52 @@
 <?xml version="1.0" encoding="UTF-8"?>
- <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
- <plist version="1.0">
- <dict>
-     <key>CFBundleDevelopmentRegion</key>
-     <string>$(DEVELOPMENT_LANGUAGE)</string>
-     <key>CFBundleExecutable</key>
-     <string>$(EXECUTABLE_NAME)</string>
-     <key>CFBundleIconFile</key>
-     <string></string>
-     <key>CFBundleIdentifier</key>
-     <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-     <key>CFBundleInfoDictionaryVersion</key>
-     <string>6.0</string>
-     <key>CFBundleName</key>
-     <string>$(PRODUCT_NAME)</string>
-     <key>CFBundlePackageType</key>
-     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
-     <key>CFBundleShortVersionString</key>
-     <string>1.0</string>
-     <key>CFBundleVersion</key>
-     <string>1</string>
-     <key>LSMinimumSystemVersion</key>
-     <string>$(MACOSX_DEPLOYMENT_TARGET)</string>
-     <key>NSAppTransportSecurity</key>
-     <dict>
-         <key>NSAllowsArbitraryLoads</key>
-         <true/>
-     </dict>
-     <key>CFBundleDocumentTypes</key>
-     <array>
-         <dict>
-             <key>CFBundleTypeExtensions</key>
-             <array>
-                 <string>html</string>
-             </array>
-             <key>CFBundleTypeMIMETypes</key>
-             <array>
-                 <string>text/html</string>
-             </array>
-             <key>CFBundleTypeName</key>
-             <string>HTML</string>
-             <key>CFBundleTypeRole</key>
-             <string>Editor</string>
-         </dict>
-     </array>
- </dict>
- </plist>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>This app uses the microphone.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>This app uses the camera.</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>html</string>
+			</array>
+			<key>CFBundleTypeMIMETypes</key>
+			<array>
+				<string>text/html</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>HTML</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Tools/SwiftBrowser/Source/AppStorageKeys.swift
+++ b/Tools/SwiftBrowser/Source/AppStorageKeys.swift
@@ -25,4 +25,6 @@ import Foundation
 
 enum AppStorageKeys {
     static let homepage = "homepage"
+    static let orientationAndMotionAuthorization = "orientationAndMotionAuthorization2"
+    static let mediaCaptureAuthorization = "mediaCaptureAuthorization2"
 }

--- a/Tools/SwiftBrowser/Source/SettingsView.swift
+++ b/Tools/SwiftBrowser/Source/SettingsView.swift
@@ -22,22 +22,57 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 
 import SwiftUI
+import WebKit
+
+private struct PermissionDecisionView: View {
+    @Binding var permissionDecision: WKPermissionDecision
+
+    let label: String
+
+    var body: some View {
+        Picker(selection: $permissionDecision) {
+            Text("Ask").tag(WKPermissionDecision.prompt)
+            Text("Grant").tag(WKPermissionDecision.grant)
+            Text("Deny").tag(WKPermissionDecision.deny)
+        } label: {
+            Text(label)
+        }
+    }
+}
 
 struct GeneralSettingsView: View {
     @AppStorage(AppStorageKeys.homepage) private var homepage = "https://www.webkit.org"
+
+    @AppStorage(AppStorageKeys.orientationAndMotionAuthorization) private var orientationAndMotionAuthorization = WKPermissionDecision.prompt
+    @AppStorage(AppStorageKeys.mediaCaptureAuthorization) private var mediaCaptureAuthorization = WKPermissionDecision.prompt
 
     let currentURL: URL?
 
     var body: some View {
         Form {
-            TextField("Homepage", text: $homepage)
+            Section {
+                TextField("Homepage:", text: $homepage)
 
-            Button("Set to Current Page") {
-                if let currentURL {
-                    homepage = currentURL.absoluteString
-                } else {
-                    fatalError()
+                Button("Set to Current Page") {
+                    if let currentURL {
+                        homepage = currentURL.absoluteString
+                    } else {
+                        fatalError()
+                    }
                 }
+            }
+
+            Section {
+                PermissionDecisionView(
+                    permissionDecision: $mediaCaptureAuthorization,
+                    label: "Allow sites to access camera:"
+                )
+                .padding(.top)
+
+                PermissionDecisionView(
+                    permissionDecision: $orientationAndMotionAuthorization,
+                    label: "Allow sites to access sensors:"
+                )
             }
         }
     }
@@ -53,7 +88,7 @@ struct SettingsView: View {
             }
         }
         .scenePadding()
-        .frame(maxWidth: 350, minHeight: 100)
+        .frame(maxWidth: 600, minHeight: 100)
     }
 }
 


### PR DESCRIPTION
#### 00588182d1cf03e9414afa467d2266b7bc293317
<pre>
[SwiftUI] Support media-related API functionality
<a href="https://bugs.webkit.org/show_bug.cgi?id=284651">https://bugs.webkit.org/show_bug.cgi?id=284651</a>
<a href="https://rdar.apple.com/141109070">rdar://141109070</a>

Reviewed by Aditya Keerthi.

Add functionality to support controlling media interaction to WebPage and WebView:

* Adds an observable `fullscreenState` to WebPage which is analogous to the one on WKWebView.
* Adds some functions to WebPage which are analogous to their WebPage counterparts, such as `setAllMediaPlaybackSuspended`
* Adds several properties and functions to WebPage to be able to observe and control camera and microphone capture state.
* Adds support for customizing when permission prompts are displayed.

* Source/WebKit/UIProcess/API/Swift/View+WebViewModifiers.swift:
(EnvironmentValues.webViewCameraCaptureState):
(EnvironmentValues.webViewMicrophoneCaptureState):
(View.webViewCameraCaptureState(_:)):
(View.webViewMicrophoneCaptureState(_:)):
* Source/WebKit/UIProcess/API/Swift/WebPage.swift:
(fullscreenState):
(pauseAllMediaPlayback):
(mediaPlaybackState):
(setAllMediaPlaybackSuspended(_:)):
(closeAllMediaPresentations):
(WebPage_v0.handlesURLScheme(_:)): Deleted.
(WebPage_v0.backForwardList): Deleted.
(WebPage_v0.url): Deleted.
(WebPage_v0.title): Deleted.
(WebPage_v0.estimatedProgress): Deleted.
(WebPage_v0.isLoading): Deleted.
(WebPage_v0.serverTrust): Deleted.
(WebPage_v0.hasOnlySecureContent): Deleted.
(WebPage_v0.isWritingToolsActive): Deleted.
(WebPage_v0.mediaType): Deleted.
(WebPage_v0.customUserAgent): Deleted.
(WebPage_v0.isInspectable): Deleted.
(WebPage_v0.backingWebView): Deleted.
(WebPage_v0.load(_:)): Deleted.
(WebPage_v0.load(_:mimeType:characterEncoding:baseURL:)): Deleted.
(WebPage_v0.load(_:baseURL:)): Deleted.
(WebPage_v0.load(fileURL:allowingReadAccessTo:)): Deleted.
(WebPage_v0.load(fileRequest:allowingReadAccessTo:)): Deleted.
(WebPage_v0.load(simulatedRequest:response:responseData:)): Deleted.
(WebPage_v0.load(simulatedRequest:responseHTML:)): Deleted.
(WebPage_v0.reload(_:)): Deleted.
(WebPage_v0.stopLoading): Deleted.
(WebPage_v0.callAsyncJavaScript(_:arguments:in:contentWorld:)): Deleted.
(WebPage_v0.snapshot(_:)): Deleted.
(WebPage_v0.pdf(_:)): Deleted.
(WebPage_v0.webArchiveData): Deleted.
* Source/WebKit/UIProcess/API/Swift/WebView.swift:
(WebViewRepresentable.makePlatformView(_:)):
(WebViewRepresentable.updatePlatformView(_:context:)):
(WebViewRepresentable.makeCoordinator):
(Coordinator.cameraCaptureState):
(Coordinator.microphoneCaptureState):
(Coordinator.observations):
(Coordinator.owner):
(Coordinator.updateObservations):
* Tools/SwiftBrowser/Resources/iOS/Info.plist:
* Tools/SwiftBrowser/Resources/mac/Info.plist:
* Tools/SwiftBrowser/Source/ContentView.swift:
(LabelConfiguration.captureState):
(LabelConfiguration.body):
(PrincipalToolbarGroup.cameraCaptureState):
(PrincipalToolbarGroup.microphoneCaptureState):
(PrincipalToolbarGroup.body):
(ContentView.cameraCaptureState):
(ContentView.microphoneCaptureState):
(ContentView.body):

Canonical link: <a href="https://commits.webkit.org/288251@main">https://commits.webkit.org/288251@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4dd97237ef34af4459649ec85f081ea5e94075a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82250 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1914 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36315 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87382 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33311 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84355 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1985 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9795 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64103 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21851 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85319 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1380 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74840 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44381 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1282 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29021 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32352 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72582 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29643 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88738 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9556 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6817 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72495 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9782 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70654 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71713 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15847 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/14864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/909 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12764 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9509 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15024 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9383 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12849 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11152 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->