### PR TITLE
Re-import content-security-policy/reporting WPT

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-clips-sample.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-clips-sample.https-expected.txt
@@ -1,5 +1,9 @@
 
 PASS Unsafe eval violation sample is clipped to 40 characters.
-FAIL Function constructor - the other kind of eval - is clipped. assert_equals: expected "Function|(a,b) {return '12345678901234567890123" but got "Function|function anonymous(a,b) {return '12345"
+PASS Unsafe indirect eval violation sample is clipped to 40 characters.
+FAIL Function constructor - the other kind of eval - is clipped. assert_equals: expected "Function|(a,b\n) {\nreturn '12345678901234567890123" but got "Function|function anonymous(a,b\n) {\nreturn '12345"
+FAIL Async Function constructor is also clipped. assert_equals: expected "Function|(a,b\n) {\nreturn '12345678901234567890123" but got "Function|async function anonymous(a,b\n) {\nreturn "
+FAIL Generator Function constructor is also clipped. assert_equals: expected "Function|(a,b\n) {\nreturn '12345678901234567890123" but got "Function|function* anonymous(a,b\n) {\nreturn '1234"
+FAIL AsyncGenerator Function constructor is also clipped. assert_equals: expected "Function|(a,b\n) {\nreturn '12345678901234567890123" but got "Function|async function* anonymous(a,b\n) {\nreturn"
 PASS Trusted Types violation sample is clipped to 40 characters excluded the sink name.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-clips-sample.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-clips-sample.https.html
@@ -9,26 +9,72 @@
 </head>
 <body>
   <script>
+  const trimmedSampleLength = 40;
+  const evalSample = "evil = '1234567890123456789012345678901234567890;'";
+  const trimmedEvalSample = evalSample.substring(0, trimmedSampleLength);
   promise_test(t => {
     let evil = false;
     assert_throws_js(EvalError, _ => {
-      eval("evil = '1234567890123456789012345678901234567890';");
+      eval(evalSample);
     });
     assert_false(evil);
     return waitUntilCSPEventForTrustedTypes(t).then(t.step_func_done(e => {
-      assert_equals(e.sample, "eval|evil = '12345678901234567890123456789012");
+      assert_equals(e.sample, `eval|${trimmedEvalSample}`);
     }));
-  }, "Unsafe eval violation sample is clipped to 40 characters.");
+  }, `Unsafe eval violation sample is clipped to ${trimmedSampleLength} characters.`);
+
+  promise_test(t => {
+    let evil = false;
+    assert_throws_js(EvalError, _ => {
+      eval?.(evalSample);
+    });
+    assert_false(evil);
+    return waitUntilCSPEventForTrustedTypes(t).then(t.step_func_done(e => {
+      assert_equals(e.sample, `eval|${trimmedEvalSample}`);
+    }));
+  }, `Unsafe indirect eval violation sample is clipped to ${trimmedSampleLength} characters.`);
+
+  const functionBody = "return '1234567890123456789012345678901234567890';";
+  const sampleWithoutFunctionPrefix = `(a,b\n) {\n${functionBody}\n}`;
 
   promise_test(t => {
     assert_throws_js(EvalError, _ => {
-      new Function("a", "b", "return '1234567890123456789012345678901234567890';");
+      new Function("a", "b", functionBody);
     });
     return waitUntilCSPEventForTrustedTypes(t).then(t.step_func_done(e => {
-      assert_equals(e.sample.replace(/\n/g, ""),
-                    "Function|(a,b) {return '12345678901234567890123");
+      assert_equals(e.sample, `Function|${sampleWithoutFunctionPrefix.substring(0, trimmedSampleLength)}`);
     }));
   }, "Function constructor - the other kind of eval - is clipped.");
+
+  promise_test(t => {
+    assert_throws_js(EvalError, _ => {
+      const AsyncFunction = async function() {}.constructor
+      new AsyncFunction("a", "b", functionBody);
+    });
+    return waitUntilCSPEventForTrustedTypes(t).then(t.step_func_done(e => {
+      assert_equals(e.sample, `Function|${sampleWithoutFunctionPrefix.substring(0, trimmedSampleLength)}`);
+    }));
+  }, "Async Function constructor is also clipped.");
+
+  promise_test(t => {
+    assert_throws_js(EvalError, _ => {
+      const GeneratorFunction = function*() {}.constructor
+      new GeneratorFunction("a", "b", functionBody);
+    });
+    return waitUntilCSPEventForTrustedTypes(t).then(t.step_func_done(e => {
+        assert_equals(e.sample, `Function|${sampleWithoutFunctionPrefix.substring(0, trimmedSampleLength)}`);
+    }));
+  }, "Generator Function constructor is also clipped.");
+
+  promise_test(t => {
+    assert_throws_js(EvalError, _ => {
+      const AsyncGeneratorFunction = async function*() {}.constructor
+      new AsyncGeneratorFunction("a", "b", functionBody);
+    });
+    return waitUntilCSPEventForTrustedTypes(t).then(t.step_func_done(e => {
+        assert_equals(e.sample, `Function|${sampleWithoutFunctionPrefix.substring(0, trimmedSampleLength)}`);
+    }));
+  }, "AsyncGenerator Function constructor is also clipped.");
 
   promise_test(t => {
     const a = document.createElement("a");

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-frame-ancestors-no-parent-cookies.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-frame-ancestors-no-parent-cookies.sub-expected.txt
@@ -1,0 +1,6 @@
+Blocked access to external URL http://www1.localhost:8800/content-security-policy/reporting/support/not-embeddable-frame.py?reportID=GENERATED_REPORT_ID&reportUriBase=http%3A%2F%2Flocalhost%3A8800
+
+
+FAIL Violation report status OK. undefined is not an object (evaluating 'data[0]["body"]')
+PASS Test report cookies.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-frame-ancestors-no-parent-cookies.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-frame-ancestors-no-parent-cookies.sub.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Cookies are not sent on cross origin violation reports for
+      frame-ancestors violations, even if the report-uri is same-origin
+      with the embedder.</title>
+    <meta name="timeout" content="long">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+    fetch(
+      "/cookies/resources/set-cookie.py?name=cspViolationReportCookie1&path=" +
+        encodeURIComponent("/"),
+      {mode: 'no-cors', credentials: 'include'})
+    .then(() => {
+
+      const iframe = document.createElement('iframe');
+      const searchParams = new URLSearchParams();
+      let reportId = "{{$id:uuid()}}";
+      searchParams.set("reportID", reportId);
+      searchParams.set("reportUriBase", "http://{{host}}:{{ports[http][0]}}");
+      iframe.src = "http://{{domains[www1]}}:{{ports[http][0]}}/" +
+        "content-security-policy/reporting/support/not-embeddable-frame.py?" +
+        searchParams.toString();
+      document.body.appendChild(iframe);
+    });
+</script>
+<script async defer src='../support/checkReport.sub.js?reportField=violated-directive&reportValue=frame-ancestors%20%27none%27&noCookies=true&reportID={{$id}}'></script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-only-cross-origin-frame.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-only-cross-origin-frame.sub-expected.txt
@@ -1,0 +1,10 @@
+Blocked access to external URL http://www1.localhost:8800/content-security-policy/support/postmessage-pass.html
+
+
+Harness Error (TIMEOUT), message = null
+
+PASS The load event triggers
+NOTRUN The iframe is allowed to load.
+PASS The securitypolicyviolation is triggered.
+PASS Violation report status OK.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-only-cross-origin-frame.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-only-cross-origin-frame.sub.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Cross origin iframes have their URI censored</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <!-- CSP headers
+Content-Security-Policy: script-src 'self' 'unsafe-inline'
+Content-Security-Policy-Report-Only: frame-src 'none'; script-src 'self' 'unsafe-inline'; report-uri /reporting/resources/report.py?op=put&reportID=$id
+-->
+</head>
+<body>
+  <script>
+    let iframe = document.createElement('iframe');
+    iframe.src = "http://{{domains[www1]}}:{{ports[http][0]}}" +
+                 "/content-security-policy/support/postmessage-pass.html";
+
+    let test_load_event = async_test("The load event triggers");
+    iframe.onload = test_load_event.step_func_done();
+
+    let test_iframe_allowed = async_test("The iframe is allowed to load.");
+    window.addEventListener("message", test_iframe_allowed.step_func(event => {
+      if (event.source === iframe.contentWindow) {
+        assert_equals(event.data, "PASS");
+        test_iframe_allowed.done();
+      }
+    }));
+
+    let test_spv = async_test("The securitypolicyviolation is triggered.");
+    window.addEventListener("securitypolicyviolation",
+                            test_spv.step_func_done(e => {
+      assert_equals(e.blockedURI,
+                    "http://{{domains[www1]}}:{{ports[http][0]}}");
+    }));
+
+    document.body.appendChild(iframe);
+  </script>
+
+  <!-- Ensure that we get the censored URI (without the full path) here: -->
+  <script async defer src='../support/checkReport.sub.js?reportField=blocked-uri&reportValue=http://{{domains[www1]}}:{{ports[http][0]}}'></script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-only-cross-origin-frame.sub.html.sub.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-only-cross-origin-frame.sub.html.sub.headers
@@ -1,0 +1,7 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Set-Cookie: report-only-cross-origin-frame={{$id:uuid()}}; Path=/content-security-policy/reporting/
+Content-Security-Policy: script-src 'self' 'unsafe-inline'
+Content-Security-Policy-Report-Only: frame-src 'none'; script-src 'self' 'unsafe-inline'; report-uri /reporting/resources/report.py?op=put&reportID={{$id}}

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-preload-and-consume.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-preload-and-consume.https.html
@@ -15,9 +15,12 @@
         const uid = token();
         const win = window.open(`./support/preload-csp-report.https.sub.html?uid=${uid}`);
         t.add_cleanup(() => win.close());
-        const reports = await pollReports(endpoint, uid);
-        const failures = reports.filter(r => r['csp-report']['blocked-uri'].endsWith('fail.png'));
-        assert_equals(failures.length, 2);
+        return t.step_wait(async () => {
+            const reports = await pollReports(endpoint, uid);
+            const failures = reports.filter(
+              r => r['csp-report']['blocked-uri'].endsWith('fail.png'));
+            return failures.length === 2;
+        }, "Should receive 2 CSP reports.", 10000, 500);
     }, "Reporting endpoints received credentials.");
   </script>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-same-origin-with-cookies.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-same-origin-with-cookies.html
@@ -15,11 +15,15 @@
     "/cookies/resources/set-cookie.py?name=cspViolationReportCookie2&path=" + encodeURIComponent("/"),
     {mode: 'no-cors', credentials: 'include'})
   .then(() => {
-    test.add_cleanup(() => {
-      document.cookie = "cspViolationReportCookie2=; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT";
-    });
-
-    // This image will generate a CSP violation report.
+    // Loading `img` will generate a CSP violation report.
+    // As this test is for covering the behavior of the deprecated "report-uri" directive [1], the
+    // underlying report is backed by a browser-initiated fetch "keepalive" request [2]. Per
+    // keepalive spec [3], such request may outlive this entire document itself. Hence, the cookie
+    // this test wants to test, i.e. "cspViolationReportCookie2", must NOT be cleared before the
+    // browser entirely sending out the report request.
+    // [1]: https://www.w3.org/TR/CSP3/#report-uri
+    // [2]: https://www.w3.org/TR/CSP3/#report-violation
+    // [3]: https://fetch.spec.whatwg.org/#request-keepalive-flag
     const img = new Image();
     img.onerror = test.step_func_done();
     img.onload = test.unreached_func("Should not have loaded the image");

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-uri-from-child-frame.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-uri-from-child-frame.html
@@ -18,6 +18,6 @@
         }
       }
     </script>
-    <iframe src="support/generate-csp-report.html"/>
+    <iframe src="support/generate-csp-report.html"></iframe>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/support/not-embeddable-frame.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/support/not-embeddable-frame.py
@@ -5,6 +5,7 @@ def main(request, response):
 
     csp_header = b'Content-Security-Policy-Report-Only' \
         if request.GET.first(b'reportOnly', None) == b'true' else b'Content-Security-Policy'
-    headers.append((csp_header, b"frame-ancestors 'none'; report-uri /reporting/resources/report.py?op=put&reportID=" + request.GET[b'reportID']))
+    report_uri_base = request.GET.first(b'reportUriBase', b'')
+    headers.append((csp_header, b"frame-ancestors 'none'; report-uri " + report_uri_base + b"/reporting/resources/report.py?op=put&reportID=" + request.GET[b'reportID']))
 
     return headers, b'{}'

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/support/set-cookie.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/support/set-cookie.py
@@ -21,8 +21,9 @@ def main(request, response):
 
     name = request.GET[b'name']
     path = request.GET[b'path']
+    value = request.GET.first(b'value', b"1")
     expiry_year = date.today().year + 1
-    cookie = b"%s=1; Path=%s; Expires=09 Jun %d 10:18:14 GMT" % (name, path, expiry_year)
+    cookie = b"%s=%s; Path=%s; Expires=09 Jun %d 10:18:14 GMT" % (name, value, path, expiry_year)
 
     headers = [
         (b"Content-Type", b"application/json"),

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/w3c-import.log
@@ -29,12 +29,15 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-clips-sample.https.html
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-cross-origin-no-cookies.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-cross-origin-no-cookies.sub.html.sub.headers
+/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-frame-ancestors-no-parent-cookies.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-frame-ancestors-with-x-frame-options.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-frame-ancestors.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-multiple-violations-01.html
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-multiple-violations-01.html.sub.headers
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-multiple-violations-02.html
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-multiple-violations-02.html.sub.headers
+/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-only-cross-origin-frame.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-only-cross-origin-frame.sub.html.sub.headers
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-only-in-meta.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-only-in-meta.sub.html.sub.headers
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-only-unsafe-eval.html

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/content-security-policy/reporting/report-frame-ancestors-no-parent-cookies.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/content-security-policy/reporting/report-frame-ancestors-no-parent-cookies.sub-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS Violation report status OK.
+FAIL Test report cookies. assert_equals: Report should not contain any cookies expected (string) "None" but got (object) object "[object Object]"
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/content-security-policy/reporting/report-only-cross-origin-frame.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/content-security-policy/reporting/report-only-cross-origin-frame.sub-expected.txt
@@ -1,0 +1,7 @@
+
+
+PASS The load event triggers
+PASS The iframe is allowed to load.
+PASS The securitypolicyviolation is triggered.
+PASS Violation report status OK.
+

--- a/LayoutTests/tests-options.json
+++ b/LayoutTests/tests-options.json
@@ -1976,6 +1976,9 @@
     "imported/w3c/web-platform-tests/content-security-policy/reporting/report-cross-origin-no-cookies.sub.html": [
         "slow"
     ],
+    "imported/w3c/web-platform-tests/content-security-policy/reporting/report-frame-ancestors-no-parent-cookies.sub.html": [
+        "slow"
+    ],
     "imported/w3c/web-platform-tests/content-security-policy/reporting/report-only-in-meta.sub.html": [
         "slow"
     ],


### PR DESCRIPTION
#### 71863b6daa9c7783d91640850061622764c7bbd8
<pre>
Re-import content-security-policy/reporting WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=284747">https://bugs.webkit.org/show_bug.cgi?id=284747</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/f4515a8ef1ad577e0b48e1609a29b80c664ebf69">https://github.com/web-platform-tests/wpt/commit/f4515a8ef1ad577e0b48e1609a29b80c664ebf69</a>

* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-clips-sample.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-clips-sample.https.html:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-frame-ancestors-no-parent-cookies.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-frame-ancestors-no-parent-cookies.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-only-cross-origin-frame.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-only-cross-origin-frame.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-only-cross-origin-frame.sub.html.sub.headers: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-preload-and-consume.https.html:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-same-origin-with-cookies.html:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-uri-from-child-frame.html:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/support/not-embeddable-frame.py:
(main):
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/support/set-cookie.py:
(main):
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/w3c-import.log:
* LayoutTests/tests-options.json:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/content-security-policy/reporting/report-frame-ancestors-no-parent-cookies.sub-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/content-security-policy/reporting/report-only-cross-origin-frame.sub-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/287930@main">https://commits.webkit.org/287930@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebafa0a747ea1c7d7abe3c686021c70a7e1423d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81348 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/873 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35291 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85877 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32334 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/891 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8690 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63501 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/21265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84417 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/605 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74034 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43796 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/502 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28197 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30792 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/71992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28780 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87312 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8578 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6100 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71809 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8759 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69862 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71043 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17689 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15105 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14012 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8540 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8376 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11897 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10184 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->