### PR TITLE
Further reduce use of memset()

### DIFF
--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h
@@ -105,6 +105,9 @@ public:
     inline const typename Adaptor::Type* typedVector() const;
     inline typename Adaptor::Type* typedVector();
 
+    std::span<const typename Adaptor::Type> typedSpan() const { return unsafeMakeSpan(typedVector(), length()); }
+    std::span<typename Adaptor::Type> typedSpan() { return unsafeMakeSpan(typedVector(), length()); }
+
     inline bool inBounds(size_t) const;
 
     // These methods are meant to match indexed access methods that JSObject

--- a/Source/WTF/wtf/GregorianDateTime.h
+++ b/Source/WTF/wtf/GregorianDateTime.h
@@ -89,7 +89,7 @@ public:
     operator tm() const
     {
         tm ret;
-        memset(&ret, 0, sizeof(ret));
+        zeroBytes(ret);
 
         ret.tm_year = m_year - 1900;
         ret.tm_mon = m_month;

--- a/Source/WTF/wtf/HashTable.h
+++ b/Source/WTF/wtf/HashTable.h
@@ -857,7 +857,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
             // This initializes the bucket without copying the empty value.
             // That makes it possible to use this with types that don't support copying.
             // The memset to 0 looks like a slow operation but is optimized by the compilers.
-            memset(static_cast<void*>(std::addressof(bucket)), 0, sizeof(bucket));
+            zeroBytes(bucket);
         }
     };
     

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -849,7 +849,7 @@ template<typename T, std::size_t Extent = std::dynamic_extent>
 std::span<uint8_t, Extent> asMutableByteSpan(T& input)
 {
     static_assert(!std::is_const_v<T>);
-    return unsafeMakeSpan<uint8_t, Extent>(reinterpret_cast<uint8_t*>(&input), sizeof(input));
+    return unsafeMakeSpan<uint8_t, Extent>(reinterpret_cast<uint8_t*>(std::addressof(input)), sizeof(input));
 }
 
 template<typename T, std::size_t Extent>
@@ -910,8 +910,8 @@ template<typename T, std::size_t TExtent, typename U, std::size_t UExtent>
 void memcpySpan(std::span<T, TExtent> destination, std::span<U, UExtent> source)
 {
     static_assert(sizeof(T) == sizeof(U));
-    static_assert(std::is_trivially_copyable_v<T>);
-    static_assert(std::is_trivially_copyable_v<U>);
+    static_assert(std::is_trivially_copyable_v<T> || std::is_floating_point_v<T>);
+    static_assert(std::is_trivially_copyable_v<U> || std::is_floating_point_v<U>);
     RELEASE_ASSERT(destination.size() >= source.size());
     memcpy(destination.data(), source.data(), source.size_bytes());
 }
@@ -920,8 +920,8 @@ template<typename T, std::size_t TExtent, typename U, std::size_t UExtent>
 void memmoveSpan(std::span<T, TExtent> destination, std::span<U, UExtent> source)
 {
     static_assert(sizeof(T) == sizeof(U));
-    static_assert(std::is_trivially_copyable_v<T>);
-    static_assert(std::is_trivially_copyable_v<U>);
+    static_assert(std::is_trivially_copyable_v<T> || std::is_floating_point_v<T>);
+    static_assert(std::is_trivially_copyable_v<U> || std::is_floating_point_v<U>);
     RELEASE_ASSERT(destination.size() >= source.size());
     memmove(destination.data(), source.data(), source.size_bytes());
 }
@@ -936,14 +936,13 @@ void memsetSpan(std::span<T, Extent> destination, uint8_t byte)
 template<typename T, std::size_t Extent>
 void zeroSpan(std::span<T, Extent> destination)
 {
-    static_assert(std::is_trivially_copyable_v<T>);
+    static_assert(std::is_trivially_copyable_v<T> || std::is_floating_point_v<T>);
     memset(destination.data(), 0, destination.size_bytes());
 }
 
 template<typename T>
 void zeroBytes(T& object)
 {
-    static_assert(std::is_trivially_copyable_v<T>);
     zeroSpan(asMutableByteSpan(object));
 }
 

--- a/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.h
@@ -27,8 +27,8 @@
 
 #include "AudioBufferSourceOptions.h"
 #include "AudioScheduledSourceNode.h"
+#include <wtf/FixedVector.h>
 #include <wtf/Lock.h>
-#include <wtf/UniqueArray.h>
 
 namespace WebCore {
 
@@ -102,9 +102,9 @@ private:
     // m_buffer holds the sample data which this node outputs.
     RefPtr<AudioBuffer> m_buffer WTF_GUARDED_BY_LOCK(m_processLock); // Only modified on the main thread but used on the audio thread.
 
-    // Pointers for the buffer and destination.
-    UniqueArray<const float*> m_sourceChannels;
-    UniqueArray<float*> m_destinationChannels;
+    // Spans for the buffer and destination.
+    FixedVector<std::span<const float>> m_sourceChannels;
+    FixedVector<std::span<float>> m_destinationChannels;
 
     Ref<AudioParam> m_detune;
     Ref<AudioParam> m_playbackRate;

--- a/Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp
@@ -41,6 +41,7 @@
 #include "WebCoreOpaqueRoot.h"
 #include <JavaScriptCore/JSTypedArrays.h>
 #include <wtf/GetPtr.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -208,7 +209,7 @@ static bool zeroJSArray(JSGlobalObject& globalObject, const Vector<Ref<AudioBus>
             auto* jsChannelArray = getArrayAtIndex<JSFloat32Array>(*jsChannelsArray, globalObject, channelIndex);
             if (!jsChannelArray || jsChannelArray->isShared() || jsChannelArray->length() != channel->length())
                 return false;
-            memset(jsChannelArray->typedVector(), 0, sizeof(float) * jsChannelArray->length());
+            zeroSpan(jsChannelArray->typedSpan());
         }
     }
     return true;

--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceCocoa.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceCocoa.cpp
@@ -31,6 +31,7 @@
 #include "AudioBus.h"
 #include "CAAudioStreamDescription.h"
 #include "Logging.h"
+#include "SpanCoreAudio.h"
 #include "WebAudioBufferList.h"
 #include <CoreAudio/CoreAudioTypes.h>
 #include <pal/avfoundation/MediaTimeAVFoundation.h>
@@ -56,7 +57,7 @@ static inline void copyChannelData(AudioChannel& channel, AudioBuffer& buffer, s
     buffer.mDataByteSize = numberOfFrames * sizeof(float);
     buffer.mNumberChannels = 1;
     if (isMuted) {
-        memset(buffer.mData, 0, buffer.mDataByteSize);
+        zeroSpan(dataMutableByteSpan(buffer));
         return;
     }
     memcpy(buffer.mData, channel.data(), buffer.mDataByteSize);

--- a/Source/WebCore/platform/audio/cocoa/AudioSampleBufferList.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioSampleBufferList.cpp
@@ -28,6 +28,7 @@
 
 #include "Logging.h"
 #include "NotImplemented.h"
+#include "SpanCoreAudio.h"
 #include "VectorMath.h"
 #include <Accelerate/Accelerate.h>
 #include <AudioToolbox/AudioConverter.h>
@@ -244,7 +245,7 @@ void AudioSampleBufferList::zero()
 void AudioSampleBufferList::zeroABL(AudioBufferList& buffer, size_t byteCount)
 {
     for (uint32_t i = 0; i < buffer.mNumberBuffers; ++i)
-        memset(buffer.mBuffers[i].mData, 0, byteCount);
+        zeroSpan(dataMutableByteSpan(buffer.mBuffers[i]).first(byteCount));
 }
 
 struct AudioConverterFromABLContext {

--- a/Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp
+++ b/Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp
@@ -30,6 +30,7 @@
 
 #include "CAAudioStreamDescription.h"
 #include "Logging.h"
+#include "SpanCoreAudio.h"
 #include <Accelerate/Accelerate.h>
 #include <CoreAudio/CoreAudioTypes.h>
 #include <wtf/MathExtras.h>
@@ -146,7 +147,10 @@ inline void ZeroABL(AudioBufferList* list, size_t destOffset, size_t nbytes)
     while (--nBuffers >= 0) {
         if (destOffset > dest->mDataByteSize)
             continue;
-        memset(static_cast<Byte*>(dest->mData) + destOffset, 0, std::min<size_t>(nbytes, dest->mDataByteSize - destOffset));
+        auto dataSpan = dataMutableByteSpan(*dest).subspan(destOffset);
+        if (nbytes < dataSpan.size())
+            dataSpan = dataSpan.first(nbytes);
+        zeroSpan(dataSpan);
         ++dest;
     }
 }

--- a/Source/WebCore/platform/audio/cocoa/SpanCoreAudio.h
+++ b/Source/WebCore/platform/audio/cocoa/SpanCoreAudio.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <CoreAudio/CoreAudioTypes.h>
+#include <span>
+#include <wtf/StdLibExtras.h>
+
+namespace WebCore {
+
+inline std::span<uint8_t> dataMutableByteSpan(AudioBuffer& buffer)
+{
+    return unsafeMakeSpan(static_cast<uint8_t*>(buffer.mData), buffer.mDataByteSize);
+}
+
+inline std::span<const uint8_t> dataByteSpan(const AudioBuffer& buffer)
+{
+    return unsafeMakeSpan(static_cast<const uint8_t*>(buffer.mData), buffer.mDataByteSize);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
@@ -34,6 +34,7 @@
 #import "CAAudioStreamDescription.h"
 #import "CARingBuffer.h"
 #import "Logging.h"
+#import "SpanCoreAudio.h"
 #import <AVFoundation/AVAssetTrack.h>
 #import <AVFoundation/AVAudioMix.h>
 #import <AVFoundation/AVMediaFormat.h>
@@ -408,7 +409,7 @@ void AudioSourceProviderAVFObjC::process(MTAudioProcessingTapRef tap, CMItemCoun
     // Mute the default audio playback by zeroing the tap-owned buffers.
     for (uint32_t i = 0; i < bufferListInOut->mNumberBuffers; ++i) {
         AudioBuffer& buffer = bufferListInOut->mBuffers[i];
-        memset(buffer.mData, 0, buffer.mDataByteSize);
+        zeroSpan(dataMutableByteSpan(buffer));
     }
     *numberFramesOut = 0;
 


### PR DESCRIPTION
#### 52af84aa93ee45a39f778c9006f78005d54afb94
<pre>
Further reduce use of memset()
<a href="https://bugs.webkit.org/show_bug.cgi?id=284684">https://bugs.webkit.org/show_bug.cgi?id=284684</a>

Reviewed by Darin Adler.

Further reduce use of memset(), in favor of safer alternatives.

* Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h:
(JSC::JSGenericTypedArrayView::typedSpan const):
(JSC::JSGenericTypedArrayView::typedSpan):
* Source/WTF/wtf/GregorianDateTime.h:
* Source/WTF/wtf/HashTable.h:
(WTF::HashTableBucketInitializer&lt;true&gt;::initialize):
* Source/WTF/wtf/StdLibExtras.h:
(WTF::memcpySpan):
(WTF::memmoveSpan):
(WTF::zeroSpan):
(WTF::zeroBytes):
* Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp:
(WebCore::AudioBufferSourceNode::process):
(WebCore::AudioBufferSourceNode::renderSilenceAndFinishIfNotLooping):
(WebCore::AudioBufferSourceNode::renderFromBuffer):
(WebCore::AudioBufferSourceNode::setBufferForBindings):
* Source/WebCore/Modules/webaudio/AudioBufferSourceNode.h:
* Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp:
(WebCore::zeroJSArray):
* Source/WebCore/Modules/webaudio/MediaStreamAudioSourceCocoa.cpp:
(WebCore::copyChannelData):
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/audio/cocoa/AudioSampleBufferList.cpp:
(WebCore::AudioSampleBufferList::zeroABL):
* Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp:
(WebCore::ZeroABL):
* Source/WebCore/platform/audio/cocoa/SpanCoreAudio.h: Added.
(WebCore::mDataMutableByteSpan):
(WebCore::mDataByteSpan):
* Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm:
(WebCore::AudioSourceProviderAVFObjC::process):
* Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm:
(WebKit::AuxiliaryProcess::registerWithStateDumper):

Canonical link: <a href="https://commits.webkit.org/287848@main">https://commits.webkit.org/287848@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2dd6584074519cfbfae7f9387c420cb803b9950

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81097 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/622 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35040 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85626 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32083 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83207 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/640 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8429 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63310 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21076 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84166 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/403 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73816 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43608 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/300 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27978 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30541 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/74076 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/71829 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28535 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87061 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/80155 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8327 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5897 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71616 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8504 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69651 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70851 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14898 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13824 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/102561 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12571 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8288 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13811 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/24921 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/struct-new_default-small-members.js.wasm-no-cjit (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8125 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11645 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9933 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->