### PR TITLE
[WebGPUSwift] implement beginRenderPass in Swift

### DIFF
--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -76,7 +76,7 @@ public:
     ~CommandEncoder();
 
     Ref<ComputePassEncoder> beginComputePass(const WGPUComputePassDescriptor&);
-    Ref<RenderPassEncoder> beginRenderPass(const WGPURenderPassDescriptor&);
+    Ref<RenderPassEncoder> beginRenderPass(const WGPURenderPassDescriptor&) HAS_SWIFTCXX_THUNK;
     void copyBufferToBuffer(const Buffer& source, uint64_t sourceOffset, Buffer& destination, uint64_t destinationOffset, uint64_t size) HAS_SWIFTCXX_THUNK;
     void copyBufferToTexture(const WGPUImageCopyBuffer& source, const WGPUImageCopyTexture& destination, const WGPUExtent3D& copySize) HAS_SWIFTCXX_THUNK;
     void copyTextureToBuffer(const WGPUImageCopyTexture& source, const WGPUImageCopyBuffer& destination, const WGPUExtent3D& copySize) HAS_SWIFTCXX_THUNK;
@@ -134,8 +134,8 @@ private:
     NSString* validateFinishError() const;
     bool validatePopDebugGroup() const;
     NSString* errorValidatingComputePassDescriptor(const WGPUComputePassDescriptor&) const;
-    NSString* errorValidatingRenderPassDescriptor(const WGPURenderPassDescriptor&) const;
 private PUBLIC_IN_WEBGPU_SWIFT:
+    NSString* errorValidatingRenderPassDescriptor(const WGPURenderPassDescriptor&) const;
     void clearTextureIfNeeded(const WGPUImageCopyTexture&, NSUInteger);
 private:
     NSString* errorValidatingImageCopyBuffer(const WGPUImageCopyBuffer&) const;
@@ -146,10 +146,14 @@ private PUBLIC_IN_WEBGPU_SWIFT:
 private:
     void discardCommandBuffer();
 
+    RefPtr<CommandBuffer> protectedCachedCommandBuffer() const { return m_cachedCommandBuffer.get(); }
+
+private PUBLIC_IN_WEBGPU_SWIFT:
     id<MTLCommandBuffer> m_commandBuffer { nil };
+    id<MTLCommandEncoder> m_existingCommandEncoder { nil };
+private:
     id<MTLSharedEvent> m_abortCommandBuffer { nil };
     id<MTLBlitCommandEncoder> m_blitCommandEncoder { nil };
-    id<MTLCommandEncoder> m_existingCommandEncoder { nil };
 
     uint64_t m_debugGroupStackSize { 0 };
     ThreadSafeWeakPtr<CommandBuffer> m_cachedCommandBuffer;

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -67,7 +67,7 @@ void CommandEncoder::generateInvalidEncoderStateError()
 {
     GENERATE_INVALID_ENCODER_STATE_ERROR();
 }
-
+#if !ENABLE(WEBGPU_SWIFT)
 static MTLLoadAction loadAction(WGPULoadOp loadOp)
 {
     switch (loadOp) {
@@ -97,12 +97,14 @@ static MTLStoreAction storeAction(WGPUStoreOp storeOp, bool hasResolveTarget = f
         return MTLStoreActionDontCare;
     }
 }
+#endif
 
 #if ENABLE(WEBGPU_SWIFT)
 
 DEFINE_SWIFTCXX_THUNK(WebGPU::CommandEncoder, copyBufferToTexture, void, const WGPUImageCopyBuffer&, const WGPUImageCopyTexture&, const WGPUExtent3D&);
 DEFINE_SWIFTCXX_THUNK(WebGPU::CommandEncoder, copyTextureToBuffer, void, const WGPUImageCopyTexture&, const WGPUImageCopyBuffer&, const WGPUExtent3D&);
 DEFINE_SWIFTCXX_THUNK(WebGPU::CommandEncoder, copyTextureToTexture, void, const WGPUImageCopyTexture&, const WGPUImageCopyTexture&, const WGPUExtent3D&);
+DEFINE_SWIFTCXX_THUNK(WebGPU::CommandEncoder, beginRenderPass, Ref<RenderPassEncoder>, const WGPURenderPassDescriptor&);
 #endif
 
 
@@ -447,7 +449,7 @@ void CommandEncoder::runClearEncoder(NSMutableDictionary<NSNumber*, TextureAndCl
     m_device->protectedQueue()->endEncoding(clearRenderCommandEncoder, m_commandBuffer);
     setExistingEncoder(nil);
 }
-
+#if !ENABLE(WEBGPU_SWIFT)
 static bool isMultisampleTexture(id<MTLTexture> texture)
 {
     return texture.textureType == MTLTextureType2DMultisample || texture.textureType == MTLTextureType2DMultisampleArray;
@@ -740,6 +742,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     setExistingEncoder(mtlRenderCommandEncoder);
     return RenderPassEncoder::create(mtlRenderCommandEncoder, descriptor, visibilityResultBufferSize, depthReadOnly, stencilReadOnly, *this, visibilityResultBuffer, maxDrawCount, m_device, mtlDescriptor);
 }
+#endif
 
 id<MTLCommandBuffer> CommandEncoder::commandBuffer() const
 {

--- a/Source/WebGPU/WebGPU/Internal/WebGPUSwiftInternal.h
+++ b/Source/WebGPU/WebGPU/Internal/WebGPUSwiftInternal.h
@@ -30,13 +30,18 @@
 #include "CommandEncoder.h"
 #include "CommandsMixin.h"
 #include "Device.h"
+#include "IsValidToUseWith.h"
 #include "QuerySet.h"
 #include "Queue.h"
+#include "RenderPassEncoder.h"
 #include "Texture.h"
+#include "TextureView.h"
 #include "WebGPU.h"
 #include <cstdint>
 #include <span>
 #include <wtf/CheckedArithmetic.h>
+#include <wtf/HashSet.h>
+#include <wtf/Ref.h>
 #include <wtf/StdLibExtras.h>
 
 using SpanConstUInt8 = std::span<const uint8_t>;
@@ -50,6 +55,8 @@ namespace WTF {
 template<typename PassedType>
 class Range;
 }
+inline unsigned long roundUpToMultipleOfNonPowerOfTwoCheckedUInt32UnsignedLong(Checked<uint32_t> x, unsigned long y) { return WTF::roundUpToMultipleOfNonPowerOfTwo<unsigned long int, Checked<uint32_t>>(x, y); }
+inline uint32_t roundUpToMultipleOfNonPowerOfTwoUInt32UInt32(uint32_t a, uint32_t b) { return WTF::roundUpToMultipleOfNonPowerOfTwo<uint32_t, Checked<uint32_t>>(a, b); }
 
 // FIXME: rdar://140819194
 constexpr unsigned long int WGPU_COPY_STRIDE_UNDEFINED_ = WGPU_COPY_STRIDE_UNDEFINED;
@@ -57,13 +64,22 @@ constexpr unsigned long int WGPU_COPY_STRIDE_UNDEFINED_ = WGPU_COPY_STRIDE_UNDEF
 // FIXME: rdar://140819448
 constexpr auto MTLBlitOptionNone_ = MTLBlitOptionNone;
 
-inline unsigned long roundUpToMultipleOfNonPowerOfTwoCheckedUInt32UnsignedLong(Checked<uint32_t> x, unsigned long y) { return WTF::roundUpToMultipleOfNonPowerOfTwo<unsigned long int, Checked<uint32_t>>(x, y); }
-
 inline Checked<size_t> checkedDifferenceSizeT(size_t left, size_t right)
 {
     return WTF::checkedDifference<size_t>(left, right);
 }
 
+using RefRenderPassEncoder = Ref<WebGPU::RenderPassEncoder>;
+using SliceSet = HashSet<uint64_t, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>>;
+inline bool isValidToUseWithTextureViewCommandEncoder(const WebGPU::TextureView& texture, const WebGPU::CommandEncoder& commandEncoder)
+{
+    return WebGPU::isValidToUseWith(texture, commandEncoder);
+}
+
+inline double clampDouble(const double& v, const double& lo, const double& hi)
+{
+    return std::clamp(v, lo, hi);
+}
 
 #ifndef __swift__
 #include "WebGPUSwift-Generated.h"

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -33,6 +33,7 @@
 #import <wtf/HashTraits.h>
 #import <wtf/Ref.h>
 #import <wtf/RefCountedAndCanMakeWeakPtr.h>
+#import <wtf/RetainReleaseSwift.h>
 #import <wtf/TZoneMalloc.h>
 #import <wtf/Vector.h>
 #import <wtf/WeakPtr.h>
@@ -204,6 +205,16 @@ private:
     bool m_clearStencilAttachment { false };
     bool m_occlusionQueryActive { false };
     bool m_passEnded { false };
-};
+} SWIFT_SHARED_REFERENCE(refRenderPassEncoder, derefRenderPassEncoder);
 
 } // namespace WebGPU
+
+inline void refRenderPassEncoder(WebGPU::RenderPassEncoder* obj)
+{
+    ref(obj);
+}
+
+inline void derefRenderPassEncoder(WebGPU::RenderPassEncoder* obj)
+{
+    deref(obj);
+}

--- a/Source/WebGPU/WebGPU/TextureView.h
+++ b/Source/WebGPU/WebGPU/TextureView.h
@@ -28,6 +28,7 @@
 #import <wtf/FastMalloc.h>
 #import <wtf/Ref.h>
 #import <wtf/RefCountedAndCanMakeWeakPtr.h>
+#import <wtf/RetainReleaseSwift.h>
 #import <wtf/TZoneMalloc.h>
 #import <wtf/WeakHashSet.h>
 #import <wtf/WeakPtr.h>
@@ -102,6 +103,16 @@ private:
     const Ref<Device> m_device;
     Ref<Texture> m_parentTexture;
     mutable WeakHashSet<CommandEncoder> m_commandEncoders;
-};
+} SWIFT_SHARED_REFERENCE(refTextureView, derefTextureView);
 
 } // namespace WebGPU
+
+inline void refTextureView(WebGPU::TextureView* obj)
+{
+    ref(obj);
+}
+
+inline void derefTextureView(WebGPU::TextureView* obj)
+{
+    deref(obj);
+}


### PR DESCRIPTION
#### 8e65a6bfc8fe48264600a9c5b70a8addfd0fa58f
<pre>
[WebGPUSwift] implement beginRenderPass in Swift
<a href="https://bugs.webkit.org/show_bug.cgi?id=284764">https://bugs.webkit.org/show_bug.cgi?id=284764</a>
<a href="https://rdar.apple.com/141558423">rdar://141558423</a>

Reviewed by Mike Wyrzykowski.

It&apos;s a 1-for-1 replacement

Tested using at desk run of the below test.
http/tests/webgpu/webgpu/api/validation/encoding/beginRenderPass.html

* Source/WebGPU/WebGPU/CommandEncoder.mm:
* Source/WebGPU/WebGPU/CommandEncoder.swift:
(WebGPU.beginRenderPass(_:)):
(WebGPU.copyBufferToTexture(_:destination:copySize:)):
(WebGPU.copyTextureToTexture(_:destination:copySize:)):
* Source/WebGPU/WebGPU/Internal/WebGPUSwiftInternal.h:
(roundUpToMultipleOfNonPowerOfTwoUInt32UInt32):

Canonical link: <a href="https://commits.webkit.org/288414@main">https://commits.webkit.org/288414@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a92f2d3af7b796f47accf9abbe26719c32de1c6a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82925 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2574 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37221 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88042 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33979 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2648 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10491 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64621 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22388 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85981 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1956 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75430 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44896 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1863 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33013 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73078 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30306 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89408 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10215 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7418 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73042 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10443 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71237 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72262 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17939 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16428 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15179 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1594 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10168 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15680 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10040 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13505 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11808 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->