### PR TITLE
std::filesystem::copy should not be used to recursively copy parent into it's child.

### DIFF
--- a/LayoutTests/storage/filesystemaccess/filesystem-directory-handle-rename-expected.txt
+++ b/LayoutTests/storage/filesystemaccess/filesystem-directory-handle-rename-expected.txt
@@ -1,0 +1,4 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Test Passes if there are no files inside the root storage location. This is verified by the absence of an output from the `debug(v)` statement above.

--- a/LayoutTests/storage/filesystemaccess/filesystem-directory-handle-rename.html
+++ b/LayoutTests/storage/filesystemaccess/filesystem-directory-handle-rename.html
@@ -1,0 +1,31 @@
+<html>
+<script src="../../resources/js-test.js"></script>
+<script>
+    window.jsTestIsAsync = true;
+    async function a() {
+        let h = await navigator.storage.getDirectory();
+        h.move(h, `\u0480`).then(() => {
+            debug("This should not be. This API should return a rejection because we are trying to move a parent directory recursively inside itself.");
+            finishJSTest(e);
+        }, async (e) => {
+            let h = await navigator.storage.getDirectory();
+            // if the directory recursion did not happen this should not print anything.
+            for await(let v of h.entries()){
+                debug(v);
+            }
+            finishJSTest(e);
+        });
+    }
+    async function runTest(){
+        if (window.testRunner)
+            window.testRunner.waitUntilDone();
+        await a();
+    }
+
+</script>
+<body onload="runTest()">
+Test Passes if there are no files inside the root storage location. This is verified by the absence of an output from the `debug(v)`
+statement above.
+</body>
+</script>
+</html>

--- a/Source/WTF/wtf/FileSystem.cpp
+++ b/Source/WTF/wtf/FileSystem.cpp
@@ -647,6 +647,9 @@ bool moveFile(const String& oldPath, const String& newPath)
     if (!ec)
         return true;
 
+    if (isAncestor(oldPath, newPath))
+        return false;
+
     // Fall back to copying and then deleting source as rename() does not work across volumes.
     ec = { };
     std::filesystem::copy(fsOldPath, fsNewPath, std::filesystem::copy_options::overwrite_existing | std::filesystem::copy_options::recursive, ec);
@@ -834,6 +837,17 @@ String parentPath(const String& path)
 String lexicallyNormal(const String& path)
 {
     return fromStdFileSystemPath(toStdFileSystemPath(path).lexically_normal());
+}
+
+bool isAncestor(const String& possibleAncestor, const String& possibleChild)
+{
+    auto possibleChildLexicallyNormal = lexicallyNormal(possibleChild);
+    auto possibleAncestorLexicallyNormal = lexicallyNormal(possibleAncestor);
+    if (possibleChildLexicallyNormal.endsWith(static_cast<UChar>(std::filesystem::path::preferred_separator)))
+        possibleChildLexicallyNormal = possibleChildLexicallyNormal.left(possibleChildLexicallyNormal.length() - 1);
+    if (possibleAncestorLexicallyNormal.endsWith(static_cast<UChar>(std::filesystem::path::preferred_separator)))
+        possibleAncestorLexicallyNormal = possibleAncestorLexicallyNormal.left(possibleAncestorLexicallyNormal.length() - 1);
+    return possibleChildLexicallyNormal.startsWith(possibleAncestorLexicallyNormal) && possibleChildLexicallyNormal.length() != possibleAncestorLexicallyNormal.length();
 }
 
 String createTemporaryFile(StringView prefix, StringView suffix)

--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -134,6 +134,7 @@ WTF_EXPORT_PRIVATE bool makeAllDirectories(const String& path);
 WTF_EXPORT_PRIVATE String pathFileName(const String&);
 WTF_EXPORT_PRIVATE String parentPath(const String&);
 WTF_EXPORT_PRIVATE String lexicallyNormal(const String&);
+WTF_EXPORT_PRIVATE bool isAncestor(const String& first, const String& second);
 WTF_EXPORT_PRIVATE std::optional<uint64_t> volumeFreeSpace(const String&);
 WTF_EXPORT_PRIVATE std::optional<uint64_t> volumeCapacity(const String&);
 WTF_EXPORT_PRIVATE std::optional<uint32_t> volumeFileBlockSize(const String&);

--- a/Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp
@@ -957,4 +957,55 @@ TEST_F(FileSystemTest, makeSafeToUseMemoryMapForPath)
 #endif
 }
 
+TEST_F(FileSystemTest, isAncestor)
+{
+    Vector<std::pair<std::pair<const char*, const char*>, bool>> narrowString {
+        { { "/a/b/c/", "/a/b/c/d" }, true },
+        { { "/a/b/c", "/a/b/c/d/e/.." }, true },
+        { { "/a/b/c/.", "/a/b/c/d" }, true },
+        { { "/a/b/c", "/a/b/c" }, false },
+        { { "/a/b/c/x/..", "/a/b/c" }, false },
+        { { "/a/b/c/dir1", "/a/b/c/dir2" }, false },
+        { { "/a/b/c", "/a/b/c/" }, false },
+        { { "/a/b/c", "/a/b/c/." }, false },
+        { { "a/b/c", "/a/b/c/" }, false },
+        { { "a/b/c", "a/b/c/" }, false },
+        { { "/a/b/c", "a/b/c/" }, false }
+    };
+    std::for_each(narrowString.begin(), narrowString.end(), [](auto input) {
+        EXPECT_EQ(
+            input.second,
+                FileSystem::isAncestor(
+                    ASCIILiteral::fromLiteralUnsafe(input.first.first),
+                    ASCIILiteral::fromLiteralUnsafe(input.first.second)
+                )
+            );
+        }
+    );
+
+    Vector<std::pair<std::pair<const char16_t *, const char16_t *>, bool>> wideString {
+        { { u"/a/b/c/", u"/a/b/c/d" }, true },
+        { { u"/a/b/c", u"/a/b/c/d/e/.." }, true },
+        { { u"/a/b/c/.", u"/a/b/c/d" }, true },
+        { { u"/a/b/c", u"/a/b/c" }, false },
+        { { u"/a/b/c/x/..", u"/a/b/c" }, false },
+        { { u"/a/b/c/dir1", u"/a/b/c/dir2" }, false },
+        { { u"/a/b/c", u"/a/b/c/" }, false },
+        { { u"/a/b/c", u"/a/b/c/." }, false },
+        { { u"a/b/c", u"/a/b/c/" }, false },
+        { { u"a/b/c", u"a/b/c/" }, false },
+        { { u"/a/b/c", u"a/b/c/" }, false }
+    };
+    std::for_each(wideString.begin(), wideString.end(), [](auto input) {
+        EXPECT_EQ(
+            input.second,
+                FileSystem::isAncestor(
+                    std::span<const UChar> { static_cast<const UChar *>(input.first.first), std::char_traits<char16_t>::length(input.first.first) },
+                    std::span<const UChar> { static_cast<const UChar*>(input.first.second), std::char_traits<char16_t>::length(input.first.second) }
+                )
+            );
+        }
+    );
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 2d83a1557ecb11064ff28a5078f31680c4505ade
<pre>
std::filesystem::copy should not be used to recursively copy parent into it&apos;s child.
<a href="https://bugs.webkit.org/show_bug.cgi?id=281280">https://bugs.webkit.org/show_bug.cgi?id=281280</a>
<a href="https://rdar.apple.com/137177339">rdar://137177339</a>

Reviewed by Sihui Liu and Alex Christensen.

The added test case filesystem-directory-handle-rename.html will cause std::filesystem::copy to be
called with top OPFS FileSystem directory being copied into itself under a subdirectory with name `\u0480`.
This will cause a recursive directory tree to be generated inside the root storage directory.
If FileSystem::directorySize() is called over that directory, it will abort with `Too many open files`.

The Unicode `\u0480` has no significance but just a weird character to use for the file name.
If you see this, It should raise questions. Thus the choice.
The same error will happen if we choose &quot;anyRandomAsciiName&quot;.

The fix added here will prevent std::filesystem::copy to be called in case source is ancestor of destination.

* LayoutTests/storage/filesystemaccess/filesystem-directory-handle-rename.html: Added.
* Source/WTF/wtf/FileSystem.cpp:
(WTF::FileSystemImpl::isAncestor):
* Source/WTF/wtf/FileSystem.h:
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp:
(WebKit::FileSystemStorageHandle::move):
* Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp:
(TestWebKitAPI::TEST_F(FileSystemTest, isAncestor)):

Originally-landed-as: 283286.251@safari-7620-branch (30ab479e8242). <a href="https://rdar.apple.com/141318843">rdar://141318843</a>
Canonical link: <a href="https://commits.webkit.org/288177@main">https://commits.webkit.org/288177@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6fe707b5971dfc3ffb57d6b91b6fe4666dfe2f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81950 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1477 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35907 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86507 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32982 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84056 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1512 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9300 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63903 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21623 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85020 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1122 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74572 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44186 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1024 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28749 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31401 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/74931 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72351 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29360 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87938 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/81004 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9192 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6552 "Found 1 new test failure: http/wpt/mediarecorder/record-96KHz-sources.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72268 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9377 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70391 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71490 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15597 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14517 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/578 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12726 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9143 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14679 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/103416 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8983 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25103 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12508 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10791 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->