### PR TITLE
Fix CLoop build after 284499@main and unsafe-buffer-usage

### DIFF
--- a/Source/JavaScriptCore/interpreter/CLoopStack.cpp
+++ b/Source/JavaScriptCore/interpreter/CLoopStack.cpp
@@ -38,6 +38,8 @@
 #include "Options.h"
 #include <wtf/Lock.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace JSC {
 
 static size_t committedBytesCount = 0;
@@ -164,5 +166,7 @@ size_t CLoopStack::committedByteCount()
 }
 
 } // namespace JSC
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(C_LOOP)

--- a/Source/JavaScriptCore/interpreter/CLoopStack.h
+++ b/Source/JavaScriptCore/interpreter/CLoopStack.h
@@ -73,10 +73,14 @@ namespace JSC {
             return m_end;
         }
 
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
         Register* highAddress() const
         {
             return reinterpret_cast_ptr<Register*>(static_cast<char*>(m_reservation.base()) + m_reservation.size());
         }
+
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
         Register* reservationTop() const
         {

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp
@@ -45,6 +45,8 @@
 
 using namespace JSC::LLInt;
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 // LLInt C Loop opcodes
 // ====================
 // In the implementation of the C loop, the LLint trampoline glue functions
@@ -480,6 +482,8 @@ JSValue CLoop::execute(OpcodeID entryOpcodeID, void* executableAddress, VM* vm, 
 } // Interpreter::llintCLoopExecute()
 
 } // namespace JSC
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #else // !ENABLE(C_LOOP)
 

--- a/Source/WTF/wtf/PlatformEnableCocoa.h
+++ b/Source/WTF/wtf/PlatformEnableCocoa.h
@@ -362,6 +362,16 @@
 #define ENABLE_FIXED_IOS_TOUCH_POINT_RADIUS 1
 #endif
 
+// If building for C_LOOP disable all JIT ENABLEs
+#if ENABLE(C_LOOP)
+#define ENABLE_JIT 0
+#define ENABLE_DFG_JIT 0
+#define ENABLE_FTL_JIT 0
+#define ENABLE_B3_JIT 0
+#define ENABLE_WEBASSEMBLY_BBQJIT 0
+#define ENABLE_WEBASSEMBLY_OMGJIT 0
+#endif
+
 #if !defined(ENABLE_FTL_JIT) && CPU(ADDRESS64)
 #define ENABLE_FTL_JIT 1
 #endif

--- a/Source/WTF/wtf/StackPointer.cpp
+++ b/Source/WTF/wtf/StackPointer.cpp
@@ -167,11 +167,15 @@ asm (
 #elif USE(GENERIC_CURRENT_STACK_POINTER)
 constexpr size_t sizeOfFrameHeader = 2 * sizeof(void*);
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 SUPPRESS_ASAN NEVER_INLINE
 void* currentStackPointer()
 {
     return reinterpret_cast<uint8_t*>(__builtin_frame_address(0)) + sizeOfFrameHeader;
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 #endif // USE(GENERIC_CURRENT_STACK_POINTER)
 
 } // namespace WTF


### PR DESCRIPTION
#### be8529be73b6d4c7f1dc9aed9c90c6bf89541878
<pre>
Fix CLoop build after 284499@main and unsafe-buffer-usage
<a href="https://bugs.webkit.org/show_bug.cgi?id=284828">https://bugs.webkit.org/show_bug.cgi?id=284828</a>
<a href="https://rdar.apple.com/141567643">rdar://141567643</a>

Reviewed by Yijia Huang.

ENABLE_C_LOOP now disables all JIT ENABLEs for Cocoa platforms, which fixes the CLoop build.

Also, add a bunch of WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN/ENDs to fix the rest of the build.

* Source/JavaScriptCore/interpreter/CLoopStack.cpp:
* Source/JavaScriptCore/interpreter/CLoopStack.h:
* Source/JavaScriptCore/llint/LowLevelInterpreter.cpp:
* Source/WTF/wtf/PlatformEnableCocoa.h:
* Source/WTF/wtf/StackPointer.cpp:

Canonical link: <a href="https://commits.webkit.org/287998@main">https://commits.webkit.org/287998@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7bd881bc9b7b96293116114cd97db74fc12468f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81507 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1033 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35455 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86039 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32501 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1052 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8851 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63617 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21354 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84576 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/751 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74193 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43908 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/650 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28361 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30954 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/74489 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72092 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28955 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87475 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/80565 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8740 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6208 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71939 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8921 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70010 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71172 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17738 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15241 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14159 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/102975 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8700 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14228 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25020 "Found 2 new JSC stress test failures: wasm.yaml/wasm/stress/struct-new_default-small-members.js.wasm-eager, wasm.yaml/wasm/stress/struct-new_default-small-members.js.wasm-no-cjit (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8538 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12060 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10345 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->