### PR TITLE
[cocoa] Adjust _allowOnlyPartitionedCookies on HTTP redirect

### DIFF
--- a/LayoutTests/http/tests/resourceLoadStatistics/only-partitioned-cookies-after-redirect.https-expected.txt
+++ b/LayoutTests/http/tests/resourceLoadStatistics/only-partitioned-cookies-after-redirect.https-expected.txt
@@ -1,0 +1,63 @@
+Tests that partitioning is enforced mid-flight in redirects.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+
+--------
+Frame: '<!--frame1-->'
+--------
+Should receive first-party cookie.
+Received cookie named 'firstPartyCookie'.
+Did not receive cookie named 'partitionedCookie'.
+Client-side document.cookie: firstPartyCookie=value
+
+--------
+Frame: '<!--frame2-->'
+--------
+Redirect case 1, should receive first-party cookie.
+Received cookie named 'firstPartyCookie'.
+Did not receive cookie named 'partitionedCookie'.
+Client-side document.cookie: firstPartyCookie=value
+
+--------
+Frame: '<!--frame3-->'
+--------
+Should receive no cookies.
+Did not receive cookie named 'firstPartyCookie'.
+Did not receive cookie named 'partitionedCookie'.
+Client-side document.cookie:
+
+--------
+Frame: '<!--frame4-->'
+--------
+Redirect case 2, should receive no cookie.
+Did not receive cookie named 'firstPartyCookie'.
+Did not receive cookie named 'partitionedCookie'.
+Client-side document.cookie:
+
+--------
+Frame: '<!--frame5-->'
+--------
+Try to set third-party cookie in blocked mode.
+
+
+--------
+Frame: '<!--frame6-->'
+--------
+After attempted cookie creation, should receive no cookie.
+Did not receive cookie named 'firstPartyCookie'.
+Received cookie named 'partitionedCookie'.
+Client-side document.cookie: partitionedCookie=value
+
+--------
+Frame: '<!--frame7-->'
+--------
+Redirect case 3, after attempted cookie creation, should receive no cookie.
+Did not receive cookie named 'firstPartyCookie'.
+Received cookie named 'partitionedCookie'.
+Client-side document.cookie: partitionedCookie=value

--- a/LayoutTests/http/tests/resourceLoadStatistics/only-partitioned-cookies-after-redirect.https.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/only-partitioned-cookies-after-redirect.https.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html><!-- webkit-test-runner [ OptInPartitionedCookiesEnabled=true ] -->
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <script src="/js-test-resources/js-test.js"></script>
+    <script src="resources/util.js"></script>
+</head>
+<body>
+<script>
+    description("Tests that partitioning is enforced mid-flight in redirects.");
+    jsTestIsAsync = true;
+
+    const partitionHost = "127.0.0.1:8443";
+    const thirdPartyOrigin = "https://localhost:8443";
+    const resourcePath = "/resourceLoadStatistics/resources";
+    const thirdPartyBaseUrl = thirdPartyOrigin + resourcePath;
+    const firstPartyCookieName = "firstPartyCookie";
+    const subPathToSetFirstPartyCookie = "/set-cookie.py?name=" + firstPartyCookieName + "&value=value";
+    const partitionedCookieName = "partitionedCookie";
+    const subPathToSetPartitionedCookie = "/set-cookie.py?name=" + partitionedCookieName + "&value=value&partitioned=1";
+    const returnUrl = "https://" + partitionHost + "/resourceLoadStatistics/only-partitioned-cookies-after-redirect.https.html";
+    const subPathToGetCookies = "/get-cookies.py?name1=" + firstPartyCookieName + "&name2=" + partitionedCookieName;
+    const redirectChainUrl = "https://" + partitionHost + resourcePath + "/redirect.py?redirectTo=" + thirdPartyBaseUrl + subPathToGetCookies;
+
+    function openIframe(url, onLoadHandler) {
+        const element = document.createElement("iframe");
+        element.src = url;
+        if (onLoadHandler) {
+            element.onload = onLoadHandler;
+        }
+        document.body.appendChild(element);
+    }
+
+    function runTest() {
+        switch (document.location.hash) {
+            case "#step1":
+                // Set first-party cookie for localhost.
+                document.location.href = thirdPartyBaseUrl + subPathToSetFirstPartyCookie + "#" + returnUrl + "#step2";
+                break;
+            case "#step2":
+                // Check that the cookie gets sent for localhost under 127.0.0.1 since localhost is not prevalent.
+                document.location.hash = "step3";
+                openIframe(thirdPartyBaseUrl + subPathToGetCookies + "&message=Should receive first-party cookie.", runTest);
+                break;
+            case "#step3":
+                document.location.hash = "step4";
+                // Load an iframe in a redirect chain that starts with 127.0.0.1 and ends with localhost. Expect a cookie for localhost.
+                openIframe(redirectChainUrl + "&message=Redirect case 1, should receive first-party cookie.", runTest);
+                break;
+            case "#step4":
+                // Set localhost as prevalent to put it in the blocking category.
+                document.location.hash = "step5";
+                testRunner.setStatisticsPrevalentResource(thirdPartyOrigin, true, function() {
+                    if (!testRunner.isStatisticsPrevalentResource(thirdPartyOrigin))
+                        testFailed("Host did not get set as prevalent resource.");
+                    testRunner.statisticsUpdateCookieBlocking(runTest);
+                });
+                break;
+            case "#step5":
+                // Check that no cookie gets sent for localhost under 127.0.0.1 since localhost's cookies are blocked.
+                document.location.hash = "step6";
+                openIframe(thirdPartyBaseUrl + subPathToGetCookies +  "&message=Should receive no cookies.", runTest);
+                break;
+            case "#step6":
+                // Load an iframe in a redirect chain that starts with 127.0.0.1 and ends with localhost. Expect no cookie for localhost.
+                document.location.hash = "step7";
+                openIframe(redirectChainUrl + "&message=Redirect case 2, should receive no cookie.", runTest);
+                break;
+            case "#step7":
+                // Try to set cookie for localhost under 127.0.0.1.
+                document.location.hash = "step8";
+                openIframe(thirdPartyBaseUrl + subPathToSetPartitionedCookie + "&message=Try to set third-party cookie in blocked mode.", runTest);
+                break;
+            case "#step8":
+                // Check that no cookie gets sent for localhost under 127.0.0.1 since localhost's cookies are blocked.
+                document.location.hash = "step9";
+                openIframe(thirdPartyBaseUrl + subPathToGetCookies +  "&message=After attempted cookie creation, should receive no cookie.", runTest);
+                break;
+            case "#step9":
+                // Load an iframe in a redirect chain that starts with 127.0.0.1 and ends with localhost. Expect no cookie for localhost.
+                document.location.hash = "step10";
+                openIframe(redirectChainUrl + "&message=Redirect case 3, after attempted cookie creation, should receive no cookie.", runTest);
+                break;
+            case "#step10":
+                setEnableFeature(false, finishJSTest);
+                break;
+        }
+    }
+
+    if (document.location.hash === "") {
+        setEnableFeature(true, function () {
+            if (testRunner.isStatisticsPrevalentResource(thirdPartyOrigin))
+                testFailed("Localhost was classified as prevalent resource before the test starts.");
+            testRunner.dumpChildFramesAsText();
+            document.location.hash = "step1";
+            runTest();
+        });
+    } else {
+        runTest();
+    }
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -131,6 +131,7 @@ http/tests/storageAccess/deny-with-prompt-does-not-preserve-gesture.html [ Skip 
 webkit.org/b/208400 http/tests/storageAccess/has-storage-access-true-if-third-party-has-cookies-ephemeral.https.html [ Crash ]
 http/tests/storageAccess/grant-with-prompt-under-general-third-party-cookie-blocking-with-partitioned-cookies.https.html [ Skip ]
 http/tests/resourceLoadStatistics/only-partitioned-third-party-cookies.https.html [ Skip ]
+http/tests/resourceLoadStatistics/only-partitioned-cookies-after-redirect.https.html [ Skip ]
 
 # Failures from upgrading mixed-content
 imported/w3c/web-platform-tests/mixed-content/gen/top.meta/unset/video-tag.https.html [ Failure ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -2813,6 +2813,7 @@ http/tests/storageAccess/has-storage-access-true-if-third-party-has-cookies.http
 # Enable on appropriate platforms: rdar://140222322
 http/tests/storageAccess/grant-with-prompt-under-general-third-party-cookie-blocking-with-partitioned-cookies.https.html [ Skip ]
 http/tests/resourceLoadStatistics/only-partitioned-third-party-cookies.https.html [ Skip ]
+http/tests/resourceLoadStatistics/only-partitioned-cookies-after-redirect.https.html [ Skip ]
 
 # Enable again when fixing https://bugs.webkit.org/show_bug.cgi?id=208400.
 http/tests/storageAccess/has-storage-access-true-if-third-party-has-cookies-ephemeral.https.html [ Skip ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -825,6 +825,7 @@ http/tests/storageAccess/deny-with-prompt-does-not-preserve-gesture.html [ Skip 
 # Enable on appropriate platforms: rdar://140222322
 http/tests/storageAccess/grant-with-prompt-under-general-third-party-cookie-blocking-with-partitioned-cookies.https.html [ Skip ]
 http/tests/resourceLoadStatistics/only-partitioned-third-party-cookies.https.html [ Skip ]
+http/tests/resourceLoadStatistics/only-partitioned-cookies-after-redirect.https.html [ Skip ]
 
 # Enable again when fixing https://bugs.webkit.org/show_bug.cgi?id=208400.
 http/tests/storageAccess/has-storage-access-true-if-third-party-has-cookies-ephemeral.https.html [ Skip ]

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -814,6 +814,7 @@ http/tests/resourceLoadStatistics/website-data-removal-for-site-without-user-int
 http/tests/resourceLoadStatistics/website-data-removal-for-site-without-user-interaction.html [ Failure ]
 
 http/tests/resourceLoadStatistics/only-partitioned-third-party-cookies.https.html [ Skip ]
+http/tests/resourceLoadStatistics/only-partitioned-cookies-after-redirect.https.html [ Skip ]
 
 http/tests/security/XFrameOptions/x-frame-options-deny.html [ Skip ] # Failure
 http/tests/security/XFrameOptions/x-frame-options-multiple-headers-conflict.html [ Skip ] # Failure

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.h
@@ -38,6 +38,7 @@ OBJC_CLASS NSURLSessionTask;
 
 namespace WebCore {
 class RegistrableDomain;
+enum class ThirdPartyCookieBlockingDecision : uint8_t;
 }
 
 namespace WebKit {
@@ -67,6 +68,11 @@ protected:
     bool needsFirstPartyCookieBlockingLatchModeQuirk(const URL& firstPartyURL, const URL& requestURL, const URL& redirectingURL) const;
     static NSString *lastRemoteIPAddress(NSURLSessionTask *);
     static WebCore::RegistrableDomain lastCNAMEDomain(String);
+    static bool shouldBlockCookies(WebCore::ThirdPartyCookieBlockingDecision);
+    WebCore::ThirdPartyCookieBlockingDecision requestThirdPartyCookieBlockingDecision(const WebCore::ResourceRequest&) const;
+#if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
+    bool isOptInCookiePartitioningEnabled() const;
+#endif
 
     bool isAlwaysOnLoggingAllowed() const { return m_isAlwaysOnLoggingAllowed; }
     virtual NSURLSessionTask* task() const = 0;


### PR DESCRIPTION
#### 66c65ee317db886cfbb7321f244b2a4ab3da4c5a
<pre>
[cocoa] Adjust _allowOnlyPartitionedCookies on HTTP redirect
<a href="https://bugs.webkit.org/show_bug.cgi?id=284660">https://bugs.webkit.org/show_bug.cgi?id=284660</a>
<a href="https://rdar.apple.com/141459915">rdar://141459915</a>

Reviewed by Sihui Liu.

When partitioned cookies are enabled, we need to adjust the
_allowOnlyPartitionedCookies of the request in two places:
1) When the request is initiated (e.g., when we are creating the task)
2) When a redirect is handled

This patch refactors some logic so it can be shared between the
NetworkDataTaskCocoa constructor and
NetworkTaskCocoa::willPerformHTTPRedirection:

1) obtaining the current third party cookies blocking mode
3) deciding if third party cookies should be blocked
4) checking if opt-in cookie partitioning is enabled

* LayoutTests/http/tests/resourceLoadStatistics/only-partitioned-cookies-after-redirect.https-expected.txt: Added.
* LayoutTests/http/tests/resourceLoadStatistics/only-partitioned-cookies-after-redirect.https.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::NetworkDataTaskCocoa):
* Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm:
(WebKit::NetworkTaskCocoa::shouldBlockCookies):
(WebKit::NetworkTaskCocoa::requestThirdPartyCookieBlockingDecision const):
(WebKit::NetworkTaskCocoa::willPerformHTTPRedirection):

Canonical link: <a href="https://commits.webkit.org/288185@main">https://commits.webkit.org/288185@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8edd977505cd3f94215ca102a89c0766cf82334f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82038 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1565 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35995 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86595 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33070 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1600 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9391 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63950 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21674 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85108 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1186 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74640 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44234 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1088 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28817 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31490 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29429 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88028 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9280 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6613 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72321 "Found 1 new test failure: compositing/animation/repaint-after-clearing-shared-backing.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9465 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70459 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71543 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15662 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14576 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12730 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9231 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14767 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9071 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12597 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10879 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->