### PR TITLE
Asynchronously delete small DOM nodes

### DIFF
--- a/LayoutTests/fast/dom/gc-dom-tree-lifetime-expected.txt
+++ b/LayoutTests/fast/dom/gc-dom-tree-lifetime-expected.txt
@@ -30,7 +30,6 @@ PASS globalDiv.id is "div2"
 PASS globalDiv.parentNode.id is "div2-parent"
 PASS globalDiv.firstChild.id is "div2-child"
 === After clearing innerHTML, divX, divY and divZ ===
-PASS All <div> objects in a DOM tree are successfully destructed.
 === Initial state ===
 PASS globalDiv.id is "div0"
 PASS globalDiv.parentNode.id is "div0-parent"
@@ -63,7 +62,6 @@ PASS globalDiv.id is "div1"
 PASS globalDiv.parentNode.id is "div1-parent"
 PASS globalDiv.firstChild.id is "div1-child"
 === After clearing innerHTML, divX, divY and divZ ===
-PASS All <div> objects in a DOM tree are successfully destructed.
 === Initial state ===
 PASS globalDiv.id is "div1"
 PASS globalDiv.parentNode.id is "div1-parent"
@@ -96,7 +94,6 @@ PASS globalDiv.id is "div2"
 PASS globalDiv.parentNode.id is "div2-parent"
 PASS globalDiv.firstChild.id is "div2-child"
 === After clearing innerHTML, divX, divY and divZ ===
-PASS All <div> objects in a DOM tree are successfully destructed.
 === Initial state ===
 PASS globalDiv.id is "div1"
 PASS globalDiv.parentNode.id is "div1-parent"
@@ -129,7 +126,6 @@ PASS globalDiv.id is "div0"
 PASS globalDiv.parentNode.id is "div0-parent"
 PASS globalDiv.firstChild.id is "div0-child"
 === After clearing innerHTML, divX, divY and divZ ===
-PASS All <div> objects in a DOM tree are successfully destructed.
 === Initial state ===
 PASS globalDiv.id is "div2"
 PASS globalDiv.parentNode.id is "div2-parent"
@@ -162,7 +158,6 @@ PASS globalDiv.id is "div1"
 PASS globalDiv.parentNode.id is "div1-parent"
 PASS globalDiv.firstChild.id is "div1-child"
 === After clearing innerHTML, divX, divY and divZ ===
-PASS All <div> objects in a DOM tree are successfully destructed.
 === Initial state ===
 PASS globalDiv.id is "div2"
 PASS globalDiv.parentNode.id is "div2-parent"

--- a/LayoutTests/fast/dom/gc-dom-tree-lifetime.html
+++ b/LayoutTests/fast/dom/gc-dom-tree-lifetime.html
@@ -5,20 +5,26 @@
 </head>
 <body>
 <script>
+jsTestIsAsync = true;
+var totalNumNodes = 0;
 var testCases = [["div0", "div1", "div2"],
                  ["div0", "div2", "div1"],
                  ["div1", "div0", "div2"],
                  ["div1", "div2", "div0"],
                  ["div2", "div0", "div1"],
                  ["div2", "div1", "div0"]];
-
+var maxFailCount = 1500;
+var failCount = 0;
 var rootDiv = document.createElement("div");
 document.body.appendChild(rootDiv);
 var testHtml = "<div id='div0-parent'><div id='div0'><div id='div0-child'></div></div><div id='div1-parent'><div id='div1'><div id='div1-child'></div></div><div id='div2-parent'><div id='div2'><div id='div2-child'></div></div></div></div></div>";
-
+var numNodesAfterTest = 0;
+var prevNodes = 0;
+var numNodesDeleted = 0;
 testCases.forEach(function (test) {
     var divX, divY, divZ;
     debug("=== Initial state ===");
+    // get the max number of nodes in case idle time occurs before doing node count check
     rootDiv.innerHTML = testHtml;
     divX = document.getElementById(test[0]);
     divY = document.getElementById(test[1]);
@@ -71,16 +77,34 @@ testCases.forEach(function (test) {
     divY = null;
     divZ = null;
     gc();
+    numNodesDeleted += (prevNodes - window.internals.numberOfLiveNodes());
+});
+if (window.internals)
+    numNodesAfterTest = window.internals.numberOfLiveNodes();
+// DOM nodes can be destructed asynchronously during idle time. Check number of nodes destructed on idle callback.
+// Use the timeout to ensure idle time occurs on the event loop after the test logic finishes so that DOM nodes will 
+// be opportunistically destructed before doing the check.
+setTimeout(() => window.requestIdleCallback(checkNumberOfNodesAlive), 500);
+
+function checkNumberOfNodesAlive() {
     if (window.internals) {
         // If all the Node objects in testHtml are successfully destructed,
-        // at least 9 <div>s objects will be removed.
+        // at least 9 <div>s objects will be removed for each test case.
         // (Actually, since testHtml rendering requires more than 9 Node objects.)
-        if (window.internals.numberOfLiveNodes() <= prevNodes - 9)
+        numNodesDeleted = Math.max(numNodesAfterTest - window.internals.numberOfLiveNodes(), numNodesDeleted);
+        if (numNodesDeleted >= (9 * testCases.length)) {
             testPassed("All <div> objects in a DOM tree are successfully destructed.");
-        else
-            testFailed("<div> objects in a DOM tree are not destructed.");
+            finishJSTest();
+        }
+        else {
+            if (++failCount >= maxFailCount) {
+                testFailed("<div> objects in a DOM tree are not destructed.");
+                finishJSTest();
+            }
+            window.requestIdleCallback(checkNumberOfNodesAlive);
+        }
     }
-});
+}
 
 function checkParentAndChildAlive(div, name) {
     globalDiv = div;

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2807,6 +2807,9 @@ imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-nestin
 #test uses test helper functions not implemented on WK1
 fast/dom/no-scroll-when-command-click-fragment-URL.html [ Skip ]
 
+# RequestIdleCallBack is disabled on WK1
+fast/dom/gc-dom-tree-lifetime.html [ Skip ]
+
 # webkit.org/b/267799 [ Ventura wk1 ] 2 tests in media/track are constant crash
 [ Ventura ] media/track/track-in-band-layout.html [ Crash ]
 [ Ventura ] media/track/track-paint-on-captions.html [ Crash ]

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1009,6 +1009,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/ActiveDOMCallback.h
     dom/ActiveDOMObject.h
     dom/AddEventListenerOptions.h
+    dom/AsyncNodeDeletionQueue.h
     dom/Attr.h
     dom/Attribute.h
     dom/BoundaryPoint.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1199,6 +1199,7 @@ dom/CaretPosition.cpp
 dom/CharacterData.cpp
 dom/ChildListMutationScope.cpp
 dom/ChildNodeList.cpp
+dom/AsyncNodeDeletionQueue.cpp
 dom/ClassCollection.cpp
 dom/ClipboardEvent.cpp
 dom/CollectionIndexCache.cpp

--- a/Source/WebCore/dom/AsyncNodeDeletionQueue.cpp
+++ b/Source/WebCore/dom/AsyncNodeDeletionQueue.cpp
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * 3.  Neither the name of Apple Inc. ("Apple") nor the names of
+ *     its contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include "config.h"
+#include "AsyncNodeDeletionQueue.h"
+
+#include "HTMLElement.h"
+#include "NodeName.h"
+
+#define MAX_SIZE_ASYNC_NODE_DELETION_QUEUE 500'000
+
+namespace WebCore {
+
+static bool isNodeLikelySmall(const Node& node)
+{
+    /*
+    static WTF::NeverDestroyed<std::unordered_map<ElementName, unsigned>> counters;
+    ASSERT(node.isElementNode());
+    auto& element = downcast<Element>(node);
+    auto elementName = element.elementName();
+    auto find = counters->find(elementName);
+    if (find == std::end(counters.get()))
+        counters.get()[elementName] = 1;
+    else
+        counters.get()[elementName] += 1;
+    WTF_ALWAYS_LOG("element " << element.tagName() << " counter: " << counters.get()[elementName]);
+    */
+
+    switch (downcast<Element>(node).elementName()) {
+    case NodeName::HTML_input:
+    case NodeName::HTML_li:
+    case NodeName::HTML_a:
+    case NodeName::HTML_div:
+    case NodeName::HTML_button:
+    case NodeName::HTML_ul:
+    case NodeName::HTML_label:
+    case NodeName::HTML_link:
+    case NodeName::HTML_p:
+    case NodeName::HTML_select:
+    case NodeName::HTML_form:
+    case NodeName::HTML_code:
+    case NodeName::HTML_i:
+    case NodeName::HTML_listing:
+    case NodeName::HTML_hr:
+    case NodeName::HTML_summary:
+    case NodeName::HTML_details:
+    case NodeName::HTML_nav:
+    case NodeName::HTML_h1:
+    case NodeName::HTML_h2:
+    case NodeName::HTML_h3:
+    case NodeName::HTML_h4:
+    case NodeName::HTML_h5:
+    case NodeName::HTML_h6:
+    case NodeName::HTML_em:
+    case NodeName::HTML_strong:
+    case NodeName::HTML_ol:
+    case NodeName::HTML_address:
+    case NodeName::HTML_b:
+    case NodeName::HTML_span:
+    case NodeName::HTML_abbr:
+    case NodeName::HTML_q:
+    case NodeName::HTML_option:
+    case NodeName::HTML_cite:
+    case NodeName::HTML_mark:
+    case NodeName::HTML_article:
+        return true;
+    default:
+        return false;
+    }
+}
+
+void AsyncNodeDeletionQueue::add(NodeVector&& children, unsigned numberOfNodes)
+{
+    if (m_numberOfNodes + numberOfNodes > MAX_SIZE_ASYNC_NODE_DELETION_QUEUE) {
+        // Synchronously deleted nodes.
+        children.clear();
+        return;
+    }
+
+    m_queue.appendVector(WTFMove(children));
+    m_numberOfNodes += numberOfNodes;
+
+    //WTF_ALWAYS_LOG("queue size: " << m_numberOfNodes);
+}
+
+bool AsyncNodeDeletionQueue::canNodeBeAsyncDeleted(const Node& node)
+{
+    if (!dynamicDowncast<HTMLElement>(node))
+        return true;
+    if (!isNodeLikelySmall(node))
+        return false;
+    return true;
+}
+
+void AsyncNodeDeletionQueue::clear()
+{
+    // WTF_ALWAYS_LOG("clearing queue from size " << m_queue.size());
+    m_queue.clear();
+    m_numberOfNodes = 0;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/dom/AsyncNodeDeletionQueue.h
+++ b/Source/WebCore/dom/AsyncNodeDeletionQueue.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * 3.  Neither the name of Apple Inc. ("Apple") nor the names of
+ *     its contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ContainerNode.h"
+#include "HTMLNames.h"
+
+namespace WebCore {
+
+class AsyncNodeDeletionQueue {
+public:
+    static bool canNodeBeAsyncDeleted(const Node&);
+    void add(NodeVector&& children, unsigned numberOfNodes);
+    void clear();
+
+private:
+    Vector<Ref<Node>> m_queue;
+    unsigned m_numberOfNodes = 0;
+};
+
+} // namespace WebCore
+
+

--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -146,6 +146,8 @@ public:
     ExceptionOr<void> ensurePreInsertionValidityForPhantomDocumentFragment(NodeVector& newChildren, Node* refChild = nullptr);
     ExceptionOr<void> insertChildrenBeforeWithoutPreInsertionValidityCheck(NodeVector&&, Node* nextChild = nullptr);
 
+    enum class ChildrenDeletionCanBeDelayed : bool { No, Yes };
+
 protected:
     explicit ContainerNode(Document&, NodeType, OptionSet<TypeFlag> = { });
 
@@ -161,10 +163,17 @@ private:
     void executePreparedChildrenRemoval();
     enum class DeferChildrenChanged : bool { No, Yes };
     enum class DidRemoveElements : bool { No, Yes };
-    DidRemoveElements removeAllChildrenWithScriptAssertion(ChildChange::Source, NodeVector& children, DeferChildrenChanged = DeferChildrenChanged::No);
+    struct RemoveAllChildrenResult
+    {
+        DidRemoveElements didRemoveElements = DidRemoveElements::No;
+        std::optional<unsigned> childrenNodesCount = {};
+        ChildrenDeletionCanBeDelayed childrenDeletionCanBeDelayed = ChildrenDeletionCanBeDelayed::No;
+    };
+    //using RemoveAllChildrenResult = std::pair<DidRemoveElements, ChildrenDeletionCanBeDelayed>;
+    RemoveAllChildrenResult removeAllChildrenWithScriptAssertion(ChildChange::Source, NodeVector& children, DeferChildrenChanged = DeferChildrenChanged::No);
     bool removeNodeWithScriptAssertion(Node&, ChildChange::Source);
     ExceptionOr<void> removeSelfOrChildNodesForInsertion(Node&, NodeVector&);
-
+    void delayDeletingRemovedChildren(NodeVector&& removedChildren, unsigned childrenCount);
     void removeBetween(Node* previousChild, Node* nextChild, Node& oldChild);
     ExceptionOr<void> appendChildWithoutPreInsertionValidityCheck(Node&);
 

--- a/Source/WebCore/dom/ContainerNodeAlgorithms.h
+++ b/Source/WebCore/dom/ContainerNodeAlgorithms.h
@@ -67,7 +67,16 @@ enum class RemovedSubtreeObservability : bool {
     NotObservable,
     MaybeObservableByRefPtr,
 };
-RemovedSubtreeObservability notifyChildNodeRemoved(ContainerNode& oldParentOfRemovedTree, Node&);
+
+struct RemovedSubtreeResult
+{
+    RemovedSubtreeObservability observability;
+    unsigned removedNodesCount = 0;
+    ContainerNode::ChildrenDeletionCanBeDelayed childrenDeletionCanBeDelayed = ContainerNode::ChildrenDeletionCanBeDelayed::No;
+};
+//using RemovedSubtreeResult = std::pair<RemovedSubtreeObservability, ContainerNode::ChildrenDeletionCanBeDelayed>;
+
+RemovedSubtreeResult notifyChildNodeRemoved(ContainerNode& oldParentOfRemovedTree, Node&);
 void removeDetachedChildrenInContainer(ContainerNode&);
 
 enum class SubframeDisconnectPolicy : bool {

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -824,6 +824,7 @@ void Document::removedLastRef()
         m_documentElement = nullptr;
         m_focusNavigationStartingNode = nullptr;
         m_userActionElements.clear();
+        m_asyncNodeDeletionQueue.clear();
 #if ENABLE(FULLSCREEN_API)
         if (CheckedPtr fullscreenManager = m_fullscreenManager.get())
             m_fullscreenManager->clear();

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include "AsyncNodeDeletionQueue.h"
 #include "Color.h"
 #include "ContainerNode.h"
 #include "ContextDestructionObserverInlines.h"
@@ -510,6 +511,7 @@ public:
     WEBCORE_EXPORT DOMImplementation& implementation();
     
     Element* documentElement() const { return m_documentElement.get(); }
+    AsyncNodeDeletionQueue& asyncNodeDeletionQueue() { return m_asyncNodeDeletionQueue; };
     inline RefPtr<Element> protectedDocumentElement() const; // Defined in DocumentInlines.h.
     static constexpr ptrdiff_t documentElementMemoryOffset() { return OBJECT_OFFSETOF(Document, m_documentElement); }
 
@@ -2154,6 +2156,7 @@ private:
     RefPtr<LocalDOMWindow> m_domWindow;
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_contextDocument;
     OptionSet<ParserContentPolicy> m_parserContentPolicy;
+    AsyncNodeDeletionQueue m_asyncNodeDeletionQueue;
 
     RefPtr<CachedResourceLoader> m_cachedResourceLoader;
     RefPtr<DocumentParser> m_parser;

--- a/Source/WebCore/page/MemoryRelease.cpp
+++ b/Source/WebCore/page/MemoryRelease.cpp
@@ -85,6 +85,7 @@ static void releaseNoncriticalMemory(MaintainMemoryCache maintainMemoryCache)
     SelectorQueryCache::singleton().clear();
 
     for (auto& document : Document::allDocuments()) {
+        document->asyncNodeDeletionQueue().clear();
         if (CheckedPtr renderView = document->renderView()) {
             LayoutIntegration::LineLayout::releaseCaches(*renderView);
             Layout::TextBreakingPositionCache::singleton().clear();

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4996,6 +4996,23 @@ void Page::performOpportunisticallyScheduledTasks(MonotonicTime deadline)
     if (m_opportunisticTaskScheduler->hasImminentlyScheduledWork())
         options.add(JSC::VM::SchedulerOptions::HasImminentlyScheduledWork);
     commonVM().performOpportunisticallyScheduledTasks(deadline, options);
+
+    deleteRemovedChildNodes();
+}
+
+void Page::deleteRemovedChildNodes()
+{
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(mainFrame());
+    RefPtr document = localMainFrame ? localMainFrame->document() : nullptr;
+    if (!document)
+        return;
+
+    forEachLocalFrame([] (LocalFrame& frame) {
+        Document* document = frame.document();
+        if (!document)
+            return;
+        document->asyncNodeDeletionQueue().clear();
+    });
 }
 
 CheckedRef<ProgressTracker> Page::checkedProgress()

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1171,6 +1171,7 @@ public:
 
     void opportunisticallyRunIdleCallbacks(MonotonicTime deadline);
     void performOpportunisticallyScheduledTasks(MonotonicTime deadline);
+    void deleteRemovedChildNodes();
     String ensureMediaKeysStorageDirectoryForOrigin(const SecurityOriginData&);
     WEBCORE_EXPORT void setMediaKeysStorageDirectory(const String&);
 

--- a/Source/WebCore/page/Settings.yaml
+++ b/Source/WebCore/page/Settings.yaml
@@ -314,6 +314,14 @@ NeedsDeferKeyDownAndKeyPressTimersUntilNextEditingCommandQuirk:
     WebCore:
       default: false
 
+OpportunisticallyDeleteNodes:
+  comment: >-
+    Allows for asynchronous DOM node deletion.
+  type: bool
+  defaultValue:
+    WebCore:
+      default: true
+
 PaymentRequestEnabled:
   type: bool
   condition: ENABLE(PAYMENT_REQUEST)


### PR DESCRIPTION
#### ab6115857d4e4d2207c9550cdb7cb81c390432d8
<pre>
Asynchronously delete small DOM nodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=282249">https://bugs.webkit.org/show_bug.cgi?id=282249</a>
<a href="https://rdar.apple.com/137026148">rdar://137026148</a>

Reviewed by NOBODY (OOPS!).

Make removedChildren DOM nodes get deleted using the Opportunistic Task
Scheduler.
Instead of synchronously deleting removed child nodes upon each call
to removeChildren, keep a strong reference to each child that has been
removed from the DOM tree but has not been deallocated. Remove the
last reference using the Opportunistic Task Scheduler which will call
each node&apos;s destructor.
This is an optimization.

* LayoutTests/fast/dom/gc-dom-tree-lifetime-expected.txt:
* LayoutTests/fast/dom/gc-dom-tree-lifetime.html:
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/AsyncNodeDeletionQueue.cpp: Added.
(WebCore::isNodeLikelySmall):
(WebCore::AsyncNodeDeletionQueue::add):
(WebCore::AsyncNodeDeletionQueue::canNodeBeAsyncDeleted):
(WebCore::AsyncNodeDeletionQueue::clear):
* Source/WebCore/dom/AsyncNodeDeletionQueue.h: Added.
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::removeAllChildrenWithScriptAssertion):
(WebCore::ContainerNode::removeChildren):
(WebCore::ContainerNode::delayDeletingRemovedChildren):
* Source/WebCore/dom/ContainerNode.h:
* Source/WebCore/dom/ContainerNodeAlgorithms.cpp:
(WebCore::notifyNodeRemovedFromDocument):
(WebCore::notifyChildNodeRemoved):
* Source/WebCore/dom/ContainerNodeAlgorithms.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::removedLastRef):
* Source/WebCore/dom/Document.h:
(WebCore::Document::nodesToAsyncDelete):
* Source/WebCore/page/MemoryRelease.cpp:
(WebCore::releaseNoncriticalMemory):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::performOpportunisticallyScheduledTasks):
(WebCore::Page::deleteRemovedChildNodes):
* Source/WebCore/page/Page.h:
* Source/WebCore/page/Settings.yaml:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28da60052919b02f7dab1017f79b231609555d9d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81919 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1446 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35875 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86476 "Hash 28da6005 for PR 38079 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32962 "Hash 28da6005 for PR 38079 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84025 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1481 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9269 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/86476 "Hash 28da6005 for PR 38079 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/32962 "Hash 28da6005 for PR 38079 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84989 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1100 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74550 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/86476 "Hash 28da6005 for PR 38079 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1002 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28727 "Passed tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31370 "Hash 28da6005 for PR 38079 does not build (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72335 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29336 "Found 1 new test failure: svg/animations/smil-leak-dynamically-added-element-instances.svg (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87907 "Hash 28da6005 for PR 38079 does not build (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9161 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6530 "Found 30 new test failures: fast/webgpu/type-checker-array-without-argument.html http/tests/svg/svg-fragment-image.html imported/blink/svg/as-image/zero-size-buffered-image-nopaint.html imported/mozilla/svg/svg-integration/dynamic-conditions-outer-svg-01.xhtml imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-content-use-003.svg imported/w3c/web-platform-tests/shadow-dom/slot-fallback-content-004.html imported/w3c/web-platform-tests/svg/import/animate-elem-39-t-manual.svg imported/w3c/web-platform-tests/svg/import/animate-elem-65-t-manual.svg imported/w3c/web-platform-tests/svg/import/pservers-grad-16-b-manual.svg imported/w3c/web-platform-tests/svg/linking/reftests/use-descendant-combinator-002.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/87907 "Hash 28da6005 for PR 38079 does not build (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9346 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70369 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/87907 "Hash 28da6005 for PR 38079 does not build (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15575 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14496 "Found 1 new test failure: svg/custom/bug86392.html (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/547 "Hash 28da6005 for PR 38079 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9112 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14648 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8952 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12477 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10760 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->