### PR TITLE
WebTransport session establishment should handle server trust challenge

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h
@@ -614,4 +614,8 @@ WTF_EXTERN_C_END
 @end
 #endif
 
+@interface NSURLProtectionSpace (SPI)
+- (void)_setServerTrust:(SecTrustRef)serverTrust;
+@end
+
 #endif // defined(__OBJC__)

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -1645,9 +1645,9 @@ void NetworkConnectionToWebProcess::navigatorGetPushPermissionState(URL&& scopeU
 }
 #endif // ENABLE(DECLARATIVE_WEB_PUSH)
 
-void NetworkConnectionToWebProcess::initializeWebTransportSession(URL&& url, WebCore::SecurityOriginData&& origin, CompletionHandler<void(std::optional<WebTransportSessionIdentifier>)>&& completionHandler)
+void NetworkConnectionToWebProcess::initializeWebTransportSession(URL&& url, WebPageProxyIdentifier&& pageID, WebCore::ClientOrigin&& clientOrigin, CompletionHandler<void(std::optional<WebTransportSessionIdentifier>)>&& completionHandler)
 {
-    NetworkTransportSession::initialize(*this, WTFMove(url), WTFMove(origin), [this, weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)] (RefPtr<NetworkTransportSession>&& session) mutable {
+    NetworkTransportSession::initialize(*this, WTFMove(url), WTFMove(pageID), WTFMove(clientOrigin), [this, weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)] (RefPtr<NetworkTransportSession>&& session) mutable {
         if (!session || !weakThis)
             return completionHandler(std::nullopt);
         auto identifier = session->identifier();

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -414,7 +414,7 @@ private:
     void navigatorGetPushPermissionState(URL&& scopeURL, CompletionHandler<void(Expected<uint8_t, WebCore::ExceptionData>&&)>&&);
 #endif
 
-    void initializeWebTransportSession(URL&&, WebCore::SecurityOriginData&&, CompletionHandler<void(std::optional<WebTransportSessionIdentifier>)>&&);
+    void initializeWebTransportSession(URL&&, WebPageProxyIdentifier&&, WebCore::ClientOrigin&&, CompletionHandler<void(std::optional<WebTransportSessionIdentifier>)>&&);
     void destroyWebTransportSession(WebTransportSessionIdentifier);
 
     struct ResourceNetworkActivityTracker {

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -137,7 +137,7 @@ messages -> NetworkConnectionToWebProcess WantsDispatchMessage {
     NavigatorGetPushPermissionState(URL scopeURL) -> (Expected<uint8_t, WebCore::ExceptionData> result)
 #endif
 
-    [EnabledBy=WebTransportEnabled] InitializeWebTransportSession(URL url, WebCore::SecurityOriginData origin) -> (std::optional<WebKit::WebTransportSessionIdentifier> identifier)
+    [EnabledBy=WebTransportEnabled] InitializeWebTransportSession(URL url, WebKit::WebPageProxyIdentifier pageID, struct WebCore::ClientOrigin clientOrigin) -> (std::optional<WebKit::WebTransportSessionIdentifier> identifier)
     [EnabledBy=WebTransportEnabled] DestroyWebTransportSession(WebKit::WebTransportSessionIdentifier identifier)
 
     ClearFrameLoadRecordsForStorageAccess(WebCore::FrameIdentifier frameID)

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp
@@ -37,7 +37,7 @@ namespace WebKit {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkTransportSession);
 
 #if !PLATFORM(COCOA)
-void NetworkTransportSession::initialize(NetworkConnectionToWebProcess&, URL&&, WebCore::SecurityOriginData&&, CompletionHandler<void(RefPtr<NetworkTransportSession>&&)>&& completionHandler)
+void NetworkTransportSession::initialize(NetworkConnectionToWebProcess&, URL&&, WebKit::WebPageProxyIdentifier&&, WebCore::ClientOrigin&&, CompletionHandler<void(RefPtr<NetworkTransportSession>&&)>&& completionHandler)
 {
     completionHandler(nullptr);
 }

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
@@ -27,6 +27,7 @@
 
 #include "MessageReceiver.h"
 #include "MessageSender.h"
+#include "WebPageProxyIdentifier.h"
 #include <WebCore/ProcessQualified.h>
 #include <wtf/Identified.h>
 #include <wtf/RefCounted.h>
@@ -38,7 +39,7 @@
 #endif
 
 namespace WebCore {
-class SecurityOriginData;
+struct ClientOrigin;
 }
 
 namespace WebKit {
@@ -57,7 +58,7 @@ using WebTransportStreamIdentifier = ObjectIdentifier<WebTransportStreamIdentifi
 class NetworkTransportSession : public RefCounted<NetworkTransportSession>, public IPC::MessageReceiver, public IPC::MessageSender, public Identified<WebTransportSessionIdentifier> {
     WTF_MAKE_TZONE_ALLOCATED(NetworkTransportSession);
 public:
-    static void initialize(NetworkConnectionToWebProcess&, URL&&, WebCore::SecurityOriginData&&, CompletionHandler<void(RefPtr<NetworkTransportSession>&&)>&&);
+    static void initialize(NetworkConnectionToWebProcess&, URL&&, WebKit::WebPageProxyIdentifier&&, WebCore::ClientOrigin&&, CompletionHandler<void(RefPtr<NetworkTransportSession>&&)>&&);
 
     ~NetworkTransportSession();
 

--- a/Source/WebKit/WebProcess/Network/WebTransportSession.cpp
+++ b/Source/WebKit/WebProcess/Network/WebTransportSession.cpp
@@ -40,10 +40,10 @@
 
 namespace WebKit {
 
-void WebTransportSession::initialize(const URL& url, const WebCore::SecurityOriginData& origin, CompletionHandler<void(RefPtr<WebTransportSession>&&)>&& completionHandler)
+void WebTransportSession::initialize(const URL& url, const WebPageProxyIdentifier& pageID, const WebCore::ClientOrigin& clientOrigin, CompletionHandler<void(RefPtr<WebTransportSession>&&)>&& completionHandler)
 {
     ASSERT(RunLoop::isMain());
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::InitializeWebTransportSession(url, origin), [completionHandler = WTFMove(completionHandler)] (std::optional<WebTransportSessionIdentifier> identifier) mutable {
+    WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::InitializeWebTransportSession(url, pageID, clientOrigin), [completionHandler = WTFMove(completionHandler)] (std::optional<WebTransportSessionIdentifier> identifier) mutable {
         ASSERT(RunLoop::isMain());
         if (!identifier)
             return completionHandler(nullptr);

--- a/Source/WebKit/WebProcess/Network/WebTransportSession.h
+++ b/Source/WebKit/WebProcess/Network/WebTransportSession.h
@@ -27,11 +27,15 @@
 
 #include "MessageReceiver.h"
 #include "MessageSender.h"
+#include "WebPageProxyIdentifier.h"
 #include <WebCore/ProcessQualified.h>
-#include <WebCore/SecurityOrigin.h>
 #include <WebCore/WebTransportSession.h>
 #include <wtf/ObjectIdentifier.h>
 #include <wtf/ThreadSafeRefCounted.h>
+
+namespace WebCore {
+struct ClientOrigin;
+}
 
 namespace WebKit {
 
@@ -48,7 +52,7 @@ using WebTransportSessionIdentifier = ObjectIdentifier<WebTransportSessionIdenti
 
 class WebTransportSession : public WebCore::WebTransportSession, public IPC::MessageReceiver, public IPC::MessageSender, public ThreadSafeRefCounted<WebTransportSession, WTF::DestructionThread::MainRunLoop> {
 public:
-    static void initialize(const URL&, const WebCore::SecurityOriginData&, CompletionHandler<void(RefPtr<WebTransportSession>&&)>&&);
+    static void initialize(const URL&, const WebPageProxyIdentifier&, const WebCore::ClientOrigin&, CompletionHandler<void(RefPtr<WebTransportSession>&&)>&&);
     ~WebTransportSession();
 
     void receiveDatagram(std::span<const uint8_t>);

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
@@ -61,7 +61,6 @@
 // 2 - Run a test exercising that type
 
 @interface NSURLProtectionSpace (WebKitNSURLProtectionSpace)
-- (void)_setServerTrust:(SecTrustRef)serverTrust;
 - (void)_setDistinguishedNames:(NSArray<NSData *> *)distinguishedNames;
 @end
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Challenge.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Challenge.mm
@@ -399,7 +399,7 @@ TEST(Challenge, BasicPersistentCredential)
     EXPECT_NULL(removedCredential);
 }
 
-static void verifyCertificateAndPublicKey(SecTrustRef trust)
+void verifyCertificateAndPublicKey(SecTrustRef trust)
 {
     EXPECT_NOT_NULL(trust);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm
@@ -29,6 +29,7 @@
 
 #import "PlatformUtilities.h"
 #import "Test.h"
+#import "TestNavigationDelegate.h"
 #import "TestUIDelegate.h"
 #import "Utilities.h"
 #import "WebTransportServer.h"
@@ -48,6 +49,15 @@ static void enableWebTransport(WKWebViewConfiguration *configuration)
     }
 }
 
+static void validateChallenge(NSURLAuthenticationChallenge *challenge, uint16_t port)
+{
+    EXPECT_WK_STREQ(challenge.protectionSpace.authenticationMethod, NSURLAuthenticationMethodServerTrust);
+    EXPECT_NOT_NULL(challenge.protectionSpace.serverTrust);
+    EXPECT_EQ(challenge.protectionSpace.port, port);
+    EXPECT_WK_STREQ(challenge.protectionSpace.host, "127.0.0.1");
+    verifyCertificateAndPublicKey(challenge.protectionSpace.serverTrust);
+}
+
 // FIXME: Fix WebTransportServer constructor and re-enable these tests once rdar://141009498 is available in OS builds.
 TEST(WebTransport, DISABLED_ClientBidirectional)
 {
@@ -60,6 +70,15 @@ TEST(WebTransport, DISABLED_ClientBidirectional)
     auto configuration = adoptNS([WKWebViewConfiguration new]);
     enableWebTransport(configuration.get());
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    auto delegate = adoptNS([TestNavigationDelegate new]);
+    [webView setNavigationDelegate:delegate.get()];
+    __block bool challenged { false };
+    __block uint16_t port = echoServer.port();
+    delegate.get().didReceiveAuthenticationChallenge = ^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^completionHandler)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
+        validateChallenge(challenge, port);
+        challenged = true;
+        completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
+    };
 
     NSString *html = [NSString stringWithFormat:@""
         "<script>async function test() {"
@@ -75,9 +94,10 @@ TEST(WebTransport, DISABLED_ClientBidirectional)
         "  } catch (e) { alert('caught ' + e); }"
         "}; test();"
         "</script>",
-        echoServer.port()];
+        port];
     [webView loadHTMLString:html baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
     EXPECT_WK_STREQ([webView _test_waitForAlert], "successfully read abc");
+    EXPECT_TRUE(challenged);
 }
 
 // FIXME: Fix WebTransportServer constructor and re-enable these tests once rdar://141009498 is available in OS builds.
@@ -92,6 +112,15 @@ TEST(WebTransport, DISABLED_Datagram)
     auto configuration = adoptNS([WKWebViewConfiguration new]);
     enableWebTransport(configuration.get());
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    auto delegate = adoptNS([TestNavigationDelegate new]);
+    [webView setNavigationDelegate:delegate.get()];
+    __block bool challenged { false };
+    __block uint16_t port = echoServer.port();
+    delegate.get().didReceiveAuthenticationChallenge = ^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^completionHandler)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
+        validateChallenge(challenge, port);
+        challenged = true;
+        completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
+    };
 
     NSString *html = [NSString stringWithFormat:@""
         "<script>async function test() {"
@@ -106,9 +135,10 @@ TEST(WebTransport, DISABLED_Datagram)
         "  } catch (e) { alert('caught ' + e); }"
         "}; test();"
         "</script>",
-        echoServer.port()];
+        port];
     [webView loadHTMLString:html baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
     EXPECT_WK_STREQ([webView _test_waitForAlert], "successfully read abc");
+    EXPECT_TRUE(challenged);
 }
 
 // FIXME: Fix WebTransportServer constructor and re-enable these tests once rdar://141009498 is available in OS builds.
@@ -124,6 +154,15 @@ TEST(WebTransport, DISABLED_Unidirectional)
     auto configuration = adoptNS([WKWebViewConfiguration new]);
     enableWebTransport(configuration.get());
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    auto delegate = adoptNS([TestNavigationDelegate new]);
+    [webView setNavigationDelegate:delegate.get()];
+    __block bool challenged { false };
+    __block uint16_t port = echoServer.port();
+    delegate.get().didReceiveAuthenticationChallenge = ^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^completionHandler)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
+        validateChallenge(challenge, port);
+        challenged = true;
+        completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
+    };
 
     NSString *html = [NSString stringWithFormat:@""
         "<script>async function test() {"
@@ -141,9 +180,10 @@ TEST(WebTransport, DISABLED_Unidirectional)
         "  } catch (e) { alert('caught ' + e); }"
         "}; test();"
         "</script>",
-        echoServer.port()];
+        port];
     [webView loadHTMLString:html baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
     EXPECT_WK_STREQ([webView _test_waitForAlert], "successfully read abc");
+    EXPECT_TRUE(challenged);
 }
 
 // FIXME: Fix WebTransportServer constructor and re-enable these tests once rdar://141009498 is available in OS builds.
@@ -159,6 +199,15 @@ TEST(WebTransport, DISABLED_ServerBidirectional)
     auto configuration = adoptNS([WKWebViewConfiguration new]);
     enableWebTransport(configuration.get());
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    auto delegate = adoptNS([TestNavigationDelegate new]);
+    [webView setNavigationDelegate:delegate.get()];
+    __block bool challenged { false };
+    __block uint16_t port = echoServer.port();
+    delegate.get().didReceiveAuthenticationChallenge = ^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^completionHandler)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
+        validateChallenge(challenge, port);
+        challenged = true;
+        completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
+    };
 
     NSString *html = [NSString stringWithFormat:@""
         "<script>async function test() {"
@@ -176,9 +225,10 @@ TEST(WebTransport, DISABLED_ServerBidirectional)
         "  } catch (e) { alert('caught ' + e); }"
         "}; test();"
         "</script>",
-        echoServer.port()];
+        port];
     [webView loadHTMLString:html baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
     EXPECT_WK_STREQ([webView _test_waitForAlert], "successfully read abc");
+    EXPECT_TRUE(challenged);
 }
 } // namespace TestWebKitAPI
 

--- a/Tools/TestWebKitAPI/cocoa/HTTPServer.h
+++ b/Tools/TestWebKitAPI/cocoa/HTTPServer.h
@@ -178,3 +178,4 @@ private:
 RetainPtr<SecCertificateRef> testCertificate();
 RetainPtr<SecIdentityRef> testIdentity();
 RetainPtr<SecIdentityRef> testIdentity2();
+void verifyCertificateAndPublicKey(SecTrustRef);


### PR DESCRIPTION
#### 8d75fca6f83fdd0cabec51b6140edb0ecf6d0a37
<pre>
WebTransport session establishment should handle server trust challenge
<a href="https://bugs.webkit.org/show_bug.cgi?id=284737">https://bugs.webkit.org/show_bug.cgi?id=284737</a>
<a href="https://rdar.apple.com/136262696">rdar://136262696</a>

Reviewed by Alex Christensen.

Server trust challenges are hooked up to AuthenticationManager.
Tests are updated to use a test delegate to handle server trust challenge.

* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::initializeWebTransportSession):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp:
(WebKit::NetworkTransportSession::initialize): Deleted.
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h:
* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm:
(WebKit::didReceiveServerTrustChallenge):
(WebKit::createParameters):
(WebKit::NetworkTransportSession::initialize):
* Source/WebKit/WebProcess/Network/WebSocketProvider.cpp:
(WebKit::WebSocketProvider::initializeWebTransportSession):
* Source/WebKit/WebProcess/Network/WebTransportSession.cpp:
(WebKit::WebTransportSession::initialize):
* Source/WebKit/WebProcess/Network/WebTransportSession.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm:
(TestWebKitAPI::TEST(WebTransport, DISABLED_ClientBidirectional)):
(TestWebKitAPI::TEST(WebTransport, DISABLED_Datagram)):
(TestWebKitAPI::TEST(WebTransport, DISABLED_Unidirectional)):
(TestWebKitAPI::TEST(WebTransport, DISABLED_ServerBidirectional)):

Canonical link: <a href="https://commits.webkit.org/287925@main">https://commits.webkit.org/287925@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42a39eccf19ccc255b74e2604879fb64f11ade40

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81352 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/877 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35295 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85881 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32338 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83462 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/895 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8694 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63502 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/21260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84421 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/607 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74037 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43798 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/504 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28201 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30796 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/71994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28784 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87316 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8582 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71813 "Found 2 new test failures: imported/blink/compositing/animation/hidden-animated-layer-should-not-have-scrollbars.html imported/w3c/web-platform-tests/css/css-animations/animation-offscreen-to-onscreen.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8763 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69863 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71047 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15109 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14013 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12613 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8544 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/14067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8380 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11901 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10188 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->