### PR TITLE
AX: Serve NSAccessibilitySelectedTextAttribute off the main-thread

### DIFF
--- a/LayoutTests/accessibility/ax-thread-text-apis/selected-text-expected.txt
+++ b/LayoutTests/accessibility/ax-thread-text-apis/selected-text-expected.txt
@@ -1,0 +1,10 @@
+This test ensures that the selected text accessibility API works as expected.
+
+PASS: contenteditable.selectedText === "One foo" === true
+PASS: contenteditable.selectedText === "Two foo" === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+One foo
+Two foo

--- a/LayoutTests/accessibility/ax-thread-text-apis/selected-text.html
+++ b/LayoutTests/accessibility/ax-thread-text-apis/selected-text.html
@@ -1,0 +1,45 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ runSingly=true AccessibilityThreadTextApisEnabled=true ] -->
+<!-- This is new test added with the accessibilityThreadTextApisEnabled effort. After accessibilityThreadTextApisEnabled is enabled by default, we should move it into LayoutTests/accessibility/mac. -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="contenteditable" contenteditable="true">
+    <div id="one">One foo</div>
+    <div id="two">Two foo</div>
+</div>
+
+<script>
+var output = "This test ensures that the selected text accessibility API works as expected.\n\n";
+
+var contenteditable;
+async function waitUntilSelected(id) {
+    let range = document.createRange();
+    let element = document.getElementById(id);
+    range.selectNodeContents(element);
+
+    let selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(range);
+    output += await expectAsync(`contenteditable.selectedText === "${element.innerText}"`, "true");
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    contenteditable = accessibilityController.accessibleElementById("contenteditable");
+    setTimeout(async function() {
+        await waitUntilSelected("one");
+        await waitUntilSelected("two");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -1303,7 +1303,7 @@ public:
     virtual AXTextMarkerRange textMarkerRangeForNSRange(const NSRange&) const = 0;
 #endif
 #if PLATFORM(MAC)
-    virtual AXTextMarkerRange selectedTextMarkerRange() = 0;
+    virtual AXTextMarkerRange selectedTextMarkerRange() const = 0;
 #endif
 
     virtual String stringForRange(const SimpleRange&) const = 0;

--- a/Source/WebCore/accessibility/AXTextRun.h
+++ b/Source/WebCore/accessibility/AXTextRun.h
@@ -116,7 +116,8 @@ struct AXTextRuns {
     }
     unsigned totalLength() const
     {
-        return runLengthSumTo(runs.size() - 1);
+        unsigned size = runs.size();
+        return size ? runLengthSumTo(size - 1) : 0;
     }
     unsigned runLengthSumTo(size_t index) const;
 

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -1735,14 +1735,14 @@ VisiblePositionRange AccessibilityObject::lineRangeForPosition(const VisiblePosi
 }
 
 #if PLATFORM(MAC)
-AXTextMarkerRange AccessibilityObject::selectedTextMarkerRange()
+AXTextMarkerRange AccessibilityObject::selectedTextMarkerRange() const
 {
     auto visibleRange = selectedVisiblePositionRange();
     if (visibleRange.isNull())
         return { };
     return { visibleRange };
 }
-#endif
+#endif // PLATFORM(MAC)
 
 bool AccessibilityObject::replacedNodeNeedsCharacter(Node& replacedNode)
 {

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -601,7 +601,7 @@ public:
     AXTextMarkerRange textMarkerRangeForNSRange(const NSRange&) const final;
 #endif
 #if PLATFORM(MAC)
-    AXTextMarkerRange selectedTextMarkerRange() final;
+    AXTextMarkerRange selectedTextMarkerRange() const final;
 #endif
     static String stringForVisiblePositionRange(const VisiblePositionRange&);
     String stringForRange(const SimpleRange&) const final;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -939,6 +939,11 @@ void AXIsolatedObject::setFocused(bool value)
 
 String AXIsolatedObject::selectedText() const
 {
+#if ENABLE(AX_THREAD_TEXT_APIS)
+    if (AXObjectCache::useAXThreadTextApis())
+        return selectedTextMarkerRange().toString();
+#endif // ENABLE(AX_THREAD_TEXT_APIS)
+
     return Accessibility::retrieveValueFromMainThread<String>([this] () -> String {
         if (auto* object = associatedAXObject())
             return object->selectedText().isolatedCopy();
@@ -1285,11 +1290,11 @@ std::optional<SimpleRange> AXIsolatedObject::rangeForCharacterRange(const Charac
 }
 
 #if PLATFORM(MAC)
-AXTextMarkerRange AXIsolatedObject::selectedTextMarkerRange()
+AXTextMarkerRange AXIsolatedObject::selectedTextMarkerRange() const
 {
     return tree()->selectedTextMarkerRange();
 }
-#endif
+#endif // PLATFORM(MAC)
 
 String AXIsolatedObject::stringForRange(const SimpleRange& range) const
 {

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -406,7 +406,7 @@ private:
     AXTextMarkerRange textMarkerRangeForNSRange(const NSRange&) const final;
 #endif
 #if PLATFORM(MAC)
-    AXTextMarkerRange selectedTextMarkerRange() final;
+    AXTextMarkerRange selectedTextMarkerRange() const final;
 #endif
     String stringForRange(const SimpleRange&) const final;
     IntRect boundsForRange(const SimpleRange&) const final;

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
@@ -125,6 +125,7 @@ public:
     RefPtr<AccessibilityUIElement> focusableAncestor();
     RefPtr<AccessibilityUIElement> editableAncestor();
     RefPtr<AccessibilityUIElement> highestEditableAncestor();
+    JSRetainPtr<JSStringRef> selectedText();
 #else
     void syncPress() { press(); }
     void asyncIncrement() { }
@@ -132,7 +133,8 @@ public:
     RefPtr<AccessibilityUIElement> focusableAncestor() { return nullptr; }
     RefPtr<AccessibilityUIElement> editableAncestor() { return nullptr; }
     RefPtr<AccessibilityUIElement> highestEditableAncestor() { return nullptr; }
-#endif
+    JSRetainPtr<JSStringRef> selectedText() { return nullptr; }
+#endif // PLATFORM(MAC)
 
     // Attributes - platform-independent implementations
     JSRetainPtr<JSStringRef> stringDescriptionOfAttributeValue(JSStringRef attribute);

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl
@@ -63,6 +63,7 @@ interface AccessibilityUIElement {
     readonly attribute DOMString orientation;
     readonly attribute unsigned long numberOfCharacters;
     readonly attribute long insertionPointLineNumber;
+    readonly attribute DOMString selectedText;
     readonly attribute DOMString selectedTextRange;
     readonly attribute DOMString intersectionWithSelectionRange;
     readonly attribute DOMString textInputMarkedRange;

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
@@ -1749,6 +1749,18 @@ void AccessibilityUIElement::scrollToMakeVisibleWithSubFocus(int x, int y, int w
     END_AX_OBJC_EXCEPTIONS
 }
 
+JSRetainPtr<JSStringRef> AccessibilityUIElement::selectedText()
+{
+    BEGIN_AX_OBJC_EXCEPTIONS
+    auto string = attributeValue(@"AXSelectedText");
+    if (![string isKindOfClass:[NSString class]])
+        return nullptr;
+    return [string createJSStringRef];
+    END_AX_OBJC_EXCEPTIONS
+
+    return nullptr;
+}
+
 JSRetainPtr<JSStringRef> AccessibilityUIElement::selectedTextRange()
 {
     NSRange range = NSMakeRange(NSNotFound, 0);


### PR DESCRIPTION
#### 38909c01395f733240beca4a5a93a59242a4d122
<pre>
AX: Serve NSAccessibilitySelectedTextAttribute off the main-thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=284866">https://bugs.webkit.org/show_bug.cgi?id=284866</a>
<a href="https://rdar.apple.com/141663736">rdar://141663736</a>

Reviewed by Chris Fleizach.

We can already compute selectedTextMarkerRange() off the main-thread, so we can serve NSAccessibilitySelectedTextAttribute
simply by calling AXTextMarkerRange::toString() on that range.

This commit also fixes a bug where AXTextRun::totalLength() didn&apos;t check that runs.size() was not zero before indexing
into its runs.

* LayoutTests/accessibility/ax-thread-text-apis/selected-text-expected.txt: Added.
* LayoutTests/accessibility/ax-thread-text-apis/selected-text.html: Added.
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXTextRun.h:
(WebCore::AXTextRuns::totalLength const):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::selectedTextMarkerRange const):
(WebCore::AccessibilityObject::selectedTextMarkerRange): Deleted.
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::selectedText const):
(WebCore::AXIsolatedObject::selectedTextMarkerRange const):
(WebCore::AXIsolatedObject::selectedTextMarkerRange): Deleted.
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h:
(WTR::AccessibilityUIElement::selectedText):
* Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl:
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
(WTR::AccessibilityUIElement::selectedText):

Canonical link: <a href="https://commits.webkit.org/288030@main">https://commits.webkit.org/288030@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3142c8e16c9b5874e3fe12f8e2548d1c516352fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81635 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1160 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35584 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86174 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32625 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83741 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1191 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8978 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63687 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21413 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84705 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/844 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74286 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43977 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/744 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28464 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31080 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29060 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87614 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8872 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6284 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72016 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9055 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70112 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71251 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17757 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15331 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14245 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8824 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14352 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8664 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12185 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10473 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->