### PR TITLE
REGRESSION(287835@main): [CoordinatedGraphics] Scrolling by clicking on any scrollbar position is broken

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
@@ -771,12 +771,12 @@ void GraphicsLayerCoordinated::computeLayerTransformIfNeeded(bool affectedByTran
 
     m_layerTransform.current.setLocalTransform(currentTransform);
 
-    m_layerTransform.current.setAnchorPoint(m_platformLayer->anchorPoint());
-    m_layerTransform.current.setPosition(FloatPoint(m_platformLayer->position() - m_platformLayer->boundsOrigin()));
-    m_layerTransform.current.setSize(m_platformLayer->size());
+    m_layerTransform.current.setAnchorPoint(m_anchorPoint);
+    m_layerTransform.current.setPosition(FloatPoint(m_position - m_boundsOrigin));
+    m_layerTransform.current.setSize(m_size);
 
     m_layerTransform.current.setFlattening(!m_preserves3D);
-    m_layerTransform.current.setChildrenTransform(m_platformLayer->childrenTransform());
+    m_layerTransform.current.setChildrenTransform(childrenTransform());
     m_layerTransform.current.combineTransforms(parent() ? downcast<GraphicsLayerCoordinated>(*parent()).m_layerTransform.current.combinedForChildren() : TransformationMatrix());
 
     m_layerTransform.cachedCombined = m_layerTransform.current.combined();


### PR DESCRIPTION
#### 9ebe9d89eaef08c00b6fb8749d7fb715b7434cd5
<pre>
REGRESSION(287835@main): [CoordinatedGraphics] Scrolling by clicking on any scrollbar position is broken
<a href="https://bugs.webkit.org/show_bug.cgi?id=284877">https://bugs.webkit.org/show_bug.cgi?id=284877</a>

Reviewed by Alejandro G. Castro.

This broke in 287835@main because the CoordinatedPlatformLayer is not
updated when GraphicsLayerCoordinated::syncPosition is called. This is
the expected behavior, the position will be set on
CoordinatedPlatformLayer later when scrolling layers are positioned. The
problem is that GraphicsLayerCoordinated is using the
CoordinatedPlatformLayer properties to compute the layer transform, and
now it&apos;s using the previous position, causing a wrong transformed
visible rect to be set in the CoordinatedPlatformLayer. We should use
the GraphicsLayer properties when computing the transforms.

* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp:
(WebCore::GraphicsLayerCoordinated::computeLayerTransformIfNeeded):

Canonical link: <a href="https://commits.webkit.org/288079@main">https://commits.webkit.org/288079@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94936bbe760710f39a0c90a8345d51b26e77dbd4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81677 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1202 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35626 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86217 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32667 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83783 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1233 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9021 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63716 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21442 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84747 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/884 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74324 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44008 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/783 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28501 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31122 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72181 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29099 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87656 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8914 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6323 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72051 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9097 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70149 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71286 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15366 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14282 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12673 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8866 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14401 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8706 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12227 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10515 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->