### PR TITLE
Non-unified source build fix of December 2024 (part 6)

### DIFF
--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -28,6 +28,7 @@
 
 #include "AnimationTimelinesController.h"
 #include "CSSNumericFactory.h"
+#include "CSSPropertyParserConsumer+Timeline.h"
 #include "Document.h"
 #include "Element.h"
 #include "LegacyRenderSVGModelObject.h"

--- a/Source/WebCore/css/calc/CSSCalcTree+ContainerProgressEvaluator.h
+++ b/Source/WebCore/css/calc/CSSCalcTree+ContainerProgressEvaluator.h
@@ -29,6 +29,7 @@
 namespace WebCore {
 
 class CSSToLengthConversionData;
+class Element;
 
 namespace CSSCalc {
 

--- a/Source/WebCore/css/calc/CSSCalcTree+MediaProgressEvaluator.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+MediaProgressEvaluator.cpp
@@ -26,7 +26,9 @@
 #include "CSSCalcTree+MediaProgressEvaluator.h"
 
 #include "CSSCalcTree.h"
+#include "Document.h"
 #include "MediaQueryFeatures.h"
+#include "RenderElement.h"
 
 namespace WebCore {
 namespace CSSCalc {

--- a/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
@@ -37,6 +37,8 @@
 #include "CSSPrimitiveValue.h"
 #include "CalculationCategory.h"
 #include "CalculationExecutor.h"
+#include "ContainerQueryFeatures.h"
+#include "MediaQueryFeatures.h"
 #include "RenderStyle.h"
 #include "RenderStyleInlines.h"
 #include "StyleBuilderState.h"

--- a/Source/WebKit/WebProcess/Network/WebTransportReceiveStreamSource.cpp
+++ b/Source/WebKit/WebProcess/Network/WebTransportReceiveStreamSource.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WebTransportReceiveStreamSource.h"
 
+#include "WebTransportSession.h"
 #include <wtf/RunLoop.h>
 #include <wtf/StdLibExtras.h>
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp
@@ -226,7 +226,7 @@ void WebFileSystemStorageConnection::createWritable(WebCore::FileSystemHandleIde
     completionHandler(WebCore::Exception { WebCore::ExceptionCode::UnknownError, "Connection is lost"_s });
 }
 
-void WebFileSystemStorageConnection::closeWritable(WebCore::FileSystemHandleIdentifier identifier, FileSystemWriteCloseReason reason, WebCore::FileSystemStorageConnection::VoidCallback&& completionHandler)
+void WebFileSystemStorageConnection::closeWritable(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemWriteCloseReason reason, WebCore::FileSystemStorageConnection::VoidCallback&& completionHandler)
 {
     if (RefPtr connection = m_connection) {
         connection->sendWithAsyncReply(Messages::NetworkStorageManager::CloseWritable(identifier, reason), [completionHandler = WTFMove(completionHandler)](auto error) mutable {


### PR DESCRIPTION
#### 58f50a114c8f66d54b1300eab0425e4f91a782d0
<pre>
Non-unified source build fix of December 2024 (part 6)
<a href="https://bugs.webkit.org/show_bug.cgi?id=283880">https://bugs.webkit.org/show_bug.cgi?id=283880</a>

Unreviewed non-unified build fix.

* Source/WebCore/animation/ViewTimeline.cpp:
* Source/WebCore/css/calc/CSSCalcTree+ContainerProgressEvaluator.h:
* Source/WebCore/css/calc/CSSCalcTree+MediaProgressEvaluator.cpp:
* Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp:
* Source/WebKit/WebProcess/Network/WebTransportReceiveStreamSource.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp:
(WebKit::WebFileSystemStorageConnection::closeWritable):

Canonical link: <a href="https://commits.webkit.org/287917@main">https://commits.webkit.org/287917@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66e26f93f57333996dda3f65f94dc4648eaadf73

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81358 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35301 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/85887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/32344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83468 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/901 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/8701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/85887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/32344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84427 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/74044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/85887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/28208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/30802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/71997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/28791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/87322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/8588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/8701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/87322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/8769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/69869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/87322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/14019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12608 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/8550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/14073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/8386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/11907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/10194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->