### PR TITLE
Add support for browser.test.sendMessage and onMessage.

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionEventListenerType.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionEventListenerType.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -75,6 +75,7 @@ enum class WebExtensionEventListenerType : uint8_t {
     TabsOnRemoved,
     TabsOnReplaced,
     TabsOnUpdated,
+    TestOnMessage,
     WebNavigationOnBeforeNavigate,
     WebNavigationOnCommitted,
     WebNavigationOnCompleted,
@@ -179,6 +180,8 @@ inline String toAPIString(WebExtensionEventListenerType eventType)
         return "onReplaced"_s;
     case WebExtensionEventListenerType::TabsOnUpdated:
         return "onUpdated"_s;
+    case WebExtensionEventListenerType::TestOnMessage:
+        return "onMessage"_s;
     case WebExtensionEventListenerType::WebNavigationOnBeforeNavigate:
         return "onBeforeNavigate"_s;
     case WebExtensionEventListenerType::WebNavigationOnCommitted:

--- a/Source/WebKit/Shared/Extensions/WebExtensionEventListenerType.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionEventListenerType.serialization.in
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Apple Inc. All rights reserved.
+# Copyright (C) 2023-2024 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -66,6 +66,7 @@ enum class WebKit::WebExtensionEventListenerType : uint8_t {
     TabsOnRemoved,
     TabsOnReplaced,
     TabsOnUpdated,
+    TestOnMessage,
     WebNavigationOnBeforeNavigate,
     WebNavigationOnCommitted,
     WebNavigationOnCompleted,

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm
@@ -831,12 +831,19 @@ static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(WKWeb
 
 - (WKWebView *)_backgroundWebView
 {
-    return Ref { *_webExtensionContext }->backgroundWebView();
+    return self._protectedWebExtensionContext->backgroundWebView();
 }
 
 - (NSURL *)_backgroundContentURL
 {
-    return Ref { *_webExtensionContext }->backgroundContentURL();
+    return self._protectedWebExtensionContext->backgroundContentURL();
+}
+
+- (void)_sendTestMessage:(NSString *)message withArgument:(id)argument
+{
+    NSParameterAssert([message isKindOfClass:NSString.class]);
+
+    self._protectedWebExtensionContext->sendTestMessage(message, argument);
 }
 
 #if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
@@ -862,6 +869,11 @@ static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(WKWeb
 }
 
 - (WebKit::WebExtensionContext&)_webExtensionContext
+{
+    return *_webExtensionContext;
+}
+
+- (Ref<WebKit::WebExtensionContext>)_protectedWebExtensionContext
 {
     return *_webExtensionContext;
 }
@@ -1248,6 +1260,10 @@ static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(WKWeb
 - (NSURL *)_backgroundContentURL
 {
     return nil;
+}
+
+- (void)_sendTestMessage:(NSString *)message withArgument:(id)argument
+{
 }
 
 - (nullable _WKWebExtensionSidebar *)sidebarForTab:(id<WKWebExtensionTab>)tab

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContextPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContextPrivate.h
@@ -38,6 +38,14 @@ WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 @property (nonatomic, nullable, readonly) NSURL *_backgroundContentURL;
 
 /*!
+ @abstract Sends a message to the JavaScript `browser.test.onMessage` API.
+ @discussion Allows code to trigger a `browser.test.onMessage` event, enabling bidirectional communication during testing.
+ @param message The message string to send.
+ @param argument The optional JSON-serializable argument to include with the message. Must be JSON-serializable according to \c NSJSONSerialization.
+ */
+- (void)_sendTestMessage:(NSString *)message withArgument:(nullable id)argument;
+
+/*!
  @abstract Retrieves the extension sidebar for a given tab, or the default sidebar if `nil` is passed.
  @param tab The tab for which to retrieve the extension sidebar, or `nil` to get the default sidebar.
  @discussion The returned object represents the sidebar specific to the tab when provided; otherwise, it returns the default sidebar.

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerDelegatePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerDelegatePrivate.h
@@ -58,6 +58,12 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 - (void)_webExtensionController:(WKWebExtensionController *)controller recordTestYieldedWithMessage:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber;
 
 /*!
+ @abstract Delegate for the `browser.test.sendMessage()` JavaScript testing API.
+ @discussion Default implementation always logs the message and argument to the system console. Test harnesses should use this to process the received message and perform actions based on its contents.
+ */
+- (void)_webExtensionController:(WKWebExtensionController *)controller receivedTestMessage:(NSString *)message withArgument:(id)argument andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber;
+
+/*!
  @abstract Delegate for the `browser.test.notifyPass()` and `browser.test.notifyFail()` JavaScript testing APIs.
  @discussion Default implementation logs a message to the system console when `result` is `NO`. Test harnesses should use this to exit the run loop and record a test pass or failure.
  */

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionControllerAPITestCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionControllerAPITestCocoa.mm
@@ -32,6 +32,7 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+#import "CocoaHelpers.h"
 #import "Logging.h"
 #import "WKWebExtensionControllerDelegatePrivate.h"
 #import "WKWebExtensionControllerInternal.h"
@@ -102,6 +103,17 @@ void WebExtensionController::testYielded(String message, String sourceURL, unsig
         message = "(no message)"_s;
 
     RELEASE_LOG_INFO(Extensions, "Test yielded: %{public}@ (%{public}@:%{public}u)", (NSString *)message, (NSString *)sourceURL, lineNumber);
+}
+
+void WebExtensionController::testSentMessage(String message, String argument, String sourceURL, unsigned lineNumber)
+{
+    auto delegate = this->delegate();
+    if ([delegate respondsToSelector:@selector(_webExtensionController:receivedTestMessage:withArgument:andSourceURL:lineNumber:)]) {
+        [delegate _webExtensionController:wrapper() receivedTestMessage:message withArgument:parseJSON(argument, JSONOptions::FragmentsAllowed) andSourceURL:sourceURL lineNumber:lineNumber];
+        return;
+    }
+
+    RELEASE_LOG_INFO(Extensions, "Test sent message: %{public}@ %{public}@ (%{public}@:%{public}u)", (NSString *)message, (NSString *)argument, (NSString *)sourceURL, lineNumber);
 }
 
 void WebExtensionController::testFinished(bool result, String message, String sourceURL, unsigned lineNumber)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -4955,6 +4955,20 @@ _WKWebExtensionStorageSQLiteStore *WebExtensionContext::storageForType(WebExtens
     return nil;
 }
 
+void WebExtensionContext::sendTestMessage(const String& message, id argument)
+{
+    ASSERT(isLoaded() && inTestingMode());
+    if (!isLoaded() || !inTestingMode())
+        return;
+
+    String argumentJSON = encodeJSONString(argument, JSONOptions::FragmentsAllowed);
+
+    constexpr auto eventType = WebExtensionEventListenerType::TestOnMessage;
+    wakeUpBackgroundContentIfNecessaryToFireEvents({ eventType }, [=, this, protectedThis = Ref { *this }] {
+        sendToProcessesForEvent(eventType, Messages::WebExtensionContextProxy::DispatchTestMessageEvent(message, argumentJSON));
+    });
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -519,6 +519,10 @@ public:
     bool inTestingMode() const;
 
 #if PLATFORM(COCOA)
+    void sendTestMessage(const String& message, id argument);
+#endif
+
+#if PLATFORM(COCOA)
     URL backgroundContentURL();
     WKWebView *backgroundWebView() const { return m_backgroundWebView.get(); }
     bool safeToLoadBackgroundContent() const { return m_safeToLoadBackgroundContent; }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -223,6 +223,7 @@ private:
     void testEqual(bool result, String expected, String actual, String message, String sourceURL, unsigned lineNumber);
     void testMessage(String message, String sourceURL, unsigned lineNumber);
     void testYielded(String message, String sourceURL, unsigned lineNumber);
+    void testSentMessage(String message, String argument, String sourceURL, unsigned lineNumber);
     void testFinished(bool result, String message, String sourceURL, unsigned lineNumber);
 
     class HTTPCookieStoreObserver : public API::HTTPCookieStoreObserver {

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.messages.in
@@ -40,6 +40,7 @@ messages -> WebExtensionController {
     [Validator=inTestingMode] TestEqual(bool result, String expected, String actual, String message, String sourceURL, unsigned lineNumber)
     [Validator=inTestingMode] TestMessage(String message, String sourceURL, unsigned lineNumber)
     [Validator=inTestingMode] TestYielded(String message, String sourceURL, unsigned lineNumber)
+    [Validator=inTestingMode] TestSentMessage(String message, String argument, String sourceURL, unsigned lineNumber)
     [Validator=inTestingMode] TestFinished(bool result, String message, String sourceURL, unsigned lineNumber)
 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,8 +36,6 @@ OBJC_CLASS NSString;
 
 namespace WebKit {
 
-class WebPage;
-
 class WebExtensionAPITest : public WebExtensionAPIObject, public JSWebExtensionWrappable {
     WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPITest, test, test);
 
@@ -47,6 +45,9 @@ public:
     void notifyPass(JSContextRef, NSString *message);
 
     void yield(JSContextRef, NSString *message);
+
+    void sendMessage(JSContextRef, NSString *message, JSValue *argument);
+    WebExtensionAPIEvent& onMessage();
 
     void log(JSContextRef, JSValue *);
 
@@ -66,6 +67,9 @@ public:
     JSValue *assertSafe(JSContextRef, JSValue *function, NSString *message);
 
     JSValue *assertSafeResolve(JSContextRef, JSValue *function, NSString *message);
+
+private:
+    RefPtr<WebExtensionAPIEvent> m_onMessage;
 #endif
 };
 

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,8 +34,14 @@
     // Notifies that test passed.
     [NeedsScriptContext] void notifyPass([Optional] DOMString message);
 
-    // Yields the running of the extension for external testing.
+    // Yields the running of the extension back to the test harness.
     [NeedsScriptContext] void yield([Optional] DOMString message);
+
+    // Sends a message to the test harness.
+    [NeedsScriptContext] void sendMessage(DOMString message, [Optional, ValuesAllowed] any argument);
+
+    // Event for receiving messages from the test harness.
+    readonly attribute WebExtensionAPIEvent onMessage;
 
     // Logs a message during testing.
     [NeedsScriptContext] void log([ValuesAllowed] any message);
@@ -67,10 +73,10 @@
     // Asserts the function throws an exception.
     [NeedsScriptContext, ProcessArgumentsLeftToRight] void assertThrows(any function, [Optional, ValuesAllowed] any expectedError, [Optional] DOMString message);
 
-    // Asserts the function does not thow an exception.
+    // Asserts the function does not throw an exception.
     [NeedsScriptContext] any assertSafe(any function, [Optional] DOMString message);
 
-    // Asserts the function does not thow an exception and the result promise is resolved.
+    // Asserts the function does not throw an exception and the result promise is resolved.
     [NeedsScriptContext] any assertSafeResolve(any function, [Optional] DOMString message);
 
 };

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -204,6 +204,9 @@ private:
     void dispatchTabsHighlightedEvent(const Vector<WebExtensionTabIdentifier>&, WebExtensionWindowIdentifier);
     void dispatchTabsRemovedEvent(WebExtensionTabIdentifier, WebExtensionWindowIdentifier, WebExtensionContext::WindowIsClosing);
 
+    // Test
+    void dispatchTestMessageEvent(const String& message, const String& argumentJSON);
+
     // Web Navigation
     void dispatchWebNavigationEvent(WebExtensionEventListenerType, WebExtensionTabIdentifier, const WebExtensionFrameParameters&, WallTime);
 

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
@@ -90,6 +90,9 @@ messages -> WebExtensionContextProxy {
     DispatchTabsHighlightedEvent(Vector<WebKit::WebExtensionTabIdentifier> tabs, WebKit::WebExtensionWindowIdentifier windowIdentifier)
     DispatchTabsRemovedEvent(WebKit::WebExtensionTabIdentifier tabIdentifier, WebKit::WebExtensionWindowIdentifier windowIdentifier, WebKit::WebExtensionContext::WindowIsClosing windowIsClosing)
 
+    // Test Events
+    DispatchTestMessageEvent(String message, String argumentJSON)
+
     // Web Navigation
     DispatchWebNavigationEvent(WebKit::WebExtensionEventListenerType type, WebKit::WebExtensionTabIdentifier tabID, struct WebKit::WebExtensionFrameParameters frameParamaters, WallTime timestamp)
 

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -325,6 +325,7 @@ Tests/WebKitCocoa/WKWebExtensionAPIStorage.mm
 Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
 Tests/WebKitCocoa/WKWebExtensionAPISidebar.mm
 Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
+Tests/WebKitCocoa/WKWebExtensionAPITest.mm
 Tests/WebKitCocoa/WKWebExtensionAPIWebNavigation.mm
 Tests/WebKitCocoa/WKWebExtensionAPIWebRequest.mm
 Tests/WebKitCocoa/WKWebExtensionAPIWindows.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -2244,6 +2244,7 @@
 		1C2B81851C89252300A5529F /* Ahem.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = Ahem.ttf; sourceTree = "<group>"; };
 		1C38A9192B7AB310006B1333 /* WKWebExtensionAPIDevTools.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionAPIDevTools.mm; sourceTree = "<group>"; };
 		1C40052E2B2CEE8C00F2D9EE /* WKWebExtensionAPICookies.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionAPICookies.mm; sourceTree = "<group>"; };
+		1C4051F12D0CD4E5001922DF /* WKWebExtensionAPITest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionAPITest.mm; sourceTree = "<group>"; };
 		1C46169E26BA510700F8C9F6 /* TextStreamCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TextStreamCocoa.mm; sourceTree = "<group>"; };
 		1C4616A626BB172F00F8C9F6 /* TextStreamCocoa.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TextStreamCocoa.cpp; sourceTree = "<group>"; };
 		1C51534B261596BD00FBC4FE /* UserInstalledAhem.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = UserInstalledAhem.html; sourceTree = "<group>"; };
@@ -4572,6 +4573,7 @@
 				02ABB97C2C46EE2100696FE3 /* WKWebExtensionAPISidebar.mm */,
 				B626B7C42B4F4DEE008E8DD1 /* WKWebExtensionAPIStorage.mm */,
 				1CF7FFA72AA7C302003609F0 /* WKWebExtensionAPITabs.mm */,
+				1C4051F12D0CD4E5001922DF /* WKWebExtensionAPITest.mm */,
 				3378222C2947C095002106BB /* WKWebExtensionAPIWebNavigation.mm */,
 				3310E2FB2B599E93003692A8 /* WKWebExtensionAPIWebRequest.mm */,
 				1C9A2E182A9FB6F400D1B4A5 /* WKWebExtensionAPIWindows.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITest.mm
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "WebExtensionUtilities.h"
+
+namespace TestWebKitAPI {
+
+static auto *manifest = @{
+    @"manifest_version": @3,
+
+    @"name": @"Test Extension",
+    @"description": @"Test Extension",
+    @"version": @"1.0",
+
+    @"background": @{
+        @"scripts": @[ @"background.js" ],
+        @"persistent": @NO
+    }
+};
+
+TEST(WKWebExtensionAPITest, MessageEvent)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.onMessage.addListener((message, data) => {",
+        @"  browser.test.assertEq(message, 'Test', 'message should be')",
+        @"  browser.test.assertEq(data?.key, 'value', 'data.key should be')",
+
+        @"  browser.test.notifyPass()",
+        @"})",
+
+        @"browser.test.yield('Send Test Message')"
+    ]);
+
+    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:manifest resources:@{ @"background.js": backgroundScript }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    [manager loadAndRun];
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Send Test Message");
+
+    [manager sendTestMessage:@"Test" withArgument:@{ @"key": @"value" }];
+
+    [manager run];
+}
+
+TEST(WKWebExtensionAPITest, MessageEventWithSendMessageReply)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.onMessage.addListener((message, data) => {",
+        @"  browser.test.assertEq(message, 'Test', 'message should be')",
+        @"  browser.test.assertEq(data, undefined, 'data should be')",
+
+        @"  browser.test.sendMessage('Received')",
+        @"})",
+
+        @"browser.test.sendMessage('Ready')",
+    ]);
+
+    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:manifest resources:@{ @"background.js": backgroundScript }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    [manager load];
+    [manager runUntilTestMessage:@"Ready"];
+    [manager sendTestMessage:@"Test"];
+    [manager runUntilTestMessage:@"Received"];
+}
+
+TEST(WKWebExtensionAPITest, SendMessage)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.sendMessage('Test', { key: 'value' });"
+    ]);
+
+    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:manifest resources:@{ @"background.js": backgroundScript }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    [manager load];
+
+    id receivedMessage = [manager runUntilTestMessage:@"Test"];
+    EXPECT_NS_EQUAL(receivedMessage, @{ @"key": @"value" });
+}
+
+TEST(WKWebExtensionAPITest, SendMessageMultipleTimes)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.sendMessage('Test', { key: 'One' });",
+        @"browser.test.sendMessage('Test', { key: 'Two' });",
+        @"browser.test.sendMessage('Test', { key: 'Three' });"
+    ]);
+
+    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:manifest resources:@{ @"background.js": backgroundScript }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    [manager load];
+
+    id firstMessage = [manager runUntilTestMessage:@"Test"];
+    EXPECT_NS_EQUAL(firstMessage, @{ @"key": @"One" });
+
+    id secondMessage = [manager runUntilTestMessage:@"Test"];
+    EXPECT_NS_EQUAL(secondMessage, @{ @"key": @"Two" });
+
+    id thirdMessage = [manager runUntilTestMessage:@"Test"];
+    EXPECT_NS_EQUAL(thirdMessage, @{ @"key": @"Three" });
+}
+
+TEST(WKWebExtensionAPITest, SendMessageOutOfOrder)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.sendMessage('Message 1', { key: 'One' });",
+        @"browser.test.sendMessage('Message 2', { key: 'Two' });",
+        @"browser.test.sendMessage('Message 3', { key: 'Three' });"
+    ]);
+
+    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:manifest resources:@{ @"background.js": backgroundScript }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    [manager load];
+
+    id secondMessage = [manager runUntilTestMessage:@"Message 2"];
+    EXPECT_NS_EQUAL(secondMessage, @{ @"key": @"Two" });
+
+    id thirdMessage = [manager runUntilTestMessage:@"Message 3"];
+    EXPECT_NS_EQUAL(thirdMessage, @{ @"key": @"Three" });
+
+    id firstMessage = [manager runUntilTestMessage:@"Message 1"];
+    EXPECT_NS_EQUAL(firstMessage, @{ @"key": @"One" });
+}
+
+} // namespace TestWebKitAPI
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
@@ -70,9 +70,13 @@ using CocoaColor = UIColor;
 
 @property (nonatomic, readonly, strong) NSString *yieldMessage;
 
+- (void)sendTestMessage:(NSString *)message;
+- (void)sendTestMessage:(NSString *)message withArgument:(id)argument;
+
 - (void)load;
 - (void)run;
 - (void)runForTimeInterval:(NSTimeInterval)interval;
+- (id)runUntilTestMessage:(NSString *)message;
 - (void)loadAndRun;
 - (void)done;
 


### PR DESCRIPTION
#### ad26abd5c5b3b14a2378a065df67a08df0bf330d
<pre>
Add support for browser.test.sendMessage and onMessage.
<a href="https://webkit.org/b/284656">https://webkit.org/b/284656</a>
<a href="https://rdar.apple.com/138401321">rdar://138401321</a>

Reviewed by Brian Weinstein.

Adds simple messaging support to the test namespace that matches the Firefox and Chrome APIs.
This allows tests and the test harness to message bidirectionally. This is done with a new extension
controller delegate method, along with a send test message method on the extension context.

TestWebExtensionManager also has new send test message and run until message methods to handle linear,
message-driven test workflows.

* Source/WebKit/Shared/Extensions/WebExtensionEventListenerType.h:
(WebKit::toAPIString):
* Source/WebKit/Shared/Extensions/WebExtensionEventListenerType.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm:
(-[WKWebExtensionContext _backgroundWebView]):
(-[WKWebExtensionContext _backgroundContentURL]):
(-[WKWebExtensionContext _sendTestMessage:withArgument:]):
(-[WKWebExtensionContext _protectedWebExtensionContext]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContextPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerDelegatePrivate.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionControllerAPITestCocoa.mm:
(WebKit::WebExtensionController::testSentMessage):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::sendTestMessage):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionController.messages.in:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm:
(WebKit::WebExtensionAPITest::sendMessage):
(WebKit::WebExtensionAPITest::onMessage):
(WebKit::WebExtensionContextProxy::dispatchTestMessageEvent):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in:
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITest.mm: Added.
(TestWebKitAPI::TEST(WKWebExtensionAPITest, MessageEvent)):
(TestWebKitAPI::TEST(WKWebExtensionAPITest, MessageEventWithSendMessageReply)):
(TestWebKitAPI::TEST(WKWebExtensionAPITest, SendMessage)):
(TestWebKitAPI::TEST(WKWebExtensionAPITest, SendMessageMultipleTimes)):
(TestWebKitAPI::TEST(WKWebExtensionAPITest, SendMessageOutOfOrder)):
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h:
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionManager sendTestMessage:]):
(-[TestWebExtensionManager sendTestMessage:withArgument:]):
(-[TestWebExtensionManager runUntilTestMessage:]):
(-[TestWebExtensionManager _webExtensionController:receivedTestMessage:withArgument:andSourceURL:lineNumber:]):

Canonical link: <a href="https://commits.webkit.org/287893@main">https://commits.webkit.org/287893@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0fe91f07adab98ff615708b7ceef9565bfa928dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81278 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/35221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/85807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/32264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83388 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/8618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/85807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/32264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84347 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/35221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/85807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/35221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/30722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/35221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/87242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/8508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/8618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/87242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/8687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/35221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/87242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/35221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12592 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/8470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/13993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/8306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/11827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/10114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->