### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE use in WebCore/contentextensions/

### DIFF
--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -828,7 +828,7 @@ std::span<uint8_t, Extent == std::dynamic_extent ? std::dynamic_extent: Extent *
 }
 
 template<typename T>
-std::span<const T> singleElementSpan(const T& object)
+std::span<T> singleElementSpan(T& object)
 {
     return unsafeMakeSpan(std::addressof(object), 1);
 }

--- a/Source/WebCore/contentextensions/ContentExtensionStringSerialization.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionStringSerialization.cpp
@@ -28,13 +28,13 @@
 
 #if ENABLE(CONTENT_EXTENSIONS)
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+#include <wtf/StdLibExtras.h>
 
 namespace WebCore::ContentExtensions {
 
 String deserializeString(std::span<const uint8_t> span)
 {
-    auto serializedLength = *reinterpret_cast<const uint32_t*>(span.data());
+    auto serializedLength = stringSerializedLength(span);
     return String::fromUTF8(span.subspan(sizeof(uint32_t), serializedLength - sizeof(uint32_t)));
 }
 
@@ -43,17 +43,15 @@ void serializeString(Vector<uint8_t>& actions, const String& string)
     auto utf8 = string.utf8();
     uint32_t serializedLength = sizeof(uint32_t) + utf8.length();
     actions.reserveCapacity(actions.size() + serializedLength);
-    actions.append(std::span { reinterpret_cast<const uint8_t*>(&serializedLength), sizeof(serializedLength) });
+    actions.append(asByteSpan(serializedLength));
     actions.append(utf8.span());
 }
 
 size_t stringSerializedLength(std::span<const uint8_t> span)
 {
-    return *reinterpret_cast<const uint32_t*>(span.data());
+    return reinterpretCastSpanStartTo<const uint32_t>(span);
 }
 
 } // namespace WebCore::ContentExtensions
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(CONTENT_EXTENSIONS)

--- a/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
@@ -53,8 +53,6 @@
 #include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore::ContentExtensions {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ContentExtensionsBackend);
@@ -434,7 +432,5 @@ void applyResultsToRequest(ContentRuleListResults&& results, Page* page, Resourc
 }
     
 } // namespace WebCore::ContentExtensions
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(CONTENT_EXTENSIONS)

--- a/Source/WebCore/contentextensions/DFABytecodeCompiler.cpp
+++ b/Source/WebCore/contentextensions/DFABytecodeCompiler.cpp
@@ -33,8 +33,6 @@
 #include "DFANode.h"
 #include <wtf/StdLibExtras.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore::ContentExtensions {
 
 template <typename IntType>
@@ -570,7 +568,5 @@ void DFABytecodeCompiler::compile()
 }
 
 } // namespace WebCore::ContentExtensions
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(CONTENT_EXTENSIONS)

--- a/Source/WebCore/contentextensions/DFABytecodeInterpreter.cpp
+++ b/Source/WebCore/contentextensions/DFABytecodeInterpreter.cpp
@@ -27,19 +27,17 @@
 #include "DFABytecodeInterpreter.h"
 
 #include "ContentExtensionsDebugging.h"
+#include <wtf/StdLibExtras.h>
 #include <wtf/text/CString.h>
 
 #if ENABLE(CONTENT_EXTENSIONS)
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore::ContentExtensions {
 
 template <typename IntType>
 static IntType getBits(std::span<const uint8_t> bytecode, uint32_t index)
 {
-    ASSERT(index + sizeof(IntType) <= bytecode.size());
-    return *reinterpret_cast<const IntType*>(bytecode.data() + index);
+    return reinterpretCastSpanStartTo<const IntType>(bytecode.subspan(index));
 }
 
 static uint32_t get24BitsUnsigned(std::span<const uint8_t> bytecode, uint32_t index)
@@ -407,7 +405,5 @@ auto DFABytecodeInterpreter::interpret(const String& urlString, ResourceFlags fl
 }
 
 } // namespace WebCore::ContentExtensions
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(CONTENT_EXTENSIONS)

--- a/Source/WebCore/contentextensions/SerializedNFA.cpp
+++ b/Source/WebCore/contentextensions/SerializedNFA.cpp
@@ -30,23 +30,18 @@
 
 #if ENABLE(CONTENT_EXTENSIONS)
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 namespace ContentExtensions {
 
 template<typename T>
 bool writeAllToFile(FileSystem::PlatformFileHandle file, const T& container)
 {
-    auto bytes = reinterpret_cast<const uint8_t*>(container.data());
-    size_t bytesLength = container.size() * sizeof(container[0]);
-    auto end = bytes + bytesLength;
-    while (bytes < end) {
-        auto written = FileSystem::writeToFile(file, { bytes, bytesLength });
+    auto bytes = spanReinterpretCast<const uint8_t>(container.span());
+    while (!bytes.empty()) {
+        auto written = FileSystem::writeToFile(file, bytes);
         if (written == -1)
             return false;
-        bytes += written;
-        bytesLength -= written;
+        bytes = bytes.subspan(written);
     }
     return true;
 }
@@ -106,39 +101,37 @@ SerializedNFA::SerializedNFA(FileSystem::MappedFileData&& file, Metadata&& metad
 }
 
 template<typename T>
-const T* SerializedNFA::pointerAtOffsetInFile(size_t offset) const
+std::span<const T> SerializedNFA::spanAtOffsetInFile(size_t offset, size_t length) const
 {
-    return reinterpret_cast<const T*>(m_file.span().subspan(offset).data());
+    return spanReinterpretCast<const T>(m_file.span().subspan(offset).first(length * sizeof(T)));
 }
 
 auto SerializedNFA::nodes() const -> const Range<ImmutableNFANode>
 {
-    return { pointerAtOffsetInFile<ImmutableNFANode>(m_metadata.nodesOffset), m_metadata.nodesSize };
+    return spanAtOffsetInFile<ImmutableNFANode>(m_metadata.nodesOffset, m_metadata.nodesSize);
 }
 
 auto SerializedNFA::transitions() const -> const Range<ImmutableRange<char>>
 {
-    return { pointerAtOffsetInFile<ImmutableRange<char>>(m_metadata.transitionsOffset), m_metadata.transitionsSize };
+    return spanAtOffsetInFile<ImmutableRange<char>>(m_metadata.transitionsOffset, m_metadata.transitionsSize);
 }
 
 auto SerializedNFA::targets() const -> const Range<uint32_t>
 {
-    return { pointerAtOffsetInFile<uint32_t>(m_metadata.targetsOffset), m_metadata.targetsSize };
+    return spanAtOffsetInFile<uint32_t>(m_metadata.targetsOffset, m_metadata.targetsSize);
 }
 
 auto SerializedNFA::epsilonTransitionsTargets() const -> const Range<uint32_t>
 {
-    return { pointerAtOffsetInFile<uint32_t>(m_metadata.epsilonTransitionsTargetsOffset), m_metadata.epsilonTransitionsTargetsSize };
+    return spanAtOffsetInFile<uint32_t>(m_metadata.epsilonTransitionsTargetsOffset, m_metadata.epsilonTransitionsTargetsSize);
 }
 
 auto SerializedNFA::actions() const -> const Range<uint64_t>
 {
-    return { pointerAtOffsetInFile<uint64_t>(m_metadata.actionsOffset), m_metadata.actionsSize };
+    return spanAtOffsetInFile<uint64_t>(m_metadata.actionsOffset, m_metadata.actionsSize);
 }
 
 } // namespace ContentExtensions
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(CONTENT_EXTENSIONS)

--- a/Source/WebCore/contentextensions/SerializedNFA.h
+++ b/Source/WebCore/contentextensions/SerializedNFA.h
@@ -29,8 +29,7 @@
 
 #include "ImmutableNFA.h"
 #include <wtf/FileSystem.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+#include <wtf/StdLibExtras.h>
 
 namespace WebCore {
 namespace ContentExtensions {
@@ -45,27 +44,21 @@ public:
     template<typename T>
     class Range {
     public:
-        Range(const T* begin, size_t size)
-            : m_begin(begin)
-            , m_size(size) { }
-        const T* begin() const { return m_begin; }
-        const T* end() const { return m_begin + m_size; }
-        size_t size() const { return m_size; }
-        const T* pointerAt(size_t i) const
-        {
-            RELEASE_ASSERT(i < m_size);
-            return begin() + i;
-        }
+        Range(std::span<const T> span)
+            : m_span(span)
+        { }
+        const T* begin() const { return std::to_address(m_span.begin()); }
+        const T* end() const { return std::to_address(m_span.end()); }
+        size_t size() const { return m_span.size(); }
+        const T* pointerAt(size_t i) const { return &m_span[i]; }
         T valueAt(size_t i) const
         {
-            RELEASE_ASSERT(i < m_size);
             T value;
-            memcpy(&value, begin() + i, sizeof(T));
+            memcpySpan(singleElementSpan(value), m_span.subspan(i, 1));
             return value;
         }
     private:
-        const T* m_begin { nullptr };
-        size_t m_size { 0 };
+        std::span<const T> m_span;
     };
 
     const Range<ImmutableNFANode> nodes() const;
@@ -188,7 +181,7 @@ private:
     SerializedNFA(FileSystem::MappedFileData&&, Metadata&&);
 
     template<typename T>
-    const T* pointerAtOffsetInFile(size_t) const;
+    std::span<const T> spanAtOffsetInFile(size_t offset, size_t length) const;
     
     FileSystem::MappedFileData m_file;
     Metadata m_metadata;
@@ -196,7 +189,5 @@ private:
 
 } // namespace ContentExtensions
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(CONTENT_EXTENSIONS)


### PR DESCRIPTION
#### aae95f124a39e3a8041e923d2454157cc8c81511
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE use in WebCore/contentextensions/
<a href="https://bugs.webkit.org/show_bug.cgi?id=284722">https://bugs.webkit.org/show_bug.cgi?id=284722</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/StdLibExtras.h:
(WTF::singleElementSpan):
* Source/WebCore/contentextensions/ContentExtensionActions.cpp:
(WebCore::ContentExtensions::append):
(WebCore::ContentExtensions::deserializeLength):
(WebCore::ContentExtensions::writeLengthToVectorAtOffset):
* Source/WebCore/contentextensions/ContentExtensionStringSerialization.cpp:
(WebCore::ContentExtensions::deserializeString):
(WebCore::ContentExtensions::serializeString):
(WebCore::ContentExtensions::stringSerializedLength):
* Source/WebCore/contentextensions/ContentExtensionsBackend.cpp:
* Source/WebCore/contentextensions/DFABytecodeCompiler.cpp:
* Source/WebCore/contentextensions/DFABytecodeInterpreter.cpp:
(WebCore::ContentExtensions::getBits):
* Source/WebCore/contentextensions/NFAToDFA.cpp:
(WebCore::ContentExtensions::UniqueNodeIdSetImpl::buffer):
(WebCore::ContentExtensions::UniqueNodeIdSetImpl::buffer const):
(WebCore::ContentExtensions::UniqueNodeIdSet::UniqueNodeIdSet):
(WebCore::ContentExtensions::UniqueNodeIdSet::operator== const):
(WebCore::ContentExtensions::createCombinedTransition):
* Source/WebCore/contentextensions/SerializedNFA.cpp:
(WebCore::ContentExtensions::writeAllToFile):
(WebCore::ContentExtensions::SerializedNFA::spanAtOffsetInFile const):
(WebCore::ContentExtensions::SerializedNFA::nodes const const):
(WebCore::ContentExtensions::SerializedNFA::transitions const const):
(WebCore::ContentExtensions::SerializedNFA::targets const const):
(WebCore::ContentExtensions::SerializedNFA::epsilonTransitionsTargets const const):
(WebCore::ContentExtensions::SerializedNFA::actions const const):
(WebCore::ContentExtensions::SerializedNFA::pointerAtOffsetInFile const): Deleted.
* Source/WebCore/contentextensions/SerializedNFA.h:
(WebCore::ContentExtensions::SerializedNFA::Range::Range):
(WebCore::ContentExtensions::SerializedNFA::Range::begin const):
(WebCore::ContentExtensions::SerializedNFA::Range::end const):
(WebCore::ContentExtensions::SerializedNFA::Range::size const):
(WebCore::ContentExtensions::SerializedNFA::Range::pointerAt const):
(WebCore::ContentExtensions::SerializedNFA::Range::valueAt const):

Canonical link: <a href="https://commits.webkit.org/287864@main">https://commits.webkit.org/287864@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3fb00c4388e7c7cacdebe015416e54231026cfeb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81160 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/685 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35103 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85689 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32146 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83270 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/703 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8495 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63364 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21132 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84229 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/453 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73865 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43662 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/350 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28027 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30604 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/74139 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71873 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28592 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87124 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/80218 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8390 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5952 "Found 9 new test failures: compositing/tiling/tiled-reflection-inwindow.html fast/forms/color/color-input-reset-crash.html fast/forms/color/color-type-change-on-input-crash.html fast/forms/color/input-color-readonly.html http/tests/navigation/page-cache-pending-ping-load-same-origin.html imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/show-picker-user-gesture.html imported/w3c/web-platform-tests/html/syntax/parsing/html5lib_tests16.html?run_type=uri media/non-existent-video-playback-interrupted.html tiled-drawing/tiled-drawing-scroll-position-page-cache-restoration.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71669 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8569 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69700 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70904 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14949 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13871 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/102625 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12577 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8351 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13875 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/24934 "Found 2 new JSC stress test failures: wasm.yaml/wasm/stress/struct-new_default-small-members.js.wasm-no-cjit, wasm.yaml/wasm/stress/struct-new_default-small-members.js.wasm-slow-memory (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8188 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11708 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9996 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->