### PR TITLE
[css-masonry] Cleanup & Remove Masonry Definite First Placement

### DIFF
--- a/Source/WebCore/rendering/GridMasonryLayout.h
+++ b/Source/WebCore/rendering/GridMasonryLayout.h
@@ -29,6 +29,7 @@
 #include "GridTrackSizingAlgorithm.h"
 #include "LayoutUnit.h"
 #include "RenderBox.h"
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -60,15 +61,13 @@ private:
     GridArea gridAreaForDefiniteGridAxisItem(const RenderBox&) const;
 
     void collectMasonryItems();
-    void placeItemsUsingOrderModifiedDocumentOrder(const GridTrackSizingAlgorithm&, GridMasonryLayout::MasonryLayoutPhase);
-    void placeItemsWithDefiniteGridAxisPosition(const GridTrackSizingAlgorithm&, GridMasonryLayout::MasonryLayoutPhase);
-    void placeItemsWithIndefiniteGridAxisPosition(const GridTrackSizingAlgorithm&, GridMasonryLayout::MasonryLayoutPhase);
+    void placeMasonryItems(const GridTrackSizingAlgorithm&, GridMasonryLayout::MasonryLayoutPhase);
     void setItemGridAxisContainingBlockToGridArea(const GridTrackSizingAlgorithm&, RenderBox&);
     void insertIntoGridAndLayoutItem(const GridTrackSizingAlgorithm&, RenderBox&, const GridArea&, GridMasonryLayout::MasonryLayoutPhase);
     LayoutUnit calculateMasonryIntrinsicLogicalWidth(RenderBox&, GridMasonryLayout::MasonryLayoutPhase);
 
     void resizeAndResetRunningPositions();
-    void allocateCapacityForMasonryVectors();
+    void allocateCapacityForMasonryVector();
     LayoutUnit masonryAxisMarginBoxForItem(const RenderBox& gridItem);
     void updateRunningPositions(const RenderBox& gridItem, const GridArea&);
     void updateItemOffset(const RenderBox& gridItem, LayoutUnit offset);
@@ -81,9 +80,7 @@ private:
 
     unsigned m_gridAxisTracksCount;
 
-    Vector<RenderBox*> m_itemsWithDefiniteGridAxisPosition;
-    Vector<RenderBox*> m_itemsWithIndefiniteGridAxisPosition;
-
+    Vector<SingleThreadWeakPtr<RenderBox>> m_masonryItems;
     Vector<LayoutUnit> m_runningPositions;
     UncheckedKeyHashMap<SingleThreadWeakRef<const RenderBox>, LayoutUnit> m_itemOffsets;
     RenderGrid& m_renderGrid;
@@ -92,11 +89,6 @@ private:
 
     GridTrackSizingDirection m_masonryAxisDirection;
     const GridSpan m_masonryAxisSpan = GridSpan::masonryAxisTranslatedDefiniteGridSpan();
-
-    // These values are based on best estimate. They may need to be updated based
-    // on common behavior seen on websites.
-    const unsigned m_masonryDefiniteItemsQuarterCapacity = 4;
-    const unsigned m_masonryIndefiniteItemsHalfCapacity = 2;
 
     unsigned m_autoFlowNextCursor;
 };


### PR DESCRIPTION
#### 64ee561131cac9e3f57f0c653a8ec3bc72f09045
<pre>
[css-masonry] Cleanup &amp; Remove Masonry Definite First Placement
<a href="https://bugs.webkit.org/show_bug.cgi?id=284818">https://bugs.webkit.org/show_bug.cgi?id=284818</a>
<a href="https://rdar.apple.com/problem/141617710">rdar://problem/141617710</a>

Reviewed by Sammy Gill.

Remove masonry definite first placement as this was removed in the css-grid-3 spec.

* Source/WebCore/rendering/GridMasonryLayout.cpp:
(WebCore::GridMasonryLayout::initializeMasonry):
(WebCore::GridMasonryLayout::performMasonryPlacement):
(WebCore::GridMasonryLayout::collectMasonryItems):
(WebCore::GridMasonryLayout::allocateCapacityForMasonryVector):
(WebCore::GridMasonryLayout::placeMasonryItems):
(WebCore::GridMasonryLayout::allocateCapacityForMasonryVectors): Deleted.
(WebCore::GridMasonryLayout::placeItemsUsingOrderModifiedDocumentOrder): Deleted.
(WebCore::GridMasonryLayout::placeItemsWithDefiniteGridAxisPosition): Deleted.
(WebCore::GridMasonryLayout::placeItemsWithIndefiniteGridAxisPosition): Deleted.
* Source/WebCore/rendering/GridMasonryLayout.h:

Canonical link: <a href="https://commits.webkit.org/288045@main">https://commits.webkit.org/288045@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5381a69945a2c3210eee9c7d323600414dba9d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81704 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1230 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35658 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86248 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32699 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83810 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1263 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9050 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63746 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21472 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84774 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/916 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74355 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44032 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/815 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28529 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31153 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29131 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87687 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8944 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6352 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72085 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9129 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70174 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71315 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17772 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15395 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14311 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8895 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14427 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8736 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12259 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10544 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->