### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE use in DocumentSharedObjectPool.cpp

### DIFF
--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -883,12 +883,14 @@ T& reinterpretCastSpanStartTo(std::span<std::byte, Extent> span)
     return spanReinterpretCast<T>(span.first(sizeof(T)))[0];
 }
 
-template<typename T, std::size_t TExtent, typename U, std::size_t UExtent>
+enum class IgnoreTypeChecks : bool { No, Yes };
+
+template<IgnoreTypeChecks ignoreTypeChecks = IgnoreTypeChecks::No, typename T, std::size_t TExtent, typename U, std::size_t UExtent>
 bool equalSpans(std::span<T, TExtent> a, std::span<U, UExtent> b)
 {
     static_assert(sizeof(T) == sizeof(U));
-    static_assert(std::has_unique_object_representations_v<T>);
-    static_assert(std::has_unique_object_representations_v<U>);
+    static_assert(ignoreTypeChecks == IgnoreTypeChecks::Yes || std::has_unique_object_representations_v<T>);
+    static_assert(ignoreTypeChecks == IgnoreTypeChecks::Yes || std::has_unique_object_representations_v<U>);
     if (a.size() != b.size())
         return false;
     return !memcmp(a.data(), b.data(), a.size_bytes());

--- a/Source/WebCore/dom/DocumentSharedObjectPool.cpp
+++ b/Source/WebCore/dom/DocumentSharedObjectPool.cpp
@@ -29,51 +29,24 @@
 
 #include "Element.h"
 #include "ElementData.h"
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
-#include <wtf/UnalignedAccess.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(DocumentSharedObjectPool);
 
-// Do comparisons 8 bytes-at-a-time on architectures where it's safe.
-#if (CPU(X86_64) || CPU(ARM64)) && !ASAN_ENABLED
-ALWAYS_INLINE bool equalAttributes(const uint8_t* a, const uint8_t* b, unsigned bytes)
-{
-    unsigned length = bytes >> 3;
-    for (unsigned i = 0; i != length; ++i) {
-        if (WTF::unalignedLoad<uint64_t>(a) != WTF::unalignedLoad<uint64_t>(b))
-            return false;
-
-        a += sizeof(uint64_t);
-        b += sizeof(uint64_t);
-    }
-
-    ASSERT(!(bytes & 4));
-    ASSERT(!(bytes & 2));
-    ASSERT(!(bytes & 1));
-
-    return true;
-}
-#else
-ALWAYS_INLINE bool equalAttributes(const uint8_t* a, const uint8_t* b, unsigned bytes)
-{
-    return !memcmp(a, b, bytes);
-}
-#endif
-
 struct DocumentSharedObjectPool::ShareableElementDataHash {
     static unsigned hash(const Ref<ShareableElementData>& data)
     {
-        return computeHash(std::span<const Attribute> { data->m_attributeArray, data->length() });
+        return computeHash(data->span());
     }
     static bool equal(const Ref<ShareableElementData>& a, const Ref<ShareableElementData>& b)
     {
-        if (a->length() != b->length())
-            return false;
-        return equalAttributes(reinterpret_cast<const uint8_t*>(a->m_attributeArray), reinterpret_cast<const uint8_t*>(b->m_attributeArray), a->length() * sizeof(Attribute));
+        // We need to disable type checking because std::has_unique_object_representations_v<Attribute>
+        // return false. Attribute contains pointers but memcmp() is safe because those pointers were
+        // atomized.
+        return equalSpans<WTF::IgnoreTypeChecks::Yes>(a->span(), b->span());
     }
     static constexpr bool safeToCompareToEmptyOrDeleted = false;
 };
@@ -86,9 +59,10 @@ struct AttributeSpanTranslator {
 
     static bool equal(const Ref<ShareableElementData>& a, std::span<const Attribute> b)
     {
-        if (a->length() != b.size())
-            return false;
-        return equalAttributes(reinterpret_cast<const uint8_t*>(a->m_attributeArray), reinterpret_cast<const uint8_t*>(b.data()), b.size() * sizeof(Attribute));
+        // We need to disable type checking because std::has_unique_object_representations_v<Attribute>
+        // return false. Attribute contains pointers but memcmp() is safe because those pointers were
+        // atomized.
+        return equalSpans<WTF::IgnoreTypeChecks::Yes>(a->span(), b);
     }
 
     static void translate(Ref<ShareableElementData>& location, std::span<const Attribute> attributes, unsigned /*hash*/)
@@ -105,5 +79,3 @@ Ref<ShareableElementData> DocumentSharedObjectPool::cachedShareableElementDataWi
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/dom/ElementData.h
+++ b/Source/WebCore/dom/ElementData.h
@@ -27,6 +27,7 @@
 
 #include "Attribute.h"
 #include "SpaceSplitString.h"
+#include <wtf/StdLibExtras.h>
 #include <wtf/TypeCasts.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -205,6 +206,8 @@ public:
     ~ShareableElementData();
 
     static constexpr ptrdiff_t attributeArrayMemoryOffset() { return OBJECT_OFFSETOF(ShareableElementData, m_attributeArray); }
+
+    std::span<const Attribute> span() const { return unsafeMakeSpan(m_attributeArray, arraySize()); }
 
     Attribute m_attributeArray[0];
 };


### PR DESCRIPTION
#### 71d72ae1c7cd3df4175dd1eeb890ecde16744d97
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE use in DocumentSharedObjectPool.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=284697">https://bugs.webkit.org/show_bug.cgi?id=284697</a>

Reviewed by Darin Adler.

* Source/WebCore/dom/DocumentSharedObjectPool.cpp:
(WebCore::DocumentSharedObjectPool::ShareableElementDataHash::hash):
(WebCore::DocumentSharedObjectPool::ShareableElementDataHash::equal):
(WebCore::AttributeSpanTranslator::equal):
(WebCore::equalAttributes): Deleted.
* Source/WebCore/dom/ElementData.h:
(WebCore::ShareableElementData::span const):

Canonical link: <a href="https://commits.webkit.org/287863@main">https://commits.webkit.org/287863@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/614a8330f98fade88a2f4d65ddd67669b9f88689

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81161 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/686 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35104 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85690 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32147 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83271 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/704 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8496 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63363 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21133 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84230 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/455 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73867 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43661 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/352 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28029 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30605 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/74140 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/71875 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28594 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87125 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/80219 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8391 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5953 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71668 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8570 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69702 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70903 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14951 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13873 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/102626 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12576 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8352 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13876 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/24935 "Found 2 new JSC stress test failures: stress/json-stringify-inspector-check.js.no-llint, wasm.yaml/wasm/stress/cc-int-to-int-cross-module-with-exception.js.default-wasm (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8189 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11709 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9997 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->