### PR TITLE
Don't allocate DFG register after a slow path

### DIFF
--- a/JSTests/stress/string-add-conversion-unused.js
+++ b/JSTests/stress/string-add-conversion-unused.js
@@ -1,0 +1,14 @@
+var x = [, 9999999999];
+var count = 0;
+for (
+  y = 10;
+  (function () {
+    z = y;
+    " " + x[y];
+    return 9;
+  })();
+  y--
+) {
+  if (count >= 99) break;
+  count++;
+}

--- a/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
@@ -528,7 +528,9 @@ private:
             
         case ToString:
         case CallStringConstructor: {
-            node->child1()->mergeFlags(NodeBytecodeUsesAsNumber | NodeBytecodeUsesAsOther | NodeBytecodeNeedsNaNOrInfinity);
+            if (typeFilterFor(node->child1().useKind()) & SpecOther)
+                node->child1()->mergeFlags(NodeBytecodeUsesAsOther);
+            node->child1()->mergeFlags(NodeBytecodeUsesAsNumber | NodeBytecodeNeedsNaNOrInfinity);
             break;
         }
             

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -3578,6 +3578,14 @@ void SpeculativeJIT::compilePutByValForIntTypedArray(Node* node, TypedArrayType 
         }
     }
 
+    GPRReg scratch2GPR = InvalidGPRReg;
+#if USE(JSVALUE64)
+    if (node->arrayMode().mayBeResizableOrGrowableSharedTypedArray()) {
+        scratch2.emplace(this);
+        scratch2GPR = scratch2->gpr();
+    }
+#endif
+
     bool result = getIntTypedArrayStoreOperand(
         value, propertyReg,
 #if USE(JSVALUE32_64)
@@ -3588,14 +3596,6 @@ void SpeculativeJIT::compilePutByValForIntTypedArray(Node* node, TypedArrayType 
         noResult(node);
         return;
     }
-
-    GPRReg scratch2GPR = InvalidGPRReg;
-#if USE(JSVALUE64)
-    if (node->arrayMode().mayBeResizableOrGrowableSharedTypedArray()) {
-        scratch2.emplace(this);
-        scratch2GPR = scratch2->gpr();
-    }
-#endif
 
     GPRReg valueGPR = value.gpr();
     GPRReg scratchGPR = scratch.gpr();

--- a/Source/WTF/wtf/LockAlgorithm.h
+++ b/Source/WTF/wtf/LockAlgorithm.h
@@ -98,7 +98,7 @@ public:
                 value = Hooks::unlockHook(value);
                 return true;
             },
-            std::memory_order_relaxed);
+            std::memory_order_release);
     }
     
     static void unlock(Atomic<LockType>& lock)

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4001,7 +4001,7 @@ void Page::setResourceUsageOverlayVisible(bool visible)
     }
 
     if (!m_resourceUsageOverlay && m_settings->acceleratedCompositingEnabled())
-        m_resourceUsageOverlay = makeUnique<ResourceUsageOverlay>(*this);
+        m_resourceUsageOverlay = ResourceUsageOverlay::create(*this);
 }
 #endif
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1520,7 +1520,7 @@ private:
     WeakPtr<ServiceWorkerGlobalScope, WeakPtrImplWithEventTargetData> m_serviceWorkerGlobalScope;
 
 #if ENABLE(RESOURCE_USAGE)
-    std::unique_ptr<ResourceUsageOverlay> m_resourceUsageOverlay;
+    RefPtr<ResourceUsageOverlay> m_resourceUsageOverlay;
 #endif
 
     PAL::SessionID m_sessionID;

--- a/Source/WebCore/page/ResourceUsageOverlay.cpp
+++ b/Source/WebCore/page/ResourceUsageOverlay.cpp
@@ -40,28 +40,38 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ResourceUsageOverlay);
 
+Ref<ResourceUsageOverlay> ResourceUsageOverlay::create(Page& page)
+{
+    return adoptRef(*new ResourceUsageOverlay(page));
+}
+
 ResourceUsageOverlay::ResourceUsageOverlay(Page& page)
     : m_page(page)
     , m_overlay(PageOverlay::create(*this, PageOverlay::OverlayType::View))
 {
+    ASSERT(isMainThread());
     // Let the event loop cycle before continuing with initialization.
     // This way we'll have access to the FrameView's dimensions.
-    callOnMainThread([this] {
-        initialize();
+    callOnMainThread([weakThis = WeakPtr { *this }] {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->initialize();
     });
 }
 
 ResourceUsageOverlay::~ResourceUsageOverlay()
 {
+    ASSERT(isMainThread());
     platformDestroy();
-    // FIXME: This is a hack so we don't try to uninstall the PageOverlay during Page destruction.
-    if (m_page.mainFrame().page())
-        m_page.pageOverlayController().uninstallPageOverlay(*m_overlay.copyRef(), PageOverlay::FadeMode::DoNotFade);
+    if (RefPtr page = m_page.get())
+        page->pageOverlayController().uninstallPageOverlay(*m_overlay.copyRef(), PageOverlay::FadeMode::DoNotFade);
 }
 
 void ResourceUsageOverlay::initialize()
 {
-    auto* frameView = m_page.mainFrame().virtualView();
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+    auto* frameView = page->mainFrame().virtualView();
     if (!frameView)
         return;
     IntRect initialRect(frameView->width() / 2 - normalWidth / 2, frameView->height() - normalHeight - 20, normalWidth, normalHeight);
@@ -73,7 +83,7 @@ void ResourceUsageOverlay::initialize()
 
     RefPtr overlay = m_overlay;
     overlay->setFrame(initialRect);
-    m_page.pageOverlayController().installPageOverlay(*overlay, PageOverlay::FadeMode::DoNotFade);
+    page->pageOverlayController().installPageOverlay(*overlay, PageOverlay::FadeMode::DoNotFade);
     platformInitialize();
 }
 
@@ -100,6 +110,9 @@ bool ResourceUsageOverlay::mouseEvent(PageOverlay&, const PlatformMouseEvent& ev
         break;
     case PlatformEvent::Type::MouseMoved:
         if (m_dragging) {
+            RefPtr page = m_page.get();
+            if (!page)
+                return false;
             IntRect newFrame = overlay->frame();
 
             // Move the new frame relative to the point where the drag was initiated.
@@ -109,9 +122,9 @@ bool ResourceUsageOverlay::mouseEvent(PageOverlay&, const PlatformMouseEvent& ev
             // Force the frame to stay inside the viewport entirely.
             if (newFrame.x() < 0)
                 newFrame.setX(0);
-            if (newFrame.y() < m_page.topContentInset())
-                newFrame.setY(m_page.topContentInset());
-            auto& frameView = *m_page.mainFrame().virtualView();
+            if (newFrame.y() < page->topContentInset())
+                newFrame.setY(page->topContentInset());
+            auto& frameView = *page->mainFrame().virtualView();
             if (newFrame.maxX() > frameView.width())
                 newFrame.setX(frameView.width() - newFrame.width());
             if (newFrame.maxY() > frameView.height())

--- a/Source/WebCore/page/ResourceUsageOverlay.h
+++ b/Source/WebCore/page/ResourceUsageOverlay.h
@@ -31,8 +31,10 @@
 #include "IntRect.h"
 #include "PageOverlay.h"
 #include <wtf/Noncopyable.h>
+#include <wtf/RefCounted.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakPtr.h>
 
 #if PLATFORM(COCOA)
 #include "PlatformCALayer.h"
@@ -48,11 +50,11 @@ class FloatRect;
 class IntPoint;
 class IntRect;
 
-class ResourceUsageOverlay final : public PageOverlayClient {
+class ResourceUsageOverlay final : public PageOverlayClient, public RefCounted<ResourceUsageOverlay>, public CanMakeWeakPtr<ResourceUsageOverlay> {
     WTF_MAKE_TZONE_ALLOCATED(ResourceUsageOverlay);
     WTF_MAKE_NONCOPYABLE(ResourceUsageOverlay);
 public:
-    explicit ResourceUsageOverlay(Page&);
+    static Ref<ResourceUsageOverlay> create(Page&);
     ~ResourceUsageOverlay();
 
     PageOverlay& overlay() { return *m_overlay; }
@@ -65,6 +67,8 @@ public:
     static const int normalHeight = 180;
 
 private:
+    explicit ResourceUsageOverlay(Page&);
+
     void willMoveToPage(PageOverlay&, Page*) override { }
     void didMoveToPage(PageOverlay&, Page*) override { }
     void drawRect(PageOverlay&, GraphicsContext&, const IntRect&) override { }
@@ -76,7 +80,7 @@ private:
     void platformInitialize();
     void platformDestroy();
 
-    Page& m_page;
+    WeakPtr<Page> m_page;
     RefPtr<PageOverlay> m_overlay;
     bool m_dragging { false };
     IntPoint m_dragPoint;


### PR DESCRIPTION
#### 82abacffb221fb67c7e144a88090fe7fc9208f3a
<pre>
Don&apos;t allocate DFG register after a slow path
<a href="https://bugs.webkit.org/show_bug.cgi?id=283063">https://bugs.webkit.org/show_bug.cgi?id=283063</a>
<a href="https://rdar.apple.com/139747120">rdar://139747120</a>

Reviewed by Yusuke Suzuki.

Allocating a DFG register after a slow path means that if the slow path
is taken, we end up with an incorrect global state.

* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::compilePutByValForIntTypedArray):

Originally-landed-as: ded4d02c0a93. <a href="https://rdar.apple.com/141317386">rdar://141317386</a>
Canonical link: <a href="https://commits.webkit.org/288064@main">https://commits.webkit.org/288064@main</a>
</pre>
----------------------------------------------------------------------
#### 03a094cce550fad6ac8d86e6df06dd04f7640668
<pre>
LockAlgorithm::unlockFast is too fast
<a href="https://bugs.webkit.org/show_bug.cgi?id=282865">https://bugs.webkit.org/show_bug.cgi?id=282865</a>
<a href="https://rdar.apple.com/139548123">rdar://139548123</a>

Reviewed by Yusuke Suzuki.

Right now it has relaxed ordering but that&apos;s not correct since it means writes to the critical section
could happen after the lock is unlocked. This could lead to arbitrary crashes or other general badness.

* Source/WTF/wtf/LockAlgorithm.h:
(WTF::LockAlgorithm::unlockFast):

Originally-landed-as: 4d456933d70e. <a href="https://rdar.apple.com/141317597">rdar://141317597</a>
Canonical link: <a href="https://commits.webkit.org/288063@main">https://commits.webkit.org/288063@main</a>
</pre>
----------------------------------------------------------------------
#### 2d5e29d47324834c4c9dda041ecb5908e1dfef78
<pre>
DFG ToString should only care about Other uses when it can be Other
<a href="https://bugs.webkit.org/show_bug.cgi?id=282661">https://bugs.webkit.org/show_bug.cgi?id=282661</a>
<a href="https://rdar.apple.com/138325184">rdar://138325184</a>

Reviewed by Yusuke Suzuki.

DFG&apos;s ToString should only backpropagate a UseAsOther when the use
has the potential to be Other. Otherwise, we end up with a mismatch
in expected value formats.

* Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp:
(JSC::DFG::BackwardsPropagationPhase::propagate):

Originally-landed-as: 299278ffc3f1. <a href="https://rdar.apple.com/141317664">rdar://141317664</a>
Canonical link: <a href="https://commits.webkit.org/288062@main">https://commits.webkit.org/288062@main</a>
</pre>
----------------------------------------------------------------------
#### 30946aa4c66c2de8b5768cfe680ca23b01207efd
<pre>
Use-after-free in `ResourceUsageOverlay::initialize()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=282350">https://bugs.webkit.org/show_bug.cgi?id=282350</a>
<a href="https://rdar.apple.com/138880313">rdar://138880313</a>

Reviewed by David Kilzer and Chris Dumez.

The ResourceUsageOverlay constructor uses callOnMainThread to call ResourceUsageOverlay::initialize(),
so the page owning ResourceUsageOverlay may be destroyed when the lambda executes. ResourceUsageOverlay
should hold a WeakPtr to m_page.

ResourceUsageOverlay also needs to be made ref counted to avoid a UAF on `this` in the lambda.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::setResourceUsageOverlayVisible):
* Source/WebCore/page/Page.h:
* Source/WebCore/page/ResourceUsageOverlay.cpp:
(WebCore::ResourceUsageOverlay::create):
(WebCore::ResourceUsageOverlay::ResourceUsageOverlay):
(WebCore::ResourceUsageOverlay::~ResourceUsageOverlay):
(WebCore::ResourceUsageOverlay::initialize):
(WebCore::ResourceUsageOverlay::mouseEvent):
* Source/WebCore/page/ResourceUsageOverlay.h:

Originally-landed-as: 283286.393@safari-7620-branch (7af554d1d875). <a href="https://rdar.apple.com/141317969">rdar://141317969</a>
Canonical link: <a href="https://commits.webkit.org/288061@main">https://commits.webkit.org/288061@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05e32b0f28410c1d7cead0b6bef2e7c4403c3655

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81577 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1103 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35525 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86303 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32571 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83687 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1122 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8921 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63781 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21389 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84646 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/799 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74239 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44067 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/697 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28420 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31024 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/74559 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72134 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29014 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87545 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/80635 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8810 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6251 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71990 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8991 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70068 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71342 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17778 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15288 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14205 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/103045 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8770 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14298 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25033 "Found 3 new JSC stress test failures: stress/json-stringify-inspector-check.js.no-llint, wasm.yaml/wasm/stress/cc-int-to-int-cross-module-with-exception.js.default-wasm, wasm.yaml/wasm/stress/struct-new_default-small-members.js.wasm-no-cjit (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8608 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12130 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10416 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->