### PR TITLE
AX: -[WKAccessibilityWebPageObjectMac accessibilityAttributeValue] hits the main-thread unnecessarily

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h
@@ -40,10 +40,12 @@ class AXCoreObject;
     NakedPtr<WebKit::WebPage> m_page;
     Markable<WebCore::PageIdentifier> m_pageID;
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    Lock m_parentLock;
     Lock m_cacheLock;
     WebCore::FloatPoint m_position WTF_GUARDED_BY_LOCK(m_cacheLock);
     WebCore::IntSize m_size WTF_GUARDED_BY_LOCK(m_cacheLock);
     ThreadSafeWeakPtr<WebCore::AXCoreObject> m_isolatedTreeRoot;
+    RetainPtr<id> m_window;
 #endif
 
     WebCore::IntPoint m_remoteFrameOffset;
@@ -56,6 +58,7 @@ class AXCoreObject;
 - (void)setPosition:(const WebCore::FloatPoint&)point;
 - (void)setSize:(const WebCore::IntSize&)size;
 - (void)setIsolatedTreeRoot:(NakedPtr<WebCore::AXCoreObject>)root;
+- (void)setWindow:(id)window;
 #endif
 - (void)setRemoteParent:(id)parent;
 - (void)setRemoteFrameOffset:(WebCore::IntPoint)offset;

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
@@ -152,6 +152,18 @@ namespace ax = WebCore::Accessibility;
     ASSERT(isMainRunLoop());
     m_isolatedTreeRoot = root.get();
 }
+
+- (void)setWindow:(id)window
+{
+    ASSERT(window);
+    // We should only set the window once before the AX thread is created to avoid thread-safety issues.
+    // Otherwise, we could write m_window while the AX thread is reading it.
+    ASSERT(isMainRunLoop());
+    ASSERT(!m_window);
+    if (m_window)
+        return;
+    m_window = window;
+}
 #endif
 
 - (void)setHasMainFramePlugin:(bool)hasPlugin
@@ -174,6 +186,10 @@ namespace ax = WebCore::Accessibility;
 - (void)setRemoteParent:(id)parent
 {
     ASSERT(isMainRunLoop());
+
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    Locker lock { m_parentLock };
+#endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     m_parent = parent;
 }
 

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
@@ -159,15 +159,23 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (id)accessibilityAttributeValue:(NSString *)attribute
 ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
-    callOnMainRunLoopAndWait([] {
-        if (!WebCore::AXObjectCache::accessibilityEnabled())
-            WebCore::AXObjectCache::enableAccessibility();
+    static std::atomic<bool> didInitialize { false };
+    static std::atomic<unsigned> screenHeight { 0 };
+    if (UNLIKELY(!didInitialize)) {
+        didInitialize = true;
+        callOnMainRunLoopAndWait([] {
+            if (!WebCore::AXObjectCache::accessibilityEnabled())
+                WebCore::AXObjectCache::enableAccessibility();
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-        if (WebCore::AXObjectCache::isIsolatedTreeEnabled())
-            WebCore::AXObjectCache::initializeAXThreadIfNeeded();
-#endif
-    });
+            if (WebCore::AXObjectCache::isIsolatedTreeEnabled())
+                WebCore::AXObjectCache::initializeAXThreadIfNeeded();
+#endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+
+            float roundedHeight = std::round(WebCore::screenRectForPrimaryScreen().size().height());
+            screenHeight = std::max(0u, static_cast<unsigned>(roundedHeight));
+        });
+    }
 
     // The following attributes can be handled off the main thread.
 
@@ -192,32 +200,19 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return [self accessibilityChildren];
     }
 
-    // The following attributes have to be retrieved from the main thread. Return nil for any other attribute.
-    if (![attribute isEqualToString:NSAccessibilityParentAttribute]
-        && ![attribute isEqualToString:NSAccessibilityWindowAttribute]
-        && ![attribute isEqualToString:NSAccessibilityTopLevelUIElementAttribute]
-        && ![attribute isEqualToString:NSAccessibilityPrimaryScreenHeightAttribute])
-        return nil;
+    if ([attribute isEqualToString:NSAccessibilityParentAttribute])
+        return [self accessibilityAttributeParentValue].get();
 
-    return ax::retrieveAutoreleasedValueFromMainThread<id>([attribute = retainPtr(attribute), PROTECTED_SELF] () -> RetainPtr<id> {
-        if ([attribute isEqualToString:NSAccessibilityParentAttribute])
-            return protectedSelf->m_parent.get();
+    if ([attribute isEqualToString:NSAccessibilityPrimaryScreenHeightAttribute])
+        return @(screenHeight.load());
 
-        if ([attribute isEqualToString:NSAccessibilityWindowAttribute])
-            return [protectedSelf->m_parent accessibilityAttributeValue:NSAccessibilityWindowAttribute];
+    if ([attribute isEqualToString:NSAccessibilityWindowAttribute])
+        return [self accessibilityAttributeWindowValue].get();
 
-        if ([attribute isEqualToString:NSAccessibilityTopLevelUIElementAttribute])
-            return [protectedSelf->m_parent accessibilityAttributeValue:NSAccessibilityTopLevelUIElementAttribute];
+    if ([attribute isEqualToString:NSAccessibilityTopLevelUIElementAttribute])
+        return [self accessibilityAttributeTopLevelUIElementValue].get();
 
-        // FIXME: do we need this check?
-        if (!protectedSelf->m_pageID)
-            return nil;
-
-        if ([attribute isEqualToString:NSAccessibilityPrimaryScreenHeightAttribute])
-            return @(WebCore::screenRectForPrimaryScreen().size().height());
-
-        return nil;
-    });
+    return nil;
 }
 
 - (NSValue *)accessibilityAttributeSizeValue
@@ -227,13 +222,9 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         Locker lock { m_cacheLock };
         return [NSValue valueWithSize:(NSSize)m_size];
     }
-#endif
+#endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 
-    return ax::retrieveAutoreleasedValueFromMainThread<id>([PROTECTED_SELF] () -> RetainPtr<id> {
-        if (!protectedSelf->m_page)
-            return nil;
-        return [NSValue valueWithSize:(NSSize)protectedSelf->m_page->size()];
-    });
+    return m_page ? [NSValue valueWithSize:m_page->size()] : nil;
 }
 
 - (NSValue *)accessibilityAttributePositionValue
@@ -243,13 +234,54 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         Locker lock { m_cacheLock };
         return [NSValue valueWithPoint:(NSPoint)m_position];
     }
-#endif
+#endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 
-    return ax::retrieveAutoreleasedValueFromMainThread<id>([PROTECTED_SELF] () -> RetainPtr<id> {
-        if (!protectedSelf->m_page)
-            return nil;
-        return [NSValue valueWithPoint:(NSPoint)protectedSelf->m_page->accessibilityPosition()];
-    });
+    return m_page ? [NSValue valueWithPoint:m_page->accessibilityPosition()] : nil;
+}
+
+- (RetainPtr<id>)accessibilityAttributeParentValue
+{
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    if (!isMainRunLoop()) {
+        Locker lock { m_parentLock };
+        return m_parent;
+    }
+#endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+
+    return m_parent;
+}
+
+// FIXME: accessibilityAttributeWindowValue and accessibilityAttributeTopLevelUIElementValue
+// always return nil for instances of this class when set up by WebPage::registerRemoteFrameAccessibilityTokens,
+// as nothing there sets m_window, setWindowUIElement, and setTopLevelUIElement.
+- (RetainPtr<id>)accessibilityAttributeWindowValue
+{
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    if (!isMainRunLoop()) {
+        // Use the cached window to avoid using m_parent (which is possibly an AppKit object) off the main-thread.
+        return m_window.get();
+    }
+#endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    return [m_parent accessibilityAttributeValue:NSAccessibilityWindowAttribute];
+    ALLOW_DEPRECATED_DECLARATIONS_END
+}
+
+- (RetainPtr<id>)accessibilityAttributeTopLevelUIElementValue
+{
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    if (!isMainRunLoop()) {
+        // Use the cached window to avoid using m_parent (which is possibly an AppKit object) off the main-thread.
+        // The TopLevelUIElement is the window, as we set it as such in WebPage::registerUIProcessAccessibilityTokens,
+        // so we can return m_window here.
+        return m_window.get();
+    }
+#endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    return [m_parent accessibilityAttributeValue:NSAccessibilityTopLevelUIElementAttribute];
+    ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 - (id)accessibilityDataDetectorValue:(NSString *)attribute point:(WebCore::FloatPoint&)point

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -457,7 +457,7 @@ void WebPage::registerUIProcessAccessibilityTokens(std::span<const uint8_t> elem
 
     [remoteElement setWindowUIElement:remoteWindow.get()];
     [remoteElement setTopLevelUIElement:remoteWindow.get()];
-
+    [accessibilityRemoteObject() setWindow:remoteWindow.get()];
     [accessibilityRemoteObject() setRemoteParent:remoteElement.get()];
 }
 


### PR DESCRIPTION
#### cd2edbe102c6e19fea3708386c74a79400f03ffb
<pre>
AX: -[WKAccessibilityWebPageObjectMac accessibilityAttributeValue] hits the main-thread unnecessarily
<a href="https://bugs.webkit.org/show_bug.cgi?id=284681">https://bugs.webkit.org/show_bug.cgi?id=284681</a>
<a href="https://rdar.apple.com/problem/141469939">rdar://problem/141469939</a>

Reviewed by Chris Fleizach.

Prior to this commit, -[WKAccessibilityWebPageObjectMac accessibilityAttributeValue] unconditionally hit the main-thread
once to initialize accessibility (even if it had already been done so), and potentially again depending on the attribute
requested.

Solve the first main-thread hit by adding a std::atomic&lt;bool&gt; that can be set after we&apos;ve initialized accessibility.
Checking an atomic bool is significantly cheaper than waiting on the main-thread, which could be busy.

Solve the second main-thread hit by making changes necessary to serve some attributes off the main-thread:

  - Cache NSAccessibilityPrimaryScreenHeightAttribute once at the same time we hit the main-thread to initialize
    accessibility for the first time, then store it in a std::atomic&lt;unsigned&gt; for subsequent use.

  - Put usage of WKAccessibilityWebPageObjectBase::m_parent behind a new lock, WKAccessibilityWebPageObjectBase::m_parentLock.
    RetainPtr reference counting is inherently threadsafe, but the lock is still necessary to ensure the main-thread
    cannot overwrite m_parent with a new value while the AX thread is reading it to serve a request.

* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h:
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm:
(-[WKAccessibilityWebPageObjectBase setRemoteParent:]):
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm:
(-[WKAccessibilityWebPageObject accessibilityAttributeValue:]):
(-[WKAccessibilityWebPageObject accessibilityAttributeSizeValue]):
(-[WKAccessibilityWebPageObject accessibilityAttributePositionValue]):
(-[WKAccessibilityWebPageObject accessibilityAttributeParentValue]):
(-[WKAccessibilityWebPageObject accessibilityAttributeWindowValue]):
(-[WKAccessibilityWebPageObject accessibilityAttributeTopLevelUIElementValue]):

Canonical link: <a href="https://commits.webkit.org/287855@main">https://commits.webkit.org/287855@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9215bb14235f3a957a5513a7dbf02efba263487e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81072 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/597 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35015 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85601 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32058 "Built successfully") 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/615 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8481 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63286 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21051 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84141 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/377 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73790 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43584 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/274 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30516 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71805 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28507 "Found 1 new test failure: fast/editing/recursive-reapply-edit-command-crash.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87036 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8302 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5940 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71591 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8479 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69625 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70827 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17642 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14873 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13798 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8263 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13786 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8100 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11620 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9908 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->