### PR TITLE
Provide an attribute on <model> that toggles the portal

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5286,6 +5286,21 @@ ModelElementEnabled:
   disableInLockdownMode: true
   sharedPreferenceForWebProcess: true
 
+ModelNoPortalAttributeEnabled:
+  type: bool
+  status: unstable
+  condition: PLATFORM(VISION) && ENABLE(MODEL_PROCESS)
+  humanReadableName: "Model noportal attribute"
+  humanReadableDescription: "Enable Model noportal attribute support"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+  disableInLockdownMode: true
+
 ModelProcessEnabled:
   type: bool
   status: unstable

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -298,6 +298,7 @@ void HTMLModelElement::createModelPlayer()
     m_modelPlayer->setAutoplay(autoplay());
     m_modelPlayer->setLoop(loop());
     m_modelPlayer->setPlaybackRate(m_playbackRate, [&](double) { });
+    m_modelPlayer->setHasPortal(hasPortal());
 #endif
 
     // FIXME: We need to tell the player if the size changes as well, so passing this
@@ -500,6 +501,10 @@ void HTMLModelElement::attributeChanged(const QualifiedName& name, const AtomStr
         updateLoop();
     else if (name == environmentmapAttr)
         updateEnvironmentMap();
+#if PLATFORM(VISION)
+    else if (document().settings().modelNoPortalAttributeEnabled() && name == noportalAttr)
+        updateHasPortal();
+#endif
 #endif
     else
         HTMLElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
@@ -691,6 +696,21 @@ void HTMLModelElement::setCurrentTime(double currentTime)
 {
     if (m_modelPlayer)
         m_modelPlayer->setCurrentTime(Seconds(currentTime), [&]() { });
+}
+
+bool HTMLModelElement::hasPortal() const
+{
+#if PLATFORM(VISION)
+    return !(document().settings().modelNoPortalAttributeEnabled() && hasAttributeWithoutSynchronization(HTMLNames::noportalAttr));
+#else
+    return true;
+#endif
+}
+
+void HTMLModelElement::updateHasPortal()
+{
+    if (RefPtr modelPlayer = m_modelPlayer)
+        modelPlayer->setHasPortal(hasPortal());
 }
 
 const URL& HTMLModelElement::environmentMap() const

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -222,6 +222,8 @@ private:
     void environmentMapRequestResource();
     void environmentMapResetAndReject(Exception&&);
     void environmentMapResourceFinished();
+    bool hasPortal() const;
+    void updateHasPortal();
 #endif
     void modelResourceFinished();
 

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.idl
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.idl
@@ -57,6 +57,8 @@
     [Conditional=MODEL_PROCESS, EnabledBySetting=ModelProcessEnabled, CEReactions=NotNeeded, Reflect, URL] attribute USVString environmentMap;
     [Conditional=MODEL_PROCESS, EnabledBySetting=ModelProcessEnabled] readonly attribute Promise<undefined> environmentMapReady;
 
+    [Conditional=MODEL_PROCESS, EnabledBySetting=ModelProcessEnabled&ModelNoPortalAttributeEnabled, Reflect] attribute boolean noportal;
+
     undefined enterFullscreen();
 
     [Conditional=ARKIT_INLINE_PREVIEW_CAMERA_TRANSFORM] Promise<HTMLModelElementCamera> getCamera();

--- a/Source/WebCore/Modules/model-element/ModelPlayer.cpp
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.cpp
@@ -110,6 +110,10 @@ void ModelPlayer::setCurrentTime(Seconds, CompletionHandler<void()>&& completion
 void ModelPlayer::setEnvironmentMap(Ref<SharedBuffer>&&)
 {
 }
+
+void ModelPlayer::setHasPortal(bool)
+{
+}
 #endif // ENABLE(MODEL_PROCESS)
 
 }

--- a/Source/WebCore/Modules/model-element/ModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.h
@@ -96,6 +96,7 @@ public:
     virtual Seconds currentTime() const;
     virtual void setCurrentTime(Seconds, CompletionHandler<void()>&&);
     virtual void setEnvironmentMap(Ref<SharedBuffer>&& data);
+    virtual void setHasPortal(bool);
 #endif
 };
 

--- a/Source/WebCore/html/HTMLAttributeNames.in
+++ b/Source/WebCore/html/HTMLAttributeNames.in
@@ -201,6 +201,7 @@ name
 nohref
 nomodule
 nonce
+noportal
 noresize
 noshade
 novalidate

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
@@ -82,6 +82,7 @@ public:
     void updateBackgroundColor();
     void updateTransform();
     void updateOpacity();
+    void updatePortalAndClipping();
     void startAnimating();
     void animationPlaybackStateDidUpdate();
 
@@ -130,6 +131,7 @@ public:
     Seconds currentTime() const final;
     void setCurrentTime(Seconds, CompletionHandler<void()>&&) final;
     void setEnvironmentMap(Ref<WebCore::SharedBuffer>&& data) final;
+    void setHasPortal(bool) final;
 
 private:
     ModelProcessModelPlayerProxy(ModelProcessModelPlayerManagerProxy&, WebCore::ModelPlayerIdentifier, Ref<IPC::Connection>&&);
@@ -162,6 +164,7 @@ private:
     double m_playbackRate { 1.0 };
 
     RefPtr<WebCore::SharedBuffer> m_transientEnvironmentMapData;
+    bool m_hasPortal { true };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in
@@ -38,6 +38,7 @@ messages -> ModelProcessModelPlayerProxy {
     SetPaused(bool paused) -> (bool succeeded) Async
     SetCurrentTime(Seconds currentTime) -> () Async
     SetEnvironmentMap(Ref<WebCore::SharedBuffer> data)
+    SetHasPortal(bool hasPortal)
 }
 
 #endif

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
@@ -1707,6 +1707,37 @@ static WebCore::EditableLinkBehavior toEditableLinkBehavior(_WKEditableLinkBehav
     return NO;
 #endif
 }
+
+- (void)_setModelElementEnabled:(BOOL)enabled
+{
+    _preferences->setModelElementEnabled(enabled);
+}
+
+- (BOOL)_modelProcessEnabled
+{
+    return _preferences->modelProcessEnabled();
+}
+
+- (void)_setModelProcessEnabled:(BOOL)enabled
+{
+    _preferences->setModelProcessEnabled(enabled);
+}
+
+- (BOOL)_modelElementEnabled
+{
+    return _preferences->modelElementEnabled();
+}
+
+- (void)_setModelNoPortalAttributeEnabled:(BOOL)enabled
+{
+    _preferences->setModelNoPortalAttributeEnabled(enabled);
+}
+
+- (BOOL)_modelNoPortalAttributeEnabled
+{
+    return _preferences->modelNoPortalAttributeEnabled();
+}
+
 @end
 
 @implementation WKPreferences (WKDeprecated)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
@@ -197,6 +197,9 @@ typedef NS_ENUM(NSInteger, _WKPitchCorrectionAlgorithm) {
 @property (nonatomic, setter=_setCSSTransformStyleSeparatedEnabled:) BOOL _cssTransformStyleSeparatedEnabled WK_API_AVAILABLE(visionos(WK_XROS_TBA));
 @property (nonatomic, setter=_setOverlayRegionsEnabled:) BOOL _overlayRegionsEnabled WK_API_AVAILABLE(visionos(WK_XROS_TBA));
 @property (nonatomic, setter=_setSpatialVideoEnabled:) BOOL _spatialVideoEnabled WK_API_AVAILABLE(visionos(WK_XROS_TBA));
+@property (nonatomic, setter=_setModelElementEnabled:) BOOL _modelElementEnabled WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic, setter=_setModelProcessEnabled:) BOOL _modelProcessEnabled WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic, setter=_setModelNoPortalAttributeEnabled:) BOOL _modelNoPortalAttributeEnabled WK_API_AVAILABLE(visionos(WK_XROS_TBA));
 
 #if !TARGET_OS_IPHONE
 @property (nonatomic, setter=_setWebGLEnabled:) BOOL _webGLEnabled WK_API_AVAILABLE(macos(10.13.4));

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
@@ -332,6 +332,14 @@ void ModelProcessModelPlayer::setEnvironmentMap(Ref<WebCore::SharedBuffer>&& dat
     send(Messages::ModelProcessModelPlayerProxy::SetEnvironmentMap(WTFMove(data)));
 }
 
+void ModelProcessModelPlayer::setHasPortal(bool hasPortal)
+{
+    if (m_hasPortal == hasPortal)
+        return;
+
+    m_hasPortal = hasPortal;
+    send(Messages::ModelProcessModelPlayerProxy::SetHasPortal(m_hasPortal));
+}
 }
 
 #endif // ENABLE(MODEL_PROCESS)

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
@@ -103,6 +103,7 @@ private:
     Seconds currentTime() const final;
     void setCurrentTime(Seconds, CompletionHandler<void()>&&) final;
     void setEnvironmentMap(Ref<WebCore::SharedBuffer>&& data) final;
+    void setHasPortal(bool) final;
 
     WebCore::ModelPlayerIdentifier m_id;
     WeakPtr<WebPage> m_page;
@@ -110,6 +111,7 @@ private:
 
     std::optional<WebCore::LayerHostingContextIdentifier> m_layerHostingContextIdentifier;
 
+    bool m_hasPortal { true };
     bool m_autoplay { false };
     bool m_loop { false };
     double m_requestedPlaybackRate { 1.0 };


### PR DESCRIPTION
#### 441ea952f1d71fe44f09d3acbfc8ca0f67fd076e
<pre>
Provide an attribute on &lt;model&gt; that toggles the portal
<a href="https://bugs.webkit.org/show_bug.cgi?id=284670">https://bugs.webkit.org/show_bug.cgi?id=284670</a>
<a href="https://rdar.apple.com/141197697">rdar://141197697</a>

Reviewed by Ada Chan and Ryosuke Niwa.

Provide an attribute on &lt;model&gt; that toggles the portal. In addition, exposes
extra properties on WKPreferences so that only web views that opt in model
process and non portaled model can have the &apos;noportal&apos; attribute functional.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::createModelPlayer):
(WebCore::HTMLModelElement::attributeChanged):
(WebCore::HTMLModelElement::portal const):
(WebCore::HTMLModelElement::updatePortal):
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/Modules/model-element/ModelPlayer.cpp:
(WebCore::ModelPlayer::setHasPortal):
* Source/WebCore/Modules/model-element/ModelPlayer.h:
Default behavior is keeping the portal.

* Source/WebCore/html/HTMLAttributeNames.in:
noportal is the attribute name

* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::ModelProcessModelPlayerProxy::createLayer):
(WebKit::ModelProcessModelPlayerProxy::computeTransform):
(WebKit::ModelProcessModelPlayerProxy::updatePortalAndClipping):
Update key paths for portal and clipping. This will be fully functional until
<a href="https://rdar.apple.com/141457267">rdar://141457267</a> (Remove clipping when &lt;model&gt; doesn&apos;t have a portal).
Currently, it&apos;s blocked on clipping not toggle-able.

(WebKit::ModelProcessModelPlayerProxy::setHasPortal):
* Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm:
(-[WKPreferences _setModelElementEnabled:]):
(-[WKPreferences _modelProcessEnabled]):
(-[WKPreferences _setModelProcessEnabled:]):
(-[WKPreferences _modelElementEnabled]):
(-[WKPreferences _setNonPortaledModelEnabled:]):
(-[WKPreferences _nonPortaledModelEnabled]):
* Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h:
Exposes extra properties on WKPreferences so that only web views that opt in
model process and non portaled model can have the &apos;noportal&apos; attribute
functional.

* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp:
(WebKit::ModelProcessModelPlayer::setHasPortal):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h:

Canonical link: <a href="https://commits.webkit.org/288029@main">https://commits.webkit.org/288029@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/993550527bf1c6bbfcbd9b4fefe89bb1582c58ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81713 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1239 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35667 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86257 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32708 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83819 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1272 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9059 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/63755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/21480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84783 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/74368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/44041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/28542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31162 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/74693 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/29144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87696 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/80767 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8953 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/72093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9138 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/70187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/71322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17756 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/15409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/14324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/103178 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8904 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/14436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/25058 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8745 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12268 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10553 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->