### PR TITLE
Generalize arguments in ToStyle<> interface functions

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -965,6 +965,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     css/typedom/numeric/CSSNumericBaseType.h
     css/typedom/numeric/CSSNumericType.h
 
+    css/values/CSSNoConversionDataRequiredToken.h
     css/values/CSSValueAggregates.h
     css/values/CSSValueTypes.h
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1029,7 +1029,6 @@ css/parser/CSSPropertyParserConsumer+Animations.cpp
 css/parser/CSSPropertyParserConsumer+Attr.cpp
 css/parser/CSSPropertyParserConsumer+Background.cpp
 css/parser/CSSPropertyParserConsumer+Box.cpp
-css/parser/CSSPropertyParserConsumer+CSSPrimitiveValueResolver.cpp
 css/parser/CSSPropertyParserConsumer+Color.cpp
 css/parser/CSSPropertyParserConsumer+ColorAdjust.cpp
 css/parser/CSSPropertyParserConsumer+ColorInterpolationMethod.cpp

--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -1041,7 +1041,7 @@ double CSSPrimitiveValue::doubleValue(const CSSToLengthConversionData& conversio
 
 double CSSPrimitiveValue::doubleValueDeprecated() const
 {
-    return isCalculated() ? m_value.calc->doubleValueDeprecated({ }) : m_value.number;
+    return isCalculated() ? m_value.calc->doubleValueDeprecated() : m_value.number;
 }
 
 // MARK: `doubleValueDividingBy100IfPercentage`.
@@ -1072,7 +1072,7 @@ double CSSPrimitiveValue::doubleValueDividingBy100IfPercentageDeprecated() const
     ASSERT(isNumberOrInteger() || isPercentage());
 
     if (isCalculated())
-        return m_value.calc->primitiveType() == CSSUnitType::CSS_PERCENTAGE ? m_value.calc->doubleValueDeprecated({ }) / 100.0 : m_value.calc->doubleValueDeprecated({ });
+        return m_value.calc->primitiveType() == CSSUnitType::CSS_PERCENTAGE ? m_value.calc->doubleValueDeprecated() / 100.0 : m_value.calc->doubleValueDeprecated();
     if (isPercentage())
         return m_value.number / 100.0;
     return m_value.number;

--- a/Source/WebCore/css/calc/CSSCalcValue.h
+++ b/Source/WebCore/css/calc/CSSCalcValue.h
@@ -56,6 +56,7 @@ class RenderStyle;
 struct CSSParserContext;
 struct CSSPropertyParserOptions;
 struct Length;
+struct NoConversionDataRequiredToken;
 
 enum CSSValueID : uint16_t;
 
@@ -71,6 +72,7 @@ public:
     ~CSSCalcValue();
 
     // Creates a copy of the CSSCalc::Tree with non-canonical dimensions and any symbols present in the provided symbol table resolved.
+    Ref<CSSCalcValue> copySimplified(const CSSToLengthConversionData&) const;
     Ref<CSSCalcValue> copySimplified(const CSSToLengthConversionData&, const CSSCalcSymbolTable&) const;
 
     Calculation::Category category() const { return m_tree.category; }
@@ -79,13 +81,18 @@ public:
     // Returns whether the CSSCalc::Tree requires `CSSToLengthConversionData` to fully resolve.
     bool requiresConversionData() const;
 
+    double doubleValue(const CSSToLengthConversionData&) const;
     double doubleValue(const CSSToLengthConversionData&, const CSSCalcSymbolTable&) const;
-    double doubleValueNoConversionDataRequired(const CSSCalcSymbolTable&) const;
-    double doubleValueDeprecated(const CSSCalcSymbolTable&) const;
+    double doubleValue(NoConversionDataRequiredToken) const;
+    double doubleValue(NoConversionDataRequiredToken, const CSSCalcSymbolTable&) const;
+    double doubleValueDeprecated() const;
 
+    double computeLengthPx(const CSSToLengthConversionData&) const;
     double computeLengthPx(const CSSToLengthConversionData&, const CSSCalcSymbolTable&) const;
 
-    Ref<CalculationValue> createCalculationValueNoConversionDataRequired(const CSSCalcSymbolTable&) const;
+    Ref<CalculationValue> createCalculationValue(NoConversionDataRequiredToken) const;
+    Ref<CalculationValue> createCalculationValue(NoConversionDataRequiredToken, const CSSCalcSymbolTable&) const;
+    Ref<CalculationValue> createCalculationValue(const CSSToLengthConversionData&) const;
     Ref<CalculationValue> createCalculationValue(const CSSToLengthConversionData&, const CSSCalcSymbolTable&) const;
 
     void collectComputedStyleDependencies(ComputedStyleDependencies&) const;

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Angle.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Angle.cpp
@@ -40,7 +40,7 @@ RefPtr<CSSPrimitiveValue> consumeAngle(CSSParserTokenRange& range, const CSSPars
         .unitless = unitless,
         .unitlessZero = unitlessZero
     };
-    return CSSPrimitiveValueResolver<CSS::Angle<CSS::All>>::consumeAndResolve(range, context, { }, { }, options);
+    return CSSPrimitiveValueResolver<CSS::Angle<CSS::All>>::consumeAndResolve(range, context, options);
 }
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+AnglePercentage.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+AnglePercentage.cpp
@@ -41,8 +41,8 @@ RefPtr<CSSPrimitiveValue> consumeAnglePercentage(CSSParserTokenRange& range, con
         .unitlessZero = unitlessZero
     };
     if (valueRange == ValueRange::All)
-        return CSSPrimitiveValueResolver<CSS::AnglePercentage<CSS::All>>::consumeAndResolve(range, context, { }, { }, options);
-    return CSSPrimitiveValueResolver<CSS::AnglePercentage<CSS::Nonnegative>>::consumeAndResolve(range, context, { }, { }, options);
+        return CSSPrimitiveValueResolver<CSS::AnglePercentage<CSS::All>>::consumeAndResolve(range, context, options);
+    return CSSPrimitiveValueResolver<CSS::AnglePercentage<CSS::Nonnegative>>::consumeAndResolve(range, context, options);
 }
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h
@@ -39,27 +39,24 @@ namespace CSSPropertyParserHelpers {
 
 /// Non-template base type for code sharing.
 struct CSSPrimitiveValueResolverBase {
-    static RefPtr<CSSPrimitiveValue> resolve(CSS::NoneRaw, const CSSCalcSymbolTable&, CSSPropertyParserOptions);
-    static RefPtr<CSSPrimitiveValue> resolve(CSS::SymbolRaw, const CSSCalcSymbolTable&, CSSPropertyParserOptions);
-
-    template<CSS::RawNumeric Raw> static RefPtr<CSSPrimitiveValue> resolve(Raw value, const CSSCalcSymbolTable&, CSSPropertyParserOptions)
+    template<CSS::RawNumeric Raw> static RefPtr<CSSPrimitiveValue> resolve(Raw value, CSSPropertyParserOptions)
     {
         return CSSPrimitiveValue::create(value.value, value.type);
     }
 
-    template<CSS::Range R, typename IntType> static RefPtr<CSSPrimitiveValue> resolve(CSS::IntegerRaw<R, IntType> value, const CSSCalcSymbolTable&, CSSPropertyParserOptions)
+    template<CSS::Range R, typename IntType> static RefPtr<CSSPrimitiveValue> resolve(CSS::IntegerRaw<R, IntType> value, CSSPropertyParserOptions)
     {
         return CSSPrimitiveValue::createInteger(value.value);
     }
 
-    template<typename T> static RefPtr<CSSPrimitiveValue> resolve(CSS::UnevaluatedCalc<T> value, const CSSCalcSymbolTable&, CSSPropertyParserOptions)
+    template<typename T> static RefPtr<CSSPrimitiveValue> resolve(CSS::UnevaluatedCalc<T> value, CSSPropertyParserOptions)
     {
         return CSSPrimitiveValue::create(value.protectedCalc());
     }
 
-    template<typename T> static RefPtr<CSSPrimitiveValue> resolve(CSS::PrimitiveNumeric<T> value, const CSSCalcSymbolTable& symbolTable, CSSPropertyParserOptions options)
+    template<typename T> static RefPtr<CSSPrimitiveValue> resolve(CSS::PrimitiveNumeric<T> value, CSSPropertyParserOptions options)
     {
-        return WTF::switchOn(WTFMove(value), [&](auto&& value) { return resolve(WTFMove(value), symbolTable, options); });
+        return WTF::switchOn(WTFMove(value), [&](auto&& value) { return resolve(WTFMove(value), options); });
     }
 };
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.cpp
@@ -150,7 +150,7 @@ static bool consumeAlphaDelimiter(CSSParserTokenRange& args)
 
 template<typename Descriptor> static CSS::AbsoluteColor<typename Descriptor::Canonical> normalizeNonCalcComponents(const CSS::AbsoluteColor<Descriptor>& unresolved, ColorParserState& state)
 {
-    ASSERT(containsUnevaluatedCalc<Descriptor>(unresolved.components));
+    ASSERT(componentsContainsUnevaluatedCalc<Descriptor>(unresolved.components));
 
     // The canonical descriptor is normally the descriptor itself, except for legacy rgb and hsl, which use the modern counterparts.
     using CanonicalDescriptor = typename Descriptor::Canonical;
@@ -182,7 +182,7 @@ template<typename Descriptor> static CSS::AbsoluteColor<typename Descriptor::Can
 
 template<typename Descriptor> static CSS::AbsoluteColor<typename Descriptor::Canonical> normalizeNonCalcRequiringConversionDataComponents(const CSS::AbsoluteColor<Descriptor>& unresolved, ColorParserState& state)
 {
-    ASSERT(containsUnevaluatedCalc<Descriptor>(unresolved.components));
+    ASSERT(componentsContainsUnevaluatedCalc<Descriptor>(unresolved.components));
 
     // Evaluated any calc values that don't require conversion data.
     auto partiallyResolved = CSS::AbsoluteColor<Descriptor> {
@@ -237,15 +237,15 @@ static std::optional<CSS::Color> consumeAbsoluteFunctionParameters(CSSParserToke
         // calc() will "resolve to a single value" when no conversion data is required.
 
         // For this legacy / eager evaluating case, we want to preserve any calc() components that require conversion data.
-        if (requiresConversionData<Descriptor>(unresolved.components))
+        if (componentsRequireConversionData<Descriptor>(unresolved.components))
             return makeCSSColor(normalizeNonCalcRequiringConversionDataComponents(unresolved, state));
     } else {
         // For the non-legacy / non-eager evaluating cases, we want preserve any calc(), not just calc() requiring conversion data, so the check is a bit more permissive.
-        if (containsUnevaluatedCalc<Descriptor>(unresolved.components))
+        if (componentsContainsUnevaluatedCalc<Descriptor>(unresolved.components))
             return makeCSSColor(normalizeNonCalcComponents(unresolved, state));
     }
 
-    ASSERT(!requiresConversionData<Descriptor>(unresolved.components));
+    ASSERT(!componentsRequireConversionData<Descriptor>(unresolved.components));
 
     // In all other cases, we can fully resolve the color all the way to an absolute Color value.
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
@@ -84,7 +84,7 @@ template<typename Result, typename... Ts> static Result forwardVariantTo(std::va
 
 template<typename T> static Ref<CSSPrimitiveValue> resolveToCSSPrimitiveValue(CSS::PrimitiveNumeric<T>&& primitive)
 {
-    return WTF::switchOn(WTFMove(primitive), [](auto&& alternative) { return CSSPrimitiveValueResolverBase::resolve(WTFMove(alternative), { }, { }); }).releaseNonNull();
+    return WTF::switchOn(WTFMove(primitive), [](auto&& alternative) { return CSSPrimitiveValueResolverBase::resolve(WTFMove(alternative), { }); }).releaseNonNull();
 }
 
 static CSSParserMode parserMode(ScriptExecutionContext& context)

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp
@@ -1154,7 +1154,7 @@ static RefPtr<CSSPrimitiveValue> consumeImageSetResolutionOrTypeFunction(CSSPars
             return CSSPrimitiveValue::create(typeFunction.value);
         },
         [&](const CSS::Resolution<>& resolution) -> RefPtr<CSSPrimitiveValue> {
-            return CSSPrimitiveValueResolverBase::resolve(resolution, CSSCalcSymbolTable { }, options);
+            return CSSPrimitiveValueResolverBase::resolve(resolution, options);
         }
     );
 }

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Integer.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Integer.cpp
@@ -36,7 +36,7 @@ namespace CSSPropertyParserHelpers {
 
 template<typename T> static RefPtr<CSSPrimitiveValue> consumeIntegerType(CSSParserTokenRange& range, const CSSParserContext& context)
 {
-    return CSSPrimitiveValueResolver<T>::consumeAndResolve(range, context, { }, { }, { });
+    return CSSPrimitiveValueResolver<T>::consumeAndResolve(range, context, { });
 }
 
 RefPtr<CSSPrimitiveValue> consumeInteger(CSSParserTokenRange& range, const CSSParserContext& context)

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Length.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Length.cpp
@@ -41,8 +41,8 @@ RefPtr<CSSPrimitiveValue> consumeLength(CSSParserTokenRange& range, const CSSPar
         .unitlessZero = UnitlessZeroQuirk::Allow
     };
     if (valueRange == ValueRange::All)
-        return CSSPrimitiveValueResolver<CSS::Length<CSS::All>>::consumeAndResolve(range, context, { }, { }, options);
-    return CSSPrimitiveValueResolver<CSS::Length<CSS::Nonnegative>>::consumeAndResolve(range, context, { }, { }, options);
+        return CSSPrimitiveValueResolver<CSS::Length<CSS::All>>::consumeAndResolve(range, context, options);
+    return CSSPrimitiveValueResolver<CSS::Length<CSS::Nonnegative>>::consumeAndResolve(range, context, options);
 }
 
 RefPtr<CSSPrimitiveValue> consumeLength(CSSParserTokenRange& range, const CSSParserContext& context, CSSParserMode overrideParserMode, ValueRange valueRange, UnitlessQuirk unitless)
@@ -53,8 +53,8 @@ RefPtr<CSSPrimitiveValue> consumeLength(CSSParserTokenRange& range, const CSSPar
         .unitlessZero = UnitlessZeroQuirk::Allow
     };
     if (valueRange == ValueRange::All)
-        return CSSPrimitiveValueResolver<CSS::Length<CSS::All>>::consumeAndResolve(range, context, { }, { }, options);
-    return CSSPrimitiveValueResolver<CSS::Length<CSS::Nonnegative>>::consumeAndResolve(range, context, { }, { }, options);
+        return CSSPrimitiveValueResolver<CSS::Length<CSS::All>>::consumeAndResolve(range, context, options);
+    return CSSPrimitiveValueResolver<CSS::Length<CSS::Nonnegative>>::consumeAndResolve(range, context, options);
 }
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+LengthPercentage.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+LengthPercentage.cpp
@@ -44,8 +44,8 @@ RefPtr<CSSPrimitiveValue> consumeLengthPercentage(CSSParserTokenRange& range, co
     };
 
     if (valueRange == ValueRange::All)
-        return CSSPrimitiveValueResolver<CSS::LengthPercentage<CSS::All>>::consumeAndResolve(range, context, { }, { }, options);
-    return CSSPrimitiveValueResolver<CSS::LengthPercentage<CSS::Nonnegative>>::consumeAndResolve(range, context, { }, { }, options);
+        return CSSPrimitiveValueResolver<CSS::LengthPercentage<CSS::All>>::consumeAndResolve(range, context, options);
+    return CSSPrimitiveValueResolver<CSS::LengthPercentage<CSS::Nonnegative>>::consumeAndResolve(range, context, options);
 }
 
 RefPtr<CSSPrimitiveValue> consumeLengthPercentage(CSSParserTokenRange& range, const CSSParserContext& context, CSSParserMode overrideParserMode, ValueRange valueRange, UnitlessQuirk unitless, UnitlessZeroQuirk unitlessZero, AnchorPolicy anchorPolicy, AnchorSizePolicy anchorSizePolicy)
@@ -59,8 +59,8 @@ RefPtr<CSSPrimitiveValue> consumeLengthPercentage(CSSParserTokenRange& range, co
     };
 
     if (valueRange == ValueRange::All)
-        return CSSPrimitiveValueResolver<CSS::LengthPercentage<CSS::All>>::consumeAndResolve(range, context, { }, { }, options);
-    return CSSPrimitiveValueResolver<CSS::LengthPercentage<CSS::Nonnegative>>::consumeAndResolve(range, context, { }, { }, options);
+        return CSSPrimitiveValueResolver<CSS::LengthPercentage<CSS::All>>::consumeAndResolve(range, context, options);
+    return CSSPrimitiveValueResolver<CSS::LengthPercentage<CSS::Nonnegative>>::consumeAndResolve(range, context, options);
 }
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaResolver.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaResolver.h
@@ -45,24 +45,24 @@ template<typename R, typename Base, typename T, typename... Ts>
 struct MetaResolver : Base {
     using ResultType = R;
 
-    static ResultType resolve(std::variant<T, Ts...>&& consumeResult, const CSSCalcSymbolTable& symbolTable, CSSPropertyParserOptions options) requires (sizeof...(Ts) > 0)
+    static ResultType resolve(std::variant<T, Ts...>&& consumeResult, CSSPropertyParserOptions options) requires (sizeof...(Ts) > 0)
     {
         return WTF::switchOn(WTFMove(consumeResult), [&](auto&& value) -> ResultType {
-            return Base::resolve(WTFMove(value), symbolTable, options);
+            return Base::resolve(WTFMove(value), options);
         });
     }
 
-    static ResultType resolve(T&& consumeResult, const CSSCalcSymbolTable& symbolTable, CSSPropertyParserOptions options) requires (sizeof...(Ts) == 0)
+    static ResultType resolve(T&& consumeResult, CSSPropertyParserOptions options) requires (sizeof...(Ts) == 0)
     {
-        return Base::resolve(WTFMove(consumeResult), symbolTable, options);
+        return Base::resolve(WTFMove(consumeResult), options);
     }
 
-    static ResultType consumeAndResolve(CSSParserTokenRange& range, const CSSParserContext& context, CSSCalcSymbolsAllowed symbolsAllowed, const CSSCalcSymbolTable& symbolTable, CSSPropertyParserOptions options)
+    static ResultType consumeAndResolve(CSSParserTokenRange& range, const CSSParserContext& context, CSSPropertyParserOptions options)
     {
-        auto result = MetaConsumer<T, Ts...>::consume(range, context, WTFMove(symbolsAllowed), options);
+        auto result = MetaConsumer<T, Ts...>::consume(range, context, { }, options);
         if (!result)
             return { };
-        return resolve(WTFMove(*result), symbolTable, options);
+        return resolve(WTFMove(*result), options);
     }
 };
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Number.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Number.cpp
@@ -41,8 +41,8 @@ RefPtr<CSSPrimitiveValue> consumeNumber(CSSParserTokenRange& range, const CSSPar
         .parserMode = context.mode,
     };
     if (valueRange == ValueRange::All)
-        return CSSPrimitiveValueResolver<CSS::Number<CSS::All>>::consumeAndResolve(range, context, { }, { }, options);
-    return CSSPrimitiveValueResolver<CSS::Number<CSS::Nonnegative>>::consumeAndResolve(range, context, { }, { }, options);
+        return CSSPrimitiveValueResolver<CSS::Number<CSS::All>>::consumeAndResolve(range, context, options);
+    return CSSPrimitiveValueResolver<CSS::Number<CSS::Nonnegative>>::consumeAndResolve(range, context, options);
 }
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Percentage.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Percentage.cpp
@@ -39,8 +39,8 @@ namespace CSSPropertyParserHelpers {
 RefPtr<CSSPrimitiveValue> consumePercentage(CSSParserTokenRange& range, const CSSParserContext& context, ValueRange valueRange)
 {
     if (valueRange == ValueRange::All)
-        return CSSPrimitiveValueResolver<CSS::Percentage<CSS::All>>::consumeAndResolve(range, context, { }, { }, { });
-    return CSSPrimitiveValueResolver<CSS::Percentage<CSS::Nonnegative>>::consumeAndResolve(range, context, { }, { }, { });
+        return CSSPrimitiveValueResolver<CSS::Percentage<CSS::All>>::consumeAndResolve(range, context, { });
+    return CSSPrimitiveValueResolver<CSS::Percentage<CSS::Nonnegative>>::consumeAndResolve(range, context, { });
 }
 
 template<auto R> static RefPtr<CSSPrimitiveValue> consumePercentageDividedBy100OrNumber(CSSParserTokenRange& range, const CSSParserContext& context)
@@ -53,14 +53,14 @@ template<auto R> static RefPtr<CSSPrimitiveValue> consumePercentageDividedBy100O
     switch (token.type()) {
     case FunctionToken:
         if (auto value = NumberConsumer::FunctionToken::consume(range, context, { }, { }))
-            return CSSPrimitiveValueResolver<CSS::Number<R>>::resolve(*value, { }, { });
+            return CSSPrimitiveValueResolver<CSS::Number<R>>::resolve(*value, { });
         if (auto value = PercentageConsumer::FunctionToken::consume(range, context, { }, { }))
-            return CSSPrimitiveValueResolver<CSS::Percentage<R>>::resolve(*value, { }, { });
+            return CSSPrimitiveValueResolver<CSS::Percentage<R>>::resolve(*value, { });
         break;
 
     case NumberToken:
         if (auto value = NumberConsumer::NumberToken::consume(range, context, { }, { }))
-            return CSSPrimitiveValueResolver<CSS::Number<R>>::resolve(*value, { }, { });
+            return CSSPrimitiveValueResolver<CSS::Number<R>>::resolve(*value, { });
         break;
 
     case PercentageToken:

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Resolution.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Resolution.cpp
@@ -34,7 +34,7 @@ namespace CSSPropertyParserHelpers {
 
 RefPtr<CSSPrimitiveValue> consumeResolution(CSSParserTokenRange& range, const CSSParserContext& context)
 {
-    return CSSPrimitiveValueResolver<CSS::Resolution<>>::consumeAndResolve(range, context, { }, { }, { });
+    return CSSPrimitiveValueResolver<CSS::Resolution<>>::consumeAndResolve(range, context, { });
 }
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Time.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Time.cpp
@@ -39,8 +39,8 @@ RefPtr<CSSPrimitiveValue> consumeTime(CSSParserTokenRange& range, const CSSParse
         .parserMode = context.mode,
     };
     if (valueRange == ValueRange::All)
-        return CSSPrimitiveValueResolver<CSS::Time<CSS::All>>::consumeAndResolve(range, context, { }, { }, options);
-    return CSSPrimitiveValueResolver<CSS::Time<CSS::Nonnegative>>::consumeAndResolve(range, context, { }, { }, options);
+        return CSSPrimitiveValueResolver<CSS::Time<CSS::All>>::consumeAndResolve(range, context, options);
+    return CSSPrimitiveValueResolver<CSS::Time<CSS::Nonnegative>>::consumeAndResolve(range, context, options);
 }
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/values/CSSNoConversionDataRequiredToken.h
+++ b/Source/WebCore/css/values/CSSNoConversionDataRequiredToken.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -22,29 +22,11 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h"
-
-#include "CSSCalcSymbolTable.h"
-#include "CSSParserTokenRange.h"
+#pragma once
 
 namespace WebCore {
-namespace CSSPropertyParserHelpers {
 
-RefPtr<CSSPrimitiveValue> CSSPrimitiveValueResolverBase::resolve(CSS::NoneRaw, const CSSCalcSymbolTable&, CSSPropertyParserOptions)
-{
-    return CSSPrimitiveValue::create(std::numeric_limits<double>::quiet_NaN(), CSSUnitType::CSS_NUMBER);
-}
+// Token passed around to indicate that the caller has checked that no conversion data is required.
+struct NoConversionDataRequiredToken { };
 
-RefPtr<CSSPrimitiveValue> CSSPrimitiveValueResolverBase::resolve(CSS::SymbolRaw value, const CSSCalcSymbolTable& symbolTable, CSSPropertyParserOptions)
-{
-    if (auto variable = symbolTable.get(value.value))
-        return CSSPrimitiveValue::create(variable->value, variable->unit);
-
-    // We should only get here if the symbol was previously looked up in the symbol table.
-    ASSERT_NOT_REACHED();
-    return nullptr;
-}
-
-} // namespace CSSPropertyParserHelpers
 } // namespace WebCore

--- a/Source/WebCore/css/values/color/CSSAbsoluteColor.h
+++ b/Source/WebCore/css/values/color/CSSAbsoluteColor.h
@@ -62,7 +62,7 @@ template<typename D> WebCore::Color createColor(const AbsoluteColor<D>& unresolv
     if (state.conversionData)
         return resolve(WTFMove(resolver), *state.conversionData);
 
-    if (!requiresConversionData(resolver.components))
+    if (!componentsRequireConversionData<D>(resolver.components))
         return resolveNoConversionDataRequired(WTFMove(resolver));
 
     return { };

--- a/Source/WebCore/css/values/color/CSSAbsoluteColorResolver.h
+++ b/Source/WebCore/css/values/color/CSSAbsoluteColorResolver.h
@@ -63,7 +63,7 @@ template<typename D> WebCore::Color resolve(const AbsoluteColorResolver<D>& abso
 // This resolve function should only be called if the components have been checked and don't require conversion data to be resolved.
 template<typename D> WebCore::Color resolveNoConversionDataRequired(const AbsoluteColorResolver<D>& absolute)
 {
-    ASSERT(!requiresConversionData(absolute.components));
+    ASSERT(!componentsRequireConversionData<D>(absolute.components));
 
     // Evaluated any calc values to their corresponding channel value.
     auto components = StyleColorParseType<D> {

--- a/Source/WebCore/css/values/color/CSSColorDescriptors.h
+++ b/Source/WebCore/css/values/color/CSSColorDescriptors.h
@@ -108,12 +108,12 @@ using StyleColorParseType = std::tuple<
     std::optional<GetStyleColorParseTypeComponentResult<Descriptor, 3>>
 >;
 
-template<typename Descriptor> constexpr bool containsUnevaluatedCalc(const StyleColorParseType<Descriptor>&)
+template<typename Descriptor> constexpr bool componentsContainsUnevaluatedCalc(const StyleColorParseType<Descriptor>&)
 {
     return false;
 }
 
-template<typename Descriptor> constexpr bool requiresConversionData(const StyleColorParseType<Descriptor>&)
+template<typename Descriptor> constexpr bool componentsRequireConversionData(const StyleColorParseType<Descriptor>&)
 {
     return false;
 }
@@ -137,7 +137,7 @@ using CSSColorParseTypeWithCalc = std::tuple<
     std::optional<GetCSSColorParseTypeWithCalcComponentResult<Descriptor, 3>>
 >;
 
-template<typename Descriptor> bool containsUnevaluatedCalc(const CSSColorParseTypeWithCalc<Descriptor>& components)
+template<typename Descriptor> bool componentsContainsUnevaluatedCalc(const CSSColorParseTypeWithCalc<Descriptor>& components)
 {
     return isUnevaluatedCalc(std::get<0>(components))
         || isUnevaluatedCalc(std::get<1>(components))
@@ -145,7 +145,7 @@ template<typename Descriptor> bool containsUnevaluatedCalc(const CSSColorParseTy
         || isUnevaluatedCalc(std::get<3>(components));
 }
 
-template<typename Descriptor> bool requiresConversionData(const CSSColorParseTypeWithCalc<Descriptor>& components)
+template<typename Descriptor> bool componentsRequireConversionData(const CSSColorParseTypeWithCalc<Descriptor>& components)
 {
     return requiresConversionData(std::get<0>(components))
         || requiresConversionData(std::get<1>(components))
@@ -172,7 +172,7 @@ using CSSColorParseTypeWithCalcAndSymbols = std::tuple<
     std::optional<GetCSSColorParseTypeWithCalcAndSymbolsComponentResult<Descriptor, 3>>
 >;
 
-template<typename Descriptor> bool containsUnevaluatedCalc(const CSSColorParseTypeWithCalcAndSymbols<Descriptor>& components)
+template<typename Descriptor> bool componentsContainsUnevaluatedCalc(const CSSColorParseTypeWithCalcAndSymbols<Descriptor>& components)
 {
     return isUnevaluatedCalc(std::get<0>(components))
         || isUnevaluatedCalc(std::get<1>(components))
@@ -180,7 +180,7 @@ template<typename Descriptor> bool containsUnevaluatedCalc(const CSSColorParseTy
         || isUnevaluatedCalc(std::get<3>(components));
 }
 
-template<typename Descriptor> bool requiresConversionData(const CSSColorParseTypeWithCalcAndSymbols<Descriptor>& components)
+template<typename Descriptor> bool componentsRequireConversionData(const CSSColorParseTypeWithCalcAndSymbols<Descriptor>& components)
 {
     return requiresConversionData(std::get<0>(components))
         || requiresConversionData(std::get<1>(components))

--- a/Source/WebCore/css/values/color/CSSRelativeColor.h
+++ b/Source/WebCore/css/values/color/CSSRelativeColor.h
@@ -80,7 +80,7 @@ WebCore::Color createColor(const RelativeColor<Descriptor>& unresolved, Platform
     if (state.conversionData)
         return resolve(WTFMove(resolver), *state.conversionData);
 
-    if (!requiresConversionData(resolver.components))
+    if (!componentsRequireConversionData<Descriptor>(resolver.components))
         return resolveNoConversionDataRequired(WTFMove(resolver));
 
     return { };

--- a/Source/WebCore/css/values/color/CSSRelativeColorResolver.h
+++ b/Source/WebCore/css/values/color/CSSRelativeColorResolver.h
@@ -86,7 +86,7 @@ WebCore::Color resolve(const RelativeColorResolver<Descriptor>& relative, const 
 template<typename Descriptor>
 WebCore::Color resolveNoConversionDataRequired(const RelativeColorResolver<Descriptor>& relative)
 {
-    ASSERT(!requiresConversionData(relative.components));
+    ASSERT(!componentsRequireConversionData<Descriptor>(relative.components));
 
     auto originColor = relative.origin;
     auto originColorAsColorType = originColor.template toColorTypeLossy<GetColorType<Descriptor>>();

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Canonicalization.cpp
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Canonicalization.cpp
@@ -25,6 +25,7 @@
 #include "config.h"
 #include "CSSPrimitiveNumericTypes+Canonicalization.h"
 
+#include "CSSNoConversionDataRequiredToken.h"
 #include "CSSPrimitiveValue.h"
 #include "CSSToLengthConversionData.h"
 #include "FloatConversion.h"
@@ -41,7 +42,7 @@ double canonicalizeAngle(double value, CSSUnitType type)
 
 // MARK: Length
 
-double canonicalizeLengthNoConversionDataRequired(double value, CSSUnitType type)
+double canonicalizeLength(double value, CSSUnitType type, NoConversionDataRequiredToken)
 {
     return CSSPrimitiveValue::computeNonCalcLengthDouble({ }, type, value);
 }
@@ -56,9 +57,9 @@ float clampLengthToAllowedLimits(double value)
     return clampTo<float>(narrowPrecisionToFloat(value), minValueForCssLength, maxValueForCssLength);
 }
 
-float canonicalizeAndClampLengthNoConversionDataRequired(double value, CSSUnitType type)
+float canonicalizeAndClampLength(double value, CSSUnitType type, NoConversionDataRequiredToken token)
 {
-    return clampLengthToAllowedLimits(canonicalizeLengthNoConversionDataRequired(value, type));
+    return clampLengthToAllowedLimits(canonicalizeLength(value, type, token));
 }
 
 float canonicalizeAndClampLength(double value, CSSUnitType type, const CSSToLengthConversionData& conversionData)

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Canonicalization.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Canonicalization.h
@@ -27,6 +27,9 @@
 #include "CSSPrimitiveNumericTypes.h"
 
 namespace WebCore {
+
+struct NoConversionDataRequiredToken;
+
 namespace CSS {
 
 // MARK: Angle
@@ -40,10 +43,10 @@ template<auto R> double canonicalize(AngleRaw<R> raw)
 
 // MARK: Length
 
-double canonicalizeLengthNoConversionDataRequired(double, CSSUnitType);
+double canonicalizeLength(double, CSSUnitType, NoConversionDataRequiredToken);
 double canonicalizeLength(double, CSSUnitType, const CSSToLengthConversionData&);
 float clampLengthToAllowedLimits(double);
-float canonicalizeAndClampLengthNoConversionDataRequired(double, CSSUnitType);
+float canonicalizeAndClampLength(double, CSSUnitType, NoConversionDataRequiredToken);
 float canonicalizeAndClampLength(double, CSSUnitType, const CSSToLengthConversionData&);
 
 // MARK: Time

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+EvaluateCalc.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+EvaluateCalc.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "CSSNoConversionDataRequiredToken.h"
 #include "CSSPrimitiveNumericTypes.h"
 #include "CSSUnevaluatedCalc.h"
 
@@ -41,12 +42,12 @@ template<typename T> bool requiresConversionData(const PrimitiveNumeric<T>& prim
 
 // FIXME: Remove "evaluateCalc" family of functions once color code has moved to the "toStyle" family of functions.
 
-template<RawNumeric T> auto evaluateCalcNoConversionDataRequired(const UnevaluatedCalc<T>& calc, const CSSCalcSymbolTable& symbolTable) -> T
+template<RawNumeric T> auto evaluateCalc(const UnevaluatedCalc<T>& calc, NoConversionDataRequiredToken token, const CSSCalcSymbolTable& symbolTable) -> T
 {
-    return { unevaluatedCalcEvaluateNoConversionDataRequired(calc.protectedCalc(), symbolTable, T::category) };
+    return { unevaluatedCalcEvaluate(calc.protectedCalc(), T::category, token, symbolTable) };
 }
 
-template<typename T> constexpr auto evaluateCalcNoConversionDataRequired(const T& component, const CSSCalcSymbolTable&) -> T
+template<typename T> constexpr auto evaluateCalc(const T& component, NoConversionDataRequiredToken, const CSSCalcSymbolTable&) -> T
 {
     return component;
 }
@@ -56,7 +57,7 @@ template<typename... Ts> auto evaluateCalcIfNoConversionDataRequired(const std::
     return WTF::switchOn(component, [&](const auto& alternative) -> std::variant<Ts...> {
         if (requiresConversionData(alternative))
             return alternative;
-        return evaluateCalcNoConversionDataRequired(alternative, symbolTable);
+        return evaluateCalc(alternative, NoConversionDataRequiredToken { }, symbolTable);
     });
 }
 
@@ -65,7 +66,7 @@ template<typename T> auto evaluateCalcIfNoConversionDataRequired(const Primitive
     return WTF::switchOn(component, [&](const auto& alternative) -> PrimitiveNumeric<T> {
         if (requiresConversionData(alternative))
             return { alternative };
-        return { evaluateCalcNoConversionDataRequired(alternative, symbolTable) };
+        return { evaluateCalc(alternative, NoConversionDataRequiredToken { }, symbolTable) };
     });
 }
 

--- a/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.cpp
+++ b/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.cpp
@@ -26,6 +26,7 @@
 #include "CSSUnevaluatedCalc.h"
 
 #include "CSSCalcSymbolTable.h"
+#include "CSSNoConversionDataRequiredToken.h"
 #include "StyleBuilderState.h"
 #include <wtf/text/StringBuilder.h>
 
@@ -57,36 +58,36 @@ Ref<CSSCalcValue> unevaluatedCalcSimplify(const Ref<CSSCalcValue>& calc, const C
     return calc->copySimplified(conversionData, symbolTable);
 }
 
-double unevaluatedCalcEvaluate(const Ref<CSSCalcValue>& calc, const Style::BuilderState& state, Calculation::Category category)
+double unevaluatedCalcEvaluate(const Ref<CSSCalcValue>& calc, Calculation::Category category, const Style::BuilderState& state)
 {
-    return unevaluatedCalcEvaluate(calc, state.cssToLengthConversionData(), { }, category);
+    return unevaluatedCalcEvaluate(calc, category, state.cssToLengthConversionData(), { });
 }
 
-double unevaluatedCalcEvaluate(const Ref<CSSCalcValue>& calc, const Style::BuilderState& state, const CSSCalcSymbolTable& symbolTable, Calculation::Category category)
+double unevaluatedCalcEvaluate(const Ref<CSSCalcValue>& calc, Calculation::Category category, const Style::BuilderState& state, const CSSCalcSymbolTable& symbolTable)
 {
-    return unevaluatedCalcEvaluate(calc, state.cssToLengthConversionData(), symbolTable, category);
+    return unevaluatedCalcEvaluate(calc, category, state.cssToLengthConversionData(), symbolTable);
 }
 
-double unevaluatedCalcEvaluate(const Ref<CSSCalcValue>& calc, const CSSToLengthConversionData& conversionData, Calculation::Category category)
+double unevaluatedCalcEvaluate(const Ref<CSSCalcValue>& calc, Calculation::Category category, const CSSToLengthConversionData& conversionData)
 {
-    return unevaluatedCalcEvaluate(calc, conversionData, { }, category);
+    return unevaluatedCalcEvaluate(calc, category, conversionData, { });
 }
 
-double unevaluatedCalcEvaluate(const Ref<CSSCalcValue>& calc, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable, Calculation::Category category)
+double unevaluatedCalcEvaluate(const Ref<CSSCalcValue>& calc, Calculation::Category category, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable)
 {
     ASSERT_UNUSED(category, calc->category() == category);
     return calc->doubleValue(conversionData, symbolTable);
 }
 
-double unevaluatedCalcEvaluateNoConversionDataRequired(const Ref<CSSCalcValue>& calc, Calculation::Category category)
+double unevaluatedCalcEvaluate(const Ref<CSSCalcValue>& calc, Calculation::Category category, NoConversionDataRequiredToken token)
 {
-    return unevaluatedCalcEvaluateNoConversionDataRequired(calc, { }, category);
+    return unevaluatedCalcEvaluate(calc, category, token, { });
 }
 
-double unevaluatedCalcEvaluateNoConversionDataRequired(const Ref<CSSCalcValue>& calc, const CSSCalcSymbolTable& symbolTable, Calculation::Category category)
+double unevaluatedCalcEvaluate(const Ref<CSSCalcValue>& calc, Calculation::Category category, NoConversionDataRequiredToken token, const CSSCalcSymbolTable& symbolTable)
 {
     ASSERT_UNUSED(category, calc->category() == category);
-    return calc->doubleValueNoConversionDataRequired(symbolTable);
+    return calc->doubleValue(token, symbolTable);
 }
 
 } // namespace CSS

--- a/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h
+++ b/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h
@@ -39,6 +39,7 @@ namespace WebCore {
 class CSSCalcSymbolTable;
 class CSSToLengthConversionData;
 struct ComputedStyleDependencies;
+struct NoConversionDataRequiredToken;
 
 namespace Calculation {
 enum class Category : uint8_t;
@@ -59,17 +60,18 @@ void unevaluatedCalcCollectComputedStyleDependencies(ComputedStyleDependencies&,
 
 Ref<CSSCalcValue> unevaluatedCalcSimplify(const Ref<CSSCalcValue>&, const CSSToLengthConversionData&, const CSSCalcSymbolTable&);
 
-double unevaluatedCalcEvaluate(const Ref<CSSCalcValue>&, const Style::BuilderState&, Calculation::Category);
-double unevaluatedCalcEvaluate(const Ref<CSSCalcValue>&, const Style::BuilderState&, const CSSCalcSymbolTable&, Calculation::Category);
-double unevaluatedCalcEvaluate(const Ref<CSSCalcValue>&, const CSSToLengthConversionData&, Calculation::Category);
-double unevaluatedCalcEvaluate(const Ref<CSSCalcValue>&, const CSSToLengthConversionData&, const CSSCalcSymbolTable&, Calculation::Category);
-double unevaluatedCalcEvaluateNoConversionDataRequired(const Ref<CSSCalcValue>&, Calculation::Category);
-double unevaluatedCalcEvaluateNoConversionDataRequired(const Ref<CSSCalcValue>&, const CSSCalcSymbolTable&, Calculation::Category);
+double unevaluatedCalcEvaluate(const Ref<CSSCalcValue>&, Calculation::Category, const Style::BuilderState&);
+double unevaluatedCalcEvaluate(const Ref<CSSCalcValue>&, Calculation::Category, const Style::BuilderState&, const CSSCalcSymbolTable&);
+double unevaluatedCalcEvaluate(const Ref<CSSCalcValue>&, Calculation::Category, const CSSToLengthConversionData&);
+double unevaluatedCalcEvaluate(const Ref<CSSCalcValue>&, Calculation::Category, const CSSToLengthConversionData&, const CSSCalcSymbolTable&);
+double unevaluatedCalcEvaluate(const Ref<CSSCalcValue>&, Calculation::Category, NoConversionDataRequiredToken);
+double unevaluatedCalcEvaluate(const Ref<CSSCalcValue>&, Calculation::Category, NoConversionDataRequiredToken, const CSSCalcSymbolTable&);
 
 // `UnevaluatedCalc` annotates a `CSSCalcValue` with the raw value type that it
 // will be evaluated to, allowing the processing of calc in generic code.
 template<typename T> struct UnevaluatedCalc {
     using RawType = T;
+    static constexpr auto category = T::category;
 
     UnevaluatedCalc(Ref<CSSCalcValue>&& value)
         : calc { WTFMove(value) }

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -161,12 +161,9 @@ Color BuilderState::createStyleColor(const CSSValue& value, ForVisitedLink forVi
     if (!element() || !element()->isLink())
         forVisitedLink = ForVisitedLink::No;
 
-    // FIXME: Figure out an extensible way to pass additional information, like ForVisitedLink, to toStyle() so we can use the normal override.
-    // FIXME: Alternatively, add ForVisitedLink state to BuilderState and push/pop on entry.
-
     if (RefPtr color = dynamicDowncast<CSSColorValue>(value))
-        return toStyleColor(color->color(), document(), m_style, m_cssToLengthConversionData, forVisitedLink);
-    return toStyleColor(CSS::Color { CSS::KeywordColor { value.valueID() } }, document(), m_style, m_cssToLengthConversionData, forVisitedLink);
+        return toStyle(color->color(), *this, forVisitedLink);
+    return toStyle(CSS::Color { CSS::KeywordColor { value.valueID() } }, *this, forVisitedLink);
 }
 
 void BuilderState::registerContentAttribute(const AtomString& attributeLocalName)

--- a/Source/WebCore/style/values/StyleValueTypes.h
+++ b/Source/WebCore/style/values/StyleValueTypes.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include "CSSCalcSymbolTable.h"
+#include "CSSNoConversionDataRequiredToken.h"
 #include "CSSValueTypes.h"
 #include <optional>
 #include <tuple>
@@ -87,28 +88,13 @@ template<typename> struct ToCSSMapping;
 //    };
 //
 //    template<> struct WebCore::Style::ToStyle<CSSType> {
-//        StyleType operator()(const CSSType&, const CSSToLengthConversionData&, const CSSCalcSymbolTable&);
-//        StyleType operator()(const CSSType&, const BuilderState&, const CSSCalcSymbolTable&);
-//        StyleType operator()(const CSSType&, NoConversionDataRequiredToken, const CSSCalcSymbolTable&);
+//        StyleType operator()(const CSSType&, const CSSToLengthConversionData&);
+//        StyleType operator()(const CSSType&, const BuilderState&);
+//        StyleType operator()(const CSSType&, NoConversionDataRequiredToken);
 //    };
-
-// Token passed to ToStyle to indicate that the caller has checked that no conversion data is required.
-struct NoConversionDataRequiredToken { };
 
 template<typename> struct ToCSS;
 template<typename> struct ToStyle;
-
-// Types can specialize `PrimaryCSSType` to provided a "primary" type the specialized type should be converted to before conversion to Style. For
-// instance, `CSS::NumberRaw`, would specialize this as `template<> struct ToPrimaryCSSTypeMapping<CSS::NumberRaw> { using type = CSS::Number };` to
-// allow callers to use `toStyle(...)` directly on values of type `CSS::NumberRaw`.
-template<typename CSSType> struct ToPrimaryCSSTypeMapping { using type = CSSType; };
-template<typename CSSType> using PrimaryCSSType = typename ToPrimaryCSSTypeMapping<CSSType>::type;
-
-// MARK: Utility Concepts
-
-template<typename T> concept HasIsZero = requires(T t) {
-    { t.isZero() } -> std::convertible_to<bool>;
-};
 
 // MARK: Common Types.
 
@@ -122,17 +108,17 @@ template<> inline constexpr bool TreatAsNonConverting<CustomIdentifier> = true;
 // MARK: - Conversion from "Style to "CSS"
 
 // Conversion Invoker
-template<typename StyleType> decltype(auto) toCSS(const StyleType& styleType, const RenderStyle& style)
+template<typename StyleType, typename... Rest> decltype(auto) toCSS(const StyleType& styleType, const RenderStyle& style, Rest&&... rest)
 {
-    return ToCSS<StyleType>{}(styleType, style);
+    return ToCSS<StyleType>{}(styleType, style, std::forward<Rest>(rest)...);
 }
 
 // Conversion Utility Types
 template<typename StyleType> using CSSType = std::decay_t<decltype(toCSS(std::declval<const StyleType&>(), std::declval<const RenderStyle&>()))>;
 
-template<typename To, typename From> auto toCSSOnTupleLike(const From& tupleLike, const RenderStyle& style) -> To
+template<typename To, typename From, typename... Rest> auto toCSSOnTupleLike(const From& tupleLike, Rest&&... rest) -> To
 {
-    return WTF::apply([&](const auto& ...x) { return To { toCSS(x, style)... }; }, tupleLike);
+    return WTF::apply([&](const auto& ...x) { return To { toCSS(x, rest...)... }; }, tupleLike);
 }
 
 // Standard Optional-Like type mappings:
@@ -221,48 +207,39 @@ template<typename StyleType, size_t inlineCapacity> struct ToCSS<CommaSeparatedV
 // MARK: - Conversion from "CSS" to "Style"
 
 // Conversion Invokers
-template<typename CSSType> decltype(auto) toStyle(const CSSType& cssType, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable)
+template<typename CSSType, typename... Rest> decltype(auto) toStyle(const CSSType& cssType, const CSSToLengthConversionData& conversionData, Rest&&... rest)
 {
-    return ToStyle<PrimaryCSSType<CSSType>>{}(cssType, conversionData, symbolTable);
+    return ToStyle<CSSType>{}(cssType, conversionData, std::forward<Rest>(rest)...);
 }
 
-template<typename CSSType> decltype(auto) toStyle(const CSSType& cssType, const CSSToLengthConversionData& conversionData)
+template<typename CSSType, typename... Rest> decltype(auto) toStyle(const CSSType& cssType, const BuilderState& builderState, Rest&&... rest)
 {
-    return ToStyle<PrimaryCSSType<CSSType>>{}(cssType, conversionData, CSSCalcSymbolTable { });
+    return ToStyle<CSSType>{}(cssType, builderState, std::forward<Rest>(rest)...);
 }
 
-template<typename CSSType> decltype(auto) toStyle(const CSSType& cssType, const BuilderState& builderState, const CSSCalcSymbolTable& symbolTable)
+template<typename CSSType, typename... Rest> decltype(auto) toStyle(const CSSType& cssType, NoConversionDataRequiredToken token, Rest&&... rest)
 {
-    return ToStyle<PrimaryCSSType<CSSType>>{}(cssType, builderState, symbolTable);
+    return ToStyle<CSSType>{}(cssType, token, std::forward<Rest>(rest)...);
 }
 
-template<typename CSSType> decltype(auto) toStyle(const CSSType& cssType, const BuilderState& builderState)
+// Convenience invoker that adds a `NoConversionDataRequiredToken` argument.
+template<typename CSSType, typename... Rest> decltype(auto) toStyleNoConversionDataRequired(const CSSType& cssType, Rest&&... rest)
 {
-    return ToStyle<PrimaryCSSType<CSSType>>{}(cssType, builderState, CSSCalcSymbolTable { });
+    return toStyle(cssType, NoConversionDataRequiredToken { }, std::forward<Rest>(rest)...);
 }
 
-template<typename CSSType> decltype(auto) toStyleNoConversionDataRequired(const CSSType& cssType, const CSSCalcSymbolTable& symbolTable)
+template<typename To, typename From, typename... Rest> auto toStyleOnTupleLike(const From& tupleLike, Rest&&... rest) -> To
 {
-    return ToStyle<PrimaryCSSType<CSSType>>{}(cssType, NoConversionDataRequiredToken { }, symbolTable);
+    return WTF::apply([&](const auto& ...x) { return To { toStyle(x, rest...)... }; }, tupleLike);
 }
 
-template<typename CSSType> decltype(auto) toStyleNoConversionDataRequired(const CSSType& cssType)
+template<typename To, typename From, typename... Rest> auto toStyleNoConversionDataRequiredOnTupleLike(const From& tupleLike, Rest&&... rest) -> To
 {
-    return ToStyle<PrimaryCSSType<CSSType>>{}(cssType, NoConversionDataRequiredToken { }, CSSCalcSymbolTable { });
-}
-
-template<typename To, typename From, typename... Args> auto toStyleOnTupleLike(const From& tupleLike, Args&&... args) -> To
-{
-    return WTF::apply([&](const auto& ...x) { return To { toStyle(x, args...)... }; }, tupleLike);
-}
-
-template<typename To, typename From, typename... Args> auto toStyleNoConversionDataRequiredOnTupleLike(const From& tupleLike, Args&&... args) -> To
-{
-    return WTF::apply([&](const auto& ...x) { return To { toStyleNoConversionDataRequired(x, args...)... }; }, tupleLike);
+    return WTF::apply([&](const auto& ...x) { return To { toStyleNoConversionDataRequired(x, rest...)... }; }, tupleLike);
 }
 
 // Conversion Utility Types
-template<typename CSSType> using StyleType = std::decay_t<decltype(toStyle(std::declval<const CSSType&>(), std::declval<const BuilderState&>(), std::declval<const CSSCalcSymbolTable&>()))>;
+template<typename CSSType> using StyleType = std::decay_t<decltype(toStyle(std::declval<const CSSType&>(), std::declval<const BuilderState&>()))>;
 
 // Standard Optional-Like type mappings:
 template<typename T> struct ToStyleMapping<std::optional<T>> { using type = std::optional<StyleType<T>>; };
@@ -289,15 +266,7 @@ template<typename... Ts> struct ToStyleMapping<std::variant<Ts...>> { using type
 
 // Constrained for `TreatAsNonConverting`.
 template<typename CSSType> requires (TreatAsNonConverting<CSSType>) struct ToStyle<CSSType> {
-    constexpr CSSType operator()(const CSSType& value, const CSSToLengthConversionData&, const CSSCalcSymbolTable&)
-    {
-        return value;
-    }
-    constexpr CSSType operator()(const CSSType& value, const BuilderState&, const CSSCalcSymbolTable&)
-    {
-        return value;
-    }
-    constexpr CSSType operator()(const CSSType& value, NoConversionDataRequiredToken, const CSSCalcSymbolTable&)
+    template<typename... Rest> constexpr CSSType operator()(const CSSType& value, Rest&&...)
     {
         return value;
     }
@@ -307,22 +276,10 @@ template<typename CSSType> requires (TreatAsNonConverting<CSSType>) struct ToSty
 template<typename CSSType> requires (TreatAsOptionalLike<CSSType>) struct ToStyle<CSSType> {
     using Result = typename ToStyleMapping<CSSType>::type;
 
-    Result operator()(const CSSType& value, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable)
+    template<typename... Rest> Result operator()(const CSSType& value, Rest&&... rest)
     {
         if (value)
-            return toStyle(*value, conversionData, symbolTable);
-        return std::nullopt;
-    }
-    Result operator()(const CSSType& value, const BuilderState& builderState, const CSSCalcSymbolTable& symbolTable)
-    {
-        if (value)
-            return toStyle(*value, builderState, symbolTable);
-        return std::nullopt;
-    }
-    Result operator()(const CSSType& value, NoConversionDataRequiredToken, const CSSCalcSymbolTable& symbolTable)
-    {
-        if (value)
-            return toStyleNoConversionDataRequired(*value, symbolTable);
+            return toStyle(*value, std::forward<Rest>(rest)...);
         return std::nullopt;
     }
 };
@@ -331,17 +288,9 @@ template<typename CSSType> requires (TreatAsOptionalLike<CSSType>) struct ToStyl
 template<typename CSSType> requires (TreatAsTupleLike<CSSType>) struct ToStyle<CSSType> {
     using Result = typename ToStyleMapping<CSSType>::type;
 
-    Result operator()(const CSSType& value, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable)
+    template<typename... Rest> Result operator()(const CSSType& value, Rest&&... rest)
     {
-        return toStyleOnTupleLike<Result>(value, conversionData, symbolTable);
-    }
-    Result operator()(const CSSType& value, const BuilderState& builderState, const CSSCalcSymbolTable& symbolTable)
-    {
-        return toStyleOnTupleLike<Result>(value, builderState, symbolTable);
-    }
-    Result operator()(const CSSType& value, NoConversionDataRequiredToken, const CSSCalcSymbolTable& symbolTable)
-    {
-        return toStyleNoConversionDataRequiredOnTupleLike<Result>(value, symbolTable);
+        return toStyleOnTupleLike<Result>(value, std::forward<Rest>(rest)...);
     }
 };
 
@@ -349,17 +298,9 @@ template<typename CSSType> requires (TreatAsTupleLike<CSSType>) struct ToStyle<C
 template<typename CSSType> requires (TreatAsVariantLike<CSSType>) struct ToStyle<CSSType> {
     using Result = typename ToStyleMapping<CSSType>::type;
 
-    Result operator()(const CSSType& value, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable)
+    template<typename... Rest> Result operator()(const CSSType& value, Rest&&... rest)
     {
-        return WTF::switchOn(value, [&](const auto& alternative) { return Result { toStyle(alternative, conversionData, symbolTable) }; });
-    }
-    Result operator()(const CSSType& value, const BuilderState& builderState, const CSSCalcSymbolTable& symbolTable)
-    {
-        return WTF::switchOn(value, [&](const auto& alternative) { return Result { toStyle(alternative, builderState, symbolTable) }; });
-    }
-    Result operator()(const CSSType& value, NoConversionDataRequiredToken, const CSSCalcSymbolTable& symbolTable)
-    {
-        return WTF::switchOn(value, [&](const auto& alternative) { return Result { toStyleNoConversionDataRequired(alternative, symbolTable) }; });
+        return WTF::switchOn(value, [&](const auto& alternative) { return Result { toStyle(alternative, std::forward<Rest>(rest)...) }; });
     }
 };
 
@@ -367,17 +308,9 @@ template<typename CSSType> requires (TreatAsVariantLike<CSSType>) struct ToStyle
 template<typename CSSType, size_t inlineCapacity> struct ToStyle<SpaceSeparatedVector<CSSType, inlineCapacity>> {
     using Result = SpaceSeparatedVector<StyleType<CSSType>, inlineCapacity>;
 
-    Result operator()(const SpaceSeparatedVector<CSSType, inlineCapacity>& value, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable)
+    template<typename... Rest> Result operator()(const SpaceSeparatedVector<CSSType, inlineCapacity>& value, Rest&&... rest)
     {
-        return Result { value.value.template map<typename Result::Vector>([&](const auto& x) { return toStyle(x, conversionData, symbolTable); }) };
-    }
-    Result operator()(const SpaceSeparatedVector<CSSType, inlineCapacity>& value, const BuilderState& builderState, const CSSCalcSymbolTable& symbolTable)
-    {
-        return Result { value.value.template map<typename Result::Vector>([&](const auto& x) { return toStyle(x, builderState, symbolTable); }) };
-    }
-    Result operator()(const SpaceSeparatedVector<CSSType, inlineCapacity>& value, NoConversionDataRequiredToken, const CSSCalcSymbolTable& symbolTable)
-    {
-        return Result { value.value.template map<typename Result::Vector>([&](const auto& x) { return toStyleNoConversionDataRequired(x, symbolTable); }) };
+        return Result { value.value.template map<typename Result::Vector>([&](const auto& x) { return toStyle(x, rest...); }) };
     }
 };
 
@@ -385,17 +318,9 @@ template<typename CSSType, size_t inlineCapacity> struct ToStyle<SpaceSeparatedV
 template<typename CSSType, size_t inlineCapacity> struct ToStyle<CommaSeparatedVector<CSSType, inlineCapacity>> {
     using Result = CommaSeparatedVector<StyleType<CSSType>, inlineCapacity>;
 
-    Result operator()(const CommaSeparatedVector<CSSType, inlineCapacity>& value, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable)
+    template<typename... Rest> Result operator()(const CommaSeparatedVector<CSSType, inlineCapacity>& value, Rest&&... rest)
     {
-        return Result { value.value.template map<typename Result::Vector>([&](const auto& x) { return toStyle(x, conversionData, symbolTable); }) };
-    }
-    Result operator()(const CommaSeparatedVector<CSSType, inlineCapacity>& value, const BuilderState& builderState, const CSSCalcSymbolTable& symbolTable)
-    {
-        return Result { value.value.template map<typename Result::Vector>([&](const auto& x) { return toStyle(x, builderState, symbolTable); }) };
-    }
-    Result operator()(const CommaSeparatedVector<CSSType, inlineCapacity>& value, NoConversionDataRequiredToken, const CSSCalcSymbolTable& symbolTable)
-    {
-        return Result { value.value.template map<typename Result::Vector>([&](const auto& x) { return toStyleNoConversionDataRequired(x, symbolTable); }) };
+        return Result { value.value.template map<typename Result::Vector>([&](const auto& x) { return toStyle(x, rest...); }) };
     }
 };
 

--- a/Source/WebCore/style/values/backgrounds/StyleBorderRadius.cpp
+++ b/Source/WebCore/style/values/backgrounds/StyleBorderRadius.cpp
@@ -49,13 +49,13 @@ auto ToCSS<BorderRadius>::operator()(const BorderRadius& value, const RenderStyl
     };
 }
 
-auto ToStyle<CSS::BorderRadius>::operator()(const CSS::BorderRadius& value, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> BorderRadius
+auto ToStyle<CSS::BorderRadius>::operator()(const CSS::BorderRadius& value, const BuilderState& state) -> BorderRadius
 {
     return {
-        .topLeft { toStyle(value.topLeft(), state, symbolTable) },
-        .topRight { toStyle(value.topRight(), state, symbolTable) },
-        .bottomRight { toStyle(value.bottomRight(), state, symbolTable) },
-        .bottomLeft { toStyle(value.bottomLeft(), state, symbolTable) },
+        .topLeft { toStyle(value.topLeft(), state) },
+        .topRight { toStyle(value.topRight(), state) },
+        .bottomRight { toStyle(value.bottomRight(), state) },
+        .bottomLeft { toStyle(value.bottomLeft(), state) },
     };
 }
 

--- a/Source/WebCore/style/values/backgrounds/StyleBorderRadius.h
+++ b/Source/WebCore/style/values/backgrounds/StyleBorderRadius.h
@@ -57,7 +57,7 @@ template<size_t I> const auto& get(const BorderRadius& value)
 }
 
 template<> struct ToCSS<BorderRadius> { auto operator()(const BorderRadius&, const RenderStyle&) -> CSS::BorderRadius; };
-template<> struct ToStyle<CSS::BorderRadius> { auto operator()(const CSS::BorderRadius&, const BuilderState&, const CSSCalcSymbolTable&) -> BorderRadius; };
+template<> struct ToStyle<CSS::BorderRadius> { auto operator()(const CSS::BorderRadius&, const BuilderState&) -> BorderRadius; };
 
 FloatRoundedRect::Radii evaluate(const BorderRadius&, FloatSize referenceBox);
 

--- a/Source/WebCore/style/values/backgrounds/StyleBoxShadow.cpp
+++ b/Source/WebCore/style/values/backgrounds/StyleBoxShadow.cpp
@@ -48,14 +48,14 @@ auto ToCSS<BoxShadow>::operator()(const BoxShadow& value, const RenderStyle& sty
     };
 }
 
-auto ToStyle<CSS::BoxShadow>::operator()(const CSS::BoxShadow& value, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> BoxShadow
+auto ToStyle<CSS::BoxShadow>::operator()(const CSS::BoxShadow& value, const BuilderState& state) -> BoxShadow
 {
     return {
-        .color = value.color ? toStyle(*value.color, state, symbolTable) : Color::currentColor(),
-        .location = toStyle(value.location, state, symbolTable),
-        .blur = value.blur ? toStyle(*value.blur, state, symbolTable) : Length<CSS::Nonnegative> { 0 },
-        .spread = value.spread ? toStyle(*value.spread, state, symbolTable) : Length<> { 0 },
-        .inset = toStyle(value.inset, state, symbolTable),
+        .color = value.color ? toStyle(*value.color, state) : Color::currentColor(),
+        .location = toStyle(value.location, state),
+        .blur = value.blur ? toStyle(*value.blur, state) : Length<CSS::Nonnegative> { 0 },
+        .spread = value.spread ? toStyle(*value.spread, state) : Length<> { 0 },
+        .inset = toStyle(value.inset, state),
         .isWebkitBoxShadow = value.isWebkitBoxShadow,
     };
 }

--- a/Source/WebCore/style/values/backgrounds/StyleBoxShadow.h
+++ b/Source/WebCore/style/values/backgrounds/StyleBoxShadow.h
@@ -57,7 +57,7 @@ template<size_t I> const auto& get(const BoxShadow& value)
 }
 
 template<> struct ToCSS<BoxShadow> { auto operator()(const BoxShadow&, const RenderStyle&) -> CSS::BoxShadow; };
-template<> struct ToStyle<CSS::BoxShadow> { auto operator()(const CSS::BoxShadow&, const BuilderState&, const CSSCalcSymbolTable&) -> BoxShadow; };
+template<> struct ToStyle<CSS::BoxShadow> { auto operator()(const CSS::BoxShadow&, const BuilderState&) -> BoxShadow; };
 
 template<> struct Blending<BoxShadow> {
     auto canBlend(const BoxShadow&, const BoxShadow&, const RenderStyle&, const RenderStyle&) -> bool;

--- a/Source/WebCore/style/values/color/StyleColor.cpp
+++ b/Source/WebCore/style/values/color/StyleColor.cpp
@@ -357,14 +357,14 @@ auto ToCSS<Color>::operator()(const Color& value, const RenderStyle& style) -> C
     return CSS::Color { CSS::ResolvedColor { style.colorResolvingCurrentColor(value) } };
 }
 
-auto ToStyle<CSS::Color>::operator()(const CSS::Color& value, const BuilderState& builderState, const CSSCalcSymbolTable&, ForVisitedLink forVisitedLink) -> Color
+auto ToStyle<CSS::Color>::operator()(const CSS::Color& value, const BuilderState& builderState, ForVisitedLink forVisitedLink) -> Color
 {
     return toStyleColor(value, builderState.document(), builderState.style(), builderState.cssToLengthConversionData(), forVisitedLink);
 }
 
-auto ToStyle<CSS::Color>::operator()(const CSS::Color& value, const BuilderState& builderState, const CSSCalcSymbolTable& symbolTable) -> Color
+auto ToStyle<CSS::Color>::operator()(const CSS::Color& value, const BuilderState& builderState) -> Color
 {
-    return (*this)(value, builderState, symbolTable, ForVisitedLink::No);
+    return toStyle(value, builderState, ForVisitedLink::No);
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/color/StyleColor.h
+++ b/Source/WebCore/style/values/color/StyleColor.h
@@ -182,8 +182,8 @@ template<> struct ToCSS<Color> {
     auto operator()(const Color&, const RenderStyle&) -> CSS::Color;
 };
 template<> struct ToStyle<CSS::Color> {
-    auto operator()(const CSS::Color&, const BuilderState&, const CSSCalcSymbolTable&, ForVisitedLink) -> Color;
-    auto operator()(const CSS::Color&, const BuilderState&, const CSSCalcSymbolTable&) -> Color;
+    auto operator()(const CSS::Color&, const BuilderState&, ForVisitedLink) -> Color;
+    auto operator()(const CSS::Color&, const BuilderState&) -> Color;
 };
 
 template<typename... F> decltype(auto) Color::switchOn(F&&... f) const

--- a/Source/WebCore/style/values/images/StyleGradient.cpp
+++ b/Source/WebCore/style/values/images/StyleGradient.cpp
@@ -84,27 +84,27 @@ auto ToCSS<GradientDeprecatedColorStop>::operator()(const GradientDeprecatedColo
 
 // MARK: - Conversion: CSS -> Style
 
-template<typename T> decltype(auto) toStyleColorStop(const T& stop, const BuilderState& state, const CSSCalcSymbolTable& symbolTable)
+template<typename T> decltype(auto) toStyleColorStop(const T& stop, const BuilderState& state)
 {
     return GradientColorStop {
-        toStyle(stop.color, state, symbolTable),
-        toStyle(stop.position, state, symbolTable)
+        toStyle(stop.color, state),
+        toStyle(stop.position, state)
     };
 }
 
-auto ToStyle<CSS::GradientAngularColorStop>::operator()(const CSS::GradientAngularColorStop& stop, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> GradientAngularColorStop
+auto ToStyle<CSS::GradientAngularColorStop>::operator()(const CSS::GradientAngularColorStop& stop, const BuilderState& state) -> GradientAngularColorStop
 {
-    return toStyleColorStop(stop, state, symbolTable);
+    return toStyleColorStop(stop, state);
 }
 
-auto ToStyle<CSS::GradientLinearColorStop>::operator()(const CSS::GradientLinearColorStop& stop, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> GradientLinearColorStop
+auto ToStyle<CSS::GradientLinearColorStop>::operator()(const CSS::GradientLinearColorStop& stop, const BuilderState& state) -> GradientLinearColorStop
 {
-    return toStyleColorStop(stop, state, symbolTable);
+    return toStyleColorStop(stop, state);
 }
 
-auto ToStyle<CSS::GradientDeprecatedColorStop>::operator()(const CSS::GradientDeprecatedColorStop& stop, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> GradientDeprecatedColorStop
+auto ToStyle<CSS::GradientDeprecatedColorStop>::operator()(const CSS::GradientDeprecatedColorStop& stop, const BuilderState& state) -> GradientDeprecatedColorStop
 {
-    return toStyleColorStop(stop, state, symbolTable);
+    return toStyleColorStop(stop, state);
 }
 
 // MARK: - Platform Gradient Resolution

--- a/Source/WebCore/style/values/images/StyleGradient.h
+++ b/Source/WebCore/style/values/images/StyleGradient.h
@@ -97,9 +97,9 @@ template<> struct ToCSS<GradientAngularColorStop> { auto operator()(const Gradie
 template<> struct ToCSS<GradientLinearColorStop> { auto operator()(const GradientLinearColorStop&, const RenderStyle&) -> CSS::GradientLinearColorStop; };
 template<> struct ToCSS<GradientDeprecatedColorStop> { auto operator()(const GradientDeprecatedColorStop&, const RenderStyle&) -> CSS::GradientDeprecatedColorStop; };
 
-template<> struct ToStyle<CSS::GradientAngularColorStop> { auto operator()(const CSS::GradientAngularColorStop&, const BuilderState&, const CSSCalcSymbolTable&) -> GradientAngularColorStop; };
-template<> struct ToStyle<CSS::GradientLinearColorStop> { auto operator()(const CSS::GradientLinearColorStop&, const BuilderState&, const CSSCalcSymbolTable&) -> GradientLinearColorStop; };
-template<> struct ToStyle<CSS::GradientDeprecatedColorStop> { auto operator()(const CSS::GradientDeprecatedColorStop&, const BuilderState&, const CSSCalcSymbolTable&) -> GradientDeprecatedColorStop; };
+template<> struct ToStyle<CSS::GradientAngularColorStop> { auto operator()(const CSS::GradientAngularColorStop&, const BuilderState&) -> GradientAngularColorStop; };
+template<> struct ToStyle<CSS::GradientLinearColorStop> { auto operator()(const CSS::GradientLinearColorStop&, const BuilderState&) -> GradientLinearColorStop; };
+template<> struct ToStyle<CSS::GradientDeprecatedColorStop> { auto operator()(const CSS::GradientDeprecatedColorStop&, const BuilderState&) -> GradientDeprecatedColorStop; };
 
 // MARK: - LinearGradient
 

--- a/Source/WebCore/style/values/primitives/StyleNone.h
+++ b/Source/WebCore/style/values/primitives/StyleNone.h
@@ -37,16 +37,14 @@ struct None {
     constexpr bool operator==(const None&) const = default;
 };
 
-template<> struct ToPrimaryCSSTypeMapping<CSS::NoneRaw> { using type = CSS::None; };
-
 template<> struct ToCSSMapping<None> { using type = CSS::None; };
-template<> struct ToCSS<None> { constexpr auto operator()(const None&, const RenderStyle&) -> CSS::None { return { }; } };
+template<> struct ToCSS<None> {
+    template<typename... Rest> constexpr auto operator()(const None&, Rest&&...) -> CSS::None { return { }; }
+};
 
 template<> struct ToStyleMapping<CSS::None> { using type = None; };
 template<> struct ToStyle<CSS::None> {
-    auto operator()(const CSS::None&, const CSSToLengthConversionData&, const CSSCalcSymbolTable&) -> None { return { }; }
-    auto operator()(const CSS::None&, const BuilderState&, const CSSCalcSymbolTable&) -> None { return { }; }
-    auto operator()(const CSS::None&, NoConversionDataRequiredToken, const CSSCalcSymbolTable&) -> None { return { }; }
+    template<typename... Rest> constexpr auto operator()(const CSS::None&, Rest&&...) -> None { return { }; }
 };
 
 template<> struct Blending<None> {

--- a/Source/WebCore/style/values/primitives/StylePosition.cpp
+++ b/Source/WebCore/style/values/primitives/StylePosition.cpp
@@ -34,7 +34,7 @@
 namespace WebCore {
 namespace Style {
 
-auto ToStyle<CSS::TwoComponentPositionHorizontal>::operator()(const CSS::TwoComponentPositionHorizontal& value, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> TwoComponentPositionHorizontal
+auto ToStyle<CSS::TwoComponentPositionHorizontal>::operator()(const CSS::TwoComponentPositionHorizontal& value, const BuilderState& state) -> TwoComponentPositionHorizontal
 {
     return WTF::switchOn(value.offset,
         [&](CSS::Keyword::Left) {
@@ -47,12 +47,12 @@ auto ToStyle<CSS::TwoComponentPositionHorizontal>::operator()(const CSS::TwoComp
             return TwoComponentPositionHorizontal { .offset = LengthPercentage<> { Percentage<> { 50 } } };
         },
         [&](const CSS::LengthPercentage<>& value) {
-            return TwoComponentPositionHorizontal { .offset = toStyle(value, state, symbolTable) };
+            return TwoComponentPositionHorizontal { .offset = toStyle(value, state) };
         }
     );
 }
 
-auto ToStyle<CSS::TwoComponentPositionVertical>::operator()(const CSS::TwoComponentPositionVertical& value, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> TwoComponentPositionVertical
+auto ToStyle<CSS::TwoComponentPositionVertical>::operator()(const CSS::TwoComponentPositionVertical& value, const BuilderState& state) -> TwoComponentPositionVertical
 {
     return WTF::switchOn(value.offset,
         [&](CSS::Keyword::Top) {
@@ -65,7 +65,7 @@ auto ToStyle<CSS::TwoComponentPositionVertical>::operator()(const CSS::TwoCompon
             return TwoComponentPositionVertical { .offset = LengthPercentage<> { Percentage<> { 50 } } };
         },
         [&](const CSS::LengthPercentage<>& value) {
-            return TwoComponentPositionVertical { .offset = toStyle(value, state, symbolTable) };
+            return TwoComponentPositionVertical { .offset = toStyle(value, state) };
         }
     );
 }
@@ -75,30 +75,30 @@ auto ToCSS<Position>::operator()(const Position& value, const RenderStyle& style
     return CSS::TwoComponentPosition { { toCSS(value.x(), style) }, { toCSS(value.y(), style) } };
 }
 
-auto ToStyle<CSS::Position>::operator()(const CSS::Position& position, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> Position
+auto ToStyle<CSS::Position>::operator()(const CSS::Position& position, const BuilderState& state) -> Position
 {
     return WTF::switchOn(position,
         [&](const CSS::TwoComponentPosition& twoComponent) {
             return Position {
-                toStyle(get<0>(twoComponent), state, symbolTable),
-                toStyle(get<1>(twoComponent), state, symbolTable)
+                toStyle(get<0>(twoComponent), state),
+                toStyle(get<1>(twoComponent), state)
             };
         },
         [&](const CSS::FourComponentPosition& fourComponent) {
             auto horizontal = WTF::switchOn(get<0>(get<0>(fourComponent)),
                 [&](CSS::Keyword::Left) {
-                    return toStyle(get<1>(get<0>(fourComponent)), state, symbolTable);
+                    return toStyle(get<1>(get<0>(fourComponent)), state);
                 },
                 [&](CSS::Keyword::Right) {
-                    return reflect(toStyle(get<1>(get<0>(fourComponent)), state, symbolTable));
+                    return reflect(toStyle(get<1>(get<0>(fourComponent)), state));
                 }
             );
             auto vertical = WTF::switchOn(get<0>(get<1>(fourComponent)),
                 [&](CSS::Keyword::Top) {
-                    return toStyle(get<1>(get<1>(fourComponent)), state, symbolTable);
+                    return toStyle(get<1>(get<1>(fourComponent)), state);
                 },
                 [&](CSS::Keyword::Bottom) {
-                    return reflect(toStyle(get<1>(get<1>(fourComponent)), state, symbolTable));
+                    return reflect(toStyle(get<1>(get<1>(fourComponent)), state));
                 }
             );
             return Position { WTFMove(horizontal), WTFMove(vertical) };

--- a/Source/WebCore/style/values/primitives/StylePosition.h
+++ b/Source/WebCore/style/values/primitives/StylePosition.h
@@ -82,13 +82,13 @@ template<size_t I> const auto& get(const Position& position)
 
 // Specialization is needed for ToStyle to implement resolution of keyword value to <length-percentage>.
 template<> struct ToCSSMapping<TwoComponentPositionHorizontal> { using type = CSS::TwoComponentPositionHorizontal; };
-template<> struct ToStyle<CSS::TwoComponentPositionHorizontal> { auto operator()(const CSS::TwoComponentPositionHorizontal&, const BuilderState&, const CSSCalcSymbolTable&) -> TwoComponentPositionHorizontal; };
+template<> struct ToStyle<CSS::TwoComponentPositionHorizontal> { auto operator()(const CSS::TwoComponentPositionHorizontal&, const BuilderState&) -> TwoComponentPositionHorizontal; };
 template<> struct ToCSSMapping<TwoComponentPositionVertical> { using type = CSS::TwoComponentPositionVertical; };
-template<> struct ToStyle<CSS::TwoComponentPositionVertical> { auto operator()(const CSS::TwoComponentPositionVertical&, const BuilderState&, const CSSCalcSymbolTable&) -> TwoComponentPositionVertical; };
+template<> struct ToStyle<CSS::TwoComponentPositionVertical> { auto operator()(const CSS::TwoComponentPositionVertical&, const BuilderState&) -> TwoComponentPositionVertical; };
 
 // Specialization is needed for both ToCSS and ToStyle due to differences in type structure.
 template<> struct ToCSS<Position> { auto operator()(const Position&, const RenderStyle&) -> CSS::Position; };
-template<> struct ToStyle<CSS::Position> { auto operator()(const CSS::Position&, const BuilderState&, const CSSCalcSymbolTable&) -> Position; };
+template<> struct ToStyle<CSS::Position> { auto operator()(const CSS::Position&, const BuilderState&) -> Position; };
 
 // MARK: - Evaluation
 

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes.h
@@ -638,6 +638,7 @@ private:
     std::variant<EmptyToken, Number<nR>, Percentage<pR>> value;
 };
 
+
 template<CSS::Range nR = CSS::All, CSS::Range pR = nR> struct NumberOrPercentageResolvedToNumber {
     Number<nR> value { 0 };
 
@@ -702,9 +703,15 @@ template<auto R> struct ToStyleMapping<CSS::Flex<R>>                   { using t
 template<auto R> struct ToStyleMapping<CSS::AnglePercentage<R>>        { using type = AnglePercentage<R>; };
 template<auto R> struct ToStyleMapping<CSS::LengthPercentage<R>>       { using type = LengthPercentage<R>; };
 
+template<auto nR, auto pR> struct ToStyleMapping<CSS::NumberOrPercentage<nR, pR>>                 { using type = NumberOrPercentage<nR, pR>; };
+template<auto nR, auto pR> struct ToStyleMapping<CSS::NumberOrPercentageResolvedToNumber<nR, pR>> { using type = NumberOrPercentageResolvedToNumber<nR, pR>; };
+
 // MARK: Style type mapping -> CSS type mappings
 
 template<StyleNumeric T> struct ToCSSMapping<T>                        { using type = typename T::CSS; };
+
+template<auto nR, auto pR> struct ToCSSMapping<NumberOrPercentage<nR, pR>>                 { using type = CSS::NumberOrPercentage<nR, pR>; };
+template<auto nR, auto pR> struct ToCSSMapping<NumberOrPercentageResolvedToNumber<nR, pR>> { using type = CSS::NumberOrPercentageResolvedToNumber<nR, pR>; };
 
 } // namespace Style
 

--- a/Source/WebCore/style/values/shapes/StyleBasicShape.cpp
+++ b/Source/WebCore/style/values/shapes/StyleBasicShape.cpp
@@ -38,9 +38,9 @@ auto ToCSS<BasicShape>::operator()(const BasicShape& value, const RenderStyle& s
     return WTF::switchOn(value, [&](const auto& alternative) { return CSS::BasicShape { toCSS(alternative, style) }; });
 }
 
-auto ToStyle<CSS::BasicShape>::operator()(const CSS::BasicShape& value, const BuilderState& builderState, const CSSCalcSymbolTable& symbolTable) -> BasicShape
+auto ToStyle<CSS::BasicShape>::operator()(const CSS::BasicShape& value, const BuilderState& builderState) -> BasicShape
 {
-    return WTF::switchOn(value, [&](const auto& alternative) { return BasicShape { toStyle(alternative, builderState, symbolTable) }; });
+    return WTF::switchOn(value, [&](const auto& alternative) { return BasicShape { toStyle(alternative, builderState) }; });
 }
 
 // MARK: - Blending

--- a/Source/WebCore/style/values/shapes/StyleBasicShape.h
+++ b/Source/WebCore/style/values/shapes/StyleBasicShape.h
@@ -55,7 +55,7 @@ template<typename T> concept ShapeWithCenterCoordinate = std::same_as<T, CircleF
 // MARK: - Conversion
 
 template<> struct ToCSS<BasicShape> { auto operator()(const BasicShape&, const RenderStyle&) -> CSS::BasicShape; };
-template<> struct ToStyle<CSS::BasicShape> { auto operator()(const CSS::BasicShape&, const BuilderState&, const CSSCalcSymbolTable&) -> BasicShape; };
+template<> struct ToStyle<CSS::BasicShape> { auto operator()(const CSS::BasicShape&, const BuilderState&) -> BasicShape; };
 
 // MARK: - Blending
 

--- a/Source/WebCore/style/values/shapes/StylePathFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StylePathFunction.cpp
@@ -99,7 +99,7 @@ auto ToCSS<Path::Data>::operator()(const Path::Data& value, const RenderStyle&) 
     return { copySVGPathByteStream(value.byteStream, PathConversion::None) };
 }
 
-auto ToStyle<CSS::Path::Data>::operator()(const CSS::Path::Data& value, const BuilderState&, const CSSCalcSymbolTable&) -> Path::Data
+auto ToStyle<CSS::Path::Data>::operator()(const CSS::Path::Data& value, const BuilderState&) -> Path::Data
 {
     return { copySVGPathByteStream(value.byteStream, PathConversion::None) };
 }
@@ -112,11 +112,11 @@ auto ToCSS<Path>::operator()(const Path& value, const RenderStyle& style) -> CSS
     };
 }
 
-auto ToStyle<CSS::Path>::operator()(const CSS::Path& value, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> Path
+auto ToStyle<CSS::Path>::operator()(const CSS::Path& value, const BuilderState& state) -> Path
 {
     return {
-        .fillRule = toStyle(value.fillRule, state, symbolTable),
-        .data = toStyle(value.data, state, symbolTable),
+        .fillRule = toStyle(value.fillRule, state),
+        .data = toStyle(value.data, state),
         .zoom = 1
     };
 }

--- a/Source/WebCore/style/values/shapes/StylePathFunction.h
+++ b/Source/WebCore/style/values/shapes/StylePathFunction.h
@@ -62,10 +62,10 @@ template<size_t I> const auto& get(const Path& value)
 }
 
 template<> struct ToCSS<Path> { auto operator()(const Path&, const RenderStyle&) -> CSS::Path; };
-template<> struct ToStyle<CSS::Path> { auto operator()(const CSS::Path&, const BuilderState&, const CSSCalcSymbolTable&) -> Path; };
+template<> struct ToStyle<CSS::Path> { auto operator()(const CSS::Path&, const BuilderState&) -> Path; };
 
 template<> struct ToCSS<Path::Data> { auto operator()(const Path::Data&, const RenderStyle&) -> CSS::Path::Data; };
-template<> struct ToStyle<CSS::Path::Data> { auto operator()(const CSS::Path::Data&, const BuilderState&, const CSSCalcSymbolTable&) -> Path::Data; };
+template<> struct ToStyle<CSS::Path::Data> { auto operator()(const CSS::Path::Data&, const BuilderState&) -> Path::Data; };
 
 // Non-standard parameters, `conversion` and `zoom`, are needed in some instances of Style <-> CSS conversions
 // for Path, so additional "override" conversion operators are provided here.

--- a/Source/WebCore/style/values/shapes/StyleRectFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleRectFunction.cpp
@@ -33,7 +33,7 @@ namespace Style {
 
 // MARK: - Conversion
 
-auto ToStyle<CSS::Rect>::operator()(const CSS::Rect& value, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> Inset
+auto ToStyle<CSS::Rect>::operator()(const CSS::Rect& value, const BuilderState& state) -> Inset
 {
     // "An auto value makes the edge of the box coincide with the corresponding edge of the
     //  reference box: it’s equivalent to 0% as the first (top) or fourth (left) value, and
@@ -46,7 +46,7 @@ auto ToStyle<CSS::Rect>::operator()(const CSS::Rect& value, const BuilderState& 
     auto convertLeadingEdge = [&](const std::variant<CSS::LengthPercentage<>, CSS::Keyword::Auto>& edge) -> LengthPercentage<> {
         return WTF::switchOn(edge,
             [&](const CSS::LengthPercentage<>& value) -> LengthPercentage<> {
-                return toStyle(value, state, symbolTable);
+                return toStyle(value, state);
             },
             [&](const CSS::Keyword::Auto&) -> LengthPercentage<> {
                 return { Percentage<> { 0 } };
@@ -57,7 +57,7 @@ auto ToStyle<CSS::Rect>::operator()(const CSS::Rect& value, const BuilderState& 
     auto convertTrailingEdge = [&](const std::variant<CSS::LengthPercentage<>, CSS::Keyword::Auto>& edge) -> LengthPercentage<> {
         return WTF::switchOn(edge,
             [&](const CSS::LengthPercentage<>& value) -> LengthPercentage<> {
-                return reflect(toStyle(value, state, symbolTable));
+                return reflect(toStyle(value, state));
             },
             [&](const CSS::Keyword::Auto&) -> LengthPercentage<> {
                 return { Percentage<> { 0 } };
@@ -72,13 +72,13 @@ auto ToStyle<CSS::Rect>::operator()(const CSS::Rect& value, const BuilderState& 
             convertTrailingEdge(value.edges.bottom()),
             convertLeadingEdge(value.edges.left()),
         },
-        .radii = toStyle(value.radii, state, symbolTable)
+        .radii = toStyle(value.radii, state)
     };
 }
 
-auto ToStyle<CSS::RectFunction>::operator()(const CSS::RectFunction& value, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> InsetFunction
+auto ToStyle<CSS::RectFunction>::operator()(const CSS::RectFunction& value, const BuilderState& state) -> InsetFunction
 {
-    return { toStyle(value.parameters, state, symbolTable) };
+    return { toStyle(value.parameters, state) };
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/shapes/StyleRectFunction.h
+++ b/Source/WebCore/style/values/shapes/StyleRectFunction.h
@@ -31,8 +31,8 @@ namespace WebCore {
 namespace Style {
 
 // NOTE: There is no Style::Rect type. Style conversion of CSS::Rect yields a Style::Inset.
-template<> struct ToStyle<CSS::Rect> { auto operator()(const CSS::Rect&, const BuilderState&, const CSSCalcSymbolTable&) -> Inset; };
-template<> struct ToStyle<CSS::RectFunction> { auto operator()(const CSS::RectFunction&, const BuilderState&, const CSSCalcSymbolTable&) -> InsetFunction; };
+template<> struct ToStyle<CSS::Rect> { auto operator()(const CSS::Rect&, const BuilderState&) -> Inset; };
+template<> struct ToStyle<CSS::RectFunction> { auto operator()(const CSS::RectFunction&, const BuilderState&) -> InsetFunction; };
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/shapes/StyleXywhFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleXywhFunction.cpp
@@ -31,10 +31,10 @@
 namespace WebCore {
 namespace Style {
 
-auto ToStyle<CSS::Xywh>::operator()(const CSS::Xywh& value, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> Inset
+auto ToStyle<CSS::Xywh>::operator()(const CSS::Xywh& value, const BuilderState& state) -> Inset
 {
-    auto location = toStyle(value.location, state, symbolTable);
-    auto size = toStyle(value.size, state, symbolTable);
+    auto location = toStyle(value.location, state);
+    auto size = toStyle(value.size, state);
 
     return {
         .insets = {
@@ -43,13 +43,13 @@ auto ToStyle<CSS::Xywh>::operator()(const CSS::Xywh& value, const BuilderState& 
             reflectSum(location.y(), size.height()),
             location.x(),
         },
-        .radii = toStyle(value.radii, state, symbolTable)
+        .radii = toStyle(value.radii, state)
     };
 }
 
-auto ToStyle<CSS::XywhFunction>::operator()(const CSS::XywhFunction& value, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> InsetFunction
+auto ToStyle<CSS::XywhFunction>::operator()(const CSS::XywhFunction& value, const BuilderState& state) -> InsetFunction
 {
-    return { toStyle(value.parameters, state, symbolTable) };
+    return { toStyle(value.parameters, state) };
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/shapes/StyleXywhFunction.h
+++ b/Source/WebCore/style/values/shapes/StyleXywhFunction.h
@@ -31,8 +31,8 @@ namespace WebCore {
 namespace Style {
 
 // NOTE: There is no Style::Xywh type. Style conversion of CSS::Xywh yields a Style::Inset.
-template<> struct ToStyle<CSS::Xywh> { auto operator()(const CSS::Xywh&, const BuilderState&, const CSSCalcSymbolTable&) -> Inset; };
-template<> struct ToStyle<CSS::XywhFunction> { auto operator()(const CSS::XywhFunction&, const BuilderState&, const CSSCalcSymbolTable&) -> InsetFunction; };
+template<> struct ToStyle<CSS::Xywh> { auto operator()(const CSS::Xywh&, const BuilderState&) -> Inset; };
+template<> struct ToStyle<CSS::XywhFunction> { auto operator()(const CSS::XywhFunction&, const BuilderState&) -> InsetFunction; };
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/text-decoration/StyleTextShadow.cpp
+++ b/Source/WebCore/style/values/text-decoration/StyleTextShadow.cpp
@@ -45,12 +45,12 @@ auto ToCSS<TextShadow>::operator()(const TextShadow& value, const RenderStyle& s
     };
 }
 
-auto ToStyle<CSS::TextShadow>::operator()(const CSS::TextShadow& value, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> TextShadow
+auto ToStyle<CSS::TextShadow>::operator()(const CSS::TextShadow& value, const BuilderState& state) -> TextShadow
 {
     return {
-        .color = value.color ? toStyle(*value.color, state, symbolTable) : Color::currentColor(),
-        .location = toStyle(value.location, state, symbolTable),
-        .blur = value.blur ? toStyle(*value.blur, state, symbolTable) : Length<CSS::Nonnegative> { 0 },
+        .color = value.color ? toStyle(*value.color, state) : Color::currentColor(),
+        .location = toStyle(value.location, state),
+        .blur = value.blur ? toStyle(*value.blur, state) : Length<CSS::Nonnegative> { 0 },
     };
 }
 

--- a/Source/WebCore/style/values/text-decoration/StyleTextShadow.h
+++ b/Source/WebCore/style/values/text-decoration/StyleTextShadow.h
@@ -50,7 +50,7 @@ template<size_t I> const auto& get(const TextShadow& value)
 }
 
 template<> struct ToCSS<TextShadow> { auto operator()(const TextShadow&, const RenderStyle&) -> CSS::TextShadow; };
-template<> struct ToStyle<CSS::TextShadow> { auto operator()(const CSS::TextShadow&, const BuilderState&, const CSSCalcSymbolTable&) -> TextShadow; };
+template<> struct ToStyle<CSS::TextShadow> { auto operator()(const CSS::TextShadow&, const BuilderState&) -> TextShadow; };
 
 template<> struct Blending<TextShadow> {
     auto canBlend(const TextShadow&, const TextShadow&, const RenderStyle&, const RenderStyle&) -> bool;


### PR DESCRIPTION
#### ffd54a4cd72465e4df689b2fe66b82d01bde9048
<pre>
Generalize arguments in ToStyle&lt;&gt; interface functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=284796">https://bugs.webkit.org/show_bug.cgi?id=284796</a>

Reviewed by Darin Adler.

Now that Color has been incorporated into the new value type system, it is
clear the symbol table is not needed generally, and is confined to a very
specific pattern. This means that most specializations of the ToStyle&lt;&gt;
interface don&apos;t need to include CSSCalcSymbolTable.

Removing CSSCalcSymbolTable from the specializations highlighted a further
simplification for the generic partial specializations, namely, that we
can usually just implement a single overload and use a variadic parameter
pack to forward any additional arguments on. The only real obstacle was
the lack of an overload of Style::toStyle() that took a `NoConversionDataRequiredToken`,
which was easily added. By continuing the pattern of using the token to
indicate &quot;no conversion data&quot; the numeric primitives were dramatically
simplified as well.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSPrimitiveValue.cpp:
* Source/WebCore/css/calc/CSSCalcValue.cpp:
* Source/WebCore/css/calc/CSSCalcValue.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Angle.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+AnglePercentage.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+CSSPrimitiveValueResolver.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Integer.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Length.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+LengthPercentage.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaResolver.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Number.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Percentage.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Resolution.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Time.cpp:
* Source/WebCore/css/values/CSSNoConversionDataRequiredToken.h: Added.
* Source/WebCore/css/values/color/CSSRelativeColorResolver.h:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Canonicalization.cpp:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Canonicalization.h:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+EvaluateCalc.h:
* Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.cpp:
* Source/WebCore/style/values/StyleValueTypes.h:
* Source/WebCore/style/values/backgrounds/StyleBorderRadius.cpp:
* Source/WebCore/style/values/backgrounds/StyleBorderRadius.h:
* Source/WebCore/style/values/backgrounds/StyleBoxShadow.cpp:
* Source/WebCore/style/values/backgrounds/StyleBoxShadow.h:
* Source/WebCore/style/values/color/StyleColor.cpp:
* Source/WebCore/style/values/color/StyleColor.h:
* Source/WebCore/style/values/images/StyleGradient.cpp:
* Source/WebCore/style/values/images/StyleGradient.h:
* Source/WebCore/style/values/primitives/StyleNone.h:
* Source/WebCore/style/values/primitives/StylePosition.cpp:
* Source/WebCore/style/values/primitives/StylePosition.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes.h:
* Source/WebCore/style/values/shapes/StyleBasicShape.cpp:
* Source/WebCore/style/values/shapes/StyleBasicShape.h:
* Source/WebCore/style/values/shapes/StylePathFunction.cpp:
* Source/WebCore/style/values/shapes/StylePathFunction.h:
* Source/WebCore/style/values/shapes/StyleRectFunction.cpp:
* Source/WebCore/style/values/shapes/StyleRectFunction.h:
* Source/WebCore/style/values/shapes/StyleXywhFunction.cpp:
* Source/WebCore/style/values/shapes/StyleXywhFunction.h:
* Source/WebCore/style/values/text-decoration/StyleTextShadow.cpp:
* Source/WebCore/style/values/text-decoration/StyleTextShadow.h:

Canonical link: <a href="https://commits.webkit.org/288005@main">https://commits.webkit.org/288005@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa327782bc0a8fd9c6e840b611d4ee09775c1928

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81607 "38 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1132 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35554 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86139 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32598 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83714 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1159 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8949 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63670 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21401 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84678 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/815 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74259 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43959 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/715 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28438 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31053 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29033 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87581 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8842 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6267 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71995 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9024 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70086 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71230 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17745 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15307 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14222 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8797 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14325 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8637 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12158 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10444 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->