### PR TITLE
[iOS 18] TestWebKitAPI.KeyboardInputTests.EditableWebViewRequiresKeyboardWhenFirstResponder is a constant failure

### DIFF
--- a/Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm
@@ -28,6 +28,7 @@
 #if PLATFORM(IOS_FAMILY)
 
 #import "CGImagePixelReader.h"
+#import "ClassMethodSwizzler.h"
 #import "InstanceMethodSwizzler.h"
 #import "PlatformUtilities.h"
 #import "TestCocoa.h"
@@ -968,19 +969,14 @@ TEST(KeyboardInputTests, DoNotCrashWhenFocusingSelectWithoutViewSnapshot)
     [webView waitForNextPresentationUpdate];
 }
 
-static BOOL overrideHardwareKeyboardAttached(id, SEL)
+TEST(KeyboardInputTests, EditableWebViewRequiresKeyboardWhenFirstResponder)
 {
-    return NO;
-}
+    auto returnNo = imp_implementationWithBlock(^{
+        return NO;
+    });
 
-// FIXME when rdar://141397449 is resolved.
-TEST(KeyboardInputTests, DISABLED_EditableWebViewRequiresKeyboardWhenFirstResponder)
-{
-    InstanceMethodSwizzler swizzler {
-        UIKeyboardImpl.class,
-        @selector(hardwareKeyboardAttached),
-        reinterpret_cast<IMP>(overrideHardwareKeyboardAttached)
-    };
+    InstanceMethodSwizzler hardwareKeyboardAttachedSwizzler { UIKeyboardImpl.class, @selector(hardwareKeyboardAttached), returnNo };
+    ClassMethodSwizzler hardwareKeyboardModeSwizzler { UIKeyboard.class, @selector(isInHardwareKeyboardMode), returnNo };
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([TestInputDelegate new]);


### PR DESCRIPTION
#### 0a51f6550adadbf4b0adec0f920de9649b2c0cdb
<pre>
[iOS 18] TestWebKitAPI.KeyboardInputTests.EditableWebViewRequiresKeyboardWhenFirstResponder is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=284578">https://bugs.webkit.org/show_bug.cgi?id=284578</a>
<a href="https://rdar.apple.com/141397449">rdar://141397449</a>

Reviewed by Aditya Keerthi.

The first step in this API test (which currently fails) verifies that when a hardware keyboard is
not attached, `-_requiresKeyboardWhenFirstResponder` returns `NO` on the content view. Prior to
iOS 18.1, UIKit used `-[UIKeyboardImpl hardwareKeyboardAttached]` to determine if there&apos;s a hardware
keyboard attached, and used that to determine if the keyboard should appear automatically when the
web view is the first responder.

However, after iOS 18.1, UIKit now uses `+[UIKeyboard isInHardwareKeyboardMode]`. Account for this
in the API test by swizzling this method as well.

* Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm:
(TestWebKitAPI::TEST(KeyboardInputTests, EditableWebViewRequiresKeyboardWhenFirstResponder)):
(TestWebKitAPI::overrideHardwareKeyboardAttached): Deleted.
(TestWebKitAPI::TEST(KeyboardInputTests, DISABLED_EditableWebViewRequiresKeyboardWhenFirstResponder)): Deleted.

Canonical link: <a href="https://commits.webkit.org/287846@main">https://commits.webkit.org/287846@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f2b4482c4a161700acc4bf037be23797dc19c89

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81081 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/606 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35024 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85610 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32067 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83191 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/624 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8420 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63295 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21058 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84150 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/386 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73799 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43593 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/283 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27960 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30525 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71812 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28516 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87045 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8311 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5886 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71598 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8488 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69634 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70834 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17632 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14881 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13807 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8272 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8109 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11629 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9917 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->