### PR TITLE
[UnifiedPDF] [iOS] Add support for copying selected text

### DIFF
--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1114,7 +1114,7 @@ public:
 
     bool httpsUpgradeEnabled() const { return m_httpsUpgradeEnabled; }
 
-    URL applyLinkDecorationFiltering(const URL&, LinkDecorationFilteringTrigger) const;
+    WEBCORE_EXPORT URL applyLinkDecorationFiltering(const URL&, LinkDecorationFilteringTrigger) const;
     String applyLinkDecorationFiltering(const String&, LinkDecorationFilteringTrigger) const;
     URL allowedQueryParametersForAdvancedPrivacyProtections(const URL&) const;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -429,7 +429,7 @@ static WebCore::Cursor::Type toWebCoreCursorType(PDFLayerControllerCursorType cu
     ASSERT(items.count >= types.count);
     for (NSUInteger i = 0, count = items.count; i < count; ++i)
         pasteboardItems.append({ [items objectAtIndex:i], [types objectAtIndex:i] });
-    _pdfPlugin->writeItemsToPasteboard(NSPasteboardNameGeneral, WTFMove(pasteboardItems));
+    _pdfPlugin->writeItemsToGeneralPasteboard(WTFMove(pasteboardItems));
 }
 
 - (void)showDefinitionForAttributedString:(NSAttributedString *)string atPoint:(CGPoint)point
@@ -1173,7 +1173,7 @@ bool PDFPlugin::handleEditingCommand(const String& commandName, const String&)
     else if (commandName == "takeFindStringFromSelection"_s) {
         NSString *string = [m_pdfLayerController currentSelection].string;
         if (string.length)
-            writeItemsToPasteboard(NSPasteboardNameFind, { { [string dataUsingEncoding:NSUTF8StringEncoding], NSPasteboardTypeString } });
+            writeStringToFindPasteboard(string);
     }
 
     return true;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -35,6 +35,7 @@
 #include <WebCore/AffineTransform.h>
 #include <WebCore/FindOptions.h>
 #include <WebCore/FloatRect.h>
+#include <WebCore/PageIdentifier.h>
 #include <WebCore/PlatformMouseEvent.h>
 #include <WebCore/PluginData.h>
 #include <WebCore/PluginViewBase.h>
@@ -309,9 +310,7 @@ public:
     virtual void didSameDocumentNavigationForFrame(WebFrame&) { }
 
     using PasteboardItem = PDFPluginPasteboardItem;
-#if PLATFORM(MAC)
-    void writeItemsToPasteboard(NSString *pasteboardName, Vector<PasteboardItem>&&) const;
-#endif
+    void writeItemsToGeneralPasteboard(Vector<PasteboardItem>&&) const;
 
     uint64_t streamedBytes() const;
     std::optional<WebCore::FrameIdentifier> rootFrameID() const final;
@@ -433,6 +432,17 @@ protected:
     virtual void teardownPasswordEntryForm() = 0;
 
     String annotationStyle() const;
+
+    static NSString *htmlPasteboardType();
+    static NSString *rtfPasteboardType();
+    static NSString *stringPasteboardType();
+    static NSString *urlPasteboardType();
+
+#if PLATFORM(MAC)
+    void writeStringToFindPasteboard(const String&) const;
+#endif
+
+    std::optional<WebCore::PageIdentifier> pageIdentifier() const;
 
     SingleThreadWeakPtr<PluginView> m_view;
     WeakPtr<WebFrame> m_frame;


### PR DESCRIPTION
#### 27f72f114ea12b0742c376697558c39c0b42d297
<pre>
[UnifiedPDF] [iOS] Add support for copying selected text
<a href="https://bugs.webkit.org/show_bug.cgi?id=284744">https://bugs.webkit.org/show_bug.cgi?id=284744</a>
<a href="https://rdar.apple.com/141325178">rdar://141325178</a>

Reviewed by Wenson Hsieh.

Previously, the codepath to write items to (any) pasteboard was guarded
behind PLATFORM(MAC), and employed some PasteboardStrategy API that was
generally no-op for iOS.

This patch introduces support for copying selected text in the plugin on
iOS by making the aforementioned codepath platform agnostic. We do so by
providing platform agnostic data types for pasteboard items and by
making use of WebCore::Pasteboard[Strategy] API that abstract away
underlying platform differences when copying text.

We also take a chance to refactor some of the copying code to break down
PDFPluginBase::writeItemsToPasteboard() into two different methods, one
to write items for copy-paste, and the other for find. This simplifies
the latter case because we only ever expect to write a single string to
the find pasteboard at a time, and it means that the &quot;writeItems...&quot;
method need not condition its codepath depending on the targeted
pasteboard (this is helpful because there is no NSPasteboardNameFind
analogy in iOS).

* Source/WebCore/page/Page.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(-[WKPDFLayerControllerDelegate writeItemsToPasteboard:withTypes:]):
(WebKit::PDFPlugin::handleEditingCommand):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::pageIdentifier const):
(WebKit::PDFPluginBase::stringPasteboardType):
(WebKit::PDFPluginBase::urlPasteboardType):
(WebKit::PDFPluginBase::htmlPasteboardType):
(WebKit::PDFPluginBase::rtfPasteboardType):
(WebKit::PDFPluginBase::writeItemsToGeneralPasteboard const):
(WebKit::PDFPluginBase::writeStringToFindPasteboard const):
(WebKit::PDFPluginBase::writeItemsToPasteboard const): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::performCopyLinkOperation const):
(WebKit::htmlDataFromSelection):
(WebKit::UnifiedPDFPlugin::performCopyEditingOperation const):
(WebKit::UnifiedPDFPlugin::takeFindStringFromSelection):

Canonical link: <a href="https://commits.webkit.org/287931@main">https://commits.webkit.org/287931@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a715f7bd516a1cf1d87618b8e2a98f2261ca254

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81411 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/936 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85940 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32397 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83521 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/954 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8755 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/63548 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/21290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84480 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/659 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74098 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43841 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/554 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28262 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30855 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28848 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87375 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8641 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/71856 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8822 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69919 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71091 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17690 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15159 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14067 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8603 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/14126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8439 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11960 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10247 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->