### PR TITLE
Update WebGL conformance tests 2024-12-10 (2010c617adfff4dbbb7b4c6bd6b3b805c5ea78dc)

### DIFF
--- a/LayoutTests/webgl/2.0.y/conformance2/wasm/bufferdata-16gb-wasm-memory-expected.txt
+++ b/LayoutTests/webgl/2.0.y/conformance2/wasm/bufferdata-16gb-wasm-memory-expected.txt
@@ -1,4 +1,7 @@
 This test runs the WebGL Test listed below in an iframe and reports PASS or FAIL.
 
 Test: ../../../resources/webgl_test_files/conformance2/wasm/bufferdata-16gb-wasm-memory.html?webglVersion=2
-[ PASS ] All tests passed
+
+[ 0: FAIL ] Allocating 17179869184 threw: TypeError: Conversion from 'BigInt' to 'number' is not allowed.
+[ 1: PASS ] successfullyParsed is true
+[ FAIL ] 1 failures reported

--- a/LayoutTests/webgl/2.0.y/conformance2/wasm/buffersubdata-16gb-wasm-memory-expected.txt
+++ b/LayoutTests/webgl/2.0.y/conformance2/wasm/buffersubdata-16gb-wasm-memory-expected.txt
@@ -1,4 +1,7 @@
 This test runs the WebGL Test listed below in an iframe and reports PASS or FAIL.
 
 Test: ../../../resources/webgl_test_files/conformance2/wasm/buffersubdata-16gb-wasm-memory.html?webglVersion=2
-[ PASS ] All tests passed
+
+[ 0: FAIL ] Allocating 17179869184 threw: TypeError: Conversion from 'BigInt' to 'number' is not allowed.
+[ 1: PASS ] successfullyParsed is true
+[ FAIL ] 1 failures reported

--- a/LayoutTests/webgl/2.0.y/conformance2/wasm/getbuffersubdata-16gb-wasm-memory-expected.txt
+++ b/LayoutTests/webgl/2.0.y/conformance2/wasm/getbuffersubdata-16gb-wasm-memory-expected.txt
@@ -1,4 +1,7 @@
 This test runs the WebGL Test listed below in an iframe and reports PASS or FAIL.
 
 Test: ../../../resources/webgl_test_files/conformance2/wasm/getbuffersubdata-16gb-wasm-memory.html?webglVersion=2
-[ PASS ] All tests passed
+
+[ 0: FAIL ] Allocating 17179869184 threw: TypeError: Conversion from 'BigInt' to 'number' is not allowed.
+[ 1: PASS ] successfullyParsed is true
+[ FAIL ] 1 failures reported

--- a/LayoutTests/webgl/2.0.y/conformance2/wasm/readpixels-16gb-wasm-memory-expected.txt
+++ b/LayoutTests/webgl/2.0.y/conformance2/wasm/readpixels-16gb-wasm-memory-expected.txt
@@ -1,4 +1,7 @@
 This test runs the WebGL Test listed below in an iframe and reports PASS or FAIL.
 
 Test: ../../../resources/webgl_test_files/conformance2/wasm/readpixels-16gb-wasm-memory.html?webglVersion=2
-[ PASS ] All tests passed
+
+[ 0: FAIL ] Allocating 17179869184 threw: TypeError: Conversion from 'BigInt' to 'number' is not allowed.
+[ 1: PASS ] successfullyParsed is true
+[ FAIL ] 1 failures reported

--- a/LayoutTests/webgl/2.0.y/conformance2/wasm/teximage2d-16gb-wasm-memory-expected.txt
+++ b/LayoutTests/webgl/2.0.y/conformance2/wasm/teximage2d-16gb-wasm-memory-expected.txt
@@ -1,4 +1,7 @@
 This test runs the WebGL Test listed below in an iframe and reports PASS or FAIL.
 
 Test: ../../../resources/webgl_test_files/conformance2/wasm/teximage2d-16gb-wasm-memory.html?webglVersion=2
-[ PASS ] All tests passed
+
+[ 0: FAIL ] Allocating 17179869184 threw: TypeError: Conversion from 'BigInt' to 'number' is not allowed.
+[ 1: PASS ] successfullyParsed is true
+[ FAIL ] 1 failures reported

--- a/LayoutTests/webgl/2.0.y/conformance2/wasm/texsubimage2d-16gb-wasm-memory-expected.txt
+++ b/LayoutTests/webgl/2.0.y/conformance2/wasm/texsubimage2d-16gb-wasm-memory-expected.txt
@@ -1,4 +1,7 @@
 This test runs the WebGL Test listed below in an iframe and reports PASS or FAIL.
 
 Test: ../../../resources/webgl_test_files/conformance2/wasm/texsubimage2d-16gb-wasm-memory.html?webglVersion=2
-[ PASS ] All tests passed
+
+[ 0: FAIL ] Allocating 17179869184 threw: TypeError: Conversion from 'BigInt' to 'number' is not allowed.
+[ 1: PASS ] successfullyParsed is true
+[ FAIL ] 1 failures reported

--- a/LayoutTests/webgl/resources/webgl_test_files/conformance/offscreencanvas/offscreencanvas-transfer-image-bitmap.html
+++ b/LayoutTests/webgl/resources/webgl_test_files/conformance/offscreencanvas/offscreencanvas-transfer-image-bitmap.html
@@ -17,18 +17,6 @@ found in the LICENSE.txt file.
 <body>
   <div id="description"></div>
   <div id="console"></div>
-  <script id='myWorker' type='text/worker'>
-  self.onmessage = function(e) {
-      var canvas = new OffscreenCanvas(128, 128);
-      var gl = canvas.getContext("webgl");
-      gl.clearColor(1.0, 1.0, 0.0, 1.0);
-      gl.clear(gl.COLOR_BUFFER_BIT);
-      var image = canvas.transferToImageBitmap();
-
-      self.postMessage({ bitmap: image },
-                       [ image ]);
-  };
-  </script>
   <script>
     "use strict";
     description("This test ensures that the transferToImageBitmap function of OffscreenCanvas webgl context is functional.");
@@ -36,14 +24,7 @@ found in the LICENSE.txt file.
         testPassed("No OffscreenCanvas support");
         finishTest();
     } else {
-      var blob = new Blob([document.getElementById('myWorker').textContent]);
-      var worker = new Worker(URL.createObjectURL(blob));
-
-      worker.onmessage = function(msg) {
-          testTransferToImageBitmap("webgl", msg.data.bitmap);
-          finishTest();
-      }
-      worker.postMessage("Start Worker");
+      runTest();
     }
   </script>
 </body>

--- a/LayoutTests/webgl/resources/webgl_test_files/conformance2/offscreencanvas/offscreencanvas-transfer-image-bitmap.html
+++ b/LayoutTests/webgl/resources/webgl_test_files/conformance2/offscreencanvas/offscreencanvas-transfer-image-bitmap.html
@@ -17,18 +17,6 @@ found in the LICENSE.txt file.
 <body>
   <div id="description"></div>
   <div id="console"></div>
-  <script id='myWorker' type='text/worker'>
-  self.onmessage = function(e) {
-      var canvas = new OffscreenCanvas(128, 128);
-      var gl = canvas.getContext("webgl2");
-      gl.clearColor(1.0, 1.0, 0.0, 1.0);
-      gl.clear(gl.COLOR_BUFFER_BIT);
-      var image = canvas.transferToImageBitmap();
-
-      self.postMessage({ bitmap: image },
-                       [ image ]);
-  };
-  </script>
   <script>
     "use strict";
     description("This test ensures that the transferToImageBitmap function of OffscreenCanvas webgl2 context is functional.");
@@ -36,14 +24,7 @@ found in the LICENSE.txt file.
         testPassed("No OffscreenCanvas support");
         finishTest();
     } else {
-      var blob = new Blob([document.getElementById('myWorker').textContent]);
-      var worker = new Worker(URL.createObjectURL(blob));
-
-      worker.onmessage = function(msg) {
-          testTransferToImageBitmap("webgl2", msg.data.bitmap);
-          finishTest();
-      }
-      worker.postMessage("Start Worker");
+      runTest();
     }
   </script>
 </body>

--- a/LayoutTests/webgl/resources/webgl_test_files/conformance2/wasm/bufferdata-16gb-wasm-memory.html
+++ b/LayoutTests/webgl/resources/webgl_test_files/conformance2/wasm/bufferdata-16gb-wasm-memory.html
@@ -29,9 +29,10 @@ const SIZE = 16 * 1024 * 1024 * 1024;
 (() => {
   let view;
   try {
-    view = new Uint8Array(new WebAssembly.Memory({ index: 'i64', initial: BigInt(SIZE / PAGE) }).buffer);
+    view = new Uint8Array(new WebAssembly.Memory({ address: 'i64', initial: BigInt(SIZE / PAGE) }).buffer);
   } catch (e) {
-    testPassed(`Allocating ${SIZE} threw: ${e}`);
+    let fn = e instanceof RangeError ? testPassed : testFailed;
+    fn(`Allocating ${SIZE} threw: ${e}`);
     return;
   }
 

--- a/LayoutTests/webgl/resources/webgl_test_files/conformance2/wasm/buffersubdata-16gb-wasm-memory.html
+++ b/LayoutTests/webgl/resources/webgl_test_files/conformance2/wasm/buffersubdata-16gb-wasm-memory.html
@@ -29,9 +29,10 @@ const SIZE = 16 * 1024 * 1024 * 1024;
 (() => {
   let view;
   try {
-    view = new Uint8Array(new WebAssembly.Memory({ index: 'i64', initial: BigInt(SIZE / PAGE) }).buffer);
+    view = new Uint8Array(new WebAssembly.Memory({ address: 'i64', initial: BigInt(SIZE / PAGE) }).buffer);
   } catch (e) {
-    testPassed(`Allocating ${SIZE} threw: ${e}`);
+    let fn = e instanceof RangeError ? testPassed : testFailed;
+    fn(`Allocating ${SIZE} threw: ${e}`);
     return;
   }
 

--- a/LayoutTests/webgl/resources/webgl_test_files/conformance2/wasm/getbuffersubdata-16gb-wasm-memory.html
+++ b/LayoutTests/webgl/resources/webgl_test_files/conformance2/wasm/getbuffersubdata-16gb-wasm-memory.html
@@ -29,9 +29,10 @@ const SIZE = 16 * 1024 * 1024 * 1024;
 (() => {
   let view;
   try {
-    view = new Uint8Array(new WebAssembly.Memory({ index: 'i64', initial: BigInt(SIZE / PAGE) }).buffer);
+    view = new Uint8Array(new WebAssembly.Memory({ address: 'i64', initial: BigInt(SIZE / PAGE) }).buffer);
   } catch (e) {
-    testPassed(`Allocating ${SIZE} threw: ${e}`);
+    let fn = e instanceof RangeError ? testPassed : testFailed;
+    fn(`Allocating ${SIZE} threw: ${e}`);
     return;
   }
 

--- a/LayoutTests/webgl/resources/webgl_test_files/conformance2/wasm/readpixels-16gb-wasm-memory.html
+++ b/LayoutTests/webgl/resources/webgl_test_files/conformance2/wasm/readpixels-16gb-wasm-memory.html
@@ -30,9 +30,10 @@ const SIZE = 16*1024*1024*1024;
 (() => {
   let view;
   try {
-    view = new Uint8Array(new WebAssembly.Memory({ index: 'i64', initial: BigInt(SIZE / PAGE) }).buffer);
+    view = new Uint8Array(new WebAssembly.Memory({ address: 'i64', initial: BigInt(SIZE / PAGE) }).buffer);
   } catch (e) {
-    testPassed(`Allocating ${SIZE} threw: ${e}`);
+    let fn = e instanceof RangeError ? testPassed : testFailed;
+    fn(`Allocating ${SIZE} threw: ${e}`);
     return;
   }
 

--- a/LayoutTests/webgl/resources/webgl_test_files/conformance2/wasm/teximage2d-16gb-wasm-memory.html
+++ b/LayoutTests/webgl/resources/webgl_test_files/conformance2/wasm/teximage2d-16gb-wasm-memory.html
@@ -29,9 +29,10 @@ const SIZE = 16*1024*1024*1024;
 (() => {
   let view;
   try {
-    view = new Uint8Array(new WebAssembly.Memory({ index: 'i64', initial: BigInt(SIZE / PAGE) }).buffer);
+    view = new Uint8Array(new WebAssembly.Memory({ address: 'i64', initial: BigInt(SIZE / PAGE) }).buffer);
   } catch (e) {
-    testPassed(`Allocating ${SIZE} threw: ${e}`);
+    let fn = e instanceof RangeError ? testPassed : testFailed;
+    fn(`Allocating ${SIZE} threw: ${e}`);
     return;
   }
 

--- a/LayoutTests/webgl/resources/webgl_test_files/conformance2/wasm/texsubimage2d-16gb-wasm-memory.html
+++ b/LayoutTests/webgl/resources/webgl_test_files/conformance2/wasm/texsubimage2d-16gb-wasm-memory.html
@@ -29,9 +29,10 @@ const SIZE = 16*1024*1024*1024;
 (() => {
   let view;
   try {
-    view = new Uint8Array(new WebAssembly.Memory({ index: 'i64', initial: BigInt(SIZE / PAGE) }).buffer);
+    view = new Uint8Array(new WebAssembly.Memory({ address: 'i64', initial: BigInt(SIZE / PAGE) }).buffer);
   } catch (e) {
-    testPassed(`Allocating ${SIZE} threw: ${e}`);
+    let fn = e instanceof RangeError ? testPassed : testFailed;
+    fn(`Allocating ${SIZE} threw: ${e}`);
     return;
   }
 

--- a/LayoutTests/webgl/resources/webgl_test_files/js/tests/offscreencanvas-transfer-image-bitmap.js
+++ b/LayoutTests/webgl/resources/webgl_test_files/js/tests/offscreencanvas-transfer-image-bitmap.js
@@ -1,3 +1,181 @@
+let wtu = WebGLTestUtils;
+function draw(gl) {
+    let vs = gl.createShader(gl.VERTEX_SHADER);
+    gl.shaderSource(vs, "attribute vec2 a_pos; void main() { gl_Position = vec4(a_pos, 0.0, 1.0); }");
+    gl.compileShader(vs);
+    let fs = gl.createShader(gl.FRAGMENT_SHADER);
+    gl.shaderSource(fs, "precision mediump float; void main() { gl_FragColor = vec4(1., 1., 1., 1.); }");
+    gl.compileShader(fs);
+    let p = gl.createProgram();
+    gl.attachShader(p, vs);
+    gl.attachShader(p, fs);
+    gl.bindAttribLocation(p, 0, "a_pos");
+    gl.linkProgram(p);
+    gl.useProgram(p);
+    gl.viewport(0, 0, 128, 128);
+    let verts = [
+        1.0,  1.0,
+        -1.0,  1.0,
+        -1.0, -1.0,
+        -1.0, -1.0,
+         1.0, -1.0,
+         1.0,  1.0
+    ];
+    let vbo = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(verts), gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(0);
+    gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
+    gl.drawArrays(gl.TRIANGLES, 0, 6);
+    gl.bindBuffer(gl.ARRAY_BUFFER, null);
+    gl.useProgram(null);
+}
+
+function testContent({contextType, depth, stencil, antialias, preserveDrawingBuffer}) {
+    var canvas = new OffscreenCanvas(128, 128);
+    var gl = canvas.getContext(contextType, {depth, stencil, antialias, preserveDrawingBuffer});
+    if (!gl)
+        return `Skipped, could not create ${contextType} context`;
+
+    // Draw the yellow contents and modify the depth and stencil buffers.
+    gl.clearColor(1.0, 1.0, 0.0, 1.0);
+    gl.clearDepth(0.0);
+    gl.clearStencil(255);
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT | gl.STENCIL_BUFFER_BIT);
+    let bitmap = canvas.transferToImageBitmap();
+
+    // Test that color buffer was cleared.
+    var buf = new Uint8Array(4);
+    gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+    let colorClear = buf[0] == 0 && buf[1] == 0 && buf[2] == 0 && buf[3] == 0;
+    gl.clearColor(0.0, 0.0, 0.0, 0.0);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+
+    // Test that depth buffer was cleared to 1.0.
+    let depthClear = true;
+    if (gl.getContextAttributes().depth) {
+        gl.enable(gl.DEPTH_TEST);
+        gl.depthFunc(gl.GREATER);
+        draw(gl);
+        gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+        depthClear = buf[0] == 0 && buf[1] == 0 && buf[2] == 0 && buf[3] == 0;
+        gl.disable(gl.DEPTH_TEST);
+        gl.clear(gl.COLOR_BUFFER_BIT);
+    }
+
+    // Test that stencil buffer was cleared to 0.
+    let stencilClear = true;
+    if (gl.getContextAttributes().stencil) {
+        gl.enable(gl.STENCIL_TEST);
+        gl.stencilOp(gl.KEEP, gl.KEEP, gl.KEEP);
+        gl.stencilFunc(gl.NOTEQUAL, 0, 0xffffffff);
+        draw(gl);
+        gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+        stencilClear = buf[0] == 0 && buf[1] == 0 && buf[2] == 0 && buf[3] == 0;
+    }
+    // Test that the context does not flip preserveDrawingBuffer.
+    let preserveDrawingBufferPreserved = preserveDrawingBuffer == gl.getContextAttributes().preserveDrawingBuffer;
+    return { bitmap, colorClear, depthClear, stencilClear, preserveDrawingBufferPreserved };
+}
+
+function workerScript(subcase) {
+    return `
+${draw}
+${testContent}
+let result = testContent({contextType: "${subcase.contextType}", depth: ${subcase.depth}, stencil: ${subcase.stencil}, antialias: ${subcase.antialias}, preserveDrawingBuffer: ${subcase.preserveDrawingBuffer}});
+self.postMessage(result, [ result.bitmap ]);
+`;
+}
+
+function nestedWorkerScript(subcase) {
+    return `
+${draw}
+${testContent}
+${workerScript}
+try {
+    let subcase = { contextType: "${subcase.contextType}", depth: ${subcase.depth}, stencil: ${subcase.stencil}, antialias: ${subcase.antialias}, preserveDrawingBuffer: ${subcase.preserveDrawingBuffer} };
+    let worker = new Worker(URL.createObjectURL(new Blob([workerScript(subcase)])));
+    worker.onmessage = function(msg) {
+        self.postMessage(msg.data, [msg.data.bitmap]);
+    };
+} catch (e) {
+    self.postMessage("Failed, got exception: " + e);
+}
+`;
+}
+
+function testMain(subcase) {
+    return testContent(subcase);
+}
+
+function testWorker(subcase) {
+    return new Promise((resolve) => {
+        let worker = new Worker(URL.createObjectURL(new Blob([workerScript(subcase)])));
+        worker.onmessage = function(msg) {
+            resolve(msg.data);
+        };
+      });
+}
+
+function testNestedWorker(subcase) {
+    return new Promise((resolve) => {
+        let worker = new Worker(URL.createObjectURL(new Blob([nestedWorkerScript(subcase)])));
+        worker.onmessage = function(msg) {
+            resolve(msg.data);
+        };
+      });
+}
+
+let tests = [
+    testMain,
+    testWorker,
+    testNestedWorker,
+];
+
+let contextType = wtu.getDefault3DContextVersion() == 2 ? "webgl2" : "webgl";
+let subcases = [];
+for (let test of tests) {
+    for (let preserveDrawingBuffer of [true, false]) {
+        for (let antialias of [true, false]) {
+            for (let depth of [true, false]) {
+                for (let stencil of [true, false])
+                    subcases.push({test, contextType, preserveDrawingBuffer, antialias, depth, stencil});
+            }
+        }
+    }
+}
+// To debug one case:
+// subcases = [{preserveDrawingBuffer: false, antialias: false, depth: true, stencil: false, contextType, test: testMain}];
+
+let colorClear;
+let depthClear;
+let stencilClear;
+let preserveDrawingBufferPreserved;
+
+async function runTest() {
+    for (let subcase of subcases) {
+        debug(`test ${subcase.test.name}, contextType: ${subcase.contextType}, depth: ${subcase.depth}, stencil: ${subcase.stencil}, antialias: ${subcase.antialias}, preserveDrawingBuffer:${subcase.preserveDrawingBuffer}`);
+        let result = await subcase.test(subcase);
+        if (typeof result === "string") {
+            if (result.startsWith("Skipped"))
+                debug(result);
+            else
+                testFailed(result);
+            continue;
+        }
+        testTransferToImageBitmap("webgl", result.bitmap);
+        colorClear = result.colorClear;
+        shouldBeTrue("colorClear");
+        depthClear = result.depthClear;
+        shouldBeTrue("depthClear");
+        stencilClear = result.stencilClear;
+        shouldBeTrue("stencilClear");
+        preserveDrawingBufferPreserved = result.preserveDrawingBufferPreserved;
+        shouldBeTrue("preserveDrawingBufferPreserved");
+    }
+    finishTest();
+}
+
 function testTransferToImageBitmap(webglContextVersion, bitmap) {
     var internalFormat = "RGBA";
     var pixelFormat = "RGBA";


### PR DESCRIPTION
#### a1bd4bbc9a3ed7b22abb233fd0a052956a3ddaa7
<pre>
Update WebGL conformance tests 2024-12-10 (2010c617adfff4dbbb7b4c6bd6b3b805c5ea78dc)
<a href="https://bugs.webkit.org/show_bug.cgi?id=284800">https://bugs.webkit.org/show_bug.cgi?id=284800</a>
<a href="https://rdar.apple.com/problem/141601829">rdar://problem/141601829</a>

Unreviewed, import from upstream.

* LayoutTests/webgl/resources/webgl_test_files/conformance/offscreencanvas/offscreencanvas-transfer-image-bitmap.html:
* LayoutTests/webgl/resources/webgl_test_files/conformance2/offscreencanvas/offscreencanvas-transfer-image-bitmap.html:
* LayoutTests/webgl/resources/webgl_test_files/conformance2/wasm/bufferdata-16gb-wasm-memory.html:
* LayoutTests/webgl/resources/webgl_test_files/conformance2/wasm/buffersubdata-16gb-wasm-memory.html:
* LayoutTests/webgl/resources/webgl_test_files/conformance2/wasm/getbuffersubdata-16gb-wasm-memory.html:
* LayoutTests/webgl/resources/webgl_test_files/conformance2/wasm/readpixels-16gb-wasm-memory.html:
* LayoutTests/webgl/resources/webgl_test_files/conformance2/wasm/teximage2d-16gb-wasm-memory.html:
* LayoutTests/webgl/resources/webgl_test_files/conformance2/wasm/texsubimage2d-16gb-wasm-memory.html:
* LayoutTests/webgl/resources/webgl_test_files/js/tests/offscreencanvas-transfer-image-bitmap.js:
(draw):
(testContent):

Canonical link: <a href="https://commits.webkit.org/292084@main">https://commits.webkit.org/292084@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0eee2ef11ef7ec9d6ab7039215e7f967af91b7bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94902 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14493 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4339 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99921 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45390 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14776 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22913 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72387 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29681 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97903 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11008 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85688 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52718 "Found 1 new API test failure: /TestWebCore:GStreamerTest.capsFromCodecString (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10715 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3407 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44732 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3501 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101962 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21934 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81383 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22181 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81712 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80775 "Found 1 new API test failure: /TestWebCore:GStreamerTest.capsFromCodecString (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20183 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25337 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2733 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15172 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21910 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21569 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25041 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23310 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->