### PR TITLE
[WPE] WPE Platform: Use default values from WPESettings for WPEView

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/WPESettings.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPESettings.cpp
@@ -97,6 +97,9 @@ struct _WPESettingsPrivate {
             { WPE_SETTING_FONT_SUBPIXEL_LAYOUT, G_VARIANT_TYPE_BYTE, g_variant_ref_sink(g_variant_new_byte(WPE_SETTINGS_SUBPIXEL_LAYOUT_RGB)) },
             { WPE_SETTING_FONT_DPI, G_VARIANT_TYPE_DOUBLE, g_variant_ref_sink(g_variant_new_double(96.0)) },
             { WPE_SETTING_CURSOR_BLINK_TIME, G_VARIANT_TYPE_UINT32, g_variant_ref_sink(g_variant_new_uint32(1200)) },
+            { WPE_SETTING_TOPLEVEL_DEFAULT_SIZE, G_VARIANT_TYPE("(uu)"), g_variant_ref_sink(g_variant_new("(uu)", 1024, 768)) },
+            { WPE_SETTING_DOUBLE_CLICK_DISTANCE, G_VARIANT_TYPE_UINT32, g_variant_ref_sink(g_variant_new_uint32(5)) },
+            { WPE_SETTING_DOUBLE_CLICK_TIME, G_VARIANT_TYPE_UINT32, g_variant_ref_sink(g_variant_new_uint32(400)) },
         };
 
         for (auto& setting : defaultSettings)

--- a/Source/WebKit/WPEPlatform/wpe/WPESettings.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPESettings.h
@@ -162,7 +162,39 @@ typedef enum {
  * Default: 1200
  */
 #define WPE_SETTING_CURSOR_BLINK_TIME "/wpe-platform/cursor-blink-time"
-
+/**
+ * WPE_SETTING_TOPLEVEL_DEFAULT_SIZE:
+ *
+ * The default size of the toplevel upon construction, represented as
+ * a pair of unsigned 32-bit integers (width, height).
+ *
+ * VariantType: (uu)
+ *
+ * Default: (1024, 768)
+ */
+#define WPE_SETTING_TOPLEVEL_DEFAULT_SIZE "/wpe-platform/toplevel-default-size"
+/**
+ * WPE_SETTING_DOUBLE_CLICK_DISTANCE:
+ *
+ * The allowed distance travelled in either the x or the y coordinate of a
+ * button press event from the previous press to be considered a double click.
+ *
+ * VariantType: uint32
+ *
+ * Default: 5
+ */
+#define WPE_SETTING_DOUBLE_CLICK_DISTANCE "/wpe-platform/events/double-click/distance"
+/**
+ * WPE_SETTING_DOUBLE_CLICK_TIME:
+ *
+ * The allowed time elapse since the previous button press event until the current
+ * press to be considered a double click.
+ *
+ * VariantType: uint32
+ *
+ * Default: 400
+ */
+#define WPE_SETTING_DOUBLE_CLICK_TIME "/wpe-platform/events/double-click/time"
 
 /**
  * WPESettingsSource:


### PR DESCRIPTION
#### 8d758321355e40d71444cd9c437deec32b32beed
<pre>
[WPE] WPE Platform: Use default values from WPESettings for WPEView
<a href="https://bugs.webkit.org/show_bug.cgi?id=284758">https://bugs.webkit.org/show_bug.cgi?id=284758</a>

Reviewed by Carlos Garcia Campos.

Set the size of the WPEView as well as the double click time and distance
with the values from WPESettings.

* Source/WebKit/WPEPlatform/wpe/WPESettings.cpp:
(_WPESettingsPrivate::_WPESettingsPrivate):
* Source/WebKit/WPEPlatform/wpe/WPESettings.h:
* Source/WebKit/WPEPlatform/wpe/WPEView.cpp:
(wpeViewConstructed):
(wpe_view_compute_press_count):

Canonical link: <a href="https://commits.webkit.org/288148@main">https://commits.webkit.org/288148@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a8779db13f2611b65596649bb51ad0b47b71d59

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81880 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1406 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35836 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86437 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32882 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1441 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9229 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63866 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21590 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84950 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1064 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74516 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44150 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/964 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31331 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72312 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29302 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87868 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9122 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6501 "Found 1 new test failure: imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-mimetype.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72225 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9307 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70335 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71448 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15540 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14465 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/496 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12708 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9073 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14609 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8912 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12438 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10720 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->