### PR TITLE
Clean-up `unicode-bidi` handling code in HTMLElement.cpp and sync remaining `dir` rules from Web Specification

### DIFF
--- a/LayoutTests/fast/css/default-bidi-css-rules-expected.txt
+++ b/LayoutTests/fast/css/default-bidi-css-rules-expected.txt
@@ -47,7 +47,7 @@ PASS styleOf("bdo", {"dir":"ltr"}).unicodeBidi is "isolate-override"
 PASS styleOf("bdo", {"dir":"rtl"}).direction is "rtl"
 PASS styleOf("bdo", {"dir":"rtl"}).unicodeBidi is "isolate-override"
 PASS styleOf("bdo", {"dir":"auto"}).direction is "ltr"
-FAIL styleOf("bdo", {"dir":"auto"}).unicodeBidi should be isolate-override. Was isolate.
+PASS styleOf("bdo", {"dir":"auto"}).unicodeBidi is "isolate-override"
 PASS styleOf("bdo", {"dir":""}).direction is "ltr"
 PASS styleOf("bdo", {"dir":""}).unicodeBidi is "isolate-override"
 PASS styleOf("textarea", {}).direction is "ltr"
@@ -71,7 +71,6 @@ PASS styleOf("pre", {"dir":"auto"}).unicodeBidi is "plaintext"
 PASS styleOf("pre", {"dir":""}).direction is "ltr"
 PASS styleOf("pre", {"dir":""}).unicodeBidi is "isolate"
 PASS successfullyParsed is true
-Some tests failed.
 
 TEST COMPLETE
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/bidi-rendering/unicode-bidi-ua-rules-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/bidi-rendering/unicode-bidi-ua-rules-expected.txt
@@ -105,7 +105,7 @@ PASS UA stylesheet rule for unicode-bidi, for <ul>
 PASS UA stylesheet rule for unicode-bidi, for <var>
 PASS UA stylesheet rule for unicode-bidi, for <video>
 PASS UA stylesheet rule for unicode-bidi, for <wbr>
-FAIL UA stylesheet rule for unicode-bidi, for <bdo> assert_equals: with dir=auto expected "isolate-override" but got "isolate"
+PASS UA stylesheet rule for unicode-bidi, for <bdo>
 PASS UA stylesheet rule for unicode-bidi, for <input type=hidden>
 PASS UA stylesheet rule for unicode-bidi, for <input type=text>
 FAIL UA stylesheet rule for unicode-bidi, for <input type=search> assert_equals: with dir=auto expected "plaintext" but got "isolate"

--- a/LayoutTests/inspector/css/shadow-scoped-style-expected.txt
+++ b/LayoutTests/inspector/css/shadow-scoped-style-expected.txt
@@ -19,7 +19,7 @@ STYLES:
 :host {
     padding: 20px;
 }
-address, blockquote, center, div, figure, figcaption, footer, form, header, hr, legend, listing, main, p, plaintext, pre, summary, xmp, article, aside, h1, h2, h3, h4, h5, h6, hgroup, nav, section, search, table, caption, colgroup, col, thead, tbody, tfoot, tr, td, th, dir, dd, dl, dt, menu, ol, ul, li, bdi, output {
+address, blockquote, center, div, figure, figcaption, footer, form, header, hr, legend, listing, main, p, plaintext, pre, summary, xmp, article, aside, h1, h2, h3, h4, h5, h6, hgroup, nav, section, search, table, caption, colgroup, col, thead, tbody, tfoot, tr, td, th, dir, dd, dl, dt, menu, ol, ul, li, bdi, output, [dir="ltr" i], [dir="rtl" i], [dir="auto" i] {
 }
 address, article, aside, div, footer, header, hgroup, main, nav, search, section {
 }
@@ -36,7 +36,7 @@ STYLES:
 div {
     color: blue;
 }
-address, blockquote, center, div, figure, figcaption, footer, form, header, hr, legend, listing, main, p, plaintext, pre, summary, xmp, article, aside, h1, h2, h3, h4, h5, h6, hgroup, nav, section, search, table, caption, colgroup, col, thead, tbody, tfoot, tr, td, th, dir, dd, dl, dt, menu, ol, ul, li, bdi, output {
+address, blockquote, center, div, figure, figcaption, footer, form, header, hr, legend, listing, main, p, plaintext, pre, summary, xmp, article, aside, h1, h2, h3, h4, h5, h6, hgroup, nav, section, search, table, caption, colgroup, col, thead, tbody, tfoot, tr, td, th, dir, dd, dl, dt, menu, ol, ul, li, bdi, output, [dir="ltr" i], [dir="rtl" i], [dir="auto" i] {
 }
 address, article, aside, div, footer, header, hgroup, main, nav, search, section {
 }

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -1407,7 +1407,8 @@ iframe {
 address, blockquote, center, div, figure, figcaption, footer, form, header, hr,
 legend, listing, main, p, plaintext, pre, summary, xmp, article, aside, h1, h2,
 h3, h4, h5, h6, hgroup, nav, section, search, table, caption, colgroup, col,
-thead, tbody, tfoot, tr, td, th, dir, dd, dl, dt, menu, ol, ul, li, bdi, output {
+thead, tbody, tfoot, tr, td, th, dir, dd, dl, dt, menu, ol, ul, li, bdi, output,
+[dir=ltr i], [dir=rtl i], [dir=auto i] {
     unicode-bidi: isolate; 
 }
 

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -1,8 +1,8 @@
 /*
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2004-2023 Apple Inc. All rights reserved.
- * Copyright (C) 2021 Google Inc. All rights reserved.
+ * Copyright (C) 2004-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2024 Google Inc. All rights reserved.
  * Copyright (C) 2009 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/)
  * Copyright (C) 2011 Motorola Mobility. All rights reserved.
  *
@@ -129,10 +129,9 @@ String HTMLElement::nodeName() const
 
 static inline CSSValueID unicodeBidiAttributeForDirAuto(HTMLElement& element)
 {
+    ASSERT(!element.hasTagName(bdoTag));
     if (element.hasTagName(preTag) || element.hasTagName(textareaTag))
         return CSSValuePlaintext;
-    // FIXME: For bdo element, dir="auto" should result in "bidi-override isolate" but we don't support having multiple values in unicode-bidi yet.
-    // See https://bugs.webkit.org/show_bug.cgi?id=73164.
     return CSSValueIsolate;
 }
 
@@ -246,13 +245,11 @@ void HTMLElement::collectPresentationalHintsForAttribute(const QualifiedName& na
             addPropertyToPresentationalHintStyle(style, CSSPropertyWebkitUserDrag, CSSValueNone);
         break;
     case AttributeNames::dirAttr:
-        if (equalLettersIgnoringASCIICase(value, "auto"_s))
-            addPropertyToPresentationalHintStyle(style, CSSPropertyUnicodeBidi, unicodeBidiAttributeForDirAuto(*this));
-        else if (equalLettersIgnoringASCIICase(value, "rtl"_s) || equalLettersIgnoringASCIICase(value, "ltr"_s)) {
+        if (equalLettersIgnoringASCIICase(value, "auto"_s)) {
+            if (!hasTagName(bdoTag))
+                addPropertyToPresentationalHintStyle(style, CSSPropertyUnicodeBidi, unicodeBidiAttributeForDirAuto(*this));
+        } else if (equalLettersIgnoringASCIICase(value, "rtl"_s) || equalLettersIgnoringASCIICase(value, "ltr"_s))
             addPropertyToPresentationalHintStyle(style, CSSPropertyDirection, value);
-            if (!hasTagName(bdiTag) && !hasTagName(bdoTag) && !hasTagName(outputTag))
-                addPropertyToPresentationalHintStyle(style, CSSPropertyUnicodeBidi, CSSValueIsolate);
-        }
         break;
     case AttributeNames::XML::langAttr:
         mapLanguageAttributeToLocale(value, style);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/AttrStyle.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/AttrStyle.mm
@@ -61,7 +61,7 @@ TEST(WebKit, AttrStyle)
 
     isDone = false;
     [webView evaluateJavaScript:@"document.body.getAttributeNode('dir').style.cssText" completionHandler:^(NSString *result, NSError *error) {
-        EXPECT_STREQ("direction: rtl; unicode-bidi: isolate;", result.UTF8String);
+        EXPECT_STREQ("direction: rtl;", result.UTF8String);
         isDone = true;
     }];
     TestWebKitAPI::Util::run(&isDone);


### PR DESCRIPTION
#### 59ef26a67c5fa01d40dc95265f35a10426c3fb46
<pre>
Clean-up `unicode-bidi` handling code in HTMLElement.cpp and sync remaining `dir` rules from Web Specification

<a href="https://bugs.webkit.org/show_bug.cgi?id=284740">https://bugs.webkit.org/show_bug.cgi?id=284740</a>
<a href="https://rdar.apple.com/141535263">rdar://141535263</a>

Reviewed by Ryosuke Niwa.

This patch aligns WebKit with Web Specification [1]:

[1] <a href="https://html.spec.whatwg.org/#bidi-rendering">https://html.spec.whatwg.org/#bidi-rendering</a>

This patch merges below two Blink commits:

<a href="https://chromium-review.googlesource.com/c/chromium/src/+/5260610">https://chromium-review.googlesource.com/c/chromium/src/+/5260610</a> &amp;
<a href="https://chromium-review.googlesource.com/c/chromium/src/+/5262983">https://chromium-review.googlesource.com/c/chromium/src/+/5262983</a>

The patch clean-ups `bdi/output` handling code from `collectPresentationalHintsForAttribute`
since now it is managed via `html.css` in UA stylesheet. Similarly, it also
adds remaining `dir` related rules in stylesheet to fix `bdo` behavior. This
give use opportunity to also remove redundant FIXME from our code.

* Source/WebCore/css/html.css:
(address, blockquote, center, div, figure, figcaption, footer, form, header, hr,):
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::unicodeBidiAttributeForDirAuto):
(WebCore::HTMLElement::collectPresentationalHintsForAttribute):

Test Rebaselines:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/bidi-rendering/unicode-bidi-ua-rules-expected.txt: Rebaselined
* LayoutTests/fast/css/default-bidi-css-rules-expected.txt: Rebaselined
* LayoutTests/inspector/css/shadow-scoped-style-expected.txt: Rebaselined
* Tools/TestWebKitAPI/Tests/WebKitCocoa/AttrStyle.mm:
(TEST(WebKit, AttrStyle)): Updated

Canonical link: <a href="https://commits.webkit.org/287919@main">https://commits.webkit.org/287919@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/846c385e1becc47ecdbe39fd14e1462089812cc2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81286 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/811 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35229 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85815 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32272 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83396 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/829 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8626 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63466 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21225 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84355 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/561 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73975 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43757 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/460 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28137 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30730 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/71955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28717 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87250 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8516 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6051 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71768 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8695 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69805 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71001 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17684 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15057 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13966 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8478 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14001 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8314 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11835 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10122 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->