### PR TITLE
Remove unnecessary rounding leading to subpixel issues in elementFromPoint hit testing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/elementFromPoint-subpixel-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/elementFromPoint-subpixel-expected.txt
@@ -1,8 +1,6 @@
 
-FAIL Hit test top left corner of box assert_equals: expected Element node <div class="box" id="box">
-      <div class="child"></div... but got Element node <div class="map"></div>
+PASS Hit test top left corner of box
 PASS Hit test top right corner of box
-FAIL Hit test bottom left corner of box assert_equals: expected Element node <div class="box" id="box">
-      <div class="child"></div... but got Element node <div class="map"></div>
+PASS Hit test bottom left corner of box
 PASS Hit test lower left corner of box
 

--- a/Source/WebCore/rendering/HitTestLocation.cpp
+++ b/Source/WebCore/rendering/HitTestLocation.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2006, 2008, 2011, 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2019 Google Inc. All rights reserved.
  * Copyright (C) 2012 Nokia Corporation and/or its subsidiary(-ies)
  *
  * This library is free software; you can redistribute it and/or
@@ -28,7 +29,7 @@ HitTestLocation::HitTestLocation() = default;
 
 HitTestLocation::HitTestLocation(const LayoutPoint& point)
     : m_point(point)
-    , m_boundingBox(LayoutRect { flooredIntPoint(point), LayoutSize { 1, 1 } })
+    , m_boundingBox(LayoutRect { point, LayoutSize { 1, 1 } })
     , m_transformedPoint(point)
     , m_transformedRect(m_boundingBox)
 {
@@ -50,6 +51,16 @@ HitTestLocation::HitTestLocation(const LayoutRect& rect)
     , m_transformedPoint { rect.center() }
     , m_transformedRect { FloatQuad { m_boundingBox } }
     , m_isRectBased { true }
+{
+}
+
+HitTestLocation::HitTestLocation(const FloatPoint& point, const LayoutRect& boundingBox)
+    : m_point { flooredLayoutPoint(point) }
+    , m_boundingBox { boundingBox }
+    , m_transformedPoint { point }
+    , m_transformedRect { FloatRect { boundingBox } }
+    , m_isRectBased { false }
+    , m_isRectilinear { true }
 {
 }
 

--- a/Source/WebCore/rendering/HitTestLocation.h
+++ b/Source/WebCore/rendering/HitTestLocation.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2006 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2019 Google Inc. All rights reserved.
  * Copyright (C) 2012 Nokia Corporation and/or its subsidiary(-ies)
  *
  * This library is free software; you can redistribute it and/or
@@ -33,6 +34,8 @@ public:
     HitTestLocation(const FloatPoint&, const FloatQuad&);
 
     HitTestLocation(const LayoutRect&);
+
+    HitTestLocation(const FloatPoint&, const LayoutRect&);
 
     // Make a copy the HitTestLocation in a new region by applying given offset to internal point and area.
     HitTestLocation(const HitTestLocation&, const LayoutSize& offset);

--- a/Source/WebCore/rendering/HitTestingTransformState.cpp
+++ b/Source/WebCore/rendering/HitTestingTransformState.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2011 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2019 Google Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -64,6 +65,14 @@ FloatQuad HitTestingTransformState::mappedArea() const
     if (auto inverse = m_accumulatedTransform.inverse())
         return inverse.value().projectQuad(m_lastPlanarArea);
     return m_lastPlanarArea;
+}
+
+LayoutRect HitTestingTransformState::boundsOfMappedQuad() const
+{
+    if (auto inverse = m_accumulatedTransform.inverse())
+        return inverse.value().clampedBoundsOfProjectedQuad(m_lastPlanarQuad);
+    TransformationMatrix identity;
+    return identity.clampedBoundsOfProjectedQuad(m_lastPlanarQuad);
 }
 
 LayoutRect HitTestingTransformState::boundsOfMappedArea() const

--- a/Source/WebCore/rendering/HitTestingTransformState.h
+++ b/Source/WebCore/rendering/HitTestingTransformState.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2011 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2019 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -56,6 +57,7 @@ public:
     FloatPoint mappedPoint() const;
     FloatQuad mappedQuad() const;
     FloatQuad mappedArea() const;
+    LayoutRect boundsOfMappedQuad() const;
     LayoutRect boundsOfMappedArea() const;
     void flatten();
 

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
- * Copyright (C) 2013-2014 Google Inc. All rights reserved.
+ * Copyright (C) 2006-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2019 Google Inc. All rights reserved.
  * Copyright (C) 2019 Adobe. All rights reserved.
  * Copyright (c) 2020, 2021, 2022 Igalia S.L.
  *
@@ -4985,13 +4985,12 @@ RenderLayer::HitLayer RenderLayer::hitTestLayerByApplyingTransform(RenderLayer* 
     // We can't just map hitTestLocation and hitTestRect because they may have been flattened (losing z)
     // by our container.
     FloatPoint localPoint = newTransformState->mappedPoint();
-    FloatQuad localPointQuad = newTransformState->mappedQuad();
     LayoutRect localHitTestRect = newTransformState->boundsOfMappedArea();
     HitTestLocation newHitTestLocation;
     if (hitTestLocation.isRectBasedTest())
-        newHitTestLocation = HitTestLocation(localPoint, localPointQuad);
+        newHitTestLocation = HitTestLocation(localPoint, newTransformState->mappedQuad());
     else
-        newHitTestLocation = HitTestLocation(flooredLayoutPoint(localPoint));
+        newHitTestLocation = HitTestLocation(localPoint, newTransformState->boundsOfMappedQuad());
 
     // Now do a hit test with the root layer shifted to be us.
     return hitTestLayer(this, containerLayer, request, result, localHitTestRect, newHitTestLocation, true, newTransformState.ptr(), zOffset);


### PR DESCRIPTION
#### 5650bc3b7e350f5aff1a106dd058c82246b8623c
<pre>
Remove unnecessary rounding leading to subpixel issues in elementFromPoint hit testing

<a href="https://bugs.webkit.org/show_bug.cgi?id=284698">https://bugs.webkit.org/show_bug.cgi?id=284698</a>
<a href="https://rdar.apple.com/141496802">rdar://141496802</a>

Reviewed by NOBODY (OOPS!).

This patch removes rounding from hit testing code which leads to sub pixel
issues in elementFromPoint API.

Above fix leads to failure in case of `transformed` elements, so this merges
below Blink fix, which uses `transformed bounding box` for this purpose:

Merge: <a href="https://chromium-review.googlesource.com/c/chromium/src/+/1891110">https://chromium-review.googlesource.com/c/chromium/src/+/1891110</a>

Hit testing uses a 1x1 rect (i.e., &quot;bounding box&quot; )at the hit test
location to test intersection with boxes in the tree. The current
implementation always uses a 1x1 bounding box in the local coordinate
space of the box being tested, which is incorrect -- for example, if the
box is scaled by 100x, then using a 1x1 bounding box in the local space
is equivalent to using a 100x100 bounding box in the viewport, and as a
result we hit the transformed box even if the hit test location is still
100px away from it.

This patch fixes the issue by also transforming the bounding box, so
that it is always equivalent to a 1x1 rect in the viewport.

* Source/WebCore/rendering/HitTestLocation.cpp:
(WebCore::HitTestLocation::HitTestLocation):
(WebCore::HitTestLocation::HitTestLocation): Introduce another helper function
* Source/WebCore/rendering/HitTestLocation.h: Helper function definition
* Source/WebCore/rendering/HitTestingTransformState.cpp:
(HitTestingTransformState::boundsOfMappedQuad):
* Source/WebCore/rendering/HitTestingTransformState.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(hitTestLayerByApplyingTransform):
* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/elementFromPoint-subpixel-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5650bc3b7e350f5aff1a106dd058c82246b8623c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108135 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27798 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18218 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113346 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/58625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110098 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28495 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36348 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82102 "Found 1 new test failure: transforms/3d/hit-testing/rotated-hit-test-2.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/58625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111083 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/22578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/97415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62534 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/21993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/15551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58086 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/91943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/15607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116471 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35200 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/25917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91130 "Found 1 new test failure: transforms/3d/hit-testing/rotated-hit-test-2.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35575 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/93692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90925 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35815 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/13578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/31004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35100 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40656 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34834 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38192 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36501 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->