### PR TITLE
[JSC] Close Iterator Helpers underlying iterator when arguments are invalid

### DIFF
--- a/JSTests/stress/iterator-helpers-close-for-invalid-argument.js
+++ b/JSTests/stress/iterator-helpers-close-for-invalid-argument.js
@@ -1,0 +1,296 @@
+function shouldThrow(errorType, func) {
+    let error;
+    try {
+        func();
+    } catch (e) {
+        error = e;
+    }
+    if (!(error instanceof errorType)) {
+        print(error.message);
+        throw new Error(`Expected ${errorType.name}! got ${error.name}`);
+    }
+}
+
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+{
+    // Iterator.prototype.map
+    let closed = false;
+    let closable = {
+      __proto__: Iterator.prototype,
+      get next() {
+        throw new Error('next should not be read');
+      },
+      return() {
+        closed = true;
+        return {};
+      },
+    };
+    shouldThrow(TypeError, function() {
+      closable.map();
+    });
+    shouldBe(closed, true);
+
+    closed = false;
+    shouldThrow(TypeError, function() {
+      closable.map({});
+    });
+    shouldBe(closed, true);
+}
+
+{
+    // Iterator.prototype.filter
+    let closed = false;
+    let closable = {
+      __proto__: Iterator.prototype,
+      get next() {
+        throw new Error('next should not be read');
+      },
+      return() {
+        closed = true;
+        return {};
+      },
+    };
+    shouldThrow(TypeError, function() {
+      closable.filter();
+    });
+    shouldBe(closed, true);
+
+    closed = false;
+    shouldThrow(TypeError, function() {
+      closable.filter({});
+    });
+    shouldBe(closed, true);
+}
+
+{
+    // Iterator.prototype.take
+    let closed = false;
+    let closable = {
+      __proto__: Iterator.prototype,
+      get next() {
+        throw new Error('next should not be read');
+      },
+      return() {
+        closed = true;
+        return {};
+      },
+    };
+
+    shouldThrow(RangeError, function() {
+      closable.take();
+    });
+    shouldBe(closed, true);
+
+    closed = false;
+    shouldThrow(RangeError, function() {
+      closable.take(NaN);
+    });
+    shouldBe(closed, true);
+
+    closed = false;
+    shouldThrow(RangeError, function() {
+      closable.take(-1);
+    });
+    shouldBe(closed, true);
+
+    closed = false;
+    function OurError() {}
+    shouldThrow(OurError, function() {
+      closable.take({ get valueOf() { throw new OurError(); }});
+    });
+    shouldBe(closed, true);
+}
+
+{
+    // Iterator.prototype.drop
+    let closed = false;
+    let closable = {
+      __proto__: Iterator.prototype,
+      get next() {
+        throw new Error('next should not be read');
+      },
+      return() {
+        closed = true;
+        return {};
+      },
+    };
+
+    shouldThrow(RangeError, function() {
+      closable.drop();
+    });
+    shouldBe(closed, true);
+
+    closed = false;
+    shouldThrow(RangeError, function() {
+      closable.drop(NaN);
+    });
+    shouldBe(closed, true);
+
+    closed = false;
+    shouldThrow(RangeError, function() {
+      closable.drop(-1);
+    });
+    shouldBe(closed, true);
+
+    closed = false;
+    function OurError() {}
+    shouldThrow(OurError, function() {
+      closable.drop({ get valueOf() { throw new OurError(); }});
+    });
+    shouldBe(closed, true);
+}
+
+{
+    // Iterator.prototype.flatMap
+    let closed = false;
+    let closable = {
+      __proto__: Iterator.prototype,
+      get next() {
+        throw new Error('next should not be read');
+      },
+      return() {
+        closed = true;
+        return {};
+      },
+    };
+    shouldThrow(TypeError, function() {
+      closable.flatMap();
+    });
+    shouldBe(closed, true);
+
+    closed = false;
+    shouldThrow(TypeError, function() {
+      closable.flatMap({});
+    });
+    shouldBe(closed, true);
+}
+
+{
+    // Iterator.prototype.some
+    let closed = false;
+    let closable = {
+      __proto__: Iterator.prototype,
+      get next() {
+        throw new Error('next should not be read');
+      },
+      return() {
+        closed = true;
+        return {};
+      },
+    };
+    shouldThrow(TypeError, function() {
+      closable.some();
+    });
+    shouldBe(closed, true);
+
+    closed = false;
+    shouldThrow(TypeError, function() {
+      closable.some({});
+    });
+    shouldBe(closed, true);
+}
+
+{
+    // Iterator.prototype.every
+    let closed = false;
+    let closable = {
+      __proto__: Iterator.prototype,
+      get next() {
+        throw new Error('next should not be read');
+      },
+      return() {
+        closed = true;
+        return {};
+      },
+    };
+    shouldThrow(TypeError, function() {
+      closable.every();
+    });
+    shouldBe(closed, true);
+
+    closed = false;
+    shouldThrow(TypeError, function() {
+      closable.every({});
+    });
+    shouldBe(closed, true);
+}
+
+{
+    // Iterator.prototype.find
+    let closed = false;
+    let closable = {
+      __proto__: Iterator.prototype,
+      get next() {
+        throw new Error('next should not be read');
+      },
+      return() {
+        closed = true;
+        return {};
+      },
+    };
+    shouldThrow(TypeError, function() {
+      closable.find();
+    });
+    shouldBe(closed, true);
+
+    closed = false;
+    shouldThrow(TypeError, function() {
+      closable.find({});
+    });
+    shouldBe(closed, true);
+}
+
+{
+    // Iterator.prototype.reduce
+    let closed = false;
+    let closable = {
+      __proto__: Iterator.prototype,
+      get next() {
+        throw new Error('next should not be read');
+      },
+      return() {
+        closed = true;
+        return {};
+      },
+    };
+    shouldThrow(TypeError, function() {
+      closable.reduce();
+    });
+    shouldBe(closed, true);
+
+    closed = false;
+    shouldThrow(TypeError, function() {
+      closable.reduce({});
+    });
+    shouldBe(closed, true);
+}
+
+{
+    // Iterator.prototype.forEach
+    let closed = false;
+    let closable = {
+      __proto__: Iterator.prototype,
+      get next() {
+        throw new Error('next should not be read');
+      },
+      return() {
+        closed = true;
+        return {};
+      },
+    };
+    shouldThrow(TypeError, function() {
+      closable.forEach();
+    });
+    shouldBe(closed, true);
+
+    closed = false;
+    shouldThrow(TypeError, function() {
+      closable.forEach({});
+    });
+    shouldBe(closed, true);
+}
+

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -25,36 +25,6 @@ test/built-ins/Iterator/concat/fresh-iterator-result.js:
 test/built-ins/Iterator/concat/next-method-returns-throwing-value.js:
   default: 'Test262Error: '
   strict mode: 'Test262Error: '
-test/built-ins/Iterator/prototype/drop/argument-validation-failure-closes-underlying.js:
-  default: 'Test262Error: Expected SameValue(«false», «true») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«false», «true») to be true'
-test/built-ins/Iterator/prototype/every/argument-validation-failure-closes-underlying.js:
-  default: 'Test262Error: Expected SameValue(«false», «true») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«false», «true») to be true'
-test/built-ins/Iterator/prototype/filter/argument-validation-failure-closes-underlying.js:
-  default: 'Test262Error: Expected SameValue(«false», «true») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«false», «true») to be true'
-test/built-ins/Iterator/prototype/find/argument-validation-failure-closes-underlying.js:
-  default: 'Test262Error: Expected SameValue(«false», «true») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«false», «true») to be true'
-test/built-ins/Iterator/prototype/flatMap/argument-validation-failure-closes-underlying.js:
-  default: 'Test262Error: Expected SameValue(«false», «true») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«false», «true») to be true'
-test/built-ins/Iterator/prototype/forEach/argument-validation-failure-closes-underlying.js:
-  default: 'Test262Error: Expected SameValue(«false», «true») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«false», «true») to be true'
-test/built-ins/Iterator/prototype/map/argument-validation-failure-closes-underlying.js:
-  default: 'Test262Error: Expected SameValue(«false», «true») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«false», «true») to be true'
-test/built-ins/Iterator/prototype/reduce/argument-validation-failure-closes-underlying.js:
-  default: 'Test262Error: Expected SameValue(«false», «true») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«false», «true») to be true'
-test/built-ins/Iterator/prototype/some/argument-validation-failure-closes-underlying.js:
-  default: 'Test262Error: Expected SameValue(«false», «true») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«false», «true») to be true'
-test/built-ins/Iterator/prototype/take/argument-validation-failure-closes-underlying.js:
-  default: 'Test262Error: Expected SameValue(«false», «true») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«false», «true») to be true'
 test/built-ins/Object/entries/order-after-define-property-with-function.js:
   default: 'Test262Error: Actual [a, name] and expected [name, a] should have the same contents. '
   strict mode: 'Test262Error: Actual [a, name] and expected [name, a] should have the same contents. '

--- a/Source/JavaScriptCore/builtins/JSIteratorPrototype.js
+++ b/Source/JavaScriptCore/builtins/JSIteratorPrototype.js
@@ -32,8 +32,10 @@ function map(mapper)
     if (!@isObject(this))
         @throwTypeError("Iterator.prototype.map requires that |this| be an Object.");
 
-    if (!@isCallable(mapper))
+    if (!@isCallable(mapper)) {
+        @iteratorGenericClose(this);
         @throwTypeError("Iterator.prototype.map callback must be a function.");
+    }
 
     var iterated = this;
     var iteratedNextMethod = iterated.next;
@@ -63,8 +65,10 @@ function filter(predicate)
     if (!@isObject(this))
         @throwTypeError("Iterator.prototype.filter requires that |this| be an Object.");
 
-    if (!@isCallable(predicate))
+    if (!@isCallable(predicate)) {
+        @iteratorGenericClose(this);
         @throwTypeError("Iterator.prototype.filter callback must be a function.");
+    }
 
     var iterated = this;
     var iteratedNextMethod = iterated.next;
@@ -94,13 +98,18 @@ function take(limit)
     if (!@isObject(this))
         @throwTypeError("Iterator.prototype.take requires that |this| be an Object.");
 
-    var numLimit = @toNumber(limit);
-    if (numLimit !== numLimit)
+    var numLimit;
+    @ifAbruptCloseIterator(this, numLimit = @toNumber(limit));
+    if (numLimit !== numLimit) {
+        @iteratorGenericClose(this);
         @throwRangeError("Iterator.prototype.take argument must not be NaN.");
+    }
 
     var intLimit = @toIntegerOrInfinity(numLimit);
-    if (intLimit < 0)
+    if (intLimit < 0) {
+        @iteratorGenericClose(this);
         @throwRangeError("Iterator.prototype.take argument must be non-negative.");
+    }
 
     var iterated = this;
     var iteratedNextMethod = iterated.next;
@@ -138,13 +147,18 @@ function drop(limit)
     if (!@isObject(this))
         @throwTypeError("Iterator.prototype.drop requires that |this| be an Object.");
 
-    var numLimit = @toNumber(limit);
-    if (numLimit !== numLimit)
+    var numLimit;
+    @ifAbruptCloseIterator(this, (numLimit = @toNumber(limit)));
+    if (numLimit !== numLimit) {
+        @iteratorGenericClose(this);
         @throwRangeError("Iterator.prototype.drop argument must not be NaN.");
+    }
 
     var intLimit = @toIntegerOrInfinity(numLimit);
-    if (intLimit < 0)
+    if (intLimit < 0) {
+        @iteratorGenericClose(this);
         @throwRangeError("Iterator.prototype.drop argument must be non-negative.");
+    }
 
     var iterated = this;
     var iteratedNextMethod = iterated.next;
@@ -179,8 +193,10 @@ function flatMap(mapper)
     if (!@isObject(this))
         @throwTypeError("Iterator.prototype.flatMap requires that |this| be an Object.");
 
-    if (!@isCallable(mapper))
+    if (!@isCallable(mapper)) {
+        @iteratorGenericClose(this);
         @throwTypeError("Iterator.prototype.flatMap callback must be a function.");
+    }
 
     var iterated = this;
     var iteratedNextMethod = iterated.next;
@@ -212,12 +228,14 @@ function some(predicate)
     if (!@isObject(this))
         @throwTypeError("Iterator.prototype.some requires that |this| be an Object.");
 
-    if (!@isCallable(predicate))
+    if (!@isCallable(predicate)) {
+        @iteratorGenericClose(this);
         @throwTypeError("Iterator.prototype.some callback must be a function.");
+    }
 
+    var iterated = this;
     var count = 0;
-    var iterator = this;
-    var wrapper = { @@iterator: function () { return iterator; }};
+    var wrapper = { @@iterator: function () { return iterated; }};
     for (var item of wrapper) {
         if (predicate(item, count++))
             return true;
@@ -234,12 +252,14 @@ function every(predicate)
     if (!@isObject(this))
         @throwTypeError("Iterator.prototype.every requires that |this| be an Object.");
 
-    if (!@isCallable(predicate))
+    if (!@isCallable(predicate)) {
+        @iteratorGenericClose(this);
         @throwTypeError("Iterator.prototype.every callback must be a function.");
+    }
 
+    var iterated = this;
     var count = 0;
-    var iterator = this;
-    var wrapper = { @@iterator: function () { return iterator; }};
+    var wrapper = { @@iterator: function () { return iterated; }};
     for (var item of wrapper) {
         if (!predicate(item, count++))
             return false;
@@ -256,12 +276,14 @@ function find(predicate)
     if (!@isObject(this))
         @throwTypeError("Iterator.prototype.find requires that |this| be an Object.");
 
-    if (!@isCallable(predicate))
+    if (!@isCallable(predicate)) {
+        @iteratorGenericClose(this);
         @throwTypeError("Iterator.prototype.find callback must be a function.");
+    }
 
+    var iterated = this;
     var count = 0;
-    var iterator = this;
-    var wrapper = { @@iterator: function () { return iterator; }};
+    var wrapper = { @@iterator: function () { return iterated; }};
     for (var item of wrapper) {
         if (predicate(item, count++))
             return item;
@@ -278,12 +300,14 @@ function reduce(reducer /*, initialValue */)
     if (!@isObject(this))
         @throwTypeError("Iterator.prototype.reduce requires that |this| be an Object.");
 
-    if (!@isCallable(reducer))
+    if (!@isCallable(reducer)) {
+        @iteratorGenericClose(this);
         @throwTypeError("Iterator.prototype.reduce reducer argument must be a function.");
-
-    var initialValue = @argument(1);
+    }
 
     var iterated = this;
+    var initialValue = @argument(1);
+
     var iteratedNextMethod = this.next;
 
     var accumulator;

--- a/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
@@ -162,8 +162,11 @@ JSC_DEFINE_HOST_FUNCTION(iteratorProtoFuncForEach, (JSGlobalObject* globalObject
         return throwVMTypeError(globalObject, scope, "Iterator.prototype.forEach requires that |this| be an Object."_s);
 
     JSValue callbackArg = callFrame->argument(0);
-    if (!callbackArg.isCallable())
+    if (!callbackArg.isCallable()) {
+        iteratorClose(globalObject, thisValue);
+        RETURN_IF_EXCEPTION(scope, { });
         return throwVMTypeError(globalObject, scope, "Iterator.prototype.forEach requires the callback argument to be callable."_s);
+    }
 
     auto callData = JSC::getCallData(callbackArg);
     ASSERT(callData.type != CallData::Type::None);


### PR DESCRIPTION
#### 6e8fef40092d06a84de870150952f169c94bd953
<pre>
[JSC] Close Iterator Helpers underlying iterator when arguments are invalid
<a href="https://bugs.webkit.org/show_bug.cgi?id=284709">https://bugs.webkit.org/show_bug.cgi?id=284709</a>

Reviewed by Yusuke Suzuki.

The normative change[1] that requires closing underlying iterators when
argument validation fails for iterator helpers reached consensus at the
TC39 meeting in December 2024[2].

This patch implements it.

[1]: <a href="https://github.com/tc39/ecma262/pull/3467">https://github.com/tc39/ecma262/pull/3467</a>
[2]: <a href="https://github.com/tc39/agendas/blob/main/2024/12.md">https://github.com/tc39/agendas/blob/main/2024/12.md</a>

* JSTests/stress/iterator-helpers-close-for-invalid-argument.js: Added.
(shouldThrow):
(shouldBe):
(throw.new.Error.let.closable.get next):
(throw.new.Error):
(shouldBe.let.closable.get next):
(shouldBe.OurError):
(let.closable.get next):
(shouldBe.get shouldBe):
(OurError):
(get shouldBe):
* Source/JavaScriptCore/builtins/JSIteratorPrototype.js:
(some.wrapper.iterator):
(some):
(every.wrapper.iterator):
(every):
(find.wrapper.iterator):
(find):
(reduce):

Canonical link: <a href="https://commits.webkit.org/290907@main">https://commits.webkit.org/290907@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9adf7e2d10c0ff0fa72c0186c2bc71b8a1ec9cde

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88634 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8153 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43079 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93596 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39388 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8540 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16337 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68339 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26042 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91636 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6537 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80159 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48704 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6300 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34569 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38496 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/81433 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76667 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35468 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95434 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/87410 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15809 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11571 "Found 7 new test failures: http/tests/webarchive/cross-origin-stylesheet-crash.html http/tests/webarchive/test-css-url-encoding-shift-jis.html http/tests/webarchive/test-css-url-encoding-utf-8.html http/tests/webarchive/test-css-url-encoding.html http/tests/webarchive/test-preload-resources.html imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-peerconnection.https.html pdf/pdf-plugin-printing.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77203 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16065 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76018 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76479 "Found 2 new API test failures: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy, /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19400 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20867 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19290 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8848 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15825 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21133 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/109903 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15566 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26412 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19015 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17348 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->