### PR TITLE
Stop using CMSampleBuffer in MediaRecorderPrivateWriter

### DIFF
--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h
@@ -52,6 +52,7 @@ struct MediaRecorderPrivateOptions;
 class MediaSample;
 class PlatformAudioData;
 class VideoFrame;
+struct AudioInfo;
 struct VideoInfo;
 
 class MediaRecorderPrivateEncoder final : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MediaRecorderPrivateEncoder, WTF::DestructionThread::Main> {
@@ -144,11 +145,11 @@ private:
     String m_audioCodecMimeType WTF_GUARDED_BY_CAPABILITY(mainThread);
     std::optional<uint8_t> m_audioTrackIndex WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     RetainPtr<CMFormatDescriptionRef> m_audioFormatDescription WTF_GUARDED_BY_CAPABILITY(queueSingleton());
-    RetainPtr<CMFormatDescriptionRef> m_audioCompressedFormatDescription WTF_GUARDED_BY_CAPABILITY(queueSingleton());
+    RefPtr<AudioInfo> m_audioCompressedAudioInfo WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     RefPtr<AudioSampleBufferConverter> m_audioConverter WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     bool m_formatChangedOccurred WTF_GUARDED_BY_CAPABILITY(queueSingleton()) { false };
     std::optional<AudioStreamBasicDescription> m_originalOutputDescription WTF_GUARDED_BY_CAPABILITY(queueSingleton());
-    Deque<Ref<MediaSample>> m_encodedAudioFrames WTF_GUARDED_BY_CAPABILITY(queueSingleton());
+    Deque<UniqueRef<MediaSamplesBlock>> m_encodedAudioFrames WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     std::optional<std::pair<const MediaTime, GenericPromise::Producer>> m_pendingAudioFramePromise WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     Lock m_ringBuffersLock;
     Deque<std::unique_ptr<InProcessCARingBuffer>> m_ringBuffers WTF_GUARDED_BY_LOCK(m_ringBuffersLock);
@@ -168,8 +169,8 @@ private:
     RetainPtr<CMFormatDescriptionRef> m_videoFormatDescription WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     RefPtr<VideoEncoder> m_videoEncoder WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     Deque<std::pair<Ref<VideoFrame>, MediaTime>> m_pendingVideoFrames WTF_GUARDED_BY_CAPABILITY(queueSingleton());
-    Deque<Ref<MediaSample>> m_encodedVideoFrames WTF_GUARDED_BY_CAPABILITY(queueSingleton());
-    Deque<Ref<MediaSample>> m_interleavedFrames WTF_GUARDED_BY_CAPABILITY(queueSingleton());
+    Deque<UniqueRef<MediaSamplesBlock>> m_encodedVideoFrames WTF_GUARDED_BY_CAPABILITY(queueSingleton());
+    Deque<UniqueRef<MediaSamplesBlock>> m_interleavedFrames WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     bool m_firstVideoFrameProcessed WTF_GUARDED_BY_CAPABILITY(queueSingleton()) { false };
     MediaTime m_lastEnqueuedRawVideoFrame WTF_GUARDED_BY_CAPABILITY(queueSingleton()) { MediaTime::negativeInfiniteTime() };
     MediaTime m_lastVideoKeyframeTime WTF_GUARDED_BY_CAPABILITY(queueSingleton());

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateWriter.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateWriter.h
@@ -39,8 +39,9 @@ struct CGAffineTransform;
 
 namespace WebCore {
 
-class AudioStreamDescription;
-class MediaSample;
+class MediaSamplesBlock;
+struct AudioInfo;
+struct VideoInfo;
 
 class MediaRecorderPrivateWriterListener : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MediaRecorderPrivateWriterListener> {
 public:
@@ -51,23 +52,24 @@ public:
 class MediaRecorderPrivateWriter {
     WTF_MAKE_TZONE_ALLOCATED(MediaRecorderPrivateWriter);
 public:
-    static std::unique_ptr<MediaRecorderPrivateWriter> create(String type, MediaRecorderPrivateWriterListener&);
+    WEBCORE_EXPORT static std::unique_ptr<MediaRecorderPrivateWriter> create(String type, MediaRecorderPrivateWriterListener&);
 
-    virtual ~MediaRecorderPrivateWriter() = default;
+    WEBCORE_EXPORT MediaRecorderPrivateWriter();
+    WEBCORE_EXPORT virtual ~MediaRecorderPrivateWriter();
 
-    virtual std::optional<uint8_t> addAudioTrack(CMFormatDescriptionRef) = 0;
-    virtual std::optional<uint8_t> addVideoTrack(CMFormatDescriptionRef, const std::optional<CGAffineTransform>&) = 0;
+    virtual std::optional<uint8_t> addAudioTrack(const AudioInfo&) = 0;
+    virtual std::optional<uint8_t> addVideoTrack(const VideoInfo&, const std::optional<CGAffineTransform>&) = 0;
     virtual bool allTracksAdded() = 0;
     enum class Result : uint8_t { Success, Failure, NotReady };
     using WriterPromise = NativePromise<void, Result>;
-    Ref<WriterPromise> writeFrames(Deque<Ref<MediaSample>>&&, const MediaTime&);
-    Ref<GenericPromise> close();
+    WEBCORE_EXPORT virtual Ref<WriterPromise> writeFrames(Deque<UniqueRef<MediaSamplesBlock>>&&, const MediaTime&);
+    WEBCORE_EXPORT virtual Ref<GenericPromise> close();
 
 private:
-    virtual Result writeFrame(const MediaSample&) = 0;
+    virtual Result writeFrame(const MediaSamplesBlock&) = 0;
     virtual void forceNewSegment(const MediaTime&) = 0;
     virtual Ref<GenericPromise> close(const MediaTime&) = 0;
-    Deque<Ref<MediaSample>> m_pendingFrames;
+    Deque<UniqueRef<MediaSamplesBlock>> m_pendingFrames;
     MediaTime m_lastEndTime { MediaTime::invalidTime() };
 };
 

--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.h
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.h
@@ -33,6 +33,7 @@
 OBJC_CLASS AVAssetWriter;
 OBJC_CLASS AVAssetWriterInput;
 OBJC_CLASS WebAVAssetWriterDelegate;
+typedef const struct opaqueCMFormatDescription *CMFormatDescriptionRef;
 
 namespace WebCore {
 
@@ -45,10 +46,10 @@ public:
 private:
     MediaRecorderPrivateWriterAVFObjC(RetainPtr<AVAssetWriter>&&, MediaRecorderPrivateWriterListener&);
 
-    std::optional<uint8_t> addAudioTrack(CMFormatDescriptionRef) final;
-    std::optional<uint8_t> addVideoTrack(CMFormatDescriptionRef, const std::optional<CGAffineTransform>&) final;
+    std::optional<uint8_t> addAudioTrack(const AudioInfo&) final;
+    std::optional<uint8_t> addVideoTrack(const VideoInfo&, const std::optional<CGAffineTransform>&) final;
     bool allTracksAdded() final;
-    Result writeFrame(const MediaSample&) final;
+    Result writeFrame(const MediaSamplesBlock&) final;
     void forceNewSegment(const WTF::MediaTime&) final;
     Ref<GenericPromise> close(const WTF::MediaTime&) final;
 
@@ -59,6 +60,8 @@ private:
     uint8_t m_currentTrackIndex { 0 };
     uint8_t m_audioTrackIndex { 0 };
     uint8_t m_videoTrackIndex  { 0 };
+    RetainPtr<CMFormatDescriptionRef> m_audioDescription;
+    RetainPtr<CMFormatDescriptionRef> m_videoDescription;
     const RetainPtr<WebAVAssetWriterDelegate> m_delegate;
     const RetainPtr<AVAssetWriter> m_writer;
 };

--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.h
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.h
@@ -43,10 +43,10 @@ public:
 private:
     MediaRecorderPrivateWriterWebM(MediaRecorderPrivateWriterListener&);
 
-    std::optional<uint8_t> addAudioTrack(CMFormatDescriptionRef) final;
-    std::optional<uint8_t> addVideoTrack(CMFormatDescriptionRef, const std::optional<CGAffineTransform>&) final;
+    std::optional<uint8_t> addAudioTrack(const AudioInfo&) final;
+    std::optional<uint8_t> addVideoTrack(const VideoInfo&, const std::optional<CGAffineTransform>&) final;
     bool allTracksAdded() final { return true; }
-    Result writeFrame(const MediaSample&) final;
+    Result writeFrame(const MediaSamplesBlock&) final;
     void forceNewSegment(const WTF::MediaTime&) final;
     Ref<GenericPromise> close(const WTF::MediaTime&) final;
 


### PR DESCRIPTION
#### 14becf89d9ce9dc33b74d5aa778b1dd21d162ef1
<pre>
Stop using CMSampleBuffer in MediaRecorderPrivateWriter
<a href="https://bugs.webkit.org/show_bug.cgi?id=284700">https://bugs.webkit.org/show_bug.cgi?id=284700</a>
<a href="https://rdar.apple.com/141498525">rdar://141498525</a>

Reviewed by Youenn Fablet and Eric Carlson.

CMSampleBuffer and its CMFormatDescription aren&apos;t serialisable over IPC. They also
have a fairly high memory requirement due to their complexity.

We move over to the platform-agnostic MediaSamplesBlock (CMSampleBuffer replacement)
and TrackInfo (CMFormatDescription replacement). Those two objects can be serialised
to be transmitted over IPC. They were currently in use by the WeBM SourceBufferParser,
we now use them in both the MediaRecorderPrivateEncoder and its MediaRecorderPrivateWriter.
For storage in the MediaRecorderPrivateEncoder we use Vector of UniqueRef&lt;MediaRecorderPrivateEncoder&gt;
so that they can be moved between queues with less complexity.

No change in observable behaviour, covered by existing tests.

* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp:
(WebCore::MediaRecorderPrivateEncoder::audioSamplesDescriptionChanged):
(WebCore::MediaRecorderPrivateEncoder::enqueueCompressedAudioSampleBuffers):
(WebCore::MediaRecorderPrivateEncoder::maybeStartWriter):
(WebCore::MediaRecorderPrivateEncoder::processVideoEncoderActiveConfiguration):
(WebCore::MediaRecorderPrivateEncoder::enqueueCompressedVideoFrame):
(WebCore::MediaRecorderPrivateEncoder::waitForMatchingAudio):
(WebCore::MediaRecorderPrivateEncoder::flushToEndSegment):
(WebCore::MediaRecorderPrivateEncoder::interleaveAndEnqueueNextFrame):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h:
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateWriter.cpp:
(WebCore::MediaRecorderPrivateWriter::create):
(WebCore::MediaRecorderPrivateWriter::writeFrames):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateWriter.h:
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.h:
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.mm:
(WebCore::MediaRecorderPrivateWriterAVFObjC::addAudioTrack):
(WebCore::MediaRecorderPrivateWriterAVFObjC::addVideoTrack):
(WebCore::MediaRecorderPrivateWriterAVFObjC::writeFrame):
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.cpp:
(WebCore::mkvCodeIcForMediaVideoCodecId): Move method at the top as it needs to be declared before its users.
(WebCore::MediaRecorderPrivateWriterWebMDelegate::addAudioTrack):
(WebCore::MediaRecorderPrivateWriterWebMDelegate::addVideoTrack):
(WebCore::MediaRecorderPrivateWriterWebM::addAudioTrack):
(WebCore::MediaRecorderPrivateWriterWebM::addVideoTrack):
(WebCore::MediaRecorderPrivateWriterWebM::writeFrame):
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.h:

Canonical link: <a href="https://commits.webkit.org/287994@main">https://commits.webkit.org/287994@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60e1a492fc0a6337f51e62848e4bf154b9683bf6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81648 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1173 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35597 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/86187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/32638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83754 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1204 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8992 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/86187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/32638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84718 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/854 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/74298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/86187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/754 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28475 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31093 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29071 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87627 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8885 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/72025 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9068 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70123 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71260 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17734 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15340 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/14256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8837 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/14365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8677 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12198 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10486 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->