### PR TITLE
Remove usage of `getCSSCanvasContext` and `-webkit-canvas` from `XMLViewer`

### DIFF
--- a/Source/WebCore/xml/XMLViewer.css
+++ b/Source/WebCore/xml/XMLViewer.css
@@ -85,11 +85,11 @@ div.collapsible > div.hidden {
 }
 
 .collapse-button {
-    background-image: -webkit-canvas(arrowDown);
+    background: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='%235a5a5a' width='10' height='10'><path d='M0 0 L8 0 L4 7 Z'/></svg>");
     height: 10px;
 }
 
 .expand-button {
-    background-image: -webkit-canvas(arrowRight);
-    height: 11px;
+    background: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='%235a5a5a' width='10' height='10'><path d='M0 0 L0 8 L7 4 Z'/></svg>");
+    height: 10px;
 }

--- a/Source/WebCore/xml/XMLViewer.js
+++ b/Source/WebCore/xml/XMLViewer.js
@@ -77,7 +77,6 @@ function sourceXMLLoaded()
     for (var i = 0; i < nodeParentPairs.length; i++)
         processNode(nodeParentPairs[i].parentElement, nodeParentPairs[i].node);
 
-    drawArrows();
     initButtons();
 
     if (typeof(onAfterWebkitXMLViewerLoaded) == 'function')
@@ -353,33 +352,6 @@ function createAttribute(attributeNode)
     attribute.appendChild(attributeValue);
     attribute.appendChild(textAfter);
     return attribute;
-}
-
-// Tree behaviour.
-
-function drawArrows()
-{
-    var ctx = document.getCSSCanvasContext("2d", "arrowRight", 10, 11);
-
-    ctx.fillStyle = "rgb(90,90,90)";
-    ctx.beginPath();
-    ctx.moveTo(0, 0);
-    ctx.lineTo(0, 8);
-    ctx.lineTo(7, 4);
-    ctx.lineTo(0, 0);
-    ctx.fill();
-    ctx.closePath();
-
-    var ctx = document.getCSSCanvasContext("2d", "arrowDown", 10, 10);
-
-    ctx.fillStyle = "rgb(90,90,90)";
-    ctx.beginPath();
-    ctx.moveTo(0, 0);
-    ctx.lineTo(8, 0);
-    ctx.lineTo(4, 7);
-    ctx.lineTo(0, 0);
-    ctx.fill();
-    ctx.closePath();
 }
 
 function expandFunction(sectionId)


### PR DESCRIPTION
#### eac7898a5b4cb720815995c62f80828e8ac7a903
<pre>
Remove usage of `getCSSCanvasContext` and `-webkit-canvas` from `XMLViewer`

<a href="https://bugs.webkit.org/show_bug.cgi?id=284900">https://bugs.webkit.org/show_bug.cgi?id=284900</a>
<a href="https://rdar.apple.com/141705353">rdar://141705353</a>

Reviewed by Tim Nguyen.

This patch is inspired to reduce usage of non-standard API and property in XMLViewer.
It takes opportunity to use `svg` instead, which fixes issue of `arrow` being pixelated
upon zoom as well.

Inspired by: <a href="https://source.chromium.org/chromium/chromium/src/+/24e58b0d8fab28fa20e69f191d833fe97aaff75d">https://source.chromium.org/chromium/chromium/src/+/24e58b0d8fab28fa20e69f191d833fe97aaff75d</a>
and <a href="https://source.chromium.org/chromium/chromium/src/+/477a9c21852a80e1e2b54e2e6ca9b23012ffbce7">https://source.chromium.org/chromium/chromium/src/+/477a9c21852a80e1e2b54e2e6ca9b23012ffbce7</a>

* Source/WebCore/xml/XMLViewer.css:
(.collapse-button):
(.expand-button):
* Source/WebCore/xml/XMLViewer.js:
(sourceXMLLoaded):
(drawArrows): Deleted.

Canonical link: <a href="https://commits.webkit.org/288065@main">https://commits.webkit.org/288065@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f89f406e02efa577a648a0d1c7821369c4771c15

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81748 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1274 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35702 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86293 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32744 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83854 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1307 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9094 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63776 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21495 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84818 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/949 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74397 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44062 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/849 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28572 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31197 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29175 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87731 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8988 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6383 "Found 2 new test failures: fast/shadow-dom/svg-animate-href-change-in-shadow-tree.html imported/w3c/web-platform-tests/media-source/mediasource-changetype.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72115 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9173 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70217 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71345 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17779 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15433 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14353 "Found 1 new test failure: fast/mediastream/getDisplayMedia-max-constraints5.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8939 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14471 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8780 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12303 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10588 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->