### PR TITLE
[CMake] Separate C files in Visual Studio

### DIFF
--- a/Source/JavaScriptCore/shell/CMakeLists.txt
+++ b/Source/JavaScriptCore/shell/CMakeLists.txt
@@ -25,7 +25,6 @@ WEBKIT_EXECUTABLE_DECLARE(jsc)
 if (DEVELOPER_MODE)
     set(testapi_SOURCES
         ../API/tests/CompareAndSwapTest.cpp
-        ../API/tests/CustomGlobalObjectClassTest.c
         ../API/tests/ExecutionTimeLimitTest.cpp
         ../API/tests/FunctionOverridesTest.cpp
         ../API/tests/FunctionToStringTests.cpp
@@ -35,8 +34,11 @@ if (DEVELOPER_MODE)
         ../API/tests/MultithreadedMultiVMExecutionTest.cpp
         ../API/tests/PingPongStackOverflowTest.cpp
         ../API/tests/TypedArrayCTest.cpp
-        ../API/tests/testapi.c
         ../API/tests/testapi.cpp
+    )
+    set(testapi_C_SOURCES
+        ../API/tests/CustomGlobalObjectClassTest.c
+        ../API/tests/testapi.c
     )
     set(testapi_DEFINITIONS ${jsc_PRIVATE_DEFINITIONS})
     set(testapi_PRIVATE_INCLUDE_DIRECTORIES ${jsc_PRIVATE_INCLUDE_DIRECTORIES})

--- a/Source/JavaScriptCore/shell/PlatformPlayStation.cmake
+++ b/Source/JavaScriptCore/shell/PlatformPlayStation.cmake
@@ -40,12 +40,3 @@ if (DEVELOPER_MODE)
     list(APPEND testair_LIBRARIES ${MEMORY_EXTRA_LIB})
     list(APPEND testdfg_LIBRARIES ${MEMORY_EXTRA_LIB})
 endif ()
-
-if (${CMAKE_GENERATOR} MATCHES "Visual Studio")
-    # With the VisualStudio generator, the compiler complains about -std=c++* for C sources.
-    set_source_files_properties(
-        ../API/tests/CustomGlobalObjectClassTest.c
-        ../API/tests/testapi.c
-        PROPERTIES COMPILE_FLAGS --std=gnu2a
-    )
-endif ()

--- a/Source/bmalloc/CMakeLists.txt
+++ b/Source/bmalloc/CMakeLists.txt
@@ -42,6 +42,23 @@ set(bmalloc_SOURCES
 
     libpas/src/libpas/bmalloc_heap.c
     libpas/src/libpas/bmalloc_heap_config.c
+    libpas/src/libpas/jit_heap.c
+    libpas/src/libpas/pas_bitfit_page_config_kind.c
+    libpas/src/libpas/pas_heap_config_kind.c
+    libpas/src/libpas/pas_segregated_page_config_kind.c
+)
+
+set_source_files_properties(
+    libpas/src/libpas/bmalloc_heap.c
+    libpas/src/libpas/bmalloc_heap_config.c
+    libpas/src/libpas/jit_heap.c
+    libpas/src/libpas/pas_bitfit_page_config_kind.c
+    libpas/src/libpas/pas_heap_config_kind.c
+    libpas/src/libpas/pas_segregated_page_config_kind.c
+    PROPERTIES LANGUAGE CXX
+)
+
+set(bmalloc_C_SOURCES
     libpas/src/libpas/bmalloc_type.c
     libpas/src/libpas/hotbit_heap.c
     libpas/src/libpas/hotbit_heap_config.c
@@ -49,7 +66,6 @@ set(bmalloc_SOURCES
     libpas/src/libpas/iso_heap_config.c
     libpas/src/libpas/iso_test_heap.c
     libpas/src/libpas/iso_test_heap_config.c
-    libpas/src/libpas/jit_heap.c
     libpas/src/libpas/jit_heap_config.c
     libpas/src/libpas/minalign32_heap.c
     libpas/src/libpas/minalign32_heap_config.c
@@ -57,9 +73,9 @@ set(bmalloc_SOURCES
     libpas/src/libpas/pagesize64k_heap_config.c
     libpas/src/libpas/pas_alignment.c
     libpas/src/libpas/pas_all_heaps.c
+    libpas/src/libpas/pas_all_shared_page_directories.c
     libpas/src/libpas/pas_allocation_callbacks.c
     libpas/src/libpas/pas_allocation_result.c
-    libpas/src/libpas/pas_all_shared_page_directories.c
     libpas/src/libpas/pas_baseline_allocator.c
     libpas/src/libpas/pas_baseline_allocator_table.c
     libpas/src/libpas/pas_basic_heap_config_enumerator_data.c
@@ -67,7 +83,6 @@ set(bmalloc_SOURCES
     libpas/src/libpas/pas_bitfit_directory.c
     libpas/src/libpas/pas_bitfit_heap.c
     libpas/src/libpas/pas_bitfit_page.c
-    libpas/src/libpas/pas_bitfit_page_config_kind.c
     libpas/src/libpas/pas_bitfit_size_class.c
     libpas/src/libpas/pas_bitfit_view.c
     libpas/src/libpas/pas_bootstrap_free_heap.c
@@ -109,7 +124,6 @@ set(bmalloc_SOURCES
     libpas/src/libpas/pas_free_granules.c
     libpas/src/libpas/pas_heap.c
     libpas/src/libpas/pas_heap_config.c
-    libpas/src/libpas/pas_heap_config_kind.c
     libpas/src/libpas/pas_heap_config_utils.c
     libpas/src/libpas/pas_heap_for_config.c
     libpas/src/libpas/pas_heap_lock.c
@@ -161,7 +175,6 @@ set(bmalloc_SOURCES
     libpas/src/libpas/pas_segregated_heap.c
     libpas/src/libpas/pas_segregated_page.c
     libpas/src/libpas/pas_segregated_page_config.c
-    libpas/src/libpas/pas_segregated_page_config_kind.c
     libpas/src/libpas/pas_segregated_page_config_kind_and_role.c
     libpas/src/libpas/pas_segregated_partial_view.c
     libpas/src/libpas/pas_segregated_shared_handle.c
@@ -176,11 +189,11 @@ set(bmalloc_SOURCES
     libpas/src/libpas/pas_status_reporter.c
     libpas/src/libpas/pas_stream.c
     libpas/src/libpas/pas_string_stream.c
-    libpas/src/libpas/pas_thread_suspend_lock.c
     libpas/src/libpas/pas_thread_local_cache.c
     libpas/src/libpas/pas_thread_local_cache_layout.c
     libpas/src/libpas/pas_thread_local_cache_layout_node.c
     libpas/src/libpas/pas_thread_local_cache_node.c
+    libpas/src/libpas/pas_thread_suspend_lock.c
     libpas/src/libpas/pas_utility_heap.c
     libpas/src/libpas/pas_utility_heap_config.c
     libpas/src/libpas/pas_utils.c
@@ -681,6 +694,11 @@ if (ATOMICS_REQUIRE_LIBATOMIC)
     list(APPEND bmalloc_LIBRARIES atomic)
 endif ()
 
+set(bmalloc_COMPILE_OPTIONS
+    -Wno-cast-align
+    -Wno-missing-field-initializers
+)
+
 set(bmalloc_INTERFACE_LIBRARIES bmalloc)
 set(bmalloc_INTERFACE_INCLUDE_DIRECTORIES ${bmalloc_FRAMEWORK_HEADERS_DIR})
 set(bmalloc_INTERFACE_DEPENDENCIES bmalloc_CopyHeaders)
@@ -692,16 +710,6 @@ if (MSVC)
     add_compile_options(/wd4206)
 endif ()
 
-set_source_files_properties(
-    libpas/src/libpas/pas_bitfit_page_config_kind.c
-    libpas/src/libpas/jit_heap.c
-    libpas/src/libpas/bmalloc_heap.c
-    libpas/src/libpas/bmalloc_heap_config.c
-    libpas/src/libpas/pas_heap_config_kind.c
-    libpas/src/libpas/pas_segregated_page_config_kind.c
-    PROPERTIES LANGUAGE CXX
-)
-
 WEBKIT_FRAMEWORK_DECLARE(bmalloc)
 WEBKIT_INCLUDE_CONFIG_FILES_IF_EXISTS()
 
@@ -712,10 +720,6 @@ WEBKIT_COPY_FILES(bmalloc_CopyHeaders
 )
 
 WEBKIT_FRAMEWORK(bmalloc)
-
-WEBKIT_ADD_TARGET_CXX_FLAGS(bmalloc
-    -Wno-missing-field-initializers
-    -Wno-cast-align)
 
 # Only build mbmalloc on platforms that MallocBench supports
 if (DEVELOPER_MODE AND (APPLE OR HAVE_MALLOC_TRIM))

--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -46,7 +46,14 @@ macro(WEBKIT_COMPUTE_SOURCES _framework)
             message(FATAL_ERROR "generate-unified-source-bundles.rb exited with non-zero status, exiting")
         endif ()
 
-        list(APPEND ${_framework}_SOURCES ${_outputTmp})
+        foreach (_file IN LISTS _outputTmp)
+            if (_file MATCHES "\\.c$")
+                list(APPEND ${_framework}_C_SOURCES ${_file})
+            else ()
+                list(APPEND ${_framework}_SOURCES ${_file})
+            endif ()
+        endforeach ()
+
         unset(_resultTmp)
         unset(_outputTmp)
     else ()
@@ -106,6 +113,9 @@ macro(WEBKIT_LIBRARY_DECLARE _target)
 
     if (${_target}_LIBRARY_TYPE STREQUAL "OBJECT")
         list(APPEND ${_target}_INTERFACE_LIBRARIES $<TARGET_OBJECTS:${_target}>)
+        if (TARGET ${_target}_c)
+            list(APPEND ${_target}_INTERFACE_LIBRARIES $<TARGET_OBJECTS:${_target}_c>)
+        endif ()
     endif ()
 endmacro()
 
@@ -114,47 +124,65 @@ macro(WEBKIT_EXECUTABLE_DECLARE _target)
 endmacro()
 
 # Private macro for setting the properties of a target.
-macro(_WEBKIT_TARGET _target)
-    target_sources(${_target} PRIVATE
-        ${${_target}_HEADERS}
-        ${${_target}_SOURCES}
-    )
-
-    if (PLAYSTATION AND CMAKE_GENERATOR MATCHES "Visual Studio")
-        set(${_target}_SOURCES_C ${${_target}_SOURCES})
-        list(FILTER ${_target}_SOURCES_C INCLUDE REGEX "\\.c$")
-        set_source_files_properties(
-            ${${_target}_SOURCES_C}
-            PROPERTIES LANGUAGE C
-            COMPILE_OPTIONS --std=gnu17
-        )
-    endif ()
-
-    target_include_directories(${_target} PUBLIC "$<BUILD_INTERFACE:${${_target}_INCLUDE_DIRECTORIES}>")
-    target_include_directories(${_target} SYSTEM PRIVATE "$<BUILD_INTERFACE:${${_target}_SYSTEM_INCLUDE_DIRECTORIES}>")
-    target_include_directories(${_target} PRIVATE "$<BUILD_INTERFACE:${${_target}_PRIVATE_INCLUDE_DIRECTORIES}>")
+macro(_WEBKIT_TARGET_SETUP _target _logical_name)
+    target_include_directories(${_target} PUBLIC "$<BUILD_INTERFACE:${${_logical_name}_INCLUDE_DIRECTORIES}>")
+    target_include_directories(${_target} SYSTEM PRIVATE "$<BUILD_INTERFACE:${${_logical_name}_SYSTEM_INCLUDE_DIRECTORIES}>")
+    target_include_directories(${_target} PRIVATE "$<BUILD_INTERFACE:${${_logical_name}_PRIVATE_INCLUDE_DIRECTORIES}>")
 
     if (DEVELOPER_MODE_CXX_FLAGS)
         target_compile_options(${_target} PRIVATE ${DEVELOPER_MODE_CXX_FLAGS})
     endif ()
 
-    target_compile_definitions(${_target} PRIVATE "BUILDING_${_target}")
-    if (${_target}_DEFINITIONS)
-        target_compile_definitions(${_target} PUBLIC ${${_target}_DEFINITIONS})
+    target_compile_definitions(${_target} PRIVATE "BUILDING_${_logical_name}")
+    if (${_logical_name}_DEFINITIONS)
+        target_compile_definitions(${_target} PUBLIC ${${_logical_name}_DEFINITIONS})
     endif ()
-    if (${_target}_PRIVATE_DEFINITIONS)
-        target_compile_definitions(${_target} PRIVATE ${${_target}_PRIVATE_DEFINITIONS})
-    endif ()
-
-    if (${_target}_LIBRARIES)
-        target_link_libraries(${_target} PUBLIC ${${_target}_LIBRARIES})
-    endif ()
-    if (${_target}_PRIVATE_LIBRARIES)
-        target_link_libraries(${_target} PRIVATE ${${_target}_PRIVATE_LIBRARIES})
+    if (${_logical_name}_PRIVATE_DEFINITIONS)
+        target_compile_definitions(${_target} PRIVATE ${${_logical_name}_PRIVATE_DEFINITIONS})
     endif ()
 
-    if (${_target}_DEPENDENCIES)
-        add_dependencies(${_target} ${${_target}_DEPENDENCIES})
+    if (${_logical_name}_COMPILE_OPTIONS)
+        target_compile_options(${_target} PRIVATE ${${_logical_name}_COMPILE_OPTIONS})
+    endif ()
+
+    if (${_logical_name}_LIBRARIES)
+        target_link_libraries(${_target} PUBLIC ${${_logical_name}_LIBRARIES})
+    endif ()
+    if (${_logical_name}_PRIVATE_LIBRARIES)
+        target_link_libraries(${_target} PRIVATE ${${_logical_name}_PRIVATE_LIBRARIES})
+    endif ()
+
+    if (${_logical_name}_DEPENDENCIES)
+        add_dependencies(${_target} ${${_logical_name}_DEPENDENCIES})
+    endif ()
+endmacro()
+
+macro(_WEBKIT_TARGET _target)
+    if (CMAKE_GENERATOR MATCHES "Visual Studio")
+        if (${_target}_C_SOURCES)
+            add_library(${_target}_c OBJECT)
+            target_sources(${_target}_c PRIVATE ${${_target}_C_SOURCES})
+
+            _WEBKIT_TARGET_SETUP(${_target}_c ${_target})
+
+            set_target_properties(${_target}_c PROPERTIES C_STANDARD 17)
+            list(APPEND ${_target}_PRIVATE_LIBRARIES ${_target}_c)
+        endif ()
+
+        target_sources(${_target} PRIVATE
+            ${${_target}_HEADERS}
+            ${${_target}_SOURCES}
+        )
+
+        _WEBKIT_TARGET_SETUP(${_target} ${_target})
+    else ()
+        target_sources(${_target} PRIVATE
+            ${${_target}_HEADERS}
+            ${${_target}_SOURCES}
+            ${${_target}_C_SOURCES}
+        )
+
+        _WEBKIT_TARGET_SETUP(${_target} ${_target})
     endif ()
 endmacro()
 
@@ -262,6 +290,9 @@ macro(_WEBKIT_FRAMEWORK_LINK_FRAMEWORK _target_name)
             list(APPEND ${_target_name}_PRIVATE_LIBRARIES WebKit::${framework})
             if (${framework}_LIBRARY_TYPE STREQUAL "OBJECT")
                 list(APPEND ${_target_name}_PRIVATE_LIBRARIES $<TARGET_OBJECTS:${framework}>)
+                if (TARGET ${framework}_c)
+                    list(APPEND ${_target_name}_PRIVATE_LIBRARIES $<TARGET_OBJECTS:${framework}_c>)
+                endif ()
             endif ()
         else ()
             list(APPEND ${_target_name}_LIBRARIES WebKit::${framework})
@@ -284,6 +315,9 @@ macro(_WEBKIT_TARGET_LINK_FRAMEWORK _target)
             # underyling library's objects are explicitly added to link properly
             if (TARGET ${framework} AND ${framework}_LIBRARY_TYPE STREQUAL "OBJECT")
                 list(APPEND ${_target}_PRIVATE_LIBRARIES $<TARGET_OBJECTS:${framework}>)
+                if (TARGET ${framework}_c)
+                    list(APPEND ${_target}_PRIVATE_LIBRARIES $<TARGET_OBJECTS:${framework}_c>)
+                endif ()
             endif ()
         endif ()
     endforeach ()


### PR DESCRIPTION
#### b5a3b27d3def6ad93ee1b43a1413b3360175275a
<pre>
[CMake] Separate C files in Visual Studio
<a href="https://bugs.webkit.org/show_bug.cgi?id=284253">https://bugs.webkit.org/show_bug.cgi?id=284253</a>

Reviewed by Ross Kirsling and Yusuke Suzuki.

Visual Studio doesn&apos;t separate C and C++ compile options. Split the target so
there is one for C files and one for C++ files. This prevents additional options
from being erroneously to a C file.

* Source/JavaScriptCore/shell/CMakeLists.txt:
* Source/JavaScriptCore/shell/PlatformPlayStation.cmake:
* Source/bmalloc/CMakeLists.txt:
* Source/cmake/WebKitMacros.cmake:

Canonical link: <a href="https://commits.webkit.org/288054@main">https://commits.webkit.org/288054@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3207350a01661088d8864d5da84cde188511bd10

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81718 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1244 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35672 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86262 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32713 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1277 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9064 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63761 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21481 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84788 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/928 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74369 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44047 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/827 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28543 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31167 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/74698 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29145 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87701 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/80772 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8958 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6363 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72092 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9143 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70188 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71321 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15405 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14325 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/103183 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12665 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8909 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14441 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25059 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8750 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12273 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10558 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->