### PR TITLE
Add Cocoa implementation to prepare content list for ResourceMonitor.

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/WebPrivacySPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/WebPrivacySPI.h
@@ -163,6 +163,17 @@ typedef void (^WPRestrictedOpenerDomainsCompletionHandler)(NSArray<WPRestrictedO
 @end
 #endif
 
+#if !defined(HAS_WEB_PRIVACY_RESOURCE_MONITOR_URLS_API)
+@class WKContentRuleList;
+@class WKContentRuleListStore;
+
+typedef void (^WPRuleListPreparationCompletionHandler)(WKContentRuleList *, bool, NSError *);
+
+@interface WPResources (Staging_141646051)
+- (void)prepareResouceMonitorRulesForStore:(WKContentRuleListStore *)store completionHandler:(WPRuleListPreparationCompletionHandler)completionHandler;
+@end
+#endif
+
 WTF_EXTERN_C_BEGIN
 
 extern NSString *const WPNotificationUserInfoResourceTypeKey;

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
@@ -45,6 +45,7 @@
 
 OBJC_CLASS WKWebPrivacyNotificationListener;
 OBJC_CLASS NSURLSession;
+OBJC_CLASS WKContentRuleList;
 
 namespace WebKit {
 
@@ -181,6 +182,17 @@ private:
     RetainPtr<WKWebPrivacyNotificationListener> m_notificationListener;
     HashMap<WebCore::RegistrableDomain, RestrictedOpenerType> m_restrictedOpenerTypes;
     uint64_t m_nextScheduledUpdateTime { 0 };
+};
+
+class ResourceMonitorURLsController {
+public:
+    static ResourceMonitorURLsController& singleton();
+
+    void prepare(CompletionHandler<void(WKContentRuleList *, bool)>&&);
+
+private:
+    friend class NeverDestroyed<ResourceMonitorURLsController, MainThreadAccessTraits>;
+    ResourceMonitorURLsController() = default;
 };
 
 #endif // ENABLE(ADVANCED_PRIVACY_PROTECTIONS)


### PR DESCRIPTION
#### cd7eb35cea44dc24ffafc3106e29eb4a19b30465
<pre>
Add Cocoa implementation to prepare content list for ResourceMonitor.
<a href="https://bugs.webkit.org/show_bug.cgi?id=284855">https://bugs.webkit.org/show_bug.cgi?id=284855</a>
<a href="https://rdar.apple.com/141646051">rdar://141646051</a>

Reviewed by Ben Nham.

The rule list needs to be prepared and they must be platform dependent way.
For Cocoa, we use WebPrivacy framework to deliver the list.

* Source/WebCore/PAL/pal/spi/cocoa/WebPrivacySPI.h:
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h:
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
(WebKit::ResourceMonitorURLsController::singleton):
(WebKit::ResourceMonitorURLsController::prepare):
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::platformLoadResourceMonitorRuleList):

Canonical link: <a href="https://commits.webkit.org/288131@main">https://commits.webkit.org/288131@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a56250d909b28fd07300028baf4c02598dcb67e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81939 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1466 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35896 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86496 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32971 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84045 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1501 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9289 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/63896 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/21619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85009 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1115 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74565 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44179 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1017 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28742 "Found 3 new test failures: fonts/monospace.html fonts/sans-serif.html fonts/serif.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31390 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29352 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87927 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9181 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/72261 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9366 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70384 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71483 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17820 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15589 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14511 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9132 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14668 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8972 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12497 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10780 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->