### PR TITLE
[WebDriver] Support proper WTF logging features

### DIFF
--- a/Source/WebDriver/CMakeLists.txt
+++ b/Source/WebDriver/CMakeLists.txt
@@ -9,6 +9,8 @@ set(WebDriver_PRIVATE_INCLUDE_DIRECTORIES
 set(WebDriver_SOURCES
     CommandResult.cpp
     HTTPServer.cpp
+    LogInitialization.cpp
+    Logging.cpp
     Session.cpp
     SessionHost.cpp
     WebDriverMain.cpp

--- a/Source/WebDriver/LogInitialization.cpp
+++ b/Source/WebDriver/LogInitialization.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "LogInitialization.h"
+
+#include "Logging.h"
+#include <wtf/NeverDestroyed.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebDriver {
+
+#if !LOG_DISABLED || !RELEASE_LOG_DISABLED
+
+class LogChannels final : public WTF::LogChannels {
+public:
+    LogChannels()
+    {
+        m_logChannels = {
+            WEBDRIVER_LOG_CHANNELS(LOG_CHANNEL_ADDRESS)
+        };
+    }
+
+private:
+    String logLevelString() final
+    {
+        return WebDriver::logLevelString();
+    }
+};
+
+WTF::LogChannels& logChannels()
+{
+    static NeverDestroyed<LogChannels> logChannels;
+    return logChannels.get();
+}
+
+WTFLogChannel* getLogChannel(const String& name)
+{
+    return logChannels().getLogChannel(name);
+}
+
+#else
+
+WTFLogChannel* getLogChannel(const String&)
+{
+    return nullptr;
+}
+
+#endif // !LOG_DISABLED || !RELEASE_LOG_DISABLED
+
+} // namespace WebDriver

--- a/Source/WebDriver/LogInitialization.h
+++ b/Source/WebDriver/LogInitialization.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2024 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/LogChannels.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebDriver {
+
+#if !LOG_DISABLED || !RELEASE_LOG_DISABLED
+
+WTF::LogChannels& logChannels();
+String logLevelString();
+
+#endif // !LOG_DISABLED || !RELEASE_LOG_DISABLED
+
+WTFLogChannel* getLogChannel(const String& name);
+
+} // namespace WebDriver

--- a/Source/WebDriver/Logging.cpp
+++ b/Source/WebDriver/Logging.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "Logging.h"
+
+namespace WebDriver {
+
+#if !LOG_DISABLED || !RELEASE_LOG_DISABLED
+
+#define DEFINE_WEBDRIVER_LOG_CHANNEL(name) DEFINE_LOG_CHANNEL(name, LOG_CHANNEL_WEBKIT_SUBSYSTEM)
+WEBDRIVER_LOG_CHANNELS(DEFINE_WEBDRIVER_LOG_CHANNEL)
+
+#endif // !LOG_DISABLED || !RELEASE_LOG_DISABLED
+
+} // namespace WebDriver

--- a/Source/WebDriver/Logging.h
+++ b/Source/WebDriver/Logging.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2003-2020 Igalia S.L.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Assertions.h>
+#include <wtf/Forward.h>
+
+
+#define COMMA() ,
+#define OPTIONAL_ARGS(...) __VA_OPT__(COMMA()) __VA_ARGS__
+
+#define RELEASE_LOG_FORWARDABLE(category, logMessage, ...) RELEASE_LOG(category, MESSAGE_##logMessage OPTIONAL_ARGS(__VA_ARGS__))
+#define RELEASE_LOG_INFO_FORWARDABLE(category, logMessage, ...) RELEASE_LOG_INFO(category, MESSAGE_##logMessage OPTIONAL_ARGS(__VA_ARGS__))
+#define RELEASE_LOG_ERROR_FORWARDABLE(category, logMessage, ...) RELEASE_LOG_ERROR(category, MESSAGE_##logMessage OPTIONAL_ARGS(__VA_ARGS__))
+#define RELEASE_LOG_FAULT_FORWARDABLE(category, logMessage, ...) RELEASE_LOG_FAULT(category, MESSAGE_##logMessage OPTIONAL_ARGS(__VA_ARGS__))
+
+namespace WebDriver {
+
+#if !LOG_DISABLED || !RELEASE_LOG_DISABLED
+
+#ifndef LOG_CHANNEL_PREFIX
+#define LOG_CHANNEL_PREFIX WebDriverLog
+#endif
+
+#define WEBDRIVER_LOG_CHANNELS(M) \
+    M(SessionHost) \
+    M(WebDriverBiDi) \
+    M(WebDriverClassic)
+
+#undef DECLARE_LOG_CHANNEL
+#define DECLARE_LOG_CHANNEL(name) \
+    extern WTFLogChannel JOIN_LOG_CHANNEL_WITH_PREFIX(LOG_CHANNEL_PREFIX, name);
+
+WEBDRIVER_LOG_CHANNELS(DECLARE_LOG_CHANNEL)
+
+#endif // !LOG_DISABLED || !RELEASE_LOG_DISABLED
+
+} // namespace WebDriver

--- a/Source/WebDriver/PlatformGTK.cmake
+++ b/Source/WebDriver/PlatformGTK.cmake
@@ -14,6 +14,8 @@ list(APPEND WebDriver_SOURCES
     gtk/WebDriverServiceGtk.cpp
 
     soup/HTTPServerSoup.cpp
+
+    unix/LoggingUnix.cpp
 )
 
 list(APPEND WebDriver_LIBRARIES

--- a/Source/WebDriver/PlatformPlayStation.cmake
+++ b/Source/WebDriver/PlatformPlayStation.cmake
@@ -7,6 +7,8 @@ list(APPEND WebDriver_SOURCES
     socket/HTTPParser.cpp
     socket/HTTPServerSocket.cpp
     socket/SessionHostSocket.cpp
+
+    unix/LoggingUnix.cpp
 )
 
 list(APPEND WebDriver_PRIVATE_INCLUDE_DIRECTORIES

--- a/Source/WebDriver/PlatformWPE.cmake
+++ b/Source/WebDriver/PlatformWPE.cmake
@@ -11,6 +11,8 @@ list(APPEND WebDriver_SOURCES
 
     soup/HTTPServerSoup.cpp
 
+    unix/LoggingUnix.cpp
+
     wpe/WebDriverServiceWPE.cpp
 )
 

--- a/Source/WebDriver/WebDriverMain.cpp
+++ b/Source/WebDriver/WebDriverMain.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 
+#include "LogInitialization.h"
 #include "WebDriverService.h"
 #include <wtf/MainThread.h>
 #include <wtf/Threading.h>
@@ -34,6 +35,9 @@ int main(int argc, char** argv)
     WebDriver::WebDriverService::platformInit();
 
     WTF::initializeMainThread();
+#if !LOG_DISABLED || !RELEASE_LOG_DISABLED
+    WebDriver::logChannels().initializeLogChannelsIfNecessary(WebDriver::logLevelString());
+#endif
 
     WebDriver::WebDriverService service;
     return service.run(argc, argv);

--- a/Source/WebDriver/WebDriverService.cpp
+++ b/Source/WebDriver/WebDriverService.cpp
@@ -28,6 +28,7 @@
 
 #include "Capabilities.h"
 #include "CommandResult.h"
+#include "Logging.h"
 #include "SessionHost.h"
 #include <wtf/Compiler.h>
 #include <wtf/LoggerHelper.h>
@@ -179,9 +180,11 @@ int WebDriverService::run(int argc, char** argv)
 #if ENABLE(WEBDRIVER_BIDI)
     if (!m_bidiServer.listen(host ? *host : nullString(), *bidiPort))
         return EXIT_FAILURE;
+    RELEASE_LOG(WebDriverBiDi, "Started WebSocket server with host %s and port %d", (host ? host->utf8().data() : ""), *bidiPort);
 #endif // ENABLE(WEBDRIVER_BIDI)
     if (!m_server.listen(host, *port))
         return EXIT_FAILURE;
+    RELEASE_LOG(WebDriverClassic, "Started HTTP server with host %s and port %d", (host ? host->utf8().data() : ""), *port);
 
     RunLoop::run();
 
@@ -400,25 +403,25 @@ bool WebDriverService::acceptHandshake(HTTPRequestHandler::Request&& request)
     auto& resources = m_bidiServer.listener()->resources;
     auto foundResource = std::find(resources.begin(), resources.end(), resourceName);
     if (foundResource == resources.end()) {
-        WTFLogAlways("Resource name %s not found in listener's list of WebSocket resources. Rejecting handshake.", resourceName.utf8().data());
+        RELEASE_LOG(WebDriverBiDi, "Resource name %s not found in listener's list of WebSocket resources. Rejecting handshake.", resourceName.utf8().data());
         return false;
     }
 
     if (*foundResource == "/session"_s) {
         // FIXME Add support for bidi-only sessions
-        WTFLogAlways("BiDi-only sessions are not supported yet. Rejecting handshake.");
+        RELEASE_LOG(WebDriverBiDi, "BiDi-only sessions are not supported yet. Rejecting handshake.");
         return false;
     }
 
     auto sessionID = m_bidiServer.getSessionID(resourceName);
     if (sessionID.isNull()) {
-        WTFLogAlways("No session ID found for resource name %s. Rejecting handshake.", resourceName.utf8().data());
+        RELEASE_LOG(WebDriverBiDi, "No session ID found for resource name %s. Rejecting handshake.", resourceName.utf8().data());
         return false;
     }
 
     // FIXME Properly support multiple sessions in the future
     if (sessionID != m_session->id()) {
-        WTFLogAlways("No active session found for session ID %s. Rejecting handshake.", sessionID.utf8().data());
+        RELEASE_LOG(WebDriverBiDi, "No active session found for session ID %s. Rejecting handshake.", sessionID.utf8().data());
         return false;
     }
 
@@ -430,7 +433,7 @@ void WebDriverService::handleMessage(WebSocketMessageHandler::Message&& message,
     // https://w3c.github.io/webdriver-bidi/#handle-an-incoming-message
 
     if (!message.connection) {
-        WTFLogAlways("Incoming message without attached connection. Ignoring message.");
+        RELEASE_LOG(WebDriverBiDi, "Incoming message without attached connection. Ignoring message.");
         completionHandler(WebSocketMessageHandler::Message::fail(CommandResult::ErrorCode::UnknownError, std::nullopt));
         return;
     }
@@ -439,7 +442,7 @@ void WebDriverService::handleMessage(WebSocketMessageHandler::Message&& message,
     auto session = m_bidiServer.session(connection);
     if (!session) {
         if (!m_bidiServer.isStaticConnection(connection)) {
-            WTFLogAlways("Unknown connection. Ignoring message.");
+            RELEASE_LOG(WebDriverBiDi, "Unknown connection. Ignoring message.");
             completionHandler(WebSocketMessageHandler::Message::fail(CommandResult::ErrorCode::InvalidSessionID, connection));
             return;
         }
@@ -449,13 +452,13 @@ void WebDriverService::handleMessage(WebSocketMessageHandler::Message&& message,
 
     auto parsedMessageValue = JSON::Value::parseJSON(String::fromUTF8(message.payload.data()));
     if (!parsedMessageValue) {
-        WTFLogAlways("WebDriver handle Message: Failed to parse incoming message");
+        RELEASE_LOG(WebDriverBiDi, "WebDriver handle Message: Failed to parse incoming message");
         completionHandler(WebSocketMessageHandler::Message::fail(CommandResult::ErrorCode::InvalidArgument, message.connection));
         return;
     }
 
     if (session && m_session && session->id() != m_session->id()) {
-        WTFLogAlways("Not an active session. Ignoring message.");
+        RELEASE_LOG(WebDriverBiDi, "Not an active session. Ignoring message.");
         return;
     }
 
@@ -463,7 +466,7 @@ void WebDriverService::handleMessage(WebSocketMessageHandler::Message&& message,
     unsigned id = 0;
     RefPtr<JSON::Object> parameters;
     if (!findBidiCommand(parsedMessageValue, &handler, id, parameters)) {
-        WTFLogAlways("Failed to find appropriate BiDi command");
+        RELEASE_LOG(WebDriverBiDi, "Failed to find appropriate BiDi command");
         std::optional<int> commandId;
         if (auto parsedMessageObject = parsedMessageValue->asObject()) {
             auto parsedCommandId = parsedMessageObject->getInteger("id"_s);
@@ -1128,11 +1131,11 @@ void WebDriverService::createSession(Vector<Capabilities>&& capabilitiesList, Re
                 capabilitiesObject->setString("webSocketUrl"_s, webSocketURL);
                 m_session->setHasBiDiEnabled(true);
             } else {
-                WTFLogAlways("BiDi support not enabled for session %s", m_session->id().utf8().data());
+                RELEASE_LOG(WebDriverBiDi, "BiDi support not enabled for session %s", m_session->id().utf8().data());
                 if (!m_session->hasBiDiEnabled())
-                    WTFLogAlways("BiDi flag not set for session %s", m_session->id().utf8().data());
+                    RELEASE_LOG(WebDriverBiDi, "BiDi flag not set for session %s", m_session->id().utf8().data());
                 if (!capabilities.webSocketURL || !*capabilities.webSocketURL)
-                    WTFLogAlways("webSocketURL not set for session %s", m_session->id().utf8().data());
+                    RELEASE_LOG(WebDriverBiDi, "webSocketURL not set for session %s", m_session->id().utf8().data());
             }
 #endif
 

--- a/Source/WebDriver/soup/HTTPServerSoup.cpp
+++ b/Source/WebDriver/soup/HTTPServerSoup.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "HTTPServer.h"
 
+#include "Logging.h"
 #include <libsoup/soup.h>
 #include <wtf/Function.h>
 #include <wtf/glib/GUniquePtr.h>
@@ -55,7 +56,7 @@ bool HTTPServer::listen(const std::optional<String>& host, unsigned port)
     m_soupServer = adoptGRef(soup_server_new("server-header", "WebKitWebDriver", nullptr));
     GUniqueOutPtr<GError> error;
     if (!soupServerListen(m_soupServer.get(), host, port, &error.outPtr())) {
-        WTFLogAlways("Failed to start HTTP server at port %u: %s", port, error->message);
+        RELEASE_LOG(WebDriverClassic, "Failed to start HTTP server at port %u: %s", port, error->message);
         return false;
     }
 

--- a/Source/WebDriver/unix/LoggingUnix.cpp
+++ b/Source/WebDriver/unix/LoggingUnix.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2024 Igalia S.L. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+
+#if !LOG_DISABLED || !RELEASE_LOG_DISABLED
+
+#include <wtf/LogInitialization.h>
+#include <wtf/text/MakeString.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebDriver {
+
+String logLevelString()
+{
+    return WTF::logLevelString();
+}
+
+} // namespace WebDriver
+
+#endif // !LOG_DISABLED || !RELEASE_LOG_DISABLED

--- a/Source/WebDriver/win/LoggingWin.cpp
+++ b/Source/WebDriver/win/LoggingWin.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2008, 2013 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "Logging.h"
+
+#if !LOG_DISABLED || !RELEASE_LOG_DISABLED
+
+#include "LogInitialization.h"
+#include <windows.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebDriver {
+
+String logLevelString()
+{
+#if !LOG_DISABLED
+    static constexpr const char* loggingEnvironmentVariable = "WebDriverLogging";
+    DWORD length = GetEnvironmentVariableA(loggingEnvironmentVariable, 0, 0);
+    if (!length)
+        return emptyString();
+
+    Vector<char> buffer(length);
+
+    if (!GetEnvironmentVariableA(loggingEnvironmentVariable, buffer.data(), length))
+        return emptyString();
+
+    return String::fromLatin1(buffer.data());
+#else
+    return String();
+#endif
+}
+
+} // namespace WebDriver
+
+#endif // !LOG_DISABLED || !RELEASE_LOG_DISABLED
+

--- a/Source/WebKit/glib/environment-variables.md.in
+++ b/Source/WebKit/glib/environment-variables.md.in
@@ -5,7 +5,22 @@ Slug: environment-variables
 
 WebKit uses several environment variables, most of which are designed for developers or debugging purposes. These variables should be used carefully, as they can impact the behavior of the software. These environment variables and their behavior are not guaranteed to remain stable across versions of WebKit. Always ensure that your WebKit version corresponds to the documentation you are referencing to avoid compatibility issues.
 
+## Debugging Variables
+
+- `WEBKIT_DEBUG`
+Defines a comma-separated list of logging channels and their levels for WebKit's debugging output. Logging channels correspond to specific areas of functionality, such as networking, storage, and scrolling. For detailed usage, refer to [WebKit's Logging Guide](https://docs.webkit.org/Build%20%26%20Debug/Logging.html).
+    - **Enabling a channel**: Specify the channel's name with an optional level (e.g., `Loading=warning` outputs warnings and errors for the Loading channel).
+    - **Disabling a channel**: Prefix the name with a minus sign (`-`) (e.g., `all,-Network` enables all channels, except Network).
+    - **Enabling all channels**: Use the wildcard `"all"` as the content of `WEBKIT_DEBUG`.
+    - **Child processes**: The same configuration is shared to child processes spawned by the browser, like the `WebProcess` and `NetworkProcess`.
+    - **WebDriver-related channels**: In addition to the browser, the WebDriver service executable also uses WebKit's logging infrastructure, defining the following channels:
+        - `WebDriverClassic` - For the HTTP-based [WebDriver](https://w3c.github.io/webdriver/) Classic prototol.
+        - `WebDriverBiDi` - For the WebSockets-based [WebDriver BiDi](https://github.com/w3c/webdriver-bidi) protocol.
+        - `SessionHost` - For messages related to the management of the Browser under automation.
+
 #if WPE
+
+## Graphics-related variables
 
 - `WPE_DRM_DEVICE`
 Specifies the primary device that WebKit will use for gpu buffer allocation when it needs access to the main device. It is interesting for DRM backend. You need to specify a file path.


### PR DESCRIPTION
#### 42ffeb6854c8e0d16e3536a8c87ea5ba40fef290
<pre>
[WebDriver] Support proper WTF logging features
<a href="https://bugs.webkit.org/show_bug.cgi?id=284824">https://bugs.webkit.org/show_bug.cgi?id=284824</a>

Reviewed by Adrian Perez de Castro.

Add the required pumbling to enable WTF LogChannels for
Source/WebDriver. This will allow us add more logging points without
polluting stdout/stderr.

Initially, it&apos;ll have 3 channels: WebDriverClassic, WebDriverBiDi,
SessionHost.

* Source/WebDriver/CMakeLists.txt:
* Source/WebDriver/LogInitialization.cpp: Added.
(WebDriver::logChannels):
(WebDriver::getLogChannel):
* Source/WebDriver/LogInitialization.h: Added.
* Source/WebDriver/Logging.cpp: Added.
* Source/WebDriver/Logging.h: Added.
* Source/WebDriver/PlatformGTK.cmake:
* Source/WebDriver/PlatformPlayStation.cmake:
* Source/WebDriver/PlatformWPE.cmake:
* Source/WebDriver/WebDriverMain.cpp:
(main):
* Source/WebDriver/WebDriverService.cpp:
(WebDriver::WebDriverService::run):
(WebDriver::WebDriverService::acceptHandshake):
(WebDriver::WebDriverService::handleMessage):
(WebDriver::WebDriverService::createSession):
* Source/WebDriver/soup/HTTPServerSoup.cpp:
(WebDriver::HTTPServer::listen):
* Source/WebDriver/soup/WebSocketServerSoup.cpp:
(WebDriver::handleIncomingHandshake):
(WebDriver::handleWebSocketMessage):
(WebDriver::WebSocketServer::listen):
* Source/WebDriver/unix/LoggingUnix.cpp: Added.
(WebDriver::logLevelString):
* Source/WebDriver/win/LoggingWin.cpp: Added.
(WebDriver::logLevelString):
* Source/WebKit/glib/environment-variables.md.in:

Canonical link: <a href="https://commits.webkit.org/288150@main">https://commits.webkit.org/288150@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/140295a1956ef44347f8cb7b3fc30723292aad18

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81790 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1316 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35744 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86337 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32786 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1349 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9136 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63795 "Found 1 new test failure: compositing/patterns/direct-pattern-compositing-position.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21519 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84860 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/980 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74428 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44081 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/880 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28602 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31239 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72262 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29206 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87773 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9030 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6408 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72141 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9215 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70248 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71373 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17831 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15462 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14380 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/402 "") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8981 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14513 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8822 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12345 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10630 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->