### PR TITLE
[TexMap][Nicosia] Incorrect damage information produced for animations with transforms

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5903,7 +5903,7 @@ ProcessSwapOnCrossSiteNavigationEnabled:
 
 PropagateDamagingInformation:
    type: bool
-   status: unstable
+   status: testable
    category: dom
    humanReadableName: "Propagate Damaging Information"
    humanReadableDescription: "Propagate Damaging Information"

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
@@ -119,7 +119,7 @@ public:
 
 #if ENABLE(DAMAGE_TRACKING)
     void setDamage(const Damage&);
-    void collectDamage(TextureMapper&, Damage&);
+    void collectDamage(TextureMapper&, Damage&, const FloatSize&);
 #endif
 
     FloatRect effectiveLayerRect() const;
@@ -184,8 +184,8 @@ private:
     void collect3DRenderingContextLayers(Vector<TextureMapperLayer*>&);
 
 #if ENABLE(DAMAGE_TRACKING)
-    void collectDamageRecursive(TextureMapperPaintOptions&, Damage&);
-    void collectDamageSelf(TextureMapperPaintOptions&, Damage&);
+    void collectDamageRecursive(TextureMapperPaintOptions&, Damage&, const FloatSize&);
+    void collectDamageSelf(TextureMapperPaintOptions&, Damage&, const FloatSize&);
     FloatRect transformRectForDamage(const FloatRect&, const TransformationMatrix&, const TextureMapperPaintOptions&);
 #endif
 

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
@@ -113,6 +113,7 @@ public:
     bool syncAnimations(MonotonicTime);
     WEBCORE_EXPORT bool descendantsOrSelfHaveRunningAnimations() const;
 
+    WEBCORE_EXPORT void prepareTreeForPainting(TextureMapper&);
     WEBCORE_EXPORT void paint(TextureMapper&);
 
     void addChild(TextureMapperLayer*);
@@ -186,6 +187,7 @@ private:
 #if ENABLE(DAMAGE_TRACKING)
     void collectDamageRecursive(TextureMapperPaintOptions&, Damage&, const FloatSize&);
     void collectDamageSelf(TextureMapperPaintOptions&, Damage&, const FloatSize&);
+    void damageWholeLayerDueToTransformChangeIfNeeded(const TransformationMatrix& beforeChange, const TransformationMatrix& afterChange);
     FloatRect transformRectForDamage(const FloatRect&, const TransformationMatrix&, const TextureMapperPaintOptions&);
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedGraphicsScene.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedGraphicsScene.cpp
@@ -77,18 +77,17 @@ void CoordinatedGraphicsScene::paintToCurrentGLContext(const TransformationMatri
             frameDamage.add(clipRect);
         } else {
             WTFBeginSignpost(this, CollectDamage);
-            currentRootLayer->collectDamage(*m_textureMapper, frameDamage);
+            currentRootLayer->collectDamage(*m_textureMapper, frameDamage, clipRect.size());
             WTFEndSignpost(this, CollectDamage);
 
-            ASSERT(!frameDamage.isInvalid());
-            if (m_damagePropagation == Damage::Propagation::Unified) {
+            if (!frameDamage.isInvalid() && m_damagePropagation == Damage::Propagation::Unified) {
                 Damage boundsDamage;
                 boundsDamage.add(frameDamage.bounds());
                 frameDamage = WTFMove(boundsDamage);
             }
         }
 
-        const auto& damageSinceLastSurfaceUse = m_client->addSurfaceDamage(frameDamage);
+        const auto& damageSinceLastSurfaceUse = m_client->addSurfaceDamage(!frameDamage.isInvalid() && !frameDamage.isEmpty() ? frameDamage : Damage::invalid());
         if (!damageSinceLastSurfaceUse.isInvalid()) {
             actualClipRect = static_cast<FloatRoundedRect>(damageSinceLastSurfaceUse.bounds());
             didChangeClipRect = true;


### PR DESCRIPTION
#### 9acd8f4d6fed2d2a9d85bda4c2c639b862899fe5
<pre>
[TexMap][Nicosia] Incorrect damage information produced for animations with transforms
<a href="https://bugs.webkit.org/show_bug.cgi?id=284808">https://bugs.webkit.org/show_bug.cgi?id=284808</a>

Reviewed by NOBODY (OOPS!).

WIP

* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
(WebCore::TextureMapperLayer::computeTransformsRecursive):
(WebCore::TextureMapperLayer::prepareTreeForPainting):
(WebCore::TextureMapperLayer::paint):
(WebCore::TextureMapperLayer::collectDamageSelf):
(WebCore::TextureMapperLayer::damageWholeLayerDueToTransformChangeIfNeeded):
(WebCore::TextureMapperLayer::setTransform):
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedGraphicsScene.cpp:
(WebKit::CoordinatedGraphicsScene::paintToCurrentGLContext):
(WebKit::CoordinatedGraphicsScene::updateSceneState):
</pre>
----------------------------------------------------------------------
#### 7e1973c7ea87ec62210c0bed03602904e4a74d23
<pre>
[GTK][WPE] Enable testing of damaging information propagation
<a href="https://bugs.webkit.org/show_bug.cgi?id=283425">https://bugs.webkit.org/show_bug.cgi?id=283425</a>

Reviewed by NOBODY (OOPS!).

This change adds two workarounds to make layout tests passing with damaging enabled:
- workaround for scrolling that invalidates the damage whever scrolling is possible
- workaround for empty damage so that WebKit compositor always treats it as &quot;full&quot; aka invalid

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
(WebCore::TextureMapperLayer::collectDamage):
(WebCore::TextureMapperLayer::collectDamageRecursive):
(WebCore::TextureMapperLayer::collectDamageSelf):
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedGraphicsScene.cpp:
(WebKit::CoordinatedGraphicsScene::paintToCurrentGLContext):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9acd8f4d6fed2d2a9d85bda4c2c639b862899fe5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81433 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/958 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35376 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85962 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32420 "Hash 9acd8f4d for PR 38066 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83543 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/976 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8777 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63563 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/32420 "Hash 9acd8f4d for PR 38066 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84502 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/677 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74118 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43856 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/572 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28282 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30877 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/74412 "Built successfully and passed tests") | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28871 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87397 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/80491 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8663 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6155 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71874 "Found 30 new test failures: css3/filters/effect-blur-hw.html fast/canvas/canvas-filter-repaint-rect.html fast/canvas/canvas-resize-reset.html fast/canvas/canvasDrawingIntoSelf.html fast/canvas/drawImage.html fast/canvas/fillrect-gradient-zero-stops.html fast/canvas/webgl/match-page-color-space-p3.html fast/canvas/webgl/match-page-color-space.html fast/css/object-fit/object-fit-canvas.html fast/mediastream/MediaStream-video-element-video-tracks-disabled.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8844 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69939 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71112 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15179 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14087 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/102900 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8625 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14154 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/24997 "Found 2 new JSC stress test failures: wasm.yaml/wasm/stress/struct-new_default-small-members.js.default-wasm, wasm.yaml/wasm/stress/struct-new_default-small-members.js.wasm-bbq (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8461 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11982 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10269 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->