### PR TITLE
Add IPInt support for streaming compilation

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmEntryPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmEntryPlan.h
@@ -95,9 +95,14 @@ public:
 
     bool completeSyncIfPossible();
 
+    virtual void completeInStreaming() = 0;
+    virtual void didCompileFunctionInStreaming() = 0;
+    virtual void didFailInStreaming(String&&) = 0;
+
 private:
     class ThreadCountHolder;
     friend class ThreadCountHolder;
+    friend class StreamingPlan;
 
 protected:
     // For some reason friendship doesn't extend to parent classes...

--- a/Source/JavaScriptCore/wasm/WasmStreamingCompiler.h
+++ b/Source/JavaScriptCore/wasm/WasmStreamingCompiler.h
@@ -42,7 +42,7 @@ class VM;
 
 namespace Wasm {
 
-class LLIntPlan;
+class EntryPlan;
 class StreamingPlan;
 
 class StreamingCompiler final : public StreamingParserClient, public ThreadSafeRefCounted<StreamingCompiler> {
@@ -76,7 +76,7 @@ private:
     DeferredWorkTimer::Ticket m_ticket;
     Ref<Wasm::ModuleInformation> m_info;
     StreamingParser m_parser;
-    RefPtr<LLIntPlan> m_plan;
+    RefPtr<EntryPlan> m_plan;
 };
 
 

--- a/Source/JavaScriptCore/wasm/WasmStreamingPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmStreamingPlan.cpp
@@ -29,7 +29,7 @@
 #if ENABLE(WEBASSEMBLY)
 
 #include "WasmCallee.h"
-#include "WasmLLIntPlan.h"
+#include "WasmEntryPlan.h"
 #include "WasmNameSection.h"
 #include "WasmTypeDefinitionInlines.h"
 #include <wtf/DataLog.h>
@@ -42,7 +42,7 @@ namespace WasmStreamingPlanInternal {
 static constexpr bool verbose = false;
 }
 
-StreamingPlan::StreamingPlan(VM& vm, Ref<ModuleInformation>&& info, Ref<LLIntPlan>&& plan, FunctionCodeIndex functionIndex, CompletionTask&& task)
+StreamingPlan::StreamingPlan(VM& vm, Ref<ModuleInformation>&& info, Ref<EntryPlan>&& plan, FunctionCodeIndex functionIndex, CompletionTask&& task)
     : Base(vm, WTFMove(info), WTFMove(task))
     , m_plan(WTFMove(plan))
     , m_functionIndex(functionIndex)

--- a/Source/JavaScriptCore/wasm/WasmStreamingPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmStreamingPlan.h
@@ -47,7 +47,7 @@ public:
     FunctionCodeIndex functionIndex() const { return m_functionIndex; }
 
     // Note: CompletionTask should not hold a reference to the Plan otherwise there will be a reference cycle.
-    StreamingPlan(VM&, Ref<ModuleInformation>&&, Ref<LLIntPlan>&&, FunctionCodeIndex functionIndex, CompletionTask&&);
+    StreamingPlan(VM&, Ref<ModuleInformation>&&, Ref<EntryPlan>&&, FunctionCodeIndex functionIndex, CompletionTask&&);
 
 private:
     // For some reason friendship doesn't extend to parent classes...
@@ -60,7 +60,7 @@ private:
         runCompletionTasks();
     }
 
-    Ref<LLIntPlan> m_plan;
+    Ref<EntryPlan> m_plan;
     FunctionCodeIndex m_functionIndex;
     bool m_completed { false };
 };


### PR DESCRIPTION
#### 3bd6409e3f117e7031d3d38d78f4d413a5d3291a
<pre>
Add IPInt support for streaming compilation
<a href="https://bugs.webkit.org/show_bug.cgi?id=284790">https://bugs.webkit.org/show_bug.cgi?id=284790</a>
<a href="https://rdar.apple.com/141581881">rdar://141581881</a>

Reviewed by Keith Miller.

To reach feature parity with LLInt, we need to support IPInt in the streaming
Wasm compilers.

* Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp:
(JSC::Wasm::StreamingCompiler::didReceiveFunctionData):
(JSC::Wasm::StreamingCompiler::didCompileFunction):
(JSC::Wasm::StreamingCompiler::didFinishParsing):
(JSC::Wasm::StreamingCompiler::completeIfNecessary):
(JSC::Wasm::StreamingCompiler::didComplete):
* Source/JavaScriptCore/wasm/WasmStreamingCompiler.h:
* Source/JavaScriptCore/wasm/WasmStreamingPlan.cpp:
(JSC::Wasm::StreamingPlan::StreamingPlan):
(JSC::Wasm::StreamingPlan::work):
* Source/JavaScriptCore/wasm/WasmStreamingPlan.h:

Canonical link: <a href="https://commits.webkit.org/287980@main">https://commits.webkit.org/287980@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa93ccb35467cbe662a568d24ace9907c8a8be1a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81505 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1031 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35453 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86037 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32499 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1050 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8849 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63616 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21352 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84574 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/742 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74188 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43907 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/641 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28356 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30952 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/74487 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28950 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87473 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/80563 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8738 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6204 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71938 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8919 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70005 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71171 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17722 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15237 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14154 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/102973 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8698 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14226 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25019 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/struct-new_default-small-members.js.wasm-no-cjit (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8536 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12058 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10343 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->