### PR TITLE
Cleanup: Delete dead Quirks code (shouldEnableApplicationCacheQuirk)

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1211,12 +1211,6 @@ bool Quirks::shouldDisableFullscreenVideoAspectRatioAdaptiveSizing() const
 }
 #endif
 
-bool Quirks::shouldEnableApplicationCacheQuirk() const
-{
-    // FIXME: Remove this when deleting ApplicationCache APIs.
-    return false;
-}
-
 // play.hbomax.com https://bugs.webkit.org/show_bug.cgi?id=244737
 bool Quirks::shouldEnableFontLoadingAPIQuirk() const
 {

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -173,7 +173,6 @@ public:
 #if PLATFORM(IOS) || PLATFORM(VISION)
     WEBCORE_EXPORT bool allowLayeredFullscreenVideos() const;
 #endif
-    bool shouldEnableApplicationCacheQuirk() const;
     bool shouldEnableFontLoadingAPIQuirk() const;
     bool needsVideoShouldMaintainAspectRatioQuirk() const;
 

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -98,7 +98,6 @@ struct WEBCORE_EXPORT QuirksData {
     bool needsYouTubeOverflowScrollQuirk { false };
     bool shouldAvoidPastingImagesAsWebContent { false };
     bool shouldDisablePointerEventsQuirk { false };
-    bool shouldEnableApplicationCacheQuirk { false };
     bool shouldIgnoreAriaForFastPathContentObservationCheckQuirk { false };
     bool shouldNavigatorPluginsBeEmpty { false };
     bool shouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreasQuirk { false };


### PR DESCRIPTION
#### 49950a5169bf53174a94e58acf9277054ef742be
<pre>
Cleanup: Delete dead Quirks code (shouldEnableApplicationCacheQuirk)
<a href="https://bugs.webkit.org/show_bug.cgi?id=284846">https://bugs.webkit.org/show_bug.cgi?id=284846</a>
<a href="https://rdar.apple.com/141640133">rdar://141640133</a>

Reviewed by NOBODY (OOPS!).

All calling sites for Quirks::shouldEnableApplicationCacheQuirk have been removed, so we
should delete this dead code.

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldEnableApplicationCacheQuirk const): Deleted.
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49950a5169bf53174a94e58acf9277054ef742be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81557 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1083 "Hash 49950a51 for PR 38099 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35505 "Hash 49950a51 for PR 38099 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86089 "Hash 49950a51 for PR 38099 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32551 "Hash 49950a51 for PR 38099 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83667 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1102 "Hash 49950a51 for PR 38099 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8901 "Hash 49950a51 for PR 38099 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/86089 "Hash 49950a51 for PR 38099 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/32551 "Hash 49950a51 for PR 38099 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84626 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/1102 "Hash 49950a51 for PR 38099 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/35505 "Hash 49950a51 for PR 38099 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/86089 "Hash 49950a51 for PR 38099 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/1102 "Hash 49950a51 for PR 38099 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/35505 "Hash 49950a51 for PR 38099 does not build (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31004 "Hash 49950a51 for PR 38099 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/1102 "Hash 49950a51 for PR 38099 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/35505 "Hash 49950a51 for PR 38099 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87525 "Hash 49950a51 for PR 38099 does not build (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8790 "Hash 49950a51 for PR 38099 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/8901 "Hash 49950a51 for PR 38099 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/87525 "Hash 49950a51 for PR 38099 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8971 "Hash 49950a51 for PR 38099 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/35505 "Hash 49950a51 for PR 38099 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/87525 "Hash 49950a51 for PR 38099 does not build (failure)") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/35505 "Hash 49950a51 for PR 38099 does not build (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8750 "Hash 49950a51 for PR 38099 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14278 "Failed to build and analyze WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8588 "Hash 49950a51 for PR 38099 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12110 "Hash 49950a51 for PR 38099 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10395 "Hash 49950a51 for PR 38099 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->