### PR TITLE
Adopt more smart pointers in WebKit message receivers

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -39,7 +39,6 @@ UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
 UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
 UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.mm
 UIProcess/WebAuthentication/Virtual/VirtualService.mm
-UIProcess/WebProcessProxy.cpp
 UIProcess/mac/WebViewImpl.mm
 WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp
 WebProcess/GPU/graphics/WebGPU/RemoteXRBindingProxy.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -20,7 +20,6 @@ UIProcess/API/Cocoa/WKWebView.mm
 UIProcess/API/Cocoa/WKWebViewTesting.mm
 UIProcess/API/Cocoa/WKWebsiteDataStore.mm
 UIProcess/BrowsingContextGroup.cpp
-UIProcess/Cocoa/VideoPresentationManagerProxy.mm
 UIProcess/Inspector/InspectorTargetProxy.cpp
 UIProcess/Launcher/ProcessLauncher.cpp
 UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp
@@ -38,7 +37,6 @@ UIProcess/WebProcessCache.cpp
 UIProcess/WebURLSchemeTask.cpp
 UIProcess/mac/WKImmediateActionController.mm
 UIProcess/mac/WebViewImpl.mm
-WebProcess/Automation/WebAutomationSessionProxy.cpp
 WebProcess/FullScreen/WebFullScreenManager.cpp
 WebProcess/Inspector/WebInspectorInternal.cpp
 WebProcess/Plugins/PDF/PDFPlugin.mm

--- a/Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -3,7 +3,6 @@ UIProcess/API/C/WKContext.cpp
 UIProcess/API/C/WKPage.cpp
 UIProcess/API/Cocoa/WKProcessPool.mm
 UIProcess/API/Cocoa/WKWebViewTesting.mm
-UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
 UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
 UIProcess/WebPageProxy.cpp
 UIProcess/mac/DisplayCaptureSessionManager.mm

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -77,8 +77,6 @@ Shared/API/c/mac/WKWebArchiveRef.cpp
 Shared/API/c/mac/WKWebArchiveResource.cpp
 Shared/APIWebArchive.mm
 Shared/APIWebArchiveResource.mm
-Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
-Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm
 Shared/BlobDataFileReferenceWithSandboxExtension.cpp
 Shared/Cocoa/APIObject.mm
 Shared/Cocoa/DefaultWebBrowserChecks.mm
@@ -230,7 +228,6 @@ UIProcess/Cocoa/WebInspectorPreferenceObserver.mm
 UIProcess/DeviceIdHashSaltStorage.cpp
 UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
 UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm
-UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
 UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
 UIProcess/Extensions/WebExtensionAlarm.cpp
 UIProcess/Extensions/WebExtensionCommand.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -5,11 +5,8 @@ NetworkProcess/cocoa/NetworkSessionCocoa.mm
 Platform/IPC/HandleMessage.h
 Platform/IPC/StreamConnectionWorkQueue.cpp
 UIProcess/AuxiliaryProcessProxy.cpp
-UIProcess/Cocoa/WebProcessPoolCocoa.mm
-UIProcess/UserContent/WebUserContentControllerProxy.cpp
 UIProcess/UserMediaProcessManager.cpp
 UIProcess/WebPageProxy.cpp
-UIProcess/WebProcessProxy.cpp
 WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
 WebProcess/GPU/media/RemoteImageDecoderAVF.cpp
 WebProcess/GPU/media/RemoteMediaPlayerManager.cpp

--- a/Source/WebKit/Shared/API/APIArray.h
+++ b/Source/WebKit/Shared/API/APIArray.h
@@ -88,7 +88,7 @@ public:
     }
 
     template<typename T, typename MatchFunction>
-    unsigned removeAllOfTypeMatching(const MatchFunction& matchFunction)
+    unsigned removeAllOfTypeMatching(NOESCAPE const MatchFunction& matchFunction)
     {
         return m_elements.removeAllMatching([&] (const RefPtr<Object>& object) -> bool {
             if (object->type() != T::APIType)

--- a/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h
+++ b/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h
@@ -201,6 +201,8 @@ private:
     void platformSetPaymentRequestUserAgent(PKPaymentRequest *, const String& userAgent);
 #endif
 
+    RefPtr<PaymentAuthorizationPresenter> protectedAuthorizationPresenter() { return m_authorizationPresenter; }
+
     WeakPtr<Client> m_client;
     std::optional<WebCore::PageIdentifier> m_destinationID;
 

--- a/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
@@ -425,34 +425,34 @@ void WebPaymentCoordinatorProxy::platformSetPaymentRequestUserAgent(PKPaymentReq
 
 void WebPaymentCoordinatorProxy::platformCompletePaymentSession(WebCore::ApplePayPaymentAuthorizationResult&& result)
 {
-    m_authorizationPresenter->completePaymentSession(WTFMove(result));
+    protectedAuthorizationPresenter()->completePaymentSession(WTFMove(result));
 }
 
 void WebPaymentCoordinatorProxy::platformCompleteMerchantValidation(const WebCore::PaymentMerchantSession& paymentMerchantSession)
 {
-    m_authorizationPresenter->completeMerchantValidation(paymentMerchantSession);
+    protectedAuthorizationPresenter()->completeMerchantValidation(paymentMerchantSession);
 }
 
 void WebPaymentCoordinatorProxy::platformCompleteShippingMethodSelection(std::optional<WebCore::ApplePayShippingMethodUpdate>&& update)
 {
-    m_authorizationPresenter->completeShippingMethodSelection(WTFMove(update));
+    protectedAuthorizationPresenter()->completeShippingMethodSelection(WTFMove(update));
 }
 
 void WebPaymentCoordinatorProxy::platformCompleteShippingContactSelection(std::optional<WebCore::ApplePayShippingContactUpdate>&& update)
 {
-    m_authorizationPresenter->completeShippingContactSelection(WTFMove(update));
+    protectedAuthorizationPresenter()->completeShippingContactSelection(WTFMove(update));
 }
 
 void WebPaymentCoordinatorProxy::platformCompletePaymentMethodSelection(std::optional<WebCore::ApplePayPaymentMethodUpdate>&& update)
 {
-    m_authorizationPresenter->completePaymentMethodSelection(WTFMove(update));
+    protectedAuthorizationPresenter()->completePaymentMethodSelection(WTFMove(update));
 }
 
 #if ENABLE(APPLE_PAY_COUPON_CODE)
 
 void WebPaymentCoordinatorProxy::platformCompleteCouponCodeChange(std::optional<WebCore::ApplePayCouponCodeUpdate>&& update)
 {
-    m_authorizationPresenter->completeCouponCodeChange(WTFMove(update));
+    protectedAuthorizationPresenter()->completeCouponCodeChange(WTFMove(update));
 }
 
 #endif // ENABLE(APPLE_PAY_COUPON_CODE)

--- a/Source/WebKit/Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm
+++ b/Source/WebKit/Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm
@@ -139,8 +139,8 @@ void WebPaymentCoordinatorProxy::platformHidePaymentUI()
 
     [[m_sheetWindow sheetParent] endSheet:m_sheetWindow.get()];
 
-    if (m_authorizationPresenter)
-        m_authorizationPresenter->dismiss();
+    if (RefPtr authorizationPresenter = m_authorizationPresenter)
+        authorizationPresenter->dismiss();
 
     m_sheetWindow = nullptr;
 }

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
@@ -320,8 +320,8 @@ void PlaybackSessionModelContext::durationChanged(double duration)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, duration);
     m_duration = duration;
-    for (auto& client : m_clients)
-        client.durationChanged(duration);
+    for (CheckedRef client : m_clients)
+        client->durationChanged(duration);
 }
 
 void PlaybackSessionModelContext::currentTimeChanged(double currentTime)
@@ -332,16 +332,16 @@ void PlaybackSessionModelContext::currentTimeChanged(double currentTime)
     if (m_playbackStartedTimeNeedsUpdate)
         playbackStartedTimeChanged(currentTime);
 
-    for (auto& client : m_clients)
-        client.currentTimeChanged(currentTime, anchorTime);
+    for (CheckedRef client : m_clients)
+        client->currentTimeChanged(currentTime, anchorTime);
 }
 
 void PlaybackSessionModelContext::bufferedTimeChanged(double bufferedTime)
 {
     INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER, bufferedTime);
     m_bufferedTime = bufferedTime;
-    for (auto& client : m_clients)
-        client.bufferedTimeChanged(bufferedTime);
+    for (CheckedRef client : m_clients)
+        client->bufferedTimeChanged(bufferedTime);
 }
 
 void PlaybackSessionModelContext::rateChanged(OptionSet<WebCore::PlaybackSessionModel::PlaybackState> playbackState, double playbackRate, double defaultPlaybackRate)
@@ -350,8 +350,8 @@ void PlaybackSessionModelContext::rateChanged(OptionSet<WebCore::PlaybackSession
     m_playbackState = playbackState;
     m_playbackRate = playbackRate;
     m_defaultPlaybackRate = defaultPlaybackRate;
-    for (auto& client : m_clients)
-        client.rateChanged(m_playbackState, m_playbackRate, m_defaultPlaybackRate);
+    for (CheckedRef client : m_clients)
+        client->rateChanged(m_playbackState, m_playbackRate, m_defaultPlaybackRate);
 }
 
 void PlaybackSessionModelContext::seekableRangesChanged(WebCore::TimeRanges& seekableRanges, double lastModifiedTime, double liveUpdateInterval)
@@ -360,23 +360,23 @@ void PlaybackSessionModelContext::seekableRangesChanged(WebCore::TimeRanges& see
     m_seekableRanges = seekableRanges;
     m_seekableTimeRangesLastModifiedTime = lastModifiedTime;
     m_liveUpdateInterval = liveUpdateInterval;
-    for (auto& client : m_clients)
-        client.seekableRangesChanged(seekableRanges, lastModifiedTime, liveUpdateInterval);
+    for (CheckedRef client : m_clients)
+        client->seekableRangesChanged(seekableRanges, lastModifiedTime, liveUpdateInterval);
 }
 
 void PlaybackSessionModelContext::canPlayFastReverseChanged(bool canPlayFastReverse)
 {
     m_canPlayFastReverse = canPlayFastReverse;
-    for (auto& client : m_clients)
-        client.canPlayFastReverseChanged(canPlayFastReverse);
+    for (CheckedRef client : m_clients)
+        client->canPlayFastReverseChanged(canPlayFastReverse);
 }
 
 void PlaybackSessionModelContext::audioMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>& audioMediaSelectionOptions, uint64_t audioMediaSelectedIndex)
 {
     m_audioMediaSelectionOptions = audioMediaSelectionOptions;
     m_audioMediaSelectedIndex = audioMediaSelectedIndex;
-    for (auto& client : m_clients)
-        client.audioMediaSelectionOptionsChanged(audioMediaSelectionOptions, audioMediaSelectedIndex);
+    for (CheckedRef client : m_clients)
+        client->audioMediaSelectionOptionsChanged(audioMediaSelectionOptions, audioMediaSelectedIndex);
 }
 
 void PlaybackSessionModelContext::legibleMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>& legibleMediaSelectionOptions, uint64_t legibleMediaSelectedIndex)
@@ -384,24 +384,24 @@ void PlaybackSessionModelContext::legibleMediaSelectionOptionsChanged(const Vect
     m_legibleMediaSelectionOptions = legibleMediaSelectionOptions;
     m_legibleMediaSelectedIndex = legibleMediaSelectedIndex;
 
-    for (auto& client : m_clients)
-        client.legibleMediaSelectionOptionsChanged(legibleMediaSelectionOptions, legibleMediaSelectedIndex);
+    for (CheckedRef client : m_clients)
+        client->legibleMediaSelectionOptionsChanged(legibleMediaSelectionOptions, legibleMediaSelectedIndex);
 }
 
 void PlaybackSessionModelContext::audioMediaSelectionIndexChanged(uint64_t selectedIndex)
 {
     m_audioMediaSelectedIndex = selectedIndex;
 
-    for (auto& client : m_clients)
-        client.audioMediaSelectionIndexChanged(selectedIndex);
+    for (CheckedRef client : m_clients)
+        client->audioMediaSelectionIndexChanged(selectedIndex);
 }
 
 void PlaybackSessionModelContext::legibleMediaSelectionIndexChanged(uint64_t selectedIndex)
 {
     m_legibleMediaSelectedIndex = selectedIndex;
 
-    for (auto& client : m_clients)
-        client.legibleMediaSelectionIndexChanged(selectedIndex);
+    for (CheckedRef client : m_clients)
+        client->legibleMediaSelectionIndexChanged(selectedIndex);
 }
 
 void PlaybackSessionModelContext::externalPlaybackChanged(bool enabled, PlaybackSessionModel::ExternalPlaybackTargetType type, const String& localizedName)
@@ -410,50 +410,50 @@ void PlaybackSessionModelContext::externalPlaybackChanged(bool enabled, Playback
     m_externalPlaybackTargetType = type;
     m_externalPlaybackLocalizedDeviceName = localizedName;
 
-    for (auto& client : m_clients)
-        client.externalPlaybackChanged(enabled, type, localizedName);
+    for (CheckedRef client : m_clients)
+        client->externalPlaybackChanged(enabled, type, localizedName);
 }
 
 void PlaybackSessionModelContext::wirelessVideoPlaybackDisabledChanged(bool wirelessVideoPlaybackDisabled)
 {
     m_wirelessVideoPlaybackDisabled = wirelessVideoPlaybackDisabled;
-    for (auto& client : m_clients)
-        client.wirelessVideoPlaybackDisabledChanged(wirelessVideoPlaybackDisabled);
+    for (CheckedRef client : m_clients)
+        client->wirelessVideoPlaybackDisabledChanged(wirelessVideoPlaybackDisabled);
 }
 
 void PlaybackSessionModelContext::mutedChanged(bool muted)
 {
     m_muted = muted;
-    for (auto& client : m_clients)
-        client.mutedChanged(muted);
+    for (CheckedRef client : m_clients)
+        client->mutedChanged(muted);
 }
 
 void PlaybackSessionModelContext::volumeChanged(double volume)
 {
     m_volume = volume;
-    for (auto& client : m_clients)
-        client.volumeChanged(volume);
+    for (CheckedRef client : m_clients)
+        client->volumeChanged(volume);
 }
 
 void PlaybackSessionModelContext::pictureInPictureSupportedChanged(bool supported)
 {
     m_pictureInPictureSupported = supported;
-    for (auto& client : m_clients)
-        client.isPictureInPictureSupportedChanged(supported);
+    for (CheckedRef client : m_clients)
+        client->isPictureInPictureSupportedChanged(supported);
 }
 
 void PlaybackSessionModelContext::pictureInPictureActiveChanged(bool active)
 {
     m_pictureInPictureActive = active;
-    for (auto& client : m_clients)
-        client.pictureInPictureActiveChanged(active);
+    for (CheckedRef client : m_clients)
+        client->pictureInPictureActiveChanged(active);
 }
 
 void PlaybackSessionModelContext::isInWindowFullscreenActiveChanged(bool active)
 {
     m_isInWindowFullscreenActive = active;
-    for (auto& client : m_clients)
-        client.isInWindowFullscreenActiveChanged(active);
+    for (CheckedRef client : m_clients)
+        client->isInWindowFullscreenActiveChanged(active);
 }
 
 #if ENABLE(LINEAR_MEDIA_PLAYER)
@@ -465,8 +465,8 @@ void PlaybackSessionModelContext::supportsLinearMediaPlayerChanged(bool supports
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, supportsLinearMediaPlayer);
     m_supportsLinearMediaPlayer = supportsLinearMediaPlayer;
 
-    for (auto& client : m_clients)
-        client.supportsLinearMediaPlayerChanged(supportsLinearMediaPlayer);
+    for (CheckedRef client : m_clients)
+        client->supportsLinearMediaPlayerChanged(supportsLinearMediaPlayer);
 
     if (RefPtr manager = m_manager.get())
         manager->updateVideoControlsManager(m_contextId);
@@ -480,8 +480,8 @@ void PlaybackSessionModelContext::spatialVideoMetadataChanged(const std::optiona
         ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, *metadata);
     m_spatialVideoMetadata = metadata;
 
-    for (auto& client : m_clients)
-        client.spatialVideoMetadataChanged(m_spatialVideoMetadata);
+    for (CheckedRef client : m_clients)
+        client->spatialVideoMetadataChanged(m_spatialVideoMetadata);
 }
 #endif
 

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -495,7 +495,7 @@ uint64_t VideoPresentationModelContext::nextChildIdentifier() const
 
 const Logger* VideoPresentationModelContext::loggerPtr() const
 {
-    return m_playbackSessionModel->loggerPtr();
+    return Ref { m_playbackSessionModel }->loggerPtr();
 }
 
 WTFLogChannel& VideoPresentationModelContext::logChannel() const

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -907,8 +907,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     }
 #endif
 
-    m_powerSourceNotifier = WTF::makeUnique<WebCore::PowerSourceNotifier>([this] (bool hasAC) {
-        sendToAllProcesses(Messages::WebProcess::PowerSourceDidChange(hasAC));
+    m_powerSourceNotifier = WTF::makeUnique<WebCore::PowerSourceNotifier>([weakThis = WeakPtr { this }] (bool hasAC) {
+        if (RefPtr webProcessPool = weakThis.get())
+            webProcessPool->sendToAllProcesses(Messages::WebProcess::PowerSourceDidChange(hasAC));
     });
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -102,10 +102,11 @@ using namespace WebKit;
     if (!uniqueIdentifier)
         return;
 
-    if (!_webExtensionController)
+    RefPtr webExtensionController = _webExtensionController.get();
+    if (!webExtensionController)
         return;
 
-    if (RefPtr context = _webExtensionController->extensionContext(uniqueIdentifier))
+    if (RefPtr context = webExtensionController->extensionContext(uniqueIdentifier))
         context->invalidateStorage();
 }
 
@@ -486,7 +487,7 @@ void WebExtensionController::addWebsiteDataStore(WebsiteDataStore& dataStore)
         m_cookieStoreObserver = HTTPCookieStoreObserver::create(*this);
 
     m_websiteDataStores.add(dataStore);
-    dataStore.protectedCookieStore()->registerObserver(*m_cookieStoreObserver);
+    dataStore.protectedCookieStore()->registerObserver(*protectedCookieStoreObserver());
 }
 
 void WebExtensionController::removeWebsiteDataStore(WebsiteDataStore& dataStore)
@@ -498,7 +499,7 @@ void WebExtensionController::removeWebsiteDataStore(WebsiteDataStore& dataStore)
     }
 
     m_websiteDataStores.remove(dataStore);
-    dataStore.protectedCookieStore()->unregisterObserver(*m_cookieStoreObserver);
+    dataStore.protectedCookieStore()->unregisterObserver(*protectedCookieStoreObserver());
 
     if (m_websiteDataStores.isEmptyIgnoringNullReferences())
         m_cookieStoreObserver = nullptr;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -254,6 +254,8 @@ private:
         WeakPtr<WebExtensionController> m_extensionController;
     };
 
+    RefPtr<HTTPCookieStoreObserver> protectedCookieStoreObserver() { return m_cookieStoreObserver; }
+
     Ref<WebExtensionControllerConfiguration> m_configuration;
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -251,3 +251,7 @@ private:
 };
 
 } // namespace WebKit
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebFrameProxy)
+    static bool isType(const API::Object& object) { return object.type() == API::Object::Type::Frame; }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3798,3 +3798,7 @@ private:
 };
 
 } // namespace WebKit
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebPageProxy)
+    static bool isType(const API::Object& object) { return object.type() == API::Object::Type::Page; }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1792,10 +1792,10 @@ RefPtr<API::Object> WebProcessProxy::transformHandlesToObjects(API::Object* obje
         {
             switch (object.type()) {
             case API::Object::Type::FrameHandle:
-                return static_cast<const API::FrameHandle&>(object).isAutoconverting();
+                return downcast<const API::FrameHandle>(object).isAutoconverting();
 
             case API::Object::Type::PageHandle:
-                return static_cast<const API::PageHandle&>(object).isAutoconverting();
+                return downcast<const API::PageHandle>(object).isAutoconverting();
 
             default:
                 return false;
@@ -1807,12 +1807,12 @@ RefPtr<API::Object> WebProcessProxy::transformHandlesToObjects(API::Object* obje
             switch (object.type()) {
             case API::Object::Type::FrameHandle: {
                 ASSERT(static_cast<API::FrameHandle&>(object).isAutoconverting());
-                auto frameID = static_cast<API::FrameHandle&>(object).frameID();
+                auto frameID = downcast<API::FrameHandle>(object).frameID();
                 return WebFrameProxy::webFrame(frameID);
             }
             case API::Object::Type::PageHandle:
                 ASSERT(static_cast<API::PageHandle&>(object).isAutoconverting());
-                return protectedProcess()->webPage(static_cast<API::PageHandle&>(object).pageProxyID());
+                return protectedProcess()->webPage(downcast<API::PageHandle>(object).pageProxyID());
 
             default:
                 return &object;
@@ -1847,10 +1847,10 @@ RefPtr<API::Object> WebProcessProxy::transformObjectsToHandles(API::Object* obje
         {
             switch (object.type()) {
             case API::Object::Type::Frame:
-                return API::FrameHandle::createAutoconverting(static_cast<const WebFrameProxy&>(object).frameID());
+                return API::FrameHandle::createAutoconverting(downcast<WebFrameProxy>(object).frameID());
 
             case API::Object::Type::Page:
-                return API::PageHandle::createAutoconverting(static_cast<const WebPageProxy&>(object).identifier(), static_cast<const WebPageProxy&>(object).webPageIDInMainFrameProcess());
+                return API::PageHandle::createAutoconverting(downcast<WebPageProxy>(object).identifier(), downcast<WebPageProxy>(object).webPageIDInMainFrameProcess());
 
             default:
                 return &object;
@@ -1885,7 +1885,7 @@ void WebProcessProxy::didChangeThrottleState(ProcessThrottleState type)
 {
     AuxiliaryProcessProxy::didChangeThrottleState(type);
 
-    auto scope = makeScopeExit([this]() {
+    auto scope = makeScopeExit([this, protectedThis = Ref { *this }]() {
         updateRuntimeStatistics();
     });
 

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -262,7 +262,7 @@ static JSValueRef evaluateJavaScriptCallback(JSContextRef context, JSObjectRef f
 JSObjectRef WebAutomationSessionProxy::scriptObject(JSGlobalContextRef context)
 {
     JSC::JSGlobalObject* globalObject = toJS(context);
-    JSC::VM& vm = globalObject->vm();
+    SUPPRESS_UNCOUNTED_LOCAL JSC::VM& vm = globalObject->vm();
     JSC::JSLockHolder locker(vm);
     auto scriptObjectID = JSC::Identifier::fromUid(m_scriptObjectIdentifier);
     if (!globalObject->hasProperty(globalObject, scriptObjectID))
@@ -274,7 +274,7 @@ JSObjectRef WebAutomationSessionProxy::scriptObject(JSGlobalContextRef context)
 void WebAutomationSessionProxy::setScriptObject(JSGlobalContextRef context, JSObjectRef object)
 {
     JSC::JSGlobalObject* globalObject = toJS(context);
-    JSC::VM& vm = globalObject->vm();
+    SUPPRESS_UNCOUNTED_LOCAL JSC::VM& vm = globalObject->vm();
     JSC::JSLockHolder locker(vm);
     auto scriptObjectID = JSC::Identifier::fromUid(m_scriptObjectIdentifier);
     JSC::PutPropertySlot slot(globalObject);
@@ -955,7 +955,7 @@ void WebAutomationSessionProxy::takeScreenshot(WebCore::PageIdentifier pageID, s
         RefPtr localMainFrame = dynamicDowncast<LocalFrame>(frame->coreFrame()->mainFrame());
         if (!localMainFrame)
             return;
-        auto snapshotRect = WebCore::IntRect(localMainFrame->view()->clientToDocumentRect(rect));
+        auto snapshotRect = WebCore::IntRect(localMainFrame->protectedView()->clientToDocumentRect(rect));
         RefPtr<WebImage> image = page->scaledSnapshotWithOptions(snapshotRect, 1, SnapshotOption::Shareable);
         if (!image)
             return completionHandler(std::nullopt, Inspector::Protocol::AutomationHelpers::getEnumConstantValue(Inspector::Protocol::Automation::ErrorMessage::ScreenshotError));
@@ -1013,7 +1013,7 @@ void WebAutomationSessionProxy::snapshotRectForScreenshot(WebCore::PageIdentifie
         return;
     }
 
-    completionHandler(std::nullopt, WebCore::IntRect(localMainFrame->view()->documentToClientRect(snapshotRect)));
+    completionHandler(std::nullopt, WebCore::IntRect(localMainFrame->protectedView()->documentToClientRect(snapshotRect)));
 }
 
 void WebAutomationSessionProxy::getCookiesForFrame(WebCore::PageIdentifier pageID, std::optional<WebCore::FrameIdentifier> frameID, CompletionHandler<void(std::optional<String>, Vector<WebCore::Cookie>)>&& completionHandler)


### PR DESCRIPTION
#### 7e7d85470bd79e782a582a3a0a595c2a1ee47354
<pre>
Adopt more smart pointers in WebKit message receivers
<a href="https://bugs.webkit.org/show_bug.cgi?id=284840">https://bugs.webkit.org/show_bug.cgi?id=284840</a>
<a href="https://rdar.apple.com/141636195">rdar://141636195</a>

Reviewed by Ryosuke Niwa.

Smart pointer adoption as per the static analyzer.

* Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebKit/Shared/API/APIArray.h:
* Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h:
* Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm:
(WebKit::WebPaymentCoordinatorProxy::platformCompletePaymentSession):
(WebKit::WebPaymentCoordinatorProxy::platformCompleteMerchantValidation):
(WebKit::WebPaymentCoordinatorProxy::platformCompleteShippingMethodSelection):
(WebKit::WebPaymentCoordinatorProxy::platformCompleteShippingContactSelection):
(WebKit::WebPaymentCoordinatorProxy::platformCompletePaymentMethodSelection):
(WebKit::WebPaymentCoordinatorProxy::platformCompleteCouponCodeChange):
* Source/WebKit/Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm:
(WebKit::WebPaymentCoordinatorProxy::platformHidePaymentUI):
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm:
(WebKit::PlaybackSessionModelContext::durationChanged):
(WebKit::PlaybackSessionModelContext::currentTimeChanged):
(WebKit::PlaybackSessionModelContext::bufferedTimeChanged):
(WebKit::PlaybackSessionModelContext::rateChanged):
(WebKit::PlaybackSessionModelContext::seekableRangesChanged):
(WebKit::PlaybackSessionModelContext::canPlayFastReverseChanged):
(WebKit::PlaybackSessionModelContext::audioMediaSelectionOptionsChanged):
(WebKit::PlaybackSessionModelContext::legibleMediaSelectionOptionsChanged):
(WebKit::PlaybackSessionModelContext::audioMediaSelectionIndexChanged):
(WebKit::PlaybackSessionModelContext::legibleMediaSelectionIndexChanged):
(WebKit::PlaybackSessionModelContext::externalPlaybackChanged):
(WebKit::PlaybackSessionModelContext::wirelessVideoPlaybackDisabledChanged):
(WebKit::PlaybackSessionModelContext::mutedChanged):
(WebKit::PlaybackSessionModelContext::volumeChanged):
(WebKit::PlaybackSessionModelContext::pictureInPictureSupportedChanged):
(WebKit::PlaybackSessionModelContext::pictureInPictureActiveChanged):
(WebKit::PlaybackSessionModelContext::isInWindowFullscreenActiveChanged):
(WebKit::PlaybackSessionModelContext::supportsLinearMediaPlayerChanged):
(WebKit::PlaybackSessionModelContext::spatialVideoMetadataChanged):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationModelContext::loggerPtr const):
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::registerNotificationObservers):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(-[_WKWebExtensionControllerHelper _didDeleteLocalStorage:]):
(WebKit::WebExtensionController::addWebsiteDataStore):
(WebKit::WebExtensionController::removeWebsiteDataStore):
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
(WebKit::WebExtensionController::protectedCookieStoreObserver):
* Source/WebKit/UIProcess/WebFrameProxy.h:
(isType):
* Source/WebKit/UIProcess/WebPageProxy.h:
(isType):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::transformHandlesToObjects):
(WebKit::WebProcessProxy::transformObjectsToHandles):
(WebKit::WebProcessProxy::didChangeThrottleState):
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::WebAutomationSessionProxy::scriptObject):
(WebKit::WebAutomationSessionProxy::setScriptObject):
(WebKit::WebAutomationSessionProxy::takeScreenshot):
(WebKit::WebAutomationSessionProxy::snapshotRectForScreenshot):

Canonical link: <a href="https://commits.webkit.org/288053@main">https://commits.webkit.org/288053@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/063576ac24a6a0e52a4ce87899e108db94f3f1d1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81706 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1232 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35660 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86250 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32701 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1265 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9052 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63751 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21473 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84776 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/917 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74361 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44037 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/816 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31155 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29137 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87689 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8946 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6354 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72084 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9131 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70180 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71314 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15396 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14317 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12664 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8897 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14429 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8738 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12261 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10546 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->