### PR TITLE
[SwiftUI] Find-in-Page integration (iOS)

### DIFF
--- a/Source/WebKit/UIProcess/API/Swift/View+WebViewModifiers.swift
+++ b/Source/WebKit/UIProcess/API/Swift/View+WebViewModifiers.swift
@@ -36,6 +36,8 @@ extension EnvironmentValues {
     @Entry var webViewAllowsTextInteraction = true
 
     @Entry var webViewAllowsElementFullscreen = false
+
+    @Entry var webViewFindContext: FindContext = .init()
 }
 
 extension View {
@@ -63,6 +65,27 @@ extension View {
     public func webViewAllowsElementFullscreen(_ value: Bool = true) -> some View {
         environment(\.webViewAllowsElementFullscreen, value)
     }
+
+    @_spi(Private)
+    public func webViewFindNavigator(isPresented: Binding<Bool>) -> some View {
+        environment(\.webViewFindContext, .init(isPresented: isPresented))
+    }
+
+    @_spi(Private)
+    public func webViewFindDisabled(_ isDisabled: Bool = true) -> some View {
+        transformEnvironment(\.webViewFindContext) { $0.canFind = !isDisabled }
+    }
+
+    @_spi(Private)
+    public func webViewReplaceDisabled(_ isDisabled: Bool = true) -> some View {
+        transformEnvironment(\.webViewFindContext) { $0.canReplace = !isDisabled }
+    }
+}
+
+struct FindContext {
+    var isPresented: Binding<Bool>?
+    var canFind = true
+    var canReplace = true
 }
 
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/Foundation+Extras.swift
+++ b/Source/WebKit/UIProcess/Cocoa/Foundation+Extras.swift
@@ -1,0 +1,37 @@
+// Copyright (C) 2024 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE_SWIFTUI && compiler(>=6.0)
+
+import Foundation
+
+@MainActor
+func onNextMainRunLoop(do body: @escaping @MainActor () -> Void) {
+    RunLoop.main.perform(inModes: [.common]) {
+        MainActor.assumeIsolated {
+            body()
+        }
+    }
+}
+
+#endif

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -138,6 +138,7 @@
 		029D6BB42C407AA30068CF99 /* JSWebExtensionAPISidePanel.h in Headers */ = {isa = PBXBuildFile; fileRef = 029D6BAF2C407AA30068CF99 /* JSWebExtensionAPISidePanel.h */; };
 		0701789E23BE9CFC005F0FAA /* RemoteMediaPlayerMIMETypeCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0701789B23BAE261005F0FAA /* RemoteMediaPlayerMIMETypeCache.cpp */; };
 		0712654928EE06F800AE69D7 /* WebChromeClientCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0712654728EE06F800AE69D7 /* WebChromeClientCocoa.mm */; };
+		0718F0C12D19046F0060C030 /* Foundation+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 073EFBB72D0F448500FAE7CF /* Foundation+Extras.swift */; };
 		071BC59023CE1EAA00680D7C /* RemoteMediaPlayerProxyMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 071BC58D23CE1EAA00680D7C /* RemoteMediaPlayerProxyMessages.h */; };
 		07297F9F1C17BBEA003F0735 /* UserMediaPermissionCheckProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 07297F9D1C17BBEA003F0735 /* UserMediaPermissionCheckProxy.h */; };
 		07297F9F1C17BBEA015F0735 /* DeviceIdHashSaltStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 07297F9D1C17BBEA223F0735 /* DeviceIdHashSaltStorage.h */; };
@@ -3069,6 +3070,7 @@
 		0736B75C260D4A4E00E06994 /* RemoteMediaSessionCoordinatorProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteMediaSessionCoordinatorProxy.cpp; sourceTree = "<group>"; };
 		0736B75D260D4A4F00E06994 /* RemoteMediaSessionCoordinatorProxy.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteMediaSessionCoordinatorProxy.messages.in; sourceTree = "<group>"; };
 		0736B75E260D4A5000E06994 /* RemoteMediaSessionCoordinatorProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteMediaSessionCoordinatorProxy.h; sourceTree = "<group>"; };
+		073EFBB72D0F448500FAE7CF /* Foundation+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Foundation+Extras.swift"; sourceTree = "<group>"; };
 		0744720525E5BD020054B231 /* MediaOverridesForTesting.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaOverridesForTesting.h; sourceTree = "<group>"; };
 		0744DA532CE05F9500AACC81 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		0744DA542CE05FE400AACC81 /* WebKitInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebKitInternal.h; sourceTree = "<group>"; };
@@ -9595,6 +9597,7 @@
 				A1AE0EC22B1663D4008A2563 /* ExtensionCapabilityGranter.mm */,
 				00B9661818E25AE100CE1F88 /* FindClient.h */,
 				00B9661718E25AE100CE1F88 /* FindClient.mm */,
+				073EFBB72D0F448500FAE7CF /* Foundation+Extras.swift */,
 				CD78E1131DB7D7ED0014A2DE /* FullscreenClient.h */,
 				CD78E1121DB7D7ED0014A2DE /* FullscreenClient.mm */,
 				2E2B3BA421D4879000538EDF /* GlobalFindInPageState.h */,
@@ -19702,6 +19705,7 @@
 				CDCDC99E248FE8DA00A69522 /* EndowmentStateTracker.mm in Sources */,
 				E31586CE2AD610F30062ED2A /* ExtensionEventHandler.mm in Sources */,
 				E34DAD392B753FA700FABEE2 /* ExtensionProcess.mm in Sources */,
+				0718F0C12D19046F0060C030 /* Foundation+Extras.swift in Sources */,
 				CDA93DB122F8BCF400490A69 /* FullscreenTouchSecheuristicParameters.cpp in Sources */,
 				86760A6B28DB30DE00D07D06 /* GeneratedSerializers.mm in Sources */,
 				522F792A28D50EC60069B45B /* HidConnection.mm in Sources */,

--- a/Tools/SwiftBrowser/Source/ContentView.swift
+++ b/Tools/SwiftBrowser/Source/ContentView.swift
@@ -117,6 +117,8 @@ fileprivate struct DialogMessageView: View {
 struct ContentView: View {
     @Binding var url: URL?
 
+    @State private var findNavigatorIsPresented = false
+
     @AppStorage(AppStorageKeys.homepage) private var homepage = "https://www.webkit.org"
 
     @Environment(BrowserViewModel.self) private var viewModel
@@ -135,6 +137,7 @@ struct ContentView: View {
                 .webViewAllowsBackForwardNavigationGestures()
                 .webViewAllowsTabFocusingLinks()
                 .webViewAllowsElementFullscreen()
+                .webViewFindNavigator(isPresented: $findNavigatorIsPresented)
                 .task {
                     for await event in viewModel.page.navigations {
                         viewModel.didReceiveNavigationEvent(event)
@@ -175,6 +178,16 @@ struct ContentView: View {
                         ) {
                             viewModel.page.load(backForwardItem: $0)
                         }
+
+                        Spacer()
+
+                        Button {
+                            findNavigatorIsPresented.toggle()
+                        } label: {
+                            Label("Find", systemImage: "magnifyingglass")
+                                .labelStyle(.iconOnly)
+                        }
+                        .keyboardShortcut("f")
                     }
                     
                     ToolbarItemGroup(placement: .principal) {


### PR DESCRIPTION
#### 31f53890413ab604b438db03c40f219b25f3ced1
<pre>
[SwiftUI] Find-in-Page integration (iOS)
<a href="https://bugs.webkit.org/show_bug.cgi?id=284715">https://bugs.webkit.org/show_bug.cgi?id=284715</a>
<a href="https://rdar.apple.com/141503364">rdar://141503364</a>

Reviewed by Wenson Hsieh.

Add support to enable &quot;Find in Page&quot; integration, on iOS only for now due to the many platform differences
between UIKit and AppKit.

* Source/WebKit/UIProcess/API/Swift/View+WebViewModifiers.swift:
(EnvironmentValues.webViewFindContext):
(View.webViewFindNavigator(_:)):
(View.webViewFindDisabled(_:)):
(View.webViewReplaceDisabled(_:)):
(FindContext.isPresented):

Add several view modifiers which correspond to their native SwiftUI counterparts. The main modifier is
`webViewFindNavigator` which actually presents the find navigator when the binding value is true. The
`webViewFindDisabled` and `webViewReplaceDisabled` modifiers are used to control specific functionality
of the find navigator.

* Source/WebKit/UIProcess/API/Swift/WebPage.swift:
(WebPageWebView.delegate):
(WebPageWebView.findInteraction(_:didBegin:)):
(WebPageWebView.findInteraction(_:didEnd:)):
(WebPageWebView.supportsTextReplacement):
(Delegate.findInteraction(_:didBegin:)):
(Delegate.findInteraction(_:didEnd:)):
(Delegate.supportsTextReplacement):

Add a delegate protocol to override and propogate some find interaction methods from WKWebView to WebView.

* Source/WebKit/UIProcess/API/Swift/WebView.swift:
(WebViewWrapper.findContext):
(WebViewWrapper.webView):
(WebViewWrapper.findInteraction(_:didBegin:)):
(WebViewWrapper.findInteraction(_:didEnd:)):
(WebViewWrapper.supportsTextReplacement):

Update the environment state&apos;s find context when the delegate methods are called.

(WebViewRepresentable.updatePlatformView(_:context:)):
(WebViewRepresentable.makeCoordinator):
(WebViewCoordinator.configuration):
(WebViewCoordinator.update(_:configuration:environment:)):
(WebViewCoordinator.updateFindInteraction(_:environment:)):

Present or dismiss the find navigator according to the find context state.

* Source/WebKit/UIProcess/Cocoa/Foundation+Extras.swift: Copied from Source/WebKit/UIProcess/API/Swift/View+WebViewModifiers.swift.
(onNextMainRunLoop(do:)):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

* Tools/SwiftBrowser/Source/ContentView.swift:
(ContentView.body):

Update SwiftBrowser to use this new functionality.

Canonical link: <a href="https://commits.webkit.org/288243@main">https://commits.webkit.org/288243@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2cb05392ae1875e95cb69d6a8cabcdea2a1af8dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82224 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1888 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36283 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87356 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33285 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84329 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1959 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9768 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64081 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21825 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85293 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/1354 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74812 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44359 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1254 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28994 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32326 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29615 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88712 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9530 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6788 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/72472 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9756 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70627 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71690 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15823 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/14847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12758 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9483 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/14969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9357 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12823 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11126 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->