### PR TITLE
Cleanup StyledElement usage in PDFPlugin

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -51,7 +51,6 @@ WebProcess/InjectedBundle/API/mac/WKDOMInternals.mm
 WebProcess/Network/NetworkProcessConnection.cpp
 WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
 WebProcess/Plugins/PDF/PDFPlugin.mm
-WebProcess/Plugins/PDF/PDFPluginAnnotation.mm
 WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
 WebProcess/Plugins/PluginView.cpp
 WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -108,7 +108,6 @@ WebProcess/Network/webrtc/LibWebRTCProvider.cpp
 WebProcess/Network/webrtc/WebMDNSRegister.cpp
 WebProcess/Notifications/WebNotificationManager.cpp
 WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
-WebProcess/Plugins/PDF/PDFPluginAnnotation.mm
 WebProcess/Plugins/PDF/PDFPluginBase.mm
 WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
 WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.mm
@@ -111,7 +111,7 @@ void PDFPluginAnnotation::updateGeometry()
 {
     auto annotationRect = m_plugin->pluginBoundsForAnnotation(m_annotation);
 
-    StyledElement* styledElement = static_cast<StyledElement*>(element());
+    Ref styledElement = downcast<StyledElement>(*element());
     styledElement->setInlineStyleProperty(CSSPropertyWidth, annotationRect.size.width, CSSUnitType::CSS_PX);
     styledElement->setInlineStyleProperty(CSSPropertyHeight, annotationRect.size.height, CSSUnitType::CSS_PX);
     styledElement->setInlineStyleProperty(CSSPropertyLeft, annotationRect.origin.x, CSSUnitType::CSS_PX);

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm
@@ -54,7 +54,7 @@ void PDFPluginChoiceAnnotation::updateGeometry()
 {
     PDFPluginAnnotation::updateGeometry();
 
-    RefPtr styledElement = downcast<StyledElement>(element());
+    Ref styledElement = downcast<StyledElement>(*element());
     styledElement->setInlineStyleProperty(CSSPropertyFontSize, annotation().font.pointSize * plugin()->contentScaleFactor(), CSSUnitType::CSS_PX);
 }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordForm.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordForm.mm
@@ -49,7 +49,7 @@ PDFPluginPasswordForm::~PDFPluginPasswordForm() = default;
 Ref<Element> PDFPluginPasswordForm::createAnnotationElement()
 {
     Ref document = parent()->document();
-    Ref element = downcast<StyledElement>(document->createElement(divTag, false));
+    Ref element = document->createElement(divTag, false);
     element->setAttributeWithoutSynchronization(classAttr, "password-form"_s);
 
     auto iconElement = document->createElement(svgTag, false);

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
@@ -83,20 +83,18 @@ Ref<Element> PDFPluginTextAnnotation::createAnnotationElement()
     RetainPtr textAnnotation = annotation();
     bool isMultiline = [textAnnotation isMultiline];
 
-    auto element = document.createElement(isMultiline ? textareaTag : inputTag, false);
+    Ref element = downcast<HTMLTextFormControlElement>(document.createElement(isMultiline ? textareaTag : inputTag, false));
     element->addEventListener(eventNames().keydownEvent, *eventListener(), false);
-
-    auto& styledElement = downcast<StyledElement>(element.get());
 
     if (!textAnnotation)
         return element;
 
     // FIXME: Match font weight and style as well?
-    styledElement.setInlineStyleProperty(CSSPropertyColor, serializationForHTML(colorFromCocoaColor([textAnnotation fontColor])));
-    styledElement.setInlineStyleProperty(CSSPropertyFontFamily, [[textAnnotation font] familyName]);
-    styledElement.setInlineStyleProperty(CSSPropertyTextAlign, cssAlignmentValueForNSTextAlignment([textAnnotation alignment]));
+    element->setInlineStyleProperty(CSSPropertyColor, serializationForHTML(colorFromCocoaColor([textAnnotation fontColor])));
+    element->setInlineStyleProperty(CSSPropertyFontFamily, [[textAnnotation font] familyName]);
+    element->setInlineStyleProperty(CSSPropertyTextAlign, cssAlignmentValueForNSTextAlignment([textAnnotation alignment]));
 
-    downcast<HTMLTextFormControlElement>(styledElement).setValue([textAnnotation widgetStringValue]);
+    element->setValue([textAnnotation widgetStringValue]);
 
     return element;
 }
@@ -105,7 +103,7 @@ void PDFPluginTextAnnotation::updateGeometry()
 {
     PDFPluginAnnotation::updateGeometry();
 
-    StyledElement* styledElement = static_cast<StyledElement*>(element());
+    Ref styledElement = downcast<StyledElement>(*element());
     styledElement->setInlineStyleProperty(CSSPropertyFontSize, annotation().font.pointSize * plugin()->contentScaleFactor(), CSSUnitType::CSS_PX);
 }
 


### PR DESCRIPTION
#### 76a2b2aa39ec7bcd9f0a976eed7d634e443e05fe
<pre>
Cleanup StyledElement usage in PDFPlugin
<a href="https://bugs.webkit.org/show_bug.cgi?id=284690">https://bugs.webkit.org/show_bug.cgi?id=284690</a>

Reviewed by Tim Nguyen.

In particular in PDFPluginPasswordForm it isn&apos;t needed at all.

* Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.mm:
(WebKit::PDFPluginAnnotation::updateGeometry):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm:
(WebKit::PDFPluginChoiceAnnotation::updateGeometry):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordForm.mm:
(WebKit::PDFPluginPasswordForm::createAnnotationElement):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm:
(WebKit::PDFPluginTextAnnotation::createAnnotationElement):
(WebKit::PDFPluginTextAnnotation::updateGeometry):

Canonical link: <a href="https://commits.webkit.org/287891@main">https://commits.webkit.org/287891@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e7fb6c1aee0eaad841818295895fe25bff9c08a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81196 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/721 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35139 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85725 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32182 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/739 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8531 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63393 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21156 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84265 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/490 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73897 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43691 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/387 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30640 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71902 "Passed tests") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87160 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8426 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71696 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8605 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69732 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70932 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14984 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12590 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8387 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13911 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8224 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11744 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10032 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->