### PR TITLE
[iOS] [SelectionHonorsOverflowScrolling] Selection sometimes ignores clipping/occlusion after pinch-zooming

### DIFF
--- a/LayoutTests/editing/selection/ios/selection-clipped-by-fixed-position-container-expected.txt
+++ b/LayoutTests/editing/selection/ios/selection-clipped-by-fixed-position-container-expected.txt
@@ -1,0 +1,12 @@
+Fixed position
+Select me
+
+Verifies that the selection highlight is clipped by fixed-position containers after pinch-zooming
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS viewBeforeShowingFixedContainer is not viewAfterShowingFixedContainer
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/selection-clipped-by-fixed-position-container.html
+++ b/LayoutTests/editing/selection/ios/selection-clipped-by-fixed-position-container.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true SelectionHonorsOverflowScrolling=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+body, html {
+    font-size: 16px;
+    font-family: system-ui;
+    margin: 0;
+}
+
+.target {
+    text-align: center;
+    font-size: 40px;
+    line-height: 40px;
+}
+
+.target > span {
+    border: 1px solid orange;
+}
+
+.fixed {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 150px;
+    line-height: 150px;
+    background: tomato;
+    color: white;
+    text-align: center;
+    display: none;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Verifies that the selection highlight is clipped by fixed-position containers after pinch-zooming");
+
+    await UIHelper.longPressElement(document.querySelector(".target > span"));
+    await UIHelper.waitForSelectionToAppear();
+
+    let selectionRects = await UIHelper.getUISelectionViewRects();
+    let {x, y} = UIHelper.midPointOfRect(selectionRects[0]);
+    viewBeforeShowingFixedContainer = await UIHelper.frontmostViewAtPoint(x, y);
+
+    // Reveal the fixed-position popup. This should occlude the selection.
+    document.querySelector(".fixed").style.display = "block";
+
+    // Force the compositing view hierarchy to be updated, by pinch-zooming in and out.
+    await UIHelper.pinch(150, 150, 150, 200, 150, 125, 150, 225);
+    await UIHelper.pinch(150, 125, 150, 225, 150, 150, 150, 200);
+    await UIHelper.waitForZoomingOrScrollingToEnd();
+
+    viewAfterShowingFixedContainer = await UIHelper.frontmostViewAtPoint(x, y);
+
+    shouldNotBe("viewBeforeShowingFixedContainer", "viewAfterShowingFixedContainer");
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div class="fixed">Fixed position</div>
+    <p class="target"><span>Select</span> me</p>
+    <div id="description"></div>
+    <div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -2249,6 +2249,15 @@ window.UIHelper = class UIHelper {
         await new Promise(resolve => setTimeout(resolve, pdfFadeInDelay));
         await new Promise(requestAnimationFrame);
     }
+
+    static async frontmostViewAtPoint(x, y) {
+        if (!this.isWebKit2())
+            return Promise.resolve();
+
+        return new Promise(resolve => {
+            testRunner.runUIScript(`uiController.frontmostViewAtPoint(${x}, ${y})`, resolve);
+        });
+    }
 }
 
 UIHelper.EventStreamBuilder = class {

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -423,4 +423,6 @@ interface UIScriptController {
     undefined requestRenderedTextForFrontmostTarget(long x, long y, object callback);
     undefined adjustVisibilityForFrontmostTarget(long x, long y, object callback);
     undefined resetVisibilityAdjustments(object callback);
+
+    DOMString frontmostViewAtPoint(long x, long y);
 };

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -423,6 +423,8 @@ public:
     virtual void adjustVisibilityForFrontmostTarget(int, int, JSValueRef) { notImplemented(); }
     virtual void resetVisibilityAdjustments(JSValueRef) { notImplemented(); }
 
+    virtual JSRetainPtr<JSStringRef> frontmostViewAtPoint(int, int) { notImplemented(); return { }; }
+
 protected:
     explicit UIScriptController(UIScriptContext&);
     

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
@@ -187,6 +187,8 @@ private:
     void presentFindNavigator() override;
     void dismissFindNavigator() override;
 
+    JSRetainPtr<JSStringRef> frontmostViewAtPoint(int, int) final;
+
     void waitForModalTransitionToFinish() const;
     void waitForSingleTapToReset() const;
     WebCore::FloatRect rectForMenuAction(CFStringRef) const;


### PR DESCRIPTION
#### 6d9f68eb11b04d9d3b7ef30f641916beb95a481e
<pre>
[iOS] [SelectionHonorsOverflowScrolling] Selection sometimes ignores clipping/occlusion after pinch-zooming
<a href="https://bugs.webkit.org/show_bug.cgi?id=284837">https://bugs.webkit.org/show_bug.cgi?id=284837</a>
<a href="https://rdar.apple.com/141635283">rdar://141635283</a>

Reviewed by Abrar Rahman Protyasha.

It&apos;s currently possible for UI-side selection views to get into a state where they&apos;re no longer
correctly occluded by compositing layers (e.g. a fixed-position container that covers the selection
container). In particular, this happens when zooming in and out in a web view, which may cause page
tiles to be recreated in such a way, that they&apos;re inserted _under_ UIKit&apos;s managed selection views.

We currently have logic that detects when the selection views need to be reparented (due to the
previous parent view being removed from the view hierarchy), but we don&apos;t have any logic to ensure
that the selection views are reinserted above the tile grid container (but below page tiles), if
the parent view doesn&apos;t change (but the compositing views underneath the same parent view have
changed).

Fix this by refactoring this aforementioned logic, so that we reinsert all managed selection views
between the tile grid container and the rest of the compositing views in the case where the subview
after the tile grid container view isn&apos;t the selection highlight view (the back-most managed
selection view).

* LayoutTests/editing/selection/ios/selection-clipped-by-fixed-position-container-expected.txt: Added.
* LayoutTests/editing/selection/ios/selection-clipped-by-fixed-position-container.html: Added.

Add a layout test to exercise the change by pinch-zooming in and out, and verifying that the
selection view remains occluded by the fixed-position banner.

* LayoutTests/resources/ui-helper.js:
(window.UIHelper.async frontmostViewAtPoint):
(window.UIHelper):

Add a testing hook to retrieve the class name of the frontmost native `UIView` at the given point in
root view coordinates.

* Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm:
(-[WKTextInteractionWrapper prepareToMoveSelectionContainer:]):

See above for more details.

* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::frontmostViewAtPoint):
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h:
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(-[UIView _wtr_frontmostViewAtPoint:]):
(WTR::UIScriptControllerIOS::frontmostViewAtPoint):

Canonical link: <a href="https://commits.webkit.org/287977@main">https://commits.webkit.org/287977@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/367684e76b9e8ca5a65ebc1ba9fd10cb62534bd2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81540 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1066 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35488 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86072 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32534 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83650 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1085 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8884 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63634 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/21372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84609 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/764 "Found 1 new test failure: fast/dynamic/content-visibility-crash-with-continuation-and-table.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74205 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43925 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/663 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28376 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30987 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28969 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87508 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8773 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71959 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8954 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70024 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71192 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17721 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15260 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14171 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8733 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/14261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8571 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12093 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10378 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->