### PR TITLE
[WGSL] Emit ids for texture_externals

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-282710.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-282710.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ enableMetalShaderValidation=true ] -->
 <script>
 async function run() {
     let adapter = await navigator.gpu.requestAdapter();

--- a/Source/WebCore/Modules/WebGPU/GPUBindGroup.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUBindGroup.cpp
@@ -40,7 +40,7 @@ void GPUBindGroup::setLabel(String&& label)
     m_backing->setLabel(WTFMove(label));
 }
 
-bool GPUBindGroup::updateExternalTextures(const GPUExternalTexture& externalTexture)
+bool GPUBindGroup::updateExternalTextures(GPUExternalTexture& externalTexture)
 {
     return m_backing->updateExternalTextures(externalTexture.backing());
 }

--- a/Source/WebCore/Modules/WebGPU/GPUBindGroup.h
+++ b/Source/WebCore/Modules/WebGPU/GPUBindGroup.h
@@ -46,7 +46,7 @@ public:
 
     WebGPU::BindGroup& backing() { return m_backing; }
     const WebGPU::BindGroup& backing() const { return m_backing; }
-    bool updateExternalTextures(const GPUExternalTexture&);
+    bool updateExternalTextures(GPUExternalTexture&);
 
 private:
     GPUBindGroup(Ref<WebGPU::BindGroup>&& backing)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUBindGroupImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUBindGroupImpl.cpp
@@ -50,7 +50,7 @@ void BindGroupImpl::setLabelInternal(const String& label)
     wgpuBindGroupSetLabel(m_backing.get(), label.utf8().data());
 }
 
-bool BindGroupImpl::updateExternalTextures(const ExternalTexture& externalTexture)
+bool BindGroupImpl::updateExternalTextures(ExternalTexture& externalTexture)
 {
     return wgpuBindGroupUpdateExternalTextures(m_backing.get(), static_cast<const ExternalTextureImpl&>(externalTexture).backing());
 }

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUBindGroupImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUBindGroupImpl.h
@@ -60,7 +60,7 @@ private:
     WGPUBindGroup backing() const { return m_backing.get(); }
 
     void setLabelInternal(const String&) final;
-    bool updateExternalTextures(const ExternalTexture&) final;
+    bool updateExternalTextures(ExternalTexture&) final;
 
     WebGPUPtr<WGPUBindGroup> m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBindGroup.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBindGroup.h
@@ -39,7 +39,7 @@ public:
     virtual ~BindGroup() = default;
 
     String label() const { return m_label; }
-    virtual bool updateExternalTextures(const ExternalTexture&) = 0;
+    virtual bool updateExternalTextures(ExternalTexture&) = 0;
 
     void setLabel(String&& label)
     {

--- a/Source/WebGPU/WebGPU/BindGroup.h
+++ b/Source/WebGPU/WebGPU/BindGroup.h
@@ -101,7 +101,7 @@ public:
     const BufferAndType* dynamicBuffer(uint32_t) const;
     uint32_t dynamicOffset(uint32_t bindingIndex, const Vector<uint32_t>*) const;
     void rebindSamplersIfNeeded() const;
-    bool updateExternalTextures(const ExternalTexture&);
+    bool updateExternalTextures(ExternalTexture&);
     bool makeSubmitInvalid(ShaderStage, const BindGroupLayout*) const;
 
 private:

--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -1179,6 +1179,7 @@ Ref<BindGroup> Device::createBindGroup(const WGPUBindGroupDescriptor& descriptor
 
                 if (stage != ShaderStage::Undefined) {
                     argumentIndices[stage].remove(index);
+                    externalTexture->updateExternalTextures(texture0, texture1);
                     [argumentEncoder[stage] setTexture:texture0 atIndex:index++];
 
                     argumentIndices[stage].remove(index);
@@ -1371,7 +1372,7 @@ void BindGroup::rebindSamplersIfNeeded() const
     }
 }
 
-bool BindGroup::updateExternalTextures(const ExternalTexture& externalTexture)
+bool BindGroup::updateExternalTextures(ExternalTexture& externalTexture)
 {
     if (!m_bindGroupLayout || externalTexture.openCommandEncoderCount())
         return false;
@@ -1380,6 +1381,7 @@ bool BindGroup::updateExternalTextures(const ExternalTexture& externalTexture)
     auto textureData = device->createExternalTextureFromPixelBuffer(externalTexture.pixelBuffer(), externalTexture.colorSpace());
     id<MTLTexture> texture0 = textureData.texture0 ?: device->placeholderTexture(WGPUTextureFormat_BGRA8Unorm);
     id<MTLTexture> texture1 = textureData.texture1 ?: device->placeholderTexture(WGPUTextureFormat_BGRA8Unorm);
+    externalTexture.updateExternalTextures(texture0, texture1);
     if (!texture0 || !texture1)
         return false;
 

--- a/Source/WebGPU/WebGPU/BindGroupLayout.mm
+++ b/Source/WebGPU/WebGPU/BindGroupLayout.mm
@@ -352,7 +352,7 @@ Ref<BindGroupLayout> Device::createBindGroupLayout(const WGPUBindGroupLayoutDesc
                     }
 
                     if (isExternalTexture)
-                        bindingOffset[stage] += maxGeneratedDescriptors;
+                        bindingOffset[stage] += (maxGeneratedDescriptors - 1);
                 }
             }
         }

--- a/Source/WebGPU/WebGPU/CommandBuffer.h
+++ b/Source/WebGPU/WebGPU/CommandBuffer.h
@@ -41,7 +41,7 @@ class CommandEncoder;
 class Device;
 
 // https://gpuweb.github.io/gpuweb/#gpucommandbuffer
-class CommandBuffer : public RefCountedAndCanMakeWeakPtr<CommandBuffer>, public WGPUCommandBufferImpl {
+class CommandBuffer : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<CommandBuffer>, public WGPUCommandBufferImpl {
     WTF_MAKE_TZONE_ALLOCATED(CommandBuffer);
 public:
     static Ref<CommandBuffer> create(id<MTLCommandBuffer> commandBuffer, Device& device, id<MTLSharedEvent> sharedEvent, uint64_t sharedEventSignalValue, CommandEncoder& commandEncoder)

--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -114,6 +114,7 @@ public:
     bool encoderIsCurrent(id<MTLCommandEncoder>) const;
     bool submitWillBeInvalid() const { return m_makeSubmitInvalid; }
     void addBuffer(id<MTLBuffer>);
+    void addTexture(id<MTLTexture>);
     void addTexture(const Texture&);
     id<MTLCommandBuffer> commandBuffer() const;
     void setExistingEncoder(id<MTLCommandEncoder>);
@@ -143,15 +144,13 @@ private PUBLIC_IN_WEBGPU_SWIFT:
 private:
     void discardCommandBuffer();
 
-    RefPtr<CommandBuffer> protectedCachedCommandBuffer() const { return m_cachedCommandBuffer.get(); }
-
     id<MTLCommandBuffer> m_commandBuffer { nil };
     id<MTLSharedEvent> m_abortCommandBuffer { nil };
     id<MTLBlitCommandEncoder> m_blitCommandEncoder { nil };
     id<MTLCommandEncoder> m_existingCommandEncoder { nil };
 
     uint64_t m_debugGroupStackSize { 0 };
-    WeakPtr<CommandBuffer> m_cachedCommandBuffer;
+    ThreadSafeWeakPtr<CommandBuffer> m_cachedCommandBuffer;
     NSString* m_lastErrorString { nil };
     int m_bufferMapCount { 0 };
     bool m_makeSubmitInvalid { false };
@@ -160,6 +159,8 @@ private:
     NSMutableSet<id<MTLTexture>> *m_managedTextures { nil };
     NSMutableSet<id<MTLBuffer>> *m_managedBuffers { nil };
 #endif
+    NSMutableSet<id<MTLTexture>> *m_retainedTextures { nil };
+    NSMutableSet<id<MTLBuffer>> *m_retainedBuffers { nil };
     id<MTLSharedEvent> m_sharedEvent { nil };
     uint64_t m_sharedEventSignalValue { 0 };
 private PUBLIC_IN_WEBGPU_SWIFT:

--- a/Source/WebGPU/WebGPU/ExternalTexture.h
+++ b/Source/WebGPU/WebGPU/ExternalTexture.h
@@ -66,6 +66,7 @@ public:
     bool isValid() const;
     void update(CVPixelBufferRef);
     size_t openCommandEncoderCount() const;
+    void updateExternalTextures(id<MTLTexture>, id<MTLTexture>);
 
 private:
     ExternalTexture(CVPixelBufferRef, WGPUColorSpace, Device&);
@@ -77,6 +78,8 @@ private:
     WGPUColorSpace m_colorSpace;
     const Ref<Device> m_device;
     bool m_destroyed { false };
+    id<MTLTexture> m_texture0 { nil };
+    id<MTLTexture> m_texture1 { nil };
     mutable WeakHashSet<CommandEncoder> m_commandEncoders;
 };
 

--- a/Source/WebGPU/WebGPU/ExternalTexture.mm
+++ b/Source/WebGPU/WebGPU/ExternalTexture.mm
@@ -85,8 +85,16 @@ void ExternalTexture::undestroy()
 void ExternalTexture::setCommandEncoder(CommandEncoder& commandEncoder) const
 {
     CommandEncoder::trackEncoder(commandEncoder, m_commandEncoders);
+    commandEncoder.addTexture(m_texture0);
+    commandEncoder.addTexture(m_texture1);
     if (isDestroyed())
         commandEncoder.makeSubmitInvalid();
+}
+
+void ExternalTexture::updateExternalTextures(id<MTLTexture> texture0, id<MTLTexture> texture1)
+{
+    m_texture0 = texture0;
+    m_texture1 = texture1;
 }
 
 bool ExternalTexture::isDestroyed() const

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.cpp
@@ -55,7 +55,7 @@ void RemoteBindGroupProxy::setLabelInternal(const String& label)
     UNUSED_VARIABLE(sendResult);
 }
 
-bool RemoteBindGroupProxy::updateExternalTextures(const WebCore::WebGPU::ExternalTexture& externalTexture)
+bool RemoteBindGroupProxy::updateExternalTextures(WebCore::WebGPU::ExternalTexture& externalTexture)
 {
     auto convertedDescriptor = Ref { m_convertToBackingContext }->convertToBacking(externalTexture);
     auto sendResult = sendSync(Messages::RemoteBindGroup::UpdateExternalTextures(WTFMove(convertedDescriptor)));

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.h
@@ -77,7 +77,7 @@ private:
     }
 
     void setLabelInternal(const String&) final;
-    bool updateExternalTextures(const WebCore::WebGPU::ExternalTexture&) final;
+    bool updateExternalTextures(WebCore::WebGPU::ExternalTexture&) final;
 
     WebGPUIdentifier m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;


### PR DESCRIPTION
#### 44618effe38365e788addd537e538a9f493f3363
<pre>
[WGSL] Emit ids for texture_externals
<a href="https://bugs.webkit.org/show_bug.cgi?id=284791">https://bugs.webkit.org/show_bug.cgi?id=284791</a>
<a href="https://rdar.apple.com/141529109">rdar://141529109</a>

Reviewed by Tadeu Zagallo.

We had omitted [[id(K)]] for texture_external types, which results
in OOB shader read at least according to the validation layer.

* LayoutTests/fast/webgpu/nocrash/fuzz-282710.html:
This test detected the error.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
Emit ids for texture_external.

* Source/WebGPU/WebGPU/BindGroupLayout.mm:
(WebGPU::Device::createBindGroupLayout):
The index was one greater than necessary, but otherwise was not
impacting functionality.

Canonical link: <a href="https://commits.webkit.org/288008@main">https://commits.webkit.org/288008@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de3ebaf10779ab8258d07eccb5e3a6272fc47280

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81619 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1143 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35567 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86152 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32609 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83725 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1171 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8960 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63675 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21403 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84689 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/825 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74268 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43964 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/725 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28448 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31064 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29043 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87595 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8856 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6273 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72007 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9038 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70096 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71242 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17748 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15316 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14230 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8808 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14336 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8648 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12169 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10455 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->