### PR TITLE
Apply text-justify: none on lines

### DIFF
--- a/LayoutTests/fast/css3-text/css3-text-justify/text-justify-none-01-expected.txt
+++ b/LayoutTests/fast/css3-text/css3-text-justify/text-justify-none-01-expected.txt
@@ -1,0 +1,2 @@
+PASS TextIsJustified is false
+This is a test paragraph with text-justify: none. This text should not be justified, and spacing between words should be consistent. Each line should start from the beginning without any indentation.

--- a/LayoutTests/fast/css3-text/css3-text-justify/text-justify-none-01.html
+++ b/LayoutTests/fast/css3-text/css3-text-justify/text-justify-none-01.html
@@ -1,0 +1,51 @@
+<html>
+<head>
+<title>This test case tests the text-justify: none; property</title>
+<style>
+.test-container {
+    width: 600px;
+    border: 1px solid black;
+    margin-bottom: 20px;
+    padding: 10px;
+    text-align: justify;
+    text-align-last: justify;
+    text-justify: none;
+}
+
+</style>
+</head>
+<script src="../../../resources/js-test-pre.js"></script>
+<body>
+<div id="results"></div>
+<div id="test" class="test-container text-justify-none">
+    <p>This is a test paragraph with <code>text-justify: none</code>. This text should not be justified, and spacing between words should be consistent. Each line should start from the beginning without any indentation.</p>
+</div>
+<script>
+    function isTextJustified(container) {
+        const words = container.querySelector("p").innerText.split(" ");
+        const spans = words.map(word => {
+            const span = document.createElement("span");
+            span.innerText = word + " ";
+            container.appendChild(span);
+            return span;
+        });
+
+        const spacings = spans.map((span, index) => {
+            if (index === spans.length - 1) return null;
+            const rect1 = span.getBoundingClientRect();
+            const rect2 = spans[index + 1].getBoundingClientRect();
+            return rect2.left - rect1.right;
+        }).filter(Boolean);
+
+        spans.forEach(span => span.remove());
+
+        const firstSpacing = spacings[0];
+        return spacings.every(space => space === firstSpacing);
+    }
+
+    const container = document.getElementById("test");
+    const TextIsJustified = isTextJustified(container);
+    shouldBe('TextIsJustified', "false");
+</script>
+</body>
+</html>

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
@@ -582,7 +582,7 @@ UniqueRef<LineContent> LineBuilder::placeInlineAndFloatContent(const InlineItemR
                 // in order to exactly fill the line box. Unless otherwise specified by text-align-last,
                 // the last line before a forced break or the end of the block is start-aligned.
                 auto hasTextAlignJustify = (isLastInlineContent || m_line.runs().last().isLineBreak()) ? rootStyle.textAlignLast() == TextAlignLast::Justify : rootStyle.textAlign() == TextAlignMode::Justify;
-                if (hasTextAlignJustify) {
+                if (hasTextAlignJustify && rootStyle.textJustify() != TextJustify::None) {
                     auto additionalSpaceForAlignedContent = InlineContentAligner::applyTextAlignJustify(m_line.runs(), spaceToDistribute, m_line.hangingTrailingWhitespaceLength());
                     m_line.inflateContentLogicalWidth(additionalSpaceForAlignedContent);
                 }


### PR DESCRIPTION
#### 4fb2286de6a966512b42fdde27d65f4822a28b0f
<pre>
Apply text-justify: none on lines
<a href="https://bugs.webkit.org/show_bug.cgi?id=241304">https://bugs.webkit.org/show_bug.cgi?id=241304</a>

Reviewed by NOBODY (OOPS!).

Verify if text-justify is set to none, and do not compute justification on lines.

* LayoutTests/fast/css3-text/css3-text-justify/text-justify-none-01-expected.txt: Added.
* LayoutTests/fast/css3-text/css3-text-justify/text-justify-none-01.html: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:
(WebCore::Layout::LineBuilder::placeInlineAndFloatContent):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4fb2286de6a966512b42fdde27d65f4822a28b0f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81396 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/921 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35339 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85925 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32382 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83506 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/939 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8740 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63538 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21280 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84465 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/643 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74075 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43824 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/538 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28239 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30840 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72139 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28824 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87360 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8626 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6129 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71842 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8807 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69896 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71078 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15141 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14045 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8588 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14111 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8424 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11945 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10232 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->