### PR TITLE
WIP: Implement `writing-mode: sideways-lr`

### DIFF
--- a/LayoutTests/editing/inserting/caret-position-sideways-lr.html
+++ b/LayoutTests/editing/inserting/caret-position-sideways-lr.html
@@ -1,0 +1,122 @@
+<html>
+<style>
+#test {
+    writing-mode: sideways-lr;
+    /* If this test ends up being flaky, consider using Ahem. But it's more rigorous not to. */
+    outline: solid gray 1px;
+    padding: 1em;
+    width: 10em;
+    height: 20ch;
+    font: 20px/1 monospace;
+    background: /* Create a 10px grid to help with debugging. */
+        repeating-linear-gradient(transparent 0em 9px, #FC88 9px 10px),
+        repeating-linear-gradient(to left, transparent 0px 9px, #FC88 9px 10px);
+}
+span {
+    border: 1px solid aqua;
+}
+</style>
+
+<div id=test contenteditable>
+This is a test <span id=first>of writingsideways in vertical text</span><br>
+with multiline <span id=second>text</span> and alongwordthat'slong andanotherword.
+</div>
+
+<hr>
+
+<ul id="console"></ul>
+
+<script>
+
+var test = document.getElementById('test');
+var first = document.getElementById('first');
+var second = document.getElementById('second');
+
+var testLeftEdge = test.offsetLeft;
+var testTopEdge = test.offsetTop;
+var testBottomEdge = test.offsetTop + test.offsetHeight;
+var measure = test.offsetHeight;
+
+function stringifyCaret(caretRect) {
+    // Convert to LTR-relative coords and stringify
+    return (caretRect.x - testLeftEdge) + ","
+        + -(caretRect.y - testBottomEdge) + ","
+        + caretRect.width + ","
+        + caretRect.height;
+}
+
+function log(str) {
+    var li = document.createElement("li");
+    li.appendChild(document.createTextNode(str));
+    var console = document.getElementById("console");
+    console.appendChild(li);
+}
+
+function testCaretPosition(testID, element)
+{
+    element.focus();
+    var caretRect = window.internals.absoluteCaretBounds();
+    log(testID + " : " + stringifyCaret(caretRect));
+}
+
+function clickInTest(target, blockCoord, inlineCoord)
+{
+    if (window.eventSender) {
+        eventSender.mouseMoveTo(testLeftEdge + blockCoord, testBottomEdge - inlineCoord);
+        eventSender.mouseDown();
+        eventSender.mouseUp();
+    }
+    else {
+        log("FAIL: could not send click event");
+    }
+}
+
+// To make it easier to reason about individual tests, this test method
+// accepts click coordinates in LTR-relative terms. See helper functions for conversion.
+function testCaretClick(testID, blockCoord, inlineCoord, element)
+{
+    clickInTest(element, blockCoord, inlineCoord);
+    testCaretPosition("Click at " + blockCoord + ", " + inlineCoord + " for " + testID, element);
+}
+
+function runTest()
+{
+    if (window.testRunner)
+        testRunner.dumpAsText();
+
+    // Tests for bugs that are oddly specific and hard to describe
+    window.getSelection().collapse(first.firstChild, 24);
+    testCaretPosition("Bug 286961", first);
+
+    // Check caret insertion
+    testCaretClick("left above first line", 5, 5, test);
+    testCaretClick("right above first line", 5, measure - 5, test);
+
+    testCaretClick("left of first line", 25, 5, test);
+    testCaretClick("right of first line", 25, measure - 5, test);
+    testCaretClick("left of second line", 45, 5, test);
+    testCaretClick("right of second line", 45, measure - 5, test);
+    testCaretClick("left of third line", 65, 5, test);
+    testCaretClick("right of third line", 65, measure - 5, test);
+    testCaretClick("left of fourth line", 85, 5, test);
+    testCaretClick("right of fourth line", 85, measure - 5, test);
+    testCaretClick("left of fifth line", 105, 5, test);
+    testCaretClick("right of fifth line", 105, measure - 5, test);
+    testCaretClick("left of sixth line", 125, 5, test);
+    testCaretClick("right of sixth line", 125, measure - 5, test);
+    testCaretClick("left of seventh line", 145, 5, test);
+    testCaretClick("right of seventh line", 145, measure - 5, test);
+
+    testCaretClick("left below last line", 170, 5, test);
+    testCaretClick("right below last line", 170, measure - 5, test);
+
+    testCaretClick("inside first root inline fragment", 25, 30, test);
+    testCaretClick("inside middle fragment of root inline fragment", 125, 30, test);
+    testCaretClick("inside middle fragment of non-root inline fragment", 45, 30, first);
+    testCaretClick("inside last fragment of non-root inline fragment", 65, 30, first);
+    testCaretClick("inside unfragmented non-root inline", 85, measure - 60, second);
+}
+
+runTest();
+
+</script>

--- a/LayoutTests/editing/inserting/caret-position-vertical-rl-expected.txt
+++ b/LayoutTests/editing/inserting/caret-position-vertical-rl-expected.txt
@@ -1,0 +1,3 @@
+This is a test of writingsideways in vertical text
+withseverallines of text and alongwordthat'slong andanotherword.
+Test 1 -81,44,20,1

--- a/LayoutTests/editing/inserting/caret-position-vertical-rl.html
+++ b/LayoutTests/editing/inserting/caret-position-vertical-rl.html
@@ -1,0 +1,67 @@
+<html style="writing-mode: vertical-rl">
+<style>
+#test {
+    /* If this test ends up being flaky, consider using Ahem. */
+    outline: solid gray 1px;
+    padding: 1em;
+    width: 10em;
+    height: 20ch;
+    font: 20px/1 monospace;
+    background: /* Create a 10px grid to help with debugging. */
+        repeating-linear-gradient(transparent 0em 9px, #8F88 9px 10px),
+        repeating-linear-gradient(to left, transparent 0px 9px, #8F88 9px 10px);
+}
+</style>
+
+<div id=test contenteditable>
+This is a test <span id=first>of writingsideways in vertical text</span><br>
+withseverallines of <span>text</span> and alongwordthat'slong andanotherword.
+</div>
+
+<hr>
+
+<ul id="console"></ul>
+
+<script>
+
+var test = document.getElementById('test');
+var testRightEdge = test.offsetLeft + test.offsetWidth;
+var testTopEdge = test.offsetTop;
+
+function stringifyCaret(caretRect) {
+    // Convert to box-relative coords and stringify
+    return (caretRect.x - testRightEdge) + ","
+        + (caretRect.y - testTopEdge) + ","
+        + caretRect.width + ","
+        + caretRect.height;
+}
+
+function log(str) {
+    var li = document.createElement("li");
+    li.appendChild(document.createTextNode(str));
+    var console = document.getElementById("console");
+    console.appendChild(li);
+}
+
+function testCaretPosition(testID, element)
+{
+    element.focus();
+    var caretRect = window.internals.absoluteCaretBounds();
+    log(testID + " " + stringifyCaret(caretRect));
+}
+
+function runTest()
+{
+    if (window.testRunner)
+        testRunner.dumpAsText();
+
+    // Bug XXX
+    var first = document.getElementById('first');
+    window.getSelection().collapse(first.firstChild, 24);
+    testCaretPosition("Test 1", first);
+
+}
+
+runTest();
+
+</script>

--- a/LayoutTests/platform/ios/editing/inserting/caret-position-vertical-rl-expected.txt
+++ b/LayoutTests/platform/ios/editing/inserting/caret-position-vertical-rl-expected.txt
@@ -1,0 +1,3 @@
+This is a test of writingsideways in vertical text
+withseverallines of text and alongwordthat'slong andanotherword.
+Test 1 -80,43,20,2

--- a/Source/WebCore/layout/integration/inline/InlineIteratorBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorBox.h
@@ -69,8 +69,10 @@ public:
     inline float logicalBottom() const;
     inline float logicalHeight() const;
     inline float logicalWidth() const;
+    inline float logicalLeft() const;
+    inline float logicalRight() const;
 
-    // Return visual left/right coords in inline direction (they are still considered logical values as there's no flip for writing mode).
+    // Return line-relative left/right coords (they are still considered logical values as there's no flip for writing mode).
     inline float logicalLeftIgnoringInlineDirection() const;
     inline float logicalRightIgnoringInlineDirection() const;
 
@@ -81,9 +83,11 @@ public:
     unsigned leftmostCaretOffset() const { return isLeftToRightDirection() ? minimumCaretOffset() : maximumCaretOffset(); }
     unsigned rightmostCaretOffset() const { return isLeftToRightDirection() ? maximumCaretOffset() : minimumCaretOffset(); }
 
+    // isLeftToRightDirection() here is not the same as writingMode().isBidiLTR().
     unsigned char bidiLevel() const;
     TextDirection direction() const { return bidiLevel() % 2 ? TextDirection::RTL : TextDirection::LTR; }
     bool isLeftToRightDirection() const { return direction() == TextDirection::LTR; }
+    bool isInlineFlipped() const { return !(isLeftToRightDirection() == writingMode().isLogicalLeftLineLeft()); }
 
     RenderObject::HighlightState selectionState() const;
 

--- a/Source/WebCore/layout/integration/inline/InlineIteratorBoxInlines.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorBoxInlines.h
@@ -38,6 +38,9 @@ inline float Box::logicalRightIgnoringInlineDirection() const { return logicalRe
 inline float Box::logicalTop() const { return logicalRectIgnoringInlineDirection().y(); }
 inline float Box::logicalWidth() const { return logicalRectIgnoringInlineDirection().width(); }
 
+inline float Box::logicalLeft() const { return isHorizontal() ? visualRect().x() : visualRect().y(); }
+inline float Box::logicalRight() const { return logicalLeft() + logicalWidth(); }
+
 inline bool Box::isHorizontal() const
 {
     return WTF::switchOn(m_pathVariant, [](auto& path) {
@@ -74,6 +77,34 @@ inline LeafBoxIterator Box::nextLogicalLeftwardOnLineIgnoringLineBreak() const
 {
     return writingMode().isLogicalLeftLineLeft()
         ? nextLineLeftwardOnLineIgnoringLineBreak() : nextLineRightwardOnLineIgnoringLineBreak();
+}
+
+inline LeafBoxIterator& LeafBoxIterator::traverseLogicalRightwardOnLine()
+{
+    return m_box.writingMode().isLogicalLeftLineLeft()
+        ? traverseLineRightwardOnLine()
+        : traverseLineLeftwardOnLine();
+}
+
+inline LeafBoxIterator& LeafBoxIterator::traverseLogicalLeftwardOnLine()
+{
+    return m_box.writingMode().isLogicalLeftLineLeft()
+        ? traverseLineLeftwardOnLine()
+        : traverseLineRightwardOnLine();
+}
+
+inline LeafBoxIterator& LeafBoxIterator::traverseLogicalRightwardOnLineIgnoringLineBreak()
+{
+    return m_box.writingMode().isLogicalLeftLineLeft()
+        ? traverseLineRightwardOnLineIgnoringLineBreak()
+        : traverseLineLeftwardOnLineIgnoringLineBreak();
+}
+
+inline LeafBoxIterator& LeafBoxIterator::traverseLogicalLeftwardOnLineIgnoringLineBreak()
+{
+    return m_box.writingMode().isLogicalLeftLineLeft()
+        ? traverseLineLeftwardOnLineIgnoringLineBreak()
+        : traverseLineRightwardOnLineIgnoringLineBreak();
 }
 
 }

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.cpp
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "InlineIteratorLineBox.h"
+#include "InlineIteratorLineBoxInlines.h"
 
 #include "InlineIteratorBoxInlines.h"
 #include "LayoutIntegrationLineLayout.h"
@@ -130,29 +131,29 @@ LeafBoxIterator closestBoxForHorizontalPosition(const LineBox& lineBox, float ho
         return box && box->renderer().node() && box->renderer().node()->hasEditableStyle();
     };
 
-    auto firstBox = lineBox.lineLeftmostLeafBox();
-    auto lastBox = lineBox.lineRightmostLeafBox();
+    auto firstBox = lineBox.logicalLeftmostLeafBox();
+    auto lastBox = lineBox.logicalRightmostLeafBox();
 
     if (firstBox != lastBox) {
         if (firstBox->isLineBreak())
-            firstBox = firstBox->nextLineRightwardOnLineIgnoringLineBreak();
+            firstBox = firstBox->nextLogicalRightwardOnLineIgnoringLineBreak();
         else if (lastBox->isLineBreak())
-            lastBox = lastBox->nextLineLeftwardOnLineIgnoringLineBreak();
+            lastBox = lastBox->nextLogicalLeftwardOnLineIgnoringLineBreak();
     }
 
     if (firstBox == lastBox && (!editableOnly || isEditable(firstBox)))
         return firstBox;
 
-    if (firstBox && horizontalPosition <= firstBox->logicalLeftIgnoringInlineDirection() && !firstBox->renderer().isRenderListMarker() && (!editableOnly || isEditable(firstBox)))
+    if (firstBox && horizontalPosition <= firstBox->logicalLeft() && !firstBox->renderer().isRenderListMarker() && (!editableOnly || isEditable(firstBox)))
         return firstBox;
 
-    if (lastBox && horizontalPosition >= lastBox->logicalRightIgnoringInlineDirection() && !lastBox->renderer().isRenderListMarker() && (!editableOnly || isEditable(lastBox)))
+    if (lastBox && horizontalPosition >= lastBox->logicalRight() && !lastBox->renderer().isRenderListMarker() && (!editableOnly || isEditable(lastBox)))
         return lastBox;
 
     auto closestBox = lastBox;
-    for (auto box = firstBox; box; box = box.traverseLineRightwardOnLineIgnoringLineBreak()) {
+    for (auto box = firstBox; box; box = box.traverseLogicalRightwardOnLineIgnoringLineBreak()) {
         if (!box->renderer().isRenderListMarker() && (!editableOnly || isEditable(box))) {
-            if (horizontalPosition < box->logicalRightIgnoringInlineDirection())
+            if (horizontalPosition < box->logicalRight())
                 return box;
             closestBox = box;
         }

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.h
@@ -88,8 +88,12 @@ public:
     bool isFirst() const;
     bool isFirstAfterPageBreak() const;
 
+    // Text-relative left/right
     LeafBoxIterator lineLeftmostLeafBox() const;
     LeafBoxIterator lineRightmostLeafBox() const;
+    // Coordinate-relative left/right
+    inline LeafBoxIterator logicalLeftmostLeafBox() const;
+    inline LeafBoxIterator logicalRightmostLeafBox() const;
 
     LineBoxIterator next() const;
     LineBoxIterator previous() const;

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxInlines.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxInlines.h
@@ -43,5 +43,19 @@ inline float contentStartInBlockDirection(const LineBox& lineBox)
     return std::min(lineBox.contentLogicalBottom(), lineBox.contentLogicalBottomAdjustedForFollowingLineBox());
 }
 
+inline LeafBoxIterator LineBox::logicalLeftmostLeafBox() const
+{
+    return formattingContextRoot().writingMode().isLogicalLeftLineLeft()
+        ? lineLeftmostLeafBox()
+        : lineRightmostLeafBox();
+}
+
+inline LeafBoxIterator LineBox::logicalRightmostLeafBox() const
+{
+    return formattingContextRoot().writingMode().isLogicalLeftLineLeft()
+        ? lineRightmostLeafBox()
+        : lineLeftmostLeafBox();
+}
+
 }
 }

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h
@@ -74,7 +74,7 @@ public:
         return LineBoxIteratorModernPath { *m_inlineContent, m_lineIndex + 1 }.contentLogicalTop();
     }
 
-    float contentLogicalLeft() const { return line().lineBoxLeft() + line().contentLogicalLeftIgnoringInlineDirection(); }
+    float contentLogicalLeft() const { return line().lineBoxLogicalRect().x() + line().contentLogicalLeftIgnoringInlineDirection(); }
     float contentLogicalRight() const { return contentLogicalLeft() + line().contentLogicalWidth(); }
     bool isHorizontal() const { return line().isHorizontal(); }
     FontBaseline baselineType() const { return line().baselineType(); }

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h
@@ -63,18 +63,25 @@ public:
 
     float contentLogicalTopAdjustedForPrecedingLineBox() const
     {
-        if (formattingContextRoot().style().writingMode().isLineInverted() || !m_lineIndex)
+        if (formattingContextRoot().writingMode().isLineInverted() || !m_lineIndex)
             return contentLogicalTop();
         return LineBoxIteratorModernPath { *m_inlineContent, m_lineIndex - 1 }.contentLogicalBottom();
     }
     float contentLogicalBottomAdjustedForFollowingLineBox() const
     {
-        if (!formattingContextRoot().style().writingMode().isLineInverted() || m_lineIndex == lines().size() - 1)
+        if (!formattingContextRoot().writingMode().isLineInverted() || m_lineIndex == lines().size() - 1)
             return contentLogicalBottom();
         return LineBoxIteratorModernPath { *m_inlineContent, m_lineIndex + 1 }.contentLogicalTop();
     }
 
-    float contentLogicalLeft() const { return line().lineBoxLogicalRect().x() + line().contentLogicalLeftIgnoringInlineDirection(); }
+    float contentLogicalLeft() const
+    {
+        auto writingMode = formattingContextRoot().writingMode();
+        if (writingMode.isLogicalLeftLineLeft())
+            return line().lineBoxLogicalRect().x() + line().contentLogicalLeftIgnoringInlineDirection();
+        ASSERT(writingMode.isVertical()); // Currently only sideways-lr gets this far.
+        return line().bottom() - (line().contentLogicalLeftIgnoringInlineDirection() + line().contentLogicalWidth());
+    }
     float contentLogicalRight() const { return contentLogicalLeft() + line().contentLogicalWidth(); }
     bool isHorizontal() const { return line().isHorizontal(); }
     FontBaseline baselineType() const { return line().baselineType(); }

--- a/Source/WebCore/rendering/LegacyInlineTextBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineTextBox.cpp
@@ -184,11 +184,17 @@ LayoutRect LegacyInlineTextBox::localSelectionRect(unsigned startPos, unsigned e
         return { };
 
     TextRun textRun = createTextRun();
+    auto writingMode = renderer().writingMode();
+    auto width = LayoutUnit { logicalWidth() };
 
-    LayoutRect selectionRect { LayoutUnit(logicalLeft()), this->selectionTop(), LayoutUnit(logicalWidth()), this->selectionHeight() };
+    LayoutRect selectionRect { 0, this->selectionTop(), width, this->selectionHeight() };
     // Avoid measuring the text when the entire line box is selected as an optimization.
     if (clampedStart || clampedEnd != textRun.length())
         lineFont().adjustSelectionRectForText(renderer().canUseSimplifiedTextMeasuring().value_or(false), textRun, selectionRect, clampedStart, clampedEnd);
+
+    if (!writingMode.isLogicalLeftLineLeft())
+        selectionRect.setX(width - selectionRect.x());
+    selectionRect.move(logicalLeft(), 0);
     // FIXME: The computation of the snapped selection rect differs from the computation of this rect
     // in paintMarkedTextBackground(). See <https://bugs.webkit.org/show_bug.cgi?id=138913>.
     return snappedSelectionRect(selectionRect, logicalRight(), renderer().writingMode());

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -295,11 +295,15 @@ static LayoutRect selectionRectForTextBox(const InlineIterator::TextBox& textBox
     }
 
     auto lineSelectionRect = LineSelection::logicalRect(*textBox.lineBox());
-    auto selectionRect = LayoutRect { textBox.logicalLeftIgnoringInlineDirection(), lineSelectionRect.y(), textBox.logicalWidth(), lineSelectionRect.height() };
+    auto selectionRect = LayoutRect { 0, lineSelectionRect.y(), textBox.logicalWidth(), lineSelectionRect.height() };
 
     auto textRun = textBox.textRun();
     if (clampedStart || clampedEnd != textRun.length())
         textBox.fontCascade().adjustSelectionRectForText(textBox.renderer().canUseSimplifiedTextMeasuring().value_or(false), textRun, selectionRect, clampedStart, clampedEnd);
+
+    if (!textBox.writingMode().isLogicalLeftLineLeft())
+        selectionRect.setX(textBox.logicalWidth() - selectionRect.maxX());
+    selectionRect.move(textBox.logicalLeftIgnoringInlineDirection(), 0);
 
     return snappedSelectionRect(selectionRect, textBox.logicalRightIgnoringInlineDirection(), textBox.writingMode());
 }
@@ -308,11 +312,16 @@ static unsigned offsetForPositionInRun(const InlineIterator::TextBox& textBox, f
 {
     if (textBox.isLineBreak())
         return 0;
-    if (x - textBox.logicalLeftIgnoringInlineDirection() > textBox.logicalWidth())
-        return textBox.isLeftToRightDirection() ? textBox.length() : 0;
-    if (x - textBox.logicalLeftIgnoringInlineDirection() < 0)
-        return textBox.isLeftToRightDirection() ? 0 : textBox.length();
-    return textBox.fontCascade().offsetForPosition(textBox.textRun(InlineIterator::TextRunMode::Editing), x - textBox.logicalLeftIgnoringInlineDirection(), true);
+
+    auto runPosition = x - textBox.logicalLeftIgnoringInlineDirection();
+    if (runPosition > textBox.logicalWidth())
+        return textBox.isInlineFlipped() ? 0 : textBox.length();
+    if (runPosition < 0)
+        return textBox.isInlineFlipped() ? textBox.length() : 0;
+
+    if (!textBox.writingMode().isLogicalLeftLineLeft())
+        runPosition = textBox.logicalWidth() - runPosition;
+    return textBox.fontCascade().offsetForPosition(textBox.textRun(InlineIterator::TextRunMode::Editing), runPosition, true);
 }
 
 inline RenderText::RenderText(Type type, Node& node, const String& text)
@@ -752,15 +761,15 @@ static bool lineDirectionPointFitsInBox(int pointLineDirection, const InlineIter
     // the x coordinate is equal to the left edge of this box
     // the affinity must be downstream so the position doesn't jump back to the previous line
     // except when box is the first box in the line
-    if (pointLineDirection <= textRun->logicalLeftIgnoringInlineDirection()) {
-        shouldAffinityBeDownstream = !textRun->nextLineLeftwardOnLine() ? UpstreamIfPositionIsNotAtStart : AlwaysDownstream;
+    if (pointLineDirection <= textRun->logicalLeft()) {
+        shouldAffinityBeDownstream = !textRun->nextLogicalLeftwardOnLine() ? UpstreamIfPositionIsNotAtStart : AlwaysDownstream;
         return true;
     }
 
 #if !PLATFORM(IOS_FAMILY)
     // and the x coordinate is to the left of the right edge of this box
     // check to see if position goes in this box
-    if (pointLineDirection < textRun->logicalRightIgnoringInlineDirection()) {
+    if (pointLineDirection < textRun->logicalRight()) {
         shouldAffinityBeDownstream = UpstreamIfPositionIsNotAtStart;
         return true;
     }
@@ -768,10 +777,10 @@ static bool lineDirectionPointFitsInBox(int pointLineDirection, const InlineIter
 
     // box is first on line
     // and the x coordinate is to the left of the first text box left edge
-    if (!textRun->nextLineLeftwardOnLineIgnoringLineBreak() && pointLineDirection < textRun->logicalLeftIgnoringInlineDirection())
+    if (!textRun->nextLogicalLeftwardOnLineIgnoringLineBreak() && pointLineDirection < textRun->logicalLeft())
         return true;
 
-    if (!textRun->nextLineRightwardOnLineIgnoringLineBreak()) {
+    if (!textRun->nextLogicalRightwardOnLineIgnoringLineBreak()) {
         // box is last on line
         // and the x coordinate is to the right of the last text box right edge
         // generate VisiblePosition, use Affinity::Upstream affinity if possible
@@ -881,8 +890,9 @@ VisiblePosition RenderText::positionForPoint(const LayoutPoint& point, HitTestSo
     if (!firstRun || !text().length())
         return createVisiblePosition(0, Affinity::Downstream);
 
-    auto pointLineDirection = firstRun->isHorizontal() ? point.x() : point.y();
-    auto pointBlockDirection = firstRun->isHorizontal() ? point.y() : point.x();
+    auto logicalPoint = firstRun->isHorizontal()
+        ? LayoutPoint { point.x(), point.y() }
+        : LayoutPoint { point.y(), point.x() };
     bool blocksAreFlipped = writingMode().isBlockFlipped();
 
     InlineIterator::TextBoxIterator lastRun;
@@ -892,22 +902,22 @@ VisiblePosition RenderText::positionForPoint(const LayoutPoint& point, HitTestSo
 
         auto lineBox = run->lineBox();
         auto top = LayoutUnit { std::min(previousLineBoxContentBottomOrBorderAndPadding(*lineBox), lineBox->contentLogicalTop()) };
-        if (pointBlockDirection > top || (!blocksAreFlipped && pointBlockDirection == top)) {
+        if (logicalPoint.y() > top || (!blocksAreFlipped && logicalPoint.y() == top)) {
             auto bottom = LayoutUnit { LineSelection::logicalBottom(*lineBox) };
             if (auto nextLineBox = lineBox->next())
                 bottom = std::min(bottom, LayoutUnit { nextLineBox->contentLogicalTop() });
 
-            if (pointBlockDirection < bottom || (blocksAreFlipped && pointBlockDirection == bottom)) {
+            if (logicalPoint.y() < bottom || (blocksAreFlipped && logicalPoint.y() == bottom)) {
                 ShouldAffinityBeDownstream shouldAffinityBeDownstream;
 #if PLATFORM(IOS_FAMILY)
-                if (pointLineDirection != run->logicalLeftIgnoringInlineDirection() && point.x() < run->visualRectIgnoringBlockDirection().x() + run->logicalWidth()) {
-                    auto half = LayoutUnit { run->visualRectIgnoringBlockDirection().x() + run->logicalWidth() / 2.f };
+                if (logicalPoint.x() != run->logicalLeft() && point.x() < run->logicalLeft() + run->logicalWidth()) {
+                    auto half = LayoutUnit { run->logicalLeft() + run->logicalWidth() / 2.f };
                     shouldAffinityBeDownstream = point.x() < half ? AlwaysDownstream : AlwaysUpstream;
-                    return createVisiblePositionAfterAdjustingOffsetForBiDi(run, offsetForPositionInRun(*run, pointLineDirection), shouldAffinityBeDownstream);
+                    return createVisiblePositionAfterAdjustingOffsetForBiDi(run, offsetForPositionInRun(*run, logicalPoint.x()), shouldAffinityBeDownstream);
                 }
 #endif
-                if (lineDirectionPointFitsInBox(pointLineDirection, run, shouldAffinityBeDownstream))
-                    return createVisiblePositionAfterAdjustingOffsetForBiDi(run, offsetForPositionInRun(*run, pointLineDirection), shouldAffinityBeDownstream);
+                if (lineDirectionPointFitsInBox(logicalPoint.x(), run, shouldAffinityBeDownstream))
+                    return createVisiblePositionAfterAdjustingOffsetForBiDi(run, offsetForPositionInRun(*run, logicalPoint.x()), shouldAffinityBeDownstream);
             }
         }
         lastRun = run;
@@ -915,8 +925,8 @@ VisiblePosition RenderText::positionForPoint(const LayoutPoint& point, HitTestSo
 
     if (lastRun) {
         ShouldAffinityBeDownstream shouldAffinityBeDownstream;
-        lineDirectionPointFitsInBox(pointLineDirection, lastRun, shouldAffinityBeDownstream);
-        return createVisiblePositionAfterAdjustingOffsetForBiDi(lastRun, offsetForPositionInRun(*lastRun, pointLineDirection) + lastRun->start(), shouldAffinityBeDownstream);
+        lineDirectionPointFitsInBox(logicalPoint.x(), lastRun, shouldAffinityBeDownstream);
+        return createVisiblePositionAfterAdjustingOffsetForBiDi(lastRun, offsetForPositionInRun(*lastRun, logicalPoint.x()) + lastRun->start(), shouldAffinityBeDownstream);
     }
     return createVisiblePosition(0, Affinity::Downstream);
 }


### PR DESCRIPTION
WIP branch for testing. This branch composes multiple fixes, see below:

**In Progress:**

9. Caret and Selection Positioning and Painting
   15. Double-painting selections

**Landed:**

1. Rotating text painting:
   1. https://github.com/WebKit/WebKit/pull/38423
2. Rotating shadow painting:
   2. https://github.com/WebKit/WebKit/pull/38424
   3. https://github.com/WebKit/WebKit/pull/38426
3. Correcting input coordinate conversion for inline layout:
   4. https://github.com/WebKit/WebKit/pull/38446
   5. https://github.com/WebKit/WebKit/pull/38447
4. Correcting output coordinate conversion for inline layout (LTR only):
   6. https://github.com/WebKit/WebKit/pull/38448
   7. https://github.com/WebKit/WebKit/pull/38449
5. Correcting IFC input/output coordinates for floats:
   8. https://github.com/WebKit/WebKit/pull/38450
6. Updating border/background fragmentation:
   9. https://github.com/WebKit/WebKit/pull/38455
7. Correcting output coordinate conversion for inline layout (bidi only):
   10. https://github.com/WebKit/WebKit/pull/38503
8. Enable on stable:
   11. https://github.com/WebKit/WebKit/pull/38506
9. Caret and Selection Positioning and Painting
   12. https://github.com/WebKit/WebKit/pull/39128
   13. https://github.com/WebKit/WebKit/pull/39940
   14. https://github.com/WebKit/WebKit/pull/40087

**Missing:**

- Static positioning of inlines in the inline (vertical) axis.

**Separately Landed:**

- The [WritingMode refactor](https://github.com/WebKit/WebKit/pull/32026).
- Form controls. (Thanks, ntim!)

END
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9553f8283a1342a882a1bed3574bc57e15032fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88006 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7522 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42401 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92953 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38756 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90057 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7903 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15699 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67932 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25676 "Found 2 new test failures: editing/inserting/caret-position-sideways-lr.html http/tests/security/contentSecurityPolicy/1.1/frame-ancestors/report-frame-ancestors-same-origin.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91008 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6051 "Found 2 new test failures: accessibility/visible-character-range-vertical-rl.html editing/inserting/caret-position-sideways-lr.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79624 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48302 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5827 "Exiting early after 10 failures. 19 tests run. 1 missing results") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34105 "Found 2 new test failures: editing/inserting/caret-position-sideways-lr.html editing/undo/redo-reapply-edit-command-crash.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37863 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76224 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34915 "Found 2 new test failures: accessibility/visible-character-range-vertical-rl.html editing/inserting/caret-position-sideways-lr.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94801 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15174 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11158 "Found 4 new test failures: accessibility/visible-character-range-vertical-rl.html editing/inserting/caret-position-sideways-lr.html editing/inserting/caret-position-vertical-rl.html imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-invoke-pause-networkState.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76785 "Found 1 new test failure: editing/inserting/caret-position-sideways-lr.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15429 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75480 "Exiting early after 10 failures. 18 tests run. 1 missing results") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76085 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20416 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18830 "Found 2 new test failures: accessibility/visible-character-range-vertical-rl.html editing/inserting/caret-position-sideways-lr.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8178 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15192 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20493 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14934 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18379 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16716 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->