### PR TITLE
Improve reliability and debuggability of http/wpt/mediarecorder/pause-recording.html and http/wpt/mediarecorder/MediaRecorder-audio-bitrate-webm.html

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2479,6 +2479,10 @@ webrtc/h265.html [ Pass Failure ]
 webrtc/h264-baseline.html [ Slow ]
 webrtc/h264-high.html [ Slow ]
 
+http/wpt/mediarecorder/MediaRecorder-audio-bitrate-webm.html [ Slow ]
+http/wpt/mediarecorder/pause-recording.html [ Slow ]
+http/wpt/mediarecorder/pause-recording-2.html [ Pass Failure ]
+
 imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-getSynchronizationSources.https.html [ Slow ]
 imported/w3c/web-platform-tests/webrtc/protocol/split.https.html [ Pass Failure ]
 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-relay-canvas.https.html [ Failure ]

--- a/LayoutTests/http/wpt/mediarecorder/MediaRecorder-audio-bitrate.js
+++ b/LayoutTests/http/wpt/mediarecorder/MediaRecorder-audio-bitrate.js
@@ -1,11 +1,30 @@
-function record(stream, bitRate, mimeType)
+async function record(stream, bitRate, mimeType)
 {
+    let blob;
+    let type;
+    let count = 0;
     const recorder = new MediaRecorder(stream, { mimeType : mimeType, audioBitsPerSecond : bitRate });
     const promise = new Promise((resolve, reject) => {
-        recorder.ondataavailable = (e) => resolve(e.data);
-        setTimeout(reject, 5000);
+        recorder.ondataavailable = (e) => {
+             if (!blob) {
+                 blob = e.data;
+                 type = e.data.type;
+             } else
+                 blob = new Blob([blob, e.data]);
+             ++count;
+             if (blob.size < 500)
+                 return;
+             resolve(blob);
+        };
+        setTimeout(() => reject("not recording enough data, blob count " + count + ", size is " + (blob?.size)), 15000);
     });
     recorder.start();
-    setTimeout(() => recorder.stop(), 2500);
-    return promise;
+    const interval = setInterval(() => recorder.requestData(), 500);
+    await promise;
+    clearInterval(interval);
+    recorder.stop();
+    return new Promise((resolve, reject) => {
+        recorder.ondataavailable = e => resolve(new Blob([blob, e.data], { type }));
+        setTimeout(() => reject("blob event when stopping timed out"), 5000);
+    });
 }

--- a/LayoutTests/http/wpt/mediarecorder/pause-recording-2-expected.txt
+++ b/LayoutTests/http/wpt/mediarecorder/pause-recording-2-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Pausing and resuming the WebM recording should impact the video duration
+

--- a/LayoutTests/http/wpt/mediarecorder/pause-recording-2.html
+++ b/LayoutTests/http/wpt/mediarecorder/pause-recording-2.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+    <script>
+function waitFor(duration)
+{
+    return new Promise((resolve) => setTimeout(resolve, duration));
+}
+
+function waitForEvent(object, eventName, testName)
+{
+    return new Promise((resolve, reject) => {
+        object.addEventListener(eventName, resolve, { once: true });
+        setTimeout(() => reject("waitForEvent " + (testName ? (testName + " ") : "") + "timed out for " + eventName), 2000);
+    });
+}
+
+promise_test(async (test) => {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+
+    const recorder = new MediaRecorder(stream, { mimeType: "video/webm" });
+    const dataPromise = new Promise(resolve => recorder.ondataavailable = (e) => resolve(e.data));
+
+    const startPromise = new Promise(resolve => recorder.onstart = resolve);
+    recorder.start();
+    await startPromise;
+
+    setTimeout(() => recorder.pause(), 50);
+    setTimeout(() => recorder.resume(), 950);
+
+    await waitFor(2000);
+    recorder.stop();
+    const blob = await dataPromise;
+
+    const video = document.createElement("video");
+    video.disableRemotePlayback = true;
+    const metadataPromise = waitForEvent(video, "loadedmetadata");
+
+    // webm generated don't have a duration located in the metadata. Determine the duration with MediaSource.
+    if (!window.ManagedMediaSource?.isTypeSupported(blob.type)) {
+        const url = URL.createObjectURL(blob);
+        video.src = url;
+        await metadataPromise;
+        URL.revokeObjectURL(url);
+        return;
+    }
+
+    const source = new ManagedMediaSource();
+    video.srcObject = source;
+    await waitForEvent(source, "sourceopen");
+    const buffer = source.addSourceBuffer(blob.type);
+    buffer.appendBuffer(await blob.arrayBuffer());
+    await waitForEvent(buffer, "update");
+    await metadataPromise;
+    source.endOfStream();
+    await waitForEvent(source, "sourceended");
+    assert_less_than(video.duration, 1.5);
+}, "Pausing and resuming the WebM recording should impact the video duration");
+    </script>
+</body>
+</html>

--- a/LayoutTests/http/wpt/mediarecorder/pause-recording-expected.txt
+++ b/LayoutTests/http/wpt/mediarecorder/pause-recording-expected.txt
@@ -2,7 +2,6 @@
 PASS Pausing and resuming the recording should impact the video duration
 PASS Calling requestData once after pausing should lead to more than header data
 PASS Once paused, the second requestData call should lead to a zero size blob
-PASS Pausing and resuming the WebM recording should impact the video duration
 PASS Calling requestData with WebM once after pausing should lead to more than header data
 PASS Once paused, the second requestData with WebM call should lead to a zero size blob
 

--- a/LayoutTests/http/wpt/mediarecorder/pause-recording.html
+++ b/LayoutTests/http/wpt/mediarecorder/pause-recording.html
@@ -2,7 +2,6 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <title>A recorded muted audio track should produce silence</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
 </head>
@@ -15,6 +14,7 @@ function waitFor(duration)
 
 promise_test(async (test) => {
     const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+    test.add_cleanup(() => { stream.getTracks().forEach(t => t.stop()); });
 
     const recorder = new MediaRecorder(stream);
     const dataPromise = new Promise(resolve => recorder.ondataavailable = (e) => resolve(e.data));
@@ -42,6 +42,7 @@ promise_test(async (test) => {
 
 promise_test(async (test) => {
     const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+    test.add_cleanup(() => { stream.getTracks().forEach(t => t.stop()); });
 
     const recorder = new MediaRecorder(stream);
     const dataPromise = new Promise(resolve => recorder.ondataavailable = (e) => resolve(e.data));
@@ -64,6 +65,7 @@ promise_test(async (test) => {
 
 promise_test(async (test) => {
     const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+    test.add_cleanup(() => { stream.getTracks().forEach(t => t.stop()); });
 
     const recorder = new MediaRecorder(stream);
     let dataPromise = new Promise(resolve => recorder.ondataavailable = (e) => resolve(e.data));
@@ -94,47 +96,7 @@ promise_test(async (test) => {
 
 promise_test(async (test) => {
     const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
-
-    const recorder = new MediaRecorder(stream, { mimeType: "video/webm" });
-    const dataPromise = new Promise(resolve => recorder.ondataavailable = (e) => resolve(e.data));
-
-    const startPromise = new Promise(resolve => recorder.onstart = resolve);
-    recorder.start();
-    await startPromise;
-
-    setTimeout(() => recorder.pause(), 50);
-    setTimeout(() => recorder.resume(), 950);
-
-    await waitFor(2000);
-    recorder.stop();
-    const blob = await dataPromise;
-
-    const video = document.createElement("video");
-    video.disableRemotePlayback = true;
-    const metadataPromise = new Promise((resolve) => video.addEventListener("loadedmetadata", resolve, { once: true }));
-
-    // webm generated don't have a duration located in the metadata. Determine the duration with MediaSource.
-    if (!window.ManagedMediaSource?.isTypeSupported(blob.type)) {
-        const url = URL.createObjectURL(blob);
-        video.src = url;
-        await metadatapromise;
-        URL.revokeObjectURL(url);
-        return ;
-    }
-    const source = new ManagedMediaSource();
-    video.srcObject = source;
-    await new Promise((resolve) => source.addEventListener("sourceopen", resolve, { once: true }));
-    const buffer = source.addSourceBuffer(blob.type);
-    buffer.appendBuffer(await blob.arrayBuffer());
-    await new Promise((resolve) => buffer.addEventListener("update", resolve, { once: true }));
-    await metadataPromise;
-    source.endOfStream();
-    await new Promise((resolve) => source.addEventListener("sourceended", resolve, { once: true }));
-    assert_less_than(video.duration, 1.5);
-}, "Pausing and resuming the WebM recording should impact the video duration");
-
-promise_test(async (test) => {
-    const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+    test.add_cleanup(() => { stream.getTracks().forEach(t => t.stop()); });
 
     const recorder = new MediaRecorder(stream, { mimeType: "video/webm" });
     const dataPromise = new Promise(resolve => recorder.ondataavailable = (e) => resolve(e.data));
@@ -157,6 +119,7 @@ promise_test(async (test) => {
 
 promise_test(async (test) => {
     const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+    test.add_cleanup(() => { stream.getTracks().forEach(t => t.stop()); });
 
     const recorder = new MediaRecorder(stream, { mimeType: "video/webm" });
     let dataPromise = new Promise(resolve => recorder.ondataavailable = (e) => resolve(e.data));


### PR DESCRIPTION
#### f2bf55e652d728e60cdc061123fe29cb31a277ec
<pre>
Improve reliability and debuggability of http/wpt/mediarecorder/pause-recording.html and http/wpt/mediarecorder/MediaRecorder-audio-bitrate-webm.html
<a href="https://rdar.apple.com/141616340">rdar://141616340</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=284816">https://bugs.webkit.org/show_bug.cgi?id=284816</a>

Reviewed by Jean-Yves Avenard.

We mark those tests as slow.
We make sure that for the audio bitrate test, we gather enough data to be able to compare correctly different bitrates.
We make sure to stop tracks in http/wpt/mediarecorder/pause-recording.html to improve efficiency.

We move one of the test in its own http/wpt/mediarecorder/pause-recording-2.html since it appears to be more flaky than other tests.
We update the test by fixing a typo in the name of a promise that is reused lowercase while it is defined mixedcase.
And we add a helper routine to wait for events with a timer so that the test will give more information in case it is timing out.

* LayoutTests/TestExpectations:
* LayoutTests/http/wpt/mediarecorder/MediaRecorder-audio-bitrate.js:
(async record):
(record): Deleted.
* LayoutTests/http/wpt/mediarecorder/pause-recording-2-expected.txt: Added.
* LayoutTests/http/wpt/mediarecorder/pause-recording-2.html: Added.
* LayoutTests/http/wpt/mediarecorder/pause-recording-expected.txt:
* LayoutTests/http/wpt/mediarecorder/pause-recording.html:

Canonical link: <a href="https://commits.webkit.org/287950@main">https://commits.webkit.org/287950@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c32230d2f294e0e594e64e036b1ea2c715c1dc41

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81470 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/995 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35413 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85999 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32460 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1013 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8814 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63589 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/21332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84539 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/708 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74150 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43882 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/604 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28315 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30914 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28903 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87434 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8700 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71904 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8881 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69971 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71142 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17705 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15206 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14119 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8662 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8498 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12019 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10306 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->