### PR TITLE
[Materials] Add rendering support for blur effects

### DIFF
--- a/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-chrome-expected.txt
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-chrome-expected.txt
@@ -1,0 +1,40 @@
+foo
+bar
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (children 2
+        (GraphicsLayer
+          (anchor 0.00 0.00)
+          (bounds 800.00 600.00)
+          (contentsOpaque 1)
+          (drawsContent 1)
+          (backgroundColor #FFFFFF)
+        )
+        (GraphicsLayer
+          (bounds 800.00 600.00)
+          (children 1
+            (GraphicsLayer
+              (position 8.00 26.00)
+              (bounds 200.00 200.00)
+              (drawsContent 1)
+              (appleVisualEffect blur-material-chrome)
+              (structural layer
+                (position 108.00 126.00)
+                (bounds 200.00 200.00)
+              )
+              (backdrop layer (material)
+                (position 0.00 0.00)
+                (bounds 200.00 200.00)
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-chrome.html
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-chrome.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html><!-- webkit-test-runner [ AppleSystemVisualEffectsEnabled=true ] -->
+<html>
+<head>
+<title>This tests that the chrome material works properly.</title>
+<style>
+
+body {
+    background: linear-gradient(red, blue) fixed;
+}
+
+.container {
+    width: 300px;
+    height: 300px;
+}
+.inner {
+    -apple-visual-effect: -apple-system-blur-material-chrome;
+    width: 200px;
+    height: 200px;
+}
+
+</style>
+<script>
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+function dumpLayers() {
+    if (window.internals)
+        document.getElementById('result').innerText = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_CONTENT_LAYERS)
+}
+window.addEventListener('load', dumpLayers, false);
+
+</script>
+</head>
+<body>
+<div class=container>foo<div class=inner>bar</div></div>
+<pre id=result></pre>
+</body>
+</html>

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-expected.txt
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-expected.txt
@@ -1,0 +1,40 @@
+foo
+bar
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (children 2
+        (GraphicsLayer
+          (anchor 0.00 0.00)
+          (bounds 800.00 600.00)
+          (contentsOpaque 1)
+          (drawsContent 1)
+          (backgroundColor #FFFFFF)
+        )
+        (GraphicsLayer
+          (bounds 800.00 600.00)
+          (children 1
+            (GraphicsLayer
+              (position 8.00 26.00)
+              (bounds 200.00 200.00)
+              (drawsContent 1)
+              (appleVisualEffect blur-material)
+              (structural layer
+                (position 108.00 126.00)
+                (bounds 200.00 200.00)
+              )
+              (backdrop layer (material)
+                (position 0.00 0.00)
+                (bounds 200.00 200.00)
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thick-expected.txt
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thick-expected.txt
@@ -1,0 +1,40 @@
+foo
+bar
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (children 2
+        (GraphicsLayer
+          (anchor 0.00 0.00)
+          (bounds 800.00 600.00)
+          (contentsOpaque 1)
+          (drawsContent 1)
+          (backgroundColor #FFFFFF)
+        )
+        (GraphicsLayer
+          (bounds 800.00 600.00)
+          (children 1
+            (GraphicsLayer
+              (position 8.00 26.00)
+              (bounds 200.00 200.00)
+              (drawsContent 1)
+              (appleVisualEffect blur-material-thick)
+              (structural layer
+                (position 108.00 126.00)
+                (bounds 200.00 200.00)
+              )
+              (backdrop layer (material)
+                (position 0.00 0.00)
+                (bounds 200.00 200.00)
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thick.html
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thick.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html><!-- webkit-test-runner [ AppleSystemVisualEffectsEnabled=true ] -->
+<html>
+<head>
+<title>This tests that the thick material works properly.</title>
+<style>
+
+body {
+    background: linear-gradient(red, blue) fixed;
+}
+
+.container {
+    width: 300px;
+    height: 300px;
+}
+
+.inner {
+    -apple-visual-effect: -apple-system-blur-material-thick;
+    width: 200px;
+    height: 200px;
+}
+
+</style>
+<script>
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+function dumpLayers() {
+    if (window.internals)
+        document.getElementById('result').innerText = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_CONTENT_LAYERS)
+}
+window.addEventListener('load', dumpLayers, false);
+
+</script>
+</head>
+<body>
+<div class=container>foo<div class=inner>bar</div></div>
+<pre id=result></pre>
+</body>
+</html>

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thin-expected.txt
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thin-expected.txt
@@ -1,0 +1,40 @@
+foo
+bar
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (children 2
+        (GraphicsLayer
+          (anchor 0.00 0.00)
+          (bounds 800.00 600.00)
+          (contentsOpaque 1)
+          (drawsContent 1)
+          (backgroundColor #FFFFFF)
+        )
+        (GraphicsLayer
+          (bounds 800.00 600.00)
+          (children 1
+            (GraphicsLayer
+              (position 8.00 26.00)
+              (bounds 200.00 200.00)
+              (drawsContent 1)
+              (appleVisualEffect blur-material-thin)
+              (structural layer
+                (position 108.00 126.00)
+                (bounds 200.00 200.00)
+              )
+              (backdrop layer (material)
+                (position 0.00 0.00)
+                (bounds 200.00 200.00)
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thin.html
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thin.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html><!-- webkit-test-runner [ AppleSystemVisualEffectsEnabled=true ] -->
+<html>
+<head>
+<title>This tests that the thin material works properly.</title>
+<style>
+
+body {
+    background: linear-gradient(red, blue) fixed;
+}
+
+.container {
+    width: 300px;
+    height: 300px;
+}
+
+.inner {
+    -apple-visual-effect: -apple-system-blur-material-thin;
+    width: 200px;
+    height: 200px;
+}
+
+</style>
+<script>
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+function dumpLayers() {
+    if (window.internals)
+        document.getElementById('result').innerText = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_CONTENT_LAYERS)
+}
+window.addEventListener('load', dumpLayers, false);
+
+</script>
+</head>
+<body>
+<div class=container>foo<div class=inner>bar</div></div>
+<pre id=result></pre>
+</body>
+</html>

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-ultra-thin-expected.txt
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-ultra-thin-expected.txt
@@ -1,0 +1,40 @@
+foo
+bar
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (children 2
+        (GraphicsLayer
+          (anchor 0.00 0.00)
+          (bounds 800.00 600.00)
+          (contentsOpaque 1)
+          (drawsContent 1)
+          (backgroundColor #FFFFFF)
+        )
+        (GraphicsLayer
+          (bounds 800.00 600.00)
+          (children 1
+            (GraphicsLayer
+              (position 8.00 26.00)
+              (bounds 200.00 200.00)
+              (drawsContent 1)
+              (appleVisualEffect blur-material-ultra-thin)
+              (structural layer
+                (position 108.00 126.00)
+                (bounds 200.00 200.00)
+              )
+              (backdrop layer (material)
+                (position 0.00 0.00)
+                (bounds 200.00 200.00)
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-ultra-thin.html
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-ultra-thin.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html><!-- webkit-test-runner [ AppleSystemVisualEffectsEnabled=true ] -->
+<html>
+<head>
+<title>This tests that the ultra thin material works properly.</title>
+<style>
+
+body {
+    background: linear-gradient(red, blue) fixed;
+}
+
+.container {
+    width: 300px;
+    height: 300px;
+}
+
+.inner {
+    -apple-visual-effect: -apple-system-blur-material-ultra-thin;
+    width: 200px;
+    height: 200px;
+}
+
+</style>
+<script>
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+function dumpLayers() {
+    if (window.internals)
+        document.getElementById('result').innerText = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_CONTENT_LAYERS)
+}
+window.addEventListener('load', dumpLayers, false);
+
+</script>
+</head>
+<body>
+<div class=container>foo<div class=inner>bar</div></div>
+<pre id=result></pre>
+</body>
+</html>

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material.html
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html><!-- webkit-test-runner [ AppleSystemVisualEffectsEnabled=true ] -->
+<html>
+<head>
+<title>This tests that the default material works properly.</title>
+<style>
+
+body {
+    background: linear-gradient(red, blue) fixed;
+}
+
+.container {
+    width: 300px;
+    height: 300px;
+}
+
+.inner {
+    -apple-visual-effect: -apple-system-blur-material;
+    width: 200px;
+    height: 200px;
+}
+
+</style>
+<script>
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+function dumpLayers() {
+    if (window.internals)
+        document.getElementById('result').innerText = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_CONTENT_LAYERS)
+}
+window.addEventListener('load', dumpLayers, false);
+
+</script>
+</head>
+<body>
+<div class=container>foo<div class=inner>bar</div></div>
+<pre id=result></pre>
+</body>
+</html>

--- a/LayoutTests/apple-visual-effects/backdrop-filter-with-apple-visual-effect-expected.html
+++ b/LayoutTests/apple-visual-effects/backdrop-filter-with-apple-visual-effect-expected.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html><!-- webkit-test-runner [ AppleSystemVisualEffectsEnabled=true ] -->
+<html>
+<head>
+<title>This tests that `backdrop-filter` is not applied on an element with `-apple-visual-effect`.</title>
+<style>
+
+body {
+    background: linear-gradient(red, blue) fixed;
+}
+
+.container {
+    width: 300px;
+    height: 300px;
+}
+
+.inner {
+    -apple-visual-effect: -apple-system-blur-material;
+    width: 200px;
+    height: 200px;
+}
+
+</style>
+</head>
+<body>
+<div class=container>foo<div class=inner>bar</div></div>
+</body>
+</html>

--- a/LayoutTests/apple-visual-effects/backdrop-filter-with-apple-visual-effect.html
+++ b/LayoutTests/apple-visual-effects/backdrop-filter-with-apple-visual-effect.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html><!-- webkit-test-runner [ AppleSystemVisualEffectsEnabled=true ] -->
+<html>
+<head>
+<title>This tests that `backdrop-filter` is not applied on an element with `-apple-visual-effect`.</title>
+<style>
+
+body {
+    background: linear-gradient(red, blue) fixed;
+}
+
+.container {
+    width: 300px;
+    height: 300px;
+}
+
+.inner {
+    -apple-visual-effect: -apple-system-blur-material;
+    width: 200px;
+    height: 200px;
+}
+
+</style>
+</head>
+<body>
+<div class=container>foo<div class=inner>bar</div></div>
+</body>
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+requestAnimationFrame(() => {
+    setTimeout(() => {
+        document.getElementsByClassName("inner")[0].style.backdropFilter = "invert()";
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }, 0);
+});
+
+</script>
+</html>

--- a/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-chrome-expected.txt
+++ b/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-chrome-expected.txt
@@ -1,0 +1,29 @@
+foo
+bar
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (position 8.00 28.00)
+          (bounds 200.00 200.00)
+          (drawsContent 1)
+          (appleVisualEffect blur-material-chrome)
+          (structural layer
+            (position 108.00 128.00)
+            (bounds 200.00 200.00)
+          )
+          (backdrop layer (material)
+            (position 0.00 0.00)
+            (bounds 200.00 200.00)
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-expected.txt
+++ b/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-expected.txt
@@ -1,0 +1,29 @@
+foo
+bar
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (position 8.00 28.00)
+          (bounds 200.00 200.00)
+          (drawsContent 1)
+          (appleVisualEffect blur-material)
+          (structural layer
+            (position 108.00 128.00)
+            (bounds 200.00 200.00)
+          )
+          (backdrop layer (material)
+            (position 0.00 0.00)
+            (bounds 200.00 200.00)
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-thick-expected.txt
+++ b/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-thick-expected.txt
@@ -1,0 +1,29 @@
+foo
+bar
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (position 8.00 28.00)
+          (bounds 200.00 200.00)
+          (drawsContent 1)
+          (appleVisualEffect blur-material-thick)
+          (structural layer
+            (position 108.00 128.00)
+            (bounds 200.00 200.00)
+          )
+          (backdrop layer (material)
+            (position 0.00 0.00)
+            (bounds 200.00 200.00)
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-thin-expected.txt
+++ b/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-thin-expected.txt
@@ -1,0 +1,29 @@
+foo
+bar
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (position 8.00 28.00)
+          (bounds 200.00 200.00)
+          (drawsContent 1)
+          (appleVisualEffect blur-material-thin)
+          (structural layer
+            (position 108.00 128.00)
+            (bounds 200.00 200.00)
+          )
+          (backdrop layer (material)
+            (position 0.00 0.00)
+            (bounds 200.00 200.00)
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-ultra-thin-expected.txt
+++ b/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-ultra-thin-expected.txt
@@ -1,0 +1,29 @@
+foo
+bar
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (position 8.00 28.00)
+          (bounds 200.00 200.00)
+          (drawsContent 1)
+          (appleVisualEffect blur-material-ultra-thin)
+          (structural layer
+            (position 108.00 128.00)
+            (bounds 200.00 200.00)
+          )
+          (backdrop layer (material)
+            (position 0.00 0.00)
+            (bounds 200.00 200.00)
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
+++ b/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
@@ -296,8 +296,11 @@
 		DD20DE6527BC90F90093D175 /* config.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C09D0571E31C57E00725F18 /* config.h */; };
 		DDB04F32278E4F1B008D3678 /* libWebKitAdditions.a in Product Dependencies */ = {isa = PBXBuildFile; fileRef = DDE99300278D07B800F60D26 /* libWebKitAdditions.a */; };
 		E34F26F62846D0D90076E549 /* PowerLogSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = E34F26F52846B7550076E549 /* PowerLogSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E544F3922CEBD95D007E1413 /* CoreMaterialSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = E544F3912CEBD95D007E1413 /* CoreMaterialSoftLink.mm */; };
+		E544F3932CEBD95D007E1413 /* CoreMaterialSoftLink.h in Headers */ = {isa = PBXBuildFile; fileRef = E544F3902CEBD95D007E1413 /* CoreMaterialSoftLink.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E57B44B529AB45F4006069DE /* VisionSoftLink.h in Headers */ = {isa = PBXBuildFile; fileRef = E57B44B329AB45F4006069DE /* VisionSoftLink.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E57B44B729AB462E006069DE /* VisionSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = E57B44B429AB45F4006069DE /* VisionSoftLink.mm */; };
+		E58381B92D0FD6F800AF08A8 /* CoreMaterialSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = E58381B82D0FD6F800AF08A8 /* CoreMaterialSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E5C5B20B2C379AA000838733 /* UIFoundationSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = E5C5B20A2C379AA000838733 /* UIFoundationSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EB3FE8E12A5DB94A00A20986 /* SQLite3SPI.h in Headers */ = {isa = PBXBuildFile; fileRef = EB3FE8E02A5DB94A00A20986 /* SQLite3SPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EBC13F3C2BD07DA500310E86 /* MobileKeyBagSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = EBC13F3B2BD07DA500310E86 /* MobileKeyBagSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -733,8 +736,11 @@
 		DF83E208263734F1000825EF /* CryptoKitPrivateSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CryptoKitPrivateSPI.h; sourceTree = "<group>"; };
 		E327C0DE260BDC90002281C5 /* NotifySPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NotifySPI.h; sourceTree = "<group>"; };
 		E34F26F52846B7550076E549 /* PowerLogSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PowerLogSPI.h; sourceTree = "<group>"; };
+		E544F3902CEBD95D007E1413 /* CoreMaterialSoftLink.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreMaterialSoftLink.h; sourceTree = "<group>"; };
+		E544F3912CEBD95D007E1413 /* CoreMaterialSoftLink.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreMaterialSoftLink.mm; sourceTree = "<group>"; };
 		E57B44B329AB45F4006069DE /* VisionSoftLink.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VisionSoftLink.h; sourceTree = "<group>"; };
 		E57B44B429AB45F4006069DE /* VisionSoftLink.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = VisionSoftLink.mm; sourceTree = "<group>"; };
+		E58381B82D0FD6F800AF08A8 /* CoreMaterialSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreMaterialSPI.h; sourceTree = "<group>"; };
 		E5C5B20A2C379AA000838733 /* UIFoundationSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UIFoundationSPI.h; sourceTree = "<group>"; };
 		E5D45D112106A07400D2B738 /* NSColorWellSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSColorWellSPI.h; sourceTree = "<group>"; };
 		E5D45D132106A18700D2B738 /* NSPopoverColorWellSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSPopoverColorWellSPI.h; sourceTree = "<group>"; };
@@ -861,6 +867,7 @@
 				7A36D0F8223AD9AB00B0522E /* CommonCryptoSPI.h */,
 				5157AE062B23CD8100C0E095 /* ContactsSPI.h */,
 				4177B3D9296CB8C3009711F0 /* CoreCryptoSPI.h */,
+				E58381B82D0FD6F800AF08A8 /* CoreMaterialSPI.h */,
 				ABCA536724895DB900361BFF /* CoreMotionSPI.h */,
 				C138EA1A2436447200656DF1 /* CoreServicesSPI.h */,
 				F43E89332AEDB71C00097D2D /* CoreTelephonySPI.h */,
@@ -1115,6 +1122,8 @@
 				077E87AF226A460200A2AFF0 /* AVFoundationSoftLink.mm */,
 				5157ADFB2B23B9F300C0E095 /* ContactsSoftLink.h */,
 				5157ADFC2B23B9F300C0E095 /* ContactsSoftLink.mm */,
+				E544F3902CEBD95D007E1413 /* CoreMaterialSoftLink.h */,
+				E544F3912CEBD95D007E1413 /* CoreMaterialSoftLink.mm */,
 				F47221F1276FC2EB00B984C7 /* CoreMLSoftLink.h */,
 				F47221F2276FC2EB00B984C7 /* CoreMLSoftLink.mm */,
 				F43E89352AEDB8C800097D2D /* CoreTelephonySoftLink.h */,
@@ -1418,6 +1427,8 @@
 				4177B3DA296CB8C3009711F0 /* CoreCryptoSPI.h in Headers */,
 				7B47F2A328587B9700E793C8 /* CoreGraphicsSoftLink.h in Headers */,
 				DD20DDD327BC90D70093D175 /* CoreGraphicsSPI.h in Headers */,
+				E544F3932CEBD95D007E1413 /* CoreMaterialSoftLink.h in Headers */,
+				E58381B92D0FD6F800AF08A8 /* CoreMaterialSPI.h in Headers */,
 				DD20DD1627BC90D60093D175 /* CoreMediaSoftLink.h in Headers */,
 				DD20DDCF27BC90D70093D175 /* CoreMediaSPI.h in Headers */,
 				DD20DD1C27BC90D60093D175 /* CoreMLSoftLink.h in Headers */,
@@ -1730,6 +1741,7 @@
 				1D2B413425F05E3500A3F70A /* ClockGeneric.cpp in Sources */,
 				5157ADFE2B23B9F300C0E095 /* ContactsSoftLink.mm in Sources */,
 				7B47F2A428587B9700E793C8 /* CoreGraphicsSoftLink.cpp in Sources */,
+				E544F3922CEBD95D007E1413 /* CoreMaterialSoftLink.mm in Sources */,
 				0CF99CA81F738437007EE793 /* CoreMediaSoftLink.cpp in Sources */,
 				F47221F4276FC2EB00B984C7 /* CoreMLSoftLink.mm in Sources */,
 				F43E89372AEDB8C800097D2D /* CoreTelephonySoftLink.mm in Sources */,

--- a/Source/WebCore/PAL/pal/PlatformMac.cmake
+++ b/Source/WebCore/PAL/pal/PlatformMac.cmake
@@ -14,6 +14,7 @@ list(APPEND PAL_PUBLIC_HEADERS
     cocoa/AppSSOSoftLink.h
     cocoa/AVFoundationSoftLink.h
     cocoa/CoreMLSoftLink.h
+    cocoa/CoreMaterialSoftLink.h
     cocoa/CoreTelephonySoftLink.h
     cocoa/CryptoKitPrivateSoftLink.h
     cocoa/DataDetectorsCoreSoftLink.h
@@ -62,6 +63,7 @@ list(APPEND PAL_PUBLIC_HEADERS
     spi/cocoa/AudioToolboxSPI.h
     spi/cocoa/CFNSURLConnectionSPI.h
     spi/cocoa/CommonCryptoSPI.h
+    spi/cocoa/CoreMaterialSPI.h
     spi/cocoa/CoreServicesSPI.h
     spi/cocoa/CoreTelephonySPI.h
     spi/cocoa/CryptoKitPrivateSPI.h
@@ -176,6 +178,7 @@ list(APPEND PAL_SOURCES
     cocoa/AppSSOSoftLink.mm
     cocoa/AVFoundationSoftLink.mm
     cocoa/CoreMLSoftLink.mm
+    cocoa/CoreMaterialSoftLink.mm
     cocoa/CoreTelephonySoftLink.mm
     cocoa/CryptoKitPrivateSoftLink.mm
     cocoa/DataDetectorsCoreSoftLink.mm

--- a/Source/WebCore/PAL/pal/cocoa/CoreMaterialSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/CoreMaterialSoftLink.h
@@ -27,33 +27,16 @@
 
 #if HAVE(CORE_MATERIAL)
 
-namespace WTF {
-class TextStream;
-}
+#import <pal/spi/cocoa/CoreMaterialSPI.h>
+#import <wtf/SoftLinking.h>
 
-namespace WebCore {
+SOFT_LINK_FRAMEWORK_FOR_HEADER(PAL, CoreMaterial)
+SOFT_LINK_CLASS_FOR_HEADER(PAL, MTMaterialLayer)
 
-enum class AppleVisualEffect : uint8_t {
-    None,
-    BlurUltraThinMaterial,
-    BlurThinMaterial,
-    BlurMaterial,
-    BlurThickMaterial,
-    BlurChromeMaterial,
-    VibrancyLabel,
-    VibrancySecondaryLabel,
-    VibrancyTertiaryLabel,
-    VibrancyQuaternaryLabel,
-    VibrancyFill,
-    VibrancySecondaryFill,
-    VibrancyTertiaryFill,
-    VibrancySeparator,
-};
-
-WEBCORE_EXPORT bool appleVisualEffectNeedsBackdrop(AppleVisualEffect);
-
-WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, AppleVisualEffect);
-
-} // namespace WebCore
+SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialRecipePlatformContentLight, NSString *)
+SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialRecipePlatformChromeLight, NSString *)
+SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialRecipePlatformContentThickLight, NSString *)
+SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialRecipePlatformContentUltraThinLight, NSString *)
+SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialRecipePlatformContentThinLight, NSString *)
 
 #endif // HAVE(CORE_MATERIAL)

--- a/Source/WebCore/PAL/pal/cocoa/CoreMaterialSoftLink.mm
+++ b/Source/WebCore/PAL/pal/cocoa/CoreMaterialSoftLink.mm
@@ -23,37 +23,21 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
 
 #if HAVE(CORE_MATERIAL)
 
-namespace WTF {
-class TextStream;
-}
+#import <pal/spi/cocoa/CoreMaterialSPI.h>
+#import <wtf/SoftLinking.h>
 
-namespace WebCore {
+SOFT_LINK_PRIVATE_FRAMEWORK_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, PAL_EXPORT)
 
-enum class AppleVisualEffect : uint8_t {
-    None,
-    BlurUltraThinMaterial,
-    BlurThinMaterial,
-    BlurMaterial,
-    BlurThickMaterial,
-    BlurChromeMaterial,
-    VibrancyLabel,
-    VibrancySecondaryLabel,
-    VibrancyTertiaryLabel,
-    VibrancyQuaternaryLabel,
-    VibrancyFill,
-    VibrancySecondaryFill,
-    VibrancyTertiaryFill,
-    VibrancySeparator,
-};
+SOFT_LINK_CLASS_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, MTMaterialLayer, PAL_EXPORT)
 
-WEBCORE_EXPORT bool appleVisualEffectNeedsBackdrop(AppleVisualEffect);
-
-WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, AppleVisualEffect);
-
-} // namespace WebCore
+SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, MTCoreMaterialRecipePlatformContentLight, NSString *, PAL_EXPORT)
+SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, MTCoreMaterialRecipePlatformChromeLight, NSString *, PAL_EXPORT)
+SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, MTCoreMaterialRecipePlatformContentThickLight, NSString *, PAL_EXPORT)
+SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, MTCoreMaterialRecipePlatformContentThinLight, NSString *, PAL_EXPORT)
+SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, MTCoreMaterialRecipePlatformContentUltraThinLight, NSString *, PAL_EXPORT)
 
 #endif // HAVE(CORE_MATERIAL)

--- a/Source/WebCore/PAL/pal/spi/cocoa/CoreMaterialSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/CoreMaterialSPI.h
@@ -27,33 +27,29 @@
 
 #if HAVE(CORE_MATERIAL)
 
-namespace WTF {
-class TextStream;
-}
+#import <Foundation/NSString.h>
+#import <pal/spi/cocoa/QuartzCoreSPI.h>
 
-namespace WebCore {
+#if USE(APPLE_INTERNAL_SDK)
 
-enum class AppleVisualEffect : uint8_t {
-    None,
-    BlurUltraThinMaterial,
-    BlurThinMaterial,
-    BlurMaterial,
-    BlurThickMaterial,
-    BlurChromeMaterial,
-    VibrancyLabel,
-    VibrancySecondaryLabel,
-    VibrancyTertiaryLabel,
-    VibrancyQuaternaryLabel,
-    VibrancyFill,
-    VibrancySecondaryFill,
-    VibrancyTertiaryFill,
-    VibrancySeparator,
-};
+#import <CoreMaterial/CoreMaterial.h>
 
-WEBCORE_EXPORT bool appleVisualEffectNeedsBackdrop(AppleVisualEffect);
+#else
 
-WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, AppleVisualEffect);
+typedef NSString * MTCoreMaterialRecipe NS_STRING_ENUM;
 
-} // namespace WebCore
+extern MTCoreMaterialRecipe const MTCoreMaterialRecipePlatformChromeLight;
+extern MTCoreMaterialRecipe const MTCoreMaterialRecipePlatformContentUltraThinLight;
+extern MTCoreMaterialRecipe const MTCoreMaterialRecipePlatformContentThinLight;
+extern MTCoreMaterialRecipe const MTCoreMaterialRecipePlatformContentLight;
+extern MTCoreMaterialRecipe const MTCoreMaterialRecipePlatformContentThickLight;
+
+@interface MTMaterialLayer : CABackdropLayer
+
+@property (nonatomic, copy) MTCoreMaterialRecipe recipe;
+
+@end
+
+#endif // USE(APPLE_INTERNAL_SDK)
 
 #endif // HAVE(CORE_MATERIAL)

--- a/Source/WebCore/page/FrameSnapshotting.cpp
+++ b/Source/WebCore/page/FrameSnapshotting.cpp
@@ -175,7 +175,12 @@ RefPtr<ImageBuffer> snapshotNode(LocalFrame& frame, Node& node, SnapshotOptions&
 
 static bool styleContainsComplexBackground(const RenderStyle& style)
 {
-    return style.hasBlendMode() || style.hasBackgroundImage() || style.hasBackdropFilter();
+    return style.hasBlendMode()
+        || style.hasBackgroundImage()
+#if HAVE(CORE_MATERIAL)
+        || style.hasAppleVisualEffectRequiringBackdropFilter()
+#endif
+        || style.hasBackdropFilter();
 }
 
 Color estimatedBackgroundColorForRange(const SimpleRange& range, const LocalFrame& frame)

--- a/Source/WebCore/platform/cocoa/AppleVisualEffect.cpp
+++ b/Source/WebCore/platform/cocoa/AppleVisualEffect.cpp
@@ -32,6 +32,31 @@
 
 namespace WebCore {
 
+bool appleVisualEffectNeedsBackdrop(AppleVisualEffect effect)
+{
+    switch (effect) {
+    case AppleVisualEffect::BlurUltraThinMaterial:
+    case AppleVisualEffect::BlurThinMaterial:
+    case AppleVisualEffect::BlurMaterial:
+    case AppleVisualEffect::BlurThickMaterial:
+    case AppleVisualEffect::BlurChromeMaterial:
+        return true;
+    case AppleVisualEffect::None:
+    case AppleVisualEffect::VibrancyLabel:
+    case AppleVisualEffect::VibrancySecondaryLabel:
+    case AppleVisualEffect::VibrancyTertiaryLabel:
+    case AppleVisualEffect::VibrancyQuaternaryLabel:
+    case AppleVisualEffect::VibrancyFill:
+    case AppleVisualEffect::VibrancySecondaryFill:
+    case AppleVisualEffect::VibrancyTertiaryFill:
+    case AppleVisualEffect::VibrancySeparator:
+        return false;
+    }
+
+    ASSERT_NOT_REACHED();
+    return false;
+}
+
 TextStream& operator<<(TextStream& ts, AppleVisualEffect effect)
 {
     switch (effect) {

--- a/Source/WebCore/platform/graphics/GraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.cpp
@@ -416,6 +416,15 @@ void GraphicsLayer::removeFromParentInternal()
     }
 }
 
+bool GraphicsLayer::needsBackdrop() const
+{
+#if HAVE(CORE_MATERIAL)
+    if (appleVisualEffectNeedsBackdrop(m_appleVisualEffect))
+        return true;
+#endif
+    return !m_backdropFilters.isEmpty();
+}
+
 void GraphicsLayer::setPreserves3D(bool b)
 {
     ASSERT_IMPLIES(m_type == Type::Structural, b);
@@ -1004,6 +1013,11 @@ void GraphicsLayer::dumpProperties(TextStream& ts, OptionSet<LayerTreeAsTextOpti
         ts << '[' << m_childrenTransform->m31() << ' ' << m_childrenTransform->m32() << ' ' << m_childrenTransform->m33() << ' ' << m_childrenTransform->m34() << "] "_s;
         ts << '[' << m_childrenTransform->m41() << ' ' << m_childrenTransform->m42() << ' ' << m_childrenTransform->m43() << ' ' << m_childrenTransform->m44() << "])\n"_s;
     }
+
+#if HAVE(CORE_MATERIAL)
+    if (m_appleVisualEffect != AppleVisualEffect::None)
+        ts << indent << "(appleVisualEffect "_s << m_appleVisualEffect << ")\n"_s;
+#endif
 
     if (m_maskLayer) {
         ts << indent << "(mask layer"_s;

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -57,6 +57,10 @@
 #include "AcceleratedEffectStack.h"
 #endif
 
+#if HAVE(CORE_MATERIAL)
+#include "AppleVisualEffect.h"
+#endif
+
 namespace WTF {
 class TextStream;
 }
@@ -438,7 +442,12 @@ public:
 #endif
 #endif
 
-    bool needsBackdrop() const { return !m_backdropFilters.isEmpty(); }
+#if HAVE(CORE_MATERIAL)
+    AppleVisualEffect appleVisualEffect() const { return m_appleVisualEffect; }
+    virtual void setAppleVisualEffect(AppleVisualEffect effect) { m_appleVisualEffect = effect; }
+#endif
+
+    bool needsBackdrop() const;
 
     // The color used to paint the layer background. Pass an invalid color to remove it.
     // Note that this covers the entire layer. Use setContentsToSolidColor() if the color should
@@ -792,6 +801,11 @@ protected:
 
     const Type m_type;
     CustomAppearance m_customAppearance { CustomAppearance::None };
+
+#if HAVE(CORE_MATERIAL)
+    AppleVisualEffect m_appleVisualEffect { AppleVisualEffect::None };
+#endif
+
     OptionSet<GraphicsLayerPaintingPhase> m_paintingPhase { GraphicsLayerPaintingPhase::Foreground, GraphicsLayerPaintingPhase::Background };
     CompositingCoordinatesOrientation m_contentsOrientation { CompositingCoordinatesOrientation::TopDown }; // affects orientation of layer contents
 
@@ -855,6 +869,7 @@ protected:
     WindRule m_shapeLayerWindRule { WindRule::NonZero };
     Path m_shapeLayerPath;
 #endif
+
     LayerHostingContextID m_layerHostingContextID { 0 };
 };
 

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -794,6 +794,24 @@ void GraphicsLayerCA::setIsDescendentOfSeparatedPortal(bool isDescendentOfSepara
 #endif
 #endif
 
+#if HAVE(CORE_MATERIAL)
+void GraphicsLayerCA::setAppleVisualEffect(AppleVisualEffect effect)
+{
+    if (effect == m_appleVisualEffect)
+        return;
+
+    bool backdropFiltersChanged = appleVisualEffectNeedsBackdrop(effect) != appleVisualEffectNeedsBackdrop(m_appleVisualEffect);
+
+    GraphicsLayer::setAppleVisualEffect(effect);
+
+    LayerChangeFlags changes = AppleVisualEffectChanged;
+    if (backdropFiltersChanged)
+        changes |= BackdropFiltersChanged;
+
+    noteLayerPropertyChanged(changes);
+}
+#endif
+
 void GraphicsLayerCA::setBackgroundColor(const Color& color)
 {
     if (m_backgroundColor == color)
@@ -2132,6 +2150,11 @@ void GraphicsLayerCA::commitLayerChangesBeforeSublayers(CommitState& commitState
     if (m_uncommittedChanges & BackdropFiltersChanged || needsBackdrop())
         updateBackdropFilters(commitState);
 
+#if HAVE(CORE_MATERIAL)
+    if (m_uncommittedChanges & AppleVisualEffectChanged)
+        updateAppleVisualEffect();
+#endif
+
     if (m_uncommittedChanges & BackdropRootChanged)
         updateBackdropRoot();
 
@@ -2573,27 +2596,49 @@ void GraphicsLayerCA::updateBackdropFilters(CommitState& commitState)
         return;
     }
 
-    bool madeLayer = !m_backdropLayer;
-    if (!m_backdropLayer) {
-        m_backdropLayer = createPlatformCALayer(PlatformCALayer::LayerType::LayerTypeBackdropLayer, this);
+    auto expectedLayerType = PlatformCALayer::LayerType::LayerTypeBackdropLayer;
+#if HAVE(CORE_MATERIAL)
+    if (appleVisualEffectNeedsBackdrop(m_appleVisualEffect))
+        expectedLayerType = PlatformCALayer::LayerType::LayerTypeMaterialLayer;
+#endif
+
+    bool makeLayer = !m_backdropLayer || (m_backdropLayer->layerType() != expectedLayerType);
+    if (makeLayer) {
+        m_backdropLayer = createPlatformCALayer(expectedLayerType, this);
         m_backdropLayer->setAnchorPoint(FloatPoint3D());
         m_backdropLayer->setMasksToBounds(true);
-        m_backdropLayer->setName(MAKE_STATIC_STRING_IMPL("backdrop"));
+#if HAVE(CORE_MATERIAL)
+        if (expectedLayerType == PlatformCALayer::LayerType::LayerTypeMaterialLayer)
+            m_backdropLayer->setName(MAKE_STATIC_STRING_IMPL("material"));
+        else
+#endif
+            m_backdropLayer->setName(MAKE_STATIC_STRING_IMPL("backdrop"));
     }
 
     m_backdropLayer->setHidden(!m_contentsVisible);
     m_backdropLayer->setBackdropRootIsOpaque(commitState.backdropRootIsOpaque);
-    m_backdropLayer->setFilters(m_backdropFilters);
+
+    bool shouldSetFilters = true;
+#if HAVE(CORE_MATERIAL)
+    if (m_appleVisualEffect != AppleVisualEffect::None) {
+        m_backdropLayer->setAppleVisualEffect(m_appleVisualEffect);
+        shouldSetFilters = false;
+    }
+#endif
+
+    if (shouldSetFilters)
+        m_backdropLayer->setFilters(m_backdropFilters);
 
     if (m_layerClones) {
         for (auto& clone : m_layerClones->backdropLayerClones.values()) {
             clone->setHidden(!m_contentsVisible);
             clone->setBackdropRootIsOpaque(commitState.backdropRootIsOpaque);
-            clone->setFilters(m_backdropFilters);
+            if (shouldSetFilters)
+                clone->setFilters(m_backdropFilters);
         }
     }
 
-    if (madeLayer) {
+    if (makeLayer) {
         updateBackdropFiltersRect();
         noteSublayersChanged(DontScheduleFlush);
     }
@@ -2688,6 +2733,14 @@ void GraphicsLayerCA::updateIsDescendentOfSeparatedPortal()
     m_layer->setIsDescendentOfSeparatedPortal(m_isDescendentOfSeparatedPortal);
 }
 #endif
+#endif
+
+#if HAVE(CORE_MATERIAL)
+void GraphicsLayerCA::updateAppleVisualEffect()
+{
+    if (m_backdropLayer && (appleVisualEffectNeedsBackdrop(m_backdropLayer->appleVisualEffect()) || appleVisualEffectNeedsBackdrop(m_appleVisualEffect)))
+        m_backdropLayer->setAppleVisualEffect(m_appleVisualEffect);
+}
 #endif
 
 void GraphicsLayerCA::updateContentsScalingFilters()
@@ -4326,8 +4379,13 @@ ASCIILiteral GraphicsLayerCA::purposeNameForInnerLayer(PlatformCALayer& layer) c
     }
     if (&layer == m_contentsShapeMaskLayer.get())
         return "contents shape mask layer"_s;
-    if (&layer == m_backdropLayer.get())
+    if (&layer == m_backdropLayer.get()) {
+#if HAVE(CORE_MATERIAL)
+        if (m_backdropLayer->appleVisualEffect() != AppleVisualEffect::None)
+            return "backdrop layer (material)"_s;
+#endif
         return "backdrop layer"_s;
+    }
     return "platform layer"_s;
 }
 
@@ -4477,6 +4535,9 @@ ASCIILiteral GraphicsLayerCA::layerChangeAsString(LayerChange layerChange)
     case LayerChange::ContentsScalingFiltersChanged: return "ContentsScalingFiltersChanged"_s;
     case LayerChange::VideoGravityChanged: return "VideoGravityChanged"_s;
     case LayerChange::BackdropRootChanged: return "BackdropRootChanged"_s;
+#if HAVE(CORE_MATERIAL)
+    case LayerChange::AppleVisualEffectChanged: return "AppleVisualEffectChanged"_s;
+#endif
     }
     ASSERT_NOT_REACHED();
     return ""_s;
@@ -4657,6 +4718,9 @@ void GraphicsLayerCA::changeLayerTypeTo(PlatformCALayer::LayerType newLayerType)
         | EventRegionChanged
         | NameChanged
         | DebugIndicatorsChanged
+#if HAVE(CORE_MATERIAL)
+        | AppleVisualEffectChanged
+#endif
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION) || HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
         | CoverageRectChanged);
 #else

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -106,6 +106,10 @@ public:
 #endif
 #endif
 
+#if HAVE(CORE_MATERIAL)
+    WEBCORE_EXPORT void setAppleVisualEffect(AppleVisualEffect) override;
+#endif
+
     WEBCORE_EXPORT void setBackgroundColor(const Color&) override;
 
     WEBCORE_EXPORT void setContentsOpaque(bool) override;
@@ -514,6 +518,10 @@ private:
 #endif
     void updateContentsScalingFilters();
 
+#if HAVE(CORE_MATERIAL)
+    void updateAppleVisualEffect();
+#endif
+
     enum StructuralLayerPurpose {
         NoStructuralLayer = 0,
         StructuralLayerForPreserves3D,
@@ -627,6 +635,9 @@ private:
         ContentsScalingFiltersChanged           = 1LLU << 43,
         VideoGravityChanged                     = 1LLU << 44,
         BackdropRootChanged                     = 1LLU << 45,
+#if HAVE(CORE_MATERIAL)
+        AppleVisualEffectChanged                = 1LLU << 46,
+#endif
     };
     typedef uint64_t LayerChangeFlags;
     static ASCIILiteral layerChangeAsString(LayerChange);

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
@@ -55,6 +55,7 @@ class AcceleratedEffect;
 struct AcceleratedEffectValues;
 #endif
 
+enum class AppleVisualEffect : uint8_t;
 enum class MediaPlayerVideoGravity : uint8_t;
 enum class ContentsFormat : uint8_t;
 
@@ -76,6 +77,9 @@ enum class PlatformCALayerLayerType : uint8_t {
         LayerTypeAVPlayerLayer,
         LayerTypeContentsProvidedLayer,
         LayerTypeBackdropLayer,
+#if HAVE(CORE_MATERIAL)
+        LayerTypeMaterialLayer,
+#endif
         LayerTypeShapeLayer,
         LayerTypeScrollContainerLayer,
 #if ENABLE(MODEL_ELEMENT)
@@ -300,6 +304,11 @@ public:
     virtual bool isDescendentOfSeparatedPortal() const = 0;
     virtual void setIsDescendentOfSeparatedPortal(bool) = 0;
 #endif
+#endif
+
+#if HAVE(CORE_MATERIAL)
+    virtual AppleVisualEffect appleVisualEffect() const = 0;
+    virtual void setAppleVisualEffect(AppleVisualEffect) = 0;
 #endif
 
     virtual TiledBacking* tiledBacking() = 0;

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.mm
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.mm
@@ -266,6 +266,11 @@ TextStream& operator<<(TextStream& ts, PlatformCALayer::LayerType layerType)
     case PlatformCALayer::LayerType::LayerTypeBackdropLayer:
         ts << "backdrop-layer";
         break;
+#if HAVE(CORE_MATERIAL)
+    case PlatformCALayer::LayerType::LayerTypeMaterialLayer:
+        ts << "material-layer";
+        break;
+#endif
     case PlatformCALayer::LayerType::LayerTypeAVPlayerLayer:
         ts << "av-player-layer";
         break;

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.h
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.h
@@ -200,6 +200,11 @@ public:
 #endif
 #endif
 
+#if HAVE(CORE_MATERIAL)
+    AppleVisualEffect appleVisualEffect() const override;
+    void setAppleVisualEffect(AppleVisualEffect) override;
+#endif
+
     TiledBacking* tiledBacking() override;
 
     Ref<PlatformCALayer> clone(PlatformCALayerClient* owner) const override;
@@ -227,6 +232,9 @@ private:
     RetainPtr<NSObject> m_delegate;
     std::unique_ptr<PlatformCALayerList> m_customSublayers;
     GraphicsLayer::CustomAppearance m_customAppearance { GraphicsLayer::CustomAppearance::None };
+#if HAVE(CORE_MATERIAL)
+    AppleVisualEffect m_appleVisualEffect { AppleVisualEffect::None };
+#endif
     std::unique_ptr<FloatRoundedRect> m_shapeRoundedRect;
 #if ENABLE(SCROLLING_THREAD)
     Markable<ScrollingNodeID> m_scrollingNodeID;

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
@@ -70,6 +70,7 @@
 #endif
 
 #import <pal/cocoa/AVFoundationSoftLink.h>
+#import <pal/cocoa/CoreMaterialSoftLink.h>
 
 namespace WebCore {
 
@@ -243,6 +244,11 @@ PlatformCALayerCocoa::PlatformCALayerCocoa(LayerType layerType, PlatformCALayerC
     case LayerType::LayerTypeBackdropLayer:
         layerClass = [CABackdropLayer class];
         break;
+#if HAVE(CORE_MATERIAL)
+    case LayerType::LayerTypeMaterialLayer:
+        layerClass = PAL::getMTMaterialLayerClass();
+        break;
+#endif
     case LayerType::LayerTypeTiledBackingLayer:
     case LayerType::LayerTypePageTiledBackingLayer:
         layerClass = [WebTiledBackingLayer class];
@@ -271,8 +277,8 @@ PlatformCALayerCocoa::PlatformCALayerCocoa(LayerType layerType, PlatformCALayerC
         m_layer = adoptNS([(CALayer *)[layerClass alloc] init]);
 
 #if PLATFORM(MAC)
-    if (layerType == LayerType::LayerTypeBackdropLayer)
-        [(CABackdropLayer*)m_layer.get() setWindowServerAware:NO];
+    if (layerType == LayerType::LayerTypeBackdropLayer || layerType == LayerType::LayerTypeMaterialLayer)
+        [(CABackdropLayer *)m_layer.get() setWindowServerAware:NO];
 #endif
 
     commonInit();
@@ -338,6 +344,11 @@ Ref<PlatformCALayer> PlatformCALayerCocoa::clone(PlatformCALayerClient* owner) c
     case PlatformCALayer::LayerType::LayerTypeBackdropLayer:
         type = PlatformCALayer::LayerType::LayerTypeBackdropLayer;
         break;
+#if HAVE(CORE_MATERIAL)
+    case PlatformCALayer::LayerType::LayerTypeMaterialLayer:
+        type = PlatformCALayer::LayerType::LayerTypeMaterialLayer;
+        break;
+#endif
     case PlatformCALayer::LayerType::LayerTypeLayer:
     default:
         type = PlatformCALayer::LayerType::LayerTypeLayer;
@@ -1130,6 +1141,22 @@ void PlatformCALayerCocoa::setIsDescendentOfSeparatedPortal(bool)
     ASSERT_NOT_REACHED();
 }
 #endif
+#endif
+
+#if HAVE(CORE_MATERIAL)
+
+AppleVisualEffect PlatformCALayerCocoa::appleVisualEffect() const
+{
+    // FIXME: Add an implementation for when UI-side compositing is disabled.
+    return m_appleVisualEffect;
+}
+
+void PlatformCALayerCocoa::setAppleVisualEffect(AppleVisualEffect effect)
+{
+    // FIXME: Add an implementation for when UI-side compositing is disabled.
+    m_appleVisualEffect = effect;
+}
+
 #endif
 
 void PlatformCALayerCocoa::updateContentsFormat()

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -448,6 +448,9 @@ bool RenderElement::repaintBeforeStyleChange(StyleDifference diff, const RenderS
             // If we don't have a layer yet, but we are going to get one because of transform or opacity, then we need to repaint the old position of the object.
             bool hasLayer = modelObject->hasLayer();
             bool willHaveLayer = newStyle.affectsTransform() || newStyle.hasOpacity() || newStyle.hasFilter() || newStyle.hasBackdropFilter();
+#if HAVE(CORE_MATERIAL)
+            willHaveLayer |= newStyle.hasAppleVisualEffect();
+#endif
             if (!hasLayer && willHaveLayer)
                 return RequiredRepaint::RendererOnly;
         }
@@ -2189,6 +2192,9 @@ void RenderElement::adjustFragmentedFlowStateOnContainingBlockChangeIfNeeded(con
         || oldStyle.hasTransformRelatedProperty() != m_style.hasTransformRelatedProperty()
         || oldStyle.willChange() != newStyle.willChange()
         || oldStyle.hasBackdropFilter() != newStyle.hasBackdropFilter()
+#if HAVE(CORE_MATERIAL)
+        || oldStyle.hasAppleVisualEffectRequiringBackdropFilter() != newStyle.hasAppleVisualEffectRequiringBackdropFilter()
+#endif
         || oldStyle.containsLayout() != newStyle.containsLayout()
         || oldStyle.containsSize() != newStyle.containsSize();
     if (!mayNotBeContainingBlockForDescendantsAnymore)

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -212,6 +212,11 @@ public:
     inline bool hasBlendMode() const;
     inline bool hasShapeOutside() const;
 
+#if HAVE(CORE_MATERIAL)
+    inline bool hasAppleVisualEffect() const;
+    inline bool hasAppleVisualEffectRequiringBackdropFilter() const;
+#endif
+
     void registerForVisibleInViewportCallback();
     void unregisterForVisibleInViewportCallback();
 

--- a/Source/WebCore/rendering/RenderElementInlines.h
+++ b/Source/WebCore/rendering/RenderElementInlines.h
@@ -42,12 +42,20 @@ inline float RenderElement::opacity() const { return style().opacity(); }
 inline FloatRect RenderElement::transformReferenceBoxRect() const { return transformReferenceBoxRect(style()); }
 inline FloatRect RenderElement::transformReferenceBoxRect(const RenderStyle& style) const { return referenceBoxRect(transformBoxToCSSBoxType(style.transformBox())); }
 
+#if HAVE(CORE_MATERIAL)
+inline bool RenderElement::hasAppleVisualEffect() const { return style().hasAppleVisualEffect(); }
+inline bool RenderElement::hasAppleVisualEffectRequiringBackdropFilter() const { return style().hasAppleVisualEffectRequiringBackdropFilter(); }
+#endif
+
 inline bool RenderElement::canContainAbsolutelyPositionedObjects() const
 {
     return isRenderView()
         || style().position() != PositionType::Static
         || (canEstablishContainingBlockWithTransform() && hasTransformRelatedProperty())
         || (hasBackdropFilter() && !isDocumentElementRenderer())
+#if HAVE(CORE_MATERIAL)
+        || (hasAppleVisualEffectRequiringBackdropFilter() && !isDocumentElementRenderer())
+#endif
         || (isRenderBlock() && style().willChange() && style().willChange()->createsContainingBlockForAbsolutelyPositioned(isDocumentElementRenderer()))
         || isRenderOrLegacyRenderSVGForeignObject()
         || shouldApplyLayoutContainment()
@@ -59,6 +67,9 @@ inline bool RenderElement::canContainFixedPositionObjects() const
     return isRenderView()
         || (canEstablishContainingBlockWithTransform() && hasTransformRelatedProperty())
         || (hasBackdropFilter() && !isDocumentElementRenderer())
+#if HAVE(CORE_MATERIAL)
+        || (hasAppleVisualEffectRequiringBackdropFilter() && !isDocumentElementRenderer())
+#endif
         || (isRenderBlock() && style().willChange() && style().willChange()->createsContainingBlockForOutOfFlowPositioned(isDocumentElementRenderer()))
         || isRenderOrLegacyRenderSVGForeignObject()
         || shouldApplyLayoutContainment()
@@ -67,7 +78,15 @@ inline bool RenderElement::canContainFixedPositionObjects() const
 
 inline bool RenderElement::createsGroupForStyle(const RenderStyle& style)
 {
-    return style.hasOpacity() || style.hasMask() || style.clipPath() || style.hasFilter() || style.hasBackdropFilter() || style.hasBlendMode();
+    return style.hasOpacity()
+        || style.hasMask()
+        || style.clipPath()
+        || style.hasFilter()
+        || style.hasBackdropFilter()
+#if HAVE(CORE_MATERIAL)
+        || style.hasAppleVisualEffect()
+#endif
+        || style.hasBlendMode();
 }
 
 inline bool RenderElement::shouldApplyAnyContainment() const

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -560,6 +560,9 @@ static bool canCreateStackingContext(const RenderLayer& layer)
         || renderer.hasFilter()
         || renderer.hasMask()
         || renderer.hasBackdropFilter()
+#if HAVE(CORE_MATERIAL)
+        || renderer.hasAppleVisualEffect()
+#endif
         || renderer.hasBlendMode()
         || renderer.isTransparent()
         || renderer.requiresRenderingConsolidationForViewTransition()
@@ -604,6 +607,9 @@ bool RenderLayer::computeCanBeBackdropRoot() const
     return isRenderViewLayer()
         || renderer().isTransparent()
         || renderer().hasBackdropFilter()
+#if HAVE(CORE_MATERIAL)
+        || renderer().hasAppleVisualEffect()
+#endif
         || renderer().hasClipPath()
         || renderer().hasFilter()
         || renderer().hasBlendMode()
@@ -2994,6 +3000,9 @@ String RenderLayer::debugDescription() const
         transform() ? " has transform"_s : ""_s,
         hasFilter() ? " has filter"_s : ""_s,
         hasBackdropFilter() ? " has backdrop filter"_s : ""_s,
+#if HAVE(CORE_MATERIAL)
+        hasAppleVisualEffect() ? " has apple visual effect"_s : ""_s,
+#endif
         hasBlendMode() ? " has blend mode"_s : ""_s,
         isolatesBlending() ? " isolates blending"_s : ""_s,
         compositedDescription);

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -804,6 +804,11 @@ public:
     bool canBeBackdropRoot() const { return m_canBeBackdropRoot; }
     bool isBackdropRoot() const { return hasBackdropFilterDescendantsWithoutRoot() && canBeBackdropRoot(); }
 
+#if HAVE(CORE_MATERIAL)
+    inline bool hasAppleVisualEffect() const;
+    inline bool hasAppleVisualEffectRequiringBackdropFilter() const;
+#endif
+
     inline bool hasBlendMode() const;
     BlendMode blendMode() const { return static_cast<BlendMode>(m_blendMode); }
 

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -567,6 +567,9 @@ void RenderLayerBacking::createPrimaryGraphicsLayer()
     updateTransform(style);
     updateFilters(style);
     updateBackdropFilters(style);
+#if HAVE(CORE_MATERIAL)
+    updateAppleVisualEffect(style);
+#endif
     updateBackdropRoot();
     updateBlendMode(style);
 #if ENABLE(VIDEO)
@@ -782,7 +785,11 @@ void RenderLayerBacking::updateBackdropFilters(const RenderStyle& style)
 
 void RenderLayerBacking::updateBackdropFiltersGeometry()
 {
-    if (!m_canCompositeBackdropFilters)
+    bool shouldUpdateBackdropFiltersGeometry = m_canCompositeBackdropFilters;
+#if HAVE(CORE_MATERIAL)
+    shouldUpdateBackdropFiltersGeometry |= renderer().hasAppleVisualEffectRequiringBackdropFilter();
+#endif
+    if (!shouldUpdateBackdropFiltersGeometry)
         return;
 
     CheckedPtr renderBox = dynamicDowncast<RenderBox>(this->renderer());
@@ -879,6 +886,13 @@ void RenderLayerBacking::updateContentsScalingFilters(const RenderStyle& style)
     m_graphicsLayer->setContentsMinificationFilter(minificationFilter);
     m_graphicsLayer->setContentsMagnificationFilter(magnificationFilter);
 }
+
+#if HAVE(CORE_MATERIAL)
+void RenderLayerBacking::updateAppleVisualEffect(const RenderStyle& style)
+{
+    m_graphicsLayer->setAppleVisualEffect(style.appleVisualEffect());
+}
+#endif
 
 static bool layerOrAncestorIsTransformedOrUsingCompositedScrolling(RenderLayer& layer)
 {
@@ -1049,6 +1063,9 @@ void RenderLayerBacking::updateConfigurationAfterStyleChange()
     updateFilters(style);
 
     updateBackdropFilters(style);
+#if HAVE(CORE_MATERIAL)
+    updateAppleVisualEffect(style);
+#endif
     updateBackdropRoot();
     updateBlendMode(style);
     updateContentsScalingFilters(style);
@@ -1428,6 +1445,9 @@ void RenderLayerBacking::updateGeometry(const RenderLayer* compositedAncestor)
     updateOpacity(style);
     updateFilters(style);
     updateBackdropFilters(style);
+#if HAVE(CORE_MATERIAL)
+    updateAppleVisualEffect(style);
+#endif
     updateBackdropRoot();
     updateBlendMode(style);
     updateContentsScalingFilters(style);

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -365,6 +365,9 @@ private:
     void updateVideoGravity(const RenderStyle&);
 #endif
     void updateContentsScalingFilters(const RenderStyle&);
+#if HAVE(CORE_MATERIAL)
+    void updateAppleVisualEffect(const RenderStyle&);
+#endif
 
     // Return the opacity value that this layer should use for compositing.
     float compositingOpacity(float rendererOpacity) const;

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -212,6 +212,11 @@ struct RenderLayerCompositor::CompositingState {
 
         if ((layer.isComposited() && layer.hasBackdropFilter()) || (layer.hasBackdropFilterDescendantsWithoutRoot() && !layer.isBackdropRoot()))
             hasBackdropFilterDescendantsWithoutRoot = true;
+
+#if HAVE(CORE_MATERIAL)
+        if (layer.isComposited() && layer.hasAppleVisualEffectRequiringBackdropFilter())
+            hasBackdropFilterDescendantsWithoutRoot = true;
+#endif
     }
 
     bool hasNonRootCompositedAncestor() const
@@ -3288,6 +3293,9 @@ bool RenderLayerCompositor::requiresOwnBackingStore(const RenderLayer& layer, co
         || renderer.hasMask()
         || renderer.hasReflection()
         || renderer.hasFilter()
+#if HAVE(CORE_MATERIAL)
+        || renderer.hasAppleVisualEffect()
+#endif
         || renderer.hasBackdropFilter())
         return true;
 
@@ -3390,6 +3398,11 @@ OptionSet<CompositingReason> RenderLayerCompositor::reasonsForCompositing(const 
 
         if (renderer.hasFilter() || renderer.hasBackdropFilter())
             reasons.add(CompositingReason::FilterWithCompositedDescendants);
+
+#if HAVE(CORE_MATERIAL)
+        if (renderer.hasAppleVisualEffect())
+            reasons.add(CompositingReason::FilterWithCompositedDescendants);
+#endif
 
         if (layer.isBackdropRoot())
             reasons.add(CompositingReason::BackdropRoot);
@@ -3864,6 +3877,11 @@ bool RenderLayerCompositor::requiresCompositingForFilters(RenderLayerModelObject
 {
     if (renderer.hasBackdropFilter())
         return true;
+
+#if HAVE(CORE_MATERIAL)
+    if (renderer.hasAppleVisualEffect())
+        return true;
+#endif
 
     if (!(m_compositingTriggers & ChromeClient::FilterTrigger))
         return false;

--- a/Source/WebCore/rendering/RenderLayerInlines.h
+++ b/Source/WebCore/rendering/RenderLayerInlines.h
@@ -38,6 +38,11 @@ inline bool RenderLayer::overlapBoundsIncludeChildren() const { return hasFilter
 inline bool RenderLayer::preserves3D() const { return renderer().style().preserves3D(); }
 inline int RenderLayer::zIndex() const { return renderer().style().usedZIndex(); }
 
+#if HAVE(CORE_MATERIAL)
+inline bool RenderLayer::hasAppleVisualEffect() const { return renderer().hasAppleVisualEffect(); }
+inline bool RenderLayer::hasAppleVisualEffectRequiringBackdropFilter() const { return renderer().hasAppleVisualEffectRequiringBackdropFilter(); }
+#endif
+
 inline bool RenderLayer::hasBlendMode() const { return renderer().hasBlendMode(); } // FIXME: Why ask the renderer this given we have m_blendMode?
 
 inline bool RenderLayer::canUseOffsetFromAncestor() const

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -843,6 +843,11 @@ static bool rareDataChangeRequiresLayout(const StyleRareNonInheritedData& first,
     if (first.hasBackdropFilters() != second.hasBackdropFilters())
         return true;
 
+#if HAVE(CORE_MATERIAL)
+    if (first.appleVisualEffect != second.appleVisualEffect)
+        return true;
+#endif
+
     if (first.inputSecurity != second.inputSecurity)
         return true;
 

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -1153,6 +1153,8 @@ public:
 
 #if HAVE(CORE_MATERIAL)
     inline AppleVisualEffect appleVisualEffect() const;
+    inline bool hasAppleVisualEffect() const;
+    inline bool hasAppleVisualEffectRequiringBackdropFilter() const;
 #endif
 
     inline MathStyle mathStyle() const;

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -271,6 +271,10 @@ inline bool RenderStyle::hasAnyPublicPseudoStyles() const { return m_nonInherite
 // FIXME: Rename this function.
 inline bool RenderStyle::hasAppearance() const { return appearance() != StyleAppearance::None && appearance() != StyleAppearance::Base; }
 inline bool RenderStyle::hasAppleColorFilter() const { return !appleColorFilter().isEmpty(); }
+#if HAVE(CORE_MATERIAL)
+inline bool RenderStyle::hasAppleVisualEffect() const { return appleVisualEffect() != AppleVisualEffect::None; }
+inline bool RenderStyle::hasAppleVisualEffectRequiringBackdropFilter() const { return appleVisualEffectNeedsBackdrop(appleVisualEffect()); }
+#endif
 inline bool RenderStyle::hasAspectRatio() const { return aspectRatioType() == AspectRatioType::Ratio || aspectRatioType() == AspectRatioType::AutoAndRatio; }
 inline bool RenderStyle::hasAttrContent() const { return m_nonInheritedData->miscData->hasAttrContent; }
 inline bool RenderStyle::hasAutoAccentColor() const { return m_rareInheritedData->hasAutoAccentColor; }

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -548,6 +548,9 @@ void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearance
             || style.boxReflect()
             || style.hasFilter()
             || style.hasBackdropFilter()
+#if HAVE(CORE_MATERIAL)
+            || style.hasAppleVisualEffect()
+#endif
             || style.hasBlendMode()
             || style.hasIsolation()
             || style.position() == PositionType::Sticky
@@ -692,6 +695,9 @@ void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearance
             || style.hasIsolation()
             || style.hasMask()
             || style.hasBackdropFilter()
+#if HAVE(CORE_MATERIAL)
+            || style.hasAppleVisualEffect()
+#endif
             || style.hasBlendMode()
             || !style.viewTransitionName().isNone();
         if (RefPtr element = m_element) {

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
@@ -437,6 +437,9 @@ enum class WebCore::PlatformCALayerLayerType : uint8_t {
     LayerTypeAVPlayerLayer,
     LayerTypeContentsProvidedLayer,
     LayerTypeBackdropLayer,
+#if HAVE(CORE_MATERIAL)
+    LayerTypeMaterialLayer,
+#endif
     LayerTypeShapeLayer,
     LayerTypeScrollContainerLayer,
 #if ENABLE(MODEL_ELEMENT)

--- a/Source/WebKit/Shared/RemoteLayerTree/LayerProperties.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/LayerProperties.h
@@ -49,6 +49,9 @@ enum class LayerChangeIndex : size_t {
     VisibleRectChanged,
 #endif
     ContentsFormatChanged,
+#if HAVE(CORE_MATERIAL)
+    AppleVisualEffectChanged,
+#endif
 };
 
 enum class LayerChange : uint64_t {
@@ -107,6 +110,9 @@ enum class LayerChange : uint64_t {
     VisibleRectChanged                  = 1LLU << static_cast<size_t>(LayerChangeIndex::VisibleRectChanged),
 #endif
     ContentsFormatChanged               = 1LLU << static_cast<size_t>(LayerChangeIndex::ContentsFormatChanged),
+#if HAVE(CORE_MATERIAL)
+    AppleVisualEffectChanged            = 1LLU << static_cast<size_t>(LayerChangeIndex::AppleVisualEffectChanged),
+#endif
 };
 
 struct RemoteLayerBackingStoreOrProperties {
@@ -205,6 +211,9 @@ struct LayerProperties {
     WebCore::FloatRect visibleRect;
 #endif
     WebCore::ContentsFormat contentsFormat { WebCore::ContentsFormat::RGBA8 };
+#if HAVE(CORE_MATERIAL)
+    WebCore::AppleVisualEffect appleVisualEffect { WebCore::AppleVisualEffect::None };
+#endif
 };
 
 }

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
@@ -419,6 +419,9 @@ void RemoteLayerBackingStore::drawInContext(GraphicsContext& context)
         break;
     case PlatformCALayer::LayerType::LayerTypeWebLayer:
     case PlatformCALayer::LayerType::LayerTypeBackdropLayer:
+#if HAVE(CORE_MATERIAL)
+    case PlatformCALayer::LayerType::LayerTypeMaterialLayer:
+#endif
         PlatformCALayer::drawLayerContents(context, m_layer.ptr(), m_paintingRects, paintBehavior);
         break;
     case PlatformCALayer::LayerType::LayerTypeLayer:

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -77,6 +77,9 @@ header: "RemoteLayerTreeTransaction.h"
     VisibleRectChanged
 #endif
     ContentsFormatChanged
+#if HAVE(CORE_MATERIAL)
+    AppleVisualEffectChanged
+#endif
 };
 
 header: "SwapBuffersDisplayRequirement.h"
@@ -275,6 +278,9 @@ headers: "LayerProperties.h" "PlatformCALayerRemote.h"
     [OptionalTupleBit=WebKit::LayerChange::VisibleRectChanged] WebCore::FloatRect visibleRect;
 #endif
     [OptionalTupleBit=WebKit::LayerChange::ContentsFormatChanged] WebCore::ContentsFormat contentsFormat;
+#if HAVE(CORE_MATERIAL)
+    [OptionalTupleBit=WebKit::LayerChange::AppleVisualEffectChanged] WebCore::AppleVisualEffect appleVisualEffect;
+#endif
 };
 
 using WebKit::LayerHostingContextID = uint32_t;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
@@ -241,6 +241,11 @@ static void dumpChangedLayers(TextStream& ts, const LayerPropertiesMap& changedL
 
         if (layerProperties.changedProperties & LayerChange::VideoGravityChanged)
             ts.dumpProperty("videoGravity", layerProperties.videoGravity);
+
+#if HAVE(CORE_MATERIAL)
+        if (layerProperties.changedProperties & LayerChange::AppleVisualEffectChanged)
+            ts.dumpProperty("appleVisualEffect", layerProperties.appleVisualEffect);
+#endif
     }
 }
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7920,6 +7920,28 @@ header: <WebCore/SharedBuffer.h>
     WebCore::SourceGraphic
 }
 
+#if HAVE(CORE_MATERIAL)
+
+header: <WebCore/AppleVisualEffect.h>
+enum class WebCore::AppleVisualEffect : uint8_t {
+    None,
+    BlurUltraThinMaterial,
+    BlurThinMaterial,
+    BlurMaterial,
+    BlurThickMaterial,
+    BlurChromeMaterial,
+    VibrancyLabel,
+    VibrancySecondaryLabel,
+    VibrancyTertiaryLabel,
+    VibrancyQuaternaryLabel,
+    VibrancyFill,
+    VibrancySecondaryFill,
+    VibrancyTertiaryFill,
+    VibrancySeparator,
+};
+
+#endif
+
 #if ENABLE(MEDIA_SOURCE)
 
 header: <WebCore/MediaSourcePrivate.h>

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -47,6 +47,7 @@
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
+#import <pal/cocoa/CoreMaterialSoftLink.h>
 #import <pal/cocoa/QuartzCoreSoftLink.h>
 
 #if PLATFORM(IOS_FAMILY)
@@ -437,6 +438,12 @@ RefPtr<RemoteLayerTreeNode> RemoteLayerTreeHost::makeNode(const RemoteLayerTreeT
 
     case PlatformCALayer::LayerType::LayerTypeBackdropLayer:
         return makeWithLayer(adoptNS([[CABackdropLayer alloc] init]));
+
+#if HAVE(CORE_MATERIAL)
+    case PlatformCALayer::LayerType::LayerTypeMaterialLayer:
+        return makeWithLayer(adoptNS([PAL::allocMTMaterialLayerInstance() init]));
+#endif
+
     case PlatformCALayer::LayerType::LayerTypeCustom:
     case PlatformCALayer::LayerType::LayerTypeAVPlayerLayer:
         if (m_isDebugLayerTreeHost)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeHostIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeHostIOS.mm
@@ -68,6 +68,11 @@ RefPtr<RemoteLayerTreeNode> RemoteLayerTreeHost::makeNode(const RemoteLayerTreeT
     case PlatformCALayer::LayerType::LayerTypeBackdropLayer:
         return makeWithView(adoptNS([[WKBackdropView alloc] init]));
 
+#if HAVE(CORE_MATERIAL)
+    case PlatformCALayer::LayerType::LayerTypeMaterialLayer:
+        return makeWithView(adoptNS([[WKMaterialView alloc] init]));
+#endif
+
     case PlatformCALayer::LayerType::LayerTypeTransformLayer:
         return makeWithView(adoptNS([[WKTransformView alloc] init]));
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.h
@@ -62,6 +62,11 @@ class WebPageProxy;
 @interface WKShapeView : WKCompositingView
 @end
 
+#if HAVE(CORE_MATERIAL)
+@interface WKMaterialView : WKCompositingView
+@end
+#endif
+
 @interface WKUIRemoteView : _UIRemoteView <WKContentControlled>
 @end
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
@@ -39,6 +39,7 @@
 #import <WebCore/TouchAction.h>
 #import <WebCore/TransformationMatrix.h>
 #import <WebCore/WebCoreCALayerExtras.h>
+#import <pal/cocoa/CoreMaterialSoftLink.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
@@ -377,6 +378,19 @@ static Class scrollViewScrollIndicatorClass()
 }
 
 @end
+
+#if HAVE(CORE_MATERIAL)
+
+@implementation WKMaterialView
+
++ (Class)layerClass
+{
+    return PAL::getMTMaterialLayerClass();
+}
+
+@end
+
+#endif
 
 @implementation WKUIRemoteView
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
@@ -231,6 +231,11 @@ public:
 #endif
 #endif
 
+#if HAVE(CORE_MATERIAL)
+    WebCore::AppleVisualEffect appleVisualEffect() const override;
+    void setAppleVisualEffect(WebCore::AppleVisualEffect) override;
+#endif
+
     WebCore::TiledBacking* tiledBacking() override { return nullptr; }
 
     Ref<WebCore::PlatformCALayer> clone(WebCore::PlatformCALayerClient* owner) const override;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
@@ -1112,6 +1112,24 @@ void PlatformCALayerRemote::setIsDescendentOfSeparatedPortal(bool value)
 #endif
 #endif
 
+#if HAVE(CORE_MATERIAL)
+
+WebCore::AppleVisualEffect PlatformCALayerRemote::appleVisualEffect() const
+{
+    return m_properties.appleVisualEffect;
+}
+
+void PlatformCALayerRemote::setAppleVisualEffect(WebCore::AppleVisualEffect effect)
+{
+    if (m_properties.appleVisualEffect == effect)
+        return;
+
+    m_properties.appleVisualEffect = effect;
+    m_properties.notePropertiesChanged(LayerChange::AppleVisualEffectChanged);
+}
+
+#endif
+
 Ref<PlatformCALayer> PlatformCALayerRemote::createCompatibleLayer(PlatformCALayer::LayerType layerType, PlatformCALayerClient* client) const
 {
     RELEASE_ASSERT(m_context.get());


### PR DESCRIPTION
#### fc46a347192024cf8083fb284cd815e0e399eb2f
<pre>
[Materials] Add rendering support for blur effects
<a href="https://bugs.webkit.org/show_bug.cgi?id=284729">https://bugs.webkit.org/show_bug.cgi?id=284729</a>
<a href="https://rdar.apple.com/141527633">rdar://141527633</a>

Reviewed by Simon Fraser.

Create and display `MTMaterialLayer`s when using `-apple-visual-effect` with
one of the `-apple-system-blur-` keywords. Note that this is not web-exposed.

`MTMaterialLayer`s are backdrop layers with a specific set of `CAFilter`s,
depending on the blur effect.

* LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-chrome-expected.txt: Added.
* LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-chrome.html: Added.
* LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-expected.txt: Added.
* LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thick-expected.txt: Added.
* LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thick.html: Added.
* LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thin-expected.txt: Added.
* LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thin.html: Added.
* LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-ultra-thin-expected.txt: Added.
* LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-ultra-thin.html: Added.
* LayoutTests/apple-visual-effects/apple-visual-effect-blur-material.html: Added.
* LayoutTests/apple-visual-effects/backdrop-filter-with-apple-visual-effect-expected.html: Added.
* LayoutTests/apple-visual-effects/backdrop-filter-with-apple-visual-effect.html: Added.
* LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-chrome-expected.txt: Added.
* LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-expected.txt: Added.
* LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-thick-expected.txt: Added.
* LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-thin-expected.txt: Added.
* LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-ultra-thin-expected.txt: Added.
* Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj:
* Source/WebCore/PAL/pal/PlatformMac.cmake:
* Source/WebCore/PAL/pal/cocoa/CoreMaterialSoftLink.h: Copied from Source/WebCore/platform/cocoa/AppleVisualEffect.h.
* Source/WebCore/PAL/pal/cocoa/CoreMaterialSoftLink.mm: Copied from Source/WebCore/platform/cocoa/AppleVisualEffect.h.
* Source/WebCore/PAL/pal/spi/cocoa/CoreMaterialSPI.h: Copied from Source/WebCore/platform/cocoa/AppleVisualEffect.h.
* Source/WebCore/page/FrameSnapshotting.cpp:
(WebCore::styleContainsComplexBackground):
* Source/WebCore/platform/cocoa/AppleVisualEffect.cpp:
(WebCore::appleVisualEffectNeedsBackdrop):

Add a helper method to distinguish visual effects which create a backdrop (blur)
from those that do not (vibrancy). Support for vibrancy will be added in a
subsequent patch.

* Source/WebCore/platform/cocoa/AppleVisualEffect.h:
* Source/WebCore/platform/graphics/GraphicsLayer.cpp:
(WebCore::GraphicsLayer::needsBackdrop const):
(WebCore::GraphicsLayer::dumpProperties const):
* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::GraphicsLayer::appleVisualEffect const):
(WebCore::GraphicsLayer::setAppleVisualEffect):

Specify `BackdropFiltersChanged` in addition to `AppleVisualEffectChanged`, as
material blurs set filters on a backdrop. A structural layer must be created,
and the backdrop filter rect must also be updated.

(WebCore::GraphicsLayer::needsBackdrop const): Deleted.
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::setAppleVisualEffect):
(WebCore::GraphicsLayerCA::commitLayerChangesBeforeSublayers):
(WebCore::GraphicsLayerCA::updateBackdropFilters):
(WebCore::GraphicsLayerCA::updateAppleVisualEffect):

Only support backdrop effects for now. Foreground effects (vibrancy) will be
implemented in a subsequent patch.

(WebCore::GraphicsLayerCA::purposeNameForInnerLayer const):
(WebCore::GraphicsLayerCA::layerChangeAsString):
(WebCore::GraphicsLayerCA::changeLayerTypeTo):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/platform/graphics/ca/PlatformCALayer.h:

Introduce a new layer type for materials.

* Source/WebCore/platform/graphics/ca/PlatformCALayer.mm:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.h:
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm:
(WebCore::PlatformCALayerCocoa::PlatformCALayerCocoa):
(WebCore::PlatformCALayerCocoa::clone const):
(WebCore::PlatformCALayerCocoa::appleVisualEffect const):
(WebCore::PlatformCALayerCocoa::setAppleVisualEffect):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::repaintBeforeStyleChange):
(WebCore::RenderElement::adjustFragmentedFlowStateOnContainingBlockChangeIfNeeded):
* Source/WebCore/rendering/RenderElement.h:
* Source/WebCore/rendering/RenderElementInlines.h:
(WebCore::RenderElement::hasAppleVisualEffect const):
(WebCore::RenderElement::hasAppleVisualEffectRequiringBackdropFilter const):
(WebCore::RenderElement::canContainAbsolutelyPositionedObjects const):
(WebCore::RenderElement::canContainFixedPositionObjects const):
(WebCore::RenderElement::createsGroupForStyle):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::canCreateStackingContext):
(WebCore::RenderLayer::computeCanBeBackdropRoot const):
(WebCore::RenderLayer::debugDescription const):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::createPrimaryGraphicsLayer):
(WebCore::RenderLayerBacking::updateBackdropFiltersGeometry):
(WebCore::RenderLayerBacking::updateAppleVisualEffect):
(WebCore::RenderLayerBacking::updateConfigurationAfterStyleChange):
(WebCore::RenderLayerBacking::updateGeometry):
* Source/WebCore/rendering/RenderLayerBacking.h:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::CompositingState::updateWithDescendantStateAndLayer):
(WebCore::RenderLayerCompositor::requiresOwnBackingStore const):
(WebCore::RenderLayerCompositor::reasonsForCompositing const):
(WebCore::RenderLayerCompositor::requiresCompositingForFilters const):
* Source/WebCore/rendering/RenderLayerInlines.h:
(WebCore::RenderLayer::hasAppleVisualEffect const):
(WebCore::RenderLayer::hasAppleVisualEffectRequiringBackdropFilter const):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::rareDataChangeRequiresLayout):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::hasAppleVisualEffect const):
(WebCore::RenderStyle::hasAppleVisualEffectRequiringBackdropFilter const):
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/LayerProperties.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::drawInContext):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::materialRecipeForAppleVisualEffect):
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToLayer):

Set a &quot;recipe&quot; on `MTMaterialLayer` to achieve the blur effect.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm:
(WebKit::dumpChangedLayers):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::makeNode):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeHostIOS.mm:
(WebKit::RemoteLayerTreeHost::makeNode):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm:
(WebKit::PlatformCALayerRemote::appleVisualEffect const):
(WebKit::PlatformCALayerRemote::setAppleVisualEffect):

Canonical link: <a href="https://commits.webkit.org/288125@main">https://commits.webkit.org/288125@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6162a8b5030b4f258908b4bb486e2218fb2420b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81878 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1404 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35832 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86435 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32881 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83984 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1437 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9227 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63863 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21589 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84948 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1063 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74514 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44147 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/963 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28691 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31327 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72311 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29300 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87866 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9118 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6499 "Found 1 new test failure: http/wpt/mediarecorder/pause-recording-timeSlice.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72235 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9303 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70333 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71450 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15538 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14463 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12698 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9069 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14607 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8910 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12433 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10718 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->