### PR TITLE
Migrate SecTrust to WebKitSecureCoding Interface

### DIFF
--- a/Source/WTF/wtf/spi/cocoa/SecuritySPI.h
+++ b/Source/WTF/wtf/spi/cocoa/SecuritySPI.h
@@ -124,6 +124,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #if PLATFORM(COCOA)
 CF_RETURNS_RETAINED CFDataRef SecTrustSerialize(SecTrustRef, CFErrorRef *);
 CF_RETURNS_RETAINED SecTrustRef SecTrustDeserialize(CFDataRef serializedTrust, CFErrorRef *);
+CF_RETURNS_RETAINED CFPropertyListRef SecTrustCopyPropertyListRepresentation(SecTrustRef, CFErrorRef *);
+CF_RETURNS_RETAINED SecTrustRef SecTrustCreateFromPropertyListRepresentation(CFPropertyListRef trustPlist, CFErrorRef *);
 #endif
 
 CF_RETURNS_RETAINED CFDictionaryRef SecTrustCopyInfo(SecTrustRef);

--- a/Source/WebKit/Shared/cf/CoreIPCSecTrust.mm
+++ b/Source/WebKit/Shared/cf/CoreIPCSecTrust.mm
@@ -1,0 +1,778 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if HAVE(WK_SECURE_CODING_SECTRUST) && USE(CF)
+
+#import "config.h"
+#import "CoreIPCSecTrust.h"
+
+#import "Logging.h"
+#import <wtf/Compiler.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
+#import <wtf/text/MakeString.h>
+
+namespace WebKit {
+
+
+static bool arrayElementsTheSameType(NSArray *array, Class c)
+{
+    if (!array.count)
+        return true;
+    for (id element in array) {
+        if (![element isKindOfClass:c])
+            return false;
+    }
+    return true;
+}
+
+CoreIPCSecTrust::PolicyOptionValueShape CoreIPCSecTrust::detectPolicyOptionShape(id option)
+{
+    if ([option isKindOfClass:NSNumber.class]) {
+        NSNumber *candidateBool = option;
+        if ([candidateBool isEqualToNumber:@YES] || [candidateBool isEqualToNumber:@NO])
+            return PolicyOptionValueShape::Bool;
+    } else if ([option isKindOfClass:NSString.class])
+        return PolicyOptionValueShape::String;
+    else if ([option isKindOfClass:NSArray.class]) {
+        NSArray *a = option;
+        id element = a.firstObject;
+        if (!element) {
+            RELEASE_LOG_ERROR(IPC, "CoreIPCSecTrust::detectPolicyOptionShape element was nil");
+            ASSERT_NOT_REACHED();
+            return PolicyOptionValueShape::Invalid;
+        }
+        if ([element isKindOfClass:NSNumber.class])
+            return PolicyOptionValueShape::ArrayOfNumbers;
+        if ([element isKindOfClass:NSString.class])
+            return PolicyOptionValueShape::ArrayOfStrings;
+        if ([element isKindOfClass:NSData.class])
+            return PolicyOptionValueShape::ArrayOfData;
+        if ([element isKindOfClass:NSArray.class])
+            return PolicyOptionValueShape::ArrayOfArrayContainingDateOrNumber;
+    } else if ([option isKindOfClass:NSDictionary.class])
+        return PolicyOptionValueShape::DictionaryValueIsNumber;
+
+    RELEASE_LOG_ERROR(IPC, "CoreIPCSecTrust::detectPolicyOptionShape was unable to detect option's shape");
+    ASSERT_NOT_REACHED();
+    return PolicyOptionValueShape::Invalid;
+}
+
+static String updatePolicyVector(NSDictionary *policyOption, CoreIPCSecTrustData::PolicyOption& policyVector)
+{
+    policyVector.reserveCapacity(policyOption.count);
+    for (NSString *optionKey in policyOption) {
+        if (![optionKey isKindOfClass:NSString.class])
+            return makeString("optionKey was not an NSString"_s);
+        CoreIPCString k { optionKey };
+        id optionValue = [policyOption objectForKey:optionKey];
+
+        CoreIPCSecTrust::PolicyOptionValueShape shape = CoreIPCSecTrust::detectPolicyOptionShape(optionValue);
+
+        switch (shape) {
+        case CoreIPCSecTrust::PolicyOptionValueShape::Invalid:
+            return makeString("policy shape for key "_s, (String)optionKey, "is invalid"_s);
+        case CoreIPCSecTrust::PolicyOptionValueShape::Bool: {
+            if (![optionValue isKindOfClass:NSNumber.class])
+                return makeString("CoreIPCSecTrust::PolicyOptionValueShape::Bool unexpected type for key "_s, (String)optionKey);
+            NSNumber *value = optionValue;
+            CoreIPCSecTrustData::PolicyVariant v = static_cast<bool>([value boolValue]);
+            policyVector.append(std::make_pair(WTFMove(k), WTFMove(v)));
+            break;
+        }
+        case CoreIPCSecTrust::PolicyOptionValueShape::String: {
+            if (![optionValue isKindOfClass:NSString.class])
+                return makeString("CoreIPCSecTrust::PolicyOptionValueShape::String unexpected type for key "_s, (String)optionKey);
+            NSString *value = optionValue;
+            CoreIPCSecTrustData::PolicyVariant v = CoreIPCString(value);
+            policyVector.append(std::make_pair(WTFMove(k), WTFMove(v)));
+            break;
+        }
+        case CoreIPCSecTrust::PolicyOptionValueShape::ArrayOfNumbers: {
+            if (![optionValue isKindOfClass:NSArray.class])
+                return makeString("CoreIPCSecTrust::PolicyOptionValueShape::ArrayOfNumbers unexpected type for key "_s, (String)optionKey, " (expecting NSArray)"_s);
+            NSArray* value = optionValue;
+            if (!value.count)
+                return makeString("CoreIPCSecTrust::PolicyOptionValueShape::ArrayOfNumbers array length 0 for key "_s, (String)optionKey);
+            if (!arrayElementsTheSameType(value, NSNumber.class))
+                return makeString("CoreIPCSecTrust::PolicyOptionValueShape::ArrayOfNumbers unexpected type for key "_s, (String)optionKey, " (expecting NSNumber)"_s);
+            Vector<CoreIPCNumber> vector;
+            vector.reserveCapacity(value.count);
+            for (NSNumber *element in value) {
+                CoreIPCNumber n { element };
+                vector.append(WTFMove(n));
+            }
+            CoreIPCSecTrustData::PolicyVariant v = WTFMove(vector);
+            policyVector.append(std::make_pair(WTFMove(k), WTFMove(v)));
+            break;
+        }
+        case CoreIPCSecTrust::PolicyOptionValueShape::ArrayOfStrings: {
+            if (![optionValue isKindOfClass:NSArray.class])
+                return makeString("CoreIPCSecTrust::PolicyOptionValueShape::ArrayOfStrings unexpected type for key "_s, (String)optionKey, " (expecting NSArray)"_s);
+            NSArray* value = optionValue;
+            if (!value.count)
+                return makeString("CoreIPCSecTrust::PolicyOptionValueShape::ArrayOfStrings array length 0 for key "_s, (String)optionKey);
+            if (!arrayElementsTheSameType(value, NSString.class))
+                return makeString("CoreIPCSecTrust::PolicyOptionValueShape::ArrayOfStrings unexpected type for key "_s, (String)optionKey, " (expecting NSString)"_s);
+            Vector<CoreIPCString> vector;
+            vector.reserveCapacity(value.count);
+            for (NSString *element in value) {
+                CoreIPCString s { element };
+                vector.append(WTFMove(s));
+            }
+            CoreIPCSecTrustData::PolicyVariant v = WTFMove(vector);
+            policyVector.append(std::make_pair(WTFMove(k), WTFMove(v)));
+            break;
+        }
+        case CoreIPCSecTrust::PolicyOptionValueShape::ArrayOfData: {
+            if (![optionValue isKindOfClass:NSArray.class])
+                return makeString("CoreIPCSecTrust::PolicyOptionValueShape::ArrayOfData unexpected type for key %@ "_s, (String)optionKey, " (expecting NSArray)"_s);
+            NSArray* value = optionValue;
+            if (!value.count)
+                return makeString("CoreIPCSecTrust::PolicyOptionValueShape::ArrayOfData array length 0 for key "_s, (String)optionKey);
+            if (!arrayElementsTheSameType(value, NSData.class))
+                return makeString("CoreIPCSecTrust::PolicyOptionValueShape::ArrayOfData unexpected type for key "_s, (String)optionKey, " (expecting NSData)"_s);
+            Vector<CoreIPCData> vector;
+            vector.reserveCapacity(value.count);
+            for (NSData *element in value) {
+                CoreIPCData d { element };
+                vector.append(WTFMove(d));
+            }
+            CoreIPCSecTrustData::PolicyVariant v = WTFMove(vector);
+            policyVector.append(std::make_pair(WTFMove(k), WTFMove(v)));
+            break;
+        }
+        case CoreIPCSecTrust::PolicyOptionValueShape::ArrayOfArrayContainingDateOrNumber: {
+            if (![optionValue isKindOfClass:NSArray.class])
+                return makeString("CoreIPCSecTrust::PolicyOptionValueShape::ArrayOfArrayContainingDateOrNumber unexpected type for key "_s, (String)optionKey, " (expecting NSArray)"_s);
+            NSArray *value = optionValue;
+            if (!value.count)
+                return makeString("CoreIPCSecTrust::PolicyOptionValueShape::ArrayOfArrayContainingDateOrNumber array length 0 for key "_s, (String)optionKey);
+            if (!arrayElementsTheSameType(value, NSArray.class))
+                return makeString("CoreIPCSecTrust::PolicyOptionValueShape::ArrayOfArrayContainingDateOrNumber unexpected type for key "_s, (String)optionKey, " (expecting NSArray)"_s);
+
+            CoreIPCSecTrustData::PolicyArrayOfArrayContainingDateOrNumbers outerVector;
+            outerVector.reserveCapacity(value.count);
+
+            for (NSArray *secondLevelArray in value) {
+                if (![secondLevelArray isKindOfClass:NSArray.class])
+                    return makeString("CoreIPCSecTrust::PolicyOptionValueShape::ArrayOfArrayContainingDateOrNumber second level array unexpected type for key "_s, (String)optionKey);
+
+                Vector<std::variant<WebKit::CoreIPCNumber, WebKit::CoreIPCDate>> innerVector;
+                innerVector.reserveCapacity(secondLevelArray.count);
+
+                for (id element in secondLevelArray) {
+                    if ([element isKindOfClass:NSNumber.class]) {
+                        NSNumber *e = element;
+                        std::variant<WebKit::CoreIPCNumber, WebKit::CoreIPCDate> v = CoreIPCNumber(e);
+                        innerVector.append(WTFMove(v));
+                    } else if ([element isKindOfClass:NSDate.class]) {
+                        NSDate *d = element;
+                        std::variant<WebKit::CoreIPCNumber, WebKit::CoreIPCDate> v = CoreIPCDate(d);
+                        innerVector.append(WTFMove(v));
+                    } else
+                        return makeString("CoreIPCSecTrust::PolicyOptionValueShape::ArrayOfArrayContainingDateOrNumber second level array contents unexpected type for key "_s, (String)optionKey);
+                }
+                outerVector.append(WTFMove(innerVector));
+            }
+            CoreIPCSecTrustData::PolicyVariant v = WTFMove(outerVector);
+            policyVector.append(std::make_pair(WTFMove(k), WTFMove(v)));
+            break;
+        }
+        case CoreIPCSecTrust::PolicyOptionValueShape::DictionaryValueIsNumber: {
+            if (![optionValue isKindOfClass:NSDictionary.class])
+                return makeString("CoreIPCSecTrust::PolicyOptionValueShape::DictionaryValueIsNumber unexpected type for key "_s, (String)optionKey, " (expecting NSDictionary)"_s);
+            NSDictionary *d = optionValue;
+            CoreIPCSecTrustData::PolicyDictionaryValueIsNumber vector;
+            vector.reserveCapacity(d.count);
+            for (NSString* key in d) {
+                if (![key isKindOfClass:NSString.class])
+                    return makeString("CoreIPCSecTrust::PolicyOptionValueShape::DictionaryValueIsNumber unexpected dictionary key type for key "_s, (String)optionKey, " (expecting NSString)"_s);
+                NSNumber *value = [d objectForKey:key];
+                if (![value isKindOfClass:NSNumber.class])
+                    return makeString("CoreIPCSecTrust::PolicyOptionValueShape::DictionaryValueIsNumber unexpected dictionary value type for key "_s, (String)optionKey, " (expecting NSNumber)"_s);
+                CoreIPCString s { key };
+                CoreIPCNumber n { value };
+                vector.append(std::make_pair(WTFMove(s), WTFMove(n)));
+            }
+            CoreIPCSecTrustData::PolicyVariant v = WTFMove(vector);
+            policyVector.append(std::make_pair(WTFMove(k), WTFMove(v)));
+            break;
+        }
+        default:
+            return makeString("unknown shape for key "_s, (String)optionKey);
+        }
+    }
+    return { }; // no error
+}
+
+#define RETURN_IF_OPTIONAL_ERROR \
+    if (!optionalDataError.isNull()) { \
+        RELEASE_LOG_ERROR(IPC, "CoreIPCSecTrust optionalArrayOfDataHelper error: %s", optionalDataError.utf8().data()); \
+        ASSERT_NOT_REACHED(); \
+        return; \
+    }
+
+static String optionalArrayOfDataHelper(std::optional<Vector<CoreIPCData>>& toSet, RetainPtr<NSDictionary> dict, NSString* topLevelKey)
+{
+    if (![dict isKindOfClass:NSDictionary.class])
+        return makeString("optionalArrayOfDataHelper was called with wrong argument"_s);
+    RetainPtr<NSArray> array = [dict objectForKey:topLevelKey];
+    if ([array isKindOfClass:NSArray.class]) {
+        Vector<CoreIPCData> vector;
+        vector.reserveCapacity([array count]);
+        for (NSData* item in array.get()) {
+            if (![item isKindOfClass:NSData.class])
+                return makeString("optionalArrayOfDataHelper had invalid type in array"_s);
+            CoreIPCData c { item };
+            vector.append(WTFMove(c));
+        }
+        toSet = { WTFMove(vector) };
+    }
+    return { }; // no error
+}
+
+CoreIPCSecTrust::CoreIPCSecTrust(SecTrustRef trust)
+{
+    CFErrorRef error;
+
+    if (!trust)
+        return;
+
+    RetainPtr cfDictionary = adoptCF(dynamic_cf_cast<CFDictionaryRef>(SecTrustCopyPropertyListRepresentation(trust, &error)));
+    if (!cfDictionary || error)
+        return;
+    RetainPtr dict = bridge_cast(cfDictionary.get());
+
+    CoreIPCSecTrustData secTrustData { };
+
+    RetainPtr<NSDate> verifyDate = [dict objectForKey:@"verifyDate"];
+    if ([verifyDate isKindOfClass:NSDate.class]) {
+        CoreIPCDate d { verifyDate.get() };
+        secTrustData.verifyDate = WTFMove(d);
+    }
+
+    RetainPtr<NSNumber> result = [dict objectForKey:@"result"];
+    if (![result isKindOfClass:NSNumber.class]) {
+        RELEASE_LOG_ERROR(IPC, "CoreIPCSecTrust 'result' value is nil or not an NSNumber and not optional");
+        return;
+    }
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    switch ([result unsignedCharValue]) {
+    case kSecTrustResultInvalid:
+        secTrustData.result = CoreIPCSecTrustResult::Invalid;
+        break;
+    case kSecTrustResultProceed:
+        secTrustData.result = CoreIPCSecTrustResult::Proceed;
+        break;
+    case kSecTrustResultConfirm: // Deprecated
+        secTrustData.result = CoreIPCSecTrustResult::Confirm;
+        break;
+    case kSecTrustResultDeny:
+        secTrustData.result = CoreIPCSecTrustResult::Deny;
+        break;
+    case kSecTrustResultUnspecified:
+        secTrustData.result = CoreIPCSecTrustResult::Unspecified;
+        break;
+    case kSecTrustResultRecoverableTrustFailure:
+        secTrustData.result = CoreIPCSecTrustResult::RecoverableTrustFailure;
+        break;
+    case kSecTrustResultFatalTrustFailure:
+        secTrustData.result = CoreIPCSecTrustResult::FatalTrustFailure;
+        break;
+    case kSecTrustResultOtherError:
+        secTrustData.result = CoreIPCSecTrustResult::OtherError;
+        break;
+    default:
+        secTrustData.result = CoreIPCSecTrustResult::Invalid;
+        RELEASE_LOG_ERROR(IPC, "CoreIPCSecTrust 'result' value was not set to a known constant");
+        ASSERT_NOT_REACHED();
+        return;
+    }
+ALLOW_DEPRECATED_DECLARATIONS_END
+    RetainPtr<NSNumber> anchorsOnly = [dict objectForKey:@"anchorsOnly"];
+    if (![anchorsOnly isKindOfClass:NSNumber.class]) {
+        RELEASE_LOG_ERROR(IPC, "CoreIPCSecTrust 'anchorsOnly' value is nil or not an NSNumber and not optional");
+        return;
+    }
+    secTrustData.anchorsOnly = [anchorsOnly boolValue];
+
+    RetainPtr<NSArray> certificates = [dict objectForKey:@"certificates"];
+    if ([certificates isKindOfClass:NSArray.class]) {
+        Vector<CoreIPCData> vector;
+        vector.reserveCapacity([certificates count]);
+        for (NSData* item in certificates.get()) {
+            if (![item isKindOfClass:NSData.class]) {
+                RELEASE_LOG_ERROR(IPC, "CoreIPCSecTrust 'certificates' array contains a non NSData item");
+                ASSERT_NOT_REACHED();
+                return;
+            }
+            CoreIPCData c { item };
+            vector.append(WTFMove(c));
+        }
+        secTrustData.certificates = WTFMove(vector);
+    }
+
+    RetainPtr<NSArray> chain = [dict objectForKey:@"chain"];
+    if ([chain isKindOfClass:NSArray.class]) {
+        Vector<CoreIPCData> vector;
+        vector.reserveCapacity([chain count]);
+        for (NSData* item in chain.get()) {
+            if (![item isKindOfClass:NSData.class]) {
+                RELEASE_LOG_ERROR(IPC, "CoreIPCSecTrust 'chain' array contains a non NSData item");
+                ASSERT_NOT_REACHED();
+                return;
+            }
+            CoreIPCData c { item };
+            vector.append(WTFMove(c));
+        }
+        secTrustData.chain = WTFMove(vector);
+    }
+
+    RetainPtr<NSArray> details = [dict objectForKey:@"details"];
+    if ([details isKindOfClass:NSArray.class]) {
+        Vector<CoreIPCSecTrustData::Detail> vector;
+        vector.reserveCapacity([details count]);
+        for (NSDictionary *detail in details.get()) {
+            if (![detail isKindOfClass:NSDictionary.class]) {
+                RELEASE_LOG_ERROR(IPC, "CoreIPCSecTrust 'details' array contains unexpected type");
+                ASSERT_NOT_REACHED();
+                return;
+            }
+            CoreIPCSecTrustData::Detail d;
+            d.reserveCapacity(detail.count);
+            for (NSString *key in detail) {
+                if (![key isKindOfClass:NSString.class]) {
+                    RELEASE_LOG_ERROR(IPC, "CoreIPCSecTrust 'details' dictionary contains unexpected key type");
+                    ASSERT_NOT_REACHED();
+                    return;
+                }
+                NSNumber *value = [detail objectForKey:key];
+                if (![value isKindOfClass:NSNumber.class]) {
+                    RELEASE_LOG_ERROR(IPC, "CoreIPCSecTrust 'details' dictionary contains unexpected value type");
+                    ASSERT_NOT_REACHED();
+                    return;
+                }
+                CoreIPCString k { key };
+                d.append(std::make_pair(WTFMove(k), [value boolValue]));
+            }
+            vector.append(WTFMove(d));
+        }
+        secTrustData.details = WTFMove(vector);
+    }
+
+    RetainPtr<NSDictionary> info = [dict objectForKey:@"info"];
+    if ([info isKindOfClass:NSDictionary.class]) {
+        CoreIPCSecTrustData::InfoType vector;
+        vector.reserveCapacity([info count]);
+        for (NSString *key in info.get()) {
+            if (![key isKindOfClass:NSString.class]) {
+                RELEASE_LOG_ERROR(IPC, "CoreIPCSecTrust 'info' dictionary key contains unexpected type");
+                ASSERT_NOT_REACHED();
+                return;
+            }
+            CoreIPCString k { key };
+            id value = [info objectForKey:key];
+            if ([value isKindOfClass:NSDate.class]) {
+                CoreIPCDate date { value };
+                CoreIPCSecTrustData::InfoOption v = WTFMove(date);
+                vector.append(std::make_pair(WTFMove(k), WTFMove(v)));
+            } else if ([value isKindOfClass:NSString.class]) {
+                CoreIPCString s { value };
+                CoreIPCSecTrustData::InfoOption v = WTFMove(s);
+                vector.append(std::make_pair(WTFMove(k), WTFMove(v)));
+            } else if ([value isKindOfClass:NSNumber.class]) {
+                NSNumber *candidateBool = value;
+                if ([candidateBool isEqualToNumber:@YES] || [candidateBool isEqualToNumber:@NO]) {
+                    bool v = [candidateBool boolValue];
+                    vector.append(std::make_pair(WTFMove(k), v));
+                } else {
+                    RELEASE_LOG_ERROR(IPC, "CoreIPCSecTrust 'info' dictionary value contains unexpected NSNumber value");
+                    ASSERT_NOT_REACHED();
+                    return;
+                }
+            } else {
+                RELEASE_LOG_ERROR(IPC, "CoreIPCSecTrust 'info' dictionary contains unexpected type");
+                ASSERT_NOT_REACHED();
+                return;
+            }
+        }
+        secTrustData.info = WTFMove(vector);
+    }
+
+    RetainPtr<NSNumber> keychainsAllowed = [dict objectForKey:@"keychainsAllowed"];
+    if (![keychainsAllowed isKindOfClass:NSNumber.class]) {
+        RELEASE_LOG_ERROR(IPC, "CoreIPCSecTrust 'keychainsAllowed' value is nil or not an NSNumber and not optional");
+        return;
+    }
+    secTrustData.keychainsAllowed = [keychainsAllowed boolValue];
+
+    RetainPtr<NSArray> policies = [dict objectForKey:@"policies"];
+    if ([policies isKindOfClass:NSArray.class]) {
+        Vector<CoreIPCSecTrustData::PolicyType> outerVector;
+        outerVector.reserveCapacity([policies count]);
+        for (NSDictionary *policy in policies.get()) {
+            if (![policy isKindOfClass:NSDictionary.class]) {
+                RELEASE_LOG_ERROR(IPC, "CoreIPCSecTrust policy is not an NSDictionary");
+                ASSERT_NOT_REACHED();
+                return;
+            }
+            CoreIPCSecTrustData::PolicyType innerVector;
+            innerVector.reserveCapacity(policy.count);
+            for (NSString *key in policy) {
+                if (![key isKindOfClass:NSString.class]) {
+                    RELEASE_LOG_ERROR(IPC, "CoreIPCSecTrust policy key is not an NSString");
+                    ASSERT_NOT_REACHED();
+                    return;
+                }
+                id value = [policy objectForKey:key];
+                if ([value isKindOfClass:NSString.class]) {
+                    CoreIPCString k { key };
+                    CoreIPCSecTrustData::PolicyValue v = CoreIPCString(value);
+                    auto p = std::make_pair(WTFMove(k), WTFMove(v));
+                    innerVector.append(WTFMove(p));
+                } else if ([value isKindOfClass:NSDictionary.class]) {
+                    CoreIPCSecTrustData::PolicyOption policyVector;
+                    String error = updatePolicyVector((NSDictionary *)value, policyVector);
+                    if (!error.isNull()) {
+                        RELEASE_LOG_ERROR(IPC, "CoreIPCSecTrust updatePolicyVector error %s", error.utf8().data());
+                        ASSERT_NOT_REACHED();
+                        return;
+                    }
+                    CoreIPCString k { key };
+                    CoreIPCSecTrustData::PolicyValue v = WTFMove(policyVector);
+                    auto p = std::make_pair(WTFMove(k), WTFMove(v));
+                    innerVector.append(WTFMove(p));
+                } else {
+                    RELEASE_LOG_ERROR(IPC, "CoreIPCSecTrust policy value is unexpected type");
+                    ASSERT_NOT_REACHED();
+                    return;
+                }
+            }
+            outerVector.append(WTFMove(innerVector));
+        }
+        secTrustData.policies = WTFMove(outerVector);
+    }
+
+    String optionalDataError;
+    optionalDataError = optionalArrayOfDataHelper(secTrustData.responses, dict, @"responses");
+    RETURN_IF_OPTIONAL_ERROR;
+
+    optionalDataError = optionalArrayOfDataHelper(secTrustData.scts, dict, @"scts");
+    RETURN_IF_OPTIONAL_ERROR;
+
+    optionalDataError = optionalArrayOfDataHelper(secTrustData.anchors, dict, @"anchors");
+    RETURN_IF_OPTIONAL_ERROR;
+
+    optionalDataError = optionalArrayOfDataHelper(secTrustData.trustedLogs, dict, @"trustedLogs");
+    RETURN_IF_OPTIONAL_ERROR;
+
+    RetainPtr<NSArray> exceptions = [dict objectForKey:@"exceptions"];
+    if ([exceptions isKindOfClass:NSArray.class]) {
+        Vector<CoreIPCSecTrustData::ExceptionType> vector;
+        vector.reserveCapacity([exceptions count]);
+        for (NSDictionary *exception in exceptions.get()) {
+            if (![exception isKindOfClass:NSDictionary.class]) {
+                RELEASE_LOG_ERROR(IPC, "CoreIPCSecTrust 'exceptions' array contains non NSDictionary member");
+                ASSERT_NOT_REACHED();
+                return;
+            }
+            CoreIPCSecTrustData::ExceptionType innerVector;
+            innerVector.reserveCapacity([exception count]);
+            for (NSString *key in exception) {
+                if (![key isKindOfClass:NSString.class]) {
+                    RELEASE_LOG_ERROR(IPC, "CoreIPCSecTrust 'exceptions' dictionary key is not an NSString");
+                    ASSERT_NOT_REACHED();
+                    return;
+                }
+                CoreIPCString k { key };
+                id value = [exception objectForKey:key];
+                if ([value isKindOfClass:NSData.class]) {
+                    CoreIPCData data { value };
+                    std::variant<CoreIPCNumber, CoreIPCData, bool> v = WTFMove(data);
+                    auto p = std::make_pair(WTFMove(k), WTFMove(v));
+                    innerVector.append(WTFMove(p));
+                } else if ([value isKindOfClass:NSNumber.class]) {
+                    NSNumber *number = value;
+                    if ([number isEqualToNumber:@YES] || [number isEqualToNumber:@NO]) {
+                        bool v = [number boolValue];
+                        auto p = std::make_pair(WTFMove(k), v);
+                        innerVector.append(WTFMove(p));
+                    } else {
+                        CoreIPCNumber n { number };
+                        auto p = std::make_pair(WTFMove(k), n);
+                        innerVector.append(WTFMove(p));
+                    }
+                } else {
+                    RELEASE_LOG_ERROR(IPC, "CoreIPCSecTrust 'exceptions' dictionary contains unexpected type");
+                    ASSERT_NOT_REACHED();
+                    return;
+                }
+            }
+            vector.append(WTFMove(innerVector));
+        }
+        secTrustData.exceptions = { WTFMove(vector) };
+    }
+
+    m_data = WTFMove(secTrustData);
+}
+
+static RetainPtr<NSDictionary> createPolicyDictionary(const CoreIPCSecTrustData::PolicyOption& options)
+{
+    RetainPtr<NSMutableDictionary> dict = adoptNS([[NSMutableDictionary alloc] initWithCapacity:options.size()]);
+    for (const auto& item : options) {
+        auto key = item.first.toID();
+        RetainPtr<id> value;
+
+        WTF::switchOn(item.second,
+            [&] (const bool& b) {
+                value = @(b);
+            },
+            [&] (const CoreIPCString& s) {
+                value = s.toID();
+            },
+            [&] (const CoreIPCSecTrustData::PolicyArrayOfNumbers& a) {
+                RetainPtr array = adoptNS([[NSMutableArray alloc] initWithCapacity:a.size()]);
+                for (const auto& number : a)
+                    [array addObject:number.toID().get()];
+                value = array;
+            },
+            [&] (const CoreIPCSecTrustData::PolicyArrayOfStrings& a) {
+                RetainPtr array = adoptNS([[NSMutableArray alloc] initWithCapacity:a.size()]);
+                for (const auto& str : a)
+                    [array addObject:str.toID().get()];
+                value = array;
+            },
+            [&] (const CoreIPCSecTrustData::PolicyArrayOfData& a) {
+                RetainPtr array = adoptNS([[NSMutableArray alloc] initWithCapacity:a.size()]);
+                for (const auto& d : a)
+                    [array addObject:d.toID().get()];
+                value = array;
+            },
+            [&] (const CoreIPCSecTrustData::PolicyArrayOfArrayContainingDateOrNumbers& a) {
+                RetainPtr outerArray = adoptNS([[NSMutableArray alloc] initWithCapacity:a.size()]);
+                for (const Vector<std::variant<CoreIPCNumber, CoreIPCDate>>& inner : a) {
+                    RetainPtr innerArray = adoptNS([[NSMutableArray alloc] initWithCapacity:inner.size()]);
+                    for (const std::variant<CoreIPCNumber, CoreIPCDate>& v : inner) {
+                        WTF::switchOn(v,
+                            [&] (const CoreIPCNumber& i) {
+                                [innerArray addObject:i.toID().get()];
+                            },
+                            [&] (const CoreIPCDate& d) {
+                                [innerArray addObject:d.toID().get()];
+                            }
+                        );
+                    }
+                    [outerArray addObject:innerArray.get()];
+                }
+                value = outerArray;
+            },
+            [&] (const CoreIPCSecTrustData::PolicyDictionaryValueIsNumber& a) {
+                RetainPtr d = adoptNS([[NSMutableDictionary alloc] initWithCapacity:a.size()]);
+                for (const auto& i : a)
+                    [d setObject:i.second.toID().get() forKey:i.first.toID().get()];
+                value = d;
+            }
+        );
+        [dict setObject:value.get() forKey:key.get()];
+    }
+    return dict;
+}
+
+static void addToDictFromOptionalDataHelper(const std::optional<Vector<CoreIPCData>>& opt, RetainPtr<NSMutableDictionary> dict, NSString* key)
+{
+    if (!opt)
+        return;
+    RetainPtr array = adoptNS([[NSMutableArray alloc] initWithCapacity:opt->size()]);
+    for (const CoreIPCData& d : *opt)
+        [array addObject:d.toID().get()];
+    [dict.get() setObject:array.get() forKey:key];
+}
+
+RetainPtr<SecTrustRef> CoreIPCSecTrust::createSecTrust() const
+{
+    if (!m_data)
+        return { nullptr };
+
+    auto dict = adoptNS([[NSMutableDictionary alloc] initWithCapacity:5]);
+
+    RetainPtr<NSNumber> result;
+
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    switch (m_data->result) {
+    case CoreIPCSecTrustResult::Invalid:
+        result = @(kSecTrustResultInvalid);
+        break;
+    case CoreIPCSecTrustResult::Proceed:
+        result = @(kSecTrustResultProceed);
+        break;
+    case CoreIPCSecTrustResult::Confirm:
+        result = @(kSecTrustResultConfirm); // Deprecated
+        break;
+    case CoreIPCSecTrustResult::Deny:
+        result = @(kSecTrustResultDeny);
+        break;
+    case CoreIPCSecTrustResult::Unspecified:
+        result = @(kSecTrustResultUnspecified);
+        break;
+    case CoreIPCSecTrustResult::RecoverableTrustFailure:
+        result = @(kSecTrustResultRecoverableTrustFailure);
+        break;
+    case CoreIPCSecTrustResult::FatalTrustFailure:
+        result = @(kSecTrustResultFatalTrustFailure);
+        break;
+    case CoreIPCSecTrustResult::OtherError:
+        result = @(kSecTrustResultOtherError);
+        break;
+    default:
+        result = @(kSecTrustResultInvalid);
+        RELEASE_LOG_ERROR(IPC, "CoreIPCSecTrustData had an unexpected value");
+        ASSERT_NOT_REACHED();
+        break;
+    }
+ALLOW_DEPRECATED_DECLARATIONS_END
+    [dict setObject:result.get() forKey:@"result"];
+
+    [dict setObject:@(m_data->anchorsOnly) forKey:@"anchorsOnly"];
+    [dict setObject:@(m_data->keychainsAllowed) forKey:@"keychainsAllowed"];
+
+    if (!m_data->certificates.isEmpty()) {
+        RetainPtr certificates = adoptNS([[NSMutableArray alloc] initWithCapacity:m_data->certificates.size()]);
+        for (const CoreIPCData& cert : m_data->certificates)
+            [certificates addObject:cert.toID().get()];
+        [dict setObject:certificates.get() forKey:@"certificates"];
+    }
+
+    if (!m_data->chain.isEmpty()) {
+        RetainPtr chain = adoptNS([[NSMutableArray alloc] initWithCapacity:m_data->chain.size()]);
+        for (const CoreIPCData& cert : m_data->chain)
+            [chain addObject:cert.toID().get()];
+        [dict setObject:chain.get() forKey:@"chain"];
+    }
+
+    if (!m_data->policies.isEmpty()) {
+        RetainPtr policies = adoptNS([[NSMutableArray alloc] initWithCapacity:m_data->policies.size()]);
+
+        for (const auto& policyType : m_data->policies) {
+            if (!policyType.isEmpty()) {
+                RetainPtr policy = adoptNS([[NSMutableDictionary alloc] initWithCapacity:policyType.size()]);
+                for (const auto& typeValue : policyType) {
+                    RetainPtr<id> value;
+                    RetainPtr<NSString> key = typeValue.first.toID();
+                    WTF::switchOn(typeValue.second,
+                        [&] (const CoreIPCString& s) {
+                            value = s.toID();
+                        },
+                        [&] (const CoreIPCSecTrustData::PolicyOption& options) {
+                            RetainPtr<NSDictionary> d = createPolicyDictionary(options);
+                            value = d;
+                        }
+                    );
+                    [policy setObject:value.get() forKey:key.get()];
+                }
+                [policies addObject:policy.get()];
+            }
+        }
+        [dict setObject:policies.get() forKey:@"policies"];
+    }
+
+    if (!m_data->details.isEmpty()) {
+        RetainPtr details = adoptNS([[NSMutableArray alloc] initWithCapacity:m_data->details.size()]);
+        for (const auto& detail : m_data->details) {
+            RetainPtr d = adoptNS([[NSMutableDictionary alloc] initWithCapacity:detail.size()]);
+            for (const auto& item : detail)
+                [d setObject:@(item.second) forKey:item.first.toID().get()];
+            [details addObject:d.get()];
+        }
+        [dict setObject:details.get() forKey:@"details"];
+    }
+
+    if (m_data->verifyDate)
+        [dict setObject:m_data->verifyDate->toID().get() forKey:@"verifyDate"];
+
+    if (m_data->info) {
+        RetainPtr info = adoptNS([[NSMutableDictionary alloc] initWithCapacity:m_data->info->size()]);
+        for (const auto& pair : *m_data->info) {
+            RetainPtr<id> value;
+            auto key = pair.first.toID();
+            WTF::switchOn(pair.second,
+                [&] (const bool& b) {
+                    value = @(b);
+                },
+                [&] (const CoreIPCDate& d) {
+                    value = d.toID();
+                },
+                [&] (const CoreIPCString& s) {
+                    value = s.toID();
+                }
+            );
+            [info setObject:value.get() forKey:key.get()];
+        }
+        [dict setObject:info.get() forKey:@"info"];
+    }
+
+    addToDictFromOptionalDataHelper(m_data->responses, dict, @"responses");
+    addToDictFromOptionalDataHelper(m_data->scts, dict, @"scts");
+    addToDictFromOptionalDataHelper(m_data->anchors, dict, @"anchors");
+    addToDictFromOptionalDataHelper(m_data->trustedLogs, dict, @"trustedLogs");
+
+    if (m_data->exceptions) {
+        RetainPtr exceptions = adoptNS([[NSMutableArray alloc] initWithCapacity:m_data->exceptions->size()]);
+        for (const auto& e : *m_data->exceptions) {
+            RetainPtr exception = adoptNS([[NSMutableDictionary alloc] initWithCapacity:e.size()]);
+            for (const auto& item : e) {
+                RetainPtr<id> value;
+                RetainPtr<NSString> key = item.first.toID();
+                WTF::switchOn(item.second,
+                    [&] (const bool& b) {
+                        value = @(b);
+                    },
+                    [&] (const CoreIPCData& d) {
+                        value = d.toID();
+                    },
+                    [&] (const CoreIPCNumber& n) {
+                        value = n.toID();
+                    }
+                );
+                [exception setObject:value.get() forKey:key.get()];
+            }
+            [exceptions addObject:exception.get()];
+        }
+        [dict setObject:exceptions.get() forKey:@"exceptions"];
+    }
+
+    CFErrorRef error;
+    RetainPtr trust = adoptCF(SecTrustCreateFromPropertyListRepresentation(dict.get(), &error));
+    if (error) {
+        RELEASE_LOG_ERROR(IPC, "CoreIPCSecTrust error creating trust object");
+        return { nullptr };
+    }
+    return trust;
+}
+
+#undef RETURN_IF_OPTIONAL_ERROR
+
+} // namespace WebKit
+
+#endif

--- a/Source/WebKit/Shared/cf/CoreIPCSecTrust.serialization.in
+++ b/Source/WebKit/Shared/cf/CoreIPCSecTrust.serialization.in
@@ -24,8 +24,60 @@
 
 webkit_platform_headers: "CoreIPCSecTrust.h"
 
+#if HAVE(WK_SECURE_CODING_SECTRUST)
+
+header: "CoreIPCSecTrust.h"
+[CustomHeader, WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] enum class WebKit::CoreIPCSecTrustResult : uint8_t {
+    Invalid,
+    Proceed,
+    Confirm,
+    Deny,
+    Unspecified,
+    RecoverableTrustFailure,
+    FatalTrustFailure,
+    OtherError
+};
+
+using WebKit::CoreIPCSecTrustData::Detail = Vector<std::pair<WebKit::CoreIPCString, bool>>;
+using WebKit::CoreIPCSecTrustData::InfoOption = std::variant<WebKit::CoreIPCDate, WebKit::CoreIPCString, bool>;
+using WebKit::CoreIPCSecTrustData::InfoType = Vector<std::pair<WebKit::CoreIPCString, WebKit::CoreIPCSecTrustData::InfoOption>>;
+using WebKit::CoreIPCSecTrustData::PolicyDictionaryValueIsNumber = Vector<std::pair<WebKit::CoreIPCString, WebKit::CoreIPCNumber>>;
+using WebKit::CoreIPCSecTrustData::PolicyArrayOfArrayContainingDateOrNumbers = Vector<Vector<std::variant<WebKit::CoreIPCNumber, WebKit::CoreIPCDate>>>;
+using WebKit::CoreIPCSecTrustData::PolicyArrayOfNumbers = Vector<WebKit::CoreIPCNumber>;
+using WebKit::CoreIPCSecTrustData::PolicyArrayOfStrings = Vector<WebKit::CoreIPCString>;
+using WebKit::CoreIPCSecTrustData::PolicyArrayOfData = Vector<WebKit::CoreIPCData>;
+using WebKit::CoreIPCSecTrustData::PolicyVariant = std::variant<bool, WebKit::CoreIPCString, WebKit::CoreIPCSecTrustData::PolicyArrayOfNumbers,WebKit::CoreIPCSecTrustData::PolicyArrayOfStrings,WebKit::CoreIPCSecTrustData::PolicyArrayOfData,WebKit::CoreIPCSecTrustData::PolicyArrayOfArrayContainingDateOrNumbers,WebKit::CoreIPCSecTrustData::PolicyDictionaryValueIsNumber>;
+using WebKit::CoreIPCSecTrustData::PolicyOption = Vector<std::pair<WebKit::CoreIPCString, WebKit::CoreIPCSecTrustData::PolicyVariant>>;
+using WebKit::CoreIPCSecTrustData::PolicyValue = std::variant<WebKit::CoreIPCString, WebKit::CoreIPCSecTrustData::PolicyOption>
+using WebKit::CoreIPCSecTrustData::PolicyType = Vector<std::pair<WebKit::CoreIPCString, WebKit::CoreIPCSecTrustData::PolicyValue>>;
+using WebKit::CoreIPCSecTrustData::ExceptionType = Vector<std::pair<WebKit::CoreIPCString, std::variant<WebKit::CoreIPCNumber, WebKit::CoreIPCData, bool>>>;
+
+header: "CoreIPCSecTrust.h"
+[CustomHeader, WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] struct WebKit::CoreIPCSecTrustData {
+    WebKit::CoreIPCSecTrustResult result;
+    bool anchorsOnly;
+    bool keychainsAllowed;
+    Vector<WebKit::CoreIPCData> certificates;
+    Vector<WebKit::CoreIPCData> chain;
+    Vector<WebKit::CoreIPCSecTrustData::Detail> details;
+    Vector<WebKit::CoreIPCSecTrustData::PolicyType> policies;
+    std::optional<WebKit::CoreIPCSecTrustData::InfoType> info;
+    std::optional<WebKit::CoreIPCDate> verifyDate;
+    std::optional<Vector<WebKit::CoreIPCData>> responses;
+    std::optional<Vector<WebKit::CoreIPCData>> scts;
+    std::optional<Vector<WebKit::CoreIPCData>> anchors;
+    std::optional<Vector<WebKit::CoreIPCData>> trustedLogs;
+    std::optional<Vector<WebKit::CoreIPCSecTrustData::ExceptionType>> exceptions;
+};
+
+[WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WebKit::CoreIPCSecTrust {
+    std::optional<WebKit::CoreIPCSecTrustData> m_data;
+}
+#endif
+#if !HAVE(WK_SECURE_CODING_SECTRUST)
 [WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WebKit::CoreIPCSecTrust {
     std::span<const uint8_t> dataReference();
 }
+#endif
 
 #endif // USE(CF)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2471,6 +2471,7 @@
 		F4ABDB632B018C4B00C5471A /* CoreIPCError.h in Headers */ = {isa = PBXBuildFile; fileRef = F4ABDB602B018C1A00C5471A /* CoreIPCError.h */; };
 		F4ABDB662B01C68F00C5471A /* CoreIPCError.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4ABDB622B018C1B00C5471A /* CoreIPCError.mm */; };
 		F4ABDB732B0417AD00C5471A /* CoreIPCLocale.h in Headers */ = {isa = PBXBuildFile; fileRef = F4ABDB722B0417AD00C5471A /* CoreIPCLocale.h */; };
+		F4B021E72D0BAC2D00D9145E /* CoreIPCSecTrust.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4B021E62D0BAB6D00D9145E /* CoreIPCSecTrust.mm */; };
 		F4BA33F225757E89000A3CE8 /* WKImageAnalysisGestureRecognizer.h in Headers */ = {isa = PBXBuildFile; fileRef = F4BA33F025757E89000A3CE8 /* WKImageAnalysisGestureRecognizer.h */; };
 		F4BCBBEC2AC332AA00C1858D /* WKFormAccessoryView.h in Headers */ = {isa = PBXBuildFile; fileRef = F4BCBBE62AC3295300C1858D /* WKFormAccessoryView.h */; };
 		F4BE0D7727AAE1CB005F0323 /* PlaybackSessionContextIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = F4BE0D7627AAE1CB005F0323 /* PlaybackSessionContextIdentifier.h */; };
@@ -8238,6 +8239,7 @@
 		F4ABDB722B0417AD00C5471A /* CoreIPCLocale.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreIPCLocale.h; sourceTree = "<group>"; };
 		F4ABDB742B041FE900C5471A /* CoreIPCLocale.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CoreIPCLocale.serialization.in; sourceTree = "<group>"; };
 		F4AC655E22A3140E00A05607 /* WebPreferencesDefaultValuesIOS.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = WebPreferencesDefaultValuesIOS.mm; path = ios/WebPreferencesDefaultValuesIOS.mm; sourceTree = "<group>"; };
+		F4B021E62D0BAB6D00D9145E /* CoreIPCSecTrust.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCSecTrust.mm; sourceTree = "<group>"; };
 		F4B378D021DDBBAB0095A378 /* WebUndoStepID.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebUndoStepID.h; sourceTree = "<group>"; };
 		F4B63E162C49586700BC59EF /* CoreIPCPlist.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCPlist.serialization.in; sourceTree = "<group>"; };
 		F4BA33F025757E89000A3CE8 /* WKImageAnalysisGestureRecognizer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKImageAnalysisGestureRecognizer.h; path = ios/WKImageAnalysisGestureRecognizer.h; sourceTree = "<group>"; };
@@ -9555,6 +9557,7 @@
 				561A54602B6438C000073A72 /* CoreIPCSecKeychainItem.h */,
 				561A545F2B6438BF00073A72 /* CoreIPCSecKeychainItem.serialization.in */,
 				562674F32B69B4C7008BB425 /* CoreIPCSecTrust.h */,
+				F4B021E62D0BAB6D00D9145E /* CoreIPCSecTrust.mm */,
 				562674F42B69B4C8008BB425 /* CoreIPCSecTrust.serialization.in */,
 			);
 			path = cf;
@@ -19739,6 +19742,7 @@
 				F4F12CB02C48B2C800BC1254 /* CoreIPCPlistDictionary.mm in Sources */,
 				F4F12CAD2C485BE200BC1254 /* CoreIPCPlistObject.mm in Sources */,
 				564599972B71C3B700BC59E6 /* CoreIPCPresentationIntent.mm in Sources */,
+				F4B021E72D0BAC2D00D9145E /* CoreIPCSecTrust.mm in Sources */,
 				5197FAED2AFD33FF009180C5 /* CoreIPCSecureCoding.mm in Sources */,
 				5131D5462AE9D5230016EF39 /* CoreTextHelpers.mm in Sources */,
 				51AD56862B1AB839001A0ECB /* GeneratedWebKitSecureCoding.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
@@ -184,11 +184,26 @@ static bool secTrustRefsEqual(SecTrustRef trust1, SecTrustRef trust2)
 {
     // SecTrust doesn't compare equal after round-tripping through SecTrustSerialize/SecTrustDeserialize <rdar://122051396>
     // Therefore, we compare all the attributes we can access to verify equality.
+    CFErrorRef error = NULL;
+    bool equal;
+#if HAVE(WK_SECURE_CODING_SECTRUST)
+    CFPropertyListRef trust1Plist = SecTrustCopyPropertyListRepresentation(trust1, &error);
+    EXPECT_FALSE(error);
+    CFPropertyListRef trust2Plist = SecTrustCopyPropertyListRepresentation(trust2, &error);
+    EXPECT_FALSE(error);
+    EXPECT_TRUE(CFGetTypeID(trust1Plist) == CFDictionaryGetTypeID());
+    EXPECT_TRUE(CFGetTypeID(trust2Plist) == CFDictionaryGetTypeID());
+    equal = CFEqual(trust1Plist, trust2Plist);
+    EXPECT_TRUE(equal);
+    CFRelease(trust1Plist);
+    CFRelease(trust2Plist);
+#endif
+
     SecKeyRef pk1 = SecTrustCopyPublicKey(trust1);
     SecKeyRef pk2 = SecTrustCopyPublicKey(trust2);
     EXPECT_TRUE(pk1);
     EXPECT_TRUE(pk2);
-    bool equal = CFEqual(pk1, pk2);
+    equal = CFEqual(pk1, pk2);
     CFRelease(pk1);
     CFRelease(pk2);
     EXPECT_TRUE(equal);
@@ -205,22 +220,33 @@ static bool secTrustRefsEqual(SecTrustRef trust1, SecTrustRef trust2)
     EXPECT_TRUE(ex1);
     EXPECT_TRUE(ex2);
     equal = CFEqual(ex1, ex2);
+
+    CFPropertyListFormat format;
+    CFPropertyListRef ex1plist = CFPropertyListCreateWithData(
+        kCFAllocatorDefault,
+        ex1,
+        kCFPropertyListImmutable,
+        &format,
+        &error
+    );
+    EXPECT_FALSE(error);
+    CFPropertyListRef ex2plist = CFPropertyListCreateWithData(
+        kCFAllocatorDefault,
+        ex2,
+        kCFPropertyListImmutable,
+        &format,
+        &error
+    );
+    EXPECT_FALSE(error);
+    equal = CFEqual(ex1plist, ex2plist);
     CFRelease(ex1);
     CFRelease(ex2);
+    CFRelease(ex1plist);
+    CFRelease(ex2plist);
     EXPECT_TRUE(equal);
     if (!equal)
         return false;
-
     CFArrayRef array1, array2;
-    EXPECT_TRUE(SecTrustCopyPolicies(trust1, &array1) == errSecSuccess);
-    EXPECT_TRUE(SecTrustCopyPolicies(trust2, &array2) == errSecSuccess);
-    equal = CFEqual(array1, array2);
-    CFRelease(array1);
-    CFRelease(array2);
-    EXPECT_TRUE(equal);
-    if (!equal)
-        return false;
-
     EXPECT_TRUE(SecTrustCopyPolicies(trust1, &array1) == errSecSuccess);
     EXPECT_TRUE(SecTrustCopyPolicies(trust2, &array2) == errSecSuccess);
     equal = CFEqual(array1, array2);
@@ -233,14 +259,16 @@ static bool secTrustRefsEqual(SecTrustRef trust1, SecTrustRef trust2)
 #if HAVE(SECTRUST_COPYPROPERTIES)
     array1 = SecTrustCopyProperties(trust1);
     array2 = SecTrustCopyProperties(trust2);
-    EXPECT_TRUE(array1);
-    EXPECT_TRUE(array2);
-    equal = CFEqual(array1, array2);
-    CFRelease(array1);
-    CFRelease(array2);
-    EXPECT_TRUE(equal);
-    if (!equal)
-        return false;
+    if (array1 && array2) {
+        equal = CFEqual(array1, array2);
+        CFRelease(array1);
+        CFRelease(array2);
+        EXPECT_TRUE(equal);
+        if (!equal)
+            return false;
+    }
+    bool onlyOneIsNil = (!array1 && array2) || (!array2 && array1);
+    EXPECT_FALSE(onlyOneIsNil);
 #endif
 
     Boolean bool1, bool2;
@@ -1346,6 +1374,302 @@ TEST(IPCSerialization, Basic)
 #endif
     runTestNS({ [NSURLCredential credentialWithUser:@"user" password:@"password" persistence:NSURLCredentialPersistenceSynchronizable] });
 }
+
+#if HAVE(WK_SECURE_CODING_SECTRUST)
+String cert1(""
+    "MIIHezCCBmOgAwIBAgIQfrZYqgaHdOKdEb5ZVqa0LTANBgkqhkiG9w0BAQsFADBRMQswCQYDVQQGEw"
+    "JVUzETMBEGA1UEChMKQXBwbGUgSW5jLjEtMCsGA1UEAxMkQXBwbGUgUHVibGljIEVWIFNlcnZlciBS"
+    "U0EgQ0EgMiAtIEcxMB4XDTI0MTIwOTE3NTcwNFoXDTI1MDQwODE5NTY1NlowgccxHTAbBgNVBA8MFF"
+    "ByaXZhdGUgT3JnYW5pemF0aW9uMRMwEQYLKwYBBAGCNzwCAQMTAlVTMRswGQYLKwYBBAGCNzwCAQIM"
+    "CkNhbGlmb3JuaWExETAPBgNVBAUTCEMwODA2NTkyMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaW"
+    "Zvcm5pYTESMBAGA1UEBwwJQ3VwZXJ0aW5vMRMwEQYDVQQKDApBcHBsZSBJbmMuMRYwFAYDVQQDDA13"
+    "d3cuYXBwbGUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxlSqT8ZVN6y8/a3TDd"
+    "V9zwNyhjeCH7AEckmzN810eAKJ/079QHFI+5KisoP9Uuu0W/dWO/NVFSH6cf6zA6I1qvewAkkaocJE"
+    "TuO+OKosPXWZpAGFUcoT1j098EQy2OCLD5DfYYGYZDIFqGzGw9jgxAfuMcIcPmHn0PbS6wX/ePTze5"
+    "kFzNTlc5//w+UtIGHi3QP327Urzyi2rjIGOWBjjKDdvqdYQl+7Sv1QKKBZpWlinNqe5POugwkOYQLb"
+    "E3MwjaVDN/iF7CE005avSxPo4G8vNKaq9VGdQuJb0qzI1M2gTD9G86oeFh5AZ0/erTAe+NshueHXK3"
+    "tX13JLNjodlwIDAQABo4ID1jCCA9IwDAYDVR0TAQH/BAIwADAfBgNVHSMEGDAWgBRQVatDoa+pSCta"
+    "waKHiQTkeg7K2jB6BggrBgEFBQcBAQRuMGwwMgYIKwYBBQUHMAKGJmh0dHA6Ly9jZXJ0cy5hcHBsZS"
+    "5jb20vYXBldnNyc2EyZzEuZGVyMDYGCCsGAQUFBzABhipodHRwOi8vb2NzcC5hcHBsZS5jb20vb2Nz"
+    "cDAzLWFwZXZzcnNhMmcxMDEwPAYDVR0RBDUwM4IQd3d3LmFwcGxlLmNvbS5jboINd3d3LmFwcGxlLm"
+    "NvbYIQaW1hZ2VzLmFwcGxlLmNvbTBgBgNVHSAEWTBXMEgGBWeBDAEBMD8wPQYIKwYBBQUHAgEWMWh0"
+    "dHBzOi8vd3d3LmFwcGxlLmNvbS9jZXJ0aWZpY2F0ZWF1dGhvcml0eS9wdWJsaWMwCwYJYIZIAYb9bA"
+    "IBMBMGA1UdJQQMMAoGCCsGAQUFBwMBMDUGA1UdHwQuMCwwKqAooCaGJGh0dHA6Ly9jcmwuYXBwbGUu"
+    "Y29tL2FwZXZzcnNhMmcxLmNybDAdBgNVHQ4EFgQURk32jbOK8tOTKUM09x18GFD6T6MwDgYDVR0PAQ"
+    "H/BAQDAgWgMA8GCSqGSIb3Y2QGVgQCBQAwggH3BgorBgEEAdZ5AgQCBIIB5wSCAeMB4QB3AH1ZHhLh"
+    "eCp7HGFnfF79+NCHXBSgTpWeuQMv2Q6MLnm4AAABk6yafEsAAAQDAEgwRgIhAOb4XXNkF7XCVLpkJY"
+    "YXdIKiD+Tziy4e0v4d+0dqXSZiAiEA5pyC6BSpmzVasV2UZLgc5Efc/JrvEJsA8gGQyeDcKZQAdgDM"
+    "+w9qhXEJZf6Vm1PO6bJ8IumFXA2XjbapflTA/kwNsAAAAZOsmnxzAAAEAwBHMEUCIQDgvdW/qcpks4"
+    "kJ8s0p3L+Dbk2oFW8WoX6Y0QTbQZ3AqAIgQKsyTTgEX7+nBebYXO9P95TnNFfZzZ8j6O3yNNBTZh4A"
+    "dgBOdaMnXJoQwzhbbNTfP1LrHfDgjhuNacCx+mSxYpo53wAAAZOsmnxNAAAEAwBHMEUCIG5b5kcJPY"
+    "mr4IYZaC0YpHwUv+qbZz8D8+PPxsfu8nGaAiEA/gFI1QZrlKSxFWnzLVNJxbnSfUxK78RfvmzAUJTu"
+    "9poAdgDgkrP8DB3I52g2H95huZZNClJ4GYpy1nLEsE2lbW9UBAAAAZOsmnxnAAAEAwBHMEUCIQCz0K"
+    "gSqiTLe9nviiPOBcnKhvfyN33UpL6gx2Ot9NF6oAIgUgLXXf+hys90XZnVumvz5omAQ8zK1iSzkLtw"
+    "GaJx6dIwDQYJKoZIhvcNAQELBQADggEBAGZWm3BMjUDhPBgvkopxXuQreRAzJmEWlD+cJdoHFYhsdf"
+    "TSIbSvO3kEsKoBzxVZPeDopZTTfqH+XLDHu46HCXYLUjEmHZi3gwd93cu8WytJc0O3Vb9HbeSChgMi"
+    "7q4zcNpzqYS9m6+z4sD6I3hCVV8iv7dqoZulTh1g9MD9bOql9eEW8LvryY6qu8JeDuha/eYU6lGJwl"
+    "eS/MTE0gr+TxmY6N0bv7xYtSlEBLXSElz7VFcq7GqsrApEqoVkk24oOpfQ4xeEDhvulyDtEOW0DT8D"
+    "l+UjuDVM264DL03VGGv1bidxXqf1ZtsLYiVfIFz+7GNj9xjKL+6JR7ir/XGGvyY="_s);
+
+String cert2(""
+    "MIIFMjCCBBqgAwIBAgIQBxd5EQBdImf2iJL2j4tQWDANBgkqhkiG9w0BAQsFADBsMQswCQYDVQQGEw"
+    "JVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3d3cuZGlnaWNlcnQuY29tMSswKQYD"
+    "VQQDEyJEaWdpQ2VydCBIaWdoIEFzc3VyYW5jZSBFViBSb290IENBMB4XDTIwMDQyOTEyNTQ1MFoXDT"
+    "MwMDQxMDIzNTk1OVowUTELMAkGA1UEBhMCVVMxEzARBgNVBAoTCkFwcGxlIEluYy4xLTArBgNVBAMT"
+    "JEFwcGxlIFB1YmxpYyBFViBTZXJ2ZXIgUlNBIENBIDIgLSBHMTCCASIwDQYJKoZIhvcNAQEBBQADgg"
+    "EPADCCAQoCggEBAOIA/aXfX7k4cUnrupPYw00z3FwU6nAvwepTO8ueUcBUsmQGppcx5BeEyngvZ8PS"
+    "ieH0GHHK7RnHbgLChyon2H9EpgYo7NQ1yrcC5THvo3VrlAP6U746ORSDxUbbv4z15kAsyvABUCFi8S"
+    "7IXkzDIjhOICNrA8fXUpUKbIccI2JvMz7Rvw5GeG7caa2u+vSI3TmBnwMcjVqlsScqY6tbE/ji7C/X"
+    "Dw7wUpMHyaQMVGPO7mJfi0/QbiUPWwnCJPYAqPpvBVjeBh0avUCGaP2ZtZc2Jns1C8h9ebJG+Z3awd"
+    "gBqQPYD2I+fy/aBtnTOkhnBJti8jxh1ThNV65S9SucZecCAwEAAaOCAekwggHlMB0GA1UdDgQWBBRQ"
+    "VatDoa+pSCtawaKHiQTkeg7K2jAfBgNVHSMEGDAWgBSxPsNpA/i/RwHUmCYaCALvY2QrwzAOBgNVHQ"
+    "8BAf8EBAMCAYYwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBIGA1UdEwEB/wQIMAYBAf8C"
+    "AQAwNAYIKwYBBQUHAQEEKDAmMCQGCCsGAQUFBzABhhhodHRwOi8vb2NzcC5kaWdpY2VydC5jb20wSw"
+    "YDVR0fBEQwQjBAoD6gPIY6aHR0cDovL2NybDMuZGlnaWNlcnQuY29tL0RpZ2lDZXJ0SGlnaEFzc3Vy"
+    "YW5jZUVWUm9vdENBLmNybDCB3AYDVR0gBIHUMIHRMIHFBglghkgBhv1sAgEwgbcwKAYIKwYBBQUHAg"
+    "EWHGh0dHBzOi8vd3d3LmRpZ2ljZXJ0LmNvbS9DUFMwgYoGCCsGAQUFBwICMH4MfEFueSB1c2Ugb2Yg"
+    "dGhpcyBDZXJ0aWZpY2F0ZSBjb25zdGl0dXRlcyBhY2NlcHRhbmNlIG9mIHRoZSBSZWx5aW5nIFBhcn"
+    "R5IEFncmVlbWVudCBsb2NhdGVkIGF0IGh0dHBzOi8vd3d3LmRpZ2ljZXJ0LmNvbS9ycGEtdWEwBwYF"
+    "Z4EMAQEwDQYJKoZIhvcNAQELBQADggEBAKZebFC2ZVwrTj+u6nDo3O03e0/g/hN+6U5iA7X9dBGmQx"
+    "3C7NkPNAV0mUoaklsceIBIQ/bC7utdgwnSKTnm5HdVipASyLloU7TP2jAtDQdAxBavmLnFwcwXBp6n"
+    "17uLp+uPU4DZgubM96LyUQilUlYERbgu66rCK18jRmobDvFT8E71oU13o1Oe/1WUHFbTynRkKW73JD"
+    "d2rZ21Pim7LEJVY3OcRmtYNHaM/lunYx1ZQ+0fw7Hc5J/xR7vlRiuyP+fJ9ucuDYupLg333Di5R7JZ"
+    "IfnX42ecX0Dd0wIeuFj0HBjH6c25FUov/Fa5Zjr0VPjmmgN6PnoMArUZXDkQe3M="_s);
+
+String chain1(""
+    "MIIHezCCBmOgAwIBAgIQfrZYqgaHdOKdEb5ZVqa0LTANBgkqhkiG9w0BAQsFADBRMQswCQYDVQQGEw"
+    "JVUzETMBEGA1UEChMKQXBwbGUgSW5jLjEtMCsGA1UEAxMkQXBwbGUgUHVibGljIEVWIFNlcnZlciBS"
+    "U0EgQ0EgMiAtIEcxMB4XDTI0MTIwOTE3NTcwNFoXDTI1MDQwODE5NTY1NlowgccxHTAbBgNVBA8MFF"
+    "ByaXZhdGUgT3JnYW5pemF0aW9uMRMwEQYLKwYBBAGCNzwCAQMTAlVTMRswGQYLKwYBBAGCNzwCAQIM"
+    "CkNhbGlmb3JuaWExETAPBgNVBAUTCEMwODA2NTkyMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaW"
+    "Zvcm5pYTESMBAGA1UEBwwJQ3VwZXJ0aW5vMRMwEQYDVQQKDApBcHBsZSBJbmMuMRYwFAYDVQQDDA13"
+    "d3cuYXBwbGUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxlSqT8ZVN6y8/a3TDd"
+    "V9zwNyhjeCH7AEckmzN810eAKJ/079QHFI+5KisoP9Uuu0W/dWO/NVFSH6cf6zA6I1qvewAkkaocJE"
+    "TuO+OKosPXWZpAGFUcoT1j098EQy2OCLD5DfYYGYZDIFqGzGw9jgxAfuMcIcPmHn0PbS6wX/ePTze5"
+    "kFzNTlc5//w+UtIGHi3QP327Urzyi2rjIGOWBjjKDdvqdYQl+7Sv1QKKBZpWlinNqe5POugwkOYQLb"
+    "E3MwjaVDN/iF7CE005avSxPo4G8vNKaq9VGdQuJb0qzI1M2gTD9G86oeFh5AZ0/erTAe+NshueHXK3"
+    "tX13JLNjodlwIDAQABo4ID1jCCA9IwDAYDVR0TAQH/BAIwADAfBgNVHSMEGDAWgBRQVatDoa+pSCta"
+    "waKHiQTkeg7K2jB6BggrBgEFBQcBAQRuMGwwMgYIKwYBBQUHMAKGJmh0dHA6Ly9jZXJ0cy5hcHBsZS"
+    "5jb20vYXBldnNyc2EyZzEuZGVyMDYGCCsGAQUFBzABhipodHRwOi8vb2NzcC5hcHBsZS5jb20vb2Nz"
+    "cDAzLWFwZXZzcnNhMmcxMDEwPAYDVR0RBDUwM4IQd3d3LmFwcGxlLmNvbS5jboINd3d3LmFwcGxlLm"
+    "NvbYIQaW1hZ2VzLmFwcGxlLmNvbTBgBgNVHSAEWTBXMEgGBWeBDAEBMD8wPQYIKwYBBQUHAgEWMWh0"
+    "dHBzOi8vd3d3LmFwcGxlLmNvbS9jZXJ0aWZpY2F0ZWF1dGhvcml0eS9wdWJsaWMwCwYJYIZIAYb9bA"
+    "IBMBMGA1UdJQQMMAoGCCsGAQUFBwMBMDUGA1UdHwQuMCwwKqAooCaGJGh0dHA6Ly9jcmwuYXBwbGUu"
+    "Y29tL2FwZXZzcnNhMmcxLmNybDAdBgNVHQ4EFgQURk32jbOK8tOTKUM09x18GFD6T6MwDgYDVR0PAQ"
+    "H/BAQDAgWgMA8GCSqGSIb3Y2QGVgQCBQAwggH3BgorBgEEAdZ5AgQCBIIB5wSCAeMB4QB3AH1ZHhLh"
+    "eCp7HGFnfF79+NCHXBSgTpWeuQMv2Q6MLnm4AAABk6yafEsAAAQDAEgwRgIhAOb4XXNkF7XCVLpkJY"
+    "YXdIKiD+Tziy4e0v4d+0dqXSZiAiEA5pyC6BSpmzVasV2UZLgc5Efc/JrvEJsA8gGQyeDcKZQAdgDM"
+    "+w9qhXEJZf6Vm1PO6bJ8IumFXA2XjbapflTA/kwNsAAAAZOsmnxzAAAEAwBHMEUCIQDgvdW/qcpks4"
+    "kJ8s0p3L+Dbk2oFW8WoX6Y0QTbQZ3AqAIgQKsyTTgEX7+nBebYXO9P95TnNFfZzZ8j6O3yNNBTZh4A"
+    "dgBOdaMnXJoQwzhbbNTfP1LrHfDgjhuNacCx+mSxYpo53wAAAZOsmnxNAAAEAwBHMEUCIG5b5kcJPY"
+    "mr4IYZaC0YpHwUv+qbZz8D8+PPxsfu8nGaAiEA/gFI1QZrlKSxFWnzLVNJxbnSfUxK78RfvmzAUJTu"
+    "9poAdgDgkrP8DB3I52g2H95huZZNClJ4GYpy1nLEsE2lbW9UBAAAAZOsmnxnAAAEAwBHMEUCIQCz0K"
+    "gSqiTLe9nviiPOBcnKhvfyN33UpL6gx2Ot9NF6oAIgUgLXXf+hys90XZnVumvz5omAQ8zK1iSzkLtw"
+    "GaJx6dIwDQYJKoZIhvcNAQELBQADggEBAGZWm3BMjUDhPBgvkopxXuQreRAzJmEWlD+cJdoHFYhsdf"
+    "TSIbSvO3kEsKoBzxVZPeDopZTTfqH+XLDHu46HCXYLUjEmHZi3gwd93cu8WytJc0O3Vb9HbeSChgMi"
+    "7q4zcNpzqYS9m6+z4sD6I3hCVV8iv7dqoZulTh1g9MD9bOql9eEW8LvryY6qu8JeDuha/eYU6lGJwl"
+    "eS/MTE0gr+TxmY6N0bv7xYtSlEBLXSElz7VFcq7GqsrApEqoVkk24oOpfQ4xeEDhvulyDtEOW0DT8D"
+    "l+UjuDVM264DL03VGGv1bidxXqf1ZtsLYiVfIFz+7GNj9xjKL+6JR7ir/XGGvyY="_s);
+
+String chain2(""
+    "MIIFMjCCBBqgAwIBAgIQBxd5EQBdImf2iJL2j4tQWDANBgkqhkiG9w0BAQsFADBsMQswCQYDVQQGEw"
+    "JVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3d3cuZGlnaWNlcnQuY29tMSswKQYD"
+    "VQQDEyJEaWdpQ2VydCBIaWdoIEFzc3VyYW5jZSBFViBSb290IENBMB4XDTIwMDQyOTEyNTQ1MFoXDT"
+    "MwMDQxMDIzNTk1OVowUTELMAkGA1UEBhMCVVMxEzARBgNVBAoTCkFwcGxlIEluYy4xLTArBgNVBAMT"
+    "JEFwcGxlIFB1YmxpYyBFViBTZXJ2ZXIgUlNBIENBIDIgLSBHMTCCASIwDQYJKoZIhvcNAQEBBQADgg"
+    "EPADCCAQoCggEBAOIA/aXfX7k4cUnrupPYw00z3FwU6nAvwepTO8ueUcBUsmQGppcx5BeEyngvZ8PS"
+    "ieH0GHHK7RnHbgLChyon2H9EpgYo7NQ1yrcC5THvo3VrlAP6U746ORSDxUbbv4z15kAsyvABUCFi8S"
+    "7IXkzDIjhOICNrA8fXUpUKbIccI2JvMz7Rvw5GeG7caa2u+vSI3TmBnwMcjVqlsScqY6tbE/ji7C/X"
+    "Dw7wUpMHyaQMVGPO7mJfi0/QbiUPWwnCJPYAqPpvBVjeBh0avUCGaP2ZtZc2Jns1C8h9ebJG+Z3awd"
+    "gBqQPYD2I+fy/aBtnTOkhnBJti8jxh1ThNV65S9SucZecCAwEAAaOCAekwggHlMB0GA1UdDgQWBBRQ"
+    "VatDoa+pSCtawaKHiQTkeg7K2jAfBgNVHSMEGDAWgBSxPsNpA/i/RwHUmCYaCALvY2QrwzAOBgNVHQ"
+    "8BAf8EBAMCAYYwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBIGA1UdEwEB/wQIMAYBAf8C"
+    "AQAwNAYIKwYBBQUHAQEEKDAmMCQGCCsGAQUFBzABhhhodHRwOi8vb2NzcC5kaWdpY2VydC5jb20wSw"
+    "YDVR0fBEQwQjBAoD6gPIY6aHR0cDovL2NybDMuZGlnaWNlcnQuY29tL0RpZ2lDZXJ0SGlnaEFzc3Vy"
+    "YW5jZUVWUm9vdENBLmNybDCB3AYDVR0gBIHUMIHRMIHFBglghkgBhv1sAgEwgbcwKAYIKwYBBQUHAg"
+    "EWHGh0dHBzOi8vd3d3LmRpZ2ljZXJ0LmNvbS9DUFMwgYoGCCsGAQUFBwICMH4MfEFueSB1c2Ugb2Yg"
+    "dGhpcyBDZXJ0aWZpY2F0ZSBjb25zdGl0dXRlcyBhY2NlcHRhbmNlIG9mIHRoZSBSZWx5aW5nIFBhcn"
+    "R5IEFncmVlbWVudCBsb2NhdGVkIGF0IGh0dHBzOi8vd3d3LmRpZ2ljZXJ0LmNvbS9ycGEtdWEwBwYF"
+    "Z4EMAQEwDQYJKoZIhvcNAQELBQADggEBAKZebFC2ZVwrTj+u6nDo3O03e0/g/hN+6U5iA7X9dBGmQx"
+    "3C7NkPNAV0mUoaklsceIBIQ/bC7utdgwnSKTnm5HdVipASyLloU7TP2jAtDQdAxBavmLnFwcwXBp6n"
+    "17uLp+uPU4DZgubM96LyUQilUlYERbgu66rCK18jRmobDvFT8E71oU13o1Oe/1WUHFbTynRkKW73JD"
+    "d2rZ21Pim7LEJVY3OcRmtYNHaM/lunYx1ZQ+0fw7Hc5J/xR7vlRiuyP+fJ9ucuDYupLg333Di5R7JZ"
+    "IfnX42ecX0Dd0wIeuFj0HBjH6c25FUov/Fa5Zjr0VPjmmgN6PnoMArUZXDkQe3M="_s);
+
+String chain3(""
+    "MIIDxTCCAq2gAwIBAgIQAqxcJmoLQJuPC3nyrkYldzANBgkqhkiG9w0BAQUFADBsMQswCQYDVQQGEw"
+    "JVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3d3cuZGlnaWNlcnQuY29tMSswKQYD"
+    "VQQDEyJEaWdpQ2VydCBIaWdoIEFzc3VyYW5jZSBFViBSb290IENBMB4XDTA2MTExMDAwMDAwMFoXDT"
+    "MxMTExMDAwMDAwMFowbDELMAkGA1UEBhMCVVMxFTATBgNVBAoTDERpZ2lDZXJ0IEluYzEZMBcGA1UE"
+    "CxMQd3d3LmRpZ2ljZXJ0LmNvbTErMCkGA1UEAxMiRGlnaUNlcnQgSGlnaCBBc3N1cmFuY2UgRVYgUm"
+    "9vdCBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMbM5XPm+9S75S0tMqbf5YE/yc0l"
+    "SbZxKsPVlDRnogocsF9ppkCxxLeyj9CYpKlBWTrT3JTWPNt0OKRKzE0lgvdKpVMSOO7zSW1xkX5jtq"
+    "umX8OkhPhPYlG++MXs2ziS4wblCJEMxChBVfvLWokVfnHoNb9Ncgk9vjo4UFt3MRuNs8ckRZqnrG0A"
+    "FFoEt7oT61EKmEFBIk5lYYeBQVCmeVyJ3hlKV9Uu5l0cUyx+mM0aBhakaHPQNAQTXKFx01p8VdteZO"
+    "E3hzBWBOURtCmAEvF5OYiiAhF8J2a3iLd48soKqDirCmTCv2ZdlYTBoSUeh10aUAsgEsxBu24LUTi4"
+    "S8sCAwEAAaNjMGEwDgYDVR0PAQH/BAQDAgGGMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFLE+w2"
+    "kD+L9HAdSYJhoIAu9jZCvDMB8GA1UdIwQYMBaAFLE+w2kD+L9HAdSYJhoIAu9jZCvDMA0GCSqGSIb3"
+    "DQEBBQUAA4IBAQAcGgaX3NecnzyIZgYIVyHbIUf4KmeqvxgydkAQV8GK83rZEWWONfqe/EW1ntlMMU"
+    "u4kehDLI6zeM7b41N5cdblIZQB2lWHmiRk9opmzN6cN82oNLFpmyPInngiK3BD41VHMWEZ71jFhS9O"
+    "MPagMRYjyOfiZRYzy78aG6A9+MpeizGLYAiJLQwGXFK3xPkKmNEVX58Svnw2Yzi9RKR/5CYrCsSXaQ"
+    "3pjOLAEFe4yHYSkVXySGnYvCoCWw9E1CAx2/S6cCZdkGCevEsXCS+0yx5DaMkHJ8HSXPfqIbloEpw8"
+    "nL+e/IBcm2PN7EeqJSdnoDfzAIJ9VNep+OkuE6N36B9K"_s);
+
+String extendedKeyUsage1("VR0lAA=="_s);
+String extendedKeyUsage2("KwYBBQUHAwE="_s);
+String extendedKeyUsage3("KwYBBAGCNwoDAw=="_s);
+String extendedKeyUsage4("YIZIAYb4QgQB"_s);
+
+TEST(IPCSerialization, SecTrustRef)
+{
+    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+    [dateFormatter setDateFormat:@"yyyy-MM-dd HH:mm:ss Z"];
+    [dateFormatter setTimeZone:[NSTimeZone timeZoneWithAbbreviation:@"UTC"]];
+
+    NSDictionary *appleCertificatePlist = @{
+        @"anchorsOnly" : @(NO),
+        @"certificates" : @[
+            [[NSData alloc] initWithBase64EncodedString:cert1 options:0],
+            [[NSData alloc] initWithBase64EncodedString:cert2 options:0]
+        ],
+        @"chain" : @[
+            [[NSData alloc] initWithBase64EncodedString:chain1 options:0],
+            [[NSData alloc] initWithBase64EncodedString:chain2 options:0],
+            [[NSData alloc] initWithBase64EncodedString:chain3 options:0],
+        ],
+        @"details" : @[
+            @{ },
+            @{ },
+            @{ },
+        ],
+        @"info" : @{
+            @"CertificateTransparency" : @(YES),
+            @"CompanyName" : @"Apple Inc.",
+            @"ExtendedValidation" : @(YES),
+            @"Organization" : @"Apple Inc.",
+            @"Revocation" : @(YES),
+            @"RevocationValidUntil" : [dateFormatter dateFromString:@"2024-12-20 15:15:45 +0000"],
+            @"TrustExpirationDate" : [dateFormatter dateFromString:@"2024-12-20 15:15:45 +0000"],
+            @"TrustExtendedValidation" : @(YES),
+            @"TrustResultNotAfter" : [dateFormatter dateFromString:@"2024-12-20 06:12:43 +0000"],
+            @"TrustResultNotBefore" : [dateFormatter dateFromString:@"2024-12-20 03:42:43 +0000"],
+            @"TrustRevocationChecked" : @(YES),
+        },
+        @"keychainsAllowed" : @(YES),
+        @"policies" : @[
+            @{
+                @"SecPolicyOid" : @"1.2.840.113635.100.1.3",
+                @"SecPolicyPolicyName" : @"sslServer",
+                @"policyOptions" : @{
+                    @"BasicConstraints" : @(YES),
+                    @"CriticalExtensions" : @(YES),
+                    @"DuplicateExtension" : @(YES),
+                    @"ExtendedKeyUsage" : @[
+                        [NSData new],
+                        [[NSData alloc] initWithBase64EncodedString:extendedKeyUsage1 options:0],
+                        [[NSData alloc] initWithBase64EncodedString:extendedKeyUsage2 options:0],
+                        [[NSData alloc] initWithBase64EncodedString:extendedKeyUsage3 options:0],
+                        [[NSData alloc] initWithBase64EncodedString:extendedKeyUsage4 options:0],
+                    ],
+                    @"GrayListedLeaf" : @(YES),
+                    @"IdLinkage" : @(YES),
+                    @"KeySize" : @{
+                        @"42" : @(2048),
+                        @"73" : @(256)
+                    },
+                    @"KeyUsage" : @[
+                        @(1),
+                        @(0)
+                    ],
+                    @"NonEmptySubject" : @(YES),
+                    @"OtherTrustValidityPeriod": @[
+                        @[
+                            [dateFormatter dateFromString:@"2019-06-30 23:00:00 +0000"],
+                            @(71283600)
+                        ]
+                    ],
+                    @"SSLHostname" : @"www.apple.com",
+                    @"ServerAuthEKU" : @(YES),
+                    @"SignatureHashAlgorithms" : @[
+                        @"SignatureDigestMD2",
+                        @"SignatureDigestMD4",
+                        @"SignatureDigestMD5",
+                        @"SignatureDigestSHA1"
+                    ],
+                    @"SystemTrustValidityPeriod" : @[
+                        @[
+                            [dateFormatter dateFromString:@"2018-03-01 00:00:00 +0000"],
+                            @(71283600)
+                        ],
+                        @[
+                            [dateFormatter dateFromString:@"2020-09-01 00:00:00 +0000"],
+                            @(34387200)
+                        ]
+                    ],
+                    @"SystemTrustedCTRequired" : @(YES),
+                    @"TemporalValidity" : @(YES),
+                    @"UnparseableExtension" : @(YES),
+                    @"WeakKeySize" : @(YES),
+                    @"WeakSignature" : @(YES)
+                }
+            }
+        ],
+        @"result" : @(4),
+        @"verifyDate" : [dateFormatter dateFromString:@"2024-12-20 04:57:08 +0000"],
+        @"responses" : @[
+            [NSData dataWithBytes:"AAAA" length:strlen("AAAA")]
+        ],
+        @"scts" : @[
+            [NSData dataWithBytes:"BBBB" length:strlen("BBBB")]
+        ],
+        @"anchors" : @[
+            [[NSData alloc] initWithBase64EncodedString:cert1 options:0]
+        ],
+        @"trustedLogs" : @[
+            [NSData dataWithBytes:"CCCC" length:strlen("CCCC")]
+        ],
+        @"exceptions" : @[
+            @{
+                @"Exception1" : @(YES),
+                @"Exception2" : @(NO),
+                @"Exception3" : [NSData dataWithBytes:"DDDD" length:strlen("DDDD")],
+                @"Exception4" : @(3)
+            }
+        ]
+    };
+
+    // The inline dictionary above does not compare equal. Do a serialization loop to get types which will compare equal.
+    CFErrorRef error = NULL;
+    RetainPtr<CFDataRef> dataBlob = adoptCF(CFPropertyListCreateData(
+        kCFAllocatorDefault,
+        appleCertificatePlist,
+        kCFPropertyListBinaryFormat_v1_0,
+        0,
+        &error
+    ));
+    EXPECT_FALSE(error);
+
+    CFPropertyListFormat format;
+    RetainPtr<CFPropertyListRef> recreatedAppleCertificatePlist = adoptCF(CFPropertyListCreateWithData(
+        kCFAllocatorDefault,
+        dataBlob.get(),
+        kCFPropertyListImmutable,
+        &format,
+        &error
+    ));
+    EXPECT_FALSE(error);
+
+    RetainPtr<SecTrustRef> trust = adoptCF(SecTrustCreateFromPropertyListRepresentation(recreatedAppleCertificatePlist.get(), &error));
+    EXPECT_FALSE(error);
+
+    RetainPtr<CFPropertyListRef> plistFromGeneratedObject = adoptCF(SecTrustCopyPropertyListRepresentation(trust.get(), &error));
+
+    bool loopedPlistEqual = CFEqual(recreatedAppleCertificatePlist.get(), plistFromGeneratedObject.get());
+    EXPECT_TRUE(loopedPlistEqual);
+
+    runTestCF({ trust.get() });
+}
+#endif
 
 TEST(IPCSerialization, NSShadow)
 {


### PR DESCRIPTION
#### 57afa59fdb669f391e5c12656a7e77da6a7b1655
<pre>
Migrate SecTrust to WebKitSecureCoding Interface
<a href="https://bugs.webkit.org/show_bug.cgi?id=284795">https://bugs.webkit.org/show_bug.cgi?id=284795</a>
<a href="https://rdar.apple.com/136786582">rdar://136786582</a>

Reviewed by Sihui Liu.

* Source/WTF/wtf/spi/cocoa/SecuritySPI.h:
* Source/WebKit/Shared/cf/CoreIPCSecTrust.h:
(WebKit::CoreIPCSecTrust::CoreIPCSecTrust):
* Source/WebKit/Shared/cf/CoreIPCSecTrust.mm: Added.
(WebKit::arrayElementsTheSameType):
(WebKit::CoreIPCSecTrust::detectPolicyOptionShape):
(WebKit::updatePolicyVector):
(WebKit::optionalArrayOfDataHelper):
(WebKit::CoreIPCSecTrust::CoreIPCSecTrust):
(WebKit::createPolicyDictionary):
(WebKit::addToDictFromOptionalDataHelper):
(WebKit::CoreIPCSecTrust::createSecTrust const):
* Source/WebKit/Shared/cf/CoreIPCSecTrust.serialization.in:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(secTrustRefsEqual):
(TEST(IPCSerialization, SecTrustRef)):

Canonical link: <a href="https://commits.webkit.org/289561@main">https://commits.webkit.org/289561@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8a8bed1f605b61591f9e72551d808313c8b350f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87148 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6658 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41507 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92009 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37887 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89198 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6934 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14726 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67351 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25095 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90150 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5309 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78879 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47671 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5082 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33290 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37004 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/80154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75571 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34134 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93894 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/85922 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14310 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10406 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76155 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14514 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74735 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75408 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18574 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19698 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18136 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7227 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14329 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19622 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/108414 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14074 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26085 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17517 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15855 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->