### PR TITLE
[JSC] Resizable TypedArray should be [[PreventExtensions]] = true

### DIFF
--- a/JSTests/stress/v8-typedarray-resizablearraybuffer.js
+++ b/JSTests/stress/v8-typedarray-resizablearraybuffer.js
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// Flags: --harmony-rab-gsab --allow-natives-syntax
-// Flags: --harmony-array-find-last
+// Flags: --allow-natives-syntax --harmony-array-find-last --js-float16array
 
 "use strict";
 
@@ -1287,6 +1286,68 @@ TestFill(ArrayFillHelper, false);
     assertThrows(
         () => { TypedArrayFillHelper(fixedLength, 3, 1, evil); }, TypeError);
   }
+  // Resizing + a length-tracking TA -> no OOB, but bounds recomputation needed.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT,
+                                           8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+
+    const evil = { valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT); return 1;
+    }};
+    TypedArrayFillHelper(lengthTracking, evil, 0, 4);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT,
+                                           8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+
+    const evil = { valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT); return 0;
+    }};
+    TypedArrayFillHelper(lengthTracking, 1, evil, 4);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT,
+                                           8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+
+    const evil = { valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT); return 4;
+    }};
+    TypedArrayFillHelper(lengthTracking, 1, 0, evil);
+  }
+  // Special case: resizing to 0 -> length-tracking TA still not OOB.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT,
+                                           8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+
+    const evil = { valueOf: () => {
+      rab.resize(0); return 1;
+    }};
+    TypedArrayFillHelper(lengthTracking, evil, 0, 4);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT,
+                                           8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+
+    const evil = { valueOf: () => {
+      rab.resize(0); return 0;
+    }};
+    TypedArrayFillHelper(lengthTracking, 1, evil, 4);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT,
+                                           8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+
+    const evil = { valueOf: () => {
+      rab.resize(0); return 4;
+    }};
+    TypedArrayFillHelper(lengthTracking, 1, 0, evil);
+  }
 })();
 
 (function ArrayFillParameterConversionResizes() {
@@ -1299,6 +1360,8 @@ TestFill(ArrayFillHelper, false);
       rab.resize(2 * ctor.BYTES_PER_ELEMENT); return 3;
     }};
     ArrayFillHelper(fixedLength, evil, 1, 2);
+    // The underlying data doesn't change: all writes fail because 'fixedLength'
+    // is OOB.
     assertEquals([0, 0], ReadDataFromBuffer(rab, ctor));
   }
   for (let ctor of ctors) {
@@ -1322,6 +1385,71 @@ TestFill(ArrayFillHelper, false);
     }};
     ArrayFillHelper(fixedLength, 3, 1, evil);
     assertEquals([0, 0], ReadDataFromBuffer(rab, ctor));
+  }
+  // Resizing + a length-tracking TA -> no OOB, but bounds recomputation needed.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT,
+                                           8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+
+    const evil = { valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT); return 3;
+    }};
+    ArrayFillHelper(lengthTracking, evil, 0, 4);
+    assertEquals([3, 3], ReadDataFromBuffer(rab, ctor));
+  }
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT,
+                                           8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+
+    const evil = { valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT); return 0;
+    }};
+    ArrayFillHelper(lengthTracking, 3, evil, 4);
+    assertEquals([3, 3], ReadDataFromBuffer(rab, ctor));
+  }
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT,
+                                           8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+
+    const evil = { valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT); return 4;
+    }};
+    ArrayFillHelper(lengthTracking, 3, 0, evil);
+    assertEquals([3, 3], ReadDataFromBuffer(rab, ctor));
+  }
+  // Special case: resizing to 0 -> length-tracking TA still not OOB.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT,
+                                           8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+
+    const evil = { valueOf: () => {
+      rab.resize(0); return 3;
+    }};
+    ArrayFillHelper(lengthTracking, evil, 0, 4);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT,
+                                           8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+
+    const evil = { valueOf: () => {
+      rab.resize(0); return 0;
+    }};
+    ArrayFillHelper(lengthTracking, 3, evil, 4);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT,
+                                           8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+
+    const evil = { valueOf: () => {
+      rab.resize(0); return 4;
+    }};
+    ArrayFillHelper(lengthTracking, 3, 0, evil);
   }
 })();
 
@@ -1390,16 +1518,56 @@ function AtParameterConversionResizes(atHelper) {
                                            8 * ctor.BYTES_PER_ELEMENT);
     const fixedLength = new ctor(rab, 0, 4);
 
-    let evil = { valueOf: () => { rab.resize(2); return 0;}};
+    const evil = { valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT); return 0;
+    }};
     assertEquals(undefined, atHelper(fixedLength, evil));
   }
-
+  // Resizing + a length-tracking TA -> no OOB, but bounds recomputation needed.
   for (let ctor of ctors) {
     const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT,
                                            8 * ctor.BYTES_PER_ELEMENT);
     const lengthTracking = new ctor(rab);
 
-    let evil = { valueOf: () => { rab.resize(2); return -1;}};
+    const evil = { valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT); return -1;
+    }};
+    // The TypedArray is *not* out of bounds since it's length-tracking.
+    assertEquals(undefined, atHelper(lengthTracking, evil));
+  }
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT,
+                                           8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    WriteToTypedArray(lengthTracking, 0, 25);
+
+    const evil = { valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT); return 0;
+    }};
+    // The TypedArray is *not* out of bounds since it's length-tracking.
+    assertEquals(25, atHelper(lengthTracking, evil));
+  }
+  // Special case: resizing to 0 -> length-tracking TA still not OOB.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT,
+                                           8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+
+    const evil = { valueOf: () => {
+      rab.resize(0); return -1;
+    }};
+    // The TypedArray is *not* out of bounds since it's length-tracking.
+    assertEquals(undefined, atHelper(lengthTracking, evil));
+  }
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT,
+                                           8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    WriteToTypedArray(lengthTracking, 0, 25);
+
+    const evil = { valueOf: () => {
+      rab.resize(0); return 0;
+    }};
     // The TypedArray is *not* out of bounds since it's length-tracking.
     assertEquals(undefined, atHelper(lengthTracking, evil));
   }
@@ -1492,6 +1660,7 @@ AtParameterConversionResizes(ArrayAtHelper);
     assertThrows(() => { fixedLength.slice(evil); }, TypeError);
     assertEquals(2 * ctor.BYTES_PER_ELEMENT, rab.byteLength);
   }
+  // Resizing + a length-tracking TA -> no OOB, but bounds recomputation needed.
   for (let ctor of ctors) {
     const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT,
                                            8 * ctor.BYTES_PER_ELEMENT);
@@ -1503,6 +1672,19 @@ AtParameterConversionResizes(ArrayAtHelper);
                                     return 0; }};
     assertEquals([1, 2, 0, 0], ToNumbers(lengthTracking.slice(evil)));
     assertEquals(2 * ctor.BYTES_PER_ELEMENT, rab.byteLength);
+  }
+  // Special case: resizing to 0 -> length-tracking TA still not OOB.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT,
+                                           8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(lengthTracking, i, i + 1);
+    }
+    const evil = { valueOf: () => { rab.resize(0);
+                                    return 0; }};
+    assertEquals([0, 0, 0, 0], ToNumbers(lengthTracking.slice(evil)));
+    assertEquals(0, rab.byteLength);
   }
 })();
 
@@ -1813,6 +1995,7 @@ TestCopyWithin(ArrayCopyWithinHelper, false);
     lengthTracking.copyWithin(evil, 0);
     assertEquals([0, 1, 0], ToNumbers(lengthTracking));
   }
+  // Resizing + a length-tracking TA -> no OOB, but bounds recomputation needed.
   for (let ctor of ctors) {
     const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT,
                                            8 * ctor.BYTES_PER_ELEMENT);
@@ -1829,6 +2012,23 @@ TestCopyWithin(ArrayCopyWithinHelper, false);
                                     return 2;}};
     lengthTracking.copyWithin(0, evil);
     assertEquals([2, 1, 2], ToNumbers(lengthTracking));
+  }
+  // Special case: resizing to 0 -> length-tracking TA still not OOB.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT,
+                                           8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(lengthTracking, i, i);
+    }
+    // [0, 1, 2, 3]
+    //        ^
+    //        start
+    // ^
+    // target
+    const evil = { valueOf: () => { rab.resize(0); return 2; }};
+    lengthTracking.copyWithin(0, evil);
+    assertEquals([], ToNumbers(lengthTracking));
   }
 })();
 
@@ -2230,7 +2430,7 @@ function EntriesKeysValuesShrinkMidIteration(
     return rab;
   }
 
-  // Iterating with entries() (the 4 loops below).
+  // Iterating with entries() (the 5 loops below).
   for (let ctor of ctors) {
     const rab = CreateRabForTest(ctor);
     const fixedLength = new ctor(rab, 0, 4);
@@ -2253,6 +2453,7 @@ function EntriesKeysValuesShrinkMidIteration(
                              rab, 1, 3 * ctor.BYTES_PER_ELEMENT); });
   }
 
+  // Resizing + a length-tracking TA -> no OOB.
   for (let ctor of ctors) {
     const rab = CreateRabForTest(ctor);
     const lengthTracking = new ctor(rab, 0);
@@ -2260,6 +2461,16 @@ function EntriesKeysValuesShrinkMidIteration(
     TestIterationAndResize(entriesHelper(lengthTracking),
                            [[0, 0], [1, 2], [2, 4]],
                            rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+  }
+
+  // Special case: resizing to 0 -> length-tracking TA still not OOB.
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+
+    TestIterationAndResize(entriesHelper(lengthTracking),
+                           [[0, 0]],
+                           rab, 1, 0);
   }
 
   for (let ctor of ctors) {
@@ -2271,7 +2482,7 @@ function EntriesKeysValuesShrinkMidIteration(
                            rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
   }
 
-  // Iterating with keys() (the 4 loops below).
+  // Iterating with keys() (the 5 loops below).
   for (let ctor of ctors) {
     const rab = CreateRabForTest(ctor);
     const fixedLength = new ctor(rab, 0, 4);
@@ -2294,6 +2505,7 @@ function EntriesKeysValuesShrinkMidIteration(
                              rab, 2, 3 * ctor.BYTES_PER_ELEMENT); });
   }
 
+  // Resizing + a length-tracking TA -> no OOB.
   for (let ctor of ctors) {
     const rab = CreateRabForTest(ctor);
     const lengthTracking = new ctor(rab, 0);
@@ -2301,6 +2513,16 @@ function EntriesKeysValuesShrinkMidIteration(
     TestIterationAndResize(keysHelper(lengthTracking),
                            [0, 1, 2],
                            rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+  }
+
+  // Special case: resizing to 0 -> length-tracking TA still not OOB.
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+
+    TestIterationAndResize(keysHelper(lengthTracking),
+                           [0],
+                           rab, 1, 0);
   }
 
   for (let ctor of ctors) {
@@ -2312,7 +2534,7 @@ function EntriesKeysValuesShrinkMidIteration(
                            rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
   }
 
-  // Iterating with values() (the 4 loops below).
+  // Iterating with values() (the 5 loops below).
   for (let ctor of ctors) {
     const rab = CreateRabForTest(ctor);
     const fixedLength = new ctor(rab, 0, 4);
@@ -2335,6 +2557,7 @@ function EntriesKeysValuesShrinkMidIteration(
                              rab, 2, 3 * ctor.BYTES_PER_ELEMENT); });
   }
 
+  // Resizing + a length-tracking TA -> no OOB.
   for (let ctor of ctors) {
     const rab = CreateRabForTest(ctor);
     const lengthTracking = new ctor(rab, 0);
@@ -2342,6 +2565,16 @@ function EntriesKeysValuesShrinkMidIteration(
     TestIterationAndResize(valuesHelper(lengthTracking),
                            [0, 2, 4],
                            rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+  }
+
+  // Special case: resizing to 0 -> length-tracking TA still not OOB.
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+
+    TestIterationAndResize(valuesHelper(lengthTracking),
+                           [0, 2],
+                           rab, 2, 0);
   }
 
   for (let ctor of ctors) {
@@ -2594,6 +2827,7 @@ function EveryShrinkMidIteration(everyHelper, hasUndefined) {
     }
   }
 
+  // Resizing + a length-tracking TA -> no OOB.
   for (let ctor of ctors) {
     rab = CreateRabForTest(ctor);
     const lengthTracking = new ctor(rab, 0);
@@ -2605,6 +2839,21 @@ function EveryShrinkMidIteration(everyHelper, hasUndefined) {
       assertEquals([0, 2, 4, undefined], values);
     } else {
       assertEquals([0, 2, 4], values);
+    }
+  }
+
+  // Special case: resizing to 0 -> length-tracking TA still not OOB.
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 0;
+    assertTrue(everyHelper(lengthTracking, CollectValuesAndResize));
+    if (hasUndefined) {
+      assertEquals([0, 2, undefined, undefined], values);
+    } else {
+      assertEquals([0, 2], values);
     }
   }
 
@@ -2762,6 +3011,7 @@ function SomeShrinkMidIteration(someHelper, hasUndefined) {
     }
   }
 
+  // Resizing + a length-tracking TA -> no OOB.
   for (let ctor of ctors) {
     rab = CreateRabForTest(ctor);
     const lengthTracking = new ctor(rab, 0);
@@ -2773,6 +3023,21 @@ function SomeShrinkMidIteration(someHelper, hasUndefined) {
       assertEquals([0, 2, 4, undefined], values);
     } else {
       assertEquals([0, 2, 4], values);
+    }
+  }
+
+  // Special case: resizing to 0 -> length-tracking TA still not OOB.
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 0;
+    assertFalse(someHelper(lengthTracking, CollectValuesAndResize));
+    if (hasUndefined) {
+      assertEquals([0, 2, undefined, undefined], values);
+    } else {
+      assertEquals([0, 2], values);
     }
   }
 
@@ -3172,6 +3437,7 @@ function FindShrinkMidIteration(findHelper) {
     assertEquals([4, undefined], values);
   }
 
+  // Resizing + a length-tracking TA -> no OOB.
   for (let ctor of ctors) {
     rab = CreateRabForTest(ctor);
     const lengthTracking = new ctor(rab, 0);
@@ -3180,6 +3446,17 @@ function FindShrinkMidIteration(findHelper) {
     resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
     assertEquals(undefined, findHelper(lengthTracking, CollectValuesAndResize));
     assertEquals([0, 2, 4, undefined], values);
+  }
+
+  // Special case: resizing to 0 -> length-tracking TA still not OOB.
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 0;
+    assertEquals(undefined, findHelper(lengthTracking, CollectValuesAndResize));
+    assertEquals([0, 2, undefined, undefined], values);
   }
 
   for (let ctor of ctors) {
@@ -3327,6 +3604,7 @@ function FindIndexShrinkMidIteration(findIndexHelper) {
     assertEquals([4, undefined], values);
   }
 
+  // Resizing + a length-tracking TA -> no OOB.
   for (let ctor of ctors) {
     rab = CreateRabForTest(ctor);
     const lengthTracking = new ctor(rab, 0);
@@ -3335,6 +3613,17 @@ function FindIndexShrinkMidIteration(findIndexHelper) {
     resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
     assertEquals(-1, findIndexHelper(lengthTracking, CollectValuesAndResize));
     assertEquals([0, 2, 4, undefined], values);
+  }
+
+  // Special case: resizing to 0 -> length-tracking TA still not OOB.
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 0;
+    assertEquals(-1, findIndexHelper(lengthTracking, CollectValuesAndResize));
+    assertEquals([0, 2, undefined, undefined], values);
   }
 
   for (let ctor of ctors) {
@@ -3480,6 +3769,7 @@ function FindLastShrinkMidIteration(findLastHelper) {
     assertEquals([6, undefined], values);
   }
 
+  // Resizing + a length-tracking TA -> no OOB.
   for (let ctor of ctors) {
     rab = CreateRabForTest(ctor);
     const lengthTracking = new ctor(rab, 0);
@@ -3489,6 +3779,18 @@ function FindLastShrinkMidIteration(findLastHelper) {
     assertEquals(undefined,
                  findLastHelper(lengthTracking, CollectValuesAndResize));
     assertEquals([6, 4, 2, 0], values);
+  }
+
+  // Special case: resizing to 0 -> length-tracking TA still not OOB.
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 0;
+    assertEquals(undefined,
+                 findLastHelper(lengthTracking, CollectValuesAndResize));
+    assertEquals([6, 4, undefined, undefined], values);
   }
 
   for (let ctor of ctors) {
@@ -3650,6 +3952,7 @@ function FindLastIndexShrinkMidIteration(findLastIndexHelper) {
     assertEquals([6, 4, 2, 0], values);
   }
 
+  // Resizing + a length-tracking TA -> no OOB.
   for (let ctor of ctors) {
     rab = CreateRabForTest(ctor);
     const lengthTracking = new ctor(rab, 0);
@@ -3659,6 +3962,18 @@ function FindLastIndexShrinkMidIteration(findLastIndexHelper) {
     assertEquals(-1,
                  findLastIndexHelper(lengthTracking, CollectValuesAndResize));
     assertEquals([6, undefined, 2, 0], values);
+  }
+
+  // Special case: resizing to 0 -> length-tracking TA still not OOB.
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 0;
+    assertEquals(-1,
+                 findLastIndexHelper(lengthTracking, CollectValuesAndResize));
+    assertEquals([6, undefined, undefined, undefined], values);
   }
 
   for (let ctor of ctors) {
@@ -3911,6 +4226,7 @@ Filter(ArrayFilterHelper, false);
     assertEquals([4, undefined], values);
   }
 
+  // Resizing + a length-tracking TA -> no OOB.
   for (let ctor of ctors) {
     rab = CreateRabForTest(ctor);
     const lengthTracking = new ctor(rab, 0);
@@ -3919,6 +4235,17 @@ Filter(ArrayFilterHelper, false);
     resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
     assertEquals([], ToNumbers(lengthTracking.filter(CollectValuesAndResize)));
     assertEquals([0, 2, 4, undefined], values);
+  }
+
+  // Special case: resizing to 0 -> length-tracking TA still not OOB.
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 0;
+    assertEquals([], ToNumbers(lengthTracking.filter(CollectValuesAndResize)));
+    assertEquals([0, 2, undefined, undefined], values);
   }
 
   for (let ctor of ctors) {
@@ -4200,12 +4527,22 @@ ForEachReduceReduceRight(ArrayForEachHelper, ArrayReduceHelper,
     assertEquals([4, undefined], ForEachHelper(fixedLengthWithOffset));
   }
 
+  // Resizing + a length-tracking TA -> no OOB.
   for (let ctor of ctors) {
     rab = CreateRabForTest(ctor);
     const lengthTracking = new ctor(rab, 0);
     resizeAfter = 2;
     resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
     assertEquals([0, 2, 4, undefined], ForEachHelper(lengthTracking));
+  }
+
+  // Special case: resizing to 0 -> length-tracking TA still not OOB.
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    resizeAfter = 2;
+    resizeTo = 0;
+    assertEquals([0, 2, undefined, undefined], ForEachHelper(lengthTracking));
   }
 
   for (let ctor of ctors) {
@@ -4234,12 +4571,22 @@ ForEachReduceReduceRight(ArrayForEachHelper, ArrayReduceHelper,
     assertEquals([4, undefined], ReduceHelper(fixedLengthWithOffset));
   }
 
+  // Resizing + a length-tracking TA -> no OOB.
   for (let ctor of ctors) {
     rab = CreateRabForTest(ctor);
     const lengthTracking = new ctor(rab, 0);
     resizeAfter = 2;
     resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
     assertEquals([0, 2, 4, undefined], ReduceHelper(lengthTracking));
+  }
+
+  // Special case: resizing to 0 -> length-tracking TA still not OOB.
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    resizeAfter = 2;
+    resizeTo = 0;
+    assertEquals([0, 2, undefined, undefined], ReduceHelper(lengthTracking));
   }
 
   for (let ctor of ctors) {
@@ -4268,6 +4615,7 @@ ForEachReduceReduceRight(ArrayForEachHelper, ArrayReduceHelper,
     assertEquals([6, undefined], ReduceRightHelper(fixedLengthWithOffset));
   }
 
+  // Resizing + a length-tracking TA -> no OOB.
   for (let ctor of ctors) {
     rab = CreateRabForTest(ctor);
     const lengthTracking = new ctor(rab, 0);
@@ -4275,6 +4623,15 @@ ForEachReduceReduceRight(ArrayForEachHelper, ArrayReduceHelper,
     resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
     // Unaffected by the shrinking, since we've already iterated past the point.
     assertEquals([6, 4, 2, 0], ReduceRightHelper(lengthTracking));
+  }
+
+  // Special case: resizing to 0 -> length-tracking TA still not OOB.
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    resizeAfter = 2;
+    resizeTo = 0;
+    assertEquals([6, 4, undefined, undefined], ReduceRightHelper(lengthTracking));
   }
 
   for (let ctor of ctors) {
@@ -4622,6 +4979,7 @@ function IncludesParameterConversionResizes(helper) {
     assertFalse(helper(fixedLength, 0, evil));
   }
 
+  // Resizing + a length-tracking TA -> no OOB.
   for (let ctor of ctors) {
     const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT,
                                            8 * ctor.BYTES_PER_ELEMENT);
@@ -4629,6 +4987,21 @@ function IncludesParameterConversionResizes(helper) {
 
     let evil = { valueOf: () => {
       rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 0;
+    }};
+    assertFalse(helper(lengthTracking, undefined));
+    // "includes" iterates until the original length and sees "undefined"s.
+    assertTrue(helper(lengthTracking, undefined, evil));
+  }
+
+  // Special case: resizing to 0 -> length-tracking TA still not OOB.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT,
+                                           8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+
+    let evil = { valueOf: () => {
+      rab.resize(0);
       return 0;
     }};
     assertFalse(helper(lengthTracking, undefined));
@@ -4951,6 +5324,41 @@ function IndexOfParameterConversionShrinks(indexOfHelper, lastIndexOfHelper) {
     // 2 no longer found.
     assertEquals(-1, indexOfHelper(lengthTracking, 2, evil));
   }
+
+  // Special case: resizing to 0 -> length-tracking TA still not OOB.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT,
+                                           8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(lengthTracking, i, i);
+    }
+
+    let evil = { valueOf: () => {
+      rab.resize(0);
+      return 2;
+    }};
+    assertEquals(2, indexOfHelper(lengthTracking, 2));
+    // 2 no longer found.
+    assertEquals(-1, indexOfHelper(lengthTracking, evil));
+  }
+
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT,
+                                           8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(lengthTracking, i, i);
+    }
+
+    let evil = { valueOf: () => {
+      rab.resize(0);
+      return 1;
+    }};
+    assertEquals(2, indexOfHelper(lengthTracking, 2));
+    // 2 no longer found.
+    assertEquals(-1, indexOfHelper(lengthTracking, 2, evil));
+  }
 }
 IndexOfParameterConversionShrinks(TypedArrayIndexOfHelper);
 IndexOfParameterConversionShrinks(ArrayIndexOfHelper);
@@ -4996,6 +5404,41 @@ function LastIndexOfParameterConversionShrinks(lastIndexOfHelper) {
 
     let evil = { valueOf: () => {
       rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 2;
+    }};
+    assertEquals(2, lastIndexOfHelper(lengthTracking, 2));
+    // 2 no longer found.
+    assertEquals(-1, lastIndexOfHelper(lengthTracking, 2, evil));
+  }
+
+  // Special case: resizing to 0 -> length-tracking TA still not OOB.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT,
+                                           8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(lengthTracking, i, i);
+    }
+
+    const evil = { valueOf: () => {
+      rab.resize(0);
+      return 2;
+    }};
+    assertEquals(2, lastIndexOfHelper(lengthTracking, 2));
+    // 2 no longer found.
+    assertEquals(-1, lastIndexOfHelper(lengthTracking, evil));
+  }
+
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT,
+                                           8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(lengthTracking, i, i);
+    }
+
+    const evil = { valueOf: () => {
+      rab.resize(0);
       return 2;
     }};
     assertEquals(2, lastIndexOfHelper(lengthTracking, 2));
@@ -5259,6 +5702,21 @@ function JoinParameterConversionShrinks(joinHelper) {
     // the new length are converted to the empty string.
     assertEquals('0.0..', joinHelper(lengthTracking, evil));
   }
+
+  // Special case: resizing to 0 -> length-tracking TA still not OOB.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT,
+                                           8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+
+    let evil = { toString: () => {
+      rab.resize(0);
+      return '.';
+    }};
+    // We iterate 4 elements, since it was the starting length. All elements are
+    // converted to the empty string.
+    assertEquals('...', joinHelper(lengthTracking, evil));
+  }
 }
 JoinParameterConversionShrinks(TypedArrayJoinHelper);
 JoinParameterConversionShrinks(ArrayJoinHelper);
@@ -5351,6 +5809,33 @@ function ToLocaleStringNumberPrototypeToLocaleStringShrinks(
     // We iterate 4 elements, since it was the starting length. Elements beyond
     // the new length are converted to the empty string.
     assertEquals('0,0,,', toLocaleStringHelper(lengthTracking));
+  }
+
+  // Special case: resizing to 0 -> length-tracking TA still not OOB.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT,
+                                           8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+
+    let resizeAfter = 1;
+    Number.prototype.toLocaleString = function() {
+      --resizeAfter;
+      if (resizeAfter == 0) {
+        rab.resize(0);
+      }
+      return oldNumberPrototypeToLocaleString.call(this);
+    }
+    BigInt.prototype.toLocaleString = function() {
+      --resizeAfter;
+      if (resizeAfter == 0) {
+        rab.resize(0);
+      }
+      return oldBigIntPrototypeToLocaleString.call(this);
+    }
+
+    // We iterate 4 elements, since it was the starting length. Elements beyond
+    // the new length are converted to the empty string.
+    assertEquals('0,,,', toLocaleStringHelper(lengthTracking));
   }
 
   Number.prototype.toLocaleString = oldNumberPrototypeToLocaleString;
@@ -5620,6 +6105,20 @@ function MapShrinkMidIteration(mapHelper, hasUndefined) {
     }
   }
 
+  // Special case: resizing to 0 -> length-tracking TA still not OOB.
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    resizeAfter = 1;
+    resizeTo = 0;
+    if (hasUndefined) {
+      assertEquals([0, undefined, undefined, undefined],
+                   Helper(lengthTracking));
+    } else {
+      assertEquals([0], Helper(lengthTracking));
+    }
+  }
+
   for (let ctor of ctors) {
     rab = CreateRabForTest(ctor);
     const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
@@ -5776,6 +6275,33 @@ MapGrowMidIteration(ArrayMapHelper);
     resizeWhenConstructorCalled = true;
     assertEquals([0, 1, undefined, undefined], Helper(lengthTracking));
     assertEquals(2 * ctor.BYTES_PER_ELEMENT, rab.byteLength);
+  }
+
+  // Special case: resizing to 0 -> length-tracking TA still not OOB.
+  for (let ctor of ctors) {
+    rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT,
+                                     8 * ctor.BYTES_PER_ELEMENT);
+
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, i);
+    }
+
+    let resizeWhenConstructorCalled = false;
+    class MyArray extends ctor {
+      constructor(...params) {
+        super(...params);
+        if (resizeWhenConstructorCalled) {
+          rab.resize(0);
+        }
+      }
+    };
+
+    const lengthTracking = new MyArray(rab);
+    resizeWhenConstructorCalled = true;
+    assertEquals([undefined, undefined, undefined, undefined],
+                 Helper(lengthTracking));
+    assertEquals(0, rab.byteLength);
   }
 })();
 
@@ -6189,6 +6715,16 @@ Reverse(ArrayReverseHelper, false);
     assertEquals([1, 2, 4], ToNumbers(new ctor(rab)));
   }
 
+  // Special case: resizing to 0 -> length-tracking TA still not OOB.
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    resizeTo = 0;
+    lengthTracking.set(CreateSourceProxy(1));
+    assertEquals([], ToNumbers(lengthTracking));
+    assertEquals([], ToNumbers(new ctor(rab)));
+  }
+
   for (let ctor of ctors) {
     rab = CreateRabForTest(ctor);
     const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
@@ -6368,6 +6904,17 @@ Reverse(ArrayReverseHelper, false);
     lengthTracking.set(CreateSourceProxy(2));
     assertEquals([1, 1, 4], ToNumbers(lengthTracking));
     assertEquals([1, 1, 4], ToNumbers(new ctor(rab)));
+  }
+
+  // Special case: resizing to 0 -> length-tracking TA still not OOB.
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    resizeAt = 2;
+    resizeTo = 0;
+    lengthTracking.set(CreateSourceProxy(2));
+    assertEquals([], ToNumbers(lengthTracking));
+    assertEquals([], ToNumbers(new ctor(rab)));
   }
 
   for (let ctor of ctors) {
@@ -6841,6 +7388,31 @@ Reverse(ArrayReverseHelper, false);
       return 3;
     }};
     assertThrows(() => { lengthTracking.subarray(0, evil); });
+  }
+
+  // Special case: resizing to 0 -> length-tracking TA still not OOB.
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab);
+
+    let evil = { valueOf: () => {
+      rab.resize(0);
+      return 1;
+    }};
+    assertThrows(() => { lengthTracking.subarray(0, evil); });
+  }
+
+  // Like the previous test, but now we construct a smaller subarray and it
+  // succeeds.
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab);
+
+    let evil = { valueOf: () => {
+      rab.resize(0);
+      return 0;
+    }};
+    assertEquals([], ToNumbers(lengthTracking.subarray(evil, 0)));
   }
 })();
 
@@ -7323,14 +7895,10 @@ function SortCallbackShrinks(sortHelper) {
     const taFull = new ctor(rab, 0);
     WriteUnsortedData(taFull);
 
-    try {
-        sortHelper(fixedLength, CustomComparison);
+    sortHelper(fixedLength, CustomComparison);
 
-        // The data is unchanged.
-        assertEquals([10, 9], ToNumbers(taFull));
-    } catch {
-        // This is actually implementation dependent.
-    }
+    // The data is unchanged.
+    assertEquals([10, 9], ToNumbers(taFull));
   }
 
   // Length-tracking TA.
@@ -7350,6 +7918,17 @@ function SortCallbackShrinks(sortHelper) {
     assertEquals(2, newData.length);
     assertTrue([10, 9, 8, 7].includes(newData[0]));
     assertTrue([10, 9, 8, 7].includes(newData[1]));
+  }
+
+  for (let ctor of ctors) {
+    rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT,
+                                     8 * ctor.BYTES_PER_ELEMENT);
+    resizeTo = 0;
+    const lengthTracking = new ctor(rab, 0);
+    const taFull = new ctor(rab, 0);
+    WriteUnsortedData(taFull);
+
+    sortHelper(lengthTracking, CustomComparison);
   }
 }
 SortCallbackShrinks(TypedArraySortHelper);
@@ -7531,6 +8110,18 @@ SortCallbackGrows(ArraySortHelper);
     }};
     assertThrows(() => { helper(lengthTracking, evil, 8); }, TypeError);
   }
+
+  // Special case: resizing to 0 -> length-tracking TA still not OOB.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT,
+                                           8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab, 0);
+    const evil = {toString: () => {
+        rab.resize(0);
+        return 0;  // Index too large after resize.
+    }};
+    assertThrows(() => { helper(lengthTracking, evil, 8); }, TypeError);
+  }
 })();
 
 (function ObjectDefinePropertyParameterConversionGrows() {
@@ -7580,7 +8171,8 @@ SortCallbackGrows(ArraySortHelper);
     assertThrows(() => { Object.freeze(lengthTracking); }, TypeError);
     assertThrows(() => { Object.freeze(lengthTrackingWithOffset); }, TypeError);
   }
-  // Freezing zero-length TAs doesn't throw.
+  // Freezing zero-length TAs throws because [[PreventExtensions]] returns false
+  // for variable-length TAs.
   for (let ctor of ctors) {
     const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT,
                                            8 * ctor.BYTES_PER_ELEMENT);
@@ -7591,12 +8183,10 @@ SortCallbackGrows(ArraySortHelper);
     const lengthTrackingWithOffset = new ctor(
         rab, 4 * ctor.BYTES_PER_ELEMENT);
 
-    Object.freeze(fixedLength);
-    Object.freeze(fixedLengthWithOffset);
-    Object.freeze(lengthTrackingWithOffset);
+    assertThrows(() => { Object.freeze(fixedLength); }, TypeError);
+    assertThrows(() => { Object.freeze(fixedLengthWithOffset); }, TypeError);
+    assertThrows(() => { Object.freeze(lengthTrackingWithOffset); }, TypeError);
   }
-  // If the buffer has been resized to make length-tracking TAs zero-length,
-  // freezing them also doesn't throw.
   for (let ctor of ctors) {
     const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT,
                                            8 * ctor.BYTES_PER_ELEMENT);
@@ -7605,10 +8195,10 @@ SortCallbackGrows(ArraySortHelper);
         rab, 2 * ctor.BYTES_PER_ELEMENT);
 
     rab.resize(2 * ctor.BYTES_PER_ELEMENT);
-    Object.freeze(lengthTrackingWithOffset);
+    assertThrows(() => { Object.freeze(lengthTrackingWithOffset); }, TypeError);
 
     rab.resize(0 * ctor.BYTES_PER_ELEMENT);
-    Object.freeze(lengthTracking);
+    assertThrows(() => { Object.freeze(lengthTracking); }, TypeError);
   }
 })();
 
@@ -7767,4 +8357,36 @@ SortCallbackGrows(ArraySortHelper);
     assertThrows(() => { targetCtor.from(lengthTrackingWithOffset); },
                  TypeError);
   });
+})();
+
+(function ArrayBufferSizeNotMultipleOfElementSize() {
+  // The buffer size is a prime, not multiple of anything.
+  const rab = CreateResizableArrayBuffer(11, 20);
+  for (let ctor of ctors) {
+    if (ctor.BYTES_PER_ELEMENT == 1) continue;
+
+    // This should not throw.
+    new ctor(rab);
+  }
+})();
+
+
+(function SetValueToNumberResizesToInBounds() {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(0,
+                                           1 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab, 0);
+
+    const evil = { valueOf: () => {
+      // Resize so that `lengthTracking` is no longer OOB.
+      rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+      if (IsBigIntTypedArray(lengthTracking)) {
+        return 2n;
+      }
+      return 2;
+    }};
+
+    lengthTracking[0] = evil;
+    assertEquals([2], ToNumbers(lengthTracking));
+  }
 })();

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -79,9 +79,6 @@ test/built-ins/Function/prototype/toString/built-in-function-object.js:
 test/built-ins/Object/entries/order-after-define-property-with-function.js:
   default: 'Test262Error: Actual [a, name] and expected [name, a] should have the same contents. '
   strict mode: 'Test262Error: Actual [a, name] and expected [name, a] should have the same contents. '
-test/built-ins/Object/freeze/typedarray-backed-by-resizable-buffer.js:
-  default: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
 test/built-ins/Object/keys/order-after-define-property-with-function.js:
   default: 'Test262Error: Actual [a, length] and expected [length, a] should have the same contents. '
   strict mode: 'Test262Error: Actual [a, length] and expected [length, a] should have the same contents. '

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h
@@ -226,6 +226,8 @@ public:
 
     static inline const ClassInfo* info();
     static inline Structure* createStructure(VM&, JSGlobalObject*, JSValue prototype);
+
+    static bool preventExtensions(JSObject*, JSGlobalObject*);
 };
 
 template<typename Adaptor> inline RefPtr<typename Adaptor::ViewType> toPossiblySharedNativeTypedView(VM&, JSValue);

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
@@ -1013,6 +1013,17 @@ template<typename PassedAdaptor> inline Structure* JSGenericResizableOrGrowableS
     return Structure::create(vm, globalObject, prototype, TypeInfo(typeForTypedArrayType(Base::Adaptor::typeValue), StructureFlags), info(), NonArray);
 }
 
+template<typename PassedAdaptor> inline bool JSGenericResizableOrGrowableSharedTypedArrayView<PassedAdaptor>::preventExtensions(JSObject* cell, JSGlobalObject* globalObject)
+{
+    // https://tc39.es/ecma262/#sec-typedarray-preventextensions
+    auto* object = jsCast<JSGenericResizableOrGrowableSharedTypedArrayView<PassedAdaptor>*>(cell);
+    if (object->isAutoLength())
+        return false;
+    if (object->isResizableNonShared())
+        return false;
+    return Base::preventExtensions(object, globalObject);
+}
+
 } // namespace JSC
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### 7c1b98e25a372bc826f4586b0f74d2d17bbbb1eb
<pre>
[JSC] Resizable TypedArray should be [[PreventExtensions]] = true
<a href="https://bugs.webkit.org/show_bug.cgi?id=284854">https://bugs.webkit.org/show_bug.cgi?id=284854</a>
<a href="https://rdar.apple.com/141646666">rdar://141646666</a>

Reviewed by Yijia Huang.

Applying the change in the spec[1]. Resizable TypedArray should be
[[PreventExtensions]] = true.

[1]: <a href="https://github.com/tc39/ecma262/pull/3453">https://github.com/tc39/ecma262/pull/3453</a>

* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h:
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h:
(JSC::JSGenericResizableOrGrowableSharedTypedArrayView&lt;PassedAdaptor&gt;::preventExtensions):

Canonical link: <a href="https://commits.webkit.org/287987@main">https://commits.webkit.org/287987@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77a82f642bb396a651f4ac6e7ebcfa3c8c075c78

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81623 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1148 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35572 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/86159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/32613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1179 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8966 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/86159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/32613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84693 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/833 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/74275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/86159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/733 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/28453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31068 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/74602 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/29048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87602 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/80677 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8860 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/72008 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9043 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/70101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71243 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15321 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/14234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/103088 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12642 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8812 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/14340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25040 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/struct-new_default-small-members.js.wasm-no-cjit (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8652 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12173 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/10460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->