### PR TITLE
Unskip `html/interaction/focus` WPT tests

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -777,12 +777,8 @@ imported/w3c/web-platform-tests/html/browsers/the-window-object/navigate-to-abou
 imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/canvas-createImageBitmap-resize.html [ Skip ]
 imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1251.html [ Skip ]
 imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1252.html [ Skip ]
-imported/w3c/web-platform-tests/html/interaction/focus/focus-01.html [ Skip ]
-imported/w3c/web-platform-tests/html/interaction/focus/focus-02.html [ Skip ]
-imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-negative.html [ Skip ]
+# Below test can be progressed if we add `TabsToLinks` as 'true'.
 imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-order.html [ Skip ]
-imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-positive.html [ Skip ]
-imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-zero.html [ Skip ]
 imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content-rendering-rules/audio-controls-001.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/playing-the-media-resource/loop-from-ended.tentative.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/src_object_blob.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/focus-01-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/focus-01-expected.txt
@@ -1,7 +1,5 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT The keydown event must be targeted at the input element Test timed out
-NOTRUN The keypress event must be targeted at the input element
-NOTRUN The keyup event must be targeted at the input element
+PASS The keydown event must be targeted at the input element
+PASS The keypress event must be targeted at the input element
+PASS The keyup event must be targeted at the input element
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/focus-02-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/focus-02-expected.txt
@@ -1,8 +1,5 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: element send_keys intercepted error
 
-Harness Error (FAIL), message = element send_keys intercepted error
-
-TIMEOUT The keydown event must be targeted at the body element Test timed out
-NOTRUN The keypress event must be targeted at the body element
-NOTRUN The keyup event must be targeted at the body element
+PASS The keydown event must be targeted at the body element
+PASS The keypress event must be targeted at the body element
+PASS The keyup event must be targeted at the body element
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-negative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-negative-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT The element with a negative tabindex must not be focused by press 'Tab' key Test timed out
+PASS The element with a negative tabindex must not be focused by press 'Tab' key
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-order-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-order-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Elements with different tabindex must be focused sequentially when pressing 'Tab' keys Test timed out
-tabindex(omitted)  tabindex(empty)  tabindex(a)  tabindex(-1)  tabindex(0)  tabindex(3)  tabindex(2)  tabindex(2) tabindex(2)  tabindex(1)
+PASS Elements with different tabindex must be focused sequentially when pressing 'Tab' keys
+tabindex(omitted)  tabindex(empty)  tabindex(a)  tabindex(-1)  tabindex(0)  tabindex(3)  tabindex(2)  tabindex(2)  tabindex(2) tabindex(1)

--- a/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-positive-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-positive-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT The element with a positive tabindex must be focused by press 'Tab' key Test timed out
+PASS The element with a positive tabindex must be focused by press 'Tab' key
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-zero-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-zero-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT The element with a zero tabindex must be focused by press 'Tab' key Test timed out
+PASS The element with a zero tabindex must be focused by press 'Tab' key
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2731,6 +2731,9 @@ imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/ [ Pa
 imported/w3c/web-platform-tests/fetch/metadata/preload.https.sub.html [ Skip ]
 imported/w3c/web-platform-tests/fetch/metadata/window-open.https.sub.html [ Skip ]
 
+# This test times out only in mac-wk1, WPE and GTK.
+imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-order.html [ Skip ]
+
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of WPT-related bugs
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7669,3 +7669,11 @@ webkit.org/b/284419 imported/w3c/web-platform-tests/html/rendering/the-details-e
 webkit.org/b/284653 http/tests/site-isolation/compositing/iframes/resize-from-zero-size.html [ Pass Failure ]
 
 webkit.org/b/284761 imported/w3c/web-platform-tests/screen-orientation/orientation-reading.html [ Skip ]
+
+# Following test fails due to lack of `tabbing` to move focus
+imported/w3c/web-platform-tests/html/interaction/focus/focus-01.html [ Skip ]
+imported/w3c/web-platform-tests/html/interaction/focus/focus-02.html [ Skip ]
+imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-negative.html [ Skip ]
+imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-order.html [ Skip ]
+imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-positive.html [ Skip ]
+imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-zero.html [ Skip ]

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2362,6 +2362,7 @@ webkit.org/b/228801 [ Release ] media/video-page-visibility-restriction.html [ P
 webkit.org/b/230071 media/video-preload.html [ Pass Failure ]
 
 webkit.org/b/232276 imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/spin-by-blocking-style-sheet.html [ Pass Failure ]
+imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-order.html [ Skip ]
 
 imported/w3c/web-platform-tests/mathml/presentation-markup/operators/operator-dictionary-arabic-002.html [ ImageOnlyFailure ]
 


### PR DESCRIPTION
#### 1d5509d81ba8cfb4a2583c53833209214a77dd3e
<pre>
Unskip `html/interaction/focus` WPT tests

<a href="https://bugs.webkit.org/show_bug.cgi?id=284714">https://bugs.webkit.org/show_bug.cgi?id=284714</a>
<a href="https://rdar.apple.com/141511153">rdar://141511153</a>

Reviewed by Tim Nguyen.

These tests were skipped despite majority of them are passing on WPT, only test which
was failing was `focus-tabindex-order.html` and it was timing out without adding `tabsToLink`
value. It is still kept as `Skip` and we will add &apos;local&apos; copy with necessary changes to
track for any regressions.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/focus-01-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/focus-02-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-negative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-order-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-positive-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-zero-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/287954@main">https://commits.webkit.org/287954@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/796c218365777bdae1f0419c4762dd5093fc816a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81374 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/899 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35317 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85903 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32360 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/917 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8717 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63514 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21268 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84443 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/623 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74057 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43809 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/518 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28221 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30818 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72006 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28805 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87338 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8604 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6115 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71826 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8785 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69878 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71062 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17708 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15122 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14028 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8566 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8402 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11923 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10210 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->