### PR TITLE
WebTransport needs implementing network process crash behavior

### DIFF
--- a/Source/WebCore/Modules/webtransport/WebTransport.h
+++ b/Source/WebCore/Modules/webtransport/WebTransport.h
@@ -98,6 +98,7 @@ private:
     void receiveDatagram(std::span<const uint8_t>) final;
     void receiveIncomingUnidirectionalStream(Ref<ReadableStreamSource>&&) final;
     void receiveBidirectionalStream(WebTransportBidirectionalStreamConstructionParameters&&) final;
+    void networkProcessCrashed() final;
 
     ListHashSet<Ref<WritableStream>> m_sendStreams;
     ListHashSet<Ref<ReadableStream>> m_receiveStreams;

--- a/Source/WebCore/Modules/webtransport/WebTransportCloseInfo.idl
+++ b/Source/WebCore/Modules/webtransport/WebTransportCloseInfo.idl
@@ -25,6 +25,8 @@
 
 [
     EnabledBySetting=WebTransportEnabled,
+    JSGenerateToJSObject,
+    JSGenerateToNativeObject
 ] dictionary WebTransportCloseInfo {
     unsigned long closeCode = 0;
     USVString reason = "";

--- a/Source/WebCore/Modules/webtransport/WebTransportSessionClient.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportSessionClient.h
@@ -38,6 +38,7 @@ public:
     virtual void receiveDatagram(std::span<const uint8_t>) = 0;
     virtual void receiveIncomingUnidirectionalStream(Ref<ReadableStreamSource>&&) = 0;
     virtual void receiveBidirectionalStream(WebTransportBidirectionalStreamConstructionParameters&&) = 0;
+    virtual void networkProcessCrashed() = 0;
 };
 
 }

--- a/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
@@ -64,8 +64,10 @@ static void didReceiveServerTrustChallenge(Ref<NetworkConnectionToWebProcess>&& 
     auto challengeCompletionHandler = [completion = makeBlockPtr(completion), secTrust = WTFMove(secTrust)] (AuthenticationChallengeDisposition disposition, const WebCore::Credential& credential) {
         switch (disposition) {
         case AuthenticationChallengeDisposition::UseCredential: {
-            if (!credential.isEmpty())
+            if (!credential.isEmpty()) {
                 completion(true);
+                return;
+            }
         }
         FALLTHROUGH;
         case AuthenticationChallengeDisposition::RejectProtectionSpaceAndContinue:

--- a/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportStreamCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportStreamCocoa.mm
@@ -45,10 +45,10 @@ NetworkTransportStream::NetworkTransportStream(NetworkTransportSession& session,
         receiveLoop();
 }
 
-void NetworkTransportStream::sendBytes(std::span<const uint8_t> data, bool)
+void NetworkTransportStream::sendBytes(std::span<const uint8_t> data, bool withFin)
 {
     ASSERT(m_streamType != NetworkTransportStreamType::IncomingUnidirectional);
-    nw_connection_send(m_connection.get(), makeDispatchData(Vector(data)).get(), NW_CONNECTION_DEFAULT_MESSAGE_CONTEXT, true, ^(nw_error_t error) {
+    nw_connection_send(m_connection.get(), makeDispatchData(Vector(data)).get(), NW_CONNECTION_DEFAULT_MESSAGE_CONTEXT, withFin, ^(nw_error_t error) {
         // FIXME: Pipe any error to JS.
         // FIXME: sendBytes should probably have a completion handler.
     });

--- a/Source/WebKit/WebProcess/Network/WebTransportSession.cpp
+++ b/Source/WebKit/WebProcess/Network/WebTransportSession.cpp
@@ -173,4 +173,9 @@ void WebTransportSession::terminate(uint32_t code, CString&& reason)
     send(Messages::NetworkTransportSession::Terminate(code, WTFMove(reason)));
 }
 
+void WebTransportSession::networkProcessCrashed()
+{
+    if (auto strongClient = m_client.get())
+        strongClient->networkProcessCrashed();
+}
 }

--- a/Source/WebKit/WebProcess/Network/WebTransportSession.h
+++ b/Source/WebKit/WebProcess/Network/WebTransportSession.h
@@ -67,6 +67,8 @@ public:
 
     // MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+
+    void networkProcessCrashed();
 private:
     WebTransportSession(WebTransportSessionIdentifier);
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1344,6 +1344,9 @@ void WebProcess::networkProcessConnectionClosed(NetworkProcessConnection* connec
     }
 
     m_cacheStorageProvider->networkProcessConnectionClosed();
+
+    for (auto& webtransportSession : m_webTransportSessions.values())
+        webtransportSession->networkProcessCrashed();
 }
 
 WebFileSystemStorageConnection& WebProcess::fileSystemStorageConnection()

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm
@@ -32,9 +32,11 @@
 #import "Test.h"
 #import "TestNavigationDelegate.h"
 #import "TestUIDelegate.h"
+#import "TestWKWebView.h"
 #import "Utilities.h"
 #import "WebTransportServer.h"
 #import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKWebsiteDataStorePrivate.h>
 #import <WebKit/_WKInternalDebugFeature.h>
 
 namespace TestWebKitAPI {
@@ -230,6 +232,179 @@ TEST(WebTransport, DISABLED_ServerBidirectional)
     [webView loadHTMLString:html baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
     EXPECT_WK_STREQ([webView _test_waitForAlert], "successfully read abc");
     EXPECT_TRUE(challenged);
+}
+
+// FIXME: Fix WebTransportServer constructor and re-enable these tests once rdar://141009498 is available in OS builds.
+TEST(WebTransport, DISABLED_NetworkProcessCrash)
+{
+    WebTransportServer echoServer([](ConnectionGroup group) -> Task {
+        auto datagramConnection = group.createWebTransportConnection(ConnectionGroup::ConnectionType::Datagram);
+        co_await datagramConnection.awaitableSend(@"abc");
+        auto bidiConnection = group.createWebTransportConnection(ConnectionGroup::ConnectionType::Bidirectional);
+        co_await bidiConnection.awaitableSend(@"abc");
+        auto uniConnection = group.createWebTransportConnection(ConnectionGroup::ConnectionType::Unidirectional);
+        co_await uniConnection.awaitableSend(@"abc");
+    });
+
+    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    enableWebTransport(configuration.get());
+    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    auto delegate = adoptNS([TestNavigationDelegate new]);
+    [webView setNavigationDelegate:delegate.get()];
+    __block bool challenged { false };
+    __block uint16_t port = echoServer.port();
+    delegate.get().didReceiveAuthenticationChallenge = ^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^completionHandler)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
+        validateChallenge(challenge, port);
+        challenged = true;
+        completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
+    };
+
+    NSString *html = [NSString stringWithFormat:@""
+        "<script>"
+        "let session = new WebTransport('https://127.0.0.1:%d/');"
+        "let bidiStream = null;"
+        "let uniStream = null;"
+        "let incomingBidiStream = null;"
+        "let incomingUniStream = null;"
+        "let data = new TextEncoder().encode('abc');"
+        "async function setupSession() {"
+        "  try {"
+        "    await session.ready;"
+        "    bidiStream = await session.createBidirectionalStream();"
+        "    uniStream = await session.createUnidirectionalStream();"
+        "    incomingBidiStream = await getIncomingBidiStream();"
+        "    incomingUniStream = await getIncomingUniStream();"
+        "    alert('successfully established');"
+        "  } catch (e) { alert('caught ' + e); }"
+        "}; setupSession();"
+        "async function getIncomingBidiStream() {"
+        "  let reader = session.incomingBidirectionalStreams.getReader();"
+        "  let {value: s, d} = await reader.read();"
+        "  reader.releaseLock();"
+        "  return s;"
+        "};"
+        "async function getIncomingUniStream() {"
+        "  let reader = session.incomingUnidirectionalStreams.getReader();"
+        "  let {value: s, d} = await reader.read();"
+        "  reader.releaseLock();"
+        "  return s;"
+        "};"
+        "async function readFromBidiStream() {"
+        "  let reader = bidiStream.readable.getReader();"
+        "  let {value: c, d} = await reader.read();"
+        "  reader.releaseLock();"
+        "  return c;"
+        "};"
+        "async function readFromIncomingBidiStream() {"
+        "  let reader = incomingBidiStream.readable.getReader();"
+        "  let {value: c, d} = await reader.read();"
+        "  reader.releaseLock();"
+        "  return c;"
+        "};"
+        "async function readFromIncomingUniStream() {"
+        "  let reader = incomingUniStream.getReader();"
+        "  let {value: c, d} = await reader.read();"
+        "  reader.releaseLock();"
+        "  return c;"
+        "};"
+        "async function readDatagram() {"
+        "  let reader = session.datagrams.readable.getReader();"
+        "  let {value: c, d} = await reader.read();"
+        "  reader.releaseLock();"
+        "  return c;"
+        "};"
+        "async function writeOnBidiStream() {"
+        "  let writer = bidiStream.writable.getWriter();"
+        "  await writer.write(data);"
+        "  writer.releaseLock();"
+        "  return;"
+        "};"
+        "async function writeOnUniStream() {"
+        "  let writer = uniStream.getWriter();"
+        "  await writer.write(data);"
+        "  writer.releaseLock();"
+        "  return;"
+        "};"
+        "async function writeOnIncomingBidiStream() {"
+        "  let writer = incomingBidiStream.writable.getWriter();"
+        "  await writer.write(data);"
+        "  writer.releaseLock();"
+        "  return;"
+        "};"
+        "async function writeDatagram() {"
+        "  let writer = session.datagrams.writable.getWriter();"
+        "  await writer.write(data);"
+        "  writer.releaseLock();"
+        "  return;"
+        "};"
+        "</script>",
+        port];
+    [webView loadHTMLString:html baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "successfully established");
+    EXPECT_TRUE(challenged);
+
+    pid_t networkProcessIdentifier = [configuration.get().websiteDataStore _networkProcessIdentifier];
+
+    kill(networkProcessIdentifier, SIGKILL);
+
+    NSError *error = nil;
+
+    id obj = [webView objectByCallingAsyncFunction:@"return await session.createBidirectionalStream()" withArguments:@{ } error:&error];
+    EXPECT_EQ(obj, nil);
+    EXPECT_NOT_NULL(error);
+    error = nil;
+
+    obj = [webView objectByCallingAsyncFunction:@"return await session.createUnidirectionalStream()" withArguments:@{ } error:&error];
+    EXPECT_EQ(obj, nil);
+    EXPECT_NOT_NULL(error);
+    error = nil;
+
+    obj = [webView objectByCallingAsyncFunction:@"return await getIncomingBidiStream()" withArguments:@{ } error:&error];
+    EXPECT_EQ(obj, nil);
+    EXPECT_NULL(error);
+
+    obj = [webView objectByCallingAsyncFunction:@"return await getIncomingUniStream()" withArguments:@{ } error:&error];
+    EXPECT_EQ(obj, nil);
+    EXPECT_NULL(error);
+
+    obj = [webView objectByCallingAsyncFunction:@"return await readFromBidiStream()" withArguments:@{ } error:&error];
+    EXPECT_EQ(obj, nil);
+    EXPECT_NULL(error);
+
+    obj = [webView objectByCallingAsyncFunction:@"return await readFromIncomingBidiStream()" withArguments:@{ } error:&error];
+    EXPECT_EQ(obj, nil);
+    EXPECT_NULL(error);
+
+    obj = [webView objectByCallingAsyncFunction:@"return await readFromIncomingUniStream()" withArguments:@{ } error:&error];
+    EXPECT_EQ(obj, nil);
+    EXPECT_NULL(error);
+
+    obj = [webView objectByCallingAsyncFunction:@"return await readDatagram()" withArguments:@{ } error:&error];
+    EXPECT_EQ(obj, nil);
+    EXPECT_NULL(error);
+
+    obj = [webView objectByCallingAsyncFunction:@"return await writeOnBidiStream()" withArguments:@{ } error:&error];
+    EXPECT_EQ(obj, nil);
+    EXPECT_NOT_NULL(error);
+    error = nil;
+
+    obj = [webView objectByCallingAsyncFunction:@"return await writeOnUniStream()" withArguments:@{ } error:&error];
+    EXPECT_EQ(obj, nil);
+    EXPECT_NOT_NULL(error);
+    error = nil;
+
+    obj = [webView objectByCallingAsyncFunction:@"return await writeOnIncomingBidiStream()" withArguments:@{ } error:&error];
+    EXPECT_EQ(obj, nil);
+    EXPECT_NOT_NULL(error);
+    error = nil;
+
+    obj = [webView objectByCallingAsyncFunction:@"return await writeDatagram()" withArguments:@{ } error:&error];
+    EXPECT_EQ(obj, nil);
+    EXPECT_NOT_NULL(error);
+    error = nil;
+
+    obj = [webView objectByEvaluatingJavaScript:@"session.close()"];
+    EXPECT_EQ(obj, nil);
 }
 } // namespace TestWebKitAPI
 


### PR DESCRIPTION
#### bda3f50c9da48d949bcc13c2a877837780770003
<pre>
WebTransport needs implementing network process crash behavior
<a href="https://bugs.webkit.org/show_bug.cgi?id=284903">https://bugs.webkit.org/show_bug.cgi?id=284903</a>
<a href="https://rdar.apple.com/136263342">rdar://136263342</a>

Reviewed by Alex Christensen.

WebTransport sessions are notified of network process crash which closes the session.
NetworkProcessCrash test tries to perform session operations after a network process crash to test the change.

* Source/WebCore/Modules/webtransport/WebTransport.cpp:
(WebCore::WebTransport::receiveIncomingUnidirectionalStream):
(WebCore::WebTransport::receiveBidirectionalStream):
(WebCore::WebTransport::cleanup):
(WebCore::WebTransport::createBidirectionalStream):
(WebCore::WebTransport::createUnidirectionalStream):
(WebCore::WebTransport::networkProcessCrashed):
* Source/WebCore/Modules/webtransport/WebTransport.h:
* Source/WebCore/Modules/webtransport/WebTransportCloseInfo.idl:
* Source/WebCore/Modules/webtransport/WebTransportSessionClient.h:
* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm:
(WebKit::didReceiveServerTrustChallenge):
* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportStreamCocoa.mm:
(WebKit::NetworkTransportStream::sendBytes):
* Source/WebKit/WebProcess/Network/WebTransportSession.cpp:
(WebKit::WebTransportSession::networkProcessCrashed):
* Source/WebKit/WebProcess/Network/WebTransportSession.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::networkProcessConnectionClosed):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm:
(TestWebKitAPI::TEST(WebTransport, DISABLED_NetworkProcessCrash)):

Canonical link: <a href="https://commits.webkit.org/288117@main">https://commits.webkit.org/288117@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c542ff0a63acef76ac812ed667477502b95732e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81886 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1413 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35842 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86443 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32888 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83992 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1447 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9236 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63869 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21593 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84956 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1071 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74521 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44153 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/971 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28698 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31337 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29307 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87874 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9128 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6506 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72229 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9313 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70340 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71452 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15545 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14470 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12694 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9079 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14615 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8919 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12444 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10727 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->