### PR TITLE
REGRESSION(287648@main): [macOS wk2 Debug] imported/blink/fast/hidpi/border-background-align.html is a constant crash (flaky in EWS)

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1962,6 +1962,4 @@ webkit.org/b/284190 [ Sequoia+ ] imported/w3c/web-platform-tests/html/cross-orig
 webkit.org/b/284492 [ Sequoia+ ] imported/w3c/web-platform-tests/fetch/api/cors/cors-cookies-redirect.any.html [ Failure ]
 webkit.org/b/284492 [ Sequoia+ ] imported/w3c/web-platform-tests/fetch/api/cors/cors-cookies-redirect.any.worker.html [ Failure ]
 
-webkit.org/b/284493 [ Debug ] imported/blink/fast/hidpi/border-background-align.html [ Crash ]
-
 webkit.org/b/232282 [ Ventura+ ] fast/scrolling/mac/scrollbars/overlay-scrollbar-hovered.html [ Pass Failure ]

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2630,7 +2630,7 @@ void Document::resolveStyle(ResolveStyleType type)
             frameView->styleAndRenderTreeDidChange();
         }
 
-        updatedCompositingLayers = frameView->updateCompositingLayersAfterStyleChange();
+        updatedCompositingLayers = frameView->layoutContext().updateCompositingLayersAfterStyleChange();
 
         if (m_renderView->needsLayout())
             frameView->layoutContext().scheduleLayout();

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -748,18 +748,6 @@ void LocalFrameView::styleAndRenderTreeDidChange()
     checkAndDispatchDidReachVisuallyNonEmptyState();
 }
 
-bool LocalFrameView::updateCompositingLayersAfterStyleChange()
-{
-    // If we expect to update compositing after an incipient layout, don't do so here.
-    auto* renderView = this->renderView();
-    if (!renderView)
-        return false;
-    if (needsLayout() || layoutContext().isInLayout())
-        return false;
-    renderView->layer()->updateLayerPositionsAfterStyleChange();
-    return renderView->compositor().didRecalcStyleWithNoPendingLayout();
-}
-
 void LocalFrameView::invalidateScrollbarsForAllScrollableAreas()
 {
     if (!m_scrollableAreas)

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -159,8 +159,6 @@ public:
 
     void willRecalcStyle();
     void styleAndRenderTreeDidChange() override;
-    bool updateCompositingLayersAfterStyleChange();
-    void updateCompositingLayersAfterLayout();
 
     // Called when changes to the GraphicsLayer hierarchy have to be synchronized with
     // content rendered via the normal painting path.

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -359,6 +359,26 @@ void LocalFrameViewLayoutContext::flushUpdateLayerPositions()
     m_lastRepaintRectEnvironment = WTFMove(repaintRectEnvironment);
 }
 
+bool LocalFrameViewLayoutContext::updateCompositingLayersAfterStyleChange()
+{
+    // If we expect to update compositing after an incipient layout, don't do so here.
+    CheckedPtr view = renderView();
+    if (!view)
+        return false;
+
+    if (needsLayout() || isInLayout())
+        return false;
+
+    auto repaintRectEnvironment = RepaintRectEnvironment { view->page().deviceScaleFactor(), document()->printing() };
+    bool environmentChanged = repaintRectEnvironment != m_lastRepaintRectEnvironment;
+
+    view->layer()->updateLayerPositionsAfterStyleChange(environmentChanged);
+
+    m_lastRepaintRectEnvironment = WTFMove(repaintRectEnvironment);
+
+    return view->compositor().didRecalcStyleWithNoPendingLayout();
+}
+
 void LocalFrameViewLayoutContext::updateCompositingLayersAfterLayout()
 {
     auto* renderView = this->renderView();

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.h
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.h
@@ -116,6 +116,7 @@ public:
 
     void flushUpdateLayerPositions();
 
+    bool updateCompositingLayersAfterStyleChange();
     void updateCompositingLayersAfterLayout();
     // Returns true if a pending compositing layer update was done.
     bool updateCompositingLayersAfterLayoutIfNeeded();

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1035,7 +1035,7 @@ static inline bool compositingLogEnabledRenderLayer()
 }
 #endif
 
-void RenderLayer::updateLayerPositionsAfterStyleChange()
+void RenderLayer::updateLayerPositionsAfterStyleChange(bool environmentChanged)
 {
     LOG(Compositing, "RenderLayer %p updateLayerPositionsAfterStyleChange - before", this);
 #if ENABLE(TREE_DEBUGGING)
@@ -1043,8 +1043,18 @@ void RenderLayer::updateLayerPositionsAfterStyleChange()
         showLayerPositionTree(this);
 #endif
 
+    auto updateLayerPositionFlags = [&](bool environmentChanged) {
+        auto flags = flagsForUpdateLayerPositions(*this);
+        if (environmentChanged)
+            flags.add(RenderLayer::EnvironmentChanged);
+        return flags;
+    };
+
+    if (environmentChanged)
+        setSelfAndDescendantsNeedPositionUpdate();
+
     willUpdateLayerPositions();
-    recursiveUpdateLayerPositions(0, flagsForUpdateLayerPositions(*this));
+    recursiveUpdateLayerPositions(0, updateLayerPositionFlags(environmentChanged));
 
     LOG(Compositing, "RenderLayer %p updateLayerPositionsAfterStyleChange - after", this);
 #if ENABLE(TREE_DEBUGGING)

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -514,7 +514,7 @@ public:
 
     bool canRender3DTransforms() const;
 
-    void updateLayerPositionsAfterStyleChange();
+    void updateLayerPositionsAfterStyleChange(bool environmentChanged = false);
     enum class CanUseSimplifiedRepaintPass : uint8_t { No, Yes };
     void updateLayerPositionsAfterLayout(RenderElement::LayoutIdentifier, bool didFullRepaint, bool environmentChanged, CanUseSimplifiedRepaintPass);
     void updateLayerPositionsAfterOverflowScroll();


### PR DESCRIPTION
#### 005288f3b10c91a1f1bf8509ee0281148667e063
<pre>
REGRESSION(287648@main): [macOS wk2 Debug] imported/blink/fast/hidpi/border-background-align.html is a constant crash (flaky in EWS)
<a href="https://bugs.webkit.org/show_bug.cgi?id=284493">https://bugs.webkit.org/show_bug.cgi?id=284493</a>
<a href="https://rdar.apple.com/141315960">rdar://141315960</a>

Reviewed by Alan Baradlay.

This is similar to 287607@main, but for `updateLayerPositionsAfterStyleChange()` instead of
`updateLayerPositionsAfterLayout()`.

We move `updateCompositingLayersAfterStyleChange()` from LocalFrameView to LocalFrameViewLayoutContext
(along the lines of 287568@main), and add a check for a change in repaint rect environment.

* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::resolveStyle):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::updateCompositingLayersAfterStyleChange): Deleted.
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::updateCompositingLayersAfterStyleChange):
* Source/WebCore/page/LocalFrameViewLayoutContext.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::updateLayerPositionsAfterStyleChange):
* Source/WebCore/rendering/RenderLayer.h:

Canonical link: <a href="https://commits.webkit.org/287832@main">https://commits.webkit.org/287832@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93a65dc91243b070794c048c4694a9d3a908a6ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80991 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/516 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34934 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85520 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31977 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83101 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/532 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8317 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63229 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20998 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84060 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/310 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73712 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43527 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/205 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27870 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30435 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/71756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28421 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86955 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8221 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5805 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71530 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8398 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69545 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70764 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17619 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14807 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13731 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8182 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13705 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8019 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11539 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9827 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->