### PR TITLE
AX: Serve NSAccessibilityInsertionPointLineNumber and AXFontChangeSearchKey off the main-thread

### DIFF
--- a/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/dynamic-style.html
+++ b/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/dynamic-style.html
@@ -1,6 +1,5 @@
 <!DOCTYPE HTML><!-- webkit-test-runner [ runSingly=true AccessibilityThreadTextApisEnabled=true ] -->
 <!-- New test added as part of the accessibilityThreadTextApisEnabled work. Move to LayoutTests/accessibility/mac/ after this feature is enabled by default. -->
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
 <script src="../../../resources/accessibility-helper.js"></script>

--- a/LayoutTests/accessibility/ax-thread-text-apis/crash-in-element-for-text-marker.html
+++ b/LayoutTests/accessibility/ax-thread-text-apis/crash-in-element-for-text-marker.html
@@ -1,6 +1,5 @@
 <!DOCTYPE HTML><!-- webkit-test-runner [ runSingly=true AccessibilityThreadTextApisEnabled=true ] -->
 <!-- Copy of existing test. Remove after accessibilityThreadTextApisEnabled is enabled by default. -->
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
 <script src="../../resources/accessibility-helper.js"></script>

--- a/LayoutTests/accessibility/ax-thread-text-apis/non-collapsed-selection-insertion-point-line-number-expected.txt
+++ b/LayoutTests/accessibility/ax-thread-text-apis/non-collapsed-selection-insertion-point-line-number-expected.txt
@@ -1,0 +1,9 @@
+This test ensures we return a -1 insertion point line number for non-collapsed selections.
+
+PASS: axTextarea.insertionPointLineNumber === 1 === true
+PASS: axTextarea.insertionPointLineNumber === -1 === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/ax-thread-text-apis/non-collapsed-selection-insertion-point-line-number.html
+++ b/LayoutTests/accessibility/ax-thread-text-apis/non-collapsed-selection-insertion-point-line-number.html
@@ -1,0 +1,38 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ runSingly=true AccessibilityThreadTextApisEnabled=true ] -->
+<!-- Copy of existing test. Remove after accessibilityThreadTextApisEnabled is enabled by default. -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<textarea id="textarea">First
+Second
+</textarea>
+
+<script>
+var output = "This test ensures we return a -1 insertion point line number for non-collapsed selections.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var textarea = document.getElementById("textarea");
+    textarea.focus();
+    textarea.setSelectionRange(9, 9);
+    var axTextarea = accessibilityController.accessibleElementById("textarea");
+
+    setTimeout(async function() {
+        output += await expectAsync("axTextarea.insertionPointLineNumber === 1", "true");
+        // Make the range non-collapsed.
+        textarea.setSelectionRange(9, 10);
+        output += await expectAsync("axTextarea.insertionPointLineNumber === -1", "true");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/accessibility/ax-thread-text-apis/search-predicate-font-change-expected.txt
+++ b/LayoutTests/accessibility/ax-thread-text-apis/search-predicate-font-change-expected.txt
@@ -1,0 +1,12 @@
+This test ensures that the AXFontChangeSearchKey works correctly.
+
+PASS: firstText.stringValue === 'AXValue: One'
+PASS: resultText.stringValue === 'AXValue: Two'
+PASS: resultText.stringValue === 'AXValue: Three'
+PASS: resultText.stringValue === 'AXValue: Four'
+PASS: Found #span-4 text after #span-1 after dynamic change.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+OneFour Two Three

--- a/LayoutTests/accessibility/ax-thread-text-apis/search-predicate-font-change.html
+++ b/LayoutTests/accessibility/ax-thread-text-apis/search-predicate-font-change.html
@@ -1,0 +1,47 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ runSingly=true AccessibilityThreadTextApisEnabled=true ] -->
+<!-- New test added as part of the accessibilityThreadTextApisEnabled work. Move to LayoutTests/accessibility/mac/ after this feature is enabled by default. -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<span id="span-1" style="font-family:sans-serif;">One</span>
+<span style="font-family:serif;">Two</span>
+<span style="font-family:sans-serif;">Three</span>
+<span id="span-4" style="font-family:serif;">Four</span>
+
+<script>
+var output = "This test ensures that the AXFontChangeSearchKey works correctly.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var webArea = accessibilityController.rootElement.childAtIndex(0);
+    var firstText = webArea.childAtIndex(0);
+    output += expect("firstText.stringValue", "'AXValue: One'");
+    var resultText = webArea.uiElementForSearchPredicate(firstText, true, "AXFontChangeSearchKey", "", false);
+    output += expect("resultText.stringValue", "'AXValue: Two'");
+    var resultText = webArea.uiElementForSearchPredicate(resultText, true, "AXFontChangeSearchKey", "", false);
+    output += expect("resultText.stringValue", "'AXValue: Three'");
+    var resultText = webArea.uiElementForSearchPredicate(resultText, true, "AXFontChangeSearchKey", "", false);
+    output += expect("resultText.stringValue", "'AXValue: Four'");
+
+    // Move the last span to be right after the first.
+    document.getElementById("span-1").after(document.getElementById("span-4"));
+    setTimeout(async function() {
+        await waitFor(() => {
+            resultText = webArea.uiElementForSearchPredicate(firstText, true, "AXFontChangeSearchKey", "", false);
+            return resultText && resultText.stringValue === "AXValue: Four";
+        });
+        output += "PASS: Found #span-4 text after #span-1 after dynamic change.\n";
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -677,6 +677,13 @@ AXCoreObject* AXCoreObject::activeDescendant() const
     return nullptr;
 }
 
+AXCoreObject* AXCoreObject::selfOrFirstTextDescendant()
+{
+    return Accessibility::findUnignoredDescendant(*this, /* includeSelf */ true, [] (auto& descendant) {
+        return descendant.isStaticText();
+    });
+}
+
 AXCoreObject::AccessibilityChildrenVector AXCoreObject::selectedCells()
 {
     if (!isTable())

--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -286,6 +286,7 @@ public:
 
     AXTextMarker start() const { return m_start; }
     AXTextMarker end() const { return m_end; }
+    bool isCollapsed() const { return m_start.isEqual(m_end); }
     bool isConfinedTo(std::optional<AXID>) const;
     bool isConfined() const;
 

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -210,7 +210,7 @@ public:
     bool isVisible() const override { return !isHidden(); }
     virtual bool isCollapsed() const { return false; }
     void setIsExpanded(bool) override { }
-    FloatRect unobscuredContentRect() const final;
+    FloatRect unobscuredContentRect() const;
     FloatRect relativeFrame() const final;
 #if PLATFORM(MAC)
     FloatRect primaryScreenRect() const final;
@@ -226,7 +226,7 @@ public:
     Vector<AXTextMarkerRange> misspellingRanges() const final;
     std::optional<SimpleRange> misspellingRange(const SimpleRange& start, AccessibilitySearchDirection) const final;
     bool hasPlainText() const override { return false; }
-    bool hasSameFont(const AXCoreObject&) const override { return false; }
+    bool hasSameFont(AXCoreObject&) override { return false; }
     bool hasSameFontColor(const AXCoreObject&) const override { return false; }
     bool hasSameStyle(const AXCoreObject&) const override { return false; }
     bool hasUnderline() const override { return false; }
@@ -409,7 +409,7 @@ public:
     // The following functions are PLATFORM(COCOA) because these are currently only used to power a
     // Cocoa API (attributed strings).
     AttributedStringStyle stylesForAttributedString() const final;
-    RetainPtr<CTFontRef> font() const;
+    RetainPtr<CTFontRef> font() const final;
     Color textColor() const;
     Color backgroundColor() const;
     bool isSubscript() const;

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -2669,7 +2669,7 @@ bool AccessibilityRenderObject::hasPlainText() const
         && style.textDecorationsInEffect().isEmpty();
 }
 
-bool AccessibilityRenderObject::hasSameFont(const AXCoreObject& object) const
+bool AccessibilityRenderObject::hasSameFont(AXCoreObject& object)
 {
     auto* renderer = object.renderer();
     if (!m_renderer || !renderer)

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.h
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.h
@@ -66,7 +66,7 @@ public:
     bool hasBoldFont() const final;
     bool hasItalicFont() const final;
     bool hasPlainText() const final;
-    bool hasSameFont(const AXCoreObject&) const final;
+    bool hasSameFont(AXCoreObject&) final;
     bool hasSameFontColor(const AXCoreObject&) const final;
     bool hasSameStyle(const AXCoreObject&) const final;
     bool hasUnderline() const final;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -118,7 +118,7 @@ private:
     void setPropertyFlag(AXPropertyFlag, bool);
     bool hasPropertyFlag(AXPropertyFlag) const;
 
-    static bool canBeMultilineTextField(AccessibilityObject&, bool isNonNativeTextControl);
+    static bool canBeMultilineTextField(AccessibilityObject&);
 
     // FIXME: consolidate all AttributeValue retrieval in a single template method.
     bool boolAttributeValue(AXPropertyName) const;
@@ -418,7 +418,6 @@ private:
     int indexForVisiblePosition(const VisiblePosition&) const final;
     int lineForPosition(const VisiblePosition&) const final;
     std::optional<SimpleRange> visibleCharacterRange() const final;
-    FloatRect unobscuredContentRect() const final;
     
     // Attribute setters.
     void setARIAGrabbed(bool) final;
@@ -477,7 +476,7 @@ private:
     bool hasItalicFont() const final { return boolAttributeValue(AXPropertyName::HasItalicFont); }
     Vector<AXTextMarkerRange> misspellingRanges() const final;
     bool hasPlainText() const final { return boolAttributeValue(AXPropertyName::HasPlainText); }
-    bool hasSameFont(const AXCoreObject&) const final;
+    bool hasSameFont(AXCoreObject&) final;
     bool hasSameFontColor(const AXCoreObject&) const final;
     bool hasSameStyle(const AXCoreObject&) const final;
     bool hasUnderline() const final { return boolAttributeValue(AXPropertyName::HasUnderline); }
@@ -506,6 +505,7 @@ private:
     unsigned textLength() const final;
 #if PLATFORM(COCOA)
     RetainPtr<NSAttributedString> attributedStringForTextMarkerRange(AXTextMarkerRange&&, SpellCheck) const final;
+    RetainPtr<CTFontRef> font() const final { return propertyValue<RetainPtr<CTFontRef>>(AXPropertyName::Font); }
 #endif
     AXObjectCache* axObjectCache() const final;
     Element* actionElement() const final;

--- a/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
+++ b/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
@@ -109,7 +109,7 @@ void AXIsolatedObject::initializePlatformProperties(const Ref<const Accessibilit
 AttributedStringStyle AXIsolatedObject::stylesForAttributedString() const
 {
     return {
-        propertyValue<RetainPtr<CTFontRef>>(AXPropertyName::Font),
+        font(),
         colorAttributeValue(AXPropertyName::TextColor),
         colorAttributeValue(AXPropertyName::BackgroundColor),
         boolAttributeValue(AXPropertyName::IsSubscript),


### PR DESCRIPTION
#### 5a419d49fdf03e29261d419fcc2eec1250f9ab33
<pre>
AX: Serve NSAccessibilityInsertionPointLineNumber and AXFontChangeSearchKey off the main-thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=284923">https://bugs.webkit.org/show_bug.cgi?id=284923</a>
<a href="https://rdar.apple.com/141720178">rdar://141720178</a>

Reviewed by Chris Fleizach.

NSAccessibilityInsertionPointLineNumber can be computed using the already cached AXIsolatedObject::selectedTextMarkerRange(),
and AXFontChangeSearchKey can be computed using AXPropertyName::Font — this commit does both, and introduces new layout
tests to ensure we behave properly.

* LayoutTests/accessibility/ax-thread-text-apis/attributed-string/dynamic-style.html:
* LayoutTests/accessibility/ax-thread-text-apis/crash-in-element-for-text-marker.html:
* LayoutTests/accessibility/ax-thread-text-apis/non-collapsed-selection-insertion-point-line-number-expected.txt: Added.
* LayoutTests/accessibility/ax-thread-text-apis/non-collapsed-selection-insertion-point-line-number.html: Added.
* LayoutTests/accessibility/ax-thread-text-apis/search-predicate-font-change-expected.txt: Added.
* LayoutTests/accessibility/ax-thread-text-apis/search-predicate-font-change.html: Added.
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::Accessibility::findUnignoredDescendant):
* Source/WebCore/accessibility/AXTextMarker.h:
(WebCore::AXTextMarkerRange::isCollapsed const):
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::hasSameFont):
(WebCore::AccessibilityRenderObject::hasSameFont const): Deleted.
* Source/WebCore/accessibility/AccessibilityRenderObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::initializeProperties):
(WebCore::AXIsolatedObject::canBeMultilineTextField):
(WebCore::AXIsolatedObject::insertionPointLineNumber const):
(WebCore::AXIsolatedObject::hasSameFont):
(WebCore::AXIsolatedObject::unobscuredContentRect const): Deleted.
(WebCore::AXIsolatedObject::hasSameFont const): Deleted.
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm:
(WebCore::AXIsolatedObject::stylesForAttributedString const):

Canonical link: <a href="https://commits.webkit.org/288108@main">https://commits.webkit.org/288108@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea3dc8c817d3a9c58ddc7effedf0621be5444136

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81827 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1353 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35781 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86375 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32823 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83933 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1386 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9174 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63812 "Found 1 new test failure: http/tests/misc/large-js-program.py (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21546 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84897 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1015 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74464 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44098 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/914 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28639 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31276 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29246 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87810 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9067 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6440 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72165 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9252 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70285 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71397 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17805 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15493 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14416 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9018 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14550 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8859 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12382 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10667 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->