### PR TITLE
[webkitpy] Change update-expectations to use ios instead of ios-wk2.

### DIFF
--- a/Tools/Scripts/webkitpy/common/net/bugzilla/results_fetcher.py
+++ b/Tools/Scripts/webkitpy/common/net/bugzilla/results_fetcher.py
@@ -63,8 +63,8 @@ def _platform_name_for_bot(bot_name):
         return "mac-wk2"
     if "mac" in name and not name.endswith("-wk2"):
         return "mac-wk1"
-    if "simulator" in name:
-        return "ios-wk2"
+    if "simulator" in name and name.startswith("ios"):
+        return "ios"
     if "win-future" in name:
         return "win"
     if "gtk" in name:

--- a/Tools/Scripts/webkitpy/common/net/bugzilla/results_fetcher_unittest.py
+++ b/Tools/Scripts/webkitpy/common/net/bugzilla/results_fetcher_unittest.py
@@ -86,12 +86,12 @@ class MockBugzilla:
 class MockRequestsGet:
     def __init__(self, url):
         self._urls_data = {
-            "https://ews.webkit.org/status/4/": b'{"mac-wk1": {"url": "https://ews-build.webkit.org/#/builders/1/builds/99"}, "mac-wk2": {"url": "https://ews-build.webkit.org/#/builders/2/builds/99"}, "mac-debug-wk1": {"url": "https://ews-build.webkit.org/#/builders/3/builds/99"}, "ios-wk2": {"url": "https://ews-build.webkit.org/#/builders/4/builds/99"}, "win": {"url": "https://ews-build.webkit.org/#/builders/5/builds/99"}}',
-            "https://ews-build.webkit.org/api/v2/builders": b'{"builders": [{"builderid": 1, "description": "mac-wk1"}, {"builderid": 2, "description": "mac-wk2"}, {"builderid": 3, "description": "mac-debug-wk1"}, {"builderid": 4, "description": "ios-wk2"}, {"builderid": 5, "description": "win"}]}',
+            "https://ews.webkit.org/status/4/": b'{"mac-wk1": {"url": "https://ews-build.webkit.org/#/builders/1/builds/99"}, "mac-wk2": {"url": "https://ews-build.webkit.org/#/builders/2/builds/99"}, "mac-debug-wk1": {"url": "https://ews-build.webkit.org/#/builders/3/builds/99"}, "ios": {"url": "https://ews-build.webkit.org/#/builders/4/builds/99"}, "win": {"url": "https://ews-build.webkit.org/#/builders/5/builds/99"}}',
+            "https://ews-build.webkit.org/api/v2/builders": b'{"builders": [{"builderid": 1, "description": "mac-wk1"}, {"builderid": 2, "description": "mac-wk2"}, {"builderid": 3, "description": "mac-debug-wk1"}, {"builderid": 4, "description": "ios"}, {"builderid": 5, "description": "win"}]}',
             "https://ews-build.webkit.org/api/v2/builders/1/builds/99/steps": b'{ "steps": [ { "complete": true, "name": "layout-tests", "results": 2, "state_string": "Ran layout tests",  "urls": [ { "name": "download layout test results", "url": "/results/mac-wk1/r12345.zip" } ] } ] }',
             "https://ews-build.webkit.org/api/v2/builders/2/builds/99/steps": b'{ "steps": [ { "complete": true, "name": "layout-tests", "results": 2, "state_string": "Ran layout tests",  "urls": [ { "name": "download layout test results", "url": "/results/mac-wk2/r12345.zip" } ] } ] }',
             "https://ews-build.webkit.org/api/v2/builders/3/builds/99/steps": b'{ "steps": [ { "complete": true, "name": "layout-tests", "results": 2, "state_string": "Ran layout tests",  "urls": [ { "name": "download layout test results", "url": "/results/mac-debug-wk1/r12345.zip" } ] } ] }',
-            "https://ews-build.webkit.org/api/v2/builders/4/builds/99/steps": b'{ "steps": [ { "complete": true, "name": "layout-tests", "results": 2, "state_string": "Ran layout tests",  "urls": [ { "name": "download layout test results", "url": "/results/ios-wk2/r12345.zip" }  ] } ] }',
+            "https://ews-build.webkit.org/api/v2/builders/4/builds/99/steps": b'{ "steps": [ { "complete": true, "name": "layout-tests", "results": 2, "state_string": "Ran layout tests",  "urls": [ { "name": "download layout test results", "url": "/results/ios/r12345.zip" }  ] } ] }',
             "https://ews-build.webkit.org/api/v2/builders/5/builds/99/steps": b'{ "steps": [ { "complete": true, "name": "layout-tests", "results": 2, "state_string": "Ran layout tests",  "urls": [ { "name": "download layout test results", "url": "/results/win/r12345.zip" }  ] } ] }',
         }
         self._url = url
@@ -234,7 +234,7 @@ class ResultsFetcherTest(unittest.TestCase):
                     "https://ews-build.webkit.org/results/mac-debug-wk1/r12345.zip",
                 ],
                 "mac-wk2": ["https://ews-build.webkit.org/results/mac-wk2/r12345.zip"],
-                "ios-wk2": ["https://ews-build.webkit.org/results/ios-wk2/r12345.zip"],
+                "ios": ["https://ews-build.webkit.org/results/ios/r12345.zip"],
                 "win": ["https://ews-build.webkit.org/results/win/r12345.zip"],
             }
             self.assertEqual(expected, actual)


### PR DESCRIPTION
#### c4b144fae478f60e453ef4b18ab9cd7e571876f1
<pre>
[webkitpy] Change update-expectations to use ios instead of ios-wk2.
<a href="https://bugs.webkit.org/show_bug.cgi?id=284658">https://bugs.webkit.org/show_bug.cgi?id=284658</a>
<a href="https://rdar.apple.com/141459504">rdar://141459504</a>

Reviewed by Sam Sneddon.

The ios-wk2 folder no longer exists in LayoutTests/platform (as we haven&apos;t made
a distinction in embedded testing between wk1 and wk2 in many years). Despite
this change, the update-expectations script still auto-imports to ios-wk2 by
default.

This change modifies the underlying code in webkitpy to use ios instead of
ios-wk2.

* Tools/Scripts/webkitpy/common/net/bugzilla/results_fetcher.py:
    -&gt; (_platform_name_for_bot): Change ios-wk2 -&gt; ios.
* Tools/Scripts/webkitpy/common/net/bugzilla/results_fetcher_unittest.py:
    -&gt; (MockRequestsGet.__init__): Ditto.
    -&gt; (ResultsFetcherTest.test_lookup_ews_results_from_bugzilla): Ditto.

Canonical link: <a href="https://commits.webkit.org/287901@main">https://commits.webkit.org/287901@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6705be78b3a2d4a4ed9c48563fe4369c5394d0b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81280 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/805 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35223 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/85809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/32266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83390 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/823 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8620 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/85809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/32266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84349 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73974 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/85809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/80737 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28136 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/30724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/71949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28716 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87244 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8510 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/71771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8689 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69804 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/71005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/15054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/13965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12597 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8472 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8308 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/11829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/10116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->