### PR TITLE
Explicitly inline some methods of Node

### DIFF
--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -203,10 +203,25 @@ inline Node* Node::firstChild() const
     return containerNode ? containerNode->firstChild() : nullptr;
 }
 
+inline RefPtr<Node> Node::protectedFirstChild() const
+{
+    return firstChild();
+}
+
 inline Node* Node::lastChild() const
 {
     auto* containerNode = dynamicDowncast<ContainerNode>(*this);
     return containerNode ? containerNode->lastChild() : nullptr;
+}
+
+inline RefPtr<Node> Node::protectedLastChild() const
+{
+    return lastChild();
+}
+
+inline bool Node::hasChildNodes() const
+{
+    return firstChild();
 }
 
 inline ContainerNode& TreeScope::rootNode() const

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -157,10 +157,10 @@ public:
     RefPtr<Node> protectedNextSibling() const { return m_next.get(); }
     static constexpr ptrdiff_t nextSiblingMemoryOffset() { return OBJECT_OFFSETOF(Node, m_next); }
     WEBCORE_EXPORT RefPtr<NodeList> childNodes();
-    Node* firstChild() const;
-    RefPtr<Node> protectedFirstChild() const { return firstChild(); }
-    Node* lastChild() const;
-    RefPtr<Node> protectedLastChild() const { return lastChild(); }
+    inline Node* firstChild() const; // Defined in ContainerNode.h
+    inline RefPtr<Node> protectedFirstChild() const; // Defined in ContainerNode.h
+    inline Node* lastChild() const; // Defined in ContainerNode.h
+    inline RefPtr<Node> protectedLastChild() const; // Defined in ContainerNode.h
     inline bool hasAttributes() const;
     inline NamedNodeMap* attributes() const;
     Node* pseudoAwareNextSibling() const;
@@ -178,7 +178,7 @@ public:
     WEBCORE_EXPORT ExceptionOr<void> removeChild(Node& child);
     WEBCORE_EXPORT ExceptionOr<void> appendChild(Node& newChild);
 
-    bool hasChildNodes() const { return firstChild(); }
+    inline bool hasChildNodes() const;
 
     enum class CloningOperation {
         OnlySelf,
@@ -469,7 +469,7 @@ public:
     RenderBoxModelObject* renderBoxModelObject() const;
 
     // Wrapper for nodes that don't have a renderer, but still cache the style (like HTMLOptionElement).
-    const RenderStyle* renderStyle() const;
+    inline const RenderStyle* renderStyle() const;
 
     WEBCORE_EXPORT const RenderStyle* computedStyle();
     virtual const RenderStyle* computedStyle(const std::optional<Style::PseudoElementIdentifier>&);


### PR DESCRIPTION
#### f5f143eb1eae67060d2241fdc2926e11bbb759a1
<pre>
Explicitly inline some methods of Node
<a href="https://bugs.webkit.org/show_bug.cgi?id=284801">https://bugs.webkit.org/show_bug.cgi?id=284801</a>

Reviewed by Tim Nguyen.

Explicitly mark some methods of Node as inline.

* Source/WebCore/dom/ContainerNode.h:
(WebCore::Node::protectedFirstChild const):
(WebCore::Node::protectedLastChild const):
(WebCore::Node::hasChildNodes const):
* Source/WebCore/dom/Node.h:
(WebCore::Node::protectedFirstChild const): Deleted.
(WebCore::Node::protectedLastChild const): Deleted.
(WebCore::Node::hasChildNodes const): Deleted.

Canonical link: <a href="https://commits.webkit.org/287933@main">https://commits.webkit.org/287933@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd204a5199768510f0753b1765e8c0a13eec48dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81425 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/950 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35368 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85954 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32412 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83535 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/968 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8769 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63555 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/21309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84494 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/671 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74109 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43848 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/566 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28273 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30869 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28862 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87389 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8655 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/71871 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8836 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69930 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71108 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15169 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14078 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12617 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8617 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/14146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8453 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11974 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10261 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->