### PR TITLE
Adopt more spans in WebAudio code

### DIFF
--- a/Source/WebCore/Modules/webaudio/AudioBuffer.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBuffer.cpp
@@ -220,13 +220,13 @@ RefPtr<Float32Array> AudioBuffer::channelData(unsigned channelIndex)
     return m_channels[channelIndex].copyRef();
 }
 
-float* AudioBuffer::rawChannelData(unsigned channelIndex)
+std::span<float> AudioBuffer::rawChannelData(unsigned channelIndex)
 {
     if (channelIndex >= m_channels.size())
-        return nullptr;
+        return { };
     if (hasDetachedChannelBuffer())
-        return nullptr;
-    return m_channels[channelIndex]->data();
+        return { };
+    return m_channels[channelIndex]->typedMutableSpan();
 }
 
 ExceptionOr<void> AudioBuffer::copyFromChannel(Ref<Float32Array>&& destination, unsigned channelNumber, unsigned bufferOffset)
@@ -333,7 +333,7 @@ bool AudioBuffer::copyTo(AudioBuffer& other) const
         return false;
 
     for (unsigned channelIndex = 0; channelIndex < numberOfChannels(); ++channelIndex)
-        memcpy(other.rawChannelData(channelIndex), m_channels[channelIndex]->data(), length() * sizeof(float));
+        memcpySpan(other.rawChannelData(channelIndex), m_channels[channelIndex]->typedSpan().first(length()));
 
     other.m_noiseInjectionMultiplier = m_noiseInjectionMultiplier;
     return true;

--- a/Source/WebCore/Modules/webaudio/AudioBuffer.h
+++ b/Source/WebCore/Modules/webaudio/AudioBuffer.h
@@ -71,7 +71,7 @@ public:
 
     // Native channel data access.
     RefPtr<Float32Array> channelData(unsigned channelIndex);
-    float* rawChannelData(unsigned channelIndex);
+    std::span<float> rawChannelData(unsigned channelIndex);
     void zero();
 
     // Because an AudioBuffer has a JavaScript wrapper, which will be garbage collected, it may take a while for this object to be deleted.

--- a/Source/WebCore/Modules/webaudio/AudioListener.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioListener.cpp
@@ -109,17 +109,17 @@ void AudioListener::updateValuesIfNeeded(size_t framesToProcess)
         ASSERT(framesToProcess <= m_upYValues.size());
         ASSERT(framesToProcess <= m_upZValues.size());
 
-        positionX().calculateSampleAccurateValues(m_positionXValues.data(), framesToProcess);
-        positionY().calculateSampleAccurateValues(m_positionYValues.data(), framesToProcess);
-        positionZ().calculateSampleAccurateValues(m_positionZValues.data(), framesToProcess);
+        positionX().calculateSampleAccurateValues(m_positionXValues.span().first(framesToProcess));
+        positionY().calculateSampleAccurateValues(m_positionYValues.span().first(framesToProcess));
+        positionZ().calculateSampleAccurateValues(m_positionZValues.span().first(framesToProcess));
 
-        forwardX().calculateSampleAccurateValues(m_forwardXValues.data(), framesToProcess);
-        forwardY().calculateSampleAccurateValues(m_forwardYValues.data(), framesToProcess);
-        forwardZ().calculateSampleAccurateValues(m_forwardZValues.data(), framesToProcess);
+        forwardX().calculateSampleAccurateValues(m_forwardXValues.span().first(framesToProcess));
+        forwardY().calculateSampleAccurateValues(m_forwardYValues.span().first(framesToProcess));
+        forwardZ().calculateSampleAccurateValues(m_forwardZValues.span().first(framesToProcess));
 
-        upX().calculateSampleAccurateValues(m_upXValues.data(), framesToProcess);
-        upY().calculateSampleAccurateValues(m_upYValues.data(), framesToProcess);
-        upZ().calculateSampleAccurateValues(m_upZValues.data(), framesToProcess);
+        upX().calculateSampleAccurateValues(m_upXValues.span().first(framesToProcess));
+        upY().calculateSampleAccurateValues(m_upYValues.span().first(framesToProcess));
+        upZ().calculateSampleAccurateValues(m_upZValues.span().first(framesToProcess));
     }
 }
 

--- a/Source/WebCore/Modules/webaudio/AudioParam.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioParam.cpp
@@ -35,17 +35,19 @@
 #include "FloatConversion.h"
 #include "Logging.h"
 #include "VectorMath.h"
+#include <algorithm>
 #include <wtf/MathExtras.h>
+#include <wtf/StdLibExtras.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 
-static void replaceNaNValues(float* values, unsigned numberOfValues, float defaultValue)
+static void replaceNaNValues(std::span<float> values, float defaultValue)
 {
-    for (unsigned i = 0; i < numberOfValues; ++i) {
-        if (std::isnan(values[i]))
-            values[i] = defaultValue;
+    for (auto& value : values) {
+        if (std::isnan(value))
+            value = defaultValue;
     }
 }
 
@@ -270,23 +272,23 @@ bool AudioParam::hasSampleAccurateValues() const
 float AudioParam::finalValue()
 {
     float value;
-    calculateFinalValues(&value, 1, false);
+    calculateFinalValues(singleElementSpan(value), false);
     return value;
 }
 
-void AudioParam::calculateSampleAccurateValues(float* values, unsigned numberOfValues)
+void AudioParam::calculateSampleAccurateValues(std::span<float> values)
 {
-    bool isSafe = context() && context()->isAudioThread() && values && numberOfValues;
+    bool isSafe = context() && context()->isAudioThread() && !values.empty();
     ASSERT(isSafe);
     if (!isSafe)
         return;
 
-    calculateFinalValues(values, numberOfValues, automationRate() == AutomationRate::ARate);
+    calculateFinalValues(values, automationRate() == AutomationRate::ARate);
 }
 
-void AudioParam::calculateFinalValues(float* values, unsigned numberOfValues, bool sampleAccurate)
+void AudioParam::calculateFinalValues(std::span<float> values, bool sampleAccurate)
 {
-    bool isGood = context() && context()->isAudioThread() && values && numberOfValues;
+    bool isGood = context() && context()->isAudioThread() && !values.empty();
     ASSERT(isGood);
     if (!isGood)
         return;
@@ -295,14 +297,14 @@ void AudioParam::calculateFinalValues(float* values, unsigned numberOfValues, bo
 
     if (sampleAccurate) {
         // Calculate sample-accurate (a-rate) intrinsic values.
-        calculateTimelineValues(values, numberOfValues);
+        calculateTimelineValues(values);
     } else {
         // Calculate control-rate (k-rate) intrinsic value.
         auto timelineValue = m_timeline.valueForContextTime(*context(), m_value, minValue(), maxValue());
 
         if (timelineValue)
             m_value = *timelineValue;
-        std::fill_n(values, numberOfValues, m_value);
+        std::ranges::fill(values, m_value);
     }
 
     if (!numberOfRenderingConnections())
@@ -313,8 +315,8 @@ void AudioParam::calculateFinalValues(float* values, unsigned numberOfValues, bo
     // If we're not sample accurate, we only need one value, so make the summing
     // bus have length 1. When the connections are added in, only the first
     // value will be added. Which is exactly what we want.
-    ASSERT(numberOfValues <= AudioUtilities::renderQuantumSize);
-    m_summingBus->setChannelMemory(0, values, sampleAccurate ? numberOfValues : 1);
+    ASSERT(values.size() <= AudioUtilities::renderQuantumSize);
+    m_summingBus->setChannelMemory(0, values.first(sampleAccurate ? values.size() : 1));
 
     for (auto& output : m_renderingOutputs) {
         ASSERT(output);
@@ -328,17 +330,17 @@ void AudioParam::calculateFinalValues(float* values, unsigned numberOfValues, bo
 
     // If we're not sample accurate, duplicate the first element of |values| to all of the elements.
     if (!sampleAccurate)
-        std::fill_n(values + 1, numberOfValues - 1, values[0]);
+        std::ranges::fill(values.subspan(1), values[0]);
 
     // As per https://webaudio.github.io/web-audio-api/#computation-of-value, we should replace NaN values
     // with the default value.
-    replaceNaNValues(values, numberOfValues, m_defaultValue);
+    replaceNaNValues(values, m_defaultValue);
 
     // Clamp values based on range allowed by AudioParam's min and max values.
-    VectorMath::clamp(values, minValue(), maxValue(), values, numberOfValues);
+    VectorMath::clamp(values.data(), minValue(), maxValue(), values.data(), values.size());
 }
 
-void AudioParam::calculateTimelineValues(float* values, unsigned numberOfValues)
+void AudioParam::calculateTimelineValues(std::span<float> values)
 {
     if (!context())
         return;
@@ -347,11 +349,11 @@ void AudioParam::calculateTimelineValues(float* values, unsigned numberOfValues)
     // Normally numberOfValues will equal AudioUtilities::renderQuantumSize (the render quantum size).
     double sampleRate = context()->sampleRate();
     size_t startFrame = context()->currentSampleFrame();
-    size_t endFrame = startFrame + numberOfValues;
+    size_t endFrame = startFrame + values.size();
 
     // Note we're running control rate at the sample-rate.
     // Pass in the current value as default value.
-    m_value = m_timeline.valuesForFrameRange(startFrame, endFrame, m_value, minValue(), maxValue(), values, numberOfValues, sampleRate, sampleRate);
+    m_value = m_timeline.valuesForFrameRange(startFrame, endFrame, m_value, minValue(), maxValue(), values, sampleRate, sampleRate);
 }
 
 void AudioParam::connect(AudioNodeOutput* output)

--- a/Source/WebCore/Modules/webaudio/AudioParam.h
+++ b/Source/WebCore/Modules/webaudio/AudioParam.h
@@ -109,7 +109,7 @@ public:
     
     // Calculates numberOfValues parameter values starting at the context's current time.
     // Must be called in the context's render thread.
-    void calculateSampleAccurateValues(float* values, unsigned numberOfValues);
+    void calculateSampleAccurateValues(std::span<float> values);
 
     // Connect an audio-rate signal to control this parameter.
     void connect(AudioNodeOutput*);
@@ -120,8 +120,8 @@ protected:
 
 private:
     // sampleAccurate corresponds to a-rate (audio rate) vs. k-rate in the Web Audio specification.
-    void calculateFinalValues(float* values, unsigned numberOfValues, bool sampleAccurate);
-    void calculateTimelineValues(float* values, unsigned numberOfValues);
+    void calculateFinalValues(std::span<float> values, bool sampleAccurate);
+    void calculateTimelineValues(std::span<float> values);
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }

--- a/Source/WebCore/Modules/webaudio/AudioParamTimeline.h
+++ b/Source/WebCore/Modules/webaudio/AudioParamTimeline.h
@@ -59,7 +59,7 @@ public:
     // controlRate is the rate (number per second) at which parameter values will be calculated.
     // It should equal sampleRate for sample-accurate parameter changes, and otherwise will usually match
     // the render quantum size such that the parameter value changes once per render quantum.
-    float valuesForFrameRange(size_t startFrame, size_t endFrame, float defaultValue, float minValue, float maxValue, float* values, unsigned numberOfValues, double sampleRate, double controlRate);
+    float valuesForFrameRange(size_t startFrame, size_t endFrame, float defaultValue, float minValue, float maxValue, std::span<float> values, double sampleRate, double controlRate);
 
     bool hasValues(size_t startFrame, double sampleRate) const;
 
@@ -163,7 +163,7 @@ private:
     struct AutomationState {
         // Parameters for the current automation request. Number of
         // values to be computed for the automation request
-        const unsigned numberOfValues;
+        const size_t numberOfValues;
         // Start and end frames for this automation request
         const size_t startFrame;
         const size_t endFrame;
@@ -174,7 +174,7 @@ private:
         const double samplingPeriod;
 
         // Parameters needed for processing the current event.
-        const unsigned fillToFrame;
+        const size_t fillToFrame;
         const size_t fillToEndFrame;
 
         // Value and time for the current event
@@ -193,7 +193,7 @@ private:
     void removeCancelledEvents(size_t firstEventToRemove) WTF_REQUIRES_LOCK(m_eventsLock);
     void removeOldEvents(size_t eventCount) WTF_REQUIRES_LOCK(m_eventsLock);
     ExceptionOr<void> insertEvent(ParamEvent&&) WTF_REQUIRES_LOCK(m_eventsLock);
-    float valuesForFrameRangeImpl(size_t startFrame, size_t endFrame, float defaultValue, float* values, unsigned numberOfValues, double sampleRate, double controlRate) WTF_REQUIRES_LOCK(m_eventsLock);
+    float valuesForFrameRangeImpl(size_t startFrame, size_t endFrame, float defaultValue, std::span<float> values, double sampleRate, double controlRate) WTF_REQUIRES_LOCK(m_eventsLock);
     float linearRampAtTime(Seconds t, float value1, Seconds time1, float value2, Seconds time2);
     float exponentialRampAtTime(Seconds t, float value1, Seconds time1, float value2, Seconds time2);
     float valueCurveAtTime(Seconds t, Seconds time1, Seconds duration, const float* curveData, size_t curveLength);

--- a/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
@@ -53,6 +53,7 @@
 #include "SerializedScriptValue.h"
 #include "WorkerRunLoop.h"
 #include <JavaScriptCore/JSLock.h>
+#include <algorithm>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -232,9 +233,9 @@ void AudioWorkletNode::process(size_t framesToProcess)
         ASSERT(paramValues);
         RELEASE_ASSERT(paramValues->size() >= framesToProcess);
         if (audioParam->hasSampleAccurateValues() && audioParam->automationRate() == AutomationRate::ARate)
-            audioParam->calculateSampleAccurateValues(paramValues->data(), framesToProcess);
+            audioParam->calculateSampleAccurateValues(paramValues->span().first(framesToProcess));
         else
-            std::fill_n(paramValues->data(), framesToProcess, audioParam->finalValue());
+            std::ranges::fill(paramValues->span().first(framesToProcess), audioParam->finalValue());
     }
 
     bool threwException = false;

--- a/Source/WebCore/Modules/webaudio/BiquadDSPKernel.cpp
+++ b/Source/WebCore/Modules/webaudio/BiquadDSPKernel.cpp
@@ -51,7 +51,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(BiquadDSPKernel);
 
-static bool hasConstantValue(float* values, int framesToProcess)
+static bool hasConstantValue(std::span<float> values)
 {
     // Load the initial value
     const float value = values[0];
@@ -60,13 +60,13 @@ static bool hasConstantValue(float* values, int framesToProcess)
     // the first frame from the subsequent comparisons in the non-SIMD paths
     // it guarantees that we don't redundantly compare the first frame again
     // during the loop execution.
-    int processedFrames = 1;
+    size_t processedFrames = 1;
 
 #if CPU(X86_SSE2)
     // Process 4 floats at a time using SIMD.
     __m128 valueVec = _mm_set1_ps(value);
     // Start at 0 for byte alignment
-    for (processedFrames = 0; processedFrames < framesToProcess - 3; processedFrames += 4) {
+    for (processedFrames = 0; processedFrames < values.size() - 3; processedFrames += 4) {
         // Load 4 floats from memory.
         __m128 inputVec = _mm_loadu_ps(&values[processedFrames]);
         // Compare the 4 floats with the value.
@@ -79,7 +79,7 @@ static bool hasConstantValue(float* values, int framesToProcess)
     // Process 4 floats at a time using SIMD.
     float32x4_t valueVec = vdupq_n_f32(value);
     // Start at 0 for byte alignment.
-    for (processedFrames = 0; processedFrames < framesToProcess - 3; processedFrames += 4) {
+    for (processedFrames = 0; processedFrames < values.size() - 3; processedFrames += 4) {
         // Load 4 floats from memory.
         float32x4_t inputVec = vld1q_f32(&values[processedFrames]);
         // Compare the 4 floats with the value.
@@ -92,7 +92,7 @@ static bool hasConstantValue(float* values, int framesToProcess)
     }
 #endif
     // Fallback implementation without SIMD optimization.
-    while (processedFrames < framesToProcess) {
+    while (processedFrames < values.size()) {
         if (values[processedFrames] != value)
             return false;
         ++processedFrames;
@@ -105,26 +105,31 @@ void BiquadDSPKernel::updateCoefficientsIfNecessary(size_t framesToProcess)
     if (biquadProcessor()->filterCoefficientsDirty()) {
         if (biquadProcessor()->hasSampleAccurateValues() && biquadProcessor()->shouldUseARate()) {
             // Use float arrays instead of AudioFloatArray to avoid heap allocations on the audio thread.
-            float cutoffFrequency[AudioUtilities::renderQuantumSize];
-            float q[AudioUtilities::renderQuantumSize];
-            float gain[AudioUtilities::renderQuantumSize];
-            float detune[AudioUtilities::renderQuantumSize]; // in Cents
+            std::array<float, AudioUtilities::renderQuantumSize> cutoffFrequency;
+            std::array<float, AudioUtilities::renderQuantumSize> q;
+            std::array<float, AudioUtilities::renderQuantumSize> gain;
+            std::array<float, AudioUtilities::renderQuantumSize> detune; // in Cents
 
             RELEASE_ASSERT(framesToProcess <= AudioUtilities::renderQuantumSize);
 
-            biquadProcessor()->parameter1().calculateSampleAccurateValues(cutoffFrequency, framesToProcess);
-            biquadProcessor()->parameter2().calculateSampleAccurateValues(q, framesToProcess);
-            biquadProcessor()->parameter3().calculateSampleAccurateValues(gain, framesToProcess);
-            biquadProcessor()->parameter4().calculateSampleAccurateValues(detune, framesToProcess);
+            auto cutoffFrequencySpan = std::span { cutoffFrequency }.first(framesToProcess);
+            auto qSpan = std::span { q }.first(framesToProcess);
+            auto gainSpan = std::span { gain }.first(framesToProcess);
+            auto detuneSpan = std::span { detune }.first(framesToProcess);
+
+            biquadProcessor()->parameter1().calculateSampleAccurateValues(cutoffFrequencySpan);
+            biquadProcessor()->parameter2().calculateSampleAccurateValues(qSpan);
+            biquadProcessor()->parameter3().calculateSampleAccurateValues(gainSpan);
+            biquadProcessor()->parameter4().calculateSampleAccurateValues(detuneSpan);
 
             // If all the values are actually constant for this render (or the
             // automation rate is "k-rate" for all of the AudioParams), we don't need
             // to compute filter coefficients for each frame since they would be the
             // same as the first.
-            bool isConstant = hasConstantValue(cutoffFrequency, framesToProcess)
-                && hasConstantValue(q, framesToProcess)
-                && hasConstantValue(gain, framesToProcess)
-                && hasConstantValue(detune, framesToProcess);
+            bool isConstant = hasConstantValue(cutoffFrequencySpan)
+                && hasConstantValue(qSpan)
+                && hasConstantValue(gainSpan)
+                && hasConstantValue(detuneSpan);
 
             updateCoefficients(isConstant ? 1 : framesToProcess, cutoffFrequency, q, gain, detune);
         } else {
@@ -132,12 +137,12 @@ void BiquadDSPKernel::updateCoefficientsIfNecessary(size_t framesToProcess)
             float q = biquadProcessor()->parameter2().finalValue();
             float gain = biquadProcessor()->parameter3().finalValue();
             float detune = biquadProcessor()->parameter4().finalValue();
-            updateCoefficients(1, &cutoffFrequency, &q, &gain, &detune);
+            updateCoefficients(1, singleElementSpan(cutoffFrequency), singleElementSpan(q), singleElementSpan(gain), singleElementSpan(detune));
         }
     }
 }
 
-void BiquadDSPKernel::updateCoefficients(size_t numberOfFrames, const float* cutoffFrequency, const float* q, const float* gain, const float* detune)
+void BiquadDSPKernel::updateCoefficients(size_t numberOfFrames, std::span<const float> cutoffFrequency, std::span<const float> q, std::span<const float> gain, std::span<const float> detune)
 {
     // Convert from Hertz to normalized frequency 0 -> 1.
     double nyquist = this->nyquist();

--- a/Source/WebCore/Modules/webaudio/BiquadDSPKernel.h
+++ b/Source/WebCore/Modules/webaudio/BiquadDSPKernel.h
@@ -54,7 +54,7 @@ public:
     double tailTime() const override;
     double latencyTime() const override;
 
-    void updateCoefficients(size_t numberOfFrames, const float* cutoffFrequency, const float* q, const float* gain, const float* detune);
+    void updateCoefficients(size_t numberOfFrames, std::span<const float> cutoffFrequency, std::span<const float> q, std::span<const float> gain, std::span<const float> detune);
 
     bool requiresTailProcessing() const final;
 

--- a/Source/WebCore/Modules/webaudio/BiquadProcessor.cpp
+++ b/Source/WebCore/Modules/webaudio/BiquadProcessor.cpp
@@ -111,13 +111,14 @@ void BiquadProcessor::process(const AudioBus* source, AudioBus* destination, siz
 
 void BiquadProcessor::processOnlyAudioParams(size_t framesToProcess)
 {
-    float values[AudioUtilities::renderQuantumSize];
+    std::array<float, AudioUtilities::renderQuantumSize> values;
     ASSERT(framesToProcess <= AudioUtilities::renderQuantumSize);
 
-    m_parameter1->calculateSampleAccurateValues(values, framesToProcess);
-    m_parameter2->calculateSampleAccurateValues(values, framesToProcess);
-    m_parameter3->calculateSampleAccurateValues(values, framesToProcess);
-    m_parameter4->calculateSampleAccurateValues(values, framesToProcess);
+    auto valuesSpan = std::span { values }.first(framesToProcess);
+    m_parameter1->calculateSampleAccurateValues(valuesSpan);
+    m_parameter2->calculateSampleAccurateValues(valuesSpan);
+    m_parameter3->calculateSampleAccurateValues(valuesSpan);
+    m_parameter4->calculateSampleAccurateValues(valuesSpan);
 }
 
 void BiquadProcessor::setType(BiquadFilterType type)
@@ -143,7 +144,7 @@ void BiquadProcessor::getFrequencyResponse(unsigned nFrequencies, const float* f
     float gain = parameter3().value();
     float detune = parameter4().value();
 
-    responseKernel->updateCoefficients(1, &cutoffFrequency, &q, &gain, &detune);
+    responseKernel->updateCoefficients(1, singleElementSpan(cutoffFrequency), singleElementSpan(q), singleElementSpan(gain), singleElementSpan(detune));
     responseKernel->getFrequencyResponse(nFrequencies, frequencyHz, magResponse, phaseResponse);
 }
 

--- a/Source/WebCore/Modules/webaudio/ConstantSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/ConstantSourceNode.cpp
@@ -83,10 +83,10 @@ void ConstantSourceNode::process(size_t framesToProcess)
     
     bool isSampleAccurate = m_offset->hasSampleAccurateValues();
     if (isSampleAccurate && m_offset->automationRate() == AutomationRate::ARate) {
-        float* offsets = m_sampleAccurateValues.data();
-        m_offset->calculateSampleAccurateValues(offsets, framesToProcess);
+        auto offsets = m_sampleAccurateValues.span();
+        m_offset->calculateSampleAccurateValues(offsets.first(framesToProcess));
         if (nonSilentFramesToProcess > 0) {
-            memcpy(outputBus.channel(0)->mutableData() + quantumFrameOffset, offsets + quantumFrameOffset, nonSilentFramesToProcess * sizeof(*offsets));
+            memcpySpan(outputBus.channel(0)->mutableSpan().subspan(quantumFrameOffset), offsets.subspan(quantumFrameOffset, nonSilentFramesToProcess));
             outputBus.clearSilentFlag();
         } else
             outputBus.zero();

--- a/Source/WebCore/Modules/webaudio/ConvolverNode.cpp
+++ b/Source/WebCore/Modules/webaudio/ConvolverNode.cpp
@@ -135,7 +135,7 @@ ExceptionOr<void> ConvolverNode::setBufferForBindings(RefPtr<AudioBuffer>&& buff
     // This memory is simply used in the Reverb constructor and no reference to it is kept for later use in that class.
     auto bufferBus = AudioBus::create(numberOfChannels, bufferLength, false);
     for (unsigned i = 0; i < numberOfChannels; ++i)
-        bufferBus->setChannelMemory(i, buffer->channelData(i)->data(), bufferLength);
+        bufferBus->setChannelMemory(i, buffer->channelData(i)->typedMutableSpan().first(bufferLength));
 
     bufferBus->setSampleRate(buffer->sampleRate());
 

--- a/Source/WebCore/Modules/webaudio/DelayDSPKernel.cpp
+++ b/Source/WebCore/Modules/webaudio/DelayDSPKernel.cpp
@@ -121,7 +121,7 @@ void DelayDSPKernel::processARate(const float* source, float* destination, size_
     size_t bufferLength = m_buffer.size();
     auto* buffer = m_buffer.data();
 
-    delayProcessor()->delayTime().calculateSampleAccurateValues(m_delayTimes.data(), framesToProcess);
+    delayProcessor()->delayTime().calculateSampleAccurateValues(m_delayTimes.span().first(framesToProcess));
 
     copyToCircularBuffer(buffer, m_writeIndex, bufferLength, source, framesToProcess);
 
@@ -214,10 +214,10 @@ void DelayDSPKernel::processOnlyAudioParams(size_t framesToProcess)
     if (!delayProcessor())
         return;
 
-    float values[AudioUtilities::renderQuantumSize];
+    std::array<float, AudioUtilities::renderQuantumSize> values;
     ASSERT(framesToProcess <= AudioUtilities::renderQuantumSize);
 
-    delayProcessor()->delayTime().calculateSampleAccurateValues(values, framesToProcess);
+    delayProcessor()->delayTime().calculateSampleAccurateValues(std::span { values }.first(framesToProcess));
 }
 
 void DelayDSPKernel::reset()

--- a/Source/WebCore/Modules/webaudio/DynamicsCompressorNode.cpp
+++ b/Source/WebCore/Modules/webaudio/DynamicsCompressorNode.cpp
@@ -97,14 +97,15 @@ void DynamicsCompressorNode::process(size_t framesToProcess)
 
 void DynamicsCompressorNode::processOnlyAudioParams(size_t framesToProcess)
 {
-    float values[AudioUtilities::renderQuantumSize];
+    std::array<float, AudioUtilities::renderQuantumSize> values;
     ASSERT(framesToProcess <= AudioUtilities::renderQuantumSize);
 
-    m_threshold->calculateSampleAccurateValues(values, framesToProcess);
-    m_knee->calculateSampleAccurateValues(values, framesToProcess);
-    m_ratio->calculateSampleAccurateValues(values, framesToProcess);
-    m_attack->calculateSampleAccurateValues(values, framesToProcess);
-    m_release->calculateSampleAccurateValues(values, framesToProcess);
+    auto valuesSpan = std::span { values }.first(framesToProcess);
+    m_threshold->calculateSampleAccurateValues(valuesSpan);
+    m_knee->calculateSampleAccurateValues(valuesSpan);
+    m_ratio->calculateSampleAccurateValues(valuesSpan);
+    m_attack->calculateSampleAccurateValues(valuesSpan);
+    m_release->calculateSampleAccurateValues(valuesSpan);
 }
 
 void DynamicsCompressorNode::initialize()

--- a/Source/WebCore/Modules/webaudio/GainNode.cpp
+++ b/Source/WebCore/Modules/webaudio/GainNode.cpp
@@ -80,9 +80,9 @@ void GainNode::process(size_t framesToProcess)
             // Apply sample-accurate gain scaling for precise envelopes, grain windows, etc.
             ASSERT(framesToProcess <= m_sampleAccurateGainValues.size());
             if (framesToProcess <= m_sampleAccurateGainValues.size()) {
-                float* gainValues = m_sampleAccurateGainValues.data();
-                gain().calculateSampleAccurateValues(gainValues, framesToProcess);
-                outputBus->copyWithSampleAccurateGainValuesFrom(*inputBus, gainValues, framesToProcess);
+                auto gainValues = m_sampleAccurateGainValues.span().first(framesToProcess);
+                gain().calculateSampleAccurateValues(gainValues);
+                outputBus->copyWithSampleAccurateGainValuesFrom(*inputBus, gainValues);
             }
         } else {
             // Apply the gain with de-zippering into the output bus.
@@ -98,10 +98,10 @@ void GainNode::process(size_t framesToProcess)
 
 void GainNode::processOnlyAudioParams(size_t framesToProcess)
 {
-    float values[AudioUtilities::renderQuantumSize];
+    std::array<float, AudioUtilities::renderQuantumSize> values;
     ASSERT(framesToProcess <= AudioUtilities::renderQuantumSize);
 
-    m_gain->calculateSampleAccurateValues(values, framesToProcess);
+    m_gain->calculateSampleAccurateValues(std::span { values }.first(framesToProcess));
 }
 
 // FIXME: this can go away when we do mixing with gain directly in summing junction of AudioNodeInput

--- a/Source/WebCore/Modules/webaudio/PannerNode.cpp
+++ b/Source/WebCore/Modules/webaudio/PannerNode.cpp
@@ -170,16 +170,17 @@ void PannerNode::processOnlyAudioParams(size_t framesToProcess)
         return;
 
     Locker locker { AdoptLock, m_processLock };
-    float values[AudioUtilities::renderQuantumSize];
+    std::array<float, AudioUtilities::renderQuantumSize> values;
     ASSERT(framesToProcess <= AudioUtilities::renderQuantumSize);
 
-    m_positionX->calculateSampleAccurateValues(values, framesToProcess);
-    m_positionY->calculateSampleAccurateValues(values, framesToProcess);
-    m_positionZ->calculateSampleAccurateValues(values, framesToProcess);
+    auto valuesSpan = std::span { values }.first(framesToProcess);
+    m_positionX->calculateSampleAccurateValues(valuesSpan);
+    m_positionY->calculateSampleAccurateValues(valuesSpan);
+    m_positionZ->calculateSampleAccurateValues(valuesSpan);
 
-    m_orientationX->calculateSampleAccurateValues(values, framesToProcess);
-    m_orientationY->calculateSampleAccurateValues(values, framesToProcess);
-    m_orientationZ->calculateSampleAccurateValues(values, framesToProcess);
+    m_orientationX->calculateSampleAccurateValues(valuesSpan);
+    m_orientationY->calculateSampleAccurateValues(valuesSpan);
+    m_orientationZ->calculateSampleAccurateValues(valuesSpan);
 
     listener().updateValuesIfNeeded(framesToProcess);
 }
@@ -188,20 +189,20 @@ void PannerNode::processSampleAccurateValues(AudioBus* destination, const AudioB
 {
     // Get the sample accurate values from all of the AudioParams, including the
     // values from the AudioListener.
-    float pannerX[AudioUtilities::renderQuantumSize];
-    float pannerY[AudioUtilities::renderQuantumSize];
-    float pannerZ[AudioUtilities::renderQuantumSize];
+    std::array<float, AudioUtilities::renderQuantumSize> pannerX;
+    std::array<float, AudioUtilities::renderQuantumSize> pannerY;
+    std::array<float, AudioUtilities::renderQuantumSize> pannerZ;
 
-    float orientationX[AudioUtilities::renderQuantumSize];
-    float orientationY[AudioUtilities::renderQuantumSize];
-    float orientationZ[AudioUtilities::renderQuantumSize];
+    std::array<float, AudioUtilities::renderQuantumSize> orientationX;
+    std::array<float, AudioUtilities::renderQuantumSize> orientationY;
+    std::array<float, AudioUtilities::renderQuantumSize> orientationZ;
 
-    m_positionX->calculateSampleAccurateValues(pannerX, framesToProcess);
-    m_positionY->calculateSampleAccurateValues(pannerY, framesToProcess);
-    m_positionZ->calculateSampleAccurateValues(pannerZ, framesToProcess);
-    m_orientationX->calculateSampleAccurateValues(orientationX, framesToProcess);
-    m_orientationY->calculateSampleAccurateValues(orientationY, framesToProcess);
-    m_orientationZ->calculateSampleAccurateValues(orientationZ, framesToProcess);
+    m_positionX->calculateSampleAccurateValues(std::span { pannerX }.first(framesToProcess));
+    m_positionY->calculateSampleAccurateValues(std::span { pannerY }.first(framesToProcess));
+    m_positionZ->calculateSampleAccurateValues(std::span { pannerZ }.first(framesToProcess));
+    m_orientationX->calculateSampleAccurateValues(std::span { orientationX }.first(framesToProcess));
+    m_orientationY->calculateSampleAccurateValues(std::span { orientationY }.first(framesToProcess));
+    m_orientationZ->calculateSampleAccurateValues(std::span { orientationZ }.first(framesToProcess));
 
     // Get the automation values from the listener.
     const float* listenerX = listener().positionXValues(AudioUtilities::renderQuantumSize);
@@ -217,9 +218,9 @@ void PannerNode::processSampleAccurateValues(AudioBus* destination, const AudioB
     const float* upZ = listener().upZValues(AudioUtilities::renderQuantumSize);
 
     // Compute the azimuth, elevation, and total gains for each position.
-    double azimuth[AudioUtilities::renderQuantumSize];
-    double elevation[AudioUtilities::renderQuantumSize];
-    float totalGain[AudioUtilities::renderQuantumSize];
+    std::array<double, AudioUtilities::renderQuantumSize> azimuth;
+    std::array<double, AudioUtilities::renderQuantumSize> elevation;
+    std::array<float, AudioUtilities::renderQuantumSize> totalGain;
 
     for (size_t k = 0; k < framesToProcess; ++k) {
         FloatPoint3D pannerPosition(pannerX[k], pannerY[k], pannerZ[k]);
@@ -236,8 +237,8 @@ void PannerNode::processSampleAccurateValues(AudioBus* destination, const AudioB
         totalGain[k] = calculateDistanceConeGain(pannerPosition, orientation, listenerPosition, m_distanceEffect, m_coneEffect);
     }
 
-    m_panner->panWithSampleAccurateValues(azimuth, elevation, source, destination, framesToProcess);
-    destination->copyWithSampleAccurateGainValuesFrom(*destination, totalGain, framesToProcess);
+    m_panner->panWithSampleAccurateValues(azimuth.data(), elevation.data(), source, destination, framesToProcess);
+    destination->copyWithSampleAccurateGainValuesFrom(*destination, std::span { totalGain }.first(framesToProcess));
 }
 
 bool PannerNode::hasSampleAccurateValues() const

--- a/Source/WebCore/Modules/webaudio/ScriptProcessorNode.cpp
+++ b/Source/WebCore/Modules/webaudio/ScriptProcessorNode.cpp
@@ -190,14 +190,14 @@ void ScriptProcessorNode::process(size_t framesToProcess)
         return;
 
     for (unsigned i = 0; i < numberOfInputChannels; i++)
-        m_internalInputBus->setChannelMemory(i, inputBuffer->rawChannelData(i) + m_bufferReadWriteIndex, framesToProcess);
+        m_internalInputBus->setChannelMemory(i, inputBuffer->rawChannelData(i).subspan(m_bufferReadWriteIndex).first(framesToProcess));
 
     if (numberOfInputChannels)
         m_internalInputBus->copyFrom(*inputBus);
 
     // Copy from the output buffer to the output. 
     for (unsigned i = 0; i < numberOfOutputChannels; ++i)
-        memcpy(outputBus->channel(i)->mutableData(), outputBuffer->rawChannelData(i) + m_bufferReadWriteIndex, sizeof(float) * framesToProcess);
+        memcpySpan(outputBus->channel(i)->mutableSpan(), outputBuffer->rawChannelData(i).subspan(m_bufferReadWriteIndex, framesToProcess));
 
     // Update the buffering index.
     m_bufferReadWriteIndex = (m_bufferReadWriteIndex + framesToProcess) % bufferSize();

--- a/Source/WebCore/Modules/webaudio/StereoPannerNode.cpp
+++ b/Source/WebCore/Modules/webaudio/StereoPannerNode.cpp
@@ -82,9 +82,9 @@ void StereoPannerNode::process(size_t framesToProcess)
     }
 
     if (m_pan->hasSampleAccurateValues() && m_pan->automationRate() == AutomationRate::ARate) {
-        float* panValues = m_sampleAccurateValues.data();
-        m_pan->calculateSampleAccurateValues(panValues, framesToProcess);
-        StereoPanner::panWithSampleAccurateValues(source, destination, panValues, framesToProcess);
+        auto panValues = m_sampleAccurateValues.span().first(framesToProcess);
+        m_pan->calculateSampleAccurateValues(panValues);
+        StereoPanner::panWithSampleAccurateValues(source, destination, panValues);
         return;
     }
     
@@ -97,10 +97,10 @@ void StereoPannerNode::process(size_t framesToProcess)
 
 void StereoPannerNode::processOnlyAudioParams(size_t framesToProcess)
 {
-    float values[AudioUtilities::renderQuantumSize];
+    std::array<float, AudioUtilities::renderQuantumSize> values;
     ASSERT(framesToProcess <= AudioUtilities::renderQuantumSize);
 
-    m_pan->calculateSampleAccurateValues(values, framesToProcess);
+    m_pan->calculateSampleAccurateValues(std::span { values }.first(framesToProcess));
 }
 
 ExceptionOr<void> StereoPannerNode::setChannelCount(unsigned channelCount)

--- a/Source/WebCore/platform/audio/AudioBus.h
+++ b/Source/WebCore/platform/audio/AudioBus.h
@@ -70,7 +70,7 @@ public:
     WEBCORE_EXPORT static RefPtr<AudioBus> create(unsigned numberOfChannels, size_t length, bool allocate = true);
 
     // Tells the given channel to use an externally allocated buffer.
-    WEBCORE_EXPORT void setChannelMemory(unsigned channelIndex, float* storage, size_t length);
+    WEBCORE_EXPORT void setChannelMemory(unsigned channelIndex, std::span<float> storage);
 
     // Channels
     unsigned numberOfChannels() const { return m_channels.size(); }
@@ -137,7 +137,7 @@ public:
     void copyWithGainFrom(const AudioBus& sourceBus, float targetGain);
 
     // Copies the sourceBus by scaling with sample-accurate gain values.
-    void copyWithSampleAccurateGainValuesFrom(const AudioBus &sourceBus, float* gainValues, unsigned numberOfGainValues);
+    void copyWithSampleAccurateGainValuesFrom(const AudioBus &sourceBus, std::span<float> gainValues);
 
     // Returns maximum absolute value across all channels (useful for normalization).
     float maxAbsValue() const;

--- a/Source/WebCore/platform/audio/AudioResampler.cpp
+++ b/Source/WebCore/platform/audio/AudioResampler.cpp
@@ -87,12 +87,12 @@ void AudioResampler::process(AudioSourceProvider* provider, AudioBus* destinatio
     for (unsigned i = 0; i < numberOfChannels; ++i) {
         // Figure out how many frames we need to get from the provider, and a pointer to the buffer.
         size_t framesNeeded;
-        float* fillPointer = m_kernels[i]->getSourcePointer(framesToProcess, &framesNeeded);
-        ASSERT(fillPointer);
-        if (!fillPointer)
+        std::span<float> fillSpan = m_kernels[i]->getSourceSpan(framesToProcess, &framesNeeded);
+        ASSERT(!fillSpan.empty());
+        if (fillSpan.empty())
             return;
-            
-        m_sourceBus->setChannelMemory(i, fillPointer, framesNeeded);
+
+        m_sourceBus->setChannelMemory(i, fillSpan.first(framesNeeded));
     }
 
     // Ask the provider to supply the desired number of source frames.

--- a/Source/WebCore/platform/audio/AudioResamplerKernel.cpp
+++ b/Source/WebCore/platform/audio/AudioResamplerKernel.cpp
@@ -48,7 +48,7 @@ AudioResamplerKernel::AudioResamplerKernel(AudioResampler* resampler)
     m_lastValues[1] = 0.0f;
 }
 
-float* AudioResamplerKernel::getSourcePointer(size_t framesToProcess, size_t* numberOfSourceFramesNeededP)
+std::span<float> AudioResamplerKernel::getSourceSpan(size_t framesToProcess, size_t* numberOfSourceFramesNeededP)
 {
     ASSERT(framesToProcess <= AudioUtilities::renderQuantumSize);
     
@@ -68,9 +68,9 @@ float* AudioResamplerKernel::getSourcePointer(size_t framesToProcess, size_t* nu
     bool isGood = m_fillIndex < m_sourceBuffer.size() && m_fillIndex + framesNeeded <= m_sourceBuffer.size();
     ASSERT(isGood);
     if (!isGood)
-        return 0;
+        return { };
 
-    return m_sourceBuffer.data() + m_fillIndex;
+    return m_sourceBuffer.span().subspan(m_fillIndex);
 }
 
 void AudioResamplerKernel::process(float* destination, size_t framesToProcess)

--- a/Source/WebCore/platform/audio/AudioResamplerKernel.h
+++ b/Source/WebCore/platform/audio/AudioResamplerKernel.h
@@ -43,14 +43,14 @@ class AudioResamplerKernel final {
 public:
     AudioResamplerKernel(AudioResampler*);
 
-    // getSourcePointer() should be called each time before process() is called.
-    // Given a number of frames to process (for subsequent call to process()), it returns a pointer and numberOfSourceFramesNeeded
+    // getSourceSpan() should be called each time before process() is called.
+    // Given a number of frames to process (for subsequent call to process()), it returns a span and numberOfSourceFramesNeeded
     // where sample data should be copied. This sample data provides the input to the resampler when process() is called.
     // framesToProcess must be less than or equal to AudioUtilities::renderQuantumSize.
-    float* getSourcePointer(size_t framesToProcess, size_t* numberOfSourceFramesNeeded);
+    std::span<float> getSourceSpan(size_t framesToProcess, size_t* numberOfSourceFramesNeeded);
 
     // process() resamples framesToProcess frames from the source into destination.
-    // Each call to process() must be preceded by a call to getSourcePointer() so that source input may be supplied.
+    // Each call to process() must be preceded by a call to getSourceSpan() so that source input may be supplied.
     // framesToProcess must be less than or equal to AudioUtilities::renderQuantumSize.
     void process(float* destination, size_t framesToProcess);
 

--- a/Source/WebCore/platform/audio/StereoPanner.h
+++ b/Source/WebCore/platform/audio/StereoPanner.h
@@ -33,7 +33,7 @@ namespace WebCore {
 
 namespace StereoPanner {
     
-void panWithSampleAccurateValues(const AudioBus* inputBus, AudioBus* outputBus, const float* panValues, size_t framesToProcess);
+void panWithSampleAccurateValues(const AudioBus* inputBus, AudioBus* outputBus, std::span<const float> panValues);
     
 void panToTargetValue(const AudioBus* inputBus, AudioBus* outputBus, float panValue, size_t framesToProcess);
 

--- a/Source/WebCore/platform/audio/cocoa/SpanCoreAudio.h
+++ b/Source/WebCore/platform/audio/cocoa/SpanCoreAudio.h
@@ -36,9 +36,19 @@ inline std::span<uint8_t> dataMutableByteSpan(AudioBuffer& buffer)
     return unsafeMakeSpan(static_cast<uint8_t*>(buffer.mData), buffer.mDataByteSize);
 }
 
+inline std::span<float> dataMutableFloatSpan(AudioBuffer& buffer)
+{
+    return unsafeMakeSpan(static_cast<float*>(buffer.mData), buffer.mDataByteSize / sizeof(float));
+}
+
 inline std::span<const uint8_t> dataByteSpan(const AudioBuffer& buffer)
 {
     return unsafeMakeSpan(static_cast<const uint8_t*>(buffer.mData), buffer.mDataByteSize);
+}
+
+inline std::span<const float> dataFloatSpan(AudioBuffer& buffer)
+{
+    return unsafeMakeSpan(static_cast<const float*>(buffer.mData), buffer.mDataByteSize / sizeof(float));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.cpp
@@ -34,6 +34,7 @@
 #include <wtf/Condition.h>
 #include <wtf/Lock.h>
 #include <wtf/Scope.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/glib/WTFGType.h>
 
@@ -298,7 +299,7 @@ static GRefPtr<GstBuffer> webKitWebAudioSrcAllocateBuffer(WebKitWebAudioSrc* src
         ASSERT(mappedBuffer);
         WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
         for (unsigned channelIndex = 0; channelIndex < priv->bus->numberOfChannels(); channelIndex++)
-            priv->bus->setChannelMemory(channelIndex, reinterpret_cast<float*>(mappedBuffer.data() + channelIndex * priv->bufferSize), priv->framesToPull);
+            priv->bus->setChannelMemory(channelIndex, spanReinterpretCast<float>(mappedBuffer.mutableSpan().subspan(channelIndex * priv->bufferSize)).first(priv->framesToPull));
         WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 


### PR DESCRIPTION
#### 4692bb90e0930842c44c92be11a311d69ae09add
<pre>
Adopt more spans in WebAudio code
<a href="https://bugs.webkit.org/show_bug.cgi?id=284704">https://bugs.webkit.org/show_bug.cgi?id=284704</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/StdLibExtras.h:
(WTF::singleElementSpan):
* Source/WebCore/Modules/webaudio/AudioBuffer.cpp:
(WebCore::AudioBuffer::rawChannelData):
(WebCore::AudioBuffer::copyTo const):
* Source/WebCore/Modules/webaudio/AudioBuffer.h:
* Source/WebCore/Modules/webaudio/AudioListener.cpp:
(WebCore::AudioListener::updateValuesIfNeeded):
* Source/WebCore/Modules/webaudio/AudioParam.cpp:
(WebCore::replaceNaNValues):
(WebCore::AudioParam::finalValue):
(WebCore::AudioParam::calculateSampleAccurateValues):
(WebCore::AudioParam::calculateFinalValues):
(WebCore::AudioParam::calculateTimelineValues):
* Source/WebCore/Modules/webaudio/AudioParam.h:
* Source/WebCore/Modules/webaudio/AudioParamTimeline.cpp:
(WebCore::AudioParamTimeline::valueForContextTime):
(WebCore::AudioParamTimeline::valuesForFrameRange):
(WebCore::AudioParamTimeline::valuesForFrameRangeImpl):
* Source/WebCore/Modules/webaudio/AudioParamTimeline.h:
* Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp:
(WebCore::AudioWorkletNode::process):
* Source/WebCore/Modules/webaudio/BiquadDSPKernel.cpp:
(WebCore::hasConstantValue):
(WebCore::BiquadDSPKernel::updateCoefficientsIfNecessary):
(WebCore::BiquadDSPKernel::updateCoefficients):
* Source/WebCore/Modules/webaudio/BiquadDSPKernel.h:
* Source/WebCore/Modules/webaudio/BiquadProcessor.cpp:
(WebCore::BiquadProcessor::processOnlyAudioParams):
(WebCore::BiquadProcessor::getFrequencyResponse):
* Source/WebCore/Modules/webaudio/ConstantSourceNode.cpp:
(WebCore::ConstantSourceNode::process):
* Source/WebCore/Modules/webaudio/ConvolverNode.cpp:
(WebCore::ConvolverNode::setBufferForBindings):
* Source/WebCore/Modules/webaudio/DelayDSPKernel.cpp:
(WebCore::DelayDSPKernel::processARate):
(WebCore::DelayDSPKernel::processOnlyAudioParams):
* Source/WebCore/Modules/webaudio/DynamicsCompressorNode.cpp:
(WebCore::DynamicsCompressorNode::processOnlyAudioParams):
* Source/WebCore/Modules/webaudio/GainNode.cpp:
(WebCore::GainNode::process):
(WebCore::GainNode::processOnlyAudioParams):
* Source/WebCore/Modules/webaudio/OscillatorNode.cpp:
(WebCore::clampFrequency):
(WebCore::OscillatorNode::calculateSampleAccuratePhaseIncrements):
(WebCore::OscillatorNode::processKRate):
(WebCore::OscillatorNode::process):
* Source/WebCore/Modules/webaudio/PannerNode.cpp:
(WebCore::PannerNode::processOnlyAudioParams):
(WebCore::PannerNode::processSampleAccurateValues):
* Source/WebCore/Modules/webaudio/ScriptProcessorNode.cpp:
(WebCore::ScriptProcessorNode::process):
* Source/WebCore/Modules/webaudio/StereoPannerNode.cpp:
(WebCore::StereoPannerNode::process):
(WebCore::StereoPannerNode::processOnlyAudioParams):
* Source/WebCore/platform/audio/AudioBus.cpp:
(WebCore::AudioBus::AudioBus):
(WebCore::AudioBus::setChannelMemory):
(WebCore::AudioBus::copyWithSampleAccurateGainValuesFrom):
* Source/WebCore/platform/audio/AudioBus.h:
* Source/WebCore/platform/audio/AudioChannel.h:
* Source/WebCore/platform/audio/AudioResampler.cpp:
(WebCore::AudioResampler::process):
* Source/WebCore/platform/audio/AudioResamplerKernel.cpp:
(WebCore::AudioResamplerKernel::getSourceSpan):
(WebCore::AudioResamplerKernel::getSourcePointer): Deleted.
* Source/WebCore/platform/audio/AudioResamplerKernel.h:
* Source/WebCore/platform/audio/StereoPanner.cpp:
(WebCore::StereoPanner::panWithSampleAccurateValues):
* Source/WebCore/platform/audio/StereoPanner.h:
* Source/WebCore/platform/audio/cocoa/AudioDestinationCocoa.cpp:
(WebCore::AudioDestinationCocoa::render):

Canonical link: <a href="https://commits.webkit.org/287880@main">https://commits.webkit.org/287880@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4752eddf1ec3e6317f83352633653a4f9765e263

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81181 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/706 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35124 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85710 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32167 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83291 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/724 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8516 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63381 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21152 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84250 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/472 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73886 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43679 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/369 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28048 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30625 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71889 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28615 "Found 1 new test failure: fast/attachment/cocoa/wide-attachment-rendering.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87145 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8411 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5971 "Found 1 new test failure: fast/attachment/cocoa/wide-attachment-rendering.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71688 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8590 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69721 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70923 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17648 "Found 1 new test failure: fast/attachment/cocoa/wide-attachment-rendering.html (failure)") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14970 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13889 "Found 1 new test failure: fast/attachment/cocoa/wide-attachment-rendering.html (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12584 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8372 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13896 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8209 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11729 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10017 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->