### PR TITLE
AudioSampleBufferConverter Incorrectly set number of out packets to 1

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/AudioSampleBufferConverter.mm
+++ b/Source/WebCore/platform/audio/cocoa/AudioSampleBufferConverter.mm
@@ -441,6 +441,9 @@ OSStatus AudioSampleBufferConverter::provideSourceDataNumOutputPackets(UInt32* n
     if (packetDescriptionOut) {
         *numOutputPacketsPtr = m_packetDescriptions.size();
         *packetDescriptionOut = m_packetDescriptions.data();
+    } else if (m_sourceFormat.mFormatID == kAudioFormatLinearPCM) {
+        ASSERT(audioBufferList->mNumberBuffers && m_sourceFormat.mBytesPerPacket);
+        *numOutputPacketsPtr = (audioBufferList->mBuffers[0].mDataByteSize / m_sourceFormat.mBytesPerPacket);
     } else
         *numOutputPacketsPtr = 1;
 

--- a/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
+++ b/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
@@ -440,22 +440,22 @@ Vector<AudioStreamPacketDescription> getPacketDescriptions(CMSampleBufferRef sam
 {
     size_t packetDescriptionsSize;
     if (PAL::CMSampleBufferGetAudioStreamPacketDescriptions(sampleBuffer, 0, nullptr, &packetDescriptionsSize) != noErr) {
-        RELEASE_LOG_FAULT(WebAudio, "Unable to get packet description list size");
+        RELEASE_LOG_FAULT(Media, "Unable to get packet description list size");
         return { };
     }
     size_t numDescriptions = packetDescriptionsSize / sizeof(AudioStreamPacketDescription);
     if (!numDescriptions) {
-        RELEASE_LOG_FAULT(WebAudio, "No packet description found.");
+        RELEASE_LOG_DEBUG(Media, "No packet description found.");
         return { };
     }
     Vector<AudioStreamPacketDescription> descriptions(numDescriptions);
     if (PAL::CMSampleBufferGetAudioStreamPacketDescriptions(sampleBuffer, packetDescriptionsSize, descriptions.data(), nullptr) != noErr) {
-        RELEASE_LOG_FAULT(WebAudio, "Unable to get packet description list");
+        RELEASE_LOG_FAULT(Media, "Unable to get packet description list");
         return { };
     }
     auto numPackets = PAL::CMSampleBufferGetNumSamples(sampleBuffer);
     if (numDescriptions != size_t(numPackets)) {
-        RELEASE_LOG_FAULT(WebAudio, "Unhandled CMSampleBuffer structure");
+        RELEASE_LOG_FAULT(Media, "Unhandled CMSampleBuffer structure");
         return { };
     }
     return descriptions;


### PR DESCRIPTION
#### d6d9a451a70c766a8c379ee933028fb12aeefebe
<pre>
AudioSampleBufferConverter Incorrectly set number of out packets to 1
<a href="https://bugs.webkit.org/show_bug.cgi?id=284702">https://bugs.webkit.org/show_bug.cgi?id=284702</a>
<a href="https://rdar.apple.com/141499128">rdar://141499128</a>

Reviewed by Eric Carlson.

Regression introduced in 287362@main.
We partially revert back to the proper frame calculation when the source is PCM.

Also change the log level in CMUtilities getPacketDescriptions as it&apos;s unnecessary verbose
when used to compress PCM data.

* Source/WebCore/platform/audio/cocoa/AudioSampleBufferConverter.mm:
(WebCore::AudioSampleBufferConverter::provideSourceDataNumOutputPackets):

Canonical link: <a href="https://commits.webkit.org/287850@main">https://commits.webkit.org/287850@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48360c0cd4916d3b58cc512b581ff63d8b4e9bfc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81101 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/626 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35044 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85630 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32087 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83211 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/644 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8433 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63314 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21078 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84170 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/405 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73819 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43612 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/302 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27981 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30545 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/71831 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28538 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87065 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8331 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5901 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71618 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8508 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69654 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70853 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17636 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14901 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13827 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8292 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13815 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8129 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11649 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9937 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->