### PR TITLE
[WebGPU] Dynamic offsets index generation is incorrect for more than two bind groups using dynamic offsets

### DIFF
--- a/LayoutTests/fast/webgpu/regression/repro_284652-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_284652-expected.txt
@@ -1,0 +1,8 @@
+CONSOLE MESSAGE: promises created
+CONSOLE MESSAGE: the end
+CONSOLE MESSAGE: repro_284652.html
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600 [color=#99DDBBCC] [bgcolor=#102030E0]
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/repro_284652.html
+++ b/LayoutTests/fast/webgpu/regression/repro_284652.html
@@ -1,0 +1,348 @@
+<!-- webkit-test-runner [ enableMetalShaderValidation=true ] -->
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = console.log;
+
+async function gc() {
+  await 0;
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUComputePassEncoder} computePassEncoder
+ */
+function clearResourceUsages(device, computePassEncoder) {
+  let code = `@compute @workgroup_size(1) fn c() {}`;
+  let module = device.createShaderModule({code});
+  computePassEncoder.setPipeline(device.createComputePipeline(
+    {
+      layout: 'auto',
+      compute: {module},
+    }));
+  computePassEncoder.dispatchWorkgroups(1);
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+const videoUrls = [
+
+];
+
+/**
+ * @param {number} index
+ * @returns {Promise<HTMLVideoElement>}
+ */
+function videoWithData(index) {
+  let video = document.createElement('video');
+  video.src = videoUrls[index % videoUrls.length];
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+/**
+ * @param {string} payload
+ * @returns {string}
+ */
+function toBlobUrl(payload) {
+  let blob = new Blob([payload], {type: 'text/javascript'});
+  return URL.createObjectURL(blob);
+}
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+// START
+adapter0 = await navigator.gpu.requestAdapter();
+device0 = await adapter0.requestDevice();
+bindGroupLayout2 = device0.createBindGroupLayout({
+  entries : [
+    {
+      binding : 499,
+      visibility : GPUShaderStage.VERTEX,
+      buffer : {hasDynamicOffset : true}
+    }]});
+{
+}
+buffer4 = device0.createBuffer({
+  size : 21404,
+  usage : GPUBufferUsage.UNIFORM | GPUBufferUsage,
+  });
+{
+}
+pipelineLayout4 = device0.createPipelineLayout({
+  bindGroupLayouts : [ bindGroupLayout2, bindGroupLayout2, bindGroupLayout2 ]});
+shaderModule3 = device0.createShaderModule({
+  code : ` ;
+              struct FragmentOutput1 {
+              @location(0) f0: vec2f,   @location(3) f1: i32,   @location(7) f2: vec2i}
+              @fragment fn fragment3() -> FragmentOutput1 {
+              var out: FragmentOutput1;
+              return out;
+            }
+             `,
+  });
+buffer11 = device0.createBuffer({
+  size : 32587,
+  usage : GPUBufferUsage.UNIFORM |
+              GPUBufferUsage});
+texture19 = device0.createTexture({
+  size : {width : 1, depthOrArrayLayers : 23},
+  dimension : '3d',
+  format : 'rg32float',
+  usage : GPUTextureUsage.RENDER_ATTACHMENT |
+              GPUTextureUsage});
+{
+}
+shaderModule5 = device0.createShaderModule({
+  code : ` ;
+             fn unconst_bool(v: bool) -> bool {
+           return v;
+           }
+             fn unconst_f32(v: f32) -> f32 {
+           return v;
+           }
+             @group(2) @binding(499) var<uniform> buffer18: VertexOutput4;
+             struct VertexOutput4 {
+             @builtin(position) f29: vec4f}
+             override override12: f16;
+             override override13: f32;
+             
+            
+            fn fn0() {
+                _ = override13;
+            }
+            
+             fn fn2(a0: VertexOutput4) -> i32 
+             {
+                 var out: i32;
+                 out &= bitcast<vec4i>(smoothstep(vec4f(), vec4f(), (vec2f(unconst_f32(0.1294))).rrrr))[2];
+                 let vf108= select(vec2h(), vec2h(), vec2((false), ));
+                 var vf109= a0;
+                 out = bitcast<i32>((vec2f((0.1103), unconst_f32(0.04778)))[0]);
+                 var vf112= (vec3i());
+                 let vf114f32 = a0.f29[u32()];
+                 let ptr54: ptr<function, vec3i> = &vf112;
+                 vf109.f29 += (f32(vf112[u32()]));
+                 var vf117= vf108[u32()];
+                 let vf118f16 = override12;
+                 out &= bitcast<vec4i>(smoothstep(vec4f(), vec4f(), vec4f((0.03282), (0.3133), (0.01408), unconst_f32(0.01364))))[3];
+                 vf109 = VertexOutput4(vec4f(vf109.f29[u32()]));
+                 vf117 = vec3h((*ptr54))[0];
+                 return out;
+               }
+            
+             @vertex fn vertex5() -> VertexOutput4 {
+             var out: VertexOutput4;
+             fn0();
+             fn2(VertexOutput4((buffer18).f29));
+             return out;
+           }
+            `,
+  });
+pipeline3 = await device0.createRenderPipelineAsync({
+  layout : pipelineLayout4,
+  multisample : {},
+  fragment : {
+    module : shaderModule3,
+    constants : {},
+    targets : [ {
+      format : 'rg32float',
+      writeMask : GPUColorWrite.GREEN
+    } ]},
+  vertex : {
+    module : shaderModule5,
+    constants : {override13 : 0, override12 : 0},
+    }});
+bindGroup14 = device0.createBindGroup({
+  layout : bindGroupLayout2,
+  entries : [
+    {binding : 499, resource : {buffer : buffer11, size : 1471}}
+  ]});
+{
+}
+({
+  });
+{
+}
+buffer31 = device0.createBuffer({
+  size : 901,
+  usage : GPUBufferUsage.UNIFORM
+});
+{
+}
+textureView25 = texture19.createView({
+  mipLevelCount : 1
+});
+bindGroup18 = device0.createBindGroup({
+  layout : bindGroupLayout2,
+  entries : [ {binding : 499, resource : {buffer : buffer4, }} ]});
+commandEncoder36 = device0.createCommandEncoder();
+renderPassEncoder12 = commandEncoder36.beginRenderPass({
+  colorAttachments : [
+    {view : textureView25, depthSlice : 9, loadOp : 'clear', storeOp : 'store'}
+  ],
+  });
+{
+}
+bindGroup24 = device0.createBindGroup({
+  layout : bindGroupLayout2,
+  entries : [
+    {binding : 499, resource : {buffer : buffer31, }}
+  ]});
+try {
+  renderPassEncoder12.setBindGroup(0, bindGroup18, new Uint32Array(1346), 629,
+                                   1)} catch {
+}
+                   try {
+                       renderPassEncoder12.setBindGroup(2, bindGroup24, new Uint32Array(2748), 0, 1);
+                   } catch {
+}
+({
+  });
+commandEncoder83 = device0.createCommandEncoder();
+{
+}
+try {
+  renderPassEncoder12.setPipeline(pipeline3)} catch {
+}
+try {
+  renderPassEncoder12.setBindGroup(1, bindGroup14, [ 11776 ]);
+  renderPassEncoder12.draw(1306)} catch {
+}
+commandBuffer13 = commandEncoder83;
+{
+}
+try {
+  renderPassEncoder12.end()} catch {
+}
+commandBuffer14 = commandEncoder36.finish();
+try {
+  device0.queue.submit([ commandBuffer14 ])} catch {
+}
+// END
+await device0.queue.onSubmittedWorkDone();
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/ShaderModule.mm
+++ b/Source/WebGPU/WebGPU/ShaderModule.mm
@@ -990,21 +990,21 @@ WGSL::PipelineLayout ShaderModule::convertPipelineLayout(const PipelineLayout& p
             if (entry.value.vertexDynamicOffset) {
                 RELEASE_ASSERT(!(entry.value.vertexDynamicOffset.value() % sizeof(uint32_t)));
                 wgslEntry.vertexBufferDynamicOffset = (vertexOffset + *entry.value.vertexDynamicOffset) / sizeof(uint32_t);
-                maxVertexOffset = std::max<size_t>(maxVertexOffset, *entry.value.vertexDynamicOffset + sizeof(uint32_t));
+                maxVertexOffset = std::max<size_t>(maxVertexOffset, *entry.value.vertexDynamicOffset + sizeof(uint32_t) + vertexOffset);
             }
             wgslEntry.fragmentArgumentBufferIndex = entry.value.argumentBufferIndices[WebGPU::ShaderStage::Fragment];
             wgslEntry.fragmentArgumentBufferSizeIndex = entry.value.bufferSizeArgumentBufferIndices[WebGPU::ShaderStage::Fragment];
             if (entry.value.fragmentDynamicOffset) {
                 RELEASE_ASSERT(!(entry.value.fragmentDynamicOffset.value() % sizeof(uint32_t)));
                 wgslEntry.fragmentBufferDynamicOffset = (fragmentOffset + *entry.value.fragmentDynamicOffset) / sizeof(uint32_t) + RenderBundleEncoder::startIndexForFragmentDynamicOffsets;
-                maxFragmentOffset = std::max<size_t>(maxFragmentOffset, *entry.value.fragmentDynamicOffset + sizeof(uint32_t));
+                maxFragmentOffset = std::max<size_t>(maxFragmentOffset, *entry.value.fragmentDynamicOffset + sizeof(uint32_t) + fragmentOffset);
             }
             wgslEntry.computeArgumentBufferIndex = entry.value.argumentBufferIndices[WebGPU::ShaderStage::Compute];
             wgslEntry.computeArgumentBufferSizeIndex = entry.value.bufferSizeArgumentBufferIndices[WebGPU::ShaderStage::Compute];
             if (entry.value.computeDynamicOffset) {
                 RELEASE_ASSERT(!(entry.value.computeDynamicOffset.value() % sizeof(uint32_t)));
                 wgslEntry.computeBufferDynamicOffset = (computeOffset + *entry.value.computeDynamicOffset) / sizeof(uint32_t);
-                maxComputeOffset = std::max<size_t>(maxComputeOffset, *entry.value.computeDynamicOffset + sizeof(uint32_t));
+                maxComputeOffset = std::max<size_t>(maxComputeOffset, *entry.value.computeDynamicOffset + sizeof(uint32_t) + computeOffset);
             }
             wgslBindGroupLayout.entries.append(wgslEntry);
         }


### PR DESCRIPTION
#### 0b1e7a02543a9c582824dc6dea32cb475fd2fd45
<pre>
[WebGPU] Dynamic offsets index generation is incorrect for more than two bind groups using dynamic offsets
<a href="https://bugs.webkit.org/show_bug.cgi?id=284652">https://bugs.webkit.org/show_bug.cgi?id=284652</a>
<a href="https://rdar.apple.com/141433334">rdar://141433334</a>

Reviewed by Dan Glastonbury.

When computing the index for dynamic offsets, we didn&apos;t take
into account the total index offset in the call to std::max(...)

* LayoutTests/fast/webgpu/regression/repro_284652-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_284652.html: Added.

* Source/WebGPU/WebGPU/ShaderModule.mm:

Canonical link: <a href="https://commits.webkit.org/287866@main">https://commits.webkit.org/287866@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89f7d740438e1e1d1463eb9c8fc58a2b4514e502

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81008 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/533 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34951 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85537 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31994 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/550 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8334 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63238 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21009 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84077 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/322 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73725 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43536 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/218 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27886 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30452 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71768 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28436 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86972 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8238 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5815 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71540 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8415 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69560 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70775 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17649 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14816 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13741 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8199 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13722 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8036 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11556 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9844 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->