### PR TITLE
on Make DocumentSyncData RefCounted, and have Page objects reference the main document copy

### DIFF
--- a/Source/WebCore/Scripts/tests/DocumentSyncData.cpp
+++ b/Source/WebCore/Scripts/tests/DocumentSyncData.cpp
@@ -27,20 +27,21 @@
 #include "DocumentSyncData.h"
 
 #include "ProcessSyncData.h"
+#include <wtf/EnumTraits.h>
 
 namespace WebCore {
 
 void DocumentSyncData::update(const ProcessSyncData& data)
 {
     switch (data.type) {
+    case ProcessSyncDataType::UserDidInteractWithPage:
+        userDidInteractWithPage = std::get<enumToUnderlyingType(ProcessSyncDataType::UserDidInteractWithPage)>(data.value);
+        break;
 #if ENABLE(DOM_AUDIO_SESSION)
     case ProcessSyncDataType::AudioSessionType:
         audioSessionType = std::get<enumToUnderlyingType(ProcessSyncDataType::AudioSessionType)>(data.value);
         break;
 #endif
-    case ProcessSyncDataType::UserDidInteractWithPage:
-        userDidInteractWithPage = std::get<enumToUnderlyingType(ProcessSyncDataType::UserDidInteractWithPage)>(data.value);
-        break;
     case ProcessSyncDataType::IsAutofocusProcessed:
         isAutofocusProcessed = std::get<enumToUnderlyingType(ProcessSyncDataType::IsAutofocusProcessed)>(data.value);
         break;
@@ -49,4 +50,19 @@ void DocumentSyncData::update(const ProcessSyncData& data)
     }
 }
 
-} //namespace WebCore
+DocumentSyncData::DocumentSyncData(
+      bool userDidInteractWithPage
+#if ENABLE(DOM_AUDIO_SESSION)
+    , WebCore::DOMAudioSessionType audioSessionType
+#endif
+    , bool isAutofocusProcessed
+)
+    : userDidInteractWithPage(userDidInteractWithPage)
+#if ENABLE(DOM_AUDIO_SESSION)
+    , audioSessionType(audioSessionType)
+#endif
+    , isAutofocusProcessed(isAutofocusProcessed)
+{
+}
+
+} // namespace WebCore

--- a/Source/WebCore/Scripts/tests/DocumentSyncData.h
+++ b/Source/WebCore/Scripts/tests/DocumentSyncData.h
@@ -25,23 +25,39 @@
 #pragma once
 
 #include "DOMAudioSession.h"
+#include <wtf/RefCounted.h>
 #include <wtf/TZoneMallocInlines.h>
-#include <wtf/URL.h>
 
 namespace WebCore {
 
 struct ProcessSyncData;
 
-struct DocumentSyncData {
+class DocumentSyncData : public RefCounted<DocumentSyncData> {
 WTF_MAKE_TZONE_ALLOCATED_INLINE(DocumentSyncData);
 public:
+    template<typename... Args>
+    static Ref<DocumentSyncData> create(Args&&... args)
+    {
+        return adoptRef(*new DocumentSyncData(std::forward<Args>(args)...));
+    }
+    static Ref<DocumentSyncData> create() { return adoptRef(*new DocumentSyncData); }
     void update(const ProcessSyncData&);
 
+    bool userDidInteractWithPage = { };
 #if ENABLE(DOM_AUDIO_SESSION)
     WebCore::DOMAudioSessionType audioSessionType = { };
 #endif
-    bool userDidInteractWithPage = { };
     bool isAutofocusProcessed = { };
+
+private:
+    DocumentSyncData() = default;
+    WEBCORE_EXPORT DocumentSyncData(
+        bool
+#if ENABLE(DOM_AUDIO_SESSION)
+      , WebCore::DOMAudioSessionType
+#endif
+      , bool
+    );
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Scripts/tests/ProcessSyncClient.cpp
+++ b/Source/WebCore/Scripts/tests/ProcessSyncClient.cpp
@@ -27,6 +27,7 @@
 #include "ProcessSyncClient.h"
 
 #include "ProcessSyncData.h"
+#include <wtf/EnumTraits.h>
 
 namespace WebCore {
 
@@ -35,26 +36,26 @@ void ProcessSyncClient::broadcastAudioSessionTypeToOtherProcesses(const WebCore:
 {
     ProcessSyncDataVariant dataVariant;
     dataVariant.emplace<enumToUnderlyingType(ProcessSyncDataType::AudioSessionType)>(data);
-    broadcastProcessSyncDataToOtherProcesses({ ProcessSyncDataType::AudioSessionType, WTFMove(dataVariant)});
+    broadcastProcessSyncDataToOtherProcesses({ ProcessSyncDataType::AudioSessionType, WTFMove(dataVariant) });
 }
 #endif
 void ProcessSyncClient::broadcastMainFrameURLChangeToOtherProcesses(const URL& data)
 {
     ProcessSyncDataVariant dataVariant;
     dataVariant.emplace<enumToUnderlyingType(ProcessSyncDataType::MainFrameURLChange)>(data);
-    broadcastProcessSyncDataToOtherProcesses({ ProcessSyncDataType::MainFrameURLChange, WTFMove(dataVariant)});
+    broadcastProcessSyncDataToOtherProcesses({ ProcessSyncDataType::MainFrameURLChange, WTFMove(dataVariant) });
 }
 void ProcessSyncClient::broadcastUserDidInteractWithPageToOtherProcesses(const bool& data)
 {
     ProcessSyncDataVariant dataVariant;
     dataVariant.emplace<enumToUnderlyingType(ProcessSyncDataType::UserDidInteractWithPage)>(data);
-    broadcastProcessSyncDataToOtherProcesses({ ProcessSyncDataType::UserDidInteractWithPage, WTFMove(dataVariant)});
+    broadcastProcessSyncDataToOtherProcesses({ ProcessSyncDataType::UserDidInteractWithPage, WTFMove(dataVariant) });
 }
 void ProcessSyncClient::broadcastIsAutofocusProcessedToOtherProcesses(const bool& data)
 {
     ProcessSyncDataVariant dataVariant;
     dataVariant.emplace<enumToUnderlyingType(ProcessSyncDataType::IsAutofocusProcessed)>(data);
-    broadcastProcessSyncDataToOtherProcesses({ ProcessSyncDataType::IsAutofocusProcessed, WTFMove(dataVariant)});
+    broadcastProcessSyncDataToOtherProcesses({ ProcessSyncDataType::IsAutofocusProcessed, WTFMove(dataVariant) });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Scripts/tests/ProcessSyncClient.h
+++ b/Source/WebCore/Scripts/tests/ProcessSyncClient.h
@@ -30,6 +30,7 @@
 
 namespace WebCore {
 
+class DocumentSyncData;
 struct ProcessSyncData;
 
 class ProcessSyncClient {
@@ -38,6 +39,8 @@ class ProcessSyncClient {
 public:
     ProcessSyncClient() = default;
     virtual ~ProcessSyncClient() = default;
+
+    virtual void broadcastTopDocumentSyncDataToOtherProcesses(DocumentSyncData&) { }
 
 #if ENABLE(DOM_AUDIO_SESSION)
     void broadcastAudioSessionTypeToOtherProcesses(const WebCore::DOMAudioSessionType&);

--- a/Source/WebCore/Scripts/tests/ProcessSyncData.h
+++ b/Source/WebCore/Scripts/tests/ProcessSyncData.h
@@ -38,7 +38,7 @@ enum class ProcessSyncDataType : uint8_t {
     UserDidInteractWithPage = 2,
     IsAutofocusProcessed = 3,
 };
- 
+
 #if !ENABLE(DOM_AUDIO_SESSION)
 using DOMAudioSessionType = bool;
 #endif

--- a/Source/WebCore/Scripts/tests/ProcessSyncData.serialization.in
+++ b/Source/WebCore/Scripts/tests/ProcessSyncData.serialization.in
@@ -25,6 +25,14 @@
 
 header: <WebCore/ProcessSyncData.h>
 
+[RefCounted] class WebCore::DocumentSyncData {
+    bool userDidInteractWithPage;
+#if ENABLE(DOM_AUDIO_SESSION)
+    WebCore::DOMAudioSessionType audioSessionType;
+#endif
+    bool isAutofocusProcessed;
+};
+
 enum class WebCore::ProcessSyncDataType : uint8_t {
 #if ENABLE(DOM_AUDIO_SESSION)
     AudioSessionType,

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -649,6 +649,7 @@ Document::Document(LocalFrame* frame, const Settings& settings, const URL& url, 
     , m_isSynthesized(constructionFlags.contains(ConstructionFlag::Synthesized))
     , m_isNonRenderedPlaceholder(constructionFlags.contains(ConstructionFlag::NonRenderedPlaceholder))
     , m_frameIdentifier(frame ? std::optional(frame->frameID()) : std::nullopt)
+    , m_syncData(DocumentSyncData::create())
 {
     setEventTargetFlag(EventTargetFlag::IsConnected);
     addToDocumentsMap();

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -31,6 +31,7 @@
 #include "ContainerNode.h"
 #include "ContextDestructionObserverInlines.h"
 #include "DocumentEventTiming.h"
+#include "DocumentSyncData.h"
 #include "FontSelectorClient.h"
 #include "FragmentDirective.h"
 #include "FrameDestructionObserver.h"
@@ -1996,10 +1997,11 @@ protected:
 
 private:
     friend class DocumentParserYieldToken;
+    friend class IgnoreDestructiveWriteCountIncrementer;
     friend class Node;
+    friend class Page;
     friend class ThrowOnDynamicMarkupInsertionCountIncrementer;
     friend class UnloadCountIncrementer;
-    friend class IgnoreDestructiveWriteCountIncrementer;
 
     void updateTitleElement(Element& changingTitleElement);
     RefPtr<Element> protectedTitleElement() const;
@@ -2146,6 +2148,8 @@ private:
 #endif
     bool isTopDocumentLegacy() const { return &topDocument() == this; }
     void securityOriginDidChange() final;
+
+    Ref<DocumentSyncData> syncData() { return m_syncData.get(); }
 
     const Ref<const Settings> m_settings;
 
@@ -2689,7 +2693,9 @@ private:
 #if ENABLE(CONTENT_EXTENSIONS)
     RefPtr<ResourceMonitor> m_resourceMonitor;
 #endif
-};
+
+    Ref<DocumentSyncData> m_syncData;
+}; // class Document
 
 Element* eventTargetElementForDocument(Document*);
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -119,6 +119,7 @@ class DOMRectList;
 class DatabaseProvider;
 class DeviceOrientationUpdateProvider;
 class DiagnosticLoggingClient;
+class DocumentSyncData;
 class CredentialRequestCoordinator;
 class DragCaretController;
 class DragController;
@@ -215,7 +216,6 @@ struct CharacterRange;
 struct ProcessSyncData;
 struct SimpleRange;
 struct TextRecognitionResult;
-struct DocumentSyncData;
 struct WindowFeatures;
 
 using PlatformDisplayID = uint32_t;
@@ -392,6 +392,8 @@ public:
     bool autofocusProcessed() const;
 
     WEBCORE_EXPORT void updateProcessSyncData(const ProcessSyncData&);
+    WEBCORE_EXPORT void updateTopDocumentSyncData(Ref<DocumentSyncData>&&);
+
     WEBCORE_EXPORT void setMainFrameURLFragment(String&&);
     String mainFrameURLFragment() const { return m_mainFrameURLFragment; }
 
@@ -1340,6 +1342,8 @@ private:
     void computeSampledPageTopColorIfNecessary();
     void clearSampledPageTopColor();
 
+    bool hasLocalMainFrame();
+
     std::optional<PageIdentifier> m_identifier;
     UniqueRef<Chrome> m_chrome;
     UniqueRef<DragCaretController> m_dragCaretController;
@@ -1703,7 +1707,7 @@ private:
     bool m_shouldDeferResizeEvents { false };
     bool m_shouldDeferScrollEvents { false };
 
-    UniqueRef<DocumentSyncData> m_topDocumentSyncData;
+    Ref<DocumentSyncData> m_topDocumentSyncData;
 
 #if HAVE(AUDIT_TOKEN)
     std::optional<audit_token_t> m_presentingApplicationAuditToken;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -7052,6 +7052,15 @@ void WebPageProxy::broadcastProcessSyncData(IPC::Connection& connection, const W
     });
 }
 
+void WebPageProxy::broadcastTopDocumentSyncData(IPC::Connection& connection, Ref<WebCore::DocumentSyncData>&& data)
+{
+    forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+        if (!webProcess.hasConnection() || &webProcess.connection() == &connection)
+            return;
+        webProcess.send(Messages::WebPage::TopDocumentSyncDataChangedInAnotherProcess(data), pageID);
+    });
+}
+
 void WebPageProxy::didFinishLoadForFrame(IPC::Connection& connection, FrameIdentifier frameID, FrameInfoData&& frameInfo, ResourceRequest&& request, std::optional<WebCore::NavigationIdentifier> navigationID, const UserData& userData)
 {
     LOG(Loading, "WebPageProxy::didFinishLoadForFrame - WebPageProxy %p with navigationID %" PRIu64 " didFinishLoad", this, navigationID ? navigationID->toUInt64() : 0);

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -119,6 +119,7 @@ class ContentFilterUnblockHandler;
 class Cursor;
 class DataSegment;
 class DestinationColorSpace;
+class DocumentSyncData;
 class DragData;
 class Exception;
 class FloatPoint;
@@ -2372,6 +2373,7 @@ public:
 
     void observeAndCreateRemoteSubframesInOtherProcesses(WebFrameProxy&, const String& frameName);
     void broadcastProcessSyncData(IPC::Connection&, const WebCore::ProcessSyncData&);
+    void broadcastTopDocumentSyncData(IPC::Connection&, Ref<WebCore::DocumentSyncData>&&);
 
     void addOpenedPage(WebPageProxy&);
     bool hasOpenedPage() const;

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -647,6 +647,7 @@ messages -> WebPageProxy {
 
     DidApplyLinkDecorationFiltering(URL originalURL, URL adjustedURL)
     [EnabledBy=SiteIsolationEnabled] BroadcastProcessSyncData(struct WebCore::ProcessSyncData processSyncData)
+    [EnabledBy=SiteIsolationEnabled] BroadcastTopDocumentSyncData(Ref<WebCore::DocumentSyncData> documentSyncData)
 
     [EnabledBy=SiteIsolationEnabled] DispatchLoadEventToFrameOwnerElement(WebCore::FrameIdentifier frameID)
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebProcessSyncClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebProcessSyncClient.cpp
@@ -61,4 +61,12 @@ void WebProcessSyncClient::broadcastProcessSyncDataToOtherProcesses(const WebCor
     protectedPage()->send(Messages::WebPageProxy::BroadcastProcessSyncData(data));
 }
 
+void WebProcessSyncClient::broadcastTopDocumentSyncDataToOtherProcesses(WebCore::DocumentSyncData& data)
+{
+    if (!siteIsolationEnabled())
+        return;
+
+    protectedPage()->send(Messages::WebPageProxy::BroadcastTopDocumentSyncData(data));
+}
+
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebProcessSyncClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebProcessSyncClient.h
@@ -43,6 +43,7 @@ private:
     bool siteIsolationEnabled();
 
     void broadcastProcessSyncDataToOtherProcesses(const WebCore::ProcessSyncData&) final;
+    void broadcastTopDocumentSyncDataToOtherProcesses(WebCore::DocumentSyncData&) final;
 
     Ref<WebPage> protectedPage() const;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1215,8 +1215,14 @@ void WebPage::frameWasRemovedInAnotherProcess(WebCore::FrameIdentifier frameID)
 
 void WebPage::processSyncDataChangedInAnotherProcess(const WebCore::ProcessSyncData& data)
 {
-    if (auto* page = corePage())
+    if (RefPtr page = corePage())
         page->updateProcessSyncData(data);
+}
+
+void WebPage::topDocumentSyncDataChangedInAnotherProcess(Ref<WebCore::DocumentSyncData>&& data)
+{
+    if (RefPtr page = corePage())
+        page->updateTopDocumentSyncData(WTFMove(data));
 }
 
 #if ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -170,6 +170,7 @@ class AXCoreObject;
 class CachedPage;
 class CaptureDevice;
 class DocumentLoader;
+class DocumentSyncData;
 class DragData;
 class WeakPtrImplWithEventTargetData;
 class FontAttributeChanges;
@@ -743,6 +744,7 @@ public:
     void frameWasRemovedInAnotherProcess(WebCore::FrameIdentifier);
 
     void processSyncDataChangedInAnotherProcess(const WebCore::ProcessSyncData&);
+    void topDocumentSyncDataChangedInAnotherProcess(Ref<WebCore::DocumentSyncData>&&);
 
     std::optional<WebCore::SimpleRange> currentSelectionAsRange();
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -207,6 +207,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
     FrameWasRemovedInAnotherProcess(WebCore::FrameIdentifier frameID)
 
     ProcessSyncDataChangedInAnotherProcess(struct WebCore::ProcessSyncData processSyncData)
+    TopDocumentSyncDataChangedInAnotherProcess(Ref<WebCore::DocumentSyncData> documentSyncData)
 
     NavigateToPDFLinkWithSimulatedClick(String url, WebCore::IntPoint documentPoint, WebCore::IntPoint screenPoint)
     GetPDFFirstPageSize(WebCore::FrameIdentifier frameID) -> (WebCore::FloatSize size)


### PR DESCRIPTION
#### f6a87862c44de5e1ce311bb7064af66428b40d48
<pre>
on Make DocumentSyncData RefCounted, and have Page objects reference the main document copy
<a href="https://rdar.apple.com/141587316">rdar://141587316</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=284792">https://bugs.webkit.org/show_bug.cgi?id=284792</a>

Reviewed by Alex Christensen.

This page makes DocumentSyncData RefCounted, and Documents always ref() their own copy.

Pages used to clear out their `m_topDocumentSyncData` member whenever the main document changed.
Now - whenever the main document changes - the Page will ref() its copy instead.

This easily propagates existing data from the new top document into the Pages concept of that data.

It also allows us to broadcast the entire DocumentSyncData to all other processes at the point in
time that the main document changes.

* Source/WebCore/Scripts/generate-process-sync-data.py:
(generate_process_sync_client_impl):
(generate_process_sync_data_header):
(generate_document_synched_data_header):
(generate_document_synched_data_impl):
(generate_process_sync_data_serialiation_in):
(generate_process_sync_data_serialiation_in.WebCore):
(sort_data_lists):
(sort_datas_for_variant_order):
(sort_datas_for_document_sync_data_order):
(main):
* Source/WebCore/Scripts/tests/DocumentSyncData.cpp:
(WebCore::DocumentSyncData::update):
(WebCore::DocumentSyncData::DocumentSyncData):
* Source/WebCore/Scripts/tests/DocumentSyncData.h:
(WebCore::DocumentSyncData::create):
* Source/WebCore/Scripts/tests/ProcessSyncClient.cpp:
(WebCore::ProcessSyncClient::broadcastAudioSessionTypeToOtherProcesses):
(WebCore::ProcessSyncClient::broadcastMainFrameURLChangeToOtherProcesses):
(WebCore::ProcessSyncClient::broadcastUserDidInteractWithPageToOtherProcesses):
(WebCore::ProcessSyncClient::broadcastIsAutofocusProcessedToOtherProcesses):
* Source/WebCore/Scripts/tests/ProcessSyncClient.h:
(WebCore::ProcessSyncClient::broadcastTopDocumentSyncDataToOtherProcesses):
* Source/WebCore/Scripts/tests/ProcessSyncData.h:
* Source/WebCore/Scripts/tests/ProcessSyncData.serialization.in:
* Source/WebCore/dom/Document.cpp:
(WebCore::m_syncData):
(WebCore::m_frameIdentifier): Deleted.
* Source/WebCore/dom/Document.h:
(WebCore::Document::syncData):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::updateTopDocumentSyncData):
(WebCore::Page::hasLocalMainFrame):
(WebCore::Page::didChangeMainDocument):
* Source/WebCore/page/Page.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::broadcastTopDocumentSyncData):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebProcessSyncClient.cpp:
(WebKit::WebProcessSyncClient::broadcastTopDocumentSyncDataToOtherProcesses):
* Source/WebKit/WebProcess/WebCoreSupport/WebProcessSyncClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::processSyncDataChangedInAnotherProcess):
(WebKit::WebPage::topDocumentSyncDataChangedInAnotherProcess):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/287960@main">https://commits.webkit.org/287960@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d162661e09aa254231191ae3fa022ce076558e2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81492 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1017 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35440 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86024 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32486 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83602 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1035 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8836 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/63613 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/21349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84561 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/733 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74175 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43904 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/631 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28340 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30939 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28934 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87460 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8727 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71933 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8907 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69990 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71165 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17712 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15231 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14141 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8687 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/14213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8523 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12045 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10330 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->