### PR TITLE
Add LIFETIME_BOUND to Vector.h methods <https://bugs.webkit.org/show_bug.cgi?id=280802> <rdar://137175142>

### DIFF
--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -383,8 +383,8 @@ public:
         Malloc::free(bufferToDeallocate);
     }
 
-    T* buffer() { return m_buffer; }
-    const T* buffer() const { return m_buffer; }
+    T* buffer() LIFETIME_BOUND { return m_buffer; }
+    const T* buffer() const LIFETIME_BOUND { return m_buffer; }
     static constexpr ptrdiff_t bufferMemoryOffset() { return OBJECT_OFFSETOF(VectorBufferBase, m_buffer); }
     size_t capacity() const { return m_capacity; }
 
@@ -456,7 +456,7 @@ public:
     void restoreInlineBufferIfNeeded() { }
 
 #if ASAN_ENABLED
-    void* endOfBuffer()
+    void* endOfBuffer() LIFETIME_BOUND
     {
         return buffer() + capacity();
     }
@@ -585,7 +585,7 @@ public:
     }
 
 #if ASAN_ENABLED
-    void* endOfBuffer()
+    void* endOfBuffer() LIFETIME_BOUND
     {
         ASSERT_WITH_SECURITY_IMPLICATION(buffer());
 
@@ -669,8 +669,8 @@ private:
         VectorTypeOperations<T>::move(right + swapBound, right + rightSize, left + swapBound);
     }
 
-    T* inlineBuffer() { return reinterpret_cast_ptr<T*>(m_inlineBuffer); }
-    const T* inlineBuffer() const { return reinterpret_cast_ptr<const T*>(m_inlineBuffer); }
+    T* inlineBuffer() LIFETIME_BOUND { return reinterpret_cast_ptr<T*>(m_inlineBuffer); }
+    const T* inlineBuffer() const LIFETIME_BOUND { return reinterpret_cast_ptr<const T*>(m_inlineBuffer); }
 
 #if ASAN_ENABLED
     // ASan needs the buffer to begin and end on 8-byte boundaries for annotations to work.
@@ -822,53 +822,53 @@ public:
     static constexpr ptrdiff_t sizeMemoryOffset() { return OBJECT_OFFSETOF(Vector, m_size); }
     size_t capacity() const { return Base::capacity(); }
     bool isEmpty() const { return !size(); }
-    std::span<const T> span() const { return { data(), size() }; }
-    std::span<T> mutableSpan() { return { data(), size() }; }
+    std::span<const T> span() const LIFETIME_BOUND { return { data(), size() }; }
+    std::span<T> mutableSpan() LIFETIME_BOUND { return { data(), size() }; }
 
     Vector<T> subvector(size_t offset, size_t length = std::dynamic_extent) const
     {
         return { span().subspan(offset, length) };
     }
 
-    std::span<const T> subspan(size_t offset, size_t length = std::dynamic_extent) const
+    std::span<const T> subspan(size_t offset, size_t length = std::dynamic_extent) const LIFETIME_BOUND
     {
         return span().subspan(offset, length);
     }
 
-    T& at(size_t i)
+    T& at(size_t i) LIFETIME_BOUND
     {
         if (UNLIKELY(i >= size()))
             OverflowHandler::overflowed();
         return Base::buffer()[i];
     }
-    const T& at(size_t i) const 
+    const T& at(size_t i) const LIFETIME_BOUND
     {
         if (UNLIKELY(i >= size()))
             OverflowHandler::overflowed();
         return Base::buffer()[i];
     }
 
-    T& operator[](size_t i) { return at(i); }
-    const T& operator[](size_t i) const { return at(i); }
+    T& operator[](size_t i) LIFETIME_BOUND { return at(i); }
+    const T& operator[](size_t i) const LIFETIME_BOUND { return at(i); }
 
-    T* data() { return Base::buffer(); }
-    const T* data() const { return Base::buffer(); }
+    T* data() LIFETIME_BOUND { return Base::buffer(); }
+    const T* data() const LIFETIME_BOUND { return Base::buffer(); }
     static constexpr ptrdiff_t dataMemoryOffset() { return Base::bufferMemoryOffset(); }
 
-    iterator begin() { return data(); }
-    iterator end() { return begin() + m_size; }
-    const_iterator begin() const { return data(); }
-    const_iterator end() const { return begin() + m_size; }
+    iterator begin() LIFETIME_BOUND { return data(); }
+    iterator end() LIFETIME_BOUND { return begin() + m_size; }
+    const_iterator begin() const LIFETIME_BOUND { return data(); }
+    const_iterator end() const LIFETIME_BOUND { return begin() + m_size; }
 
-    reverse_iterator rbegin() { return reverse_iterator(end()); }
-    reverse_iterator rend() { return reverse_iterator(begin()); }
-    const_reverse_iterator rbegin() const { return const_reverse_iterator(end()); }
-    const_reverse_iterator rend() const { return const_reverse_iterator(begin()); }
+    reverse_iterator rbegin() LIFETIME_BOUND { return reverse_iterator(end()); }
+    reverse_iterator rend() LIFETIME_BOUND { return reverse_iterator(begin()); }
+    const_reverse_iterator rbegin() const LIFETIME_BOUND { return const_reverse_iterator(end()); }
+    const_reverse_iterator rend() const LIFETIME_BOUND { return const_reverse_iterator(begin()); }
 
-    T& first() { return at(0); }
-    const T& first() const { return at(0); }
-    T& last() { return at(size() - 1); }
-    const T& last() const { return at(size() - 1); }
+    T& first() LIFETIME_BOUND { return at(0); }
+    const T& first() const LIFETIME_BOUND { return at(0); }
+    T& last() LIFETIME_BOUND { return at(size() - 1); }
+    const T& last() const LIFETIME_BOUND { return at(size() - 1); }
     
     T takeLast()
     {

--- a/Source/WebCore/Modules/mediastream/SFrameUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/SFrameUtils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -114,11 +114,11 @@ SFrameCompatibilityPrefixBuffer computeH264PrefixBuffer(std::span<const uint8_t>
     static const uint8_t prefixDeltaFrame[6] = { 0x00, 0x00, 0x00, 0x01, 0x21, 0xe0 };
 
     if (frameData.size() < 5)
-        return { };
+        return std::span<const uint8_t> { };
 
     // We assume a key frame starts with SPS, then PPS. Otherwise we wrap it as a delta frame.
     if (!isSPSNALU(frameData[4]))
-        return SFrameCompatibilityPrefixBuffer { prefixDeltaFrame, sizeof(prefixDeltaFrame), { } };
+        return std::span<const uint8_t> { prefixDeltaFrame };
 
     // Search for PPS
     size_t spsPpsLength = 0;
@@ -128,7 +128,7 @@ SFrameCompatibilityPrefixBuffer computeH264PrefixBuffer(std::span<const uint8_t>
         return true;
     });
     if (!spsPpsLength)
-        return SFrameCompatibilityPrefixBuffer { prefixDeltaFrame, sizeof(prefixDeltaFrame), { } };
+        return std::span<const uint8_t> { prefixDeltaFrame };
 
     // Search for next NALU to compute the real spsPpsLength, including the next 00 00 00 01.
     findNalus(frameData, spsPpsLength + 1, [&spsPpsLength](auto position) {
@@ -143,7 +143,7 @@ IGNORE_GCC_WARNINGS_BEGIN("restrict")
 IGNORE_GCC_WARNINGS_END
     buffer[spsPpsLength] = 0x25;
     buffer[spsPpsLength + 1] = 0xb8;
-    return { buffer.data(), buffer.size(), WTFMove(buffer) };
+    return buffer;
 }
 
 static inline void findEscapeRbspPatterns(const Vector<uint8_t>& frame, size_t offset, const Function<void(size_t, bool)>& callback)
@@ -201,7 +201,7 @@ size_t computeVP8PrefixOffset(std::span<const uint8_t> frame)
 SFrameCompatibilityPrefixBuffer computeVP8PrefixBuffer(std::span<const uint8_t> frame)
 {
     Vector<uint8_t> prefix(frame.first(isVP8KeyFrame(frame) ? 10 : 3));
-    return { prefix.data(), prefix.size(), WTFMove(prefix) };
+    return prefix;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/SFrameUtils.h
+++ b/Source/WebCore/Modules/mediastream/SFrameUtils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,11 +33,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 
-struct SFrameCompatibilityPrefixBuffer {
-    const uint8_t* data { nullptr };
-    size_t size { 0 };
-    Vector<uint8_t> buffer;
-};
+using SFrameCompatibilityPrefixBuffer = std::variant<std::span<const uint8_t>, Vector<uint8_t>>;
 
 size_t computeH264PrefixOffset(std::span<const uint8_t>);
 SFrameCompatibilityPrefixBuffer computeH264PrefixBuffer(std::span<const uint8_t>);

--- a/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
+++ b/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
@@ -502,7 +502,8 @@ String getURL(const DragDataMap* data, DragData::FilenameConversionPolicy filena
     if (!getDataMapItem(data, filenameWFormat(), stringData))
         getDataMapItem(data, filenameFormat(), stringData);
 
-    auto wcharData = stringData.wideCharacters().data();
+    auto wideCharacters = stringData.wideCharacters();
+    auto wcharData = wideCharacters.data();
     if (stringData.isEmpty() || (!PathFileExists(wcharData) && !PathIsUNC(wcharData)))
         return url;
 

--- a/Source/WebCore/platform/win/PasteboardWin.cpp
+++ b/Source/WebCore/platform/win/PasteboardWin.cpp
@@ -1003,7 +1003,8 @@ static HGLOBAL createGlobalHDropContent(const URL& url, String& fileName, Fragme
         // windows does not enjoy a leading slash on paths
         if (localPath[0] == '/')
             localPath = localPath.substring(1);
-        LPCWSTR localPathStr = localPath.wideCharacters().data();
+        auto wideCharacters = localPath.wideCharacters();
+        LPCWSTR localPathStr = wideCharacters.data();
         if (localPathStr && wcslen(localPathStr) + 1 < MAX_PATH)
             wcscpy_s(filePath, MAX_PATH, localPathStr);
         else


### PR DESCRIPTION
#### b93fdedab723cda3137b3e2bf26411d7900bc1a0
<pre>
Add LIFETIME_BOUND to Vector.h methods &lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=280802">https://bugs.webkit.org/show_bug.cgi?id=280802</a>&gt; &lt;<a href="https://rdar.apple.com/137175142">rdar://137175142</a>&gt;

Reviewed by Darin Adler.

Change SFrameCompatibilityPrefixBuffer into a Vector&lt;uint8_t&gt;.

* Source/WTF/wtf/Vector.h:
- Add LIFETIME_BOUND attributes to methods in Vector.h that return
  pointers or references to inner data.

* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.cpp:
(WebCore::RTCRtpSFrameTransformer::encryptFrame):
- Extract std::span from SFrameCompatibilityPrefixBuffer, which is now a
  std::variant.
- Switch to use size() methods on std::span.
- Switch to use memcpySpan() instead of memcpy().
* Source/WebCore/Modules/mediastream/SFrameUtils.cpp:
(WebCore::computeH264PrefixBuffer):
(WebCore::computeVP8PrefixBuffer):
- Update return expressions for std::variant construction.
* Source/WebCore/Modules/mediastream/SFrameUtils.h:
(WebCore::SFrameCompatibilityPrefixBuffer):
- Replace struct SFrameCompatibilityPrefixBuffer with std::variant.
* Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp:
(WebCore::getURL):
- Fix temporary Vector&lt;wchar_t&gt;.
* Source/WebCore/platform/win/PasteboardWin.cpp:
(WebCore::createGlobalHDropContent): Ditto.

Originally-landed-as: 283286.203@safari-7620-branch (dbe14535006e). <a href="https://rdar.apple.com/141322982">rdar://141322982</a>
Canonical link: <a href="https://commits.webkit.org/288142@main">https://commits.webkit.org/288142@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f4c87034fae115d790c45b8f533de4b618cad47

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81952 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1479 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35909 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86509 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32984 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84058 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1514 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9302 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63902 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21631 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85022 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1123 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74576 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44185 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1025 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28753 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31403 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/74933 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29364 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Running apply-patch; Checked out pull request; Skipped layout-tests; Running layout-tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87940 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/81006 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9194 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6556 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72270 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-transforms/animation/transform-percent-with-width-and-height-separate.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9379 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70395 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71492 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15601 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14520 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12704 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9145 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14681 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/103418 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8985 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25104 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12510 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10793 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->