### PR TITLE
Remove non-standard legacy alias of Canvas Compositing (setCompositeOperation & setAlpha)

### DIFF
--- a/LayoutTests/inspector/canvas/recording-2d-full-expected.txt
+++ b/LayoutTests/inspector/canvas/recording-2d-full-expected.txt
@@ -634,32 +634,6 @@ frames:
         1: (anonymous function)
         2: executeFrameFunction
   47: (duration)
-    0: setAlpha(null)
-      swizzleTypes: [Number]
-      trace:
-        0: setAlpha
-        1: (anonymous function)
-        2: executeFrameFunction
-    1: setAlpha(1)
-      swizzleTypes: [Number]
-      trace:
-        0: setAlpha
-        1: (anonymous function)
-        2: executeFrameFunction
-  48: (duration)
-    0: setCompositeOperation("")
-      swizzleTypes: [String]
-      trace:
-        0: setCompositeOperation
-        1: (anonymous function)
-        2: executeFrameFunction
-    1: setCompositeOperation("test")
-      swizzleTypes: [String]
-      trace:
-        0: setCompositeOperation
-        1: (anonymous function)
-        2: executeFrameFunction
-  49: (duration)
     0: setFillColor("testA")
       swizzleTypes: [String]
       trace:
@@ -690,7 +664,7 @@ frames:
         0: setFillColor
         1: (anonymous function)
         2: executeFrameFunction
-  50: (duration)
+  48: (duration)
     0: setLineCap("")
       swizzleTypes: [String]
       trace:
@@ -703,14 +677,14 @@ frames:
         0: setLineCap
         1: (anonymous function)
         2: executeFrameFunction
-  51: (duration)
+  49: (duration)
     0: setLineDash([1,2])
       swizzleTypes: [Array]
       trace:
         0: setLineDash
         1: (anonymous function)
         2: executeFrameFunction
-  52: (duration)
+  50: (duration)
     0: setLineJoin("")
       swizzleTypes: [String]
       trace:
@@ -723,7 +697,7 @@ frames:
         0: setLineJoin
         1: (anonymous function)
         2: executeFrameFunction
-  53: (duration)
+  51: (duration)
     0: setLineWidth(null)
       swizzleTypes: [Number]
       trace:
@@ -736,7 +710,7 @@ frames:
         0: setLineWidth
         1: (anonymous function)
         2: executeFrameFunction
-  54: (duration)
+  52: (duration)
     0: setMiterLimit(null)
       swizzleTypes: [Number]
       trace:
@@ -749,7 +723,7 @@ frames:
         0: setMiterLimit
         1: (anonymous function)
         2: executeFrameFunction
-  55: (duration)
+  53: (duration)
     0: setShadow(1, 2, 3, "")
       swizzleTypes: [Number, Number, Number, String]
       trace:
@@ -786,7 +760,7 @@ frames:
         0: setShadow
         1: (anonymous function)
         2: executeFrameFunction
-  56: (duration)
+  54: (duration)
     0: setStrokeColor("testA")
       swizzleTypes: [String]
       trace:
@@ -817,7 +791,7 @@ frames:
         0: setStrokeColor
         1: (anonymous function)
         2: executeFrameFunction
-  57: (duration)
+  55: (duration)
     0: setTransform(1, 2, 3, 4, 5, 6)
       swizzleTypes: [Number, Number, Number, Number, Number, Number]
       trace:
@@ -840,7 +814,7 @@ frames:
         2: ignoreException
         3: (anonymous function)
         4: executeFrameFunction
-  58: (duration)
+  56: (duration)
     0: shadowBlur
       trace:
         0: (anonymous function)
@@ -850,7 +824,7 @@ frames:
       trace:
         0: (anonymous function)
         1: executeFrameFunction
-  59: (duration)
+  57: (duration)
     0: shadowColor
       trace:
         0: (anonymous function)
@@ -860,7 +834,7 @@ frames:
       trace:
         0: (anonymous function)
         1: executeFrameFunction
-  60: (duration)
+  58: (duration)
     0: shadowOffsetX
       trace:
         0: (anonymous function)
@@ -870,7 +844,7 @@ frames:
       trace:
         0: (anonymous function)
         1: executeFrameFunction
-  61: (duration)
+  59: (duration)
     0: shadowOffsetY
       trace:
         0: (anonymous function)
@@ -880,7 +854,7 @@ frames:
       trace:
         0: (anonymous function)
         1: executeFrameFunction
-  62: (duration)
+  60: (duration)
     0: stroke()
       trace:
         0: stroke
@@ -892,14 +866,14 @@ frames:
         0: stroke
         1: (anonymous function)
         2: executeFrameFunction
-  63: (duration)
+  61: (duration)
     0: strokeRect(1, 2, 3, 4)
       swizzleTypes: [Number, Number, Number, Number]
       trace:
         0: strokeRect
         1: (anonymous function)
         2: executeFrameFunction
-  64: (duration)
+  62: (duration)
     0: strokeStyle
       trace:
         0: (anonymous function)
@@ -924,7 +898,7 @@ frames:
       trace:
         0: (anonymous function)
         1: executeFrameFunction
-  65: (duration)
+  63: (duration)
     0: strokeText("testA", 1, 2)
       swizzleTypes: [String, Number, Number]
       trace:
@@ -937,31 +911,31 @@ frames:
         0: strokeText
         1: (anonymous function)
         2: executeFrameFunction
-  66: (duration)
+  64: (duration)
     0: textAlign
       trace:
         0: (anonymous function)
         1: executeFrameFunction
-  67: (duration)
+  65: (duration)
     0: textBaseline
       trace:
         0: (anonymous function)
         1: executeFrameFunction
-  68: (duration)
+  66: (duration)
     0: transform(1, 2, 3, 4, 5, 6)
       swizzleTypes: [Number, Number, Number, Number, Number, Number]
       trace:
         0: transform
         1: (anonymous function)
         2: executeFrameFunction
-  69: (duration)
+  67: (duration)
     0: translate(1, 2)
       swizzleTypes: [Number, Number]
       trace:
         0: translate
         1: (anonymous function)
         2: executeFrameFunction
-  70: (duration)
+  68: (duration)
     0: webkitLineDash
       trace:
         0: (anonymous function)
@@ -971,7 +945,7 @@ frames:
       trace:
         0: (anonymous function)
         1: executeFrameFunction
-  71: (duration)
+  69: (duration)
     0: webkitLineDashOffset
       trace:
         0: (anonymous function)
@@ -981,7 +955,7 @@ frames:
       trace:
         0: (anonymous function)
         1: executeFrameFunction
-  72: (duration)
+  70: (duration)
     0: width
       trace:
         0: (anonymous function)
@@ -991,7 +965,7 @@ frames:
       trace:
         0: (anonymous function)
         1: executeFrameFunction
-  73: (duration)
+  71: (duration)
     0: height
       trace:
         0: (anonymous function)
@@ -1001,7 +975,7 @@ frames:
       trace:
         0: (anonymous function)
         1: executeFrameFunction
-  74: (duration)
+  72: (duration)
     0: roundRect(0, 0, 50, 50, 42)
       swizzleTypes: [Number, Number, Number, Number, Number]
       trace:

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.idl
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.idl
@@ -40,10 +40,6 @@ enum RenderingMode {
 
     CanvasRenderingContext2DSettings getContextAttributes();
 
-    // Non-standard legacy aliases (Compositing).
-    [ImplementedAs=setGlobalAlpha] undefined setAlpha(optional unrestricted float alpha = NaN);
-    [ImplementedAs=setGlobalCompositeOperation] undefined setCompositeOperation(optional DOMString compositeOperation);
-
     // Non-standard functionality (CanvasDrawImage).
     undefined drawImageFromRect(HTMLImageElement image,
         optional unrestricted float sx = 0, optional unrestricted float sy = 0, optional unrestricted float sw = 0, optional unrestricted float sh = 0,


### PR DESCRIPTION
#### 354bf3ed2753c2ae542846d977414e160aa0d29b
<pre>
Remove non-standard legacy alias of Canvas Compositing (setCompositeOperation &amp; setAlpha)
<a href="https://bugs.webkit.org/show_bug.cgi?id=284712">https://bugs.webkit.org/show_bug.cgi?id=284712</a>
<a href="https://rdar.apple.com/141510218">rdar://141510218</a>

Reviewed by Tim Nguyen.

This patch is to align WebKit with Gecko / Firefox and Blink / Chromium.

We have our current implementation based on standards while marked as
alias for these legacy , this patch aims to get rid of legacy aliases
of `setCompositeOperation` and `setAlpha`.

Blink removed these as well in 2014 in below commit:

Commit: <a href="https://github.com/chromium/chromium/commit/ce07cefc396fdf4016e731b4e75592586785c6b0">https://github.com/chromium/chromium/commit/ce07cefc396fdf4016e731b4e75592586785c6b0</a>

From MDN data, Safari / WebKit has supported standard alternatives since Safari 2,
so this is about time to try to get rid of non-standard legacy ones.

* Source/WebCore/html/canvas/CanvasRenderingContext2D.idl:
* LayoutTests/inspector/canvas/recording-2d-full-expected.txt:

Canonical link: <a href="https://commits.webkit.org/287871@main">https://commits.webkit.org/287871@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca86275ced638f36faaa57cc02d4e136ebfc7c15

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81125 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/650 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35068 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85654 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32111 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83235 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/668 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8457 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63334 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21099 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84194 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/423 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73832 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43632 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/320 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27994 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30569 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71849 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28554 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87089 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8355 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5918 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71637 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8533 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69667 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70872 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17652 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14916 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13840 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8316 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13839 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8153 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11673 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9961 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->