### PR TITLE
[iOS] Implement PlaybackSessionInterfaceAVKit in terms of AVMediaSource

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/AVKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/AVKitSPI.h
@@ -485,3 +485,140 @@ typedef NS_ENUM(NSInteger, AVPlayerControllerTimeControlStatus) {
 NS_ASSUME_NONNULL_END
 
 #endif // PLATFORM(APPLETV)
+
+#if HAVE(AVKIT_CONTENT_SOURCE)
+
+#if USE(APPLE_INTERNAL_SDK)
+
+#import <AVKit/AVMediaSource.h>
+
+#else
+
+@class CALayer;
+@class AVInterstitialTimeRange;
+
+typedef struct REEntity *REEntityRef;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol AVMediaPlaybackSource <NSObject>
+
+@property (nonatomic, readonly) double rate;
+@property (nonatomic, readonly) BOOL canTogglePlayback;
+@property (nonatomic, readonly) BOOL isLoading;
+@property (nonatomic, readonly) BOOL canSeek;
+@property (nonatomic, readonly) BOOL isSeeking;
+@property (nonatomic, readonly) BOOL canScanForward;
+@property (nonatomic, readonly) BOOL canScanBackward;
+@property (nonatomic, readonly) BOOL requiresLinearPlayback;
+@property (nonatomic, readonly) BOOL hasLiveStreamContent;
+@property (nonatomic, readonly, nullable) NSError *playbackError;
+- (void)play;
+- (void)pause;
+- (void)seekTo:(double)time;
+- (void)beginScanningForward;
+- (void)endScanningForward;
+- (void)beginScanningBackward;
+- (void)endScanningBackward;
+
+@end
+
+@protocol AVMediaTimelineSource <NSObject>
+
+@property (nonatomic, readonly) float minValue;
+@property (nonatomic, readonly) float maxValue;
+@property (nonatomic, readonly) float currentValue;
+
+@optional
+
+@property (nonatomic, readonly, nullable) NSArray<NSValue *> *seekableTimeRanges;
+- (void)beginScrubbing;
+- (void)endScrubbing;
+
+@end
+
+@protocol AVListable <NSObject>
+
+@property (nonatomic, readonly) NSString *localizedTitle;
+
+@end
+
+@protocol AVMediaAudioAndCaptionSource <NSObject>
+
+@property (nonatomic, readonly, nullable) id<AVListable> currentAudioOption;
+@property (nonatomic, readonly, nullable) NSArray<AVListable> *audioOptions;
+- (void)updateCurrentAudioOption:(id<AVListable>)currentAudioOption;
+@property (nonatomic, readonly, nullable) id<AVListable> currentCaptionOption;
+@property (nonatomic, readonly, nullable) NSArray<AVListable> *captionOptions;
+- (void)updateCurrentCaptionOption:(id<AVListable>)currentCaptionOption;
+@property (nonatomic, readonly, nullable) CALayer *captionLayer;
+- (void)setCaptionContentInsets:(UIEdgeInsets)insets;
+
+@end
+
+@protocol AVMediaVolumeSource <NSObject>
+
+@property (nonatomic, readonly) BOOL hasAudio;
+@property (nonatomic, readonly) BOOL muted;
+@property (nonatomic, readonly) double volume;
+- (void)updateVolume:(double)volume;
+- (void)updateMuted:(BOOL)muted;
+
+@optional
+
+- (void)beginChangingVolume;
+- (void)endChangingVolume;
+
+@end
+
+@protocol AVMediaContainerSource <NSObject>
+
+@property (nonatomic, readonly, nullable) CALayer *videoLayer;
+#if PLATFORM(VISION)
+@property (nonatomic, readonly, nullable) REEntityRef entityRef;
+#endif
+@property (nonatomic, readonly) CGSize videoSize;
+
+@end
+
+@protocol AVMediaThumbnailSource <NSObject>
+@end
+
+@protocol AVMediaInterstitialSource <NSObject>
+
+@property (nonatomic, readonly, nullable) NSArray<AVInterstitialTimeRange *> *interstitialTimeRanges;
+@property (nonatomic, readonly) BOOL isInterstitialActive;
+- (void)skipActiveInterstitial;
+
+@end
+
+@protocol AVMediaMetadataSource <NSObject>
+
+@property (nonatomic, readonly, nullable) NSString *title;
+@property (nonatomic, readonly, nullable) NSString *subtitle;
+
+@optional
+
+@property (nonatomic, readonly, nullable) NSDate *approximateStartDate;
+@property (nonatomic, readonly, nullable) NSDate *approximateEndDate;
+@property (nonatomic, readonly, nullable) NSDate *exactStartDate;
+@property (nonatomic, readonly, nullable) NSDate *exactEndDate;
+
+@end
+
+@protocol AVMediaSource <
+    AVMediaTimelineSource,
+    AVMediaPlaybackSource,
+    AVMediaAudioAndCaptionSource,
+    AVMediaVolumeSource,
+    AVMediaContainerSource,
+    AVMediaThumbnailSource,
+    AVMediaMetadataSource
+>
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif // USE(APPLE_INTERNAL_SDK)
+
+#endif // HAVE(AVKIT_CONTENT_SOURCE)

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -457,6 +457,7 @@ platform/graphics/cocoa/ImageAdapterCocoa.mm
 platform/graphics/cocoa/MediaEngineConfigurationFactoryCocoa.cpp
 platform/graphics/cocoa/MediaPlayerCocoa.mm
 platform/graphics/cocoa/MediaPlayerPrivateWebM.mm @no-unify
+platform/graphics/cocoa/PlatformTimeRangesCocoa.mm @no-unify
 platform/graphics/cocoa/SourceBufferParser.cpp
 platform/graphics/cocoa/SourceBufferParserWebM.cpp
 platform/graphics/cocoa/SystemFontDatabaseCocoa.mm

--- a/Source/WebCore/platform/graphics/PlatformTimeRanges.h
+++ b/Source/WebCore/platform/graphics/PlatformTimeRanges.h
@@ -31,6 +31,8 @@
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
+OBJC_CLASS NSArray;
+
 namespace WTF {
 class PrintStream;
 }
@@ -139,6 +141,10 @@ private:
 
     Vector<Range> m_ranges;
 };
+
+#if PLATFORM(COCOA)
+RetainPtr<NSArray> makeNSArray(const PlatformTimeRanges&);
+#endif
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/cocoa/PlatformTimeRangesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/PlatformTimeRangesCocoa.mm
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "PlatformTimeRanges.h"
+
+#if PLATFORM(COCOA)
+
+#import <AVFoundation/AVFoundation.h>
+#import <pal/avfoundation/MediaTimeAVFoundation.h>
+
+#import <pal/cf/CoreMediaSoftLink.h>
+
+namespace WebCore {
+
+RetainPtr<NSArray> makeNSArray(const PlatformTimeRanges& timeRanges)
+{
+    RetainPtr ranges = adoptNS([[NSMutableArray alloc] initWithCapacity:timeRanges.length()]);
+
+    for (unsigned i = 0; i < timeRanges.length(); ++i) {
+        bool startValid;
+        MediaTime start = timeRanges.start(i, startValid);
+        RELEASE_ASSERT(startValid);
+
+        bool endValid;
+        MediaTime end = timeRanges.end(i, endValid);
+        RELEASE_ASSERT(endValid);
+
+        [ranges addObject:[NSValue valueWithCMTimeRange:PAL::CMTimeRangeMake(PAL::toCMTime(start), PAL::toCMTime(end - start))]];
+    }
+
+    return adoptNS([ranges copy]);
+}
+
+} // namespace WebCore
+
+#endif // PLATFORM(COCOA)

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h
@@ -30,6 +30,8 @@
 #include "PlaybackSessionInterfaceIOS.h"
 #include <wtf/TZoneMalloc.h>
 
+OBJC_CLASS WebAVContentSource;
+
 namespace WebCore {
 
 class PlaybackSessionInterfaceAVKit final : public PlaybackSessionInterfaceIOS {
@@ -39,31 +41,36 @@ public:
     WEBCORE_EXPORT static Ref<PlaybackSessionInterfaceAVKit> create(PlaybackSessionModel&);
     ~PlaybackSessionInterfaceAVKit();
 
+    void nowPlayingMetadataChanged(const NowPlayingMetadata&);
+
     // PlaybackSessionInterfaceIOS overrides
     WebAVPlayerController *playerController() const final { return nullptr; }
     WKSLinearMediaPlayer *linearMediaPlayer() const final { return nullptr; }
-    void durationChanged(double) final { }
-    void currentTimeChanged(double, double) final { }
+    void durationChanged(double) final;
+    void currentTimeChanged(double, double) final;
     void bufferedTimeChanged(double) final { }
-    void rateChanged(OptionSet<PlaybackSessionModel::PlaybackState>, double, double) final { }
-    void seekableRangesChanged(const TimeRanges&, double, double) final { }
-    void canPlayFastReverseChanged(bool) final { }
-    void audioMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>&, uint64_t) final { }
-    void legibleMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>&, uint64_t) final { }
-    void audioMediaSelectionIndexChanged(uint64_t) final { }
-    void legibleMediaSelectionIndexChanged(uint64_t) final { }
+    void rateChanged(OptionSet<PlaybackSessionModel::PlaybackState>, double, double) final;
+    void seekableRangesChanged(const TimeRanges&, double, double) final;
+    void canPlayFastReverseChanged(bool) final;
+    void audioMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>&, uint64_t) final;
+    void legibleMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>&, uint64_t) final;
+    void audioMediaSelectionIndexChanged(uint64_t) final;
+    void legibleMediaSelectionIndexChanged(uint64_t) final;
     void externalPlaybackChanged(bool, PlaybackSessionModel::ExternalPlaybackTargetType, const String&) final { }
     void wirelessVideoPlaybackDisabledChanged(bool) final { }
-    void mutedChanged(bool) final { }
-    void volumeChanged(double) final { }
-    void startObservingNowPlayingMetadata() final { }
-    void stopObservingNowPlayingMetadata() final { }
+    void mutedChanged(bool) final;
+    void volumeChanged(double) final;
+    void startObservingNowPlayingMetadata() final;
+    void stopObservingNowPlayingMetadata() final;
 #if !RELEASE_LOG_DISABLED
     ASCIILiteral logClassName() const final;
 #endif
 
 private:
     PlaybackSessionInterfaceAVKit(PlaybackSessionModel&);
+
+    RetainPtr<WebAVContentSource> m_contentSource;
+    NowPlayingMetadataObserver m_nowPlayingMetadataObserver;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.mm
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.mm
@@ -28,7 +28,180 @@
 
 #if HAVE(AVKIT_CONTENT_SOURCE)
 
+#import "MediaSelectionOption.h"
+#import "NowPlayingInfo.h"
+#import "TimeRanges.h"
+#import <pal/spi/cocoa/AVKitSPI.h>
 #import <wtf/TZoneMallocInlines.h>
+
+@interface WebAVListItem : NSObject <AVListable>
++ (instancetype)new NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithLocalizedTitle:(NSString *)localizedTitle;
+
+@property (nonatomic, strong) NSString *localizedTitle;
+
+@end
+
+@implementation WebAVListItem
+
+- (instancetype)initWithLocalizedTitle:(NSString *)localizedTitle
+{
+    self = [super init];
+    if (!self)
+        return nil;
+
+    self.localizedTitle = localizedTitle;
+    return self;
+}
+
+@end
+
+@interface WebAVContentSource : NSObject <AVMediaSource>
++ (instancetype)new NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithModel:(WebCore::PlaybackSessionModel&)model;
+
+@property (nonatomic, strong, nullable) NSArray<AVListable> *audioOptions;
+@property (nonatomic) BOOL canScanBackward;
+@property (nonatomic) BOOL canScanForward;
+@property (nonatomic) BOOL canSeek;
+@property (nonatomic) BOOL canTogglePlayback;
+@property (nonatomic, strong, nullable) CALayer *captionLayer;
+@property (nonatomic, strong, nullable) NSArray<AVListable> *captionOptions;
+@property (nonatomic, strong, nullable) id<AVListable> currentAudioOption;
+@property (nonatomic, strong, nullable) id<AVListable> currentCaptionOption;
+@property (nonatomic) float currentValue;
+#if PLATFORM(VISION)
+@property (nonatomic, nullable) REEntityRef entityRef;
+#endif
+@property (nonatomic) BOOL hasAudio;
+@property (nonatomic) BOOL hasLiveStreamContent;
+@property (nonatomic) BOOL isLoading;
+@property (nonatomic) BOOL isSeeking;
+@property (nonatomic) float maxValue;
+@property (nonatomic) float minValue;
+@property (nonatomic) BOOL muted;
+@property (nonatomic, strong, nullable) NSError *playbackError;
+@property (nonatomic) double rate;
+@property (nonatomic) BOOL requiresLinearPlayback;
+@property (nonatomic, strong, nullable) NSArray<NSValue *> *seekableTimeRanges;
+@property (nonatomic, strong, nullable) NSString *subtitle;
+@property (nonatomic, strong, nullable) NSString *title;
+@property (nonatomic, strong, nullable) CALayer *videoLayer;
+@property (nonatomic) CGSize videoSize;
+@property (nonatomic) double volume;
+
+@end
+
+@implementation WebAVContentSource {
+    WeakPtr<WebCore::PlaybackSessionModel> _model;
+}
+
+- (instancetype)initWithModel:(WebCore::PlaybackSessionModel&)model
+{
+    self = [super init];
+    if (!self)
+        return nil;
+
+    _model = model;
+    return self;
+}
+
+- (void)beginScanningBackward
+{
+    if (auto model = _model.get())
+        model->beginScanningBackward();
+}
+
+- (void)beginScanningForward
+{
+    if (auto model = _model.get())
+        model->beginScanningForward();
+}
+
+- (void)endScanningBackward
+{
+    if (auto model = _model.get())
+        model->endScanning();
+}
+
+- (void)endScanningForward
+{
+    if (auto model = _model.get())
+        model->endScanning();
+}
+
+- (void)beginScrubbing
+{
+    if (auto model = _model.get())
+        model->beginScrubbing();
+}
+
+- (void)endScrubbing
+{
+    if (auto model = _model.get())
+        model->endScrubbing();
+}
+
+- (void)pause
+{
+    if (auto model = _model.get())
+        model->pause();
+}
+
+- (void)play
+{
+    if (auto model = _model.get())
+        model->play();
+}
+
+- (void)seekTo:(double)time
+{
+    if (auto model = _model.get())
+        model->seekToTime(time);
+}
+
+- (void)setCaptionContentInsets:(UIEdgeInsets)insets
+{
+    // FIXME: Implement caption content insets
+}
+
+- (void)updateCurrentAudioOption:(nonnull id<AVListable>)currentAudioOption
+{
+    auto model = _model.get();
+    if (!model)
+        return;
+
+    NSUInteger index = currentAudioOption ? [self.audioOptions indexOfObject:currentAudioOption] : 0;
+    if (index != NSNotFound)
+        model->selectAudioMediaOption(index);
+}
+
+- (void)updateCurrentCaptionOption:(nonnull id<AVListable>)currentCaptionOption
+{
+    auto model = _model.get();
+    if (!model)
+        return;
+
+    NSUInteger index = currentCaptionOption ? [self.captionOptions indexOfObject:currentCaptionOption] : 0;
+    if (index != NSNotFound)
+        model->selectLegibleMediaOption(index);
+}
+
+- (void)updateMuted:(BOOL)muted
+{
+    if (auto model = _model.get())
+        model->setMuted(muted);
+}
+
+- (void)updateVolume:(double)volume
+{
+    if (auto model = _model.get())
+        model->setVolume(volume);
+}
+
+@end
 
 namespace WebCore {
 
@@ -41,14 +214,121 @@ Ref<PlaybackSessionInterfaceAVKit> PlaybackSessionInterfaceAVKit::create(Playbac
     return interface;
 }
 
+static NowPlayingMetadataObserver nowPlayingMetadataObserver(PlaybackSessionInterfaceAVKit& interface)
+{
+    return {
+        [weakInterface = WeakPtr { interface }](auto& metadata) {
+            if (RefPtr interface = weakInterface.get())
+                interface->nowPlayingMetadataChanged(metadata);
+        }
+    };
+}
+
 PlaybackSessionInterfaceAVKit::PlaybackSessionInterfaceAVKit(PlaybackSessionModel& model)
     : PlaybackSessionInterfaceIOS { model }
+    , m_contentSource { adoptNS([[WebAVContentSource alloc] initWithModel:model]) }
+    , m_nowPlayingMetadataObserver { nowPlayingMetadataObserver(*this) }
 {
 }
 
 PlaybackSessionInterfaceAVKit::~PlaybackSessionInterfaceAVKit()
 {
     invalidate();
+}
+
+void PlaybackSessionInterfaceAVKit::durationChanged(double duration)
+{
+    // FIXME: Is setting a min value of 0 correct for, e.g., live streams?
+    [m_contentSource setMinValue:0];
+    [m_contentSource setMaxValue:duration];
+    [m_contentSource setCanTogglePlayback:YES];
+}
+
+void PlaybackSessionInterfaceAVKit::currentTimeChanged(double currentTime, double)
+{
+    [m_contentSource setCurrentValue:currentTime];
+}
+
+void PlaybackSessionInterfaceAVKit::rateChanged(OptionSet<PlaybackSessionModel::PlaybackState> playbackState, double playbackRate, double)
+{
+    if (!playbackState.contains(PlaybackSessionModel::PlaybackState::Stalled))
+        [m_contentSource setRate:playbackState.contains(PlaybackSessionModel::PlaybackState::Playing) ? playbackRate : 0];
+}
+
+void PlaybackSessionInterfaceAVKit::seekableRangesChanged(const TimeRanges& timeRanges, double, double)
+{
+    [m_contentSource setSeekableTimeRanges:makeNSArray(timeRanges.ranges()).get()];
+}
+
+void PlaybackSessionInterfaceAVKit::canPlayFastReverseChanged(bool canPlayFastReverse)
+{
+    [m_contentSource setCanScanBackward:canPlayFastReverse];
+}
+
+void PlaybackSessionInterfaceAVKit::audioMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>& options, uint64_t selectedIndex)
+{
+    RetainPtr audioOptions = adoptNS([[NSMutableArray alloc] initWithCapacity:options.size()]);
+    for (auto& option : options) {
+        RetainPtr audioOption = adoptNS([[WebAVListItem alloc] initWithLocalizedTitle:option.displayName]);
+        [audioOptions addObject:audioOption.get()];
+    }
+
+    [m_contentSource setAudioOptions:(NSArray<AVListable> *)audioOptions.get()];
+    audioMediaSelectionIndexChanged(selectedIndex);
+}
+
+void PlaybackSessionInterfaceAVKit::legibleMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>& options, uint64_t selectedIndex)
+{
+    RetainPtr captionOptions = adoptNS([[NSMutableArray alloc] initWithCapacity:options.size()]);
+    for (auto& option : options) {
+        RetainPtr captionOption = adoptNS([[WebAVListItem alloc] initWithLocalizedTitle:option.displayName]);
+        [captionOptions addObject:captionOption.get()];
+    }
+
+    [m_contentSource setCaptionOptions:(NSArray<AVListable> *)captionOptions.get()];
+    legibleMediaSelectionIndexChanged(selectedIndex);
+}
+
+void PlaybackSessionInterfaceAVKit::audioMediaSelectionIndexChanged(uint64_t selectedIndex)
+{
+    NSArray *audioOptions = [m_contentSource audioOptions];
+    if (selectedIndex < audioOptions.count)
+        [m_contentSource setCurrentAudioOption:audioOptions[selectedIndex]];
+}
+
+void PlaybackSessionInterfaceAVKit::legibleMediaSelectionIndexChanged(uint64_t selectedIndex)
+{
+    NSArray *captionOptions = [m_contentSource captionOptions];
+    if (selectedIndex < captionOptions.count)
+        [m_contentSource setCurrentCaptionOption:captionOptions[selectedIndex]];
+}
+
+void PlaybackSessionInterfaceAVKit::mutedChanged(bool muted)
+{
+    [m_contentSource setMuted:muted];
+}
+
+void PlaybackSessionInterfaceAVKit::volumeChanged(double volume)
+{
+    [m_contentSource setVolume:volume];
+}
+
+void PlaybackSessionInterfaceAVKit::startObservingNowPlayingMetadata()
+{
+    if (m_playbackSessionModel)
+        m_playbackSessionModel->addNowPlayingMetadataObserver(m_nowPlayingMetadataObserver);
+}
+
+void PlaybackSessionInterfaceAVKit::stopObservingNowPlayingMetadata()
+{
+    if (m_playbackSessionModel)
+        m_playbackSessionModel->removeNowPlayingMetadataObserver(m_nowPlayingMetadataObserver);
+}
+
+void PlaybackSessionInterfaceAVKit::nowPlayingMetadataChanged(const NowPlayingMetadata& metadata)
+{
+    [m_contentSource setTitle:metadata.title];
+    [m_contentSource setSubtitle:metadata.artist];
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKitLegacy.mm
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKitLegacy.mm
@@ -141,22 +141,8 @@ void PlaybackSessionInterfaceAVKitLegacy::rateChanged(OptionSet<PlaybackSessionM
 
 void PlaybackSessionInterfaceAVKitLegacy::seekableRangesChanged(const TimeRanges& timeRanges, double lastModifiedTime, double liveUpdateInterval)
 {
-    RetainPtr<NSMutableArray> seekableRanges = adoptNS([[NSMutableArray alloc] init]);
-
-#if !PLATFORM(WATCHOS)
-    for (unsigned i = 0; i < timeRanges.length(); i++) {
-        double start = timeRanges.start(i).releaseReturnValue();
-        double end = timeRanges.end(i).releaseReturnValue();
-
-        CMTimeRange range = PAL::CMTimeRangeMake(PAL::CMTimeMakeWithSeconds(start, 1000), PAL::CMTimeMakeWithSeconds(end-start, 1000));
-        [seekableRanges addObject:[NSValue valueWithCMTimeRange:range]];
-    }
-#else
-    UNUSED_PARAM(timeRanges);
-#endif
-
-    [m_playerController setSeekableTimeRanges:seekableRanges.get()];
-    [m_playerController setSeekableTimeRangesLastModifiedTime: lastModifiedTime];
+    [m_playerController setSeekableTimeRanges:makeNSArray(timeRanges.ranges()).get()];
+    [m_playerController setSeekableTimeRangesLastModifiedTime:lastModifiedTime];
     [m_playerController setLiveUpdateInterval:liveUpdateInterval];
 }
 


### PR DESCRIPTION
#### 7c47403ad6ee2fbedfbcbf2d713f0c6c9d45dee1
<pre>
[iOS] Implement PlaybackSessionInterfaceAVKit in terms of AVMediaSource
<a href="https://bugs.webkit.org/show_bug.cgi?id=284799">https://bugs.webkit.org/show_bug.cgi?id=284799</a>
<a href="https://rdar.apple.com/problem/141601785">rdar://problem/141601785</a>

Reviewed by Eric Carlson.

Implemented PlaybackSessionInterfaceAVKit in terms of a content source object (WebAVContentSource)
that conforms to AVMediaSource. AVMediaSource declares a number of read-only properties that are
expected to be key-value observable, and WebAVContentSource conforms by declaring readwrite
properties that are set by various PlaybackSessionInterfaceAVKit functions. AVMediaSource methods
(e.g., -play) are implemented by calling into PlaybackSessionModel.

To avoid duplicating the method from PlaybackSessionInterfaceAVKitLegacy that converts a TimeRanges
to an NSArray of NSValues, a helper function was added to PlatformTimeRanges.

* Source/WebCore/PAL/pal/spi/cocoa/AVKitSPI.h:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/PlatformTimeRanges.h:
* Source/WebCore/platform/graphics/cocoa/PlatformTimeRangesCocoa.mm: Added.
(WebCore::makeNSArray):
* Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h:
* Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.mm:
(-[WebAVListItem initWithLocalizedTitle:]):
(-[WebAVContentSource initWithModel:]):
(-[WebAVContentSource beginScanningBackward]):
(-[WebAVContentSource beginScanningForward]):
(-[WebAVContentSource endScanningBackward]):
(-[WebAVContentSource endScanningForward]):
(-[WebAVContentSource beginScrubbing]):
(-[WebAVContentSource endScrubbing]):
(-[WebAVContentSource pause]):
(-[WebAVContentSource play]):
(-[WebAVContentSource seekTo:]):
(-[WebAVContentSource setCaptionContentInsets:]):
(-[WebAVContentSource updateCurrentAudioOption:]):
(-[WebAVContentSource updateCurrentCaptionOption:]):
(-[WebAVContentSource updateMuted:]):
(-[WebAVContentSource updateVolume:]):
(WebCore::nowPlayingMetadataObserver):
(WebCore::PlaybackSessionInterfaceAVKit::PlaybackSessionInterfaceAVKit):
(WebCore::PlaybackSessionInterfaceAVKit::durationChanged):
(WebCore::PlaybackSessionInterfaceAVKit::currentTimeChanged):
(WebCore::PlaybackSessionInterfaceAVKit::rateChanged):
(WebCore::PlaybackSessionInterfaceAVKit::seekableRangesChanged):
(WebCore::PlaybackSessionInterfaceAVKit::canPlayFastReverseChanged):
(WebCore::PlaybackSessionInterfaceAVKit::audioMediaSelectionOptionsChanged):
(WebCore::PlaybackSessionInterfaceAVKit::legibleMediaSelectionOptionsChanged):
(WebCore::PlaybackSessionInterfaceAVKit::audioMediaSelectionIndexChanged):
(WebCore::PlaybackSessionInterfaceAVKit::legibleMediaSelectionIndexChanged):
(WebCore::PlaybackSessionInterfaceAVKit::mutedChanged):
(WebCore::PlaybackSessionInterfaceAVKit::volumeChanged):
(WebCore::PlaybackSessionInterfaceAVKit::startObservingNowPlayingMetadata):
(WebCore::PlaybackSessionInterfaceAVKit::stopObservingNowPlayingMetadata):
(WebCore::PlaybackSessionInterfaceAVKit::nowPlayingMetadataChanged):
* Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKitLegacy.mm:
(WebCore::PlaybackSessionInterfaceAVKitLegacy::seekableRangesChanged):

Canonical link: <a href="https://commits.webkit.org/287992@main">https://commits.webkit.org/287992@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7414f53f97801711770af8b4c9734525371a8b31

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81559 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1085 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35507 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86091 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32553 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83669 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1104 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8903 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63644 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21380 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84628 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/784 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74224 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43935 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/684 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28404 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31006 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28997 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87527 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8792 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6238 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71976 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8973 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70052 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71209 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17733 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15275 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14190 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8752 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14280 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8590 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12112 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10397 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->