### PR TITLE
Decrease fake Safari version in user agent header

### DIFF
--- a/Source/WebCore/platform/glib/UserAgentGLib.cpp
+++ b/Source/WebCore/platform/glib/UserAgentGLib.cpp
@@ -105,12 +105,13 @@ static String buildUserAgentString(const UserAgentQuirks& quirks)
     } else
         // Version/X is mandatory *before* Safari/X to be a valid Safari UA.
         //
-        // Actual Safari uses the Safari version (17.0, 18.0, etc.) here rather
-        // than the 605.1.15, but this is not web compatible for us because many
-        // websites discriminate against relatively recent Safari versions. We
-        // need to pick a higher version number than real Safari to avoid these.
+        // Many websites discriminate against relatively recent Safari versions,
+        // so we need to pick a higher version number than real Safari.
         // https://github.com/nextcloud/server/issues/40793#issuecomment-1750678596
-        uaString.append("Version/605.1.15 "_s);
+        //
+        // But beware, because some websites also discriminate against high Safari versions.
+        // https://webkit.org/b/284775
+        uaString.append("Version/60.5 "_s);
 
     if (chassisType() == WTF::ChassisType::Mobile)
         uaString.append("Mobile "_s);


### PR DESCRIPTION
#### 33d4afe1c1d9d7cff7afbd0d0458f5218563c456
<pre>
Decrease fake Safari version in user agent header
<a href="https://bugs.webkit.org/show_bug.cgi?id=284775">https://bugs.webkit.org/show_bug.cgi?id=284775</a>

Reviewed by Carlos Garcia Campos.

* Source/WebCore/platform/glib/UserAgentGLib.cpp:
(WebCore::buildUserAgentString):

Canonical link: <a href="https://commits.webkit.org/287944@main">https://commits.webkit.org/287944@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77d414b44142e49f0582acac40993ff9dc73c00a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81316 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/841 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35259 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85845 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32302 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83426 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/859 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8657 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63478 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21243 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84385 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/583 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74007 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43773 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/481 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28169 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30760 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71975 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28750 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87280 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8546 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6083 "Found 60 new test failures: compositing/repaint/become-overlay-composited-layer.html editing/execCommand/apply-inline-style-to-element-with-no-renderer-crash.html fast/table/multiple-captions-crash3.html fast/text/emoji-gender-fe0f-3.html fonts/ligature.html http/tests/canvas/canvas-tainted-after-draw-image.html http/tests/media/video-webm-stall-seek.html http/wpt/opener/parent-access-child-via-windowproxy.html imported/w3c/web-platform-tests/css/css-highlight-api/highlight-image.html imported/w3c/web-platform-tests/css/css-highlight-api/highlight-text-dynamic.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71792 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8727 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69837 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71025 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17701 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15079 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13992 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8508 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14031 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8344 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11865 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10152 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->