### PR TITLE
[iOS] Several drag and drop API tests are failing after 287851@main

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/dump-datatransfer-types.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/dump-datatransfer-types.html
@@ -125,6 +125,7 @@ function select(element) {
         element.setSelectionRange(0, element.value.length);
     else
         getSelection().setBaseAndExtent(element, 0, element, 1);
+    element.focus();
 }
 
 checkbox.addEventListener("change", () => window.writeCustomData = checkbox.checked);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/textarea-to-input.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/textarea-to-input.html
@@ -35,5 +35,6 @@
     editor.addEventListener("dragstart", postEventType);
     source.selectionStart = 0;
     source.selectionEnd = source.value.length;
+    source.focus();
     </script>
 </body>


### PR DESCRIPTION
#### 4241736760941ab557f8c72c799c952f99beaf9d
<pre>
[iOS] Several drag and drop API tests are failing after 287851@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=284728">https://bugs.webkit.org/show_bug.cgi?id=284728</a>

Reviewed by Abrar Rahman Protyasha.

After the changes in 287851@main, these tests need to explicitly `focus()` their respective text
fields (in addition to setting selection).

* Tools/TestWebKitAPI/Tests/WebKitCocoa/dump-datatransfer-types.html:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/textarea-to-input.html:

Canonical link: <a href="https://commits.webkit.org/287879@main">https://commits.webkit.org/287879@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2d4494692456f77baa4eb1f88ddc491fd54a0a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81175 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/700 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35118 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85704 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32161 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83285 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/718 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8510 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63377 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21142 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84244 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/468 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73879 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43675 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/365 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28041 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30619 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71887 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28607 "Found 1 new test failure: fast/attachment/cocoa/wide-attachment-rendering.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87139 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8405 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5966 "Found 9 new test failures: compositing/tiling/tiled-reflection-inwindow.html fast/forms/color/color-input-reset-crash.html fast/forms/color/color-type-change-on-input-crash.html fast/forms/color/input-color-readonly.html http/tests/navigation/page-cache-pending-ping-load-same-origin.html imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/show-picker-user-gesture.html imported/w3c/web-platform-tests/html/syntax/parsing/html5lib_tests16.html?run_type=uri media/non-existent-video-playback-interrupted.html tiled-drawing/tiled-drawing-scroll-position-page-cache-restoration.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71679 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/new-content-root-scrollbar-with-fixed-background.html imported/w3c/web-platform-tests/css/css-view-transitions/no-named-elements.html imported/w3c/web-platform-tests/css/css-view-transitions/root-to-shared-animation-end.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8584 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69714 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70914 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17658 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14963 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13885 "Found 1 new test failure: fast/attachment/cocoa/wide-attachment-rendering.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8366 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8203 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11723 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10011 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->