### PR TITLE
[TextureMapper] Preserve 3d may split layers unnecessarily when they don't intersect

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/ClipPath.h
+++ b/Source/WebCore/platform/graphics/texmap/ClipPath.h
@@ -37,6 +37,7 @@ namespace WebCore {
 class ClipPath final {
     WTF_MAKE_TZONE_ALLOCATED(ClipPath);
 public:
+    ClipPath() = default;
     ClipPath(Vector<FloatPoint>&& vertices, unsigned bufferID, unsigned bufferOffsetInBytes);
 
     bool isEmpty() const { return m_vertices.isEmpty(); }
@@ -44,13 +45,13 @@ public:
     const void* bufferDataOffsetAsPtr() const;
     unsigned numberOfVertices() const { return m_vertices.size(); }
 
-    FloatRect bounds() const { return m_bounds; }
+    const FloatRect& bounds() const { return m_bounds; }
 
 private:
 
     const Vector<FloatPoint> m_vertices;
-    unsigned m_bufferID;
-    unsigned m_bufferOffsetInBytes;
+    unsigned m_bufferID { 0 };
+    unsigned m_bufferOffsetInBytes { 0 };
 
     FloatRect m_bounds;
 };

--- a/Source/WebCore/platform/graphics/texmap/FloatPolygon3D.cpp
+++ b/Source/WebCore/platform/graphics/texmap/FloatPolygon3D.cpp
@@ -28,6 +28,8 @@
 #include "config.h"
 #include "FloatPolygon3D.h"
 
+#include "FloatPlane3D.h"
+#include "FloatRect.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/graphics/texmap/FloatPolygon3D.h
+++ b/Source/WebCore/platform/graphics/texmap/FloatPolygon3D.h
@@ -27,14 +27,15 @@
 
 #pragma once
 
-#include "FloatPlane3D.h"
 #include "FloatPoint3D.h"
-#include "FloatRect.h"
 #include "TransformationMatrix.h"
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
+
+class FloatPlane3D;
+class FloatRect;
 
 // FloatPolygon3D represents planar polygon in 3D space
 
@@ -55,7 +56,7 @@ private:
     FloatPolygon3D(Vector<FloatPoint3D>&&, const FloatPoint3D&);
 
     Vector<FloatPoint3D> m_vertices;
-    FloatPoint3D m_normal = { 0, 0, 1 };
+    FloatPoint3D m_normal { 0, 0, 1 };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
@@ -144,7 +144,7 @@ private:
 
     void processDescendantLayersFlatteningRequirements();
     void processFlatteningRequirements();
-    void computeFlattenedRegion(Region&, bool);
+    void computeFlattenedRegion(Region&, bool) const;
     void destroyFlattenedDescendantLayers();
 
     struct ComputeTransformData;
@@ -196,6 +196,7 @@ private:
     bool flattensAsLeafOf3DSceneOr3DPerspective() const;
 
     bool preserves3D() const { return m_state.preserves3D; }
+    bool isLeafOf3DRenderingContext() const { return !m_state.preserves3D && (m_parent && m_parent->preserves3D()); }
     bool isFlattened() const { return !!m_flattenedLayer; }
     bool hasMask() const { return !!m_state.maskLayer; }
     bool hasBackdrop() const  { return !!m_state.backdropLayer; }

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer3DRenderingContext.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer3DRenderingContext.cpp
@@ -30,39 +30,149 @@
 
 #include "ClipPath.h"
 #include "FloatPlane3D.h"
+#include "FloatPolygon3D.h"
+#include "GeometryUtilities.h"
 #include "TextureMapperGPUBuffer.h"
 #include "TextureMapperLayer.h"
-#include <wtf/Deque.h>
+#include <numeric>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
+static inline FloatQuad projectPolygonToZYPlane(const FloatPolygon3D& polygon)
+{
+    auto p1 = polygon.vertexAt(0);
+    auto p2 = polygon.vertexAt(1);
+    auto p3 = polygon.vertexAt(2);
+    auto p4 = polygon.vertexAt(3);
+    return { { p1.z(), p1.y() }, { p2.z(), p2.y() }, { p3.z(), p3.y() }, { p4.z(), p4.y() } };
+}
+
+// Given two points defining an edge, returns the perpendicular axis (normalized)
+static inline FloatPoint edgeNormal(const FloatPoint& p1, const FloatPoint& p2)
+{
+    auto edge = p2 - p1;
+
+    // A perpendicular to (x,y) is (y,-x)
+    FloatPoint normal = { edge.height(), -edge.width() };
+    normal.normalize();
+
+    return normal;
+}
+
+// Project a convex polygon onto an axis and return min/max scalar values
+static inline std::pair<float, float> projectQuadOnAxis(const FloatQuad& quad, const FloatPoint& axis)
+{
+    float p1 = quad.p1().dot(axis);
+    float p2 = quad.p2().dot(axis);
+    float p3 = quad.p3().dot(axis);
+    float p4 = quad.p4().dot(axis);
+
+    float min = min4(p1, p2, p3, p4);
+    float max = max4(p1, p2, p3, p4);
+
+    return { min, max };
+}
+
+// Intersection check using Separating Axis Theorem
+// For more information:
+// https://en.wikipedia.org/wiki/Hyperplane_separation_theorem
+static inline bool quadsIntersect(const FloatQuad& quadA, const FloatQuad& quadB)
+{
+    std::array<FloatPoint, 8> axes;
+
+    // QuadA edges: (1->2), (2->3), (3->4), (4->0)
+    axes[0] = edgeNormal(quadA.p1(), quadA.p2());
+    axes[1] = edgeNormal(quadA.p2(), quadA.p3());
+    axes[2] = edgeNormal(quadA.p3(), quadA.p4());
+    axes[3] = edgeNormal(quadA.p4(), quadA.p1());
+
+    // QuadB edges: (1->2), (2->3), (3->4), (4->0)
+    axes[4] = edgeNormal(quadB.p1(), quadB.p2());
+    axes[5] = edgeNormal(quadB.p2(), quadB.p3());
+    axes[6] = edgeNormal(quadB.p3(), quadB.p4());
+    axes[7] = edgeNormal(quadB.p4(), quadB.p1());
+
+    for (auto& axis : axes) {
+        auto [minA, maxA] = projectQuadOnAxis(quadA, axis);
+        auto [minB, maxB] = projectQuadOnAxis(quadB, axis);
+
+        // Check if two intervals [minA, maxA] and [minB, maxB] do not overlap
+        if (maxA < minB || maxB < minA)
+            return false; // Separating axis found
+    }
+
+    return true; // No separating axis found
+}
+
 WTF_MAKE_TZONE_ALLOCATED_IMPL(TextureMapperLayer3DRenderingContext);
 
-void TextureMapperLayer3DRenderingContext::paint(TextureMapper& textureMapper, const Vector<TextureMapperLayer*>& layers,
+void TextureMapperLayer3DRenderingContext::paint(TextureMapper& textureMapper, const Vector<TextureMapperLayer*>& textureMapperLayers,
     const std::function<void(TextureMapperLayer*, const ClipPath&)>& paintLayerFunction)
 {
-    if (layers.isEmpty())
+    if (textureMapperLayers.isEmpty())
         return;
 
-    Deque<TextureMapperLayerPolygon> layerList;
-    for (auto* layer : layers)
-        layerList.append({ { layer->effectiveLayerRect(), layer->toSurfaceTransform() }, layer, false });
+    Vector<Layer> layers;
+    for (auto* textureMapperLayer : textureMapperLayers) {
+        FloatPolygon3D geometry(textureMapperLayer->effectiveLayerRect(), textureMapperLayer->toSurfaceTransform());
+        BoundingBox boundingBox = computeBoundingBox(geometry);
+        layers.append({ geometry, boundingBox, textureMapperLayer });
+    }
 
-    auto root = makeUnique<TextureMapperLayerNode>(layerList.takeFirst());
-    buildTree(*root, layerList);
+    // Perform a broad-phase sweep-and-prune to identify potential intersections.
+    // By determining which layers might intersect, we can limit BSP cutting planes to those areas only,
+    // preventing unnecessary splitting of layers that are spatially distant.
+    // This optimization matters because the TextureMapper uses stencil operations to render split layers,
+    // and on some hardware, stencil usage is slow. Reducing unnecessary splits helps improve performance.
+    auto potentialIntersections = sweepAndPrune(layers);
+
+    // Determine if any layer pairs intersect on the ZY plane. An intersection implies that the rendering
+    // order is either ambiguous or overlapping, necessitating the use of a BSP tree for proper ordering.
+    bool hasIntersections = false;
+    for (const auto& p : potentialIntersections) {
+        auto quadA = projectPolygonToZYPlane(layers[p.first].geometry);
+        auto quadB = projectPolygonToZYPlane(layers[p.second].geometry);
+        if (quadsIntersect(quadA, quadB)) {
+            hasIntersections = true;
+            break;
+        }
+    }
+
+    // If no intersections are detected, the BSP tree building process is skipped and a fast path is taken.
+    // Other scenarios are not currently considered for optimization.
+    if (!hasIntersections) {
+        // Sort back to front
+        std::sort(layers.begin(), layers.end(), [](const Layer& layerA, const Layer& layerB) {
+            auto layerAminZ = layerA.boundingBox.min.z();
+            auto layerBminZ = layerB.boundingBox.min.z();
+            return layerAminZ < layerBminZ;
+        });
+
+        for (auto& layer : layers)
+            paintLayerFunction(layer.textureMapperLayer, { });
+        return;
+    }
+
+    Deque<Layer> layerDeque;
+    for (auto& layer : layers)
+        layerDeque.append(WTFMove(layer));
+    layers.clear();
+
+    auto root = makeUnique<LayerNode>(layerDeque.takeFirst());
+    buildTree(*root, layerDeque);
 
     // Collect clip data
     Vector<float> clipVertices;
-    traverseTree(*root, [&clipVertices](TextureMapperLayerNode& node) {
-        for (auto& polygon : node.polygons) {
-            auto toLayerTransform = polygon.layer->toSurfaceTransform().inverse();
-            if (polygon.isSplitted && toLayerTransform) {
-                polygon.clipVertexBufferOffset = clipVertices.size();
+    traverseTree(*root, [&clipVertices](LayerNode& node) {
+        for (auto& layer : node.layers) {
+            auto toLayerTransform = layer.textureMapperLayer->toSurfaceTransform().inverse();
+            if (layer.isSplitted && toLayerTransform) {
+                layer.clipVertexBufferOffset = clipVertices.size();
 
-                unsigned numVertices = polygon.geometry.numberOfVertices();
-                for (unsigned i = 0; i < numVertices; i++) {
-                    auto v = toLayerTransform->mapPoint(polygon.geometry.vertexAt(i));
+                unsigned numVertices = layer.geometry.numberOfVertices();
+                for (unsigned i = 0; i < numVertices; ++i) {
+                    auto v = toLayerTransform->mapPoint(layer.geometry.vertexAt(i));
                     clipVertices.append(v.x());
                     clipVertices.append(v.y());
                 }
@@ -75,72 +185,131 @@ void TextureMapperLayer3DRenderingContext::paint(TextureMapper& textureMapper, c
     clipBuffer->updateData(clipVertices.data(), 0, clipBufferSize);
 
     // Paint
-    traverseTree(*root, [&clipVertices, &clipBuffer, &paintLayerFunction](TextureMapperLayerNode& node) {
-        for (auto& polygon : node.polygons) {
-            unsigned numberOfClipVertices = polygon.isSplitted ? polygon.geometry.numberOfVertices() : 0;
+    traverseTree(*root, [&clipVertices, &clipBuffer, &paintLayerFunction](LayerNode& node) {
+        for (auto& layer : node.layers) {
+            unsigned numberOfClipVertices = layer.isSplitted ? layer.geometry.numberOfVertices() : 0;
 
             Vector<FloatPoint> points;
             if (numberOfClipVertices > 0) {
                 points.reserveCapacity(numberOfClipVertices);
-                auto xy = clipVertices.subvector(polygon.clipVertexBufferOffset, numberOfClipVertices * 2);
+                auto xy = clipVertices.subvector(layer.clipVertexBufferOffset, numberOfClipVertices * 2);
                 for (size_t i = 0; i < xy.size(); i += 2)
                     points.append(FloatPoint(xy.at(i), xy.at(i + 1)));
             }
 
-            ClipPath clipPath(WTFMove(points), clipBuffer->bufferID(), polygon.clipVertexBufferOffset * sizeof(float));
+            ClipPath clipPath(WTFMove(points), clipBuffer->bufferID(), layer.clipVertexBufferOffset * sizeof(float));
 
-            paintLayerFunction(polygon.layer, clipPath);
+            paintLayerFunction(layer.textureMapperLayer, clipPath);
         }
     });
 }
 
-// Build BSP tree for rendering polygons with painter's algorithm.
+TextureMapperLayer3DRenderingContext::BoundingBox TextureMapperLayer3DRenderingContext::computeBoundingBox(const FloatPolygon3D& polygon)
+{
+    FloatPoint3D minCorner = polygon.vertexAt(0);
+    FloatPoint3D maxCorner = polygon.vertexAt(0);
+
+    for (unsigned i = 1; i < polygon.numberOfVertices(); i++) {
+        auto point = polygon.vertexAt(i);
+        minCorner.setX(std::min(minCorner.x(), point.x()));
+        minCorner.setY(std::min(minCorner.y(), point.y()));
+        minCorner.setZ(std::min(minCorner.z(), point.z()));
+
+        maxCorner.setX(std::max(maxCorner.x(), point.x()));
+        maxCorner.setY(std::max(maxCorner.y(), point.y()));
+        maxCorner.setZ(std::max(maxCorner.z(), point.z()));
+    }
+
+    return { minCorner, maxCorner };
+}
+
+TextureMapperLayer3DRenderingContext::SweepAndPrunePairs TextureMapperLayer3DRenderingContext::sweepAndPrune(const Vector<Layer>& layers)
+{
+    std::vector<size_t> indices(layers.size());
+    std::iota(indices.begin(), indices.end(), 0);
+
+    // Sort left to right along axis
+    std::sort(indices.begin(), indices.end(), [&layers](size_t a, size_t b) {
+        return layers[a].boundingBox.min.x() < layers[b].boundingBox.min.x();
+    });
+
+    SweepAndPrunePairs potentialIntersectionPairs;
+    for (size_t i = 0; i < indices.size(); ++i) {
+        for (size_t j = i + 1; j < indices.size(); ++j) {
+            auto firstIndex = indices[i];
+            auto secondIndex = indices[j];
+
+            // Check overlap on sorted X-axis
+            if (layers[secondIndex].boundingBox.min.x() >= layers[firstIndex].boundingBox.max.x())
+                break; // No further overlap possible
+
+            // Check overlap on Y-axis
+            if (layers[firstIndex].boundingBox.min.y() >= layers[secondIndex].boundingBox.max.y()
+                || layers[firstIndex].boundingBox.max.y() <= layers[secondIndex].boundingBox.min.y())
+                continue;
+
+            // Check overlap on Z-axis
+            if (layers[firstIndex].boundingBox.min.z() >= layers[secondIndex].boundingBox.max.z()
+                || layers[firstIndex].boundingBox.max.z() <= layers[secondIndex].boundingBox.min.z())
+                continue;
+
+            // Ensure canonical order (smaller index first)
+            if (firstIndex > secondIndex)
+                std::swap(firstIndex, secondIndex);
+
+            potentialIntersectionPairs.add({ firstIndex, secondIndex });
+        }
+    }
+    return potentialIntersectionPairs;
+}
+
+// Build BSP tree for rendering layers with painter's algorithm.
 // For more information:
 // https://en.wikipedia.org/wiki/Binary_space_partitioning
-void TextureMapperLayer3DRenderingContext::buildTree(TextureMapperLayerNode& root, Deque<TextureMapperLayerPolygon>& polygons)
+void TextureMapperLayer3DRenderingContext::buildTree(LayerNode& root, Deque<Layer>& layers)
 {
-    if (polygons.isEmpty())
+    if (layers.isEmpty())
         return;
 
-    auto& rootGeometry = root.firstPolygon().geometry;
+    auto& rootGeometry = root.firstLayer().geometry;
     FloatPlane3D rootPlane(rootGeometry.normal(), rootGeometry.vertexAt(0));
 
-    Deque<TextureMapperLayerPolygon> backList, frontList;
-    for (auto& polygon : polygons) {
-        switch (classifyPolygon(polygon, rootPlane)) {
-        case PolygonPosition::InFront:
-            frontList.append(WTFMove(polygon));
+    Deque<Layer> backList, frontList;
+    for (auto& layer : layers) {
+        switch (classifyLayer(layer, rootPlane)) {
+        case LayerPosition::InFront:
+            frontList.append(WTFMove(layer));
             break;
-        case PolygonPosition::Behind:
-            backList.append(WTFMove(polygon));
+        case LayerPosition::Behind:
+            backList.append(WTFMove(layer));
             break;
-        case PolygonPosition::Coplanar:
-            root.polygons.append(WTFMove(polygon));
+        case LayerPosition::Coplanar:
+            root.layers.append(WTFMove(layer));
             break;
-        case PolygonPosition::Intersecting:
-            auto [backGeometry, frontGeometry] = polygon.geometry.split(rootPlane);
+        case LayerPosition::Intersecting:
+            auto [backGeometry, frontGeometry] = layer.geometry.split(rootPlane);
             if (backGeometry.numberOfVertices() > 2)
-                backList.append({ backGeometry, polygon.layer, true });
+                backList.append({ backGeometry, { }, layer.textureMapperLayer, true });
             if (frontGeometry.numberOfVertices() > 2)
-                frontList.append({ frontGeometry, polygon.layer, true });
+                frontList.append({ frontGeometry, { }, layer.textureMapperLayer, true });
             break;
         }
     }
 
     if (!frontList.isEmpty()) {
-        root.frontNode = makeUnique<TextureMapperLayerNode>(frontList.takeFirst());
+        root.frontNode = makeUnique<LayerNode>(frontList.takeFirst());
         buildTree(*root.frontNode, frontList);
     }
 
     if (!backList.isEmpty()) {
-        root.backNode = makeUnique<TextureMapperLayerNode>(backList.takeFirst());
+        root.backNode = makeUnique<LayerNode>(backList.takeFirst());
         buildTree(*root.backNode, backList);
     }
 }
 
-void TextureMapperLayer3DRenderingContext::traverseTree(TextureMapperLayerNode& node, const std::function<void(TextureMapperLayerNode&)>& processNode)
+void TextureMapperLayer3DRenderingContext::traverseTree(LayerNode& node, const std::function<void(LayerNode&)>& processNode)
 {
-    auto& geometry = node.firstPolygon().geometry;
+    auto& geometry = node.firstLayer().geometry;
     FloatPlane3D plane(geometry.normal(), geometry.vertexAt(0));
 
     auto* frontNode = node.frontNode.get();
@@ -160,14 +329,14 @@ void TextureMapperLayer3DRenderingContext::traverseTree(TextureMapperLayerNode& 
         traverseTree(*frontNode, processNode);
 }
 
-TextureMapperLayer3DRenderingContext::PolygonPosition TextureMapperLayer3DRenderingContext::classifyPolygon(const TextureMapperLayerPolygon& polygon, const FloatPlane3D& plane)
+TextureMapperLayer3DRenderingContext::LayerPosition TextureMapperLayer3DRenderingContext::classifyLayer(const Layer& layer, const FloatPlane3D& plane)
 {
     const float epsilon = 0.05f; // Tolerance for intersection check
 
     int inFrontCount = 0;
     int behindCount = 0;
-    for (unsigned i = 0; i < polygon.geometry.numberOfVertices(); i++) {
-        const auto& vertex = polygon.geometry.vertexAt(i);
+    for (unsigned i = 0; i < layer.geometry.numberOfVertices(); ++i) {
+        const auto& vertex = layer.geometry.vertexAt(i);
         float distance = plane.distanceToPoint(vertex);
 
         if (distance > epsilon)
@@ -177,12 +346,12 @@ TextureMapperLayer3DRenderingContext::PolygonPosition TextureMapperLayer3DRender
     }
 
     if (inFrontCount > 0 && behindCount > 0)
-        return PolygonPosition::Intersecting;
+        return LayerPosition::Intersecting;
     if (inFrontCount > 0)
-        return PolygonPosition::InFront;
+        return LayerPosition::InFront;
     if (behindCount > 0)
-        return PolygonPosition::Behind;
-    return PolygonPosition::Coplanar;
+        return LayerPosition::Behind;
+    return LayerPosition::Coplanar;
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### ca6c3486ddd32d840ebdaee645aa025d93090955
<pre>
[TextureMapper] Preserve 3d may split layers unnecessarily when they don&apos;t intersect
<a href="https://bugs.webkit.org/show_bug.cgi?id=284250">https://bugs.webkit.org/show_bug.cgi?id=284250</a>

Reviewed by Fujii Hironori.

Add preprocessing to conditionally skip BSP tree building for 3D rendering

Introduce a preprocessing step to determine if BSP tree construction can be
bypassed. If the 3D scene lacks intersecting layers or has an unambiguous
rendering order, building the BSP tree is unnecessary. Skipping BSP tree
layer splits enhances performance, especially on devices with slow stencil
performance like RPi3.

This patch implements:
- **Broad Phase:** Sweep-and-prune algorithm to identify potential intersecting layers.
- **Narrow Phase:** Projects potential collision pairs onto the ZY plane for intersection checks.

The ZY projection effectively detects both intersections and ambiguous rendering
orders, ensuring that BSP tree building is only performed when necessary.

* Source/WebCore/platform/graphics/texmap/ClipPath.h:
* Source/WebCore/platform/graphics/texmap/FloatPolygon3D.cpp:
* Source/WebCore/platform/graphics/texmap/FloatPolygon3D.h:
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
(WebCore::TextureMapperLayer::computeFlattenedRegion const):
(WebCore::TextureMapperLayer::flattensAsLeafOf3DSceneOr3DPerspective const):
(WebCore::TextureMapperLayer::collect3DRenderingContextLayers):
(WebCore::TextureMapperLayer::effectiveLayerRect const):
(WebCore::TextureMapperLayer::computeFlattenedRegion): Deleted.
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h:
(WebCore::TextureMapperLayer::isLeafOf3DRenderingContext const):
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer3DRenderingContext.cpp:
(WebCore::projectPolygonToZYPlane):
(WebCore::edgeNormal):
(WebCore::projectQuadOnAxis):
(WebCore::quadsIntersect):
(WebCore::TextureMapperLayer3DRenderingContext::paint):
(WebCore::TextureMapperLayer3DRenderingContext::computeBoundingBox):
(WebCore::TextureMapperLayer3DRenderingContext::sweepAndPrune):
(WebCore::TextureMapperLayer3DRenderingContext::buildTree):
(WebCore::TextureMapperLayer3DRenderingContext::traverseTree):
(WebCore::TextureMapperLayer3DRenderingContext::classifyLayer):
(WebCore::TextureMapperLayer3DRenderingContext::classifyPolygon): Deleted.
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer3DRenderingContext.h:

Canonical link: <a href="https://commits.webkit.org/288080@main">https://commits.webkit.org/288080@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d354a60932c1e8fe1357e366c3bf6c772e822733

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81826 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1352 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35780 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86374 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32822 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83932 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1385 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9173 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63811 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21543 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84896 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1014 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74461 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44097 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/913 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28636 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31275 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29243 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87809 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9066 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6439 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72162 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9251 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70282 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71394 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15492 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14413 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12674 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9017 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14549 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8858 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12381 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10666 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->