### PR TITLE
imported/w3c/web-platform-tests/navigation-api/navigation-methods/back-forward-multiple-frames.html is failing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-traverseTo-in-iframe-same-document-preventDefault-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-traverseTo-in-iframe-same-document-preventDefault-expected.txt
@@ -1,6 +1,4 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT navigation.traverseTo() in an iframe with same-document preventDefault in its parent Test timed out
+FAIL navigation.traverseTo() in an iframe with same-document preventDefault in its parent assert_unreached: navigate event should not fire in the iframe, because the traversal was cancelled in the top window Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-traverseTo-navigates-top-and-same-doc-child-and-cross-doc-child-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-traverseTo-navigates-top-and-same-doc-child-and-cross-doc-child-expected.txt
@@ -1,6 +1,4 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT navigation.traverseTo() can navigate 3 frames of different types with correct navigate event cancelable values Test timed out
+PASS navigation.traverseTo() can navigate 3 frames of different types with correct navigate event cancelable values
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/back-forward-multiple-frames-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/back-forward-multiple-frames-expected.txt
@@ -1,6 +1,4 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT navigation.back() and navigation.forward() can navigate multiple frames Test timed out
+PASS navigation.back() and navigation.forward() can navigate multiple frames
 

--- a/Source/WebCore/bindings/js/JSDOMPromiseDeferred.h
+++ b/Source/WebCore/bindings/js/JSDOMPromiseDeferred.h
@@ -164,6 +164,15 @@ public:
     WEBCORE_EXPORT void reject(Exception, RejectAsHandled = RejectAsHandled::No);
     WEBCORE_EXPORT void reject(ExceptionCode, const String& = { }, RejectAsHandled = RejectAsHandled::No);
 
+    bool wasRejected() const
+    {
+        auto* lexicalGlobalObject = globalObject();
+        ASSERT(lexicalGlobalObject);
+
+        ASSERT(deferred());
+        return deferred()->status(lexicalGlobalObject->vm()) == JSC::JSPromise::Status::Rejected;
+    }
+
     template<typename Callback>
     void resolveWithCallback(Callback callback)
     {

--- a/Source/WebCore/loader/HistoryController.h
+++ b/Source/WebCore/loader/HistoryController.h
@@ -100,21 +100,26 @@ private:
     friend class Page;
     bool shouldStopLoadingForHistoryItem(HistoryItem&) const;
     void goToItem(HistoryItem&, FrameLoadType, ShouldTreatAsContinuingLoad);
+    void goToItemForNavigationAPI(HistoryItem&, FrameLoadType, const String& targetNavigationEntryKey);
 
     void initializeItem(HistoryItem&, RefPtr<DocumentLoader>);
     Ref<HistoryItem> createItem(HistoryItemClient&);
     Ref<HistoryItem> createItemTree(HistoryItemClient&, LocalFrame& targetFrame, bool clipAtTarget);
 
-    void recursiveSetProvisionalItem(HistoryItem&, HistoryItem*);
+    enum class ForNavigationAPI : bool { No, Yes };
+    void recursiveSetProvisionalItem(HistoryItem&, HistoryItem*, ForNavigationAPI = ForNavigationAPI::No);
     void recursiveGoToItem(HistoryItem&, HistoryItem*, FrameLoadType, ShouldTreatAsContinuingLoad);
     bool isReplaceLoadTypeWithProvisionalItem(FrameLoadType);
     bool isReloadTypeWithProvisionalItem(FrameLoadType);
     void recursiveUpdateForCommit();
     void recursiveUpdateForSameDocumentNavigation();
-    bool itemsAreClones(HistoryItem&, HistoryItem*) const;
+    static bool itemsAreClones(HistoryItem&, HistoryItem*);
     void updateBackForwardListClippedAtTarget(bool doClip);
     void updateCurrentItem();
     bool isFrameLoadComplete() const { return m_frameLoadComplete; }
+
+    struct FrameToNavigate;
+    static void recursiveGatherFramesToNavigate(LocalFrame&, Vector<FrameToNavigate>&, HistoryItem& targetItem, HistoryItem* fromItem);
 
     Ref<Frame> protectedFrame() const;
 

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -387,8 +387,10 @@ public:
         }
 
         auto completionHandler = std::exchange(m_completionHandler, nullptr);
+
         Ref rootFrame = localFrame->rootFrame();
-        page->goToItem(rootFrame, *historyItem, FrameLoadType::IndexedBackForward, ShouldTreatAsContinuingLoad::No);
+        page->goToItemForNavigationAPI(rootFrame, *historyItem, FrameLoadType::IndexedBackForward, m_key);
+
         completionHandler(ScheduleHistoryNavigationResult::Completed);
     }
 

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -163,6 +163,8 @@ public:
     ScriptExecutionContext* scriptExecutionContext() const final;
     RefPtr<ScriptExecutionContext> protectedScriptExecutionContext() const;
 
+    NavigationAPIMethodTracker* upcomingTraverseMethodTracker(const String& key) const { return m_upcomingTraverseMethodTrackers.get(key); }
+
 private:
     explicit Navigation(LocalDOMWindow&);
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -944,6 +944,14 @@ void Page::goToItem(LocalFrame& frame, HistoryItem& item, FrameLoadType type, Sh
     frame.checkedHistory()->goToItem(item, type, shouldTreatAsContinuingLoad);
 }
 
+void Page::goToItemForNavigationAPI(LocalFrame& frame, HistoryItem& item, FrameLoadType type, const String& targetNavigationEntryKey)
+{
+    ASSERT(frame.isRootFrame());
+    if (frame.checkedHistory()->shouldStopLoadingForHistoryItem(item))
+        frame.protectedLoader()->stopAllLoadersAndCheckCompleteness();
+    frame.checkedHistory()->goToItemForNavigationAPI(item, type, targetNavigationEntryKey);
+}
+
 void Page::setGroupName(const String& name)
 {
     if (m_group && !m_group->name().isEmpty()) {

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -406,6 +406,7 @@ public:
     void setOpenedByDOMWithOpener(bool value) { m_openedByDOMWithOpener = value; }
 
     WEBCORE_EXPORT void goToItem(LocalFrame& rootFrame, HistoryItem&, FrameLoadType, ShouldTreatAsContinuingLoad);
+    void goToItemForNavigationAPI(LocalFrame& rootFrame, HistoryItem&, FrameLoadType, const String& targetNavigationEntryKey);
 
     WEBCORE_EXPORT void setGroupName(const String&);
     WEBCORE_EXPORT const String& groupName() const;


### PR DESCRIPTION
#### 45eb3846b6f4bdd85e0e7181411942dd4c71960c
<pre>
imported/w3c/web-platform-tests/navigation-api/navigation-methods/back-forward-multiple-frames.html is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=284865">https://bugs.webkit.org/show_bug.cgi?id=284865</a>

Reviewed by Rob Buis.

When calling `navigation.back()` / `navigation.forward()`, we would call `Page::goToItem()` which
would navigate a single frame. However, per the HTML specification, several frames may get navigated.
In particular, if a frame get navigated within the same document (e.g. fragment navigation), its
descendant frames may get navigated to whatever their URL was when their ancestor last was on this
HistoryItem.

In particular, the &quot;apply the history step&quot; [1] says:
&quot;&quot;&quot;
Let changingNavigables be the result of get all navigables whose current session history entry will change or reload given traversable and targetStep.
&quot;&quot;&quot;
Which refers to the algorithm at [2] to gather the changing navigables.

[1] <a href="https://html.spec.whatwg.org/#apply-the-history-step">https://html.spec.whatwg.org/#apply-the-history-step</a>
[2] <a href="https://html.spec.whatwg.org/#get-all-navigables-whose-current-session-history-entry-will-change-or-reload">https://html.spec.whatwg.org/#get-all-navigables-whose-current-session-history-entry-will-change-or-reload</a>

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-traverseTo-in-iframe-same-document-preventDefault-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-traverseTo-navigates-top-and-same-doc-child-and-cross-doc-child-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/back-forward-multiple-frames-expected.txt:
Rebaseline tests that are now passing or running further.

* Source/WebCore/bindings/js/JSDOMPromiseDeferred.h:
(WebCore::DeferredPromise::wasRejected const):
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::goToItem):
(WebCore::HistoryController::goToItemForNavigationAPI):
(WebCore::HistoryController::recursiveGatherFramesToNavigate):
(WebCore::HistoryController::recursiveSetProvisionalItem):
(WebCore::HistoryController::itemsAreClones):
(WebCore::HistoryController::itemsAreClones const): Deleted.
* Source/WebCore/loader/HistoryController.h:
* Source/WebCore/loader/NavigationScheduler.cpp:
* Source/WebCore/page/Navigation.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::goToItemForNavigationAPI):
* Source/WebCore/page/Page.h:

Canonical link: <a href="https://commits.webkit.org/288123@main">https://commits.webkit.org/288123@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4cb34e96e90d6d45b4b8454b2f2094c5ff771345

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81927 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35884 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86484 "") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/32958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84033 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1489 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9277 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/86484 "") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/32958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84997 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/1109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74554 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/86484 "") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1011 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28731 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31378 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29340 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87915 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9169 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/72253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9354 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70373 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/71475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17814 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15579 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/14500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9120 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14656 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8960 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12485 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10768 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->