### PR TITLE
[WebAuthn] Implement Set Pin for security keys

### DIFF
--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid-silent.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid-silent.https.html
@@ -68,7 +68,7 @@
         };
 
         if (window.internals)
-            internals.setMockWebAuthenticationConfiguration({ silentFailure: true, hid: { stage: "request", subStage: "msg", error: "unsupported-options" } });
+            internals.setMockWebAuthenticationConfiguration({ silentFailure: true, hid: { stage: "request", subStage: "msg", error: "unsupported-options", supportClientPin: true } });
         return promiseRejects(t, "NotAllowedError", navigator.credentials.create(options), "Operation timed out.");
     }, "PublicKeyCredential's [[create]] with mixed options in a mock hid authenticator.");
 

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid.https.html
@@ -113,7 +113,7 @@
         };
 
         if (window.internals)
-            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "unsupported-options" } });
+            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "unsupported-options", supportClientPin: true } });
         return promiseRejects(t, "NotAllowedError", navigator.credentials.create(options), "This request has been cancelled by the user.");
     }, "PublicKeyCredential's [[create]] with mixed options in a mock hid authenticator.");
 
@@ -135,7 +135,7 @@
         };
 
         if (window.internals)
-            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "unsupported-options" } });
+            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "unsupported-options", supportClientPin: true } });
         return promiseRejects(t, "UnknownError", navigator.credentials.create(options), "Unknown internal error. Error code: 43");
     }, "PublicKeyCredential's [[create]] with mixed options in a mock hid authenticator. 2");
 

--- a/Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.cpp
@@ -90,6 +90,13 @@ AuthenticatorGetInfoResponse& AuthenticatorGetInfoResponse::setRemainingDiscover
     return *this;
 }
 
+AuthenticatorGetInfoResponse& AuthenticatorGetInfoResponse::setMinPINLength(uint32_t minPINLength)
+{
+    m_minPINLength = minPINLength;
+    return *this;
+}
+
+
 Vector<uint8_t> encodeAsCBOR(const AuthenticatorGetInfoResponse& response)
 {
     using namespace cbor;
@@ -98,7 +105,7 @@ Vector<uint8_t> encodeAsCBOR(const AuthenticatorGetInfoResponse& response)
 
     CBORValue::ArrayValue versionArray;
     for (const auto& version : response.versions())
-        versionArray.append(version == ProtocolVersion::kCtap ? kCtap2Version : kU2fVersion);
+        versionArray.append(toString(version));
     deviceInfoMap.emplace(CBORValue(1), CBORValue(WTFMove(versionArray)));
 
     if (response.extensions())
@@ -119,7 +126,10 @@ Vector<uint8_t> encodeAsCBOR(const AuthenticatorGetInfoResponse& response)
     }
 
     if (response.remainingDiscoverableCredentials())
-        deviceInfoMap.emplace(CBORValue(8), CBORValue(static_cast<int64_t>(*response.maxMsgSize())));
+        deviceInfoMap.emplace(CBORValue(8), CBORValue(static_cast<int64_t>(*response.remainingDiscoverableCredentials())));
+
+    if (auto minPINLength = response.minPINLength())
+        deviceInfoMap.emplace(CBORValue(13), CBORValue(static_cast<int64_t>(*minPINLength)));
 
     auto encodedBytes = CBORWriter::write(CBORValue(WTFMove(deviceInfoMap)));
     ASSERT(encodedBytes);

--- a/Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.h
+++ b/Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.h
@@ -55,6 +55,8 @@ public:
     AuthenticatorGetInfoResponse& setOptions(AuthenticatorSupportedOptions&&);
     AuthenticatorGetInfoResponse& setTransports(Vector<WebCore::AuthenticatorTransport>&&);
     AuthenticatorGetInfoResponse& setRemainingDiscoverableCredentials(uint32_t);
+    AuthenticatorGetInfoResponse& setMinPINLength(uint32_t);
+
 
     const StdSet<ProtocolVersion>& versions() const { return m_versions; }
     const Vector<uint8_t>& aaguid() const { return m_aaguid; }
@@ -62,8 +64,10 @@ public:
     const std::optional<Vector<uint8_t>>& pinProtocol() const { return m_pinProtocols; }
     const std::optional<Vector<String>>& extensions() const { return m_extensions; }
     const AuthenticatorSupportedOptions& options() const { return m_options; }
+    AuthenticatorSupportedOptions& mutableOptions() { return m_options; }
     const std::optional<Vector<WebCore::AuthenticatorTransport>>& transports() const { return m_transports; }
     const std::optional<uint32_t>& remainingDiscoverableCredentials() const { return m_remainingDiscoverableCredentials; }
+    const std::optional<uint32_t>& minPINLength() const { return m_minPINLength; }
 
 private:
     StdSet<ProtocolVersion> m_versions;
@@ -73,6 +77,7 @@ private:
     std::optional<Vector<String>> m_extensions;
     AuthenticatorSupportedOptions m_options;
     std::optional<Vector<WebCore::AuthenticatorTransport>> m_transports;
+    std::optional<uint32_t> m_minPINLength;
     std::optional<uint32_t> m_remainingDiscoverableCredentials;
 };
 

--- a/Source/WebCore/Modules/webauthn/fido/DeviceRequestConverter.h
+++ b/Source/WebCore/Modules/webauthn/fido/DeviceRequestConverter.h
@@ -57,6 +57,9 @@ WEBCORE_EXPORT Vector<uint8_t> encodeMakeCredentialRequestAsCBOR(const Vector<ui
 // https://fidoalliance.org/specs/fido-v2.0-ps-20170927/fido-client-to-authenticator-protocol-v2.0-ps-20170927.html#authenticatorGetAssertion
 WEBCORE_EXPORT Vector<uint8_t> encodeGetAssertionRequestAsCBOR(const Vector<uint8_t>& hash, const WebCore::PublicKeyCredentialRequestOptions&, AuthenticatorSupportedOptions::UserVerificationAvailability, const Vector<String>& authenticatorSupportedExtensions, std::optional<PinParameters> = std::nullopt);
 
+
+WEBCORE_EXPORT Vector<uint8_t> encodeBogusRequestForAuthenticatorSelection();
+
 // Represents CTAP requests with empty parameters, including
 // AuthenticatorGetInfo, AuthenticatorReset and AuthenticatorGetNextAssertion commands.
 WEBCORE_EXPORT Vector<uint8_t> encodeEmptyAuthenticatorRequest(CtapRequestCommand);

--- a/Source/WebCore/Modules/webauthn/fido/DeviceResponseConverter.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/DeviceResponseConverter.cpp
@@ -48,8 +48,12 @@ using CBOR = cbor::CBORValue;
 
 static ProtocolVersion convertStringToProtocolVersion(const String& version)
 {
+    if (version == kCtap21Version)
+        return ProtocolVersion::kCtap21;
+    if (version == kCtap21PreVersion)
+        return ProtocolVersion::kCtap21Pre;
     if (version == kCtap2Version)
-        return ProtocolVersion::kCtap;
+        return ProtocolVersion::kCtap2;
     if (version == kU2fVersion)
         return ProtocolVersion::kU2f;
 
@@ -340,6 +344,13 @@ std::optional<AuthenticatorGetInfoResponse> readCTAPGetInfoResponse(const Vector
                 transports.append(*transport);
         }
         response.setTransports(WTFMove(transports));
+    }
+
+    it = responseMap.find(CBOR(0x0D));
+    if (it != responseMap.end()) {
+        if (!it->second.isUnsigned())
+            return std::nullopt;
+        response.setMinPINLength(it->second.getUnsigned());
     }
 
     it = responseMap.find(CBOR(20));

--- a/Source/WebCore/Modules/webauthn/fido/FidoConstants.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/FidoConstants.cpp
@@ -35,6 +35,34 @@
 namespace fido {
 using namespace WebCore;
 
+bool isCtap2Protocol(ProtocolVersion protocol)
+{
+    switch (protocol) {
+    case ProtocolVersion::kCtap2:
+    case ProtocolVersion::kCtap21:
+    case ProtocolVersion::kCtap21Pre:
+        return true;
+    default:
+        return false;
+    }
+}
+
+String toString(ProtocolVersion protocol)
+{
+    switch (protocol) {
+    case ProtocolVersion::kCtap2:
+        return "FIDO_2_0"_s;
+    case ProtocolVersion::kCtap21:
+        return "FIDO_2_1"_s;
+    case ProtocolVersion::kCtap21Pre:
+        return "FIDO_2_1_PRE"_s;
+    case ProtocolVersion::kU2f:
+        return "U2F_V2"_s;
+    default:
+        return "UNKNOWN"_s;
+    }
+}
+
 bool isCtapDeviceResponseCode(CtapDeviceResponseCode code)
 {
     switch (code) {

--- a/Source/WebCore/Modules/webauthn/fido/FidoConstants.h
+++ b/Source/WebCore/Modules/webauthn/fido/FidoConstants.h
@@ -37,10 +37,16 @@
 namespace fido {
 
 enum class ProtocolVersion {
-    kCtap,
+    kCtap2,
+    kCtap21,
+    kCtap21Pre,
     kU2f,
     kUnknown,
 };
+
+WEBCORE_EXPORT bool isCtap2Protocol(ProtocolVersion);
+
+WEBCORE_EXPORT String toString(ProtocolVersion);
 
 // Length of the U2F challenge/application parameter:
 // https://fidoalliance.org/specs/fido-u2f-v1.2-ps-20170411/fido-u2f-raw-message-formats-v1.2-ps-20170411.html#registration-request-message---u2f_register
@@ -170,6 +176,8 @@ constexpr size_t kHidInitNonceLength = 8;
 
 constexpr uint8_t kHidMaxLockSeconds = 10;
 
+constexpr size_t kPINMaxSizeInBytes = 63;
+
 // Messages are limited to an initiation packet and 128 continuation packets.
 constexpr size_t kHidMaxMessageSize = 7609;
 
@@ -194,6 +202,7 @@ enum class CtapRequestCommand : uint8_t {
     kAuthenticatorGetInfo = 0x04,
     kAuthenticatorClientPin = 0x06,
     kAuthenticatorReset = 0x07,
+    kAuthenticatorAuthenticatorSelection = 0x0B,
 };
 
 // APDU instruction code for U2F request encoding.
@@ -220,6 +229,8 @@ ASCIILiteral publicKeyCredentialTypeToString(WebCore::PublicKeyCredentialType);
 
 // FIXME: Add url to the official spec once it's standardized.
 constexpr auto kCtap2Version = "FIDO_2_0"_s;
+constexpr auto kCtap21Version = "FIDO_2_1"_s;
+constexpr auto kCtap21PreVersion = "FIDO_2_1_PRE"_s;
 constexpr auto kU2fVersion = "U2F_V2"_s;
 
 // CTAPHID Usage Page and Usage

--- a/Source/WebCore/Modules/webauthn/fido/Pin.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/Pin.cpp
@@ -301,6 +301,11 @@ const WebCore::CryptoKeyAES& SetPinRequest::sharedKey() const
     return m_sharedKey;
 }
 
+const Vector<uint8_t>& SetPinRequest::pinAuth() const
+{
+    return m_pinUvAuthParam;
+}
+
 std::optional<SetPinRequest> SetPinRequest::tryCreate(const String& inputPin, const WebCore::CryptoKeyEC& peerKey)
 {
     std::optional<CString> newPin = validateAndConvertToUTF8(inputPin);
@@ -365,7 +370,7 @@ Vector<uint8_t> encodeAsCBOR(const SetPinRequest& request)
     return encodePinCommand(Subcommand::kSetPin, [coseKey = WTFMove(request.m_coseKey), encryptedPin = request.m_newPinEnc, pinUvAuthParam = request.m_pinUvAuthParam] (CBORValue::MapValue* map) mutable {
         map->emplace(static_cast<int64_t>(RequestKey::kKeyAgreement), WTFMove(coseKey));
         map->emplace(static_cast<int64_t>(RequestKey::kNewPinEnc), WTFMove(encryptedPin));
-        map->emplace(static_cast<int64_t>(RequestKey::kPinUvAuthParam), WTFMove(pinUvAuthParam));
+        map->emplace(static_cast<int64_t>(RequestKey::kPinAuth), WTFMove(pinUvAuthParam));
     });
 }
 

--- a/Source/WebCore/Modules/webauthn/fido/Pin.h
+++ b/Source/WebCore/Modules/webauthn/fido/Pin.h
@@ -67,7 +67,6 @@ enum class RequestKey : uint8_t {
     kPinAuth = 4,
     kNewPinEnc = 5,
     kPinHashEnc = 6,
-    kPinUvAuthParam = 7,
 };
 
 // ResponseKey enumerates the keys in the top-level CBOR map for all PIN
@@ -138,6 +137,7 @@ struct SetPinRequest {
 public:
     WEBCORE_EXPORT const WebCore::CryptoKeyAES& sharedKey() const;
     WEBCORE_EXPORT static std::optional<SetPinRequest> tryCreate(const String& newPin, const WebCore::CryptoKeyEC&);
+    WEBCORE_EXPORT const Vector<uint8_t>& pinAuth() const;
 
     friend Vector<uint8_t> encodeAsCBOR(const SetPinRequest&);
 

--- a/Source/WebKit/Platform/spi/Cocoa/AuthenticationServicesCoreSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/AuthenticationServicesCoreSPI.h
@@ -73,6 +73,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)presentError:(NSError *)error forService:(NSString *)service completionHandler:(void (^)(void))completionHandler;
 - (void)updateInterfaceWithLoginChoices:(NSArray<id <ASCLoginChoiceProtocol>> *)loginChoices;
 - (void)presentPINEntryInterface;
+- (void)presentNewPINEntryInterfaceWithMinLength:(NSUInteger)minLength;
 - (void)updateInterfaceForUserVisibleError:(NSError *)userVisibleError;
 - (void)dismissWithError:(nullable NSError *)error;
 
@@ -428,6 +429,8 @@ typedef NS_ERROR_ENUM(ASCAuthorizationErrorDomain, ASCAuthorizationError) {
     ASCAuthorizationErrorInvalidResponse = 14,
     ASCAuthorizationErrorNotSupportedInSTP = 16,
     ASCAuthorizationErrorSecurityError = 17,
+    ASCAuthorizationErrorPINTooShort = 18,
+    ASCAuthorizationErrorPINTooLong = 19,
 };
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/API/APIWebAuthenticationPanelClient.h
+++ b/Source/WebKit/UIProcess/API/APIWebAuthenticationPanelClient.h
@@ -52,6 +52,7 @@ public:
     virtual void updatePanel(WebKit::WebAuthenticationStatus) const { }
     virtual void dismissPanel(WebKit::WebAuthenticationResult) const { }
     virtual void requestPin(uint64_t, CompletionHandler<void(const WTF::String&)>&& completionHandler) const { completionHandler(WTF::String()); }
+    virtual void requestNewPin(uint64_t, CompletionHandler<void(const WTF::String&)>&& completionHandler) const { completionHandler(WTF::String()); }
     virtual void selectAssertionResponse(Vector<Ref<WebCore::AuthenticatorAssertionResponse>>&&, WebKit::WebAuthenticationSource, CompletionHandler<void(WebCore::AuthenticatorAssertionResponse*)>&& completionHandler) const { completionHandler(nullptr); }
     virtual void decidePolicyForLocalAuthenticator(CompletionHandler<void(WebKit::LocalAuthenticatorPolicy)>&& completionHandler) const { completionHandler(WebKit::LocalAuthenticatorPolicy::Disallow); }
     virtual void requestLAContextForUserVerification(CompletionHandler<void(LAContext *)>&& completionHandler) const { completionHandler(nullptr); }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.h
@@ -52,6 +52,8 @@ typedef NS_ENUM(NSInteger, _WKWebAuthenticationPanelUpdate) {
     _WKWebAuthenticationPanelUpdateLAExcludeCredentialsMatched,
     _WKWebAuthenticationPanelUpdateLANoCredential,
     _WKWebAuthenticationPanelUpdateKeyStoreFull,
+    _WKWebAuthenticationPanelUpdatePINTooShort,
+    _WKWebAuthenticationPanelUpdatePINTooLong,
 } WK_API_AVAILABLE(macos(10.15.4), ios(13.4));
 
 typedef NS_ENUM(NSInteger, _WKWebAuthenticationResult) {
@@ -114,6 +116,7 @@ WK_EXTERN NSString * const _WKLocalAuthenticatorCredentialLastUsedDateKey;
 
 - (void)panel:(_WKWebAuthenticationPanel *)panel updateWebAuthenticationPanel:(_WKWebAuthenticationPanelUpdate)update WK_API_AVAILABLE(macos(11.0), ios(14.0));
 - (void)panel:(_WKWebAuthenticationPanel *)panel requestPINWithRemainingRetries:(NSUInteger)retries completionHandler:(void (^)(NSString *))completionHandler WK_API_AVAILABLE(macos(11.0), ios(14.0));
+- (void)panel:(_WKWebAuthenticationPanel *)panel requestNewPINWithMinLength:(NSUInteger)minLength completionHandler:(void (^)(NSString *))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 - (void)panel:(_WKWebAuthenticationPanel *)panel selectAssertionResponse:(NSArray < _WKWebAuthenticationAssertionResponse *> *)responses source:(_WKWebAuthenticationSource)source completionHandler:(void (^)(_WKWebAuthenticationAssertionResponse * _Nullable))completionHandler WK_API_AVAILABLE(macos(11.0), ios(14.0));
 - (void)panel:(_WKWebAuthenticationPanel *)panel requestLAContextForUserVerificationWithCompletionHandler:(void (^)(LAContext *context))completionHandler WK_API_AVAILABLE(macos(12.0), ios(15.0));
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Authenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Authenticator.h
@@ -55,6 +55,7 @@ public:
     virtual void downgrade(Authenticator* id, Ref<Authenticator>&& downgradedAuthenticator) = 0;
     virtual void authenticatorStatusUpdated(WebAuthenticationStatus) = 0;
     virtual void requestPin(uint64_t retries, CompletionHandler<void(const WTF::String&)>&&) = 0;
+    virtual void requestNewPin(uint64_t minLength, CompletionHandler<void(const WTF::String&)>&&) = 0;
     virtual void selectAssertionResponse(Vector<Ref<WebCore::AuthenticatorAssertionResponse>>&&, WebAuthenticationSource, CompletionHandler<void(WebCore::AuthenticatorAssertionResponse*)>&&) = 0;
     virtual void decidePolicyForLocalAuthenticator(CompletionHandler<void(LocalAuthenticatorPolicy)>&&) = 0;
     virtual void requestLAContextForUserVerification(CompletionHandler<void(LAContext *)>&&) = 0;

--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h
@@ -105,6 +105,7 @@ private:
     void downgrade(Authenticator* id, Ref<Authenticator>&& downgradedAuthenticator) final;
     void authenticatorStatusUpdated(WebAuthenticationStatus) final;
     void requestPin(uint64_t retries, CompletionHandler<void(const WTF::String&)>&&) final;
+    void requestNewPin(uint64_t minLength, CompletionHandler<void(const WTF::String&)>&&) final;
     void requestLAContextForUserVerification(CompletionHandler<void(LAContext *)>&&) final;
     void cancelRequest() final;
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.h
@@ -61,6 +61,7 @@ public:
 
     void updatePresenter(WebAuthenticationStatus);
     void requestPin(uint64_t retries, CompletionHandler<void(const String&)>&&);
+    void requestNewPin(uint64_t, CompletionHandler<void(const String&)>&&);
     void selectAssertionResponse(Vector<Ref<WebCore::AuthenticatorAssertionResponse>>&&, WebAuthenticationSource, CompletionHandler<void(WebCore::AuthenticatorAssertionResponse*)>&&);
     void requestLAContextForUserVerification(CompletionHandler<void(LAContext *)>&&);
     void dimissPresenter(WebAuthenticationResult);

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm
@@ -128,6 +128,16 @@ void AuthenticatorPresenterCoordinator::updatePresenter(WebAuthenticationStatus 
         m_credentialRequestHandler(nil, error.get());
         break;
     }
+    case WebAuthenticationStatus::PINTooShort: {
+        RetainPtr error = adoptNS([[NSError alloc] initWithDomain:ASCAuthorizationErrorDomain code:ASCAuthorizationErrorPINTooShort userInfo:nil]);
+        m_credentialRequestHandler(nil, error.get());
+        break;
+    }
+    case WebAuthenticationStatus::PINTooLong: {
+        RetainPtr error = adoptNS([[NSError alloc] initWithDomain:ASCAuthorizationErrorDomain code:ASCAuthorizationErrorPINTooLong userInfo:nil]);
+        m_credentialRequestHandler(nil, error.get());
+        break;
+    }
     case WebAuthenticationStatus::MultipleNFCTagsPresent: {
         auto error = adoptNS([[NSError alloc] initWithDomain:ASCAuthorizationErrorDomain code:ASCAuthorizationErrorMultipleNFCTagsPresent userInfo:nil]);
         [m_presenter updateInterfaceForUserVisibleError:error.get()];
@@ -183,6 +193,20 @@ void AuthenticatorPresenterCoordinator::requestPin(uint64_t, CompletionHandler<v
         return;
     m_presentedPIN = true;
     [m_presenter presentPINEntryInterface];
+#endif // HAVE(ASC_AUTH_UI)
+}
+
+void AuthenticatorPresenterCoordinator::requestNewPin(uint64_t minLength, CompletionHandler<void(const String&)>&& completionHandler)
+{
+#if HAVE(ASC_AUTH_UI)
+    if (m_pinHandler)
+        m_pinHandler(String());
+    m_pinHandler = WTFMove(completionHandler);
+
+    if (m_presentedPIN)
+        return;
+    m_presentedPIN = true;
+    [m_presenter presentNewPINEntryInterfaceWithMinLength:minLength];
 #endif // HAVE(ASC_AUTH_UI)
 }
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.h
@@ -52,6 +52,7 @@ private:
     void updatePanel(WebAuthenticationStatus) const final;
     void dismissPanel(WebAuthenticationResult) const final;
     void requestPin(uint64_t, CompletionHandler<void(const WTF::String&)>&&) const final;
+    void requestNewPin(uint64_t, CompletionHandler<void(const WTF::String&)>&&) const final;
     void selectAssertionResponse(Vector<Ref<WebCore::AuthenticatorAssertionResponse>>&&, WebAuthenticationSource, CompletionHandler<void(WebCore::AuthenticatorAssertionResponse*)>&&) const final;
     void decidePolicyForLocalAuthenticator(CompletionHandler<void(LocalAuthenticatorPolicy)>&&) const final;
     void requestLAContextForUserVerification(CompletionHandler<void(LAContext *)>&&) const final;
@@ -63,6 +64,7 @@ private:
         bool panelUpdateWebAuthenticationPanel : 1;
         bool panelDismissWebAuthenticationPanelWithResult : 1;
         bool panelRequestPinWithRemainingRetriesCompletionHandler : 1;
+        bool panelRequestNewPinWithMinLengthCompletionHandler : 1;
         bool panelSelectAssertionResponseSourceCompletionHandler : 1;
         bool panelDecidePolicyForLocalAuthenticatorCompletionHandler : 1;
         bool panelRequestLAContextForUserVerificationCompletionHandler : 1;

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidConnection.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidConnection.cpp
@@ -219,9 +219,9 @@ void MockHidConnection::feedReports()
         // FIXME(205839):
         Vector<uint8_t> infoData;
         if (m_configuration.hid->canDowngrade)
-            infoData = encodeAsCBOR(AuthenticatorGetInfoResponse({ ProtocolVersion::kCtap, ProtocolVersion::kU2f }, Vector<uint8_t>(aaguidLength, 0u)));
+            infoData = encodeAsCBOR(AuthenticatorGetInfoResponse({ ProtocolVersion::kCtap2, ProtocolVersion::kU2f }, Vector<uint8_t>(aaguidLength, 0u)));
         else {
-            AuthenticatorGetInfoResponse infoResponse({ ProtocolVersion::kCtap }, Vector<uint8_t>(aaguidLength, 0u));
+            AuthenticatorGetInfoResponse infoResponse({ ProtocolVersion::kCtap2 }, Vector<uint8_t>(aaguidLength, 0u));
             AuthenticatorSupportedOptions options;
             if (m_configuration.hid->supportClientPin) {
                 infoResponse.setPinProtocols({ pin::kProtocolVersion });

--- a/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualService.mm
@@ -63,7 +63,7 @@ Ref<AuthenticatorTransportService> VirtualService::createVirtual(WebCore::Authen
 
 static AuthenticatorGetInfoResponse authenticatorInfoForConfig(const VirtualAuthenticatorConfiguration& config)
 {
-    AuthenticatorGetInfoResponse infoResponse({ ProtocolVersion::kCtap }, Vector<uint8_t>(aaguidLength, 0u));
+    AuthenticatorGetInfoResponse infoResponse({ ProtocolVersion::kCtap2 }, Vector<uint8_t>(aaguidLength, 0u));
     AuthenticatorSupportedOptions options;
     infoResponse.setOptions(WTFMove(options));
     return infoResponse;

--- a/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticationFlags.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticationFlags.h
@@ -50,6 +50,8 @@ enum class WebAuthenticationStatus : uint8_t {
     LAExcludeCredentialsMatched,
     LANoCredential,
     KeyStoreFull,
+    PINTooShort,
+    PINTooLong,
 };
 
 enum class LocalAuthenticatorPolicy : bool {

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h
@@ -29,15 +29,12 @@
 
 #include "FidoAuthenticator.h"
 #include <WebCore/AuthenticatorGetInfoResponse.h>
+#include <WebCore/CryptoKeyEC.h>
 
 namespace fido {
 namespace pin {
 class TokenRequest;
 }
-}
-
-namespace WebCore {
-class CryptoKeyEC;
 }
 
 namespace WebKit {
@@ -72,6 +69,13 @@ private:
     Vector<WebCore::AuthenticatorTransport> transports() const;
 
     String aaguidForDebugging() const;
+
+    bool isUVSetup() const;
+
+    void continueSetupPinAfterCommand(Vector<uint8_t>&&, const String& pin, Ref<WebCore::CryptoKeyEC> peerKey);
+    void continueSetupPinAfterGetKeyAgreement(Vector<uint8_t>&&, const String& pin);
+    void performAuthenticatorSelectionForSetupPin();
+    void setupPin();
 
     fido::AuthenticatorGetInfoResponse m_info;
     bool m_isDowngraded { false };

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapCcidDriver.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapCcidDriver.cpp
@@ -51,7 +51,7 @@ void CtapCcidDriver::transact(Vector<uint8_t>&& data, ResponseCallback&& callbac
 {
     // For CTAP2, commands follow:
     // https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#nfc-command-framing
-    if (protocol() == ProtocolVersion::kCtap) {
+    if (isCtap2Protocol()) {
 
         if (!isValidSize(data.size()))
             RELEASE_LOG(WebAuthn, "CtapCcidDriver::transact Sending data larger than maxSize. msgSize=%ld", data.size());

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapDriver.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapDriver.h
@@ -49,6 +49,7 @@ public:
 
     WebCore::AuthenticatorTransport transport() const { return m_transport; }
     fido::ProtocolVersion protocol() const { return m_protocol; }
+    bool isCtap2Protocol() const { return fido::isCtap2Protocol(m_protocol); }
     void setMaxMsgSize(std::optional<uint32_t> maxMsgSize) { m_maxMsgSize = maxMsgSize; }
     bool isValidSize(size_t msgSize) { return !m_maxMsgSize || msgSize <= static_cast<size_t>(*m_maxMsgSize); }
 
@@ -60,7 +61,7 @@ protected:
     { }
 
 private:
-    fido::ProtocolVersion m_protocol { fido::ProtocolVersion::kCtap };
+    fido::ProtocolVersion m_protocol { fido::ProtocolVersion::kCtap2 };
     WebCore::AuthenticatorTransport m_transport;
     std::optional<uint32_t> m_maxMsgSize;
 };

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.cpp
@@ -237,7 +237,7 @@ void CtapHidDriver::continueAfterChannelAllocated(std::optional<FidoHidMessage>&
     m_channelId |= static_cast<uint32_t>(payload[index++]) << 8;
     m_channelId |= static_cast<uint32_t>(payload[index]);
     // FIXME(191534): Check the rest of the payload.
-    auto cmd = FidoHidMessage::create(m_channelId, protocol() == ProtocolVersion::kCtap ? FidoHidDeviceCommand::kCbor : FidoHidDeviceCommand::kMsg, m_requestData);
+    auto cmd = FidoHidMessage::create(m_channelId, isCtap2Protocol() ?  FidoHidDeviceCommand::kCbor : FidoHidDeviceCommand::kMsg, m_requestData);
     ASSERT(cmd);
     protectedWorker()->transact(WTFMove(*cmd), [weakThis = WeakPtr { *this }](std::optional<FidoHidMessage>&& response) mutable {
         ASSERT(RunLoop::isMain());
@@ -272,7 +272,7 @@ void CtapHidDriver::reset()
 
 void CtapHidDriver::cancel()
 {
-    if (m_state == State::Idle || protocol() != ProtocolVersion::kCtap)
+    if (m_state == State::Idle || !isCtap2Protocol())
         return;
     // Cancel any outstanding requests.
     if (m_state == State::Ready) {

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapNfcDriver.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapNfcDriver.cpp
@@ -54,7 +54,7 @@ void CtapNfcDriver::transact(Vector<uint8_t>&& data, ResponseCallback&& callback
 {
     // For CTAP2, commands follow:
     // https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#nfc-command-framing
-    if (protocol() == ProtocolVersion::kCtap) {
+    if (isCtap2Protocol()) {
         if (!isValidSize(data.size()))
             RELEASE_LOG(WebAuthn, "CtapNfcDriver::transact Sending data larger than maxSize. msgSize=%ld", data.size());
         ApduCommand command;

--- a/Tools/TestWebKitAPI/Tests/WebCore/CtapResponseTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CtapResponseTest.cpp
@@ -587,7 +587,7 @@ TEST(CTAPResponseTest, TestReadGetInfoResponse)
     ASSERT_TRUE(getInfoResponse);
     ASSERT_TRUE(getInfoResponse->maxMsgSize());
     EXPECT_EQ(*getInfoResponse->maxMsgSize(), 1200u);
-    EXPECT_NE(getInfoResponse->versions().find(ProtocolVersion::kCtap), getInfoResponse->versions().end());
+    EXPECT_NE(getInfoResponse->versions().find(ProtocolVersion::kCtap2), getInfoResponse->versions().end());
     EXPECT_NE(getInfoResponse->versions().find(ProtocolVersion::kU2f), getInfoResponse->versions().end());
     EXPECT_TRUE(getInfoResponse->options().isPlatformDevice());
     EXPECT_EQ(AuthenticatorSupportedOptions::ResidentKeyAvailability::kSupported, getInfoResponse->options().residentKeyAvailability());
@@ -602,7 +602,7 @@ TEST(CTAPResponseTest, TestReadGetInfoResponse2)
     ASSERT_TRUE(getInfoResponse);
     ASSERT_TRUE(getInfoResponse->maxMsgSize());
     EXPECT_EQ(*getInfoResponse->maxMsgSize(), 1200u);
-    EXPECT_NE(getInfoResponse->versions().find(ProtocolVersion::kCtap), getInfoResponse->versions().end());
+    EXPECT_NE(getInfoResponse->versions().find(ProtocolVersion::kCtap2), getInfoResponse->versions().end());
     EXPECT_NE(getInfoResponse->versions().find(ProtocolVersion::kU2f), getInfoResponse->versions().end());
     EXPECT_TRUE(getInfoResponse->options().isPlatformDevice());
     EXPECT_EQ(AuthenticatorSupportedOptions::ResidentKeyAvailability::kSupported, getInfoResponse->options().residentKeyAvailability());
@@ -617,7 +617,7 @@ TEST(CTAPResponseTest, TestReadGetInfoResponseDeviceYubikey5c)
     ASSERT_TRUE(getInfoResponse);
     ASSERT_TRUE(getInfoResponse->maxMsgSize());
     EXPECT_EQ(*getInfoResponse->maxMsgSize(), 1200u);
-    EXPECT_NE(getInfoResponse->versions().find(ProtocolVersion::kCtap), getInfoResponse->versions().end());
+    EXPECT_NE(getInfoResponse->versions().find(ProtocolVersion::kCtap2), getInfoResponse->versions().end());
     EXPECT_NE(getInfoResponse->versions().find(ProtocolVersion::kU2f), getInfoResponse->versions().end());
     EXPECT_FALSE(getInfoResponse->options().isPlatformDevice());
     EXPECT_EQ(AuthenticatorSupportedOptions::ResidentKeyAvailability::kSupported, getInfoResponse->options().residentKeyAvailability());
@@ -638,7 +638,7 @@ TEST(CTAPResponseTest, TestReadGetInfoResponseWithIncorrectFormat)
 
 TEST(CTAPResponseTest, TestSerializeGetInfoResponse)
 {
-    AuthenticatorGetInfoResponse response({ ProtocolVersion::kCtap, ProtocolVersion::kU2f }, convertBytesToVector(kTestDeviceAaguid, sizeof(kTestDeviceAaguid)));
+    AuthenticatorGetInfoResponse response({ ProtocolVersion::kCtap2, ProtocolVersion::kU2f }, convertBytesToVector(kTestDeviceAaguid, sizeof(kTestDeviceAaguid)));
     response.setExtensions({ "uvm"_s, "hmac-secret"_s });
     AuthenticatorSupportedOptions options;
     options.setResidentKeyAvailability(AuthenticatorSupportedOptions::ResidentKeyAvailability::kSupported);


### PR DESCRIPTION
#### 2968de52d0664b1fd91876cf47cd91a02faa6fb5
<pre>
[WebAuthn] Implement Set Pin for security keys
<a href="https://bugs.webkit.org/show_bug.cgi?id=269083">https://bugs.webkit.org/show_bug.cgi?id=269083</a>
<a href="https://rdar.apple.com/122660610">rdar://122660610</a>

Reviewed by Brent Fulgham.

This change implements setting a pin for security keys. This is accomplished by asking the user
for a new pin whenever presented with an operation that requires a security key to have user
verification setup, but it does not.

The minimum pin length is fetched from the authenticator, or a default of 4 defined in the
CTAP spec. The maximum length is defined by the spec to be 63. We bubble up errors to show
in the prompt whenever an entered PIN did not meet requirements.

The way setting a pin works is as follows: Whenever an operation requires UV, but it is not setup,
first authenticator selection is performed to confirm a authenticator is desired for the operation.
For CTAP2.1 keys, the authenticatorSelection command is used, on older FIDO2.0 authenticators, a non-rk
makeCredential with zero length pinAuth is used instead. Then, whenever an authenticator without uv is
chosen, a new pin is collected from the user and setup on the security key, which is then able to perform
the operation requiring uv.

The SetPin code is covered by unit tests. I have manually tested setting up a PIN on both CTAP2.1 and CTAP2.0
security keys.

* Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.cpp:
(fido::AuthenticatorGetInfoResponse::setMinPINLength):
(fido::encodeAsCBOR):
* Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.h:
* Source/WebCore/Modules/webauthn/fido/DeviceRequestConverter.cpp:
(fido::encodeBogusRequestForAuthenticatorSelection):
* Source/WebCore/Modules/webauthn/fido/DeviceRequestConverter.h:
* Source/WebCore/Modules/webauthn/fido/DeviceResponseConverter.cpp:
(fido::convertStringToProtocolVersion):
(fido::readCTAPGetInfoResponse):
* Source/WebCore/Modules/webauthn/fido/FidoConstants.cpp:
(fido::isCtap2Protocol):
(fido::toString):
* Source/WebCore/Modules/webauthn/fido/FidoConstants.h:
* Source/WebCore/Modules/webauthn/fido/Pin.cpp:
(fido::pin::SetPinRequest::pinAuth const):
(fido::pin::encodeAsCBOR):
* Source/WebCore/Modules/webauthn/fido/Pin.h:
* Source/WebKit/Platform/spi/Cocoa/AuthenticationServicesCoreSPI.h:
* Source/WebKit/UIProcess/API/APIWebAuthenticationPanelClient.h:
(API::WebAuthenticationPanelClient::requestNewPin const):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.h:
* Source/WebKit/UIProcess/WebAuthentication/Authenticator.h:
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp:
(WebKit::AuthenticatorManager::requestNewPin):
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm:
(WebKit::AuthenticatorPresenterCoordinator::updatePresenter):
(WebKit::AuthenticatorPresenterCoordinator::requestNewPin):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.mm:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidService.mm:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.mm:
(WebKit::WebAuthenticationPanelClient::WebAuthenticationPanelClient):
(WebKit::wkWebAuthenticationPanelUpdate):
(WebKit::WebAuthenticationPanelClient::requestNewPin const):
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidConnection.cpp:
(WebKit::MockHidConnection::feedReports):
* Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualService.mm:
(WebKit::authenticatorInfoForConfig):
* Source/WebKit/UIProcess/WebAuthentication/WebAuthenticationFlags.h:
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp:
(WebKit::CtapAuthenticator::makeCredential):
(WebKit::CtapAuthenticator::isUVSetup const):
(WebKit::CtapAuthenticator::continueSetupPinAfterCommand):
(WebKit::CtapAuthenticator::continueSetupPinAfterGetKeyAgreement):
(WebKit::CtapAuthenticator::setupPin):
(WebKit::CtapAuthenticator::performAuthenticatorSelectionForSetupPin):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h:
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapCcidDriver.cpp:
(WebKit::CtapCcidDriver::transact):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapDriver.h:
(WebKit::CtapDriver::isCtap2Protocol const):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.cpp:
(WebKit::CtapHidDriver::continueAfterChannelAllocated):
(WebKit::CtapHidDriver::cancel):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapNfcDriver.cpp:
(WebKit::CtapNfcDriver::transact):
* Source/WebKit/UIProcess/WebAuthentication/fido/FidoService.cpp:
(WebKit::FidoService::continueAfterGetInfo):
* Tools/TestWebKitAPI/Tests/WebCore/CtapResponseTest.cpp:
(TestWebKitAPI::TEST(CTAPResponseTest, TestReadGetInfoResponse)):
(TestWebKitAPI::TEST(CTAPResponseTest, TestReadGetInfoResponse2)):
(TestWebKitAPI::TEST(CTAPResponseTest, TestReadGetInfoResponseDeviceYubikey5c)):
(TestWebKitAPI::TEST(CTAPResponseTest, TestSerializeGetInfoResponse)):

Canonical link: <a href="https://commits.webkit.org/288259@main">https://commits.webkit.org/288259@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed2faaa80d07d6b1115f3cd87e804a1e0c310cc8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82266 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1930 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36332 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87398 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33327 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84371 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2001 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9812 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64116 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21864 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85335 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1393 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74857 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44394 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1295 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29038 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32368 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72594 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29662 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88754 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9572 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6832 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72508 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9798 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70671 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71726 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17884 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15862 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/14877 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/927 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9525 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15046 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9399 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12865 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11169 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->