### PR TITLE
AX: -[WKAccessibilityWebPageObjectMac accessibilityAttributeValue] hits the main-thread unnecessarily

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h
@@ -27,6 +27,7 @@
 #import <WebCore/PageIdentifier.h>
 #import <wtf/Lock.h>
 #import <wtf/NakedPtr.h>
+#import <wtf/WeakObjCPtr.h>
 
 namespace WebKit {
 class WebPage;
@@ -44,9 +45,15 @@ class AXCoreObject;
     WebCore::FloatPoint m_position WTF_GUARDED_BY_LOCK(m_cacheLock);
     WebCore::IntSize m_size WTF_GUARDED_BY_LOCK(m_cacheLock);
     ThreadSafeWeakPtr<WebCore::AXCoreObject> m_isolatedTreeRoot;
-#endif
+
+    Lock m_windowLock;
+    WeakObjCPtr<id> m_window;
+#endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 
     WebCore::IntPoint m_remoteFrameOffset;
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    Lock m_parentLock;
+#endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     RetainPtr<id> m_parent;
     bool m_hasMainFramePlugin;
 }
@@ -56,6 +63,7 @@ class AXCoreObject;
 - (void)setPosition:(const WebCore::FloatPoint&)point;
 - (void)setSize:(const WebCore::IntSize&)size;
 - (void)setIsolatedTreeRoot:(NakedPtr<WebCore::AXCoreObject>)root;
+- (void)setWindow:(id)window;
 #endif
 - (void)setRemoteParent:(id)parent;
 - (void)setRemoteFrameOffset:(WebCore::IntPoint)offset;

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
@@ -152,6 +152,16 @@ namespace ax = WebCore::Accessibility;
     ASSERT(isMainRunLoop());
     m_isolatedTreeRoot = root.get();
 }
+
+- (void)setWindow:(id)window
+{
+    ASSERT(window);
+    ASSERT(isMainRunLoop());
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    Locker lock { m_windowLock };
+#endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    m_window = window;
+}
 #endif
 
 - (void)setHasMainFramePlugin:(bool)hasPlugin
@@ -174,6 +184,10 @@ namespace ax = WebCore::Accessibility;
 - (void)setRemoteParent:(id)parent
 {
     ASSERT(isMainRunLoop());
+
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    Locker lock { m_parentLock };
+#endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     m_parent = parent;
 }
 

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
@@ -159,15 +159,23 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (id)accessibilityAttributeValue:(NSString *)attribute
 ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
-    callOnMainRunLoopAndWait([] {
-        if (!WebCore::AXObjectCache::accessibilityEnabled())
-            WebCore::AXObjectCache::enableAccessibility();
+    static std::atomic<bool> didInitialize { false };
+    static std::atomic<unsigned> screenHeight { 0 };
+    if (UNLIKELY(!didInitialize)) {
+        didInitialize = true;
+        callOnMainRunLoopAndWait([] {
+            if (!WebCore::AXObjectCache::accessibilityEnabled())
+                WebCore::AXObjectCache::enableAccessibility();
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-        if (WebCore::AXObjectCache::isIsolatedTreeEnabled())
-            WebCore::AXObjectCache::initializeAXThreadIfNeeded();
-#endif
-    });
+            if (WebCore::AXObjectCache::isIsolatedTreeEnabled())
+                WebCore::AXObjectCache::initializeAXThreadIfNeeded();
+#endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+
+            float roundedHeight = std::round(WebCore::screenRectForPrimaryScreen().size().height());
+            screenHeight = std::max(0u, static_cast<unsigned>(roundedHeight));
+        });
+    }
 
     // The following attributes can be handled off the main thread.
 
@@ -192,32 +200,19 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return [self accessibilityChildren];
     }
 
-    // The following attributes have to be retrieved from the main thread. Return nil for any other attribute.
-    if (![attribute isEqualToString:NSAccessibilityParentAttribute]
-        && ![attribute isEqualToString:NSAccessibilityWindowAttribute]
-        && ![attribute isEqualToString:NSAccessibilityTopLevelUIElementAttribute]
-        && ![attribute isEqualToString:NSAccessibilityPrimaryScreenHeightAttribute])
-        return nil;
+    if ([attribute isEqualToString:NSAccessibilityParentAttribute])
+        return [self accessibilityAttributeParentValue].get();
 
-    return ax::retrieveAutoreleasedValueFromMainThread<id>([attribute = retainPtr(attribute), PROTECTED_SELF] () -> RetainPtr<id> {
-        if ([attribute isEqualToString:NSAccessibilityParentAttribute])
-            return protectedSelf->m_parent.get();
+    if ([attribute isEqualToString:NSAccessibilityPrimaryScreenHeightAttribute])
+        return @(screenHeight.load());
 
-        if ([attribute isEqualToString:NSAccessibilityWindowAttribute])
-            return [protectedSelf->m_parent accessibilityAttributeValue:NSAccessibilityWindowAttribute];
+    if ([attribute isEqualToString:NSAccessibilityWindowAttribute])
+        return [self accessibilityAttributeWindowValue].get();
 
-        if ([attribute isEqualToString:NSAccessibilityTopLevelUIElementAttribute])
-            return [protectedSelf->m_parent accessibilityAttributeValue:NSAccessibilityTopLevelUIElementAttribute];
+    if ([attribute isEqualToString:NSAccessibilityTopLevelUIElementAttribute])
+        return [self accessibilityAttributeTopLevelUIElementValue].get();
 
-        // FIXME: do we need this check?
-        if (!protectedSelf->m_pageID)
-            return nil;
-
-        if ([attribute isEqualToString:NSAccessibilityPrimaryScreenHeightAttribute])
-            return @(WebCore::screenRectForPrimaryScreen().size().height());
-
-        return nil;
-    });
+    return nil;
 }
 
 - (NSValue *)accessibilityAttributeSizeValue
@@ -227,13 +222,9 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         Locker lock { m_cacheLock };
         return [NSValue valueWithSize:(NSSize)m_size];
     }
-#endif
+#endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 
-    return ax::retrieveAutoreleasedValueFromMainThread<id>([PROTECTED_SELF] () -> RetainPtr<id> {
-        if (!protectedSelf->m_page)
-            return nil;
-        return [NSValue valueWithSize:(NSSize)protectedSelf->m_page->size()];
-    });
+    return m_page ? [NSValue valueWithSize:m_page->size()] : nil;
 }
 
 - (NSValue *)accessibilityAttributePositionValue
@@ -243,13 +234,56 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         Locker lock { m_cacheLock };
         return [NSValue valueWithPoint:(NSPoint)m_position];
     }
-#endif
+#endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 
-    return ax::retrieveAutoreleasedValueFromMainThread<id>([PROTECTED_SELF] () -> RetainPtr<id> {
-        if (!protectedSelf->m_page)
-            return nil;
-        return [NSValue valueWithPoint:(NSPoint)protectedSelf->m_page->accessibilityPosition()];
-    });
+    return m_page ? [NSValue valueWithPoint:m_page->accessibilityPosition()] : nil;
+}
+
+- (RetainPtr<id>)accessibilityAttributeParentValue
+{
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    if (!isMainRunLoop()) {
+        Locker lock { m_parentLock };
+        return m_parent;
+    }
+#endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+
+    return m_parent;
+}
+
+// FIXME: accessibilityAttributeWindowValue and accessibilityAttributeTopLevelUIElementValue
+// always return nil for instances of this class when set up by WebPage::registerRemoteFrameAccessibilityTokens,
+// as nothing there sets m_window, setWindowUIElement, and setTopLevelUIElement.
+- (RetainPtr<id>)accessibilityAttributeWindowValue
+{
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    if (!isMainRunLoop()) {
+        // Use the cached window to avoid using m_parent (which is possibly an AppKit object) off the main-thread.
+        Locker lock { m_windowLock };
+        return m_window.get();
+    }
+#endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    return [m_parent accessibilityAttributeValue:NSAccessibilityWindowAttribute];
+    ALLOW_DEPRECATED_DECLARATIONS_END
+}
+
+- (RetainPtr<id>)accessibilityAttributeTopLevelUIElementValue
+{
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    if (!isMainRunLoop()) {
+        // Use the cached window to avoid using m_parent (which is possibly an AppKit object) off the main-thread.
+        // The TopLevelUIElement is the window, as we set it as such in WebPage::registerUIProcessAccessibilityTokens,
+        // so we can return m_window here.
+        Locker lock { m_windowLock };
+        return m_window.get();
+    }
+#endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    return [m_parent accessibilityAttributeValue:NSAccessibilityTopLevelUIElementAttribute];
+    ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 - (id)accessibilityDataDetectorValue:(NSString *)attribute point:(WebCore::FloatPoint&)point

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -457,7 +457,7 @@ void WebPage::registerUIProcessAccessibilityTokens(std::span<const uint8_t> elem
 
     [remoteElement setWindowUIElement:remoteWindow.get()];
     [remoteElement setTopLevelUIElement:remoteWindow.get()];
-
+    [accessibilityRemoteObject() setWindow:remoteWindow.get()];
     [accessibilityRemoteObject() setRemoteParent:remoteElement.get()];
 }
 


### PR DESCRIPTION
#### 498510277e2c87eee205596bd973049eece62837
<pre>
AX: -[WKAccessibilityWebPageObjectMac accessibilityAttributeValue] hits the main-thread unnecessarily
<a href="https://bugs.webkit.org/show_bug.cgi?id=284681">https://bugs.webkit.org/show_bug.cgi?id=284681</a>
<a href="https://rdar.apple.com/problem/141629794">rdar://problem/141629794</a>

Reviewed by Chris Fleizach.

Prior to this commit, -[WKAccessibilityWebPageObjectMac accessibilityAttributeValue] unconditionally hit the main-thread
once to initialize accessibility (even if it had already been done so), and potentially again depending on the attribute
requested.

Solve the first main-thread hit by adding a std::atomic&lt;bool&gt; that can be set after we&apos;ve initialized accessibility.
Checking an atomic bool is significantly cheaper than waiting on the main-thread, which could be busy.

Solve the second main-thread hit by making changes necessary to serve some attributes off the main-thread:

  - Cache NSAccessibilityPrimaryScreenHeightAttribute once at the same time we hit the main-thread to initialize
    accessibility for the first time, then store it in a std::atomic&lt;unsigned&gt; for subsequent use.

  - Put usage of WKAccessibilityWebPageObjectBase::m_parent behind a new lock, WKAccessibilityWebPageObjectBase::m_parentLock.
    RetainPtr reference counting is inherently threadsafe, but the lock is still necessary to ensure the main-thread
    cannot overwrite m_parent with a new value while the AX thread is reading it to serve a request.

The first attempt at making this change was reverted in <a href="https://commits.webkit.org/287865@main">https://commits.webkit.org/287865@main</a> because it caused
crashes in debug macOS layout tests with added assert:

ASSERT(!m_window);

This commit changes the assert to allow the window to be set to the same value, i.e.:

ASSERT(!m_window || m_window.get() == window);

* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h:
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm:
(-[WKAccessibilityWebPageObjectBase setRemoteParent:]):
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm:
(-[WKAccessibilityWebPageObject accessibilityAttributeValue:]):
(-[WKAccessibilityWebPageObject accessibilityAttributeSizeValue]):
(-[WKAccessibilityWebPageObject accessibilityAttributePositionValue]):
(-[WKAccessibilityWebPageObject accessibilityAttributeParentValue]):
(-[WKAccessibilityWebPageObject accessibilityAttributeWindowValue]):
(-[WKAccessibilityWebPageObject accessibilityAttributeTopLevelUIElementValue]):

Canonical link: <a href="https://commits.webkit.org/288040@main">https://commits.webkit.org/288040@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e5dcacdb472835969fd818e9794fe4271c5f69a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81617 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1141 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35565 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86150 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32607 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1169 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8958 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63672 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21404 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84687 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/823 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74266 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43961 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/723 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31062 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72151 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29041 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87593 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8854 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6334 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72067 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9036 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70094 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71235 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17765 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15315 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14228 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8806 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14334 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8646 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12167 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10453 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->