### PR TITLE
[iOS] Rename {PlaybackSessionInterface,VideoPresentationInterface}AVKit to {PlaybackSessionInterface,VideoPresentationInterface}AVKitLegacy

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -555,7 +555,7 @@ platform/ios/PasteboardIOS.mm
 platform/ios/PlatformEventFactoryIOS.mm @no-unify
 platform/ios/PlatformPasteboardIOS.mm
 platform/ios/PlatformScreenIOS.mm
-platform/ios/PlaybackSessionInterfaceAVKit.mm @no-unify
+platform/ios/PlaybackSessionInterfaceAVKitLegacy.mm @no-unify
 platform/ios/PlaybackSessionInterfaceIOS.mm @no-unify
 platform/ios/PlaybackSessionInterfaceTVOS.cpp
 platform/ios/PreviewConverterIOS.mm

--- a/Source/WebCore/platform/graphics/PlatformPlaybackSessionInterface.h
+++ b/Source/WebCore/platform/graphics/PlatformPlaybackSessionInterface.h
@@ -28,7 +28,7 @@
 namespace WebCore {
 
 class NullPlaybackSessionInterface;
-class PlaybackSessionInterfaceAVKit;
+class PlaybackSessionInterfaceAVKitLegacy;
 class PlaybackSessionInterfaceIOS;
 class PlaybackSessionInterfaceMac;
 class PlaybackSessionInterfaceTVOS;
@@ -40,7 +40,7 @@ using PlatformPlaybackSessionInterface = PlaybackSessionInterfaceIOS;
 #elif PLATFORM(APPLETV)
 using PlatformPlaybackSessionInterface = PlaybackSessionInterfaceTVOS;
 #elif PLATFORM(IOS_FAMILY)
-using PlatformPlaybackSessionInterface = PlaybackSessionInterfaceAVKit;
+using PlatformPlaybackSessionInterface = PlaybackSessionInterfaceAVKitLegacy;
 #elif PLATFORM(MAC)
 using PlatformPlaybackSessionInterface = PlaybackSessionInterfaceMac;
 #endif

--- a/Source/WebCore/platform/graphics/PlatformVideoPresentationInterface.h
+++ b/Source/WebCore/platform/graphics/PlatformVideoPresentationInterface.h
@@ -28,7 +28,7 @@
 namespace WebCore {
 
 class NullVideoPresentationInterface;
-class VideoPresentationInterfaceAVKit;
+class VideoPresentationInterfaceAVKitLegacy;
 class VideoPresentationInterfaceIOS;
 class VideoPresentationInterfaceMac;
 class VideoPresentationInterfaceTVOS;
@@ -40,7 +40,7 @@ using PlatformVideoPresentationInterface = VideoPresentationInterfaceIOS;
 #elif PLATFORM(APPLETV)
 using PlatformVideoPresentationInterface = VideoPresentationInterfaceTVOS;
 #elif PLATFORM(IOS_FAMILY)
-using PlatformVideoPresentationInterface = VideoPresentationInterfaceAVKit;
+using PlatformVideoPresentationInterface = VideoPresentationInterfaceAVKitLegacy;
 #elif PLATFORM(MAC)
 using PlatformVideoPresentationInterface = VideoPresentationInterfaceMac;
 #endif

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKitLegacy.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKitLegacy.h
@@ -32,12 +32,12 @@
 
 namespace WebCore {
 
-class WEBCORE_EXPORT PlaybackSessionInterfaceAVKit final : public PlaybackSessionInterfaceIOS {
-    WTF_MAKE_TZONE_ALLOCATED_EXPORT(PlaybackSessionInterfaceAVKit, WEBCORE_EXPORT);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PlaybackSessionInterfaceAVKit);
+class WEBCORE_EXPORT PlaybackSessionInterfaceAVKitLegacy final : public PlaybackSessionInterfaceIOS {
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(PlaybackSessionInterfaceAVKitLegacy, WEBCORE_EXPORT);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PlaybackSessionInterfaceAVKitLegacy);
 public:
-    static Ref<PlaybackSessionInterfaceAVKit> create(PlaybackSessionModel&);
-    ~PlaybackSessionInterfaceAVKit();
+    static Ref<PlaybackSessionInterfaceAVKitLegacy> create(PlaybackSessionModel&);
+    ~PlaybackSessionInterfaceAVKitLegacy();
     void invalidate() final;
 
     WebAVPlayerController *playerController() const final;
@@ -59,7 +59,7 @@ public:
 #endif
 
 private:
-    PlaybackSessionInterfaceAVKit(PlaybackSessionModel&);
+    PlaybackSessionInterfaceAVKitLegacy(PlaybackSessionModel&);
 
     RetainPtr<WebAVPlayerController> m_playerController;
 

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKitLegacy.mm
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKitLegacy.mm
@@ -25,7 +25,7 @@
 
 
 #import "config.h"
-#import "PlaybackSessionInterfaceAVKit.h"
+#import "PlaybackSessionInterfaceAVKitLegacy.h"
 
 #if PLATFORM(COCOA) && HAVE(AVKIT)
 
@@ -47,16 +47,16 @@ SOFT_LINK_CLASS_OPTIONAL(AVKit, AVValueTiming)
 
 namespace WebCore {
 
-WTF_MAKE_TZONE_ALLOCATED_IMPL(PlaybackSessionInterfaceAVKit);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PlaybackSessionInterfaceAVKitLegacy);
 
-Ref<PlaybackSessionInterfaceAVKit> PlaybackSessionInterfaceAVKit::create(PlaybackSessionModel& model)
+Ref<PlaybackSessionInterfaceAVKitLegacy> PlaybackSessionInterfaceAVKitLegacy::create(PlaybackSessionModel& model)
 {
-    Ref interface = adoptRef(*new PlaybackSessionInterfaceAVKit(model));
+    Ref interface = adoptRef(*new PlaybackSessionInterfaceAVKitLegacy(model));
     interface->initialize();
     return interface;
 }
 
-PlaybackSessionInterfaceAVKit::PlaybackSessionInterfaceAVKit(PlaybackSessionModel& model)
+PlaybackSessionInterfaceAVKitLegacy::PlaybackSessionInterfaceAVKitLegacy(PlaybackSessionModel& model)
     : PlaybackSessionInterfaceIOS(model)
     , m_playerController(createWebAVPlayerController())
 {
@@ -65,23 +65,23 @@ PlaybackSessionInterfaceAVKit::PlaybackSessionInterfaceAVKit(PlaybackSessionMode
     [m_playerController setDelegate:&model];
 }
 
-PlaybackSessionInterfaceAVKit::~PlaybackSessionInterfaceAVKit()
+PlaybackSessionInterfaceAVKitLegacy::~PlaybackSessionInterfaceAVKitLegacy()
 {
     ASSERT(isUIThread());
     invalidate();
 }
 
-WebAVPlayerController *PlaybackSessionInterfaceAVKit::playerController() const
+WebAVPlayerController *PlaybackSessionInterfaceAVKitLegacy::playerController() const
 {
     return m_playerController.get();
 }
 
-WKSLinearMediaPlayer *PlaybackSessionInterfaceAVKit::linearMediaPlayer() const
+WKSLinearMediaPlayer *PlaybackSessionInterfaceAVKitLegacy::linearMediaPlayer() const
 {
     return nullptr;
 }
 
-void PlaybackSessionInterfaceAVKit::invalidate()
+void PlaybackSessionInterfaceAVKitLegacy::invalidate()
 {
     if (!m_playbackSessionModel)
         return;
@@ -92,7 +92,7 @@ void PlaybackSessionInterfaceAVKit::invalidate()
     PlaybackSessionInterfaceIOS::invalidate();
 }
 
-void PlaybackSessionInterfaceAVKit::durationChanged(double duration)
+void PlaybackSessionInterfaceAVKitLegacy::durationChanged(double duration)
 {
     WebAVPlayerController* playerController = m_playerController.get();
 
@@ -108,7 +108,7 @@ void PlaybackSessionInterfaceAVKit::durationChanged(double duration)
     playerController.status = AVPlayerControllerStatusReadyToPlay;
 }
 
-void PlaybackSessionInterfaceAVKit::currentTimeChanged(double currentTime, double anchorTime)
+void PlaybackSessionInterfaceAVKitLegacy::currentTimeChanged(double currentTime, double anchorTime)
 {
     if ([m_playerController isScrubbing])
         return;
@@ -120,7 +120,7 @@ void PlaybackSessionInterfaceAVKit::currentTimeChanged(double currentTime, doubl
     [m_playerController setTiming:timing];
 }
 
-void PlaybackSessionInterfaceAVKit::bufferedTimeChanged(double bufferedTime)
+void PlaybackSessionInterfaceAVKitLegacy::bufferedTimeChanged(double bufferedTime)
 {
     WebAVPlayerController* playerController = m_playerController.get();
     double duration = playerController.contentDuration;
@@ -132,14 +132,14 @@ void PlaybackSessionInterfaceAVKit::bufferedTimeChanged(double bufferedTime)
     playerController.loadedTimeRanges = @[@0, @(normalizedBufferedTime)];
 }
 
-void PlaybackSessionInterfaceAVKit::rateChanged(OptionSet<PlaybackSessionModel::PlaybackState> playbackState, double playbackRate, double defaultPlaybackRate)
+void PlaybackSessionInterfaceAVKitLegacy::rateChanged(OptionSet<PlaybackSessionModel::PlaybackState> playbackState, double playbackRate, double defaultPlaybackRate)
 {
     [m_playerController setDefaultPlaybackRate:defaultPlaybackRate fromJavaScript:YES];
     if (!playbackState.contains(PlaybackSessionModel::PlaybackState::Stalled))
         [m_playerController setRate:playbackState.contains(PlaybackSessionModel::PlaybackState::Playing) ? playbackRate : 0. fromJavaScript:YES];
 }
 
-void PlaybackSessionInterfaceAVKit::seekableRangesChanged(const TimeRanges& timeRanges, double lastModifiedTime, double liveUpdateInterval)
+void PlaybackSessionInterfaceAVKitLegacy::seekableRangesChanged(const TimeRanges& timeRanges, double lastModifiedTime, double liveUpdateInterval)
 {
     RetainPtr<NSMutableArray> seekableRanges = adoptNS([[NSMutableArray alloc] init]);
 
@@ -160,7 +160,7 @@ void PlaybackSessionInterfaceAVKit::seekableRangesChanged(const TimeRanges& time
     [m_playerController setLiveUpdateInterval:liveUpdateInterval];
 }
 
-void PlaybackSessionInterfaceAVKit::canPlayFastReverseChanged(bool canPlayFastReverse)
+void PlaybackSessionInterfaceAVKitLegacy::canPlayFastReverseChanged(bool canPlayFastReverse)
 {
     [m_playerController setCanScanBackward:canPlayFastReverse];
 }
@@ -195,7 +195,7 @@ static RetainPtr<NSArray> mediaSelectionOptions(const Vector<MediaSelectionOptio
     });
 }
 
-void PlaybackSessionInterfaceAVKit::audioMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>& options, uint64_t selectedIndex)
+void PlaybackSessionInterfaceAVKitLegacy::audioMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>& options, uint64_t selectedIndex)
 {
     auto webOptions = mediaSelectionOptions(options);
     [m_playerController setAudioMediaSelectionOptions:webOptions.get()];
@@ -203,7 +203,7 @@ void PlaybackSessionInterfaceAVKit::audioMediaSelectionOptionsChanged(const Vect
         [m_playerController setCurrentAudioMediaSelectionOption:[webOptions objectAtIndex:static_cast<NSUInteger>(selectedIndex)]];
 }
 
-void PlaybackSessionInterfaceAVKit::legibleMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>& options, uint64_t selectedIndex)
+void PlaybackSessionInterfaceAVKitLegacy::legibleMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>& options, uint64_t selectedIndex)
 {
     auto webOptions = mediaSelectionOptions(options);
     [m_playerController setLegibleMediaSelectionOptions:webOptions.get()];
@@ -211,7 +211,7 @@ void PlaybackSessionInterfaceAVKit::legibleMediaSelectionOptionsChanged(const Ve
         [m_playerController setCurrentLegibleMediaSelectionOption:[webOptions objectAtIndex:static_cast<NSUInteger>(selectedIndex)]];
 }
 
-void PlaybackSessionInterfaceAVKit::externalPlaybackChanged(bool enabled, PlaybackSessionModel::ExternalPlaybackTargetType targetType, const String& localizedDeviceName)
+void PlaybackSessionInterfaceAVKitLegacy::externalPlaybackChanged(bool enabled, PlaybackSessionModel::ExternalPlaybackTargetType targetType, const String& localizedDeviceName)
 {
     AVPlayerControllerExternalPlaybackType externalPlaybackType = AVPlayerControllerExternalPlaybackTypeNone;
     if (enabled && targetType == PlaybackSessionModel::ExternalPlaybackTargetType::TargetTypeAirPlay)
@@ -225,25 +225,25 @@ void PlaybackSessionInterfaceAVKit::externalPlaybackChanged(bool enabled, Playba
     playerController.externalPlaybackActive = enabled;
 }
 
-void PlaybackSessionInterfaceAVKit::wirelessVideoPlaybackDisabledChanged(bool disabled)
+void PlaybackSessionInterfaceAVKitLegacy::wirelessVideoPlaybackDisabledChanged(bool disabled)
 {
     [m_playerController setAllowsExternalPlayback:!disabled];
 }
 
-void PlaybackSessionInterfaceAVKit::mutedChanged(bool muted)
+void PlaybackSessionInterfaceAVKitLegacy::mutedChanged(bool muted)
 {
     [m_playerController setMuted:muted];
 }
 
-void PlaybackSessionInterfaceAVKit::volumeChanged(double volume)
+void PlaybackSessionInterfaceAVKitLegacy::volumeChanged(double volume)
 {
     [m_playerController volumeChanged:volume];
 }
 
 #if !RELEASE_LOG_DISABLED
-ASCIILiteral PlaybackSessionInterfaceAVKit::logClassName() const
+ASCIILiteral PlaybackSessionInterfaceAVKitLegacy::logClassName() const
 {
-    return "PlaybackSessionInterfaceAVKit"_s;
+    return "PlaybackSessionInterfaceAVKitLegacy"_s;
 }
 #endif
 } // namespace WebCore

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.h
@@ -41,17 +41,17 @@ namespace WebCore {
 
 class PlaybackSessionInterfaceIOS;
 
-class VideoPresentationInterfaceAVKit final : public VideoPresentationInterfaceIOS {
-    WTF_MAKE_TZONE_ALLOCATED_EXPORT(VideoPresentationInterfaceAVKit, WEBCORE_EXPORT);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(VideoPresentationInterfaceAVKit);
+class VideoPresentationInterfaceAVKitLegacy final : public VideoPresentationInterfaceIOS {
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(VideoPresentationInterfaceAVKitLegacy, WEBCORE_EXPORT);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(VideoPresentationInterfaceAVKitLegacy);
 public:
-    WEBCORE_EXPORT static Ref<VideoPresentationInterfaceAVKit> create(PlaybackSessionInterfaceIOS&);
-    WEBCORE_EXPORT ~VideoPresentationInterfaceAVKit();
+    WEBCORE_EXPORT static Ref<VideoPresentationInterfaceAVKitLegacy> create(PlaybackSessionInterfaceIOS&);
+    WEBCORE_EXPORT ~VideoPresentationInterfaceAVKitLegacy();
 
     WEBCORE_EXPORT void hasVideoChanged(bool) final;
 
 #if !RELEASE_LOG_DISABLED
-    ASCIILiteral logClassName() const { return "VideoPresentationInterfaceAVKit"_s; };
+    ASCIILiteral logClassName() const { return "VideoPresentationInterfaceAVKitLegacy"_s; };
 #endif
 
     WEBCORE_EXPORT AVPlayerViewController *avPlayerViewController() const final;
@@ -68,7 +68,7 @@ public:
     WEBCORE_EXPORT void setupCaptionsLayer(CALayer *parent, const WebCore::FloatSize&) final;
 
 private:
-    WEBCORE_EXPORT VideoPresentationInterfaceAVKit(PlaybackSessionInterfaceIOS&);
+    WEBCORE_EXPORT VideoPresentationInterfaceAVKitLegacy(PlaybackSessionInterfaceIOS&);
 
     void updateRouteSharingPolicy() final;
     void setupPlayerViewController() final;

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.mm
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.mm
@@ -24,13 +24,13 @@
  */
 
 #import "config.h"
-#import "VideoPresentationInterfaceAVKit.h"
+#import "VideoPresentationInterfaceAVKitLegacy.h"
 
 #if PLATFORM(IOS_FAMILY) && HAVE(AVKIT)
 
 #import "Logging.h"
 #import "PictureInPictureSupport.h"
-#import "PlaybackSessionInterfaceAVKit.h"
+#import "PlaybackSessionInterfaceAVKitLegacy.h"
 #import "UIViewControllerUtilities.h"
 #import "WebAVPlayerController.h"
 #import "WebAVPlayerLayer.h"
@@ -80,9 +80,9 @@ SOFT_LINK_CLASS_OPTIONAL(AVKit, AVPictureInPictureContentViewController)
     , AVPictureInPictureControllerDelegate
 #endif
 > {
-    ThreadSafeWeakPtr<WebCore::VideoPresentationInterfaceAVKit> _fullscreenInterface;
+    ThreadSafeWeakPtr<WebCore::VideoPresentationInterfaceAVKitLegacy> _fullscreenInterface;
 }
-@property (nonatomic, assign /* weak */) RefPtr<WebCore::VideoPresentationInterfaceAVKit> fullscreenInterface;
+@property (nonatomic, assign /* weak */) RefPtr<WebCore::VideoPresentationInterfaceAVKitLegacy> fullscreenInterface;
 #if !PLATFORM(APPLETV)
 - (BOOL)playerViewController:(AVPlayerViewController *)playerViewController shouldExitFullScreenWithReason:(AVPlayerViewControllerExitFullScreenReason)reason;
 #else
@@ -91,13 +91,13 @@ SOFT_LINK_CLASS_OPTIONAL(AVKit, AVPictureInPictureContentViewController)
 @end
 
 @implementation WebAVPlayerViewControllerDelegate
-- (RefPtr<WebCore::VideoPresentationInterfaceAVKit>)fullscreenInterface
+- (RefPtr<WebCore::VideoPresentationInterfaceAVKitLegacy>)fullscreenInterface
 {
     ASSERT(isMainThread());
     return _fullscreenInterface.get();
 }
 
-- (void)setFullscreenInterface:(RefPtr<WebCore::VideoPresentationInterfaceAVKit>)fullscreenInterface
+- (void)setFullscreenInterface:(RefPtr<WebCore::VideoPresentationInterfaceAVKitLegacy>)fullscreenInterface
 {
     ASSERT(isMainThread());
     if (!fullscreenInterface) {
@@ -155,19 +155,19 @@ IGNORE_WARNINGS_BEGIN("deprecated-implementations")
 
 #if !PLATFORM(APPLETV)
 
-static WebCore::VideoPresentationInterfaceAVKit::ExitFullScreenReason convertToExitFullScreenReason(AVPlayerViewControllerExitFullScreenReason reason)
+static WebCore::VideoPresentationInterfaceAVKitLegacy::ExitFullScreenReason convertToExitFullScreenReason(AVPlayerViewControllerExitFullScreenReason reason)
 {
     switch (reason) {
     case AVPlayerViewControllerExitFullScreenReasonDoneButtonTapped:
-        return WebCore::VideoPresentationInterfaceAVKit::ExitFullScreenReason::DoneButtonTapped;
+        return WebCore::VideoPresentationInterfaceAVKitLegacy::ExitFullScreenReason::DoneButtonTapped;
     case AVPlayerViewControllerExitFullScreenReasonFullScreenButtonTapped:
-        return WebCore::VideoPresentationInterfaceAVKit::ExitFullScreenReason::FullScreenButtonTapped;
+        return WebCore::VideoPresentationInterfaceAVKitLegacy::ExitFullScreenReason::FullScreenButtonTapped;
     case AVPlayerViewControllerExitFullScreenReasonPictureInPictureStarted:
-        return WebCore::VideoPresentationInterfaceAVKit::ExitFullScreenReason::PictureInPictureStarted;
+        return WebCore::VideoPresentationInterfaceAVKitLegacy::ExitFullScreenReason::PictureInPictureStarted;
     case AVPlayerViewControllerExitFullScreenReasonPinchGestureHandled:
-        return WebCore::VideoPresentationInterfaceAVKit::ExitFullScreenReason::PinchGestureHandled;
+        return WebCore::VideoPresentationInterfaceAVKitLegacy::ExitFullScreenReason::PinchGestureHandled;
     case AVPlayerViewControllerExitFullScreenReasonRemoteControlStopEventReceived:
-        return WebCore::VideoPresentationInterfaceAVKit::ExitFullScreenReason::RemoteControlStopEventReceived;
+        return WebCore::VideoPresentationInterfaceAVKitLegacy::ExitFullScreenReason::RemoteControlStopEventReceived;
     }
 }
 
@@ -186,7 +186,7 @@ static WebCore::VideoPresentationInterfaceAVKit::ExitFullScreenReason convertToE
 {
     UNUSED_PARAM(playerViewController);
     if (auto fullscreenInterface = self.fullscreenInterface)
-        return fullscreenInterface->shouldExitFullscreenWithReason(WebCore::VideoPresentationInterfaceAVKit::ExitFullScreenReason::PinchGestureHandled);
+        return fullscreenInterface->shouldExitFullscreenWithReason(WebCore::VideoPresentationInterfaceAVKitLegacy::ExitFullScreenReason::PinchGestureHandled);
 
     return YES;
 }
@@ -352,7 +352,7 @@ static WebAVPictureInPictureContentViewController *allocWebAVPictureInPictureCon
 NS_ASSUME_NONNULL_BEGIN
 @interface WebAVPlayerViewController : NSObject<AVPlayerViewControllerDelegate>
 @property (readonly, nonatomic) WebAVPlayerLayerView *playerLayerView;
-- (instancetype)initWithFullscreenInterface:(WebCore::VideoPresentationInterfaceAVKit *)interface;
+- (instancetype)initWithFullscreenInterface:(WebCore::VideoPresentationInterfaceAVKitLegacy *)interface;
 - (void)enterFullScreenAnimated:(BOOL)animated completionHandler:(void (^)(BOOL success, NSError *))completionHandler;
 - (void)exitFullScreenAnimated:(BOOL)animated completionHandler:(void (^)(BOOL success, NSError *))completionHandler;
 - (void)startPictureInPicture;
@@ -370,7 +370,7 @@ NS_ASSUME_NONNULL_BEGIN
 NS_ASSUME_NONNULL_END
 
 @implementation WebAVPlayerViewController {
-    ThreadSafeWeakPtr<WebCore::VideoPresentationInterfaceAVKit> _fullscreenInterface;
+    ThreadSafeWeakPtr<WebCore::VideoPresentationInterfaceAVKitLegacy> _fullscreenInterface;
 #if PLATFORM(WATCHOS) || PLATFORM(APPLETV)
     RetainPtr<UIViewController> _presentingViewController;
 #endif
@@ -385,7 +385,7 @@ NS_ASSUME_NONNULL_END
 #endif
 }
 
-- (instancetype)initWithFullscreenInterface:(WebCore::VideoPresentationInterfaceAVKit *)interface
+- (instancetype)initWithFullscreenInterface:(WebCore::VideoPresentationInterfaceAVKitLegacy *)interface
 {
     if (!(self = [super init]))
         return nil;
@@ -428,7 +428,7 @@ NS_ASSUME_NONNULL_END
 }
 
 #if PLATFORM(APPLETV)
-- (void)configurePlayerViewControllerWithFullscreenInterface:(WebCore::VideoPresentationInterfaceAVKit *)interface
+- (void)configurePlayerViewControllerWithFullscreenInterface:(WebCore::VideoPresentationInterfaceAVKitLegacy *)interface
 {
     // FIXME (116592344): This is a proof-of-concept hack to work around lack support for a custom
     // AVPlayerLayerView in tvOS's version of AVPlayerViewController. This will be replaced once
@@ -774,38 +774,38 @@ static const NSTimeInterval startPictureInPictureTimeInterval = 5.0;
 
 namespace WebCore {
 
-WTF_MAKE_TZONE_ALLOCATED_IMPL(VideoPresentationInterfaceAVKit);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(VideoPresentationInterfaceAVKitLegacy);
 
-Ref<VideoPresentationInterfaceAVKit> VideoPresentationInterfaceAVKit::create(PlaybackSessionInterfaceIOS& playbackSessionInterface)
+Ref<VideoPresentationInterfaceAVKitLegacy> VideoPresentationInterfaceAVKitLegacy::create(PlaybackSessionInterfaceIOS& playbackSessionInterface)
 {
-    return adoptRef(*new VideoPresentationInterfaceAVKit(playbackSessionInterface));
+    return adoptRef(*new VideoPresentationInterfaceAVKitLegacy(playbackSessionInterface));
 }
 
-VideoPresentationInterfaceAVKit::VideoPresentationInterfaceAVKit(PlaybackSessionInterfaceIOS& playbackSessionInterface)
+VideoPresentationInterfaceAVKitLegacy::VideoPresentationInterfaceAVKitLegacy(PlaybackSessionInterfaceIOS& playbackSessionInterface)
     : VideoPresentationInterfaceIOS(playbackSessionInterface)
     , m_playerViewControllerDelegate(adoptNS([[WebAVPlayerViewControllerDelegate alloc] init]))
 {
     [m_playerViewControllerDelegate setFullscreenInterface:this];
 }
 
-VideoPresentationInterfaceAVKit::~VideoPresentationInterfaceAVKit()
+VideoPresentationInterfaceAVKitLegacy::~VideoPresentationInterfaceAVKitLegacy()
 {
     WebAVPlayerController* playerController = this->playerController();
     if (playerController && playerController.externalPlaybackActive)
         externalPlaybackChanged(false, PlaybackSessionModel::ExternalPlaybackTargetType::TargetTypeNone, emptyString());
 }
 
-UIViewController *VideoPresentationInterfaceAVKit::playerViewController() const
+UIViewController *VideoPresentationInterfaceAVKitLegacy::playerViewController() const
 {
     return avPlayerViewController();
 }
 
-AVPlayerViewController *VideoPresentationInterfaceAVKit::avPlayerViewController() const
+AVPlayerViewController *VideoPresentationInterfaceAVKitLegacy::avPlayerViewController() const
 {
     return [m_playerViewController avPlayerViewController];
 }
 
-void VideoPresentationInterfaceAVKit::setupFullscreen(const FloatRect& initialRect, const FloatSize& videoDimensions, UIView* parentView, HTMLMediaElementEnums::VideoFullscreenMode mode, bool allowsPictureInPicturePlayback, bool standby, bool blocksReturnToFullscreenFromPictureInPicture)
+void VideoPresentationInterfaceAVKitLegacy::setupFullscreen(const FloatRect& initialRect, const FloatSize& videoDimensions, UIView* parentView, HTMLMediaElementEnums::VideoFullscreenMode mode, bool allowsPictureInPicturePlayback, bool standby, bool blocksReturnToFullscreenFromPictureInPicture)
 {
     [playerController() setContentDimensions:videoDimensions];
     VideoPresentationInterfaceIOS::setupFullscreen(initialRect, videoDimensions, parentView, mode, allowsPictureInPicturePlayback, standby, blocksReturnToFullscreenFromPictureInPicture);
@@ -813,24 +813,24 @@ void VideoPresentationInterfaceAVKit::setupFullscreen(const FloatRect& initialRe
         playerLayer().captionsLayer = captionsLayer();
 }
 
-void VideoPresentationInterfaceAVKit::updateRouteSharingPolicy()
+void VideoPresentationInterfaceAVKitLegacy::updateRouteSharingPolicy()
 {
     if (m_playerViewController && !m_routingContextUID.isEmpty())
         [m_playerViewController setWebKitOverrideRouteSharingPolicy:(NSUInteger)m_routeSharingPolicy routingContextUID:m_routingContextUID];
 }
 
-void VideoPresentationInterfaceAVKit::hasVideoChanged(bool hasVideo)
+void VideoPresentationInterfaceAVKitLegacy::hasVideoChanged(bool hasVideo)
 {
     [playerController() setHasEnabledVideo:hasVideo];
     [playerController() setHasVideo:hasVideo];
 }
 
-bool VideoPresentationInterfaceAVKit::pictureInPictureWasStartedWhenEnteringBackground() const
+bool VideoPresentationInterfaceAVKitLegacy::pictureInPictureWasStartedWhenEnteringBackground() const
 {
     return [m_playerViewController pictureInPictureWasStartedWhenEnteringBackground];
 }
 
-void VideoPresentationInterfaceAVKit::setPlayerIdentifier(std::optional<MediaPlayerIdentifier> identifier)
+void VideoPresentationInterfaceAVKitLegacy::setPlayerIdentifier(std::optional<MediaPlayerIdentifier> identifier)
 {
 #if !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)
     if (!identifier)
@@ -839,12 +839,12 @@ void VideoPresentationInterfaceAVKit::setPlayerIdentifier(std::optional<MediaPla
     VideoPresentationInterfaceIOS::setPlayerIdentifier(identifier);
 }
 
-bool VideoPresentationInterfaceAVKit::mayAutomaticallyShowVideoPictureInPicture() const
+bool VideoPresentationInterfaceAVKitLegacy::mayAutomaticallyShowVideoPictureInPicture() const
 {
     return [playerController() isPlaying] && (m_standby || m_currentMode.isFullscreen()) && supportsPictureInPicture();
 }
 
-void VideoPresentationInterfaceAVKit::setupPlayerViewController()
+void VideoPresentationInterfaceAVKitLegacy::setupPlayerViewController()
 {
     if (!m_playerViewController)
         m_playerViewController = adoptNS([[WebAVPlayerViewController alloc] initWithFullscreenInterface:this]);
@@ -867,7 +867,7 @@ void VideoPresentationInterfaceAVKit::setupPlayerViewController()
 #endif
 }
 
-void VideoPresentationInterfaceAVKit::invalidatePlayerViewController()
+void VideoPresentationInterfaceAVKitLegacy::invalidatePlayerViewController()
 {
     returnVideoView();
 
@@ -876,57 +876,57 @@ void VideoPresentationInterfaceAVKit::invalidatePlayerViewController()
     m_playerViewController = nil;
 }
 
-void VideoPresentationInterfaceAVKit::presentFullscreen(bool animated, Function<void(BOOL, NSError *)>&& completionHandler)
+void VideoPresentationInterfaceAVKitLegacy::presentFullscreen(bool animated, Function<void(BOOL, NSError *)>&& completionHandler)
 {
     [m_playerViewController enterFullScreenAnimated:animated completionHandler:makeBlockPtr(WTFMove(completionHandler)).get()];
 }
 
-void VideoPresentationInterfaceAVKit::dismissFullscreen(bool animated, Function<void(BOOL, NSError *)>&& completionHandler)
+void VideoPresentationInterfaceAVKitLegacy::dismissFullscreen(bool animated, Function<void(BOOL, NSError *)>&& completionHandler)
 {
     [m_playerViewController exitFullScreenAnimated:animated completionHandler:makeBlockPtr(WTFMove(completionHandler)).get()];
 }
 
-void VideoPresentationInterfaceAVKit::tryToStartPictureInPicture()
+void VideoPresentationInterfaceAVKitLegacy::tryToStartPictureInPicture()
 {
     [m_playerViewController tryToStartPictureInPicture];
 }
 
-void VideoPresentationInterfaceAVKit::stopPictureInPicture()
+void VideoPresentationInterfaceAVKitLegacy::stopPictureInPicture()
 {
     [m_playerViewController stopPictureInPicture];
 }
 
-bool VideoPresentationInterfaceAVKit::isPlayingVideoInEnhancedFullscreen() const
+bool VideoPresentationInterfaceAVKitLegacy::isPlayingVideoInEnhancedFullscreen() const
 {
     return hasMode(WebCore::HTMLMediaElementEnums::VideoFullscreenModePictureInPicture) && [playerController() isPlaying];
 }
 
-void VideoPresentationInterfaceAVKit::setAllowsPictureInPicturePlayback(bool allowsPictureInPicturePlayback)
+void VideoPresentationInterfaceAVKitLegacy::setAllowsPictureInPicturePlayback(bool allowsPictureInPicturePlayback)
 {
     [m_playerViewController setAllowsPictureInPicturePlayback:allowsPictureInPicturePlayback];
 }
 
-void VideoPresentationInterfaceAVKit::setShowsPlaybackControls(bool showsPlaybackControls)
+void VideoPresentationInterfaceAVKitLegacy::setShowsPlaybackControls(bool showsPlaybackControls)
 {
     [m_playerViewController setShowsPlaybackControls:showsPlaybackControls];
 }
 
-void VideoPresentationInterfaceAVKit::setContentDimensions(const FloatSize& contentDimensions)
+void VideoPresentationInterfaceAVKitLegacy::setContentDimensions(const FloatSize& contentDimensions)
 {
     [playerController() setContentDimensions:contentDimensions];
 }
 
-bool VideoPresentationInterfaceAVKit::isExternalPlaybackActive() const
+bool VideoPresentationInterfaceAVKitLegacy::isExternalPlaybackActive() const
 {
     return [playerController() isExternalPlaybackActive];
 }
 
-bool VideoPresentationInterfaceAVKit::willRenderToLayer() const
+bool VideoPresentationInterfaceAVKitLegacy::willRenderToLayer() const
 {
     return true;
 }
 
-void VideoPresentationInterfaceAVKit::returnVideoView()
+void VideoPresentationInterfaceAVKitLegacy::returnVideoView()
 {
     [[m_playerViewController playerLayerView] transferVideoViewTo:playerLayerView()];
 }
@@ -949,7 +949,7 @@ bool supportsPictureInPicture()
 #endif
 }
 
-void VideoPresentationInterfaceAVKit::setupCaptionsLayer(CALayer *, const WebCore::FloatSize&)
+void VideoPresentationInterfaceAVKitLegacy::setupCaptionsLayer(CALayer *, const WebCore::FloatSize&)
 {
     [CATransaction begin];
     [CATransaction setDisableActions:YES];

--- a/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
+++ b/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
@@ -32,11 +32,11 @@
 #import "LocalFrameView.h"
 #import "Logging.h"
 #import "MediaSelectionOption.h"
-#import "PlaybackSessionInterfaceAVKit.h"
+#import "PlaybackSessionInterfaceAVKitLegacy.h"
 #import "PlaybackSessionModelMediaElement.h"
 #import "RenderVideo.h"
 #import "TimeRanges.h"
-#import "VideoPresentationInterfaceAVKit.h"
+#import "VideoPresentationInterfaceAVKitLegacy.h"
 #import "VideoPresentationModelVideoElement.h"
 #import "WebCoreThreadRun.h"
 #import <QuartzCore/CoreAnimation.h>
@@ -1024,8 +1024,8 @@ void VideoFullscreenControllerContext::setUpFullscreen(HTMLVideoElement& videoEl
     RunLoop::main().dispatch([protectedThis = Ref { *this }, this, videoElementClientRect, videoDimensions, viewRef, mode, allowsPictureInPicture] {
         ASSERT(isUIThread());
         WebThreadLock();
-        Ref<PlaybackSessionInterfaceIOS> sessionInterface = PlaybackSessionInterfaceAVKit::create(*this);
-        m_interface = VideoPresentationInterfaceAVKit::create(sessionInterface.get());
+        Ref<PlaybackSessionInterfaceIOS> sessionInterface = PlaybackSessionInterfaceAVKitLegacy::create(*this);
+        m_interface = VideoPresentationInterfaceAVKitLegacy::create(sessionInterface.get());
         m_interface->setVideoPresentationModel(this);
 
         m_videoFullscreenView = adoptNS([PAL::allocUIViewInstance() init]);

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
@@ -38,7 +38,7 @@
 #import "WebProcessPool.h"
 #import "WebProcessProxy.h"
 #import <WebCore/NullPlaybackSessionInterface.h>
-#import <WebCore/PlaybackSessionInterfaceAVKit.h>
+#import <WebCore/PlaybackSessionInterfaceAVKitLegacy.h>
 #import <WebCore/PlaybackSessionInterfaceMac.h>
 #import <WebCore/PlaybackSessionInterfaceTVOS.h>
 #import <wtf/LoggerHelper.h>
@@ -556,7 +556,7 @@ PlaybackSessionManagerProxy::ModelInterfaceTuple PlaybackSessionManagerProxy::cr
         lmkInterface->setSpatialVideoEnabled(page->preferences().spatialVideoEnabled());
         interface = WTFMove(lmkInterface);
     } else
-        interface = PlaybackSessionInterfaceAVKit::create(model);
+        interface = PlaybackSessionInterfaceAVKitLegacy::create(model);
 #else
     interface = PlatformPlaybackSessionInterface::create(model);
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -48,11 +48,11 @@
 #import <QuartzCore/CoreAnimation.h>
 #import <WebCore/MediaPlayerEnums.h>
 #import <WebCore/NullVideoPresentationInterface.h>
-#import <WebCore/PlaybackSessionInterfaceAVKit.h>
+#import <WebCore/PlaybackSessionInterfaceAVKitLegacy.h>
 #import <WebCore/PlaybackSessionInterfaceMac.h>
 #import <WebCore/PlaybackSessionInterfaceTVOS.h>
 #import <WebCore/TimeRanges.h>
-#import <WebCore/VideoPresentationInterfaceAVKit.h>
+#import <WebCore/VideoPresentationInterfaceAVKitLegacy.h>
 #import <WebCore/VideoPresentationInterfaceMac.h>
 #import <WebCore/VideoPresentationInterfaceTVOS.h>
 #import <WebCore/WebAVPlayerLayer.h>
@@ -631,7 +631,7 @@ VideoPresentationManagerProxy::ModelInterfaceTuple VideoPresentationManagerProxy
     if (m_page->preferences().linearMediaPlayerEnabled())
         interface = VideoPresentationInterfaceLMK::create(playbackSessionInterface.get());
     else
-        interface = VideoPresentationInterfaceAVKit::create(playbackSessionInterface.get());
+        interface = VideoPresentationInterfaceAVKitLegacy::create(playbackSessionInterface.get());
 #else
     interface = PlatformVideoPresentationInterface::create(playbackSessionInterface.get());
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -77,7 +77,7 @@
 #import <WebCore/NowPlayingInfo.h>
 #import <WebCore/NullPlaybackSessionInterface.h>
 #import <WebCore/PlatformPlaybackSessionInterface.h>
-#import <WebCore/PlaybackSessionInterfaceAVKit.h>
+#import <WebCore/PlaybackSessionInterfaceAVKitLegacy.h>
 #import <WebCore/PlaybackSessionInterfaceMac.h>
 #import <WebCore/PlaybackSessionInterfaceTVOS.h>
 #import <WebCore/RunLoopObserver.h>

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -298,7 +298,7 @@
 #include <WebCore/CoreAudioCaptureDeviceManager.h>
 #include <WebCore/LegacyWebArchive.h>
 #include <WebCore/NullPlaybackSessionInterface.h>
-#include <WebCore/PlaybackSessionInterfaceAVKit.h>
+#include <WebCore/PlaybackSessionInterfaceAVKitLegacy.h>
 #include <WebCore/PlaybackSessionInterfaceMac.h>
 #include <WebCore/PlaybackSessionInterfaceTVOS.h>
 #include <WebCore/RunLoopObserver.h>

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -40,9 +40,9 @@
 #import "WebPageProxy.h"
 #import "WebPreferences.h"
 #import <WebCore/LocalizedStrings.h>
-#import <WebCore/PlaybackSessionInterfaceAVKit.h>
+#import <WebCore/PlaybackSessionInterfaceAVKitLegacy.h>
 #import <WebCore/PlaybackSessionInterfaceTVOS.h>
-#import <WebCore/VideoPresentationInterfaceAVKit.h>
+#import <WebCore/VideoPresentationInterfaceAVKitLegacy.h>
 #import <WebCore/VideoPresentationInterfaceTVOS.h>
 #import <pal/spi/cocoa/AVKitSPI.h>
 #import <wtf/CheckedRef.h>

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -49,7 +49,7 @@
 #import <WebCore/GeometryUtilities.h>
 #import <WebCore/IntRect.h>
 #import <WebCore/LocalizedStrings.h>
-#import <WebCore/VideoPresentationInterfaceAVKit.h>
+#import <WebCore/VideoPresentationInterfaceAVKitLegacy.h>
 #import <WebCore/VideoPresentationModel.h>
 #import <WebCore/ViewportArguments.h>
 #import <objc/runtime.h>

--- a/Source/WebKitLegacy/mac/WebView/WebVideoFullscreenController.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebVideoFullscreenController.mm
@@ -29,7 +29,7 @@
 
 #import <AVFoundation/AVPlayer.h>
 #import <WebCore/HTMLVideoElement.h>
-#import <WebCore/PlaybackSessionInterfaceAVKit.h>
+#import <WebCore/PlaybackSessionInterfaceAVKitLegacy.h>
 #import <WebCore/PlaybackSessionModelMediaElement.h>
 #import <WebCore/WebAVPlayerController.h>
 #import <WebCore/WebCoreFullScreenWindow.h>
@@ -148,7 +148,7 @@ static WebAVPlayerView *allocWebAVPlayerViewInstance()
     if (!self)
         return nil;
     _playbackModel = WebCore::PlaybackSessionModelMediaElement::create();
-    _playbackInterface = WebCore::PlaybackSessionInterfaceAVKit::create(*_playbackModel);
+    _playbackInterface = WebCore::PlaybackSessionInterfaceAVKitLegacy::create(*_playbackModel);
     _contentOverlay = adoptNS([[NSView alloc] initWithFrame:NSZeroRect]);
     _contentOverlay.get().layerContentsRedrawPolicy = NSViewLayerContentsRedrawNever;
     _contentOverlay.get().layer = adoptNS([[WebVideoFullscreenOverlayLayer alloc] init]).get();


### PR DESCRIPTION
#### f7d9e28ef63047bc414077cb34702918b9fe4c95
<pre>
[iOS] Rename {PlaybackSessionInterface,VideoPresentationInterface}AVKit to {PlaybackSessionInterface,VideoPresentationInterface}AVKitLegacy
<a href="https://bugs.webkit.org/show_bug.cgi?id=284736">https://bugs.webkit.org/show_bug.cgi?id=284736</a>
<a href="https://rdar.apple.com/problem/141530991">rdar://problem/141530991</a>

Reviewed by Eric Carlson.

In preparation for introducing fullscreen and playback session interfaces based on
AVPlayerViewControllerContentSource, renamed the existing PlaybackSessionInterfaceAVKit and
VideoPresentationInterfaceAVKit to PlaybackSessionInterfaceAVKitLegacy and
VideoPresentationInterfaceAVKitLegacy respectively.

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/PlatformPlaybackSessionInterface.h:
* Source/WebCore/platform/graphics/PlatformVideoPresentationInterface.h:
* Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKitLegacy.h: Renamed from Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h.
* Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKitLegacy.mm: Renamed from Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.mm.
* Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.h: Renamed from Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.h.
* Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.mm: Renamed from Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.mm.
* Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm:
(VideoFullscreenControllerContext::setUpFullscreen):
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm:
(WebKit::PlaybackSessionManagerProxy::createModelAndInterface):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::createModelAndInterface):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
* Source/WebKitLegacy/mac/WebView/WebVideoFullscreenController.mm:
(-[WebVideoFullscreenController init]):

Canonical link: <a href="https://commits.webkit.org/287905@main">https://commits.webkit.org/287905@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5dedf8199a6e0e7a408dfda2ae943e626667314

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81187 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/712 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35130 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85716 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32173 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83297 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/730 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8522 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63387 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21150 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84256 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/481 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73888 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43685 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/378 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28050 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30631 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71897 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28619 "Found 1 new test failure: fast/attachment/cocoa/wide-attachment-rendering.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87151 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8417 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5976 "Found 1 new test failure: fast/attachment/cocoa/wide-attachment-rendering.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71689 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8596 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69723 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70924 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17673 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14973 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13891 "Found 1 new test failure: fast/attachment/cocoa/wide-attachment-rendering.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8378 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13902 "Build is in progress. Recent messages:OS: Sequoia (15.0.1), Xcode: 16.0; Checked out pull request; Found 54985 issues") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8215 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11735 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10023 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->