### PR TITLE
REGRESSION(287851@main): Crash under `HTMLTextFormControlElement::setSelectionRange`

### DIFF
--- a/LayoutTests/editing/selection/setSelectionRange-no-frame-crash-expected.txt
+++ b/LayoutTests/editing/selection/setSelectionRange-no-frame-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if it does not crash

--- a/LayoutTests/editing/selection/setSelectionRange-no-frame-crash.html
+++ b/LayoutTests/editing/selection/setSelectionRange-no-frame-crash.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+let doc = document.implementation.createHTMLDocument();
+let input = doc.createElement('input');
+input.value = 'hello';
+doc.body.appendChild(input);
+input.setSelectionRange(0, 1);
+</script>
+<p>PASS if it does not crash</p>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -337,7 +337,7 @@ bool HTMLTextFormControlElement::setSelectionRange(unsigned start, unsigned end,
         bool cacheSelectionIfNotFocusedOrSelected = true;
 #endif
         // Cache selection if neither selection or focus is on the input.
-        if (cacheSelectionIfNotFocusedOrSelected && enclosingTextFormControl(frame->selection().selection().start()) != this)
+        if (cacheSelectionIfNotFocusedOrSelected && frame && enclosingTextFormControl(frame->selection().selection().start()) != this)
             return cacheSelection(start, end, direction);
 
         // Cache selection if renderer is invisible.


### PR DESCRIPTION
#### 33acc7313b66be9cbcf588a9b1e3529bb708d4a7
<pre>
REGRESSION(287851@main): Crash under `HTMLTextFormControlElement::setSelectionRange`
<a href="https://bugs.webkit.org/show_bug.cgi?id=284798">https://bugs.webkit.org/show_bug.cgi?id=284798</a>
<a href="https://rdar.apple.com/141585652">rdar://141585652</a>

Reviewed by Ryosuke Niwa.

Check if frame is null before consulting the frame selection.

Testcase from Ryosuke Niwa.

* LayoutTests/editing/selection/setSelectionRange-no-frame-crash-expected.txt: Added.
* LayoutTests/editing/selection/setSelectionRange-no-frame-crash.html: Added.
* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(WebCore::HTMLTextFormControlElement::setSelectionRange):

Canonical link: <a href="https://commits.webkit.org/287929@main">https://commits.webkit.org/287929@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bcc92a8490b4ca0ada44cbddfb09a21ba3a81ca4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81414 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/939 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35357 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85943 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32400 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83524 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/957 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8758 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63543 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/21289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84483 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/658 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74095 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43836 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/553 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28259 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30858 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28844 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87378 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8644 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/71857 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8825 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69916 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71092 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17688 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15162 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14064 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8606 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/14129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8442 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11963 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10250 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->