### PR TITLE
Add bounds checks to FastBitVector

### DIFF
--- a/Source/WTF/wtf/FastBitVector.h
+++ b/Source/WTF/wtf/FastBitVector.h
@@ -61,7 +61,7 @@ public:
     
     uint32_t word(size_t index) const
     {
-        ASSERT_WITH_SECURITY_IMPLICATION(index < fastBitVectorArrayLength(numBits()));
+        RELEASE_ASSERT(index < fastBitVectorArrayLength(numBits()));
         return m_words[index];
     }
     
@@ -149,13 +149,13 @@ public:
     
     uint32_t word(size_t index) const
     {
-        ASSERT_WITH_SECURITY_IMPLICATION(index < arrayLength());
+        RELEASE_ASSERT(index < arrayLength());
         return m_words[index];
     }
     
     uint32_t& word(size_t index)
     {
-        ASSERT_WITH_SECURITY_IMPLICATION(index < arrayLength());
+        RELEASE_ASSERT(index < arrayLength());
         return m_words[index];
     }
     
@@ -569,7 +569,7 @@ public:
     
     FastBitReference at(size_t index)
     {
-        ASSERT_WITH_SECURITY_IMPLICATION(index < numBits());
+        RELEASE_ASSERT(index < numBits());
         return FastBitReference(&m_words.word(index >> 5), 1 << (index & 31));
     }
     


### PR DESCRIPTION
#### a1fc5cb7c15cd65d8c5b784f8f0e6db3fb2df7df
<pre>
Add bounds checks to FastBitVector
<a href="https://bugs.webkit.org/show_bug.cgi?id=284691">https://bugs.webkit.org/show_bug.cgi?id=284691</a>

Reviewed by Darin Adler.

Enforce bounds checking in release builds for FastBitVector,
as security hardening.

This tested as performance neutral on Speedometer and JetStream.

* Source/WTF/wtf/FastBitVector.h:
(WTF::FastBitVectorWordView::word const):
(WTF::FastBitVectorWordOwner::word const):
(WTF::FastBitVectorWordOwner::word):
(WTF::FastBitVector::at):

Canonical link: <a href="https://commits.webkit.org/287860@main">https://commits.webkit.org/287860@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bed6a4a40d546d1f131a9f99733d5d35800586db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81074 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/599 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35017 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85603 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32060 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/617 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8405 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63288 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21055 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84143 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/379 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73792 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43586 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/276 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27952 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30518 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/74053 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71806 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28509 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87038 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/80132 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8304 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5874 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71589 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8481 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69627 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70825 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14875 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13800 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/102538 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12575 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8265 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13788 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/24913 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/struct-new_default-small-members.js.wasm-slow-memory (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8102 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11622 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9910 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->