### PR TITLE
[GStreamer] imported/w3c/web-platform-tests/webcodecs/audio-encoder-codec-specific.https.any.html is a permanent failure

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1303,22 +1303,9 @@ imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.
 
 webkit.org/b/284626 imported/w3c/web-platform-tests/webcodecs/audio-data.any.html [ Failure ]
 webkit.org/b/284626 imported/w3c/web-platform-tests/webcodecs/audio-data.any.worker.html [ Failure ]
-webkit.org/b/284447 imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?pcm_u8 [ Failure ]
-webkit.org/b/284447 imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?pcm_f32 [ Failure ]
-webkit.org/b/284447 imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?pcm_s16 [ Failure ]
-webkit.org/b/284447 imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?pcm_s24 [ Failure ]
-webkit.org/b/284447 imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?pcm_s32 [ Failure ]
-webkit.org/b/284447 imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?pcm_u8 [ Failure ]
-webkit.org/b/284447 imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?pcm_f32 [ Failure ]
-webkit.org/b/284447 imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?pcm_s16 [ Failure ]
-webkit.org/b/284447 imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?pcm_s24 [ Failure ]
-webkit.org/b/284447 imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?pcm_s32 [ Failure ]
 
-webkit.org/b/284426 imported/w3c/web-platform-tests/webcodecs/audio-encoder-codec-specific.https.any.html [ Failure ]
-webkit.org/b/284428 imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any.html [ Failure ]
-webkit.org/b/284428 imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any.worker.html [ Failure ]
+# Input/output waveforms don't match...
 webkit.org/b/284429 imported/w3c/web-platform-tests/webcodecs/audio-encoder.https.any.html [ Failure ]
-http/wpt/webcodecs/encoder-task-failing.html [ Pass ]
 
 # H.264 high-4:2:2 encoding is supported in the GStreamer ports, so this test (checking that profile
 # is not supported) is expected to fail.

--- a/Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp
@@ -83,24 +83,14 @@ void GStreamerAudioDecoder::create(const String& codecName, const Config& config
         GST_DEBUG_CATEGORY_INIT(webkit_audio_decoder_debug, "webkitaudiodecoder", 0, "WebKit WebCodecs Audio Decoder");
     });
 
-    GRefPtr<GstElement> element;
-    if (codecName.startsWith("pcm-"_s)) {
-        auto components = codecName.split('-');
-        if (components.size() != 2) {
-            GST_WARNING("Invalid LPCM codec string: %s", codecName.utf8().data());
-            callback(makeUnexpected(makeString("Invalid LPCM codec string: "_s, codecName)));
-            return;
-        }
-    } else {
-        auto& scanner = GStreamerRegistryScanner::singleton();
-        auto lookupResult = scanner.isCodecSupported(GStreamerRegistryScanner::Configuration::Decoding, codecName);
-        if (!lookupResult) {
-            GST_WARNING("No decoder found for codec %s", codecName.utf8().data());
-            callback(makeUnexpected(makeString("No decoder found for codec "_s, codecName)));
-            return;
-        }
-        element = gst_element_factory_create(lookupResult.factory.get(), nullptr);
+    auto& scanner = GStreamerRegistryScanner::singleton();
+    auto lookupResult = scanner.isCodecSupported(GStreamerRegistryScanner::Configuration::Decoding, codecName);
+    if (!lookupResult) {
+        GST_WARNING("No decoder found for codec %s", codecName.utf8().data());
+        callback(makeUnexpected(makeString("No decoder found for codec "_s, codecName)));
+        return;
     }
+    GRefPtr<GstElement> element = gst_element_factory_create(lookupResult.factory.get(), nullptr);
 
     Ref decoder = adoptRef(*new GStreamerAudioDecoder(codecName, config, WTFMove(outputCallback), WTFMove(element)));
     Ref internalDecoder = decoder->m_internalDecoder;
@@ -215,26 +205,26 @@ GStreamerInternalAudioDecoder::GStreamerInternalAudioDecoder(const String& codec
         m_inputCaps = adoptGRef(gst_caps_new_simple("audio/x-raw", "format", G_TYPE_STRING, gst_audio_format_to_string(gstPcmFormat),
             "rate", G_TYPE_INT, config.sampleRate, "channels", G_TYPE_INT, config.numberOfChannels,
             "layout", G_TYPE_STRING, "interleaved", nullptr));
-        parser = "rawaudioparse";
     } else
         return;
 
     configureAudioDecoderForHarnessing(element);
 
-    GRefPtr<GstElement> harnessedElement;
-    bool isParserRequired = false;
-    if (element) {
-        auto* factory = gst_element_get_factory(element.get());
-        isParserRequired = !gst_element_factory_can_sink_all_caps(factory, m_inputCaps.get());
-    }
-    if (!g_strcmp0(parser, "rawaudioparse")) {
-        harnessedElement = makeGStreamerElement(parser, nullptr);
-        if (!harnessedElement) {
-            GST_WARNING_OBJECT(element.get(), "Required parser %s not found", parser);
-            m_inputCaps.clear();
-            return;
-        }
-    } else if (parser && isParserRequired) {
+    auto factory = gst_element_get_factory(element.get());
+    bool isParserRequired = !gst_element_factory_can_sink_all_caps(factory, m_inputCaps.get());
+
+    static Atomic<uint64_t> counter = 0;
+    auto binName = makeString("audio-decoder-"_s, span(GST_OBJECT_NAME(element.get())), '-', counter.exchangeAdd(1));
+
+    GRefPtr<GstElement> harnessedElement = gst_bin_new(binName.ascii().data());
+    auto audioconvert = gst_element_factory_make("audioconvert", nullptr);
+    auto outputCapsFilter = gst_element_factory_make("capsfilter", nullptr);
+    auto outputCaps = adoptGRef(gst_caps_new_simple("audio/x-raw", "format", G_TYPE_STRING, "F32LE", nullptr));
+    g_object_set(outputCapsFilter, "caps", outputCaps.get(), nullptr);
+    gst_bin_add_many(GST_BIN_CAST(harnessedElement.get()), audioconvert, outputCapsFilter, element.get(), nullptr);
+
+    GRefPtr<GstElement> head = element;
+    if (parser && isParserRequired) {
         // The decoder won't accept the input caps, so put a parser in front.
         auto* parserElement = makeGStreamerElement(parser, nullptr);
         if (!parserElement) {
@@ -242,15 +232,19 @@ GStreamerInternalAudioDecoder::GStreamerInternalAudioDecoder(const String& codec
             m_inputCaps.clear();
             return;
         }
-        harnessedElement = gst_bin_new(nullptr);
-        gst_bin_add_many(GST_BIN_CAST(harnessedElement.get()), parserElement, element.get(), nullptr);
+
+        gst_bin_add(GST_BIN_CAST(harnessedElement.get()), parserElement);
         gst_element_link(parserElement, element.get());
-        auto sinkPad = adoptGRef(gst_element_get_static_pad(parserElement, "sink"));
-        gst_element_add_pad(harnessedElement.get(), gst_ghost_pad_new("sink", sinkPad.get()));
-        auto srcPad = adoptGRef(gst_element_get_static_pad(element.get(), "src"));
-        gst_element_add_pad(harnessedElement.get(), gst_ghost_pad_new("src", srcPad.get()));
-    } else
-        harnessedElement = WTFMove(element);
+        head = parserElement;
+    }
+
+    gst_element_link_many(head.get(), audioconvert, outputCapsFilter, nullptr);
+
+    auto pad = adoptGRef(gst_element_get_static_pad(head.get(), "sink"));
+    gst_element_add_pad(harnessedElement.get(), gst_ghost_pad_new("sink", pad.get()));
+
+    pad = adoptGRef(gst_element_get_static_pad(outputCapsFilter, "src"));
+    gst_element_add_pad(harnessedElement.get(), gst_ghost_pad_new("src", pad.get()));
 
     m_harness = GStreamerElementHarness::create(WTFMove(harnessedElement), [weakThis = ThreadSafeWeakPtr { *this }, this](auto&, GRefPtr<GstSample>&& outputSample) {
         RefPtr protectedThis = weakThis.get();

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -619,6 +619,15 @@ void GStreamerRegistryScanner::initializeDecoders(const GStreamerRegistryScanner
         if (factories.hasElementForMediaType(ElementFactories::Type::VideoDecoder, "video/x-vp10"_s))
             m_decoderMimeTypeSet.add("video/webm"_s);
     }
+
+    // WebCodecs linear PCM codecs.
+    if (auto result = factories.hasElementForMediaType(ElementFactories::Type::AudioParser, "audio/x-raw"_s)) {
+        m_decoderCodecMap.add("pcm-u8"_s, result);
+        m_decoderCodecMap.add("pcm-s16"_s, result);
+        m_decoderCodecMap.add("pcm-s24"_s, result);
+        m_decoderCodecMap.add("pcm-f32"_s, result);
+        m_decoderCodecMap.add("pcm-s32"_s, result);
+    }
 }
 
 void GStreamerRegistryScanner::initializeEncoders(const GStreamerRegistryScanner::ElementFactories& factories)


### PR DESCRIPTION
#### 910440412733f17f3fdcdea8aed2265b9c8c5172
<pre>
[GStreamer] imported/w3c/web-platform-tests/webcodecs/audio-encoder-codec-specific.https.any.html is a permanent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=284426">https://bugs.webkit.org/show_bug.cgi?id=284426</a>

Reviewed by Xabier Rodriguez-Calvar.

The opus encoder now correctly configures bitrate and bitrateMode, even if no Opus-specific
parameters were supplied. The mp3 encoder also handles bitrateMode. The decoder now outputs F32
instead of the underlying decoder&apos;s format, which can be S16 for Opus, for instance. The decoder
also now properly handles lpcm formats.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp:
(WebCore::GStreamerInternalAudioDecoder::GStreamerInternalAudioDecoder):
* Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp:
(WebCore::GStreamerAudioEncoder::encode):
(WebCore::GStreamerInternalAudioEncoder::initialize):

Canonical link: <a href="https://commits.webkit.org/287875@main">https://commits.webkit.org/287875@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d6593f38b8a889f15bf527dd9258d3047d70f32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81209 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/734 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35152 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85738 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32195 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83319 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/752 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8546 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63407 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21168 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84278 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/500 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73913 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43705 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/399 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28075 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30653 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/71911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/28646 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87173 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8439 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71710 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8618 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69748 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70946 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17654 "Found 1 new test failure: fast/attachment/cocoa/wide-attachment-rendering.html (failure)") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14995 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/13910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12583 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8400 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13924 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8237 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11757 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10045 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->