### PR TITLE
[iOS18] 2 tests in TestWebKitAPI.WebKit.SystemPreview are a constant crash(failure in EWS)

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SystemPreview.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SystemPreview.mm
@@ -28,7 +28,7 @@
 #if (PLATFORM(IOS) || PLATFORM(VISION)) && USE(SYSTEM_PREVIEW)
 
 #import "TestUIDelegate.h"
-#import "TestWKWebView.h"
+#import "TestWKWebViewController.h"
 #import "Utilities.h"
 #import "WKWebViewConfigurationExtras.h"
 #import <WebKit/WKWebViewConfigurationPrivate.h>
@@ -121,19 +121,14 @@ TEST(WebKit, SystemPreviewLoad)
     Util::run(&wasTriggered);
 }
 
-// FIXME when rdar://141378456 is resolved.
-#if PLATFORM(IOS)
-TEST(WebKit, DISABLED_SystemPreviewFail)
-#else
 TEST(WebKit, SystemPreviewFail)
-#endif
 {
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
+    RetainPtr configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
     [configuration _setSystemPreviewEnabled:YES];
 
-    auto viewController = adoptNS([[UIViewController alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
-    auto uiDelegate = adoptNS([[TestSystemPreviewUIDelegate alloc] init]);
+    RetainPtr viewController = adoptNS([[TestWKWebViewController alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = [viewController webView];
+    RetainPtr uiDelegate = adoptNS([[TestSystemPreviewUIDelegate alloc] init]);
     uiDelegate.get().viewController = viewController.get();
     [webView setUIDelegate:uiDelegate.get()];
     [viewController setView:webView.get()];
@@ -190,19 +185,14 @@ TEST(WebKit, SystemPreviewBlobRevokedImmediately)
     Util::run(&wasTriggered);
 }
 
-// FIXME when rdar://141378456 is resolved.
-#if PLATFORM(IOS)
-TEST(WebKit, DISABLED_SystemPreviewBlob)
-#else
 TEST(WebKit, SystemPreviewBlob)
-#endif
 {
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
+    RetainPtr configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
     [configuration _setSystemPreviewEnabled:YES];
 
-    auto viewController = adoptNS([[UIViewController alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
-    auto uiDelegate = adoptNS([[TestSystemPreviewUIDelegate alloc] init]);
+    RetainPtr viewController = adoptNS([[TestWKWebViewController alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = [viewController webView];
+    RetainPtr uiDelegate = adoptNS([[TestSystemPreviewUIDelegate alloc] init]);
     uiDelegate.get().viewController = viewController.get();
     [webView setUIDelegate:uiDelegate.get()];
     [viewController setView:webView.get()];


### PR DESCRIPTION
#### 2ffc143345427497f3ba39da7992a97f7ee62a84
<pre>
[iOS18] 2 tests in TestWebKitAPI.WebKit.SystemPreview are a constant crash(failure in EWS)
<a href="https://bugs.webkit.org/show_bug.cgi?id=284572">https://bugs.webkit.org/show_bug.cgi?id=284572</a>
<a href="https://rdar.apple.com/141378456">rdar://141378456</a>

Reviewed by Abrar Rahman Protyasha.

Fix these test failures after updating to iOS 18 by deploying `TestWKWebViewController` here.
Importantly, this testing helper class works around the lack of UIApp in TestWebKitAPI by
intercepting the view controller animated dismissal hook.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/SystemPreview.mm:
(TestWebKitAPI::TEST(WebKit, SystemPreviewFail)):
(TestWebKitAPI::TEST(WebKit, SystemPreviewBlob)):

Canonical link: <a href="https://commits.webkit.org/287914@main">https://commits.webkit.org/287914@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7034aa07ac9c9757d3790c046fdbd7b1ecb87146

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81318 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/843 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35261 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85847 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/32304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83428 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/861 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8659 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/63482 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/32304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84387 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/587 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74009 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43777 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28171 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30762 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/71978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28752 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87282 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8548 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/71790 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8729 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69839 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71023 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17680 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15081 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/13994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8510 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8346 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/11867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10154 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->