### PR TITLE
[Navigation API] NavigationHistoryEntry JS wrapper is not kept alive until the dispose event is fired

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-handler-throws-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-handler-throws-expected.txt
@@ -1,3 +1,6 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: a message
+
+Harness Error (FAIL), message = Unhandled rejection: a message
 
 PASS event.intercept() should abort if the handler throws
 

--- a/Source/WebCore/page/NavigateEvent.cpp
+++ b/Source/WebCore/page/NavigateEvent.cpp
@@ -48,13 +48,14 @@ NavigateEvent::NavigateEvent(const AtomString& type, const NavigateEvent::Init& 
     , m_signal(init.signal)
     , m_formData(init.formData)
     , m_downloadRequest(init.downloadRequest)
-    , m_info(init.info)
     , m_canIntercept(init.canIntercept)
     , m_userInitiated(init.userInitiated)
     , m_hashChange(init.hashChange)
     , m_hasUAVisualTransition(init.hasUAVisualTransition)
     , m_abortController(abortController)
 {
+    Locker<JSC::JSLock> locker(commonVM().apiLock());
+    m_info.setWeakly(init.info);
 }
 
 Ref<NavigateEvent> NavigateEvent::create(const AtomString& type, const NavigateEvent::Init& init, AbortController* abortController)

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -159,12 +159,15 @@ public:
 
     void setFocusChanged(FocusDidChange changed) { m_focusChangedDuringOngoingNavigation = changed; }
 
+    // EventTarget.
+    ScriptExecutionContext* scriptExecutionContext() const final;
+    RefPtr<ScriptExecutionContext> protectedScriptExecutionContext() const;
+
 private:
     explicit Navigation(LocalDOMWindow&);
 
+    // EventTarget.
     enum EventTargetInterfaceType eventTargetInterface() const final;
-    RefPtr<ScriptExecutionContext> protectedScriptExecutionContext() const;
-    ScriptExecutionContext* scriptExecutionContext() const final;
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 

--- a/Source/WebCore/page/NavigationHistoryEntry.h
+++ b/Source/WebCore/page/NavigationHistoryEntry.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "ContextDestructionObserver.h"
+#include "ActiveDOMObject.h"
 #include "EventHandler.h"
 #include "EventTarget.h"
 #include "HistoryItem.h"
@@ -38,16 +38,17 @@ class JSValue;
 
 namespace WebCore {
 
+class Navigation;
 class SerializedScriptValue;
 
-class NavigationHistoryEntry final : public RefCounted<NavigationHistoryEntry>, public EventTarget, public ContextDestructionObserver {
+class NavigationHistoryEntry final : public RefCounted<NavigationHistoryEntry>, public EventTarget, public ActiveDOMObject {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(NavigationHistoryEntry);
 public:
-    using RefCounted<NavigationHistoryEntry>::ref;
-    using RefCounted<NavigationHistoryEntry>::deref;
+    static Ref<NavigationHistoryEntry> create(Navigation&, Ref<HistoryItem>&&);
+    static Ref<NavigationHistoryEntry> create(Navigation&, const NavigationHistoryEntry&);
 
-    static Ref<NavigationHistoryEntry> create(ScriptExecutionContext*, Ref<HistoryItem>&&);
-    static Ref<NavigationHistoryEntry> create(ScriptExecutionContext*, const NavigationHistoryEntry&);
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     const String& url() const;
     String key() const;
@@ -60,6 +61,7 @@ public:
     SerializedScriptValue* state() const { return m_state.get(); }
 
     HistoryItem& associatedHistoryItem() const { return m_associatedHistoryItem; }
+    void dispatchDisposeEvent();
 
 private:
     struct DocumentState {
@@ -69,19 +71,27 @@ private:
         ReferrerPolicy referrerPolicy { ReferrerPolicy::Default };
     };
 
-    NavigationHistoryEntry(ScriptExecutionContext*, const DocumentState&, Ref<HistoryItem>&&, String urlString, WTF::UUID key, RefPtr<SerializedScriptValue>&& state = { }, WTF::UUID = WTF::UUID::createVersion4());
+    NavigationHistoryEntry(Navigation&, const DocumentState&, Ref<HistoryItem>&&, String urlString, WTF::UUID key, RefPtr<SerializedScriptValue>&& state = { }, WTF::UUID = WTF::UUID::createVersion4());
 
+    // ActiveDOMObject.
+    bool virtualHasPendingActivity() const;
+
+    // EventTarget.
     enum EventTargetInterfaceType eventTargetInterface() const final;
     ScriptExecutionContext* scriptExecutionContext() const final;
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
+    void eventListenersDidChange() final;
 
+    WeakPtr<Navigation, WeakPtrImplWithEventTargetData> m_navigation;
     const String m_urlString;
     const WTF::UUID m_key;
     const WTF::UUID m_id;
     RefPtr<SerializedScriptValue> m_state;
     Ref<HistoryItem> m_associatedHistoryItem;
     DocumentState m_originalDocumentState;
+    bool m_hasDisposeEventListener { false };
+    bool m_hasDispatchedDisposeEvent { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/NavigationHistoryEntry.idl
+++ b/Source/WebCore/page/NavigationHistoryEntry.idl
@@ -1,4 +1,5 @@
 [
+  ActiveDOMObject,
   EnabledBySetting=NavigationAPIEnabled,
   Exposed=Window
 ] interface NavigationHistoryEntry : EventTarget {


### PR DESCRIPTION
#### 4016aa647924537a988fe198b589aceeb71add23
<pre>
[Navigation API] NavigationHistoryEntry JS wrapper is not kept alive until the dispose event is fired
<a href="https://bugs.webkit.org/show_bug.cgi?id=284663">https://bugs.webkit.org/show_bug.cgi?id=284663</a>

Reviewed by Ryosuke Niwa.

When a NavigationHistoryEntry object gets removed from a Navigation object, a `dispose` event is
dispatched on the NavigationHistoryEntry. However, NavigationHistoryEntry was not an ActiveDOMObject
and therefore nothing was keeping its JS wrapper alive alive as long as a `dispose` event could get
dispatched. This would lead to flaky crashes in the tests, when dispatching the event.

To address the issue, make NavigationHistoryEntry an ActiveDOMObject and provide an implementation
for virtualHasPendingActivity() so that its JS wrapper is kept alive as long as we haven&apos;t dispatched
the `dispose` event on it.

Also add a couple of missing JSLocks to address debug assertions I was seeing on the tests locally.

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-handler-throws-expected.txt:
Rebaseline the test. While the output looks a bit worse, I do not believe this is a regression from my
change but rather a timing change on a flaky test.

* Source/WebCore/page/NavigateEvent.cpp:
(WebCore::NavigateEvent::NavigateEvent):
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::initializeForNewWindow):
(WebCore::Navigation::updateForActivation):
(WebCore::Navigation::createForPageswapEvent):
(WebCore::createDOMPromise):
(WebCore::Navigation::updateForNavigation):
(WebCore::Navigation::updateForReactivation):
* Source/WebCore/page/Navigation.h:
* Source/WebCore/page/NavigationHistoryEntry.cpp:
(WebCore::NavigationHistoryEntry::NavigationHistoryEntry):
(WebCore::NavigationHistoryEntry::create):
(WebCore::NavigationHistoryEntry::eventListenersDidChange):
(WebCore::NavigationHistoryEntry::virtualHasPendingActivity const):
(WebCore::NavigationHistoryEntry::dispatchDisposeEvent):
* Source/WebCore/page/NavigationHistoryEntry.h:
* Source/WebCore/page/NavigationHistoryEntry.idl:

Canonical link: <a href="https://commits.webkit.org/287839@main">https://commits.webkit.org/287839@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b7704e52817b32c9e80b014915f7022fd299066

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80981 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/506 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34924 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85510 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31967 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83091 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/518 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8307 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63221 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20989 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84050 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/306 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73701 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43519 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/200 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27859 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-008.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30425 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71752 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28409 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86945 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8211 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5797 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71523 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8388 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69534 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70757 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14801 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13721 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12568 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8172 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13695 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8009 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11529 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9817 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->