### PR TITLE
Avoid OSAllocator::protect on PlayStation

### DIFF
--- a/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp
+++ b/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp
@@ -128,7 +128,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     static void commitBlock(void* block)
     {
-#if OS(UNIX) && ASSERT_ENABLED
+#if OS(UNIX) && !PLATFORM(PLAYSTATION) && ASSERT_ENABLED
         constexpr bool readable = true;
         constexpr bool writable = true;
         OSAllocator::protect(block, MarkedBlock::blockSize, readable, writable);
@@ -141,7 +141,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     static void decommitBlock(void* block)
     {
-#if OS(UNIX) && ASSERT_ENABLED
+#if OS(UNIX) && !PLATFORM(PLAYSTATION) && ASSERT_ENABLED
         constexpr bool readable = false;
         constexpr bool writable = false;
         OSAllocator::protect(block, MarkedBlock::blockSize, readable, writable);


### PR DESCRIPTION
#### 1b3bd4c52dec455af0aedfa158b3d2abbcb7e8db
<pre>
Avoid OSAllocator::protect on PlayStation
<a href="https://bugs.webkit.org/show_bug.cgi?id=284926">https://bugs.webkit.org/show_bug.cgi?id=284926</a>

Reviewed by Basuke Suzuki.

Guard against usage of OSAllocator::protect when PLATFORM(PLAYSTATION). The call
causes issues with Debug builds.

* Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp:
(JSC::StructureMemoryManager::commitBlock):
(JSC::StructureMemoryManager::decommitBlock):

Canonical link: <a href="https://commits.webkit.org/288067@main">https://commits.webkit.org/288067@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f44d90ef099b2cb89beedcbb32b363918f5cbd26

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81805 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1331 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35759 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/86352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32801 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1364 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9152 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/86352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21526 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84875 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/993 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74443 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/86352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/892 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28618 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31254 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/74785 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29224 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87788 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/80859 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9045 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72145 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9230 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70264 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71377 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17782 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15469 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14394 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/103271 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8996 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/14528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25073 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8837 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12360 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10645 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->