### PR TITLE
REGRESSION(287633@main): Release assert failure in Node::moveTreeToNewScope

### DIFF
--- a/LayoutTests/fast/shadow-dom/clone-node-in-shadow-tree-crash-expected.txt
+++ b/LayoutTests/fast/shadow-dom/clone-node-in-shadow-tree-crash-expected.txt
@@ -1,0 +1,4 @@
+This tests cloning a node in a shadow tree and inserts it into body.
+WebKit should not hit any debug or release assertions.
+
+

--- a/LayoutTests/fast/shadow-dom/clone-node-in-shadow-tree-crash.html
+++ b/LayoutTests/fast/shadow-dom/clone-node-in-shadow-tree-crash.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>This tests cloning a node in a shadow tree and inserts it into body.<br>
+WebKit should not hit any debug or release assertions.</p>
+<script>
+
+window.testRunner?.dumpAsText();
+
+const host = document.createElement('div');
+const shadowRoot = host.attachShadow({mode: 'closed'});
+shadowRoot.innerHTML = '<div>PASS</div>';
+
+const otherHost = document.createElement('div');
+document.body.appendChild(otherHost);
+otherHost.attachShadow({mode: 'closed'}).append(shadowRoot.querySelector('div').cloneNode(true));
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -804,6 +804,12 @@ void Node::normalize()
     }
 }
 
+Ref<Node> Node::cloneNode(bool deep)
+{
+    ASSERT(!isShadowRoot());
+    return cloneNodeInternal(document(), deep ? CloningOperation::Everything : CloningOperation::OnlySelf);
+}
+
 ExceptionOr<Ref<Node>> Node::cloneNodeForBindings(bool deep)
 {
     if (UNLIKELY(isShadowRoot()))

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -186,7 +186,7 @@ public:
         Everything,
     };
     virtual Ref<Node> cloneNodeInternal(TreeScope&, CloningOperation) = 0;
-    Ref<Node> cloneNode(bool deep) { return cloneNodeInternal(treeScope(), deep ? CloningOperation::Everything : CloningOperation::OnlySelf); }
+    Ref<Node> cloneNode(bool deep);
     WEBCORE_EXPORT ExceptionOr<Ref<Node>> cloneNodeForBindings(bool deep);
 
     virtual const AtomString& localName() const;


### PR DESCRIPTION
#### 3485279ce29b2c912052bff9facdadede856145d
<pre>
REGRESSION(287633@main): Release assert failure in Node::moveTreeToNewScope
<a href="https://bugs.webkit.org/show_bug.cgi?id=284863">https://bugs.webkit.org/show_bug.cgi?id=284863</a>

Reviewed by Chris Dumez.

The release assertion failure was caused by Node::cloneNode erroneously cloning nodes
using a shadow tree as the tree scope when cloning a node in the shadow tree. Fixed
the bug by always cloning using the document as the tree scope.

* LayoutTests/fast/shadow-dom/clone-node-in-shadow-tree-crash-expected.txt: Added.
* LayoutTests/fast/shadow-dom/clone-node-in-shadow-tree-crash.html: Added.
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::cloneNode):
* Source/WebCore/dom/Node.h:
(WebCore::Node::cloneNode): Deleted.

Canonical link: <a href="https://commits.webkit.org/288014@main">https://commits.webkit.org/288014@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/878b0a2496f01e74cee18fe0ad70220dbac61077

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81644 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1169 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35593 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86183 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32634 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83750 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1200 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8988 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63697 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21424 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84714 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/856 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74294 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43987 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/756 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28472 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31089 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29068 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87623 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8881 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6291 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72031 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9064 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70120 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71266 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15339 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14253 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12645 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8833 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14361 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8673 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12194 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10482 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->