### PR TITLE
Add damage visualizer starting on 'WEBKIT_SHOW_DAMAGE'

### DIFF
--- a/Source/WebCore/platform/TextureMapper.cmake
+++ b/Source/WebCore/platform/TextureMapper.cmake
@@ -13,6 +13,7 @@ list(APPEND WebCore_SOURCES
     platform/graphics/texmap/TextureMapper.cpp
     platform/graphics/texmap/TextureMapperAnimation.cpp
     platform/graphics/texmap/TextureMapperBackingStore.cpp
+    platform/graphics/texmap/TextureMapperDamageVisualizer.cpp
     platform/graphics/texmap/TextureMapperFPSCounter.cpp
     platform/graphics/texmap/TextureMapperGCGLPlatformLayer.cpp
     platform/graphics/texmap/TextureMapperGPUBuffer.cpp
@@ -35,6 +36,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/texmap/TextureMapper.h
     platform/graphics/texmap/TextureMapperAnimation.h
     platform/graphics/texmap/TextureMapperBackingStore.h
+    platform/graphics/texmap/TextureMapperDamageVisualizer.h
     platform/graphics/texmap/TextureMapperFlags.h
     platform/graphics/texmap/TextureMapperFPSCounter.h
     platform/graphics/texmap/TextureMapperGLHeaders.h

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperDamageVisualizer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperDamageVisualizer.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE COMPUTER, INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE COMPUTER, INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if ENABLE(DAMAGE_TRACKING)
+#include "TextureMapperDamageVisualizer.h"
+
+#include "Damage.h"
+#include "TextureMapper.h"
+#include <wtf/text/StringToIntegerConversion.h>
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TextureMapperDamageVisualizer);
+
+TextureMapperDamageVisualizer::TextureMapperDamageVisualizer()
+    : m_active(false)
+    , m_margin(0)
+{
+    if (const auto* showDmageEnvvar = getenv("WEBKIT_SHOW_DAMAGE")) {
+        const auto value = parseInteger<unsigned>(StringView::fromLatin1(showDmageEnvvar));
+        if (value && *value > 0) {
+            m_active = true;
+            m_margin = *value - 1;
+        }
+    }
+}
+
+void TextureMapperDamageVisualizer::updateDamageAndDisplay(TextureMapper& textureMapper, const Damage& damage)
+{
+    if (!m_active || damage.isInvalid())
+        return;
+
+    const FloatPoint offset(m_margin, m_margin);
+    const FloatSize extraSize(m_margin * 2, m_margin * 2);
+    for (const auto& rect : damage.rects()) {
+        FloatRect rectToDraw(rect);
+        rectToDraw.moveBy(-offset);
+        rectToDraw.expand(extraSize);
+        textureMapper.drawSolidColor(rectToDraw, { }, SRGBA<uint8_t> { 255, 0, 0, 200 }, true);
+    }
+}
+
+}
+
+#endif // ENABLE(DAMAGE_TRACKING)

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperDamageVisualizer.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperDamageVisualizer.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE COMPUTER, INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE COMPUTER, INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(DAMAGE_TRACKING)
+
+#include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+class TextureMapper;
+class Damage;
+
+class TextureMapperDamageVisualizer {
+    WTF_MAKE_TZONE_ALLOCATED(TextureMapperDamageVisualizer);
+    WTF_MAKE_NONCOPYABLE(TextureMapperDamageVisualizer);
+public:
+    TextureMapperDamageVisualizer();
+
+    void updateDamageAndDisplay(TextureMapper&, const Damage&);
+    bool isActive() const { return m_active; }
+
+private:
+    bool m_active;
+    unsigned m_margin;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(DAMAGE_TRACKING)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedGraphicsScene.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedGraphicsScene.h
@@ -23,6 +23,9 @@
 #if USE(COORDINATED_GRAPHICS)
 #include <WebCore/Damage.h>
 #include <WebCore/TextureMapper.h>
+#if ENABLE(DAMAGE_TRACKING)
+#include <WebCore/TextureMapperDamageVisualizer.h>
+#endif
 #include <WebCore/TextureMapperFPSCounter.h>
 #include <WebCore/TextureMapperLayer.h>
 #include <wtf/Function.h>
@@ -76,6 +79,7 @@ private:
     WebCore::TextureMapperFPSCounter m_fpsCounter;
 #if ENABLE(DAMAGE_TRACKING)
     WebCore::Damage::Propagation m_damagePropagation { WebCore::Damage::Propagation::None };
+    WebCore::TextureMapperDamageVisualizer m_damageVisualizer;
 #endif
 };
 


### PR DESCRIPTION
#### 95073ed4ada0ffab4bd286d5f421a3e461d1dd9d
<pre>
Add damage visualizer starting on &apos;WEBKIT_SHOW_DAMAGE&apos;
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95073ed4ada0ffab4bd286d5f421a3e461d1dd9d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85973 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5594 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40341 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90988 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36883 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88018 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5833 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13599 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66718 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24517 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88976 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4470 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77986 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47012 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4316 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32271 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35968 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74925 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33134 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92765 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13222 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9684 "Found 60 new test failures: http/tests/security/referrer-policy-header-multipart.html http/tests/site-isolation/page-zoom.html http/tests/site-isolation/text-zoom.html imported/blink/fast/sub-pixel/negative-composited-offset.html imported/blink/fast/sub-pixel/sub-pixel-transparency-layer.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-update-005.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-update-006.html imported/w3c/web-platform-tests/css/css-fonts/font-palette-13.html imported/w3c/web-platform-tests/css/css-fonts/font-palette-16.html imported/w3c/web-platform-tests/css/css-fonts/font-palette-17.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75495 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13436 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73833 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74660 "Found 99 new API test failures: /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/reset, /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginAndEndEditingEvents, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/query-permission-requests, /TestWebKit:WebKit.EnumerateDevicesCrash, /TestWebKit:WebKit.DOMWindowExtensionCrashOnReload, /TestWebKit:WebKit.Find, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/simple, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/invalid-sequence, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/insert/image, /TestWebKit:WebKit.UserMediaBasic ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18858 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17288 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6089 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13254 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18602 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13027 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16460 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14814 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->