### PR TITLE
AX: Revert 287855@main, caused crashes in macOS debug tests

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h
@@ -40,12 +40,10 @@ class AXCoreObject;
     NakedPtr<WebKit::WebPage> m_page;
     Markable<WebCore::PageIdentifier> m_pageID;
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    Lock m_parentLock;
     Lock m_cacheLock;
     WebCore::FloatPoint m_position WTF_GUARDED_BY_LOCK(m_cacheLock);
     WebCore::IntSize m_size WTF_GUARDED_BY_LOCK(m_cacheLock);
     ThreadSafeWeakPtr<WebCore::AXCoreObject> m_isolatedTreeRoot;
-    RetainPtr<id> m_window;
 #endif
 
     WebCore::IntPoint m_remoteFrameOffset;
@@ -58,7 +56,6 @@ class AXCoreObject;
 - (void)setPosition:(const WebCore::FloatPoint&)point;
 - (void)setSize:(const WebCore::IntSize&)size;
 - (void)setIsolatedTreeRoot:(NakedPtr<WebCore::AXCoreObject>)root;
-- (void)setWindow:(id)window;
 #endif
 - (void)setRemoteParent:(id)parent;
 - (void)setRemoteFrameOffset:(WebCore::IntPoint)offset;

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
@@ -152,18 +152,6 @@ namespace ax = WebCore::Accessibility;
     ASSERT(isMainRunLoop());
     m_isolatedTreeRoot = root.get();
 }
-
-- (void)setWindow:(id)window
-{
-    ASSERT(window);
-    // We should only set the window once before the AX thread is created to avoid thread-safety issues.
-    // Otherwise, we could write m_window while the AX thread is reading it.
-    ASSERT(isMainRunLoop());
-    ASSERT(!m_window);
-    if (m_window)
-        return;
-    m_window = window;
-}
 #endif
 
 - (void)setHasMainFramePlugin:(bool)hasPlugin
@@ -186,10 +174,6 @@ namespace ax = WebCore::Accessibility;
 - (void)setRemoteParent:(id)parent
 {
     ASSERT(isMainRunLoop());
-
-#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    Locker lock { m_parentLock };
-#endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     m_parent = parent;
 }
 

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
@@ -159,23 +159,15 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (id)accessibilityAttributeValue:(NSString *)attribute
 ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
-    static std::atomic<bool> didInitialize { false };
-    static std::atomic<unsigned> screenHeight { 0 };
-    if (UNLIKELY(!didInitialize)) {
-        didInitialize = true;
-        callOnMainRunLoopAndWait([] {
-            if (!WebCore::AXObjectCache::accessibilityEnabled())
-                WebCore::AXObjectCache::enableAccessibility();
+    callOnMainRunLoopAndWait([] {
+        if (!WebCore::AXObjectCache::accessibilityEnabled())
+            WebCore::AXObjectCache::enableAccessibility();
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-            if (WebCore::AXObjectCache::isIsolatedTreeEnabled())
-                WebCore::AXObjectCache::initializeAXThreadIfNeeded();
-#endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-
-            float roundedHeight = std::round(WebCore::screenRectForPrimaryScreen().size().height());
-            screenHeight = std::max(0u, static_cast<unsigned>(roundedHeight));
-        });
-    }
+        if (WebCore::AXObjectCache::isIsolatedTreeEnabled())
+            WebCore::AXObjectCache::initializeAXThreadIfNeeded();
+#endif
+    });
 
     // The following attributes can be handled off the main thread.
 
@@ -200,19 +192,32 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return [self accessibilityChildren];
     }
 
-    if ([attribute isEqualToString:NSAccessibilityParentAttribute])
-        return [self accessibilityAttributeParentValue].get();
+    // The following attributes have to be retrieved from the main thread. Return nil for any other attribute.
+    if (![attribute isEqualToString:NSAccessibilityParentAttribute]
+        && ![attribute isEqualToString:NSAccessibilityWindowAttribute]
+        && ![attribute isEqualToString:NSAccessibilityTopLevelUIElementAttribute]
+        && ![attribute isEqualToString:NSAccessibilityPrimaryScreenHeightAttribute])
+        return nil;
 
-    if ([attribute isEqualToString:NSAccessibilityPrimaryScreenHeightAttribute])
-        return @(screenHeight.load());
+    return ax::retrieveAutoreleasedValueFromMainThread<id>([attribute = retainPtr(attribute), PROTECTED_SELF] () -> RetainPtr<id> {
+        if ([attribute isEqualToString:NSAccessibilityParentAttribute])
+            return protectedSelf->m_parent.get();
 
-    if ([attribute isEqualToString:NSAccessibilityWindowAttribute])
-        return [self accessibilityAttributeWindowValue].get();
+        if ([attribute isEqualToString:NSAccessibilityWindowAttribute])
+            return [protectedSelf->m_parent accessibilityAttributeValue:NSAccessibilityWindowAttribute];
 
-    if ([attribute isEqualToString:NSAccessibilityTopLevelUIElementAttribute])
-        return [self accessibilityAttributeTopLevelUIElementValue].get();
+        if ([attribute isEqualToString:NSAccessibilityTopLevelUIElementAttribute])
+            return [protectedSelf->m_parent accessibilityAttributeValue:NSAccessibilityTopLevelUIElementAttribute];
 
-    return nil;
+        // FIXME: do we need this check?
+        if (!protectedSelf->m_pageID)
+            return nil;
+
+        if ([attribute isEqualToString:NSAccessibilityPrimaryScreenHeightAttribute])
+            return @(WebCore::screenRectForPrimaryScreen().size().height());
+
+        return nil;
+    });
 }
 
 - (NSValue *)accessibilityAttributeSizeValue
@@ -222,9 +227,13 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         Locker lock { m_cacheLock };
         return [NSValue valueWithSize:(NSSize)m_size];
     }
-#endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+#endif
 
-    return m_page ? [NSValue valueWithSize:m_page->size()] : nil;
+    return ax::retrieveAutoreleasedValueFromMainThread<id>([PROTECTED_SELF] () -> RetainPtr<id> {
+        if (!protectedSelf->m_page)
+            return nil;
+        return [NSValue valueWithSize:(NSSize)protectedSelf->m_page->size()];
+    });
 }
 
 - (NSValue *)accessibilityAttributePositionValue
@@ -234,54 +243,13 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         Locker lock { m_cacheLock };
         return [NSValue valueWithPoint:(NSPoint)m_position];
     }
-#endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+#endif
 
-    return m_page ? [NSValue valueWithPoint:m_page->accessibilityPosition()] : nil;
-}
-
-- (RetainPtr<id>)accessibilityAttributeParentValue
-{
-#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    if (!isMainRunLoop()) {
-        Locker lock { m_parentLock };
-        return m_parent;
-    }
-#endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-
-    return m_parent;
-}
-
-// FIXME: accessibilityAttributeWindowValue and accessibilityAttributeTopLevelUIElementValue
-// always return nil for instances of this class when set up by WebPage::registerRemoteFrameAccessibilityTokens,
-// as nothing there sets m_window, setWindowUIElement, and setTopLevelUIElement.
-- (RetainPtr<id>)accessibilityAttributeWindowValue
-{
-#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    if (!isMainRunLoop()) {
-        // Use the cached window to avoid using m_parent (which is possibly an AppKit object) off the main-thread.
-        return m_window.get();
-    }
-#endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    return [m_parent accessibilityAttributeValue:NSAccessibilityWindowAttribute];
-    ALLOW_DEPRECATED_DECLARATIONS_END
-}
-
-- (RetainPtr<id>)accessibilityAttributeTopLevelUIElementValue
-{
-#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    if (!isMainRunLoop()) {
-        // Use the cached window to avoid using m_parent (which is possibly an AppKit object) off the main-thread.
-        // The TopLevelUIElement is the window, as we set it as such in WebPage::registerUIProcessAccessibilityTokens,
-        // so we can return m_window here.
-        return m_window.get();
-    }
-#endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    return [m_parent accessibilityAttributeValue:NSAccessibilityTopLevelUIElementAttribute];
-    ALLOW_DEPRECATED_DECLARATIONS_END
+    return ax::retrieveAutoreleasedValueFromMainThread<id>([PROTECTED_SELF] () -> RetainPtr<id> {
+        if (!protectedSelf->m_page)
+            return nil;
+        return [NSValue valueWithPoint:(NSPoint)protectedSelf->m_page->accessibilityPosition()];
+    });
 }
 
 - (id)accessibilityDataDetectorValue:(NSString *)attribute point:(WebCore::FloatPoint&)point

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -457,7 +457,7 @@ void WebPage::registerUIProcessAccessibilityTokens(std::span<const uint8_t> elem
 
     [remoteElement setWindowUIElement:remoteWindow.get()];
     [remoteElement setTopLevelUIElement:remoteWindow.get()];
-    [accessibilityRemoteObject() setWindow:remoteWindow.get()];
+
     [accessibilityRemoteObject() setRemoteParent:remoteElement.get()];
 }
 


### PR DESCRIPTION
#### cb2211aada671f08dc4f95014d8d667a6ba88370
<pre>
AX: Revert 287855@main, caused crashes in macOS debug tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=284727">https://bugs.webkit.org/show_bug.cgi?id=284727</a>
<a href="https://rdar.apple.com/141526825">rdar://141526825</a>

Unreviewed build fix.

* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h:
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm:
(-[WKAccessibilityWebPageObjectBase setIsolatedTreeRoot:]):
(-[WKAccessibilityWebPageObjectBase setRemoteParent:]):
(-[WKAccessibilityWebPageObjectBase setWindow:]): Deleted.
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm:
(-[WKAccessibilityWebPageObject accessibilityAttributeValue:]):
(-[WKAccessibilityWebPageObject accessibilityAttributeSizeValue]):
(-[WKAccessibilityWebPageObject accessibilityAttributePositionValue]):
(-[WKAccessibilityWebPageObject accessibilityAttributeParentValue]): Deleted.
(-[WKAccessibilityWebPageObject accessibilityAttributeWindowValue]): Deleted.
(-[WKAccessibilityWebPageObject accessibilityAttributeTopLevelUIElementValue]): Deleted.
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::registerUIProcessAccessibilityTokens):

Canonical link: <a href="https://commits.webkit.org/287865@main">https://commits.webkit.org/287865@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b2a19392702c47f2bd7444fb6d5572023d03f96

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81168 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/693 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35111 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85697 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32154 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/711 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8503 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63370 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21138 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84237 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/462 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73873 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43668 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/359 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30612 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71882 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/28600 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87132 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8398 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5961 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/71675 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8577 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69708 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70910 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14958 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/13879 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12578 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8359 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13883 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8196 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11716 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10004 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->