### PR TITLE
Suppress more clang static analyzer warnings in WTF

### DIFF
--- a/Source/WTF/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -1,7 +1,4 @@
 WebKitBuild/Release/usr/local/include/wtf/text/AtomString.h
-WebKitBuild/Release/usr/local/include/wtf/text/AtomStringImpl.h
-WebKitBuild/Release/usr/local/include/wtf/text/StringImpl.h
-WebKitBuild/Release/usr/local/include/wtf/text/WTFString.h
 wtf/NeverDestroyed.h
 wtf/Ref.h
 wtf/RefPtr.h

--- a/Source/WTF/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1,5 +1,4 @@
 WebKitBuild/Release/usr/local/include/wtf/text/StringImpl.h
-WebKitBuild/Release/usr/local/include/wtf/text/StringView.h
 WebKitBuild/Release/usr/local/include/wtf/text/WTFString.h
 wtf/AutomaticThread.cpp
 wtf/JSONValues.cpp

--- a/Source/WTF/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -1,4 +1,3 @@
-WebKitBuild/Release/usr/local/include/wtf/text/StringImpl.h
 wtf/AutomaticThread.cpp
 wtf/MemoryPressureHandler.cpp
 wtf/MetaAllocator.h

--- a/Source/WTF/wtf/text/AtomString.h
+++ b/Source/WTF/wtf/text/AtomString.h
@@ -259,8 +259,8 @@ static_assert(sizeof(AtomString) == sizeof(StaticAtomString), "AtomString and St
 extern WTF_EXPORT_PRIVATE const StaticAtomString nullAtomData;
 extern WTF_EXPORT_PRIVATE const StaticAtomString emptyAtomData;
 
-inline const AtomString& nullAtom() { return *reinterpret_cast<const AtomString*>(&nullAtomData); }
-inline const AtomString& emptyAtom() { return *reinterpret_cast<const AtomString*>(&emptyAtomData); }
+inline const AtomString& nullAtom() { SUPPRESS_MEMORY_UNSAFE_CAST return *reinterpret_cast<const AtomString*>(&nullAtomData); }
+inline const AtomString& emptyAtom() { SUPPRESS_MEMORY_UNSAFE_CAST return *reinterpret_cast<const AtomString*>(&emptyAtomData); }
 
 inline AtomString::AtomString(ASCIILiteral literal)
     : m_string(literal.length() ? AtomStringImpl::add(literal.span8()) : Ref { *emptyAtom().impl() })

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -405,7 +405,7 @@ public:
     };
 
     WTF_EXPORT_PRIVATE static StaticStringImpl s_emptyAtomString;
-    ALWAYS_INLINE static StringImpl* empty() { return reinterpret_cast<StringImpl*>(&s_emptyAtomString); }
+    ALWAYS_INLINE static StringImpl* empty() { SUPPRESS_MEMORY_UNSAFE_CAST return reinterpret_cast<StringImpl*>(&s_emptyAtomString); }
 
     // FIXME: Do these functions really belong in StringImpl?
     template<typename CharacterType>
@@ -1027,10 +1027,10 @@ ALWAYS_INLINE Ref<StringImpl> StringImpl::createSubstringSharingImpl(StringImpl&
             return create(rep.span16().subspan(offset, length));
     }
 
-    auto* ownerRep = ((rep.bufferOwnership() == BufferSubstring) ? rep.substringBuffer() : &rep);
+    SUPPRESS_UNCOUNTED_LOCAL auto* ownerRep = ((rep.bufferOwnership() == BufferSubstring) ? rep.substringBuffer() : &rep);
 
     // We allocate a buffer that contains both the StringImpl struct as well as the pointer to the owner string.
-    auto* stringImpl = static_cast<StringImpl*>(StringImplMalloc::malloc(substringSize));
+    SUPPRESS_UNCOUNTED_LOCAL auto* stringImpl = static_cast<StringImpl*>(StringImplMalloc::malloc(substringSize));
     if (rep.is8Bit())
         return adoptRef(*new (NotNull, stringImpl) StringImpl(rep.span8().subspan(offset, length), *ownerRep));
     return adoptRef(*new (NotNull, stringImpl) StringImpl(rep.span16().subspan(offset, length), *ownerRep));
@@ -1047,9 +1047,7 @@ template<typename CharacterType> ALWAYS_INLINE RefPtr<StringImpl> StringImpl::tr
         output = { };
         return nullptr;
     }
-    StringImpl* result;
-
-    result = (StringImpl*)StringImplMalloc::tryMalloc(allocationSize<CharacterType>(length));
+    SUPPRESS_UNCOUNTED_LOCAL StringImpl* result = (StringImpl*)StringImplMalloc::tryMalloc(allocationSize<CharacterType>(length));
     if (!result) {
         output = { };
         return nullptr;
@@ -1262,7 +1260,7 @@ template<unsigned characterCount> constexpr StringImpl::StaticStringImpl::Static
 
 inline StringImpl::StaticStringImpl::operator StringImpl&()
 {
-    return *reinterpret_cast<StringImpl*>(this);
+    SUPPRESS_MEMORY_UNSAFE_CAST return *reinterpret_cast<StringImpl*>(this);
 }
 
 inline bool equalIgnoringASCIICase(const StringImpl& a, const StringImpl& b)

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -1418,12 +1418,12 @@ inline bool String::endsWithIgnoringASCIICase(StringView string) const
 
 inline bool String::hasInfixStartingAt(StringView prefix, unsigned start) const
 {
-    return m_impl && prefix && m_impl->hasInfixStartingAt(prefix, start);
+    SUPPRESS_UNCOUNTED_ARG return m_impl && prefix && m_impl->hasInfixStartingAt(prefix, start);
 }
 
 inline bool String::hasInfixEndingAt(StringView suffix, unsigned end) const
 {
-    return m_impl && suffix && m_impl->hasInfixEndingAt(suffix, end);
+    SUPPRESS_UNCOUNTED_ARG return m_impl && suffix && m_impl->hasInfixEndingAt(suffix, end);
 }
 
 inline size_t AtomString::find(StringView string, size_t start) const

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -362,8 +362,8 @@ static_assert(sizeof(String) == sizeof(StaticString), "String and StaticString m
 extern WTF_EXPORT_PRIVATE const StaticString nullStringData;
 extern WTF_EXPORT_PRIVATE const StaticString emptyStringData;
 
-inline const String& nullString() { return *reinterpret_cast<const String*>(&nullStringData); }
-inline const String& emptyString() { return *reinterpret_cast<const String*>(&emptyStringData); }
+inline const String& nullString() { SUPPRESS_MEMORY_UNSAFE_CAST return *reinterpret_cast<const String*>(&nullStringData); }
+inline const String& emptyString() { SUPPRESS_MEMORY_UNSAFE_CAST return *reinterpret_cast<const String*>(&emptyStringData); }
 
 template<typename> struct DefaultHash;
 template<> struct DefaultHash<String>;
@@ -473,7 +473,7 @@ WTF_EXPORT_PRIVATE String makeStringByJoining(std::span<const String> strings, c
 inline std::optional<UCharDirection> String::defaultWritingDirection() const
 {
     if (m_impl)
-        return m_impl->defaultWritingDirection();
+        SUPPRESS_UNCOUNTED_ARG return m_impl->defaultWritingDirection();
     return std::nullopt;
 }
 
@@ -491,7 +491,7 @@ inline String String::substring(unsigned position, unsigned length) const
     if (!position && length >= m_impl->length())
         return *this;
 
-    return m_impl->substring(position, length);
+    SUPPRESS_UNCOUNTED_ARG return m_impl->substring(position, length);
 }
 
 template<typename Func>
@@ -508,7 +508,7 @@ inline String::operator NSString *() const
 {
     if (!m_impl)
         return @"";
-    return *m_impl;
+    SUPPRESS_UNCOUNTED_ARG return *m_impl;
 }
 
 inline NSString * nsStringNilIfEmpty(const String& string)
@@ -535,7 +535,7 @@ inline bool codePointCompareLessThan(const String& a, const String& b)
 template<typename Predicate>
 String String::removeCharacters(const Predicate& findMatch) const
 {
-    return m_impl ? m_impl->removeCharacters(findMatch) : String { };
+    SUPPRESS_UNCOUNTED_ARG return m_impl ? m_impl->removeCharacters(findMatch) : String { };
 }
 
 inline bool equalLettersIgnoringASCIICase(const String& string, ASCIILiteral literal)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommand.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommand.mm
@@ -94,7 +94,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionCommand, WebExtensionCommand
 
 - (NSString *)activationKey
 {
-    if (auto& activationKey = _webExtensionCommand->activationKey(); !activationKey.isEmpty())
+    if (auto& activationKey = self._protectedWebExtensionCommand->activationKey(); !activationKey.isEmpty())
         return activationKey;
     return nil;
 }


### PR DESCRIPTION
#### 0477b9ff225fc4e685c25b2d91621354ab3bdd0b
<pre>
Suppress more clang static analyzer warnings in WTF
<a href="https://bugs.webkit.org/show_bug.cgi?id=284783">https://bugs.webkit.org/show_bug.cgi?id=284783</a>

Reviewed by Chris Dumez.

Suppressed more clang static analyzer warnings.

* Source/WTF/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WTF/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WTF/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WTF/wtf/text/AtomString.h:
(WTF::nullAtom):
(WTF::emptyAtom):
* Source/WTF/wtf/text/AtomStringImpl.h:
(WTF::AtomStringImpl::lookUp):
(WTF::AtomStringImpl::add):
(isType):
* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::empty):
(WTF::StringImpl::createSubstringSharingImpl):
(WTF::StringImpl::tryCreateUninitialized):
(WTF::StringImpl::StaticStringImpl::operator StringImpl&amp;):
* Source/WTF/wtf/text/StringView.h:
(WTF::String::hasInfixStartingAt const):
(WTF::String::hasInfixEndingAt const):
* Source/WTF/wtf/text/WTFString.h:
(WTF::nullString):
(WTF::emptyString):
(WTF::String::defaultWritingDirection const):
(WTF::String::substring const):
(WTF::String::operator NSString * const):
(WTF::String::removeCharacters const):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommand.mm:
(-[WKWebExtensionCommand activationKey]):

Canonical link: <a href="https://commits.webkit.org/288214@main">https://commits.webkit.org/288214@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce4ba45bf25af6f4614bb8721ad82b27d39603c9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82100 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1630 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36063 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86660 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33138 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1667 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9457 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64003 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21730 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85170 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1254 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74705 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44284 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1153 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28884 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31557 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/75083 "Found 1 jsc stress test failure: stress/scoped-arguments-table-should-be-tolerant-for-oom.js.no-cjit-collect-continuously") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29496 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88096 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/81155 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9344 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6673 "Found 2 new test failures: fast/selectors/text-field-selection-stroke-color.html imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-no-sink.https.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72377 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9529 "Failed to checkout and rebase branch from PR 38038") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70522 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71597 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14635 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12745 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9297 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14835 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/103567 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9135 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25130 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12664 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10944 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->