### PR TITLE
[JSC] BBQJIT::addCatchToUnreachable should unbind all temps

### DIFF
--- a/JSTests/wasm/stress/compile-unreachable-catch.js
+++ b/JSTests/wasm/stress/compile-unreachable-catch.js
@@ -1,0 +1,77 @@
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+const watGetGlobalsSameTempReturnCall = `
+(module
+  (tag $e (param f32))
+  (global $f0 (mut f32)(f32.const 2.0))
+  (global $i0 (mut i64)(i64.const 1))
+  (func (export "test") (local i64)
+    try
+      local.get 0
+      global.get $f0
+      return_call $bar
+    catch_all
+      global.get $i0
+      return_call $foo
+    end
+  )
+  (func $foo)
+  (func $bar)
+)
+`;
+
+const watGetGlobalCatchArgSameTempReturnCall = `
+(module
+  (tag $e (param i64))
+  (global $f0 (mut f32)(f32.const 2.0))
+  (global $i0 (mut i64)(i64.const 1))
+  (func (export "test") (result i64)
+    try (result i64)
+      global.get $f0
+      global.get $f0
+      return_call $bar
+    catch $e
+      global.get $i0
+      i64.add
+    end
+  )
+  (func $bar (param f32) (result i64) i64.const 3)
+)
+`;
+
+const watGetGlobalsSameTempUnreachable = `
+(module
+  (tag $e (param f32))
+  (global $f0 (mut f32)(f32.const 2.0))
+  (global $i0 (mut i64)(i64.const 1))
+  (func (export "test") (local i64)
+    try
+      local.get 0
+      global.get $f0
+      unreachable
+    catch_all
+      global.get $i0
+      return_call $foo
+    end
+  )
+  (func $foo)
+  (func $bar)
+)
+`;
+
+async function runOne(wat, isUnreachable) {
+    const instance = await instantiate(wat, {}, { exceptions: true, tail_call: true });
+    const {test} = instance.exports;
+    if (isUnreachable) {
+        assert.throws(() => {
+            test();
+        }, WebAssembly.RuntimeError, `Unreachable code`);
+    } else {
+        test();
+    }
+}
+
+assert.asyncTest(runOne(watGetGlobalsSameTempReturnCall, false));
+assert.asyncTest(runOne(watGetGlobalCatchArgSameTempReturnCall, false));
+assert.asyncTest(runOne(watGetGlobalsSameTempUnreachable, true));

--- a/LayoutTests/security/contentSecurityPolicy/block-javascripturl-non-inline-csp-expected.txt
+++ b/LayoutTests/security/contentSecurityPolicy/block-javascripturl-non-inline-csp-expected.txt
@@ -1,0 +1,3 @@
+CONSOLE MESSAGE: Script is executing and is not blocked by CSP.
+CONSOLE MESSAGE: Refused to execute a script because its hash or 'unsafe-inline' does not appear in the script-src directive of the Content Security Policy.
+Test output should contain a CSP violation.

--- a/LayoutTests/security/contentSecurityPolicy/block-javascripturl-non-inline-csp.html
+++ b/LayoutTests/security/contentSecurityPolicy/block-javascripturl-non-inline-csp.html
@@ -1,0 +1,9 @@
+<html>
+<meta http-equiv="Content-Security-Policy" content="script-src 'self'">
+<script src="resources/csp-javascript-url.js"></script>
+<head>
+</head>
+<body id="id-body">
+<p>Test output should contain a CSP violation.</p>
+</body>
+</html>

--- a/LayoutTests/security/contentSecurityPolicy/resources/csp-javascript-url.js
+++ b/LayoutTests/security/contentSecurityPolicy/resources/csp-javascript-url.js
@@ -1,0 +1,13 @@
+console.log("Script is executing and is not blocked by CSP.");
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function sleep(ms = 0) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+window.no_csp = window.open("resources/no-csp.html", "no_csp");
+window.no_csp.location.href = "javascript:console.log('This should not be logged');";
+sleep(500).then(() => {testRunner.notifyDone();});

--- a/Source/JavaScriptCore/tools/FunctionAllowlist.cpp
+++ b/Source/JavaScriptCore/tools/FunctionAllowlist.cpp
@@ -63,7 +63,7 @@ FunctionAllowlist::FunctionAllowlist(const char* filename)
 
         // Get rid of newlines at the ends of the strings.
         size_t length = strlen(line);
-        if (line[length - 1] == '\n') {
+        if (length && line[length - 1] == '\n') {
             line[length - 1] = '\0';
             length--;
         }

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -1972,6 +1972,8 @@ private:
 
     void unbind(Value value, Location loc);
 
+    void unbindAllRegisters();
+
     template<typename Register>
     static Register fromJSCReg(Reg reg)
     {

--- a/Source/ThirdParty/ANGLE/src/compiler/translator/msl/EmitMetal.cpp
+++ b/Source/ThirdParty/ANGLE/src/compiler/translator/msl/EmitMetal.cpp
@@ -181,12 +181,17 @@ class GenMetalTraverser : public TIntermTraverser
 
     void emitSingleConstant(const TConstantUnion *const constUnion);
 
+    void emitForwardProgressStore();
+    void emitForwardProgressSignal();
+    bool shouldEnsureForwardProgress() const { return mForwardProgressStoreNestingCount >= 0; }
+
   private:
     Sink &mOut;
     const TCompiler &mCompiler;
     const PipelineStructs &mPipelineStructs;
     SymbolEnv &mSymbolEnv;
     IdGen &mIdGen;
+    int mForwardProgressStoreNestingCount  = -1; // Negative means forward progress is not ensured.
     int mIndentLevel                  = -1;
     int mLastIndentationPos           = -1;
     int mOpenPointerParenCount        = 0;
@@ -201,8 +206,44 @@ class GenMetalTraverser : public TIntermTraverser
     size_t mDriverUniformsBindingIndex     = 0;
     size_t mUBOArgumentBufferBindingIndex  = 0;
     bool mRasterOrderGroupsSupported       = false;
-    bool mInjectAsmStatementIntoLoopBodies = false;
+    friend class ScopedForwardProgressStore;
 };
+
+class ScopedForwardProgressStore
+{
+public:
+    ScopedForwardProgressStore(GenMetalTraverser& traverser);
+    ~ScopedForwardProgressStore();
+private:
+    GenMetalTraverser& mTraverser;
+};
+
+ScopedForwardProgressStore::ScopedForwardProgressStore(GenMetalTraverser& traverser)
+    : mTraverser(traverser)
+{
+    if (mTraverser.shouldEnsureForwardProgress())
+    {
+        if (mTraverser.mForwardProgressStoreNestingCount == 0)
+        {
+            mTraverser.emitOpenBrace();
+            mTraverser.emitForwardProgressStore();
+        }
+        ++mTraverser.mForwardProgressStoreNestingCount;
+    }
+}
+
+ScopedForwardProgressStore::~ScopedForwardProgressStore()
+{
+    if (mTraverser.shouldEnsureForwardProgress())
+    {
+        --mTraverser.mForwardProgressStoreNestingCount;
+        if (mTraverser.mForwardProgressStoreNestingCount == 0)
+        {
+            mTraverser.emitCloseBrace();
+        }
+    }
+}
+
 }  // anonymous namespace
 
 GenMetalTraverser::~GenMetalTraverser()
@@ -228,9 +269,11 @@ GenMetalTraverser::GenMetalTraverser(const TCompiler &compiler,
       mDriverUniformsBindingIndex(compileOptions.metal.driverUniformsBindingIndex),
       mUBOArgumentBufferBindingIndex(compileOptions.metal.UBOArgumentBufferBindingIndex),
       mRasterOrderGroupsSupported(compileOptions.pls.fragmentSyncType ==
-                                  ShFragmentSynchronizationType::RasterOrderGroups_Metal),
-      mInjectAsmStatementIntoLoopBodies(compileOptions.metal.injectAsmStatementIntoLoopBodies)
-{}
+                                  ShFragmentSynchronizationType::RasterOrderGroups_Metal)
+{
+    if (compileOptions.metal.injectAsmStatementIntoLoopBodies)
+        mForwardProgressStoreNestingCount = 0;
+}
 
 void GenMetalTraverser::emitIndentation()
 {
@@ -882,17 +925,14 @@ void GenMetalTraverser::emitPostQualifier(const EmitVariableDeclarationConfig &e
 
 void GenMetalTraverser::emitLoopBody(TIntermBlock *bodyNode)
 {
-    if (mInjectAsmStatementIntoLoopBodies)
+    const bool emitForwardProgress = shouldEnsureForwardProgress();
+    if (emitForwardProgress)
     {
         emitOpenBrace();
-
-        emitIndentation();
-        mOut << "__asm__(\"\");\n";
+        emitForwardProgressSignal();
     }
-
     bodyNode->traverse(this);
-
-    if (mInjectAsmStatementIntoLoopBodies)
+    if (emitForwardProgress)
     {
         emitCloseBrace();
     }
@@ -2406,6 +2446,26 @@ void GenMetalTraverser::emitCloseBrace()
     mOut << "}";
 }
 
+void GenMetalTraverser::emitForwardProgressStore()
+{
+    // https://eel.is/c++draft/intro.progress
+    // "The implementation may assume that any thread will eventually do one of the following:""
+    //  - ...
+    //  - "perform an access through a volatile glvalue"
+    // Emit a volatile variable which all loops in the stack will access.
+    emitIndentation();
+    mOut << "volatile bool ANGLE_p;\n";
+}
+
+void GenMetalTraverser::emitForwardProgressSignal()
+{
+    // Emit a read though the volatile variable. This marks the loop as making forward progress even
+    // if the compiler can otherwise analyze it to be infinite. This ensures that the loop
+    // has defined behavior.
+    emitIndentation();
+    mOut << "(void) ANGLE_p;\n";
+}
+
 static bool RequiresSemicolonTerminator(TIntermNode &node)
 {
     if (node.getAsBlock())
@@ -2607,6 +2667,8 @@ bool GenMetalTraverser::visitForLoop(TIntermLoop *loopNode)
     TIntermTyped *condNode = loopNode->getCondition();
     TIntermTyped *exprNode = loopNode->getExpression();
 
+    ScopedForwardProgressStore scopedProgress(*this);
+
     mOut << "for (";
 
     if (initNode)
@@ -2649,6 +2711,7 @@ bool GenMetalTraverser::visitWhileLoop(TIntermLoop *loopNode)
     ASSERT(condNode);
     ASSERT(!initNode && !exprNode);
 
+    ScopedForwardProgressStore scopedProgress(*this);
     emitIndentation();
     mOut << "while (";
     condNode->traverse(this);
@@ -2668,6 +2731,7 @@ bool GenMetalTraverser::visitDoWhileLoop(TIntermLoop *loopNode)
     ASSERT(condNode);
     ASSERT(!initNode && !exprNode);
 
+    ScopedForwardProgressStore scopedProgress(*this);
     emitIndentation();
     mOut << "do\n";
     emitLoopBody(loopNode->getBody());

--- a/Source/ThirdParty/ANGLE/src/tests/angle_end2end_tests.gni
+++ b/Source/ThirdParty/ANGLE/src/tests/angle_end2end_tests.gni
@@ -167,6 +167,7 @@ angle_end2end_tests_sources = [
   "gl_tests/TextureTest.cpp",
   "gl_tests/TextureUploadFormatTest.cpp",
   "gl_tests/TiledRenderingTest.cpp",
+  "gl_tests/TimeoutDrawTest.cpp",
   "gl_tests/TimerQueriesTest.cpp",
   "gl_tests/TransformFeedbackTest.cpp",
   "gl_tests/UniformBufferTest.cpp",

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/TimeoutDrawTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/TimeoutDrawTest.cpp
@@ -1,0 +1,176 @@
+//
+// Copyright 2015 The ANGLE Project Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+//
+
+#include "test_utils/ANGLETest.h"
+
+#include "test_utils/gl_raii.h"
+#include "util/shader_utils.h"
+
+using namespace angle;
+
+namespace
+{
+class TimeoutDrawTest : public ANGLETest<>
+{
+  protected:
+    TimeoutDrawTest()
+    {
+        setWindowWidth(128);
+        setWindowHeight(128);
+        setConfigRedBits(8);
+        setConfigGreenBits(8);
+        setConfigBlueBits(8);
+        setConfigAlphaBits(8);
+        // Tests should skip if robustness not supported, but this can be done only after
+        // Metal supports robustness.
+        if (IsEGLClientExtensionEnabled("EGL_EXT_create_context_robustness"))
+        {
+            setContextResetStrategy(EGL_LOSE_CONTEXT_ON_RESET_EXT);
+        }
+        else
+        {
+            setContextResetStrategy(EGL_NO_RESET_NOTIFICATION_EXT);
+        }
+    }
+    void testSetUp() override
+    {
+        glClear(GL_COLOR_BUFFER_BIT);
+        glFinish();
+    }
+};
+
+// Tests that trivial infinite loops in vertex shaders hang instead of progress.
+TEST_P(TimeoutDrawTest, TrivialInfiniteLoopVS)
+{
+    constexpr char kVS[] = R"(precision highp float;
+attribute vec4 a_position;
+void main()
+{
+    for (;;) {}
+    gl_Position = a_position;
+})";
+    ANGLE_GL_PROGRAM(program, kVS, essl1_shaders::fs::Red());
+    drawQuad(program, essl1_shaders::PositionAttrib(), 0.5f);
+    glFinish();
+    EXPECT_GL_ERROR(GL_CONTEXT_LOST);
+    EXPECT_PIXEL_COLOR_EQ(0, 0, GLColor::transparentBlack);  // Should read through client buffer since context should be lost.
+}
+
+// Tests that trivial infinite loops in fragment shaders hang instead of progress.
+TEST_P(TimeoutDrawTest, TrivialInfiniteLoopFS)
+{
+    constexpr char kFS[] = R"(precision mediump float;
+void main()
+{
+    for (;;) {}
+    gl_FragColor = vec4(1, 0, 0, 1);
+})";
+    ANGLE_GL_PROGRAM(program, essl1_shaders::vs::Simple(), kFS);
+    drawQuad(program, essl1_shaders::PositionAttrib(), 0.5f);
+    glFinish();
+    EXPECT_GL_ERROR(GL_CONTEXT_LOST);
+    EXPECT_PIXEL_COLOR_EQ(0, 0, GLColor::transparentBlack);  // Should read through client buffer since context should be lost.
+}
+
+
+// Tests that infinite loops based on user-supplied values in vertex shaders hang instead of progress.
+// Otherwise optimizer would be able to assume something about the domain of the user-supplied value.
+TEST_P(TimeoutDrawTest, DynamicInfiniteLoopVS)
+{
+    constexpr char kVS[] = R"(precision highp float;
+attribute vec4 a_position;
+uniform int f;
+void main()
+{
+    for (;f != 0;) {}
+    gl_Position = a_position;
+})";
+    ANGLE_GL_PROGRAM(program, kVS, essl1_shaders::fs::Red());
+
+    glUseProgram(program);
+    GLint uniformLocation = glGetUniformLocation(program, "f");
+    glUniform1i(uniformLocation, 77);
+
+    drawQuad(program, essl1_shaders::PositionAttrib(), 0.5f);
+    glFinish();
+    EXPECT_PIXEL_COLOR_EQ(0, 0, GLColor::transparentBlack);  // Should read through client buffer since context should be lost.
+    EXPECT_GL_ERROR(GL_CONTEXT_LOST);
+}
+
+// Tests that infinite loops based on user-supplied values in fragment shaders hang instead of progress.
+// Otherwise optimizer would be able to assume something about the domain of the user-supplied value.
+TEST_P(TimeoutDrawTest, DynamicInfiniteLoopFS)
+{
+    constexpr char kFS[] = R"(precision mediump float;
+uniform int f;
+void main()
+{
+    for (;f != 0;) {}
+    gl_FragColor = vec4(1, 0, 0, 1);
+})";
+    ANGLE_GL_PROGRAM(program, essl1_shaders::vs::Simple(), kFS);
+    glUseProgram(program);
+    GLint uniformLocation = glGetUniformLocation(program, "f");
+    glUniform1i(uniformLocation, 88);
+    EXPECT_GL_NO_ERROR();
+    drawQuad(program, essl1_shaders::PositionAttrib(), 0.5f);
+    glFinish();
+    EXPECT_GL_ERROR(GL_CONTEXT_LOST);
+    EXPECT_PIXEL_COLOR_EQ(0, 0, GLColor::transparentBlack);  // Should read through client buffer since context should be lost.
+}
+
+// Tests that infinite loops based on user-supplied values in vertex shaders hang instead of progress.
+// Otherwise optimizer would be able to assume something about the domain of the user-supplied value.
+// Explicit value break variant.
+TEST_P(TimeoutDrawTest, DynamicInfiniteLoop2VS)
+{
+    constexpr char kVS[] = R"(precision highp float;
+attribute vec4 a_position;
+uniform int f;
+void main()
+{
+    for (;;) { if (f <= 1) break; }
+    gl_Position = a_position;
+})";
+    ANGLE_GL_PROGRAM(program, kVS, essl1_shaders::fs::Red());
+    glUseProgram(program);
+    GLint uniformLocation = glGetUniformLocation(program, "f");
+    glUniform1i(uniformLocation, 66);
+    EXPECT_GL_NO_ERROR();
+    drawQuad(program, essl1_shaders::PositionAttrib(), 0.5f);
+    glFinish();
+    EXPECT_GL_ERROR(GL_CONTEXT_LOST);
+    EXPECT_PIXEL_COLOR_EQ(0, 0, GLColor::transparentBlack);  // Should read through client buffer since context should be lost.
+}
+
+// Tests that infinite loops based on user-supplied values in fragment shaders hang instead of progress.
+// Otherwise optimizer would be able to assume something about the domain of the user-supplied value.
+// Explicit value break variant.
+TEST_P(TimeoutDrawTest, DynamicInfiniteLoop2FS)
+{
+    constexpr char kFS[] = R"(precision mediump float;
+uniform float f;
+void main()
+{
+    for (;;) { if (f < 0.1) break; }
+    gl_FragColor = vec4(1, 0, f, 1);
+})";
+    ANGLE_GL_PROGRAM(program, essl1_shaders::vs::Simple(), kFS);
+    glUseProgram(program);
+    GLint uniformLocation = glGetUniformLocation(program, "f");
+    glUniform1f(uniformLocation, .5f);
+    EXPECT_GL_NO_ERROR();
+    drawQuad(program, essl1_shaders::PositionAttrib(), 0.5f);
+    glFinish();
+    EXPECT_GL_ERROR(GL_CONTEXT_LOST);
+    EXPECT_PIXEL_COLOR_EQ(0, 0, GLColor::transparentBlack);  // Should read through client buffer since context should be lost.
+}
+
+}
+
+ANGLE_INSTANTIATE_TEST(TimeoutDrawTest,
+                       WithRobustness(ES2_METAL().enable(Feature::InjectAsmStatementIntoLoopBodies)),
+                       WithRobustness(ES3_METAL().enable(Feature::InjectAsmStatementIntoLoopBodies)));

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h
@@ -61,6 +61,8 @@ public:
     void handleContextMenuWritingTools(WebCore::WritingTools::RequestedTool);
 #endif
 
+    void handleShareMenuItem();
+
 #if ENABLE(SERVICE_CONTROLS)
     void clearServicesMenu();
     void removeBackgroundFromControlledImage();
@@ -85,7 +87,9 @@ private:
     void getContextMenuFromItems(const Vector<WebContextMenuItemData>&, CompletionHandler<void(NSMenu *)>&&);
 
 #if ENABLE(SERVICE_CONTROLS)
-    void getShareMenuItem(CompletionHandler<void(NSMenuItem *)>&&);
+    enum class ShareMenuItemType : uint8_t { Placeholder, Popover };
+    RetainPtr<NSMenuItem> createShareMenuItem(ShareMenuItemType);
+
     void showServicesMenu();
     void setupServicesMenu();
     void appendRemoveBackgroundItemToControlledImageMenuIfNeeded();


### PR DESCRIPTION
#### 032dd069dcf03d18e0b2f21b0955f55d09e1ab83
<pre>
[JSC] BBQJIT::addCatchToUnreachable should unbind all temps
<a href="https://bugs.webkit.org/show_bug.cgi?id=282180">https://bugs.webkit.org/show_bug.cgi?id=282180</a>
<a href="https://rdar.apple.com/138178927">rdar://138178927</a>

Reviewed by David Degazio.

BBQJIT::addCatchToUnreachable() and BBQJIT::addCatchAllToUnreachable()
are used after a control flow instruction is reached that makes the
end of the block unreachable, so they both avoid emitting code to
flush temps. However, they still need to unbind temps, otherwise
temps that are used within the catch will refer to stale bindings.

This issue occurs when catch or catch_all follows return_call or
unreachable bytecodes as these do not themselves flush the temps
back to their canonical locations (whereas uncondtional branch will since
the temps can still be live).

* JSTests/wasm/stress/compile-unreachable-catch.js: Added.
(async runOne):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addCatchToUnreachable):
(JSC::Wasm::BBQJITImpl::BBQJIT::addCatchAllToUnreachable):
(JSC::Wasm::BBQJITImpl::BBQJIT::addEndToUnreachable):
(JSC::Wasm::BBQJITImpl::BBQJIT::unbindAllRegisters):
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:

Originally-landed-as: 283286.367@safari-7620-branch (6146215d9220). <a href="https://rdar.apple.com/141318083">rdar://141318083</a>
Canonical link: <a href="https://commits.webkit.org/288023@main">https://commits.webkit.org/288023@main</a>
</pre>
----------------------------------------------------------------------
#### 477e22399befde2a767c6d0c3742f0c00f1169f5
<pre>
[CoreIPC] Messages::WebPageProxy::ShowContextMenuFromFrame allows arbitrary PDF rendering in UI process from web content
<a href="https://bugs.webkit.org/show_bug.cgi?id=282103">https://bugs.webkit.org/show_bug.cgi?id=282103</a>
<a href="https://rdar.apple.com/135720091">rdar://135720091</a>

Reviewed by Wenson Hsieh.

WebKit supplies images to the sharing service picker so that they can be shared
out to the system when the user right clicks on an image and clicks &quot;Share&quot;.

Since the sharing service picker must be created in order to obtain the menu item
itself, the supplied `NSImage` is created when the context menu is displayed, rather
than when the user clicks &quot;Share&quot;. This means that the code which creates the
`NSImage` is reachable simply with the `ShowContextMenuFromFrame` IPC message.
Additionally, the image is created with raw data rather than using a ShareableBitmap,
as the original format should be preserved when sharing. Consequently, the IPC
message can act as a way to perform image processing in the UI process.

To fix, supply a placeholder `NSImage` when creating the sharing service picker,
solely for the purpose of obtaining the menu item. Then, when the menu item is
clicked, another item is created with the real image, and then programmatically
invoked to present the sharing picker. This solution ensures that image processing
does not occur until the user actually clicks &quot;Share&quot;.

* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h:
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(-[WKMenuTarget performShare:]):
(WebKit::WebContextMenuProxyMac::handleShareMenuItem):

Set a `menu` on the created menu item, to ensure that the sharing service
picker has knowledge of the presenting view and the associated context menu.

The picker uses that information to make decisions about its presentation.

(WebKit::WebContextMenuProxyMac::createShareMenuItem):

Specify a placeholder image when needed, and simply grab the title of the sharing
menu item to create an item for display in the context menu.

(WebKit::WebContextMenuProxyMac::getContextMenuItem):
(WebKit::WebContextMenuProxyMac::getShareMenuItem): Deleted.
* Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm:
(-[NSSharingServicePicker swizzled_initWithItems:]):
(TestWebKitAPI::TEST(ContextMenuTests, ShowSharePopoverForImage)):

Add a test to ensure that the sharing picker is still presented when right clicking
on an image and clicking share, and that the image is preserved.

Originally-landed-as: 283286.355@safari-7620-branch (c2423adca8d6). <a href="https://rdar.apple.com/141318263">rdar://141318263</a>
Canonical link: <a href="https://commits.webkit.org/288022@main">https://commits.webkit.org/288022@main</a>
</pre>
----------------------------------------------------------------------
#### efb106b8c785760b692c24a000dbbb0ca2cfea47
<pre>
`javascript: url` navigation to another browsing context (created from `window.open`) misses checking the source&apos;s CSP
<a href="https://rdar.apple.com/137941234">rdar://137941234</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=281477">https://bugs.webkit.org/show_bug.cgi?id=281477</a>

Reviewed by Alex Christensen.

A change in window.location.href causes a navigation. Were were not checking the CSP in
that flow. This change adds that.

* LayoutTests/security/contentSecurityPolicy/block-javascripturl-non-inline-csp-expected.txt: Added.
* LayoutTests/security/contentSecurityPolicy/block-javascripturl-non-inline-csp.html: Added.
* LayoutTests/security/contentSecurityPolicy/resources/csp-javascript-url.js: Added.
(sleep):
(sleep.500.then):
* LayoutTests/security/contentSecurityPolicy/resources/no-csp.html: Added.
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadWithNavigationAction):

Originally-landed-as: 283286.352@safari-7620-branch (378ba1584ade). <a href="https://rdar.apple.com/141318344">rdar://141318344</a>
Canonical link: <a href="https://commits.webkit.org/288021@main">https://commits.webkit.org/288021@main</a>
</pre>
----------------------------------------------------------------------
#### 1b27a467e7957fc4c49fb294d8f244d00127c2c2
<pre>
WebGL infinite loops are optimized out in certain cases
<a href="https://bugs.webkit.org/show_bug.cgi?id=281902">https://bugs.webkit.org/show_bug.cgi?id=281902</a>
<a href="https://rdar.apple.com/136486349">rdar://136486349</a>

Reviewed by Mike Wyrzykowski.

Metal: Ensure potentially infinite loops have defined behavior

The MSL compiler would omit infinite loops and assume number domains
based on the omission logic. This would induce incorrect number domains
in case the infinite loops would be invokable. Infinite loops are
undefined in C++ and thus in MSL. It is the job of the programmer
to ensure undefined behavior cannot happen.

Consider GLSL loop like:
uniform float i;
...
    if (i != 0.5) for(;;) { }
    gl_FragColor = vec4(i);

Historically this would emit MSL loop in spirit of:
    if (i != 0.5) {
      bool c = true;
      while (c) { }
    }
    ANGLE_fragmentOut.gl_FragColor = metal::float4(i, i, i, i);

Since This could cause the MSL compiler to optimize the function to
equivalent of:
    ANGLE_fragmentOut.gl_FragColor = metal::float4(0.5, 0.5, 0.5, 0.5);

Presumably this loop omission would happen at the clang frontend part.

Before, was worked around by emitting asm statements to the MSL:
    bool c = true;
    while (c) {
        __asm__(&quot;&quot;);
    }

The asm injection would would work for this particular source pattern,
presumably because injecting the asm would avoid the loop omission at
the clang frontend part.

The MSL/C++ code is still UB, though. The asm statement does not cause
anything that C++ would consider as &quot;forward progress&quot; of the loop. The
success was just due to how the backend worked. The bitcode produced
would be similar to:

4:
    tail call void asm sideeffect &quot;&quot;, &quot;&quot;() #6, !srcloc !28
    br label %4, !llvm.loop !29

Here, the compiler can be seen to simply fail to detect a loop that
does not make forward progress.

Considering GLSL of form:
uniform int f;
...
    for (;;) { if (f &lt;= 1) break; }

With asm injection to the loop, this would produce:

5:
    tail call void asm sideeffect &quot;&quot;, &quot;&quot;() #8, !srcloc !29
    %6 = load i32, i32 addrspace(2)* %4, align 4, !tbaa !30
    %7 = icmp slt i32 %6, 2
    br i1 %7, label %8, label %5
8:

This code is still assumed to make progress. The backend optimizer is
free to assume that the condition holds, since the load to break the
loop is from constant address space. I.e. uniform f does not change its
value during the loop.

Instead of injecting asm, inject a read of unused volatile variable.
The volatile variable access is defined in C++ as forward progress.
This means infinite loop containing such read is considered defined.
To simplify the implementation and to avoid volatile writes, the read
is to a dummy variable instead of the loop condition bool.

The tests here do not pass completely for MSL backend. In case the
compiler would omit the infinite loop (unpatched code), they would fail
with demonstration of how the values behave. After fixing, the loops
cause timeout but Metal backend does not have implementation to report
context loss. Also, the ReadPixels is just for demostration purposes of the
unpatched code.

* Source/ThirdParty/ANGLE/src/compiler/translator/msl/EmitMetal.cpp:
(GenMetalTraverser::GenMetalTraverser):
(GenMetalTraverser::emitLoopBody):
(GenMetalTraverser::emitForwardProgressStore):
(GenMetalTraverser::emitForwardProgressSignal):
(GenMetalTraverser::visitForLoop):
(GenMetalTraverser::visitWhileLoop):
(GenMetalTraverser::visitDoWhileLoop):
* Source/ThirdParty/ANGLE/src/tests/angle_end2end_tests.gni:
* Source/ThirdParty/ANGLE/src/tests/gl_tests/TimeoutDrawTest.cpp: Added.
(angle::TimeoutDrawTest::TimeoutDrawTest):
(angle::TEST_P):

Originally-landed-as: 283286.350@safari-7620-branch (b82d94e60f49). <a href="https://rdar.apple.com/141318430">rdar://141318430</a>
Canonical link: <a href="https://commits.webkit.org/288020@main">https://commits.webkit.org/288020@main</a>
</pre>
----------------------------------------------------------------------
#### 0d784010f50ea442e32b2fb0edd4b1d113bee66e
<pre>
Potential unsigned integer underflow in JSC::FunctionAllowlist::FunctionAllowlist constructor
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=281675">https://bugs.webkit.org/show_bug.cgi?id=281675</a>&gt;
&lt;<a href="https://rdar.apple.com/138127490">rdar://138127490</a>&gt;

Reviewed by Darin Adler.

* Source/JavaScriptCore/tools/FunctionAllowlist.cpp:
(JSC::FunctionAllowlist::FunctionAllowlist):
- Check that `length` returned from strlen() is non-zero before checking
  the end of the C-string for a newline character.

Originally-landed-as: 283286.315@safari-7620-branch (98b6fa893826). <a href="https://rdar.apple.com/141318696">rdar://141318696</a>
Canonical link: <a href="https://commits.webkit.org/288019@main">https://commits.webkit.org/288019@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/612e4f7720f2e36deb37bbd2e4eb32ef039a1fdb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81518 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1044 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35466 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86050 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32512 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83628 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1063 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8862 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63623 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21359 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84587 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/754 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74195 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43914 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/653 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28363 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30965 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/74500 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72094 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28957 "Found 1 new test failure: fast/editing/recursive-reapply-edit-command-crash.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87486 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/80576 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8751 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6213 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71947 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8932 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70012 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71180 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15245 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14161 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/102986 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12648 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8711 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14239 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25023 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8549 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12071 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10356 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->