### PR TITLE
Drop mock dependency

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/archive_context_unittest.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/archive_context_unittest.py
@@ -22,12 +22,13 @@
 
 import base64
 import io
-import mock
 import os
 import zipfile
+from unittest import mock
 
 from fakeredis import FakeStrictRedis
 from redis import StrictRedis
+
 from resultsdbpy.controller.configuration import Configuration
 from resultsdbpy.model.cassandra_context import CassandraContext
 from resultsdbpy.model.mock_cassandra_context import MockCassandraContext

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/docker_unittest.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/docker_unittest.py
@@ -20,7 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import mock
+from unittest import mock
 
 from resultsdbpy.model.docker import Docker
 from resultsdbpy.model.wait_for_docker_test_case import WaitForDockerTestCase

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/mock_cassandra_context.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/mock_cassandra_context.py
@@ -20,13 +20,19 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import mock
 import re
 import time
-
-from cassandra.metadata import ColumnMetadata, KeyspaceMetadata, Metadata, TableMetadataV3
-from cassandra.util import OrderedDict
 from collections import defaultdict
+from unittest import mock
+
+from cassandra.metadata import (
+    ColumnMetadata,
+    KeyspaceMetadata,
+    Metadata,
+    TableMetadataV3,
+)
+from cassandra.util import OrderedDict
+
 from resultsdbpy.model.cassandra_context import CassandraContext
 
 

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py
@@ -24,12 +24,14 @@ import calendar
 import os
 import re
 import time
+from unittest.mock import patch
 
-from .base import Base
-
-from webkitbugspy import User, Issue, radar
 from webkitcorepy import string_utils
 from webkitcorepy.mocks import ContextStack
+
+from webkitbugspy import Issue, User, radar
+
+from .base import Base
 
 
 class AppleDirectoryUserEntry(object):
@@ -583,7 +585,6 @@ class Radar(Base, ContextStack):
         self.AppleDirectoryQuery = AppleDirectoryQuery(self)
         self.RadarClient = lambda authentication_strategy, client_system_identifier, retry_policy=None: RadarClient(self, authentication_strategy)
 
-        from mock import patch
         self.patches.append(patch('webkitbugspy.radar.Tracker.radarclient', new=lambda s=None: self))
 
         self.request_count = 0
@@ -595,5 +596,4 @@ class NoRadar(ContextStack):
     def __init__(self):
         super(NoRadar, self).__init__(NoRadar)
 
-        from mock import patch
         self.patches.append(patch('webkitbugspy.radar.Tracker.radarclient', new=lambda s=None: None))

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
@@ -21,13 +21,15 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import json
-import re
 import logging
+import re
 import unittest
+from unittest.mock import patch
 
-from mock import patch
+from webkitcorepy import OutputCapture
+from webkitcorepy import mocks as wkmocks
+
 from webkitbugspy import Tracker, User, bugzilla, mocks, radar
-from webkitcorepy import OutputCapture, mocks as wkmocks
 
 
 class TestBugzilla(unittest.TestCase):

--- a/Tools/Scripts/libraries/webkitcorepy/README.md
+++ b/Tools/Scripts/libraries/webkitcorepy/README.md
@@ -4,7 +4,7 @@ Provides a number of utilities intended to support intermediate to advanced Pyth
 
 ## Requirements
 
-The mock, requests and six libraries.
+The requests, six, and tblib libraries.
  
 ## Usage
 
@@ -14,7 +14,7 @@ from webkitcorepy import Version
 version = Version(1, 2, 3)
 ```
 
-Unicode stream management across Python 2 and 3
+Unicode stream management, designed to ease transition to Python 3
 ```
 from webkitcorepy import BytesIO, StringIO, UnicodeIO, unicode
 ```

--- a/Tools/Scripts/libraries/webkitcorepy/setup.py
+++ b/Tools/Scripts/libraries/webkitcorepy/setup.py
@@ -56,8 +56,6 @@ setup(
         'webkitcorepy.tests.mocks',
     ],
     install_requires=[
-        'inspect2',
-        'mock',
         'requests',
         'six',
         'tblib',

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
@@ -56,8 +56,6 @@ version = Version(1, 0, 1)
 
 from webkitcorepy.autoinstall import Package, AutoInstall
 
-AutoInstall.register(Package('mock', Version(5, 1, 0), wheel=True))
-
 if sys.version_info >= (3, 12):
     AutoInstall.register(Package('setuptools', Version(68, 1, 2)))
 else:

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/environment.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/environment.py
@@ -21,6 +21,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
+from unittest.mock import patch
 
 from webkitcorepy.mocks import ContextStack
 
@@ -32,7 +33,6 @@ class Environment(ContextStack):
         super(Environment, self).__init__(cls=Environment)
         self.environ = kwargs
 
-        from mock import patch
         from webkitcorepy.credentials import _cache
 
         self.patches.append(patch.dict(os.environ, kwargs))

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/requests_.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/requests_.py
@@ -21,6 +21,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import json
+from unittest import mock
 
 from webkitcorepy import string_utils
 from webkitcorepy.mocks import ContextStack
@@ -110,9 +111,8 @@ class Requests(ContextStack):
         return Response.create404(url)
 
     def __enter__(self):
-        # Allow requests and mock to be managed via autoinstall
+        # Allow requests to be managed via autoinstall
         import requests
-        from mock import patch
 
         this = self
 
@@ -127,14 +127,14 @@ class Requests(ContextStack):
                 return super(Session, self).request(method, url, **kwargs)
 
         self._temp_patches = [
-            patch('requests.Session', new=Session),
-            patch('requests.request', new=lambda *args, **kwargs: Session().request(*args, **kwargs)),
-            patch('requests.get', new=lambda *args, **kwargs: Session().request('GET', *args, **kwargs)),
-            patch('requests.head', new=lambda *args, **kwargs: Session().request('HEAD', *args, **kwargs)),
-            patch('requests.post', new=lambda *args, **kwargs: Session().request('POST', *args, **kwargs)),
-            patch('requests.put', new=lambda *args, **kwargs: Session().request('PUT', *args, **kwargs)),
-            patch('requests.patch', new=lambda *args, **kwargs: Session().request('PATCH', *args, **kwargs)),
-            patch('requests.delete', new=lambda *args, **kwargs: Session().request('DELETE', *args, **kwargs)),
+            mock.patch('requests.Session', new=Session),
+            mock.patch('requests.request', new=lambda *args, **kwargs: Session().request(*args, **kwargs)),
+            mock.patch('requests.get', new=lambda *args, **kwargs: Session().request('GET', *args, **kwargs)),
+            mock.patch('requests.head', new=lambda *args, **kwargs: Session().request('HEAD', *args, **kwargs)),
+            mock.patch('requests.post', new=lambda *args, **kwargs: Session().request('POST', *args, **kwargs)),
+            mock.patch('requests.put', new=lambda *args, **kwargs: Session().request('PUT', *args, **kwargs)),
+            mock.patch('requests.patch', new=lambda *args, **kwargs: Session().request('PATCH', *args, **kwargs)),
+            mock.patch('requests.delete', new=lambda *args, **kwargs: Session().request('DELETE', *args, **kwargs)),
         ]
         for patch in self._temp_patches:
             patch.__enter__()

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/subprocess.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/subprocess.py
@@ -21,8 +21,9 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import re
-
 from functools import cmp_to_key
+from unittest.mock import patch
+
 from webkitcorepy import string_utils, unicode
 from webkitcorepy.mocks import ContextStack
 
@@ -186,7 +187,5 @@ class Subprocess(ContextStack):
 
         super(Subprocess, self).__init__(cls=Subprocess)
 
-        # Allow mock to be managed via autoinstall
-        from mock import patch
         from webkitcorepy.mocks.popen import Popen
         self.patches.append(patch('subprocess.Popen', new=Popen))

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/terminal.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/terminal.py
@@ -20,14 +20,14 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from unittest.mock import patch
+
 
 class Terminal(object):
     index = 0
 
     @classmethod
     def input(cls, *args):
-        from mock import patch
-
         cls.index = 0
 
         def function(output):

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/partial_proxy.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/partial_proxy.py
@@ -20,6 +20,8 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from unittest import mock
+
 from webkitcorepy import mocks
 
 
@@ -35,11 +37,8 @@ class PartialProxy(mocks.ContextStack):
         self._temp_patches = None
 
     def __enter__(self):
-        # Allow requests and mock to be managed via autoinstall
+        # Allow requests to be managed via autoinstall
         import requests
-        from mock import patch
-
-        this = self
 
         class Session(requests.Session):
             def request(self, method, url, **kwargs):
@@ -61,14 +60,14 @@ class PartialProxy(mocks.ContextStack):
                 return super(Session, self).request(method, url, **kwargs)
 
         self._temp_patches = [
-            patch('requests.Session', new=Session),
-            patch('requests.request', new=lambda *args, **kwargs: Session().request(*args, **kwargs)),
-            patch('requests.get', new=lambda *args, **kwargs: Session().request('GET', *args, **kwargs)),
-            patch('requests.head', new=lambda *args, **kwargs: Session().request('HEAD', *args, **kwargs)),
-            patch('requests.post', new=lambda *args, **kwargs: Session().request('POST', *args, **kwargs)),
-            patch('requests.put', new=lambda *args, **kwargs: Session().request('PUT', *args, **kwargs)),
-            patch('requests.patch', new=lambda *args, **kwargs: Session().request('PATCH', *args, **kwargs)),
-            patch('requests.delete', new=lambda *args, **kwargs: Session().request('DELETE', *args, **kwargs)),
+            mock.patch('requests.Session', new=Session),
+            mock.patch('requests.request', new=lambda *args, **kwargs: Session().request(*args, **kwargs)),
+            mock.patch('requests.get', new=lambda *args, **kwargs: Session().request('GET', *args, **kwargs)),
+            mock.patch('requests.head', new=lambda *args, **kwargs: Session().request('HEAD', *args, **kwargs)),
+            mock.patch('requests.post', new=lambda *args, **kwargs: Session().request('POST', *args, **kwargs)),
+            mock.patch('requests.put', new=lambda *args, **kwargs: Session().request('PUT', *args, **kwargs)),
+            mock.patch('requests.patch', new=lambda *args, **kwargs: Session().request('PATCH', *args, **kwargs)),
+            mock.patch('requests.delete', new=lambda *args, **kwargs: Session().request('DELETE', *args, **kwargs)),
         ]
         for patch in self._temp_patches:
             patch.__enter__()

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/task_pool.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/task_pool.py
@@ -24,10 +24,9 @@ import io
 import logging
 import math
 import multiprocessing
+import queue as Queue
 import signal
 import sys
-
-import queue as Queue
 
 from webkitcorepy import OutputCapture, Timeout, log
 
@@ -374,7 +373,6 @@ class TaskPool(object):
     Queue = _Queue
     Process = _Process
 
-
     class Exception(RuntimeError):
         pass
 
@@ -386,7 +384,7 @@ class TaskPool(object):
         mutually_exclusive_groups=None,
     ):
         # Ensure tblib is installed before creating child processes
-        import tblib
+        import tblib  # noqa: F401
 
         name = name or 'worker'
         if name == self.Process.name:
@@ -426,8 +424,6 @@ class TaskPool(object):
                 self._setup_args[0](*self._setup_args[1], **self._setup_args[2])
             TaskPool.Process.working = True
             return self
-
-        from mock import patch
 
         self.queue = self.BiDirectionalQueue()
         self._group_queues = {

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/mocks/context_stack_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/mocks/context_stack_unittest.py
@@ -20,8 +20,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import mock
 import unittest
+from unittest.mock import patch
 
 from webkitcorepy import mocks
 
@@ -35,7 +35,7 @@ class ExampleStack(mocks.ContextStack):
 
     def __init__(self):
         super(ExampleStack, self).__init__(cls=ExampleStack)
-        self.patches.append(mock.patch(
+        self.patches.append(patch(
             'webkitcorepy.tests.mocks.context_stack_unittest.to_be_replaced',
             new=lambda: str(self),
         ))

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/partial_proxy_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/partial_proxy_unittest.py
@@ -21,6 +21,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import unittest
+from unittest.mock import patch
 
 
 class DummySession(object):
@@ -37,8 +38,6 @@ class PartialProxyTest(unittest.TestCase):
     def test_session(self):
         # Some imports must be done within mock contexts because we're attempting to
         # test an override of request.Session with an override of request.Session
-        from mock import patch
-
         with patch('requests.Session', new=DummySession):
             from webkitcorepy import PartialProxy
 

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/terminal_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/terminal_unittest.py
@@ -25,8 +25,7 @@ import logging
 import sys
 import typing
 import unittest
-
-from mock import patch
+from unittest.mock import patch
 
 from webkitcorepy import OutputCapture, Terminal, mocks
 

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/timeout.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/timeout.py
@@ -25,11 +25,11 @@ import collections
 import math
 import os
 import signal
-import time
 import threading
+import time
+from unittest import mock
 
 from webkitcorepy import log, string_utils
-
 
 ORIGINAL_SLEEP = time.sleep
 
@@ -58,9 +58,7 @@ class Timeout(object):
     class DisableAlarm(object):
         def __init__(self, patch=True):
             if patch:
-                # Allows mock to be managed via autoinstall
-                from mock import patch
-                self._patch = patch('time.sleep', new=ORIGINAL_SLEEP)
+                self._patch = mock.patch('time.sleep', new=ORIGINAL_SLEEP)
             else:
                 self._patch = None
 
@@ -166,9 +164,7 @@ class Timeout(object):
         self.data = None
 
         if patch:
-            # Allows mock to be managed via autoinstall
-            from mock import patch
-            self._patch = patch('time.sleep', new=self.sleep)
+            self._patch = mock.patch('time.sleep', new=self.sleep)
         else:
             self._patch = None
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/branch_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/branch_unittest.py
@@ -23,12 +23,17 @@
 import logging
 import os
 import time
+from unittest.mock import patch
 
-from mock import patch
-from webkitbugspy import bugzilla, mocks as bmocks, radar, Tracker
-from webkitcorepy import OutputCapture, testing, mocks as wkmocks
-from webkitcorepy.mocks import Time as MockTime, Terminal as MockTerminal, Environment
-from webkitscmpy import local, program, mocks, log, Commit
+from webkitbugspy import Tracker, bugzilla, radar
+from webkitbugspy import mocks as bmocks
+from webkitcorepy import OutputCapture, testing
+from webkitcorepy import mocks as wkmocks
+from webkitcorepy.mocks import Environment
+from webkitcorepy.mocks import Terminal as MockTerminal
+from webkitcorepy.mocks import Time as MockTime
+
+from webkitscmpy import Commit, local, log, mocks, program
 
 
 class TestBranch(testing.PathTestCase):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/cherry_pick_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/cherry_pick_unittest.py
@@ -23,12 +23,14 @@
 import os
 import shutil
 import tempfile
+from unittest.mock import patch
 
-from mock import patch
-from webkitbugspy import Tracker, radar, mocks as bmocks
+from webkitbugspy import Tracker, radar
+from webkitbugspy import mocks as bmocks
 from webkitcorepy import OutputCapture, testing
 from webkitcorepy.mocks import Time as MockTime
-from webkitscmpy import program, mocks
+
+from webkitscmpy import mocks, program
 
 
 class TestCherryPick(testing.PathTestCase):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/clone_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/clone_unittest.py
@@ -22,12 +22,15 @@
 
 import os
 import time
+from unittest.mock import patch
 
-from mock import patch
+from webkitbugspy import Tracker, radar
+from webkitbugspy import mocks as bmocks
 from webkitcorepy import OutputCapture, testing
-from webkitcorepy.mocks import Terminal as MockTerminal, Environment
-from webkitbugspy import Tracker, radar, mocks as bmocks
-from webkitscmpy import program, mocks
+from webkitcorepy.mocks import Environment
+from webkitcorepy.mocks import Terminal as MockTerminal
+
+from webkitscmpy import mocks, program
 
 
 class TestClone(testing.PathTestCase):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/commit_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/commit_unittest.py
@@ -24,13 +24,15 @@ import json
 import logging
 import os
 import unittest
-
-from mock import patch
 from datetime import datetime
-from webkitbugspy import bugzilla, mocks as bmocks, Tracker, radar
+from unittest.mock import patch
+
+from webkitbugspy import Tracker, bugzilla, radar
+from webkitbugspy import mocks as bmocks
 from webkitcorepy import OutputCapture, testing
 from webkitcorepy.mocks import Environment
-from webkitscmpy import Contributor, Commit, program, mocks
+
+from webkitscmpy import Commit, Contributor, mocks, program
 
 
 class TestCommit(unittest.TestCase):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/conflict_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/conflict_unittest.py
@@ -22,13 +22,13 @@
 
 import os
 import time
+from unittest.mock import Mock, patch
 
-from mock import patch
-from mock.mock import Mock
+from webkitbugspy import mocks as bmocks
 from webkitcorepy import OutputCapture, testing
 from webkitcorepy.mocks import Time as MockTime
-from webkitscmpy import program, mocks, local, Contributor, Commit
-from webkitbugspy import mocks as bmocks
+
+from webkitscmpy import Commit, Contributor, local, mocks, program
 
 
 class TestConflict(testing.PathTestCase):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/install_git_lfs_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/install_git_lfs_unittest.py
@@ -21,10 +21,12 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
+from unittest.mock import patch
 
-from mock import patch
-from webkitcorepy import OutputCapture, testing, mocks as wkmocks
-from webkitscmpy import local, program, mocks
+from webkitcorepy import OutputCapture, testing
+from webkitcorepy import mocks as wkmocks
+
+from webkitscmpy import local, mocks, program
 
 
 class TestInstallGitLFS(testing.PathTestCase):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/land_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/land_unittest.py
@@ -23,12 +23,16 @@
 import logging
 import os
 import time
+from unittest.mock import patch
 
-from mock import patch
-from webkitbugspy import Tracker, User, bugzilla, radar, mocks as bmocks
+from webkitbugspy import Tracker, User, bugzilla, radar
+from webkitbugspy import mocks as bmocks
 from webkitcorepy import OutputCapture, testing
-from webkitcorepy.mocks import Terminal as MockTerminal, Time as MockTime, Environment
-from webkitscmpy import Contributor, Commit, local, program, mocks
+from webkitcorepy.mocks import Environment
+from webkitcorepy.mocks import Terminal as MockTerminal
+from webkitcorepy.mocks import Time as MockTime
+
+from webkitscmpy import Commit, Contributor, local, mocks, program
 
 
 def repository(path, has_oops=True, remote=None, remotes=None, git_svn=False, issue_url=None):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
@@ -24,12 +24,15 @@ import logging
 import os
 import time
 import unittest
+from unittest.mock import patch
 
-from mock import patch
-from webkitbugspy import Tracker, bugzilla, github, radar, mocks as bmocks
+from webkitbugspy import Tracker, bugzilla, github, radar
+from webkitbugspy import mocks as bmocks
 from webkitcorepy import OutputCapture, testing
-from webkitcorepy.mocks import Terminal as MockTerminal, Environment
-from webkitscmpy import Contributor, Commit, PullRequest, local, program, mocks, remote
+from webkitcorepy.mocks import Environment
+from webkitcorepy.mocks import Terminal as MockTerminal
+
+from webkitscmpy import Commit, Contributor, PullRequest, local, mocks, program, remote
 
 
 class TestPullRequest(unittest.TestCase):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py
@@ -23,12 +23,16 @@
 import logging
 import os
 import time
+from unittest.mock import patch
 
-from mock import patch
-from webkitbugspy import bugzilla, mocks as bmocks, radar, Tracker
+from webkitbugspy import Tracker, bugzilla, radar
+from webkitbugspy import mocks as bmocks
 from webkitcorepy import OutputCapture, testing
-from webkitscmpy import local, program, mocks, Contributor, Commit
-from webkitcorepy.mocks import Time as MockTime, Terminal as MockTerminal, Environment
+from webkitcorepy.mocks import Environment
+from webkitcorepy.mocks import Terminal as MockTerminal
+from webkitcorepy.mocks import Time as MockTime
+
+from webkitscmpy import Commit, Contributor, local, mocks, program
 
 
 class TestRevert(testing.PathTestCase):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/squash_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/squash_unittest.py
@@ -22,11 +22,11 @@
 
 import logging
 import os
+from unittest.mock import patch
 
-from mock import patch
-from webkitcorepy import OutputCapture, testing
-from webkitscmpy import local, program, mocks
-from webkitcorepy import run
+from webkitcorepy import OutputCapture, run, testing
+
+from webkitscmpy import local, mocks, program
 
 
 class TestSquash(testing.PathTestCase):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/trace_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/trace_unittest.py
@@ -24,13 +24,15 @@ import logging
 import os
 import sys
 import time
-
-from mock import patch
 from unittest import TestCase
-from webkitbugspy import radar, mocks as bmocks
+from unittest.mock import patch
+
+from webkitbugspy import mocks as bmocks
+from webkitbugspy import radar
 from webkitcorepy import OutputCapture, Terminal, testing
-from webkitscmpy import local, mocks, Commit, program
-from webkitscmpy.program.trace import Relationship, CommitsStory
+
+from webkitscmpy import Commit, local, mocks, program
+from webkitscmpy.program.trace import CommitsStory, Relationship
 
 
 class TestRelationship(TestCase):

--- a/Tools/Scripts/webkitpy/common/net/bugzilla/results_fetcher_unittest.py
+++ b/Tools/Scripts/webkitpy/common/net/bugzilla/results_fetcher_unittest.py
@@ -27,8 +27,8 @@
 
 import json
 import unittest
+from unittest import mock
 
-from mock import mock
 from webkitcorepy.testing import PathTestCase
 from webkitscmpy import PullRequest, local, mocks, remote
 

--- a/Tools/Scripts/webkitpy/port/ios_device_unittest.py
+++ b/Tools/Scripts/webkitpy/port/ios_device_unittest.py
@@ -21,18 +21,14 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import time
+from unittest.mock import Mock
 
-from mock import Mock
-
-from webkitcorepy import Version
+from webkitcorepy import OutputCapture, Version
 
 from webkitpy.common.system.executive_mock import MockExecutive2, ScriptError
+from webkitpy.port import ios_testcase, port_testcase
 from webkitpy.port.ios_device import IOSDevicePort
-from webkitpy.port import ios_testcase
-from webkitpy.port import port_testcase
 from webkitpy.xcode.device_type import DeviceType
-
-from webkitcorepy import OutputCapture
 
 
 class IOSDeviceTest(ios_testcase.IOSTest):

--- a/Tools/Scripts/webkitpy/static_analysis/results_unittest.py
+++ b/Tools/Scripts/webkitpy/static_analysis/results_unittest.py
@@ -20,9 +20,9 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import mock
 import os
 import unittest
+from unittest import mock
 
 from .results import get_project_issue_count_as_string
 

--- a/Tools/Scripts/webkitpy/style/checkers/jsonchecker_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/jsonchecker_unittest.py
@@ -23,8 +23,7 @@
 """Unit test for jsonchecker.py."""
 
 import unittest
-
-from mock import Mock
+from unittest.mock import Mock
 
 from pyfakefs import fake_filesystem_unittest
 


### PR DESCRIPTION
#### 331b82635e5a6e732ebf0b3415346e77a4e33ef9
<pre>
Drop mock dependency
<a href="https://bugs.webkit.org/show_bug.cgi?id=284843">https://bugs.webkit.org/show_bug.cgi?id=284843</a>

Reviewed by Jonathan Bedard.

Now we&apos;re only Python 3.9 and later, there&apos;s no need to rely on the
backport. This removes a dependency from webkitcorepy, which feels
like an especially big win. (Actually two, as we also remove the
unneeded/unused inspect2.)

Note the fixes in webkitscmpy.mocks.local.{git,svn}, where we
previously were relying on a wing and a prayer to get the correct
stacking behaviour, despite actually relying on this behaviour in a
number of our tests. We now directly have tests for this in
webkitscmpy.test.{git,svn}_unittest, too.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/archive_context_unittest.py:
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/docker_unittest.py:
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/mock_cassandra_context.py:
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py:
(Radar.__init__):
(NoRadar.__init__):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py:
* Tools/Scripts/libraries/webkitcorepy/README.md:
* Tools/Scripts/libraries/webkitcorepy/setup.py:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/environment.py:
(Environment.__init__):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/requests_.py:
(Requests.__enter__):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/subprocess.py:
(Subprocess.__init__):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/terminal.py:
(Terminal.input):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/time_.py:
(_MetaTime.__enter__):
(Time):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/partial_proxy.py:
(PartialProxy.__enter__):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/task_pool.py:
(TaskPool):
(TaskPool.__enter__):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/mocks/context_stack_unittest.py:
(ExampleStack.__init__):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/partial_proxy_unittest.py:
(PartialProxyTest.test_session):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/terminal_unittest.py:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/timeout.py:
(Timeout.DisableAlarm.__init__):
(Timeout.__init__):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/svn.py:
(Svn.__enter__):
(Svn.__exit__):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/branch_unittest.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/cherry_pick_unittest.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/clone_unittest.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/commit_unittest.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/conflict_unittest.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/install_git_lfs_unittest.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/land_unittest.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/squash_unittest.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/svn_unittest.py:
(TestLocalSvn.test_revision_cache):
(TestMockSvn):
(TestMockSvn.setUp):
(TestMockSvn.test_executable):
(TestMockSvn.test_executable_stack):
(TestMockSvn.test_executable_stack_2):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/trace_unittest.py:
* Tools/Scripts/webkitpy/common/net/bugzilla/results_fetcher_unittest.py:
* Tools/Scripts/webkitpy/port/ios_device_unittest.py:
* Tools/Scripts/webkitpy/static_analysis/results_unittest.py:
* Tools/Scripts/webkitpy/style/checkers/jsonchecker_unittest.py:

Canonical link: <a href="https://commits.webkit.org/292652@main">https://commits.webkit.org/292652@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01b90c17e66a66d2d2607e552e56f82adc741353

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96700 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16314 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6458 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101773 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47220 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98745 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16610 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24753 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73695 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30914 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99703 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12505 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/87468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54030 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/96187 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12262 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5270 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46548 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/82365 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5358 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103796 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23768 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17332 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82743 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/96271 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24018 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83524 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82126 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26785 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/4322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17242 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15574 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23730 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23389 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26869 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25130 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->