### PR TITLE
[ResourceMonitor] Send ContentRuleList of Checker from UIProcess to WebProcess.

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1546,6 +1546,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     loader/ResourceLoaderIdentifier.h
     loader/ResourceLoaderOptions.h
     loader/ResourceLoaderTypes.h
+    loader/ResourceMonitor.h
+    loader/ResourceMonitorChecker.h
     loader/ResourceTimingInformation.h
     loader/ShouldTreatAsContinuingLoad.h
     loader/SubframeLoader.h

--- a/Source/WebCore/loader/ResourceMonitorChecker.h
+++ b/Source/WebCore/loader/ResourceMonitorChecker.h
@@ -44,13 +44,13 @@ class ResourceMonitorChecker final {
 public:
     using Eligibility = ResourceMonitor::Eligibility;
 
-    static ResourceMonitorChecker& singleton();
+    WEBCORE_EXPORT static ResourceMonitorChecker& singleton();
 
     ~ResourceMonitorChecker();
 
     void checkEligibility(ContentExtensions::ResourceLoadInfo&&, CompletionHandler<void(Eligibility)>&&);
 
-    void setContentRuleList(ContentExtensions::ContentExtensionsBackend&&);
+    WEBCORE_EXPORT void setContentRuleList(ContentExtensions::ContentExtensionsBackend&&);
 
 private:
     ResourceMonitorChecker();

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -1333,4 +1333,11 @@ void WebProcessPool::setCachedHardwareKeyboardState(HardwareKeyboardState hardwa
 }
 #endif
 
+#if ENABLE(CONTENT_EXTENSIONS)
+void WebProcessPool::platformLoadResourceMonitorRuleList(CompletionHandler<void()>&& completionHandler)
+{
+    completionHandler();
+}
+#endif
+
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2048,6 +2048,11 @@ void WebPageProxy::loadRequestWithNavigationShared(Ref<WebProcessProxy>&& proces
     loadParameters.isRequestFromClientOrUserInput = navigation.isRequestFromClientOrUserInput();
     loadParameters.isPerformingHTTPFallback = isPerformingHTTPFallback == IsPerformingHTTPFallback::Yes;
 
+#if ENABLE(CONTENT_EXTENSIONS)
+    if (preferences().iFrameResourceMonitoringEnabled())
+        process->requestResourceMonitorRuleLists();
+#endif
+
     maybeInitializeSandboxExtensionHandle(process, url, internals().pageLoadState.resourceDirectoryURL(), true, [weakThis = WeakPtr { *this }, weakProcess = WeakPtr { process }, loadParameters = WTFMove(loadParameters), url, navigation = Ref { navigation }, webPageID, shouldTreatAsContinuingLoad] (std::optional<SandboxExtension::Handle> sandboxExtensionHandle) mutable {
         RefPtr protectedProcess = weakProcess.get();
         RefPtr protectedThis = weakThis.get();

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -121,6 +121,7 @@ class SuspendedPageProxy;
 class UIGamepad;
 class WebAutomationSession;
 class WebBackForwardCache;
+class WebCompiledContentRuleList;
 class WebContextSupplement;
 class WebPageGroup;
 class WebPageProxy;
@@ -612,6 +613,10 @@ public:
     void updateWebProcessSuspensionDelayWithPacing(WeakHashSet<WebProcessProxy>&&);
 #endif
 
+#if ENABLE(CONTENT_EXTENSIONS)
+    WebCompiledContentRuleList* cachedResourceMonitorRuleList();
+#endif
+
 private:
     enum class NeedsGlobalStaticInitialization : bool { No, Yes };
     void platformInitialize(NeedsGlobalStaticInitialization);
@@ -723,6 +728,12 @@ private:
 
 #if ENABLE(MODEL_PROCESS)
     ModelProcessProxy& ensureModelProcess();
+#endif
+
+#if ENABLE(CONTENT_EXTENSIONS)
+    void loadOrUpdateResourceMonitorRuleList();
+
+    void platformLoadResourceMonitorRuleList(CompletionHandler<void()>&&);
 #endif
 
     Ref<API::ProcessPoolConfiguration> m_configuration;
@@ -949,6 +960,13 @@ private:
 #if ENABLE(WEB_PROCESS_SUSPENSION_DELAY)
     ApproximateTime m_lastMemoryPressureStatusTime;
     RunLoop::Timer m_checkMemoryPressureStatusTimer;
+#endif
+
+#if ENABLE(CONTENT_EXTENSIONS)
+    RefPtr<WebCompiledContentRuleList> m_resourceMonitorRuleListCache;
+    bool m_resourceMonitorRuleListLoading { false };
+    bool m_resourceMonitorRuleListFailed { false };
+    RunLoop::Timer m_resourceMonitorRuleListRefreshTimer;
 #endif
 
 #if ENABLE(IPC_TESTING_API)

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -3096,6 +3096,26 @@ const WebCore::ProcessIdentity& WebProcessProxy::processIdentity()
 }
 #endif
 
+#if ENABLE(CONTENT_EXTENSIONS)
+void WebProcessProxy::requestResourceMonitorRuleLists()
+{
+    if (RefPtr processPool = m_processPool.get()) {
+        m_resourceMonitorRuleListRequestedBySomePage = true;
+
+        if (RefPtr ruleList = processPool->cachedResourceMonitorRuleList())
+            setResourceMonitorRuleListsIfRequired(ruleList.get());
+    }
+}
+
+void WebProcessProxy::setResourceMonitorRuleListsIfRequired(WebCompiledContentRuleList* ruleList)
+{
+    if (!m_resourceMonitorRuleListRequestedBySomePage || m_resourceMonitorRuleList == ruleList)
+        return;
+
+    m_resourceMonitorRuleList = ruleList;
+    send(Messages::WebProcess::SetResourceMonitorContentRuleList(ruleList->data()), 0);
+}
+#endif
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -117,6 +117,7 @@ class SuspendedPageProxy;
 class UserMediaCaptureManagerProxy;
 class VisitedLinkStore;
 class WebBackForwardListItem;
+class WebCompiledContentRuleList;
 class WebCompiledContentRuleListData;
 class WebFrameProxy;
 class WebLockRegistryProxy;
@@ -536,6 +537,11 @@ public:
     HashMap<WebCore::PageIdentifier, CoreIPCAuditToken> presentingApplicationAuditTokens() const;
 #endif
 
+#if ENABLE(CONTENT_EXTENSIONS)
+    void requestResourceMonitorRuleLists();
+    void setResourceMonitorRuleListsIfRequired(WebCompiledContentRuleList*);
+#endif
+
 private:
     Type type() const final { return Type::WebContent; }
 
@@ -831,6 +837,12 @@ private:
 #if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
     IPC::ScopedActiveMessageReceiveQueue<LogStream> m_logStream;
 #endif
+
+#if ENABLE(CONTENT_EXTENSIONS)
+    bool m_resourceMonitorRuleListRequestedBySomePage { false };
+    RefPtr<WebCompiledContentRuleList> m_resourceMonitorRuleList;
+#endif
+
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, const WebProcessProxy&);

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -143,6 +143,7 @@ class WebAutomationSessionProxy;
 class WebBadgeClient;
 class WebBroadcastChannelRegistry;
 class WebCacheStorageProvider;
+class WebCompiledContentRuleListData;
 class WebCookieJar;
 class WebFileSystemStorageConnection;
 class WebFrame;
@@ -399,6 +400,10 @@ public:
 #if ENABLE(NOTIFY_BLOCKING)
     void postNotification(const String& message, std::optional<uint64_t> state);
     void postObserverNotification(const String& message);
+#endif
+
+#if ENABLE(CONTENT_EXTENSIONS)
+    void setResourceMonitorContentRuleList(WebCompiledContentRuleListData&&);
 #endif
 
     bool areAllPagesThrottleable() const;

--- a/Source/WebKit/WebProcess/WebProcess.messages.in
+++ b/Source/WebKit/WebProcess/WebProcess.messages.in
@@ -229,4 +229,8 @@ messages -> WebProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
     PostNotification(String message, std::optional<uint64_t> state)
     PostObserverNotification(String message)
 #endif
+
+#if ENABLE(CONTENT_EXTENSIONS)
+    [DeferSendingIfSuspended] SetResourceMonitorContentRuleList(WebKit::WebCompiledContentRuleListData ruleListData)
+#endif
 }


### PR DESCRIPTION
#### a097c5ab60cdccd9f066cf7c44a69d88cb14b60c
<pre>
[ResourceMonitor] Send ContentRuleList of Checker from UIProcess to WebProcess.
<a href="https://bugs.webkit.org/show_bug.cgi?id=284694">https://bugs.webkit.org/show_bug.cgi?id=284694</a>
<a href="https://rdar.apple.com/141645827">rdar://141645827</a>

Reviewed by Ben Nham.

Every web content process has its own checker. They share same content rule list which is mapped file to be
shared among the processes. We need to send the list from UIProcess that initialize the rule list to web
content process where ResourceMonitorChecker is running in it.

In this patch, actual preparation of rule list is not included.

* Source/WebCore/Headers.cmake:
* Source/WebCore/loader/ResourceMonitorChecker.h:
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::platformLoadResourceMonitorRuleList):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::loadRequest):
(WebKit::WebPageProxy::loadRequestWithNavigationShared):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::cachedResourceMonitorRuleList):
(WebKit::WebProcessPool::loadOrUpdateResourceMonitorRuleList):
(WebKit::WebProcessPool::platformLoadResourceMonitorRuleList):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::requestResourceMonitorRuleLists):
(WebKit::WebProcessProxy::setResourceMonitorRuleListsIfRequired):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::setResourceMonitorContentRuleList):
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/WebProcess.messages.in:

Canonical link: <a href="https://commits.webkit.org/288017@main">https://commits.webkit.org/288017@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7090a23c3b6219b8273e7eff5c090fc6275c54bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81689 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1214 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35638 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86230 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32683 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83795 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1245 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9033 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/63736 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21461 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84759 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/901 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74341 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44021 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/800 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28515 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31141 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29117 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87673 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8926 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/72071 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9110 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70160 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/71301 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17753 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15381 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14297 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8878 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/14412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8718 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12245 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10527 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->