### PR TITLE
Sync `bidi-rendering` from WPT upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/bidi-rendering/unicode-bidi-ua-rules-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/bidi-rendering/unicode-bidi-ua-rules-expected.txt
@@ -1,52 +1,131 @@
 
+PASS UA stylesheet rule for unicode-bidi, for <a>
+PASS UA stylesheet rule for unicode-bidi, for <abbr>
 PASS UA stylesheet rule for unicode-bidi, for <address>
-PASS UA stylesheet rule for unicode-bidi, for <blockquote>
-PASS UA stylesheet rule for unicode-bidi, for <center>
-PASS UA stylesheet rule for unicode-bidi, for <div>
-PASS UA stylesheet rule for unicode-bidi, for <figure>
-PASS UA stylesheet rule for unicode-bidi, for <figcaption>
-PASS UA stylesheet rule for unicode-bidi, for <footer>
-PASS UA stylesheet rule for unicode-bidi, for <form>
-PASS UA stylesheet rule for unicode-bidi, for <header>
-PASS UA stylesheet rule for unicode-bidi, for <hr>
-PASS UA stylesheet rule for unicode-bidi, for <legend>
-PASS UA stylesheet rule for unicode-bidi, for <listing>
-PASS UA stylesheet rule for unicode-bidi, for <main>
-PASS UA stylesheet rule for unicode-bidi, for <p>
-PASS UA stylesheet rule for unicode-bidi, for <plaintext>
-PASS UA stylesheet rule for unicode-bidi, for <pre>
-PASS UA stylesheet rule for unicode-bidi, for <summary>
-PASS UA stylesheet rule for unicode-bidi, for <xmp>
+PASS UA stylesheet rule for unicode-bidi, for <area>
 PASS UA stylesheet rule for unicode-bidi, for <article>
 PASS UA stylesheet rule for unicode-bidi, for <aside>
+PASS UA stylesheet rule for unicode-bidi, for <audio>
+PASS UA stylesheet rule for unicode-bidi, for <b>
+PASS UA stylesheet rule for unicode-bidi, for <base>
+PASS UA stylesheet rule for unicode-bidi, for <bdi>
+PASS UA stylesheet rule for unicode-bidi, for <blockquote>
+PASS UA stylesheet rule for unicode-bidi, for <body>
+PASS UA stylesheet rule for unicode-bidi, for <br>
+PASS UA stylesheet rule for unicode-bidi, for <button>
+PASS UA stylesheet rule for unicode-bidi, for <canvas>
+PASS UA stylesheet rule for unicode-bidi, for <caption>
+PASS UA stylesheet rule for unicode-bidi, for <cite>
+PASS UA stylesheet rule for unicode-bidi, for <code>
+PASS UA stylesheet rule for unicode-bidi, for <col>
+PASS UA stylesheet rule for unicode-bidi, for <colgroup>
+PASS UA stylesheet rule for unicode-bidi, for <data>
+PASS UA stylesheet rule for unicode-bidi, for <datalist>
+PASS UA stylesheet rule for unicode-bidi, for <dd>
+PASS UA stylesheet rule for unicode-bidi, for <del>
+PASS UA stylesheet rule for unicode-bidi, for <details>
+PASS UA stylesheet rule for unicode-bidi, for <dfn>
+PASS UA stylesheet rule for unicode-bidi, for <dialog>
+PASS UA stylesheet rule for unicode-bidi, for <div>
+PASS UA stylesheet rule for unicode-bidi, for <dl>
+PASS UA stylesheet rule for unicode-bidi, for <dt>
+PASS UA stylesheet rule for unicode-bidi, for <em>
+PASS UA stylesheet rule for unicode-bidi, for <embed>
+PASS UA stylesheet rule for unicode-bidi, for <fieldset>
+PASS UA stylesheet rule for unicode-bidi, for <figcaption>
+PASS UA stylesheet rule for unicode-bidi, for <figure>
+PASS UA stylesheet rule for unicode-bidi, for <footer>
+PASS UA stylesheet rule for unicode-bidi, for <form>
 PASS UA stylesheet rule for unicode-bidi, for <h1>
 PASS UA stylesheet rule for unicode-bidi, for <h2>
 PASS UA stylesheet rule for unicode-bidi, for <h3>
 PASS UA stylesheet rule for unicode-bidi, for <h4>
 PASS UA stylesheet rule for unicode-bidi, for <h5>
 PASS UA stylesheet rule for unicode-bidi, for <h6>
-PASS UA stylesheet rule for unicode-bidi, for <hgroup>
-PASS UA stylesheet rule for unicode-bidi, for <nav>
-PASS UA stylesheet rule for unicode-bidi, for <section>
-PASS UA stylesheet rule for unicode-bidi, for <search>
-PASS UA stylesheet rule for unicode-bidi, for <table>
-PASS UA stylesheet rule for unicode-bidi, for <caption>
-PASS UA stylesheet rule for unicode-bidi, for <colgroup>
-PASS UA stylesheet rule for unicode-bidi, for <col>
-PASS UA stylesheet rule for unicode-bidi, for <thead>
-PASS UA stylesheet rule for unicode-bidi, for <tbody>
-PASS UA stylesheet rule for unicode-bidi, for <tfoot>
-PASS UA stylesheet rule for unicode-bidi, for <tr>
-PASS UA stylesheet rule for unicode-bidi, for <td>
-PASS UA stylesheet rule for unicode-bidi, for <th>
-PASS UA stylesheet rule for unicode-bidi, for <dir>
-PASS UA stylesheet rule for unicode-bidi, for <dd>
-PASS UA stylesheet rule for unicode-bidi, for <dl>
-PASS UA stylesheet rule for unicode-bidi, for <dt>
-PASS UA stylesheet rule for unicode-bidi, for <menu>
-PASS UA stylesheet rule for unicode-bidi, for <ol>
-PASS UA stylesheet rule for unicode-bidi, for <ul>
+PASS UA stylesheet rule for unicode-bidi, for <head>
+PASS UA stylesheet rule for unicode-bidi, for <header>
+PASS UA stylesheet rule for unicode-bidi, for <hr>
+PASS UA stylesheet rule for unicode-bidi, for <html>
+PASS UA stylesheet rule for unicode-bidi, for <i>
+PASS UA stylesheet rule for unicode-bidi, for <iframe>
+PASS UA stylesheet rule for unicode-bidi, for <img>
+PASS UA stylesheet rule for unicode-bidi, for <ins>
+PASS UA stylesheet rule for unicode-bidi, for <kbd>
+PASS UA stylesheet rule for unicode-bidi, for <label>
+PASS UA stylesheet rule for unicode-bidi, for <legend>
 PASS UA stylesheet rule for unicode-bidi, for <li>
-PASS UA stylesheet rule for unicode-bidi, for <bdi>
+PASS UA stylesheet rule for unicode-bidi, for <link>
+PASS UA stylesheet rule for unicode-bidi, for <main>
+PASS UA stylesheet rule for unicode-bidi, for <map>
+PASS UA stylesheet rule for unicode-bidi, for <mark>
+PASS UA stylesheet rule for unicode-bidi, for <menu>
+PASS UA stylesheet rule for unicode-bidi, for <meta>
+PASS UA stylesheet rule for unicode-bidi, for <meter>
+PASS UA stylesheet rule for unicode-bidi, for <nav>
+PASS UA stylesheet rule for unicode-bidi, for <noscript>
+PASS UA stylesheet rule for unicode-bidi, for <object>
+PASS UA stylesheet rule for unicode-bidi, for <ol>
+PASS UA stylesheet rule for unicode-bidi, for <optgroup>
+PASS UA stylesheet rule for unicode-bidi, for <option>
 PASS UA stylesheet rule for unicode-bidi, for <output>
+PASS UA stylesheet rule for unicode-bidi, for <p>
+PASS UA stylesheet rule for unicode-bidi, for <param>
+PASS UA stylesheet rule for unicode-bidi, for <progress>
+PASS UA stylesheet rule for unicode-bidi, for <q>
+PASS UA stylesheet rule for unicode-bidi, for <rp>
+PASS UA stylesheet rule for unicode-bidi, for <rt>
+FAIL UA stylesheet rule for unicode-bidi, for <ruby> assert_equals: expected "normal" but got "isolate"
+PASS UA stylesheet rule for unicode-bidi, for <s>
+PASS UA stylesheet rule for unicode-bidi, for <samp>
+PASS UA stylesheet rule for unicode-bidi, for <script>
+PASS UA stylesheet rule for unicode-bidi, for <section>
+PASS UA stylesheet rule for unicode-bidi, for <select>
+PASS UA stylesheet rule for unicode-bidi, for <slot>
+PASS UA stylesheet rule for unicode-bidi, for <small>
+PASS UA stylesheet rule for unicode-bidi, for <source>
+PASS UA stylesheet rule for unicode-bidi, for <span>
+PASS UA stylesheet rule for unicode-bidi, for <strong>
+PASS UA stylesheet rule for unicode-bidi, for <style>
+PASS UA stylesheet rule for unicode-bidi, for <sub>
+PASS UA stylesheet rule for unicode-bidi, for <sup>
+PASS UA stylesheet rule for unicode-bidi, for <summary>
+PASS UA stylesheet rule for unicode-bidi, for <table>
+PASS UA stylesheet rule for unicode-bidi, for <tbody>
+PASS UA stylesheet rule for unicode-bidi, for <td>
+PASS UA stylesheet rule for unicode-bidi, for <template>
+PASS UA stylesheet rule for unicode-bidi, for <tfoot>
+PASS UA stylesheet rule for unicode-bidi, for <th>
+PASS UA stylesheet rule for unicode-bidi, for <thead>
+PASS UA stylesheet rule for unicode-bidi, for <time>
+PASS UA stylesheet rule for unicode-bidi, for <title>
+PASS UA stylesheet rule for unicode-bidi, for <tr>
+PASS UA stylesheet rule for unicode-bidi, for <track>
+PASS UA stylesheet rule for unicode-bidi, for <u>
+PASS UA stylesheet rule for unicode-bidi, for <ul>
+PASS UA stylesheet rule for unicode-bidi, for <var>
+PASS UA stylesheet rule for unicode-bidi, for <video>
+PASS UA stylesheet rule for unicode-bidi, for <wbr>
+FAIL UA stylesheet rule for unicode-bidi, for <bdo> assert_equals: with dir=auto expected "isolate-override" but got "isolate"
+PASS UA stylesheet rule for unicode-bidi, for <input type=hidden>
+PASS UA stylesheet rule for unicode-bidi, for <input type=text>
+FAIL UA stylesheet rule for unicode-bidi, for <input type=search> assert_equals: with dir=auto expected "plaintext" but got "isolate"
+FAIL UA stylesheet rule for unicode-bidi, for <input type=tel> assert_equals: with dir=auto expected "plaintext" but got "isolate"
+FAIL UA stylesheet rule for unicode-bidi, for <input type=url> assert_equals: with dir=auto expected "plaintext" but got "isolate"
+FAIL UA stylesheet rule for unicode-bidi, for <input type=email> assert_equals: with dir=auto expected "plaintext" but got "isolate"
+PASS UA stylesheet rule for unicode-bidi, for <input type=password>
+PASS UA stylesheet rule for unicode-bidi, for <input type=date>
+PASS UA stylesheet rule for unicode-bidi, for <input type=time>
+PASS UA stylesheet rule for unicode-bidi, for <input type=datetime-local>
+PASS UA stylesheet rule for unicode-bidi, for <input type=number>
+PASS UA stylesheet rule for unicode-bidi, for <input type=range>
+PASS UA stylesheet rule for unicode-bidi, for <input type=color>
+PASS UA stylesheet rule for unicode-bidi, for <input type=checkbox>
+PASS UA stylesheet rule for unicode-bidi, for <input type=radio>
+PASS UA stylesheet rule for unicode-bidi, for <input type=file>
+PASS UA stylesheet rule for unicode-bidi, for <input type=submit>
+PASS UA stylesheet rule for unicode-bidi, for <input type=image>
+PASS UA stylesheet rule for unicode-bidi, for <input type=reset>
+PASS UA stylesheet rule for unicode-bidi, for <input type=button>
+PASS UA stylesheet rule for unicode-bidi, for <textarea>
+PASS UA stylesheet rule for unicode-bidi, for <pre>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/bidi-rendering/unicode-bidi-ua-rules.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/bidi-rendering/unicode-bidi-ua-rules.html
@@ -4,22 +4,104 @@
 <link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#bidi-rendering">
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
+<script src='../../resources/common.js'></script>
 
 <body>
 <script>
-  const elements = ['address', 'blockquote', 'center', 'div', 'figure',
+  function getUnicodeBidi(el) {
+    return window.getComputedStyle(el, "").unicodeBidi;
+  }
+
+  // These elements should have `unicode-bidi: isolate` in the UA stylesheet:
+  const isolateElements = ['address', 'blockquote', 'center', 'div', 'figure',
       'figcaption', 'footer', 'form', 'header', 'hr', 'legend', 'listing',
       'main', 'p', 'plaintext', 'pre', 'summary', 'xmp', 'article', 'aside',
       'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hgroup', 'nav', 'section', 'search',
       'table', 'caption', 'colgroup', 'col', 'thead', 'tbody', 'tfoot', 'tr',
       'td', 'th', 'dir', 'dd', 'dl', 'dt', 'menu', 'ol', 'ul', 'li', 'bdi',
       'output'];
-  for(let tagname of elements) {
+  const allButSeparateTests = HTML5_ELEMENTS.filter(el => (!['bdo','input','textarea','pre'].includes(el)));
+  for(let tagname of allButSeparateTests) {
     test((t) => {
       const element = document.createElement(tagname);
       t.add_cleanup(() => element.remove());
       document.body.appendChild(element);
-      assert_equals(window.getComputedStyle(element, "").unicodeBidi,'isolate');
+      const expectation = isolateElements.includes(tagname) ? 'isolate' : 'normal';
+      assert_equals(getUnicodeBidi(element),expectation);
+
+      element.setAttribute('dir','ltr');
+      assert_equals(getUnicodeBidi(element),'isolate','with dir=ltr');
+      element.setAttribute('dir','LtR');
+      assert_equals(getUnicodeBidi(element),'isolate','with dir=LtR (case insensitive)');
+      element.setAttribute('dir','rtl');
+      assert_equals(getUnicodeBidi(element),'isolate','with dir=rtl');
+      element.setAttribute('dir','auto');
+      assert_equals(getUnicodeBidi(element),'isolate','with dir=auto');
+      element.setAttribute('dir','INVALID');
+      assert_equals(getUnicodeBidi(element),expectation,'invalid dir value goes back to normal defaults');
+    },`UA stylesheet rule for unicode-bidi, for <${tagname}>`);
+  }
+
+  test((t) => {
+    const element = document.createElement('bdo');
+    t.add_cleanup(() => element.remove());
+    document.body.appendChild(element);
+    assert_equals(getUnicodeBidi(element),'isolate-override');
+    element.setAttribute('dir','ltr');
+    assert_equals(getUnicodeBidi(element),'isolate-override','with dir=ltr');
+    element.setAttribute('dir','LtR');
+    assert_equals(getUnicodeBidi(element),'isolate-override','with dir=LtR (case insensitive)');
+    element.setAttribute('dir','rtl');
+    assert_equals(getUnicodeBidi(element),'isolate-override','with dir=rtl');
+    element.setAttribute('dir','auto');
+    assert_equals(getUnicodeBidi(element),'isolate-override','with dir=auto');
+    element.setAttribute('dir','INVALID');
+    assert_equals(getUnicodeBidi(element),'isolate-override','invalid dir value');
+  },`UA stylesheet rule for unicode-bidi, for <bdo>`);
+
+  const shouldBePlaintext = ['search','tel','url','email'];
+  for(let type of HTML5_INPUT_TYPES) {
+    test((t) => {
+      const element = document.createElement('input');
+      t.add_cleanup(() => element.remove());
+      element.type = type;
+      document.body.appendChild(element);
+      const autoExpectation = shouldBePlaintext.includes(type) ? 'plaintext' : 'isolate';
+      assert_equals(getUnicodeBidi(element),'normal');
+      element.setAttribute('dir','ltr');
+      assert_equals(getUnicodeBidi(element),'isolate','with dir=ltr');
+      element.setAttribute('dir','LtR');
+      assert_equals(getUnicodeBidi(element),'isolate','with dir=LtR (case insensitive)');
+      element.setAttribute('dir','rtl');
+      assert_equals(getUnicodeBidi(element),'isolate','with dir=rtl');
+      element.setAttribute('dir','auto');
+      assert_equals(getUnicodeBidi(element),autoExpectation,'with dir=auto');
+      element.setAttribute('dir','AuTo');
+      assert_equals(getUnicodeBidi(element),autoExpectation,'with dir=auto (case insensitive)');
+      element.setAttribute('dir','INVALID');
+      assert_equals(getUnicodeBidi(element),'normal','invalid dir value');
+    },`UA stylesheet rule for unicode-bidi, for <input type=${type}>`);
+  }
+
+  for(let tagname of ['textarea','pre']) {
+    test((t) => {
+      const element = document.createElement(tagname);
+      t.add_cleanup(() => element.remove());
+      document.body.appendChild(element);
+      const expectation = tagname === 'textarea' ? 'normal' : 'isolate';
+      assert_equals(getUnicodeBidi(element),expectation);
+      element.setAttribute('dir','ltr');
+      assert_equals(getUnicodeBidi(element),'isolate','with dir=ltr');
+      element.setAttribute('dir','LtR');
+      assert_equals(getUnicodeBidi(element),'isolate','with dir=LtR (case insensitive)');
+      element.setAttribute('dir','rtl');
+      assert_equals(getUnicodeBidi(element),'isolate','with dir=rtl');
+      element.setAttribute('dir','auto');
+      assert_equals(getUnicodeBidi(element),'plaintext','with dir=auto');
+      element.setAttribute('dir','AuTo');
+      assert_equals(getUnicodeBidi(element),'plaintext','with dir=auto (case insensitive)');
+      element.setAttribute('dir','INVALID');
+      assert_equals(getUnicodeBidi(element),expectation,'invalid dir value');
     },`UA stylesheet rule for unicode-bidi, for <${tagname}>`);
   }
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/resources/common.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/resources/common.js
@@ -32,6 +32,11 @@ var HTML5_VOID_ELEMENTS = [
 var HTML5_FORM_ASSOCIATED_ELEMENTS = [ 'button', 'fieldset', 'input',
         'object', 'output', 'select', 'textarea' ];
 
+// https://html.spec.whatwg.org/#category-label
+const HTML5_LABELABLE_ELEMENTS = [
+  'button', 'input', 'meter', 'output', 'progress', 'select', 'textarea'
+];
+
 const HTML5_SHADOW_ALLOWED_ELEMENTS = [
   'article', 'aside', 'blockquote', 'body', 'div', 'footer', 'h1', 'h2', 'h3',
   'h4', 'h5', 'h6', 'header', 'main', 'nav', 'p', 'section', 'span'
@@ -47,6 +52,12 @@ const HTML5_DEPRECATED_ELEMENTS = [
   'frameset', 'hgroup',  'image',    'isindex',  'keygen',    'marquee',
   'menuitem', 'nobr',    'noembed',  'noframes', 'plaintext', 'rb',
   'rtc',      'shadow',  'spacer',   'strike',   'tt',        'xmp'
+];
+
+const HTML5_INPUT_TYPES = [
+  'hidden', 'text', 'search', 'tel', 'url', 'email', 'password', 'date',
+  'time', 'datetime-local', 'number', 'range', 'color', 'checkbox', 'radio',
+  'file', 'submit', 'image', 'reset', 'button'
 ];
 
 function newDocument() {


### PR DESCRIPTION
#### 8a9d9df97dcffb093d28317792b9cb76dd690ad6
<pre>
Sync `bidi-rendering` from WPT upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=284699">https://bugs.webkit.org/show_bug.cgi?id=284699</a>
<a href="https://rdar.apple.com/141497561">rdar://141497561</a>

Reviewed by Tim Nguyen.

After 287842@main, I noticed that the test has been updated and
we have outdated copy, so syncing now.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/38623a53d6598cb7aab4be8a810102b352a652df">https://github.com/web-platform-tests/wpt/commit/38623a53d6598cb7aab4be8a810102b352a652df</a>

* LayoutTests/imported/w3c/web-platform-tests/html/rendering/bidi-rendering/unicode-bidi-ua-rules-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/bidi-rendering/unicode-bidi-ua-rules.html:
* LayoutTests/imported/w3c/web-platform-tests/html/resources/common.js:

Canonical link: <a href="https://commits.webkit.org/287847@main">https://commits.webkit.org/287847@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4fabd3aeef4d529c24df6af44349454acf24b05e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81089 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/614 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35032 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85618 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32075 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/632 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8421 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63302 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21064 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84158 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/392 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73807 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43600 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/289 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27969 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30533 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71818 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28525 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87053 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8319 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5887 "Found 1 new test failure: fast/webgpu/type-checker-array-without-argument.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71606 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8496 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69642 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70841 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17634 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14888 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13815 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8280 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8117 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11637 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9925 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->