### PR TITLE
Further reduce use of memcpy()

### DIFF
--- a/Source/WebCore/Modules/webaudio/BiquadDSPKernel.cpp
+++ b/Source/WebCore/Modules/webaudio/BiquadDSPKernel.cpp
@@ -199,17 +199,17 @@ void BiquadDSPKernel::updateCoefficients(size_t numberOfFrames, std::span<const 
     updateTailTime(numberOfFrames - 1);
 }
 
-void BiquadDSPKernel::process(const float* source, float* destination, size_t framesToProcess)
+void BiquadDSPKernel::process(std::span<const float> source, std::span<float> destination)
 {
-    ASSERT(source && destination && biquadProcessor());
+    ASSERT(source.data() && destination.data() && biquadProcessor());
     
     // Recompute filter coefficients if any of the parameters have changed.
     // FIXME: as an optimization, implement a way that a Biquad object can simply copy its internal filter coefficients from another Biquad object.
     // Then re-factor this code to only run for the first BiquadDSPKernel of each BiquadProcessor.
 
-    updateCoefficientsIfNecessary(framesToProcess);
+    updateCoefficientsIfNecessary(source.size());
 
-    m_biquad.process(source, destination, framesToProcess);
+    m_biquad.process(source, destination);
 }
 
 void BiquadDSPKernel::getFrequencyResponse(unsigned nFrequencies, const float* frequencyHz, float* magResponse, float* phaseResponse)

--- a/Source/WebCore/Modules/webaudio/BiquadDSPKernel.h
+++ b/Source/WebCore/Modules/webaudio/BiquadDSPKernel.h
@@ -44,7 +44,7 @@ public:
     }
     
     // AudioDSPKernel
-    void process(const float* source, float* dest, size_t framesToProcess) override;
+    void process(std::span<const float> source, std::span<float> destination) final;
     void reset() override { m_biquad.reset(); }
 
     // Get the magnitude and phase response of the filter at the given

--- a/Source/WebCore/Modules/webaudio/BiquadProcessor.cpp
+++ b/Source/WebCore/Modules/webaudio/BiquadProcessor.cpp
@@ -106,7 +106,7 @@ void BiquadProcessor::process(const AudioBus* source, AudioBus* destination, siz
             
     // For each channel of our input, process using the corresponding BiquadDSPKernel into the output channel.
     for (unsigned i = 0; i < m_kernels.size(); ++i)
-        m_kernels[i]->process(source->channel(i)->data(), destination->channel(i)->mutableData(), framesToProcess);
+        m_kernels[i]->process(source->channel(i)->span().first(framesToProcess), destination->channel(i)->mutableSpan());
 }
 
 void BiquadProcessor::processOnlyAudioParams(size_t framesToProcess)

--- a/Source/WebCore/Modules/webaudio/DelayDSPKernel.h
+++ b/Source/WebCore/Modules/webaudio/DelayDSPKernel.h
@@ -39,7 +39,7 @@ public:
     explicit DelayDSPKernel(DelayProcessor*);
     DelayDSPKernel(double maxDelayTime, float sampleRate);
     
-    void process(const float* source, float* destination, size_t framesToProcess) override;
+    void process(std::span<const float> source, std::span<float> destination) override;
     void processOnlyAudioParams(size_t framesToProcess) final;
     void reset() override;
     
@@ -52,8 +52,8 @@ public:
     bool requiresTailProcessing() const final;
 
 private:
-    void processARate(const float* source, float* destination, size_t framesToProcess);
-    void processKRate(const float* source, float* destination, size_t framesToProcess);
+    void processARate(std::span<const float> source, std::span<float> destination);
+    void processKRate(std::span<const float> source, std::span<float> destination);
 
     AudioFloatArray m_buffer;
     double m_maxDelayTime;

--- a/Source/WebCore/Modules/webaudio/IIRDSPKernel.cpp
+++ b/Source/WebCore/Modules/webaudio/IIRDSPKernel.cpp
@@ -42,11 +42,11 @@ IIRDSPKernel::IIRDSPKernel(IIRProcessor& processor)
 {
 }
 
-void IIRDSPKernel::getFrequencyResponse(unsigned length, const float* frequencyHz, float* magResponse, float* phaseResponse)
+void IIRDSPKernel::getFrequencyResponse(unsigned length, std::span<const float> frequencyHz, std::span<float> magResponse, std::span<float> phaseResponse)
 {
-    ASSERT(frequencyHz);
-    ASSERT(magResponse);
-    ASSERT(phaseResponse);
+    ASSERT(frequencyHz.data());
+    ASSERT(magResponse.data());
+    ASSERT(phaseResponse.data());
 
     Vector<float> frequency(length);
     double nyquist = this->nyquist();
@@ -55,15 +55,15 @@ void IIRDSPKernel::getFrequencyResponse(unsigned length, const float* frequencyH
     for (unsigned k = 0; k < length; ++k)
         frequency[k] = frequencyHz[k] / nyquist;
 
-    m_iirFilter.getFrequencyResponse(length, frequency.data(), magResponse, phaseResponse);
+    m_iirFilter.getFrequencyResponse(length, frequency.span(), magResponse, phaseResponse);
 }
 
-void IIRDSPKernel::process(const float* source, float* destination, size_t framesToProcess)
+void IIRDSPKernel::process(std::span<const float> source, std::span<float> destination)
 {
-    ASSERT(source);
-    ASSERT(destination);
+    ASSERT(source.data());
+    ASSERT(destination.data());
 
-    m_iirFilter.process(source, destination, framesToProcess);
+    m_iirFilter.process(source, destination);
 }
 
 void IIRDSPKernel::reset()

--- a/Source/WebCore/Modules/webaudio/IIRDSPKernel.h
+++ b/Source/WebCore/Modules/webaudio/IIRDSPKernel.h
@@ -38,13 +38,13 @@ public:
     explicit IIRDSPKernel(IIRProcessor&);
 
     // Get the magnitude and phase response of the filter at the given set of frequencies (in Hz). The phase response is in radians.
-    void getFrequencyResponse(unsigned length, const float* frequencyHz, float* magResponse, float* phaseResponse);
+    void getFrequencyResponse(unsigned length, std::span<const float> frequencyHz, std::span<float> magResponse, std::span<float> phaseResponse);
 
 private:
     IIRProcessor* iirProcessor() { return static_cast<IIRProcessor*>(processor()); }
 
     // AudioDSPKernel
-    void process(const float* source, float* destination, size_t framesToProcess) final;
+    void process(std::span<const float> source, std::span<float> destination) final;
     double tailTime() const final { return m_tailTime; }
     double latencyTime() const final { return 0; }
     void reset() final;

--- a/Source/WebCore/Modules/webaudio/IIRFilterNode.cpp
+++ b/Source/WebCore/Modules/webaudio/IIRFilterNode.cpp
@@ -127,7 +127,7 @@ ExceptionOr<void> IIRFilterNode::getFrequencyResponse(Float32Array& frequencyHz,
 
     // Nothing to do if the length is 0.
     if (expectedLength > 0)
-        iirProcessor()->getFrequencyResponse(expectedLength, frequencyHz.data(), magResponse.data(), phaseResponse.data());
+        iirProcessor()->getFrequencyResponse(expectedLength, frequencyHz.typedSpan(), magResponse.typedMutableSpan(), phaseResponse.typedMutableSpan());
 
     return { };
 }

--- a/Source/WebCore/Modules/webaudio/IIRProcessor.cpp
+++ b/Source/WebCore/Modules/webaudio/IIRProcessor.cpp
@@ -95,10 +95,10 @@ void IIRProcessor::process(const AudioBus* source, AudioBus* destination, size_t
     // For each channel of our input, process using the corresponding IIRDSPKernel
     // into the output channel.
     for (size_t i = 0; i < m_kernels.size(); ++i)
-        m_kernels[i]->process(source->channel(i)->data(), destination->channel(i)->mutableData(), framesToProcess);
+        m_kernels[i]->process(source->channel(i)->span().first(framesToProcess), destination->channel(i)->mutableSpan());
 }
 
-void IIRProcessor::getFrequencyResponse(unsigned length, const float* frequencyHz, float* magResponse, float* phaseResponse)
+void IIRProcessor::getFrequencyResponse(unsigned length, std::span<const float> frequencyHz, std::span<float> magResponse, std::span<float> phaseResponse)
 {
     m_responseKernel->getFrequencyResponse(length, frequencyHz, magResponse, phaseResponse);
 }

--- a/Source/WebCore/Modules/webaudio/IIRProcessor.h
+++ b/Source/WebCore/Modules/webaudio/IIRProcessor.h
@@ -44,7 +44,7 @@ public:
     std::unique_ptr<AudioDSPKernel> createKernel() final;
 
     // Get the magnitude and phase response of the filter at the given set of frequencies (in Hz). The phase response is in radians.
-    void getFrequencyResponse(unsigned length, const float* frequencyHz, float* magResponse, float* phaseResponse);
+    void getFrequencyResponse(unsigned length, std::span<const float> frequencyHz, std::span<float> magResponse, std::span<float> phaseResponse);
 
     const Vector<double>& feedforward() const { return m_feedforward; }
     const Vector<double>& feedback() const { return m_feedback; }

--- a/Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.cpp
+++ b/Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.cpp
@@ -33,8 +33,10 @@
 #include <JavaScriptCore/Float32Array.h>
 #include <algorithm>
 #include <wtf/MainThread.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/Threading.h>
+#include <wtf/ZippedRange.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -63,18 +65,18 @@ void WaveShaperDSPKernel::lazyInitializeOversampling()
     }
 }
 
-void WaveShaperDSPKernel::process(const float* source, float* destination, size_t framesToProcess)
+void WaveShaperDSPKernel::process(std::span<const float> source, std::span<float> destination)
 {
     assertIsHeld(waveShaperProcessor()->processLock());
     switch (waveShaperProcessor()->oversample()) {
     case WaveShaperProcessor::OverSampleNone:
-        processCurve(source, destination, framesToProcess);
+        processCurve(source, destination);
         break;
     case WaveShaperProcessor::OverSample2x:
-        processCurve2x(source, destination, framesToProcess);
+        processCurve2x(source, destination);
         break;
     case WaveShaperProcessor::OverSample4x:
-        processCurve4x(source, destination, framesToProcess);
+        processCurve4x(source, destination);
         break;
 
     default:
@@ -82,15 +84,15 @@ void WaveShaperDSPKernel::process(const float* source, float* destination, size_
     }
 }
 
-void WaveShaperDSPKernel::processCurve(const float* source, float* destination, size_t framesToProcess)
+void WaveShaperDSPKernel::processCurve(std::span<const float> source, std::span<float> destination)
 {
-    ASSERT(source && destination && waveShaperProcessor());
+    ASSERT(source.data() && destination.data() && waveShaperProcessor());
 
     assertIsHeld(waveShaperProcessor()->processLock());
     Float32Array* curve = waveShaperProcessor()->curve();
     if (!curve) {
         // Act as "straight wire" pass-through if no curve is set.
-        memcpy(destination, source, sizeof(float) * framesToProcess);
+        memcpySpan(destination, source);
         return;
     }
 
@@ -100,63 +102,61 @@ void WaveShaperDSPKernel::processCurve(const float* source, float* destination, 
     ASSERT(curveData);
 
     if (!curveData || !curveLength) {
-        memcpy(destination, source, sizeof(float) * framesToProcess);
+        memcpySpan(destination, source);
         return;
     }
 
     // Apply waveshaping curve.
-    for (unsigned i = 0; i < framesToProcess; ++i) {
-        const float input = source[i];
-
+    for (auto [input, output] : zippedRange(source, destination)) {
         float v = (curveLength - 1) * 0.5f * (input + 1);
         if (v < 0)
-            destination[i] = curveData[0];
+            output = curveData[0];
         else if (v >= curveLength - 1)
-            destination[i] = curveData[curveLength - 1];
+            output = curveData[curveLength - 1];
         else {
             float k = std::floor(v);
             float f = v - k;
             unsigned kIndex = k;
-            destination[i] = (1 - f) * curveData[kIndex] + f * curveData[kIndex + 1];
+            output = (1 - f) * curveData[kIndex] + f * curveData[kIndex + 1];
         }
     }
 }
 
-void WaveShaperDSPKernel::processCurve2x(const float* source, float* destination, size_t framesToProcess)
+void WaveShaperDSPKernel::processCurve2x(std::span<const float> source, std::span<float> destination)
 {
-    bool isSafe = framesToProcess == AudioUtilities::renderQuantumSize;
+    bool isSafe = source.size() == AudioUtilities::renderQuantumSize;
     ASSERT(isSafe);
     if (!isSafe)
         return;
 
-    float* tempP = m_tempBuffer->data();
+    auto tempP = m_tempBuffer->span().first(source.size() * 2);
 
-    m_upSampler->process(source, tempP, framesToProcess);
+    m_upSampler->process(source, tempP);
 
     // Process at 2x up-sampled rate.
-    processCurve(tempP, tempP, framesToProcess * 2);
+    processCurve(tempP, tempP);
 
-    m_downSampler->process(tempP, destination, framesToProcess * 2);
+    m_downSampler->process(tempP, destination);
 }
 
-void WaveShaperDSPKernel::processCurve4x(const float* source, float* destination, size_t framesToProcess)
+void WaveShaperDSPKernel::processCurve4x(std::span<const float> source, std::span<float> destination)
 {
-    bool isSafe = framesToProcess == AudioUtilities::renderQuantumSize;
+    bool isSafe = source.size() == AudioUtilities::renderQuantumSize;
     ASSERT(isSafe);
     if (!isSafe)
         return;
 
-    float* tempP = m_tempBuffer->data();
-    float* tempP2 = m_tempBuffer2->data();
+    auto tempP = m_tempBuffer->span().first(source.size() * 2);
+    auto tempP2 = m_tempBuffer2->span().first(source.size() * 4);
 
-    m_upSampler->process(source, tempP, framesToProcess);
-    m_upSampler2->process(tempP, tempP2, framesToProcess * 2);
+    m_upSampler->process(source, tempP);
+    m_upSampler2->process(tempP, tempP2);
 
     // Process at 4x up-sampled rate.
-    processCurve(tempP2, tempP2, framesToProcess * 4);
+    processCurve(tempP2, tempP2);
 
-    m_downSampler2->process(tempP2, tempP, framesToProcess * 4);
-    m_downSampler->process(tempP, destination, framesToProcess * 2);
+    m_downSampler2->process(tempP2, tempP);
+    m_downSampler->process(tempP, destination);
 }
 
 void WaveShaperDSPKernel::reset()

--- a/Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.h
+++ b/Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.h
@@ -42,7 +42,7 @@ public:
     explicit WaveShaperDSPKernel(WaveShaperProcessor*);
 
     // AudioDSPKernel
-    void process(const float* source, float* dest, size_t framesToProcess) final;
+    void process(std::span<const float> source, std::span<float> destination) final;
     void reset() final;
     double tailTime() const final { return 0; }
     double latencyTime() const final;
@@ -52,11 +52,11 @@ public:
 
 private:
     // Apply the shaping curve.
-    void processCurve(const float* source, float* dest, size_t framesToProcess);
+    void processCurve(std::span<const float> source, std::span<float> destination);
 
     // Use up-sampling, process at the higher sample-rate, then down-sample.
-    void processCurve2x(const float* source, float* dest, size_t framesToProcess);
-    void processCurve4x(const float* source, float* dest, size_t framesToProcess);
+    void processCurve2x(std::span<const float> source, std::span<float> destination);
+    void processCurve4x(std::span<const float> source, std::span<float> destination);
 
     bool requiresTailProcessing() const final;
 

--- a/Source/WebCore/Modules/webaudio/WaveShaperProcessor.cpp
+++ b/Source/WebCore/Modules/webaudio/WaveShaperProcessor.cpp
@@ -98,7 +98,7 @@ void WaveShaperProcessor::process(const AudioBus* source, AudioBus* destination,
 
     // For each channel of our input, process using the corresponding WaveShaperDSPKernel into the output channel.
     for (size_t i = 0; i < m_kernels.size(); ++i)
-        static_cast<WaveShaperDSPKernel&>(*m_kernels[i]).process(source->channel(i)->data(), destination->channel(i)->mutableData(), framesToProcess);
+        static_cast<WaveShaperDSPKernel&>(*m_kernels[i]).process(source->channel(i)->span().first(framesToProcess), destination->channel(i)->mutableSpan());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/audio/AudioDSPKernel.h
+++ b/Source/WebCore/platform/audio/AudioDSPKernel.h
@@ -57,7 +57,7 @@ public:
     virtual ~AudioDSPKernel() { };
 
     // Subclasses must override process() to do the processing and reset() to reset DSP state.
-    virtual void process(const float* source, float* destination, size_t framesToProcess) = 0;
+    virtual void process(std::span<const float> source, std::span<float> destination) = 0;
 
     // Subclasses that have AudioParams must override this to process the AudioParams.
     virtual void processOnlyAudioParams(size_t) { }

--- a/Source/WebCore/platform/audio/AudioDSPKernelProcessor.cpp
+++ b/Source/WebCore/platform/audio/AudioDSPKernelProcessor.cpp
@@ -96,7 +96,7 @@ void AudioDSPKernelProcessor::process(const AudioBus* source, AudioBus* destinat
         return;
         
     for (unsigned i = 0; i < m_kernels.size(); ++i)
-        m_kernels[i]->process(source->channel(i)->data(), destination->channel(i)->mutableData(), framesToProcess);
+        m_kernels[i]->process(source->channel(i)->span().first(framesToProcess), destination->channel(i)->mutableSpan());
 }
 
 void AudioDSPKernelProcessor::processOnlyAudioParams(size_t framesToProcess)

--- a/Source/WebCore/platform/audio/Biquad.cpp
+++ b/Source/WebCore/platform/audio/Biquad.cpp
@@ -76,10 +76,10 @@ Biquad::Biquad()
 
 Biquad::~Biquad() = default;
 
-void Biquad::process(const float* sourceP, float* destP, size_t framesToProcess)
+void Biquad::process(std::span<const float> source, std::span<float> destination)
 {
     if (hasSampleAccurateValues()) {
-        size_t n = framesToProcess;
+        size_t n = source.size();
 
         // Create local copies of member variables
         double x1 = m_x1;
@@ -93,12 +93,14 @@ void Biquad::process(const float* sourceP, float* destP, size_t framesToProcess)
         auto* a1 = m_a1.data();
         auto* a2 = m_a2.data();
 
+        size_t sourceIndex = 0;
+        size_t destinationIndex = 0;
         for (size_t k = 0; k < n; ++k) {
             // FIXME: this can be optimized by pipelining the multiply adds...
-            float x = *sourceP++;
+            float x = source[sourceIndex++];
             float y = b0[k] * x + b1[k] * x1 + b2[k] * x2 - a1[k] * y1 - a2[k] * y2;
 
-            *destP++ = y;
+            destination[destinationIndex++] = y;
 
             // Update state variables
             x2 = x1;
@@ -126,8 +128,8 @@ void Biquad::process(const float* sourceP, float* destP, size_t framesToProcess)
     }
 
 #if USE(ACCELERATE)
-    auto* inputP = m_inputBuffer.data();
-    auto* outputP = m_outputBuffer.data();
+    auto inputP = m_inputBuffer.span();
+    auto outputP = m_outputBuffer.span();
 
     // Set up filter state. This is needed in case we're switching from
     // filtering with variable coefficients (i.e., with automations) to
@@ -138,22 +140,22 @@ void Biquad::process(const float* sourceP, float* destP, size_t framesToProcess)
     outputP[1] = m_y1;
 
     // Use vecLib if available
-    processFast(sourceP, destP, framesToProcess);
+    processFast(source, destination);
 
-    ASSERT(framesToProcess >= 2);
+    ASSERT(source.size() >= 2);
 
     // Copy the last inputs and outputs to the filter memory variables.
     // This is needed because the next rendering quantum might be an
     // automation which needs the history to continue correctly. Because
-    // sourceP and destP can be the same block of memory, we can't read from
-    // sourceP to get the last inputs. Fortunately, processFast has put the
+    // source and destP can be the same block of memory, we can't read from
+    // source to get the last inputs. Fortunately, processFast has put the
     // last inputs in input[0] and input[1].
     m_x1 = inputP[1];
     m_x2 = inputP[0];
-    m_y1 = destP[framesToProcess - 1];
-    m_y2 = destP[framesToProcess - 2];
+    m_y1 = destination[source.size() - 1];
+    m_y2 = destination[source.size() - 2];
 #else
-    size_t n = framesToProcess;
+    size_t n = source.size();
 
     // Create local copies of member variables
     double x1 = m_x1;
@@ -167,12 +169,14 @@ void Biquad::process(const float* sourceP, float* destP, size_t framesToProcess)
     double a1 = m_a1[0];
     double a2 = m_a2[0];
 
+    size_t sourceIndex = 0;
+    size_t destinationIndex = 0;
     while (n--) {
         // FIXME: this can be optimized by pipelining the multiply adds...
-        float x = *sourceP++;
+        float x = source[sourceIndex++];
         float y = b0 * x + b1 * x1 + b2 * x2 - a1 * y1 - a2 * y2;
 
-        *destP++ = y;
+        destination[destinationIndex++] = y;
 
         // Update state variables
         x2 = x1;
@@ -194,54 +198,57 @@ void Biquad::process(const float* sourceP, float* destP, size_t framesToProcess)
 
 // Here we have optimized version using Accelerate.framework
 
-void Biquad::processFast(const float* sourceP, float* destP, size_t framesToProcess)
+void Biquad::processFast(std::span<const float> source, std::span<float> destination)
 {
-    double filterCoefficients[5];
-    filterCoefficients[0] = m_b0[0];
-    filterCoefficients[1] = m_b1[0];
-    filterCoefficients[2] = m_b2[0];
-    filterCoefficients[3] = m_a1[0];
-    filterCoefficients[4] = m_a2[0];
+    std::array<double, 5> filterCoefficients {
+        m_b0[0],
+        m_b1[0],
+        m_b2[0],
+        m_a1[0],
+        m_a2[0]
+    };
 
-    double* inputP = m_inputBuffer.data();
-    double* outputP = m_outputBuffer.data();
+    auto inputP = m_inputBuffer.span();
+    auto outputP = m_outputBuffer.span();
 
-    double* input2P = inputP + 2;
-    double* output2P = outputP + 2;
+    auto input2P = inputP.subspan(2);
+    auto output2P = outputP.subspan(2);
 
     // Break up processing into smaller slices (kBufferSize) if necessary.
 
-    size_t n = framesToProcess;
+    size_t n = source.size();
 
+    size_t sourceIndex = 0;
+    size_t destinationIndex = 0;
     while (n > 0) {
         int framesThisTime = n < kBufferSize ? n : kBufferSize;
 
         // Copy input to input buffer
         for (int i = 0; i < framesThisTime; ++i)
-            input2P[i] = *sourceP++;
+            input2P[i] = source[sourceIndex++];
 
-        processSliceFast(inputP, outputP, filterCoefficients, framesThisTime);
+        processSliceFast(inputP, outputP, std::span { filterCoefficients }, framesThisTime);
 
         // Copy output buffer to output (converts float -> double).
         for (int i = 0; i < framesThisTime; ++i)
-            *destP++ = static_cast<float>(output2P[i]);
+            destination[destinationIndex++] = static_cast<float>(output2P[i]);
 
         n -= framesThisTime;
     }
 }
 
-void Biquad::processSliceFast(double* sourceP, double* destP, double* coefficientsP, size_t framesToProcess)
+void Biquad::processSliceFast(std::span<double> source, std::span<double> destination, std::span<double> coefficients, size_t framesToProcess)
 {
     // Use double-precision for filter stability
-    vDSP_deq22D(sourceP, 1, coefficientsP, destP, 1, framesToProcess);
+    vDSP_deq22D(source.data(), 1, coefficients.data(), destination.data(), 1, framesToProcess);
 
-    // Save history. Note that sourceP and destP reference m_inputBuffer and m_outputBuffer respectively.
+    // Save history. Note that source and destination reference m_inputBuffer and m_outputBuffer respectively.
     // These buffers are allocated (in the constructor) with space for two extra samples so it's OK to access
     // array values two beyond framesToProcess.
-    sourceP[0] = sourceP[framesToProcess - 2 + 2];
-    sourceP[1] = sourceP[framesToProcess - 1 + 2];
-    destP[0] = destP[framesToProcess - 2 + 2];
-    destP[1] = destP[framesToProcess - 1 + 2];
+    source[0] = source[framesToProcess - 2 + 2];
+    source[1] = source[framesToProcess - 1 + 2];
+    destination[0] = destination[framesToProcess - 2 + 2];
+    destination[1] = destination[framesToProcess - 1 + 2];
 }
 
 #endif // USE(ACCELERATE)

--- a/Source/WebCore/platform/audio/Biquad.h
+++ b/Source/WebCore/platform/audio/Biquad.h
@@ -47,7 +47,7 @@ public:
     Biquad();
     ~Biquad();
 
-    void process(const float* sourceP, float* destP, size_t framesToProcess);
+    void process(std::span<const float> source, std::span<float> destination);
 
     bool hasSampleAccurateValues() const { return m_hasSampleAccurateValues; }
     void setHasSampleAccurateValues(bool hasSampleAccurateValues) { m_hasSampleAccurateValues = hasSampleAccurateValues; }
@@ -91,8 +91,8 @@ private:
     AudioDoubleArray m_a2;
 
 #if USE(ACCELERATE)
-    void processFast(const float* sourceP, float* destP, size_t framesToProcess);
-    void processSliceFast(double* sourceP, double* destP, double* coefficientsP, size_t framesToProcess);
+    void processFast(std::span<const float> source, std::span<float> destination);
+    void processSliceFast(std::span<double> source, std::span<double> destination, std::span<double> coefficients, size_t framesToProcess);
     AudioDoubleArray m_inputBuffer;
     AudioDoubleArray m_outputBuffer;
 #endif

--- a/Source/WebCore/platform/audio/DirectConvolver.h
+++ b/Source/WebCore/platform/audio/DirectConvolver.h
@@ -41,7 +41,7 @@ class DirectConvolver final {
 public:
     explicit DirectConvolver(size_t inputBlockSize);
 
-    void process(AudioFloatArray* convolutionKernel, const float* sourceP, float* destP, size_t framesToProcess);
+    void process(AudioFloatArray* convolutionKernel, std::span<const float> source, std::span<float> destination);
 
     void reset();
 

--- a/Source/WebCore/platform/audio/DownSampler.cpp
+++ b/Source/WebCore/platform/audio/DownSampler.cpp
@@ -33,6 +33,7 @@
 #include "DownSampler.h"
 
 #include <wtf/MathExtras.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -84,14 +85,14 @@ void DownSampler::initializeKernel()
     }
 }
 
-void DownSampler::process(const float* sourceP, float* destP, size_t sourceFramesToProcess)
+void DownSampler::process(std::span<const float> source, std::span<float> destination)
 {
-    bool isInputBlockSizeGood = sourceFramesToProcess == m_inputBlockSize;
+    bool isInputBlockSizeGood = source.size() == m_inputBlockSize;
     ASSERT(isInputBlockSizeGood);
     if (!isInputBlockSizeGood)
         return;
 
-    size_t destFramesToProcess = sourceFramesToProcess / 2;
+    size_t destFramesToProcess = source.size() / 2;
 
     bool isTempBufferGood = destFramesToProcess == m_tempBuffer.size();
     ASSERT(isTempBufferGood);
@@ -106,34 +107,34 @@ void DownSampler::process(const float* sourceP, float* destP, size_t sourceFrame
     size_t halfSize = DefaultKernelSize / 2;
 
     // Copy source samples to 2nd half of input buffer.
-    bool isInputBufferGood = m_inputBuffer.size() == sourceFramesToProcess * 2 && halfSize <= sourceFramesToProcess;
+    bool isInputBufferGood = m_inputBuffer.size() == source.size() * 2 && halfSize <= source.size();
     ASSERT(isInputBufferGood);
     if (!isInputBufferGood)
         return;
 
-    float* inputP = m_inputBuffer.data() + sourceFramesToProcess;
-    memcpy(inputP, sourceP, sizeof(float) * sourceFramesToProcess);
+    auto inputP = m_inputBuffer.span().subspan(source.size());
+    memcpySpan(inputP, source);
 
-    // Copy the odd sample-frames from sourceP, delayed by one sample-frame (destination sample-rate)
+    // Copy the odd sample-frames from source, delayed by one sample-frame (destination sample-rate)
     // to match shifting forward in time in m_reducedKernel.
-    float* oddSamplesP = m_tempBuffer.data();
-    for (unsigned i = 0; i < destFramesToProcess; ++i)
-        oddSamplesP[i] = *((inputP - 1) + i * 2);
+    auto oddSamplesP = m_tempBuffer.span().first(destFramesToProcess);
+    for (size_t i = 0; i < oddSamplesP.size(); ++i)
+        oddSamplesP[i] = *((inputP.data() - 1) + i * 2);
 
     // Actually process oddSamplesP with m_reducedKernel for efficiency.
     // The theoretical kernel is double this size with 0 values for even terms (except center).
-    m_convolver.process(&m_reducedKernel, oddSamplesP, destP, destFramesToProcess);
+    m_convolver.process(&m_reducedKernel, oddSamplesP, destination);
 
     // Now, account for the 0.5 term right in the middle of the kernel.
     // This amounts to a delay-line of length halfSize (at the source sample-rate),
     // scaled by 0.5.
 
     // Sum into the destination.
-    for (unsigned i = 0; i < destFramesToProcess; ++i)
-        destP[i] += 0.5 * *((inputP - halfSize) + i * 2);
+    for (size_t i = 0; i < destFramesToProcess; ++i)
+        destination[i] += 0.5 * *((inputP.data() - halfSize) + i * 2);
 
     // Copy 2nd half of input buffer to 1st half.
-    memcpy(m_inputBuffer.data(), inputP, sizeof(float) * sourceFramesToProcess);
+    memcpySpan(m_inputBuffer.span(), inputP);
 }
 
 void DownSampler::reset()

--- a/Source/WebCore/platform/audio/DownSampler.h
+++ b/Source/WebCore/platform/audio/DownSampler.h
@@ -42,8 +42,8 @@ class DownSampler final {
 public:
     explicit DownSampler(size_t inputBlockSize);
 
-    // The destination buffer |destP| is of size sourceFramesToProcess / 2.
-    void process(const float* sourceP, float* destP, size_t sourceFramesToProcess);
+    // The destination buffer |destination| is of size source.size() / 2.
+    void process(std::span<const float> source, std::span<float> destination);
 
     void reset();
 

--- a/Source/WebCore/platform/audio/FFTConvolver.h
+++ b/Source/WebCore/platform/audio/FFTConvolver.h
@@ -42,14 +42,14 @@ public:
     // fftSize must be a power of two
     FFTConvolver(size_t fftSize);
 
-    // For now, with multiple calls to Process(), framesToProcess MUST add up EXACTLY to fftSize / 2
+    // For now, with multiple calls to Process(), source.size() MUST add up EXACTLY to fftSize / 2
     //
     // FIXME: Later, we can do more sophisticated buffering to relax this requirement...
     //
     // The input to output latency is equal to fftSize / 2
     //
     // Processing in-place is allowed...
-    void process(FFTFrame* fftKernel, const float* sourceP, float* destP, size_t framesToProcess);
+    void process(FFTFrame* fftKernel, std::span<const float> source, std::span<float> destination);
 
     void reset();
 

--- a/Source/WebCore/platform/audio/HRTFPanner.cpp
+++ b/Source/WebCore/platform/audio/HRTFPanner.cpp
@@ -170,10 +170,10 @@ void HRTFPanner::pan(double desiredAzimuth, double elevation, const AudioBus* in
     const AudioChannel* inputChannelR = numInputChannels > 1 ? inputBus->channelByType(AudioBus::ChannelRight) : 0;
 
     // Get source and destination pointers.
-    const float* sourceL = inputChannelL->data();
-    const float* sourceR = numInputChannels > 1 ? inputChannelR->data() : sourceL;
-    float* destinationL = outputBus->channelByType(AudioBus::ChannelLeft)->mutableData();
-    float* destinationR = outputBus->channelByType(AudioBus::ChannelRight)->mutableData();
+    auto sourceL = inputChannelL->span();
+    auto sourceR = numInputChannels > 1 ? inputChannelR->span() : sourceL;
+    auto destinationL = outputBus->channelByType(AudioBus::ChannelLeft)->mutableSpan();
+    auto destinationR = outputBus->channelByType(AudioBus::ChannelRight)->mutableSpan();
 
     double azimuthBlend;
     int desiredAzimuthIndex = calculateDesiredAzimuthIndexAndBlend(azimuth, azimuthBlend);
@@ -247,36 +247,36 @@ void HRTFPanner::pan(double desiredAzimuth, double elevation, const AudioBus* in
 
         // Calculate the source and destination pointers for the current segment.
         unsigned offset = segment * framesPerSegment;
-        const float* segmentSourceL = sourceL + offset;
-        const float* segmentSourceR = sourceR + offset;
-        float* segmentDestinationL = destinationL + offset;
-        float* segmentDestinationR = destinationR + offset;
+        auto segmentSourceL = sourceL.subspan(offset, framesPerSegment);
+        auto segmentSourceR = sourceR.subspan(offset, framesPerSegment);
+        auto segmentDestinationL = destinationL.subspan(offset, framesPerSegment);
+        auto segmentDestinationR = destinationR.subspan(offset, framesPerSegment);
 
         // First run through delay lines for inter-aural time difference.
         m_delayLineL.setDelayFrames(frameDelayL);
         m_delayLineR.setDelayFrames(frameDelayR);
-        m_delayLineL.process(segmentSourceL, segmentDestinationL, framesPerSegment);
-        m_delayLineR.process(segmentSourceR, segmentDestinationR, framesPerSegment);
+        m_delayLineL.process(segmentSourceL, segmentDestinationL);
+        m_delayLineR.process(segmentSourceR, segmentDestinationR);
 
         bool needsCrossfading = m_crossfadeIncr;
         
         // Have the convolvers render directly to the final destination if we're not cross-fading.
-        float* convolutionDestinationL1 = needsCrossfading ? m_tempL1.data() : segmentDestinationL;
-        float* convolutionDestinationR1 = needsCrossfading ? m_tempR1.data() : segmentDestinationR;
-        float* convolutionDestinationL2 = needsCrossfading ? m_tempL2.data() : segmentDestinationL;
-        float* convolutionDestinationR2 = needsCrossfading ? m_tempR2.data() : segmentDestinationR;
+        auto convolutionDestinationL1 = needsCrossfading ? m_tempL1.span() : segmentDestinationL;
+        auto convolutionDestinationR1 = needsCrossfading ? m_tempR1.span() : segmentDestinationR;
+        auto convolutionDestinationL2 = needsCrossfading ? m_tempL2.span() : segmentDestinationL;
+        auto convolutionDestinationR2 = needsCrossfading ? m_tempR2.span() : segmentDestinationR;
 
         // Now do the convolutions.
         // Note that we avoid doing convolutions on both sets of convolvers if we're not currently cross-fading.
         
         if (m_crossfadeSelection == CrossfadeSelection1 || needsCrossfading) {
-            m_convolverL1.process(kernelL1->fftFrame(), segmentDestinationL, convolutionDestinationL1, framesPerSegment);
-            m_convolverR1.process(kernelR1->fftFrame(), segmentDestinationR, convolutionDestinationR1, framesPerSegment);
+            m_convolverL1.process(kernelL1->fftFrame(), segmentDestinationL, convolutionDestinationL1);
+            m_convolverR1.process(kernelR1->fftFrame(), segmentDestinationR, convolutionDestinationR1);
         }
 
         if (m_crossfadeSelection == CrossfadeSelection2 || needsCrossfading) {
-            m_convolverL2.process(kernelL2->fftFrame(), segmentDestinationL, convolutionDestinationL2, framesPerSegment);
-            m_convolverR2.process(kernelR2->fftFrame(), segmentDestinationR, convolutionDestinationR2, framesPerSegment);
+            m_convolverL2.process(kernelL2->fftFrame(), segmentDestinationL, convolutionDestinationL2);
+            m_convolverR2.process(kernelR2->fftFrame(), segmentDestinationR, convolutionDestinationR2);
         }
         
         if (needsCrossfading) {

--- a/Source/WebCore/platform/audio/IIRFilter.h
+++ b/Source/WebCore/platform/audio/IIRFilter.h
@@ -38,8 +38,8 @@ public:
 
     void reset();
 
-    void process(const float* source, float* destination, size_t framesToProcess);
-    void getFrequencyResponse(unsigned length, const float* frequency, float* magResponse, float* phaseResponse);
+    void process(std::span<const float> source, std::span<float> destination);
+    void getFrequencyResponse(unsigned length, std::span<const float> frequency, std::span<float> magResponse, std::span<float> phaseResponse);
     double tailTime(double sampleRate, bool isFilterStable);
 
     const Vector<double>& feedforward() const { return m_feedforward; }

--- a/Source/WebCore/platform/audio/ReverbConvolver.cpp
+++ b/Source/WebCore/platform/audio/ReverbConvolver.cpp
@@ -177,19 +177,19 @@ void ReverbConvolver::process(const AudioChannel* sourceChannel, AudioChannel* d
     if (!isSafe)
         return;
         
-    const float* source = sourceChannel->data();
+    auto source = sourceChannel->span().first(framesToProcess);
     auto destination = destinationChannel->mutableSpan();
-    bool isDataSafe = source && destination.data();
+    bool isDataSafe = source.data() && destination.data();
     ASSERT(isDataSafe);
     if (!isDataSafe)
         return;
 
     // Feed input buffer (read by all threads)
-    m_inputBuffer.write(source, framesToProcess);
+    m_inputBuffer.write(source);
 
     // Accumulate contributions from each stage
     for (size_t i = 0; i < m_stages.size(); ++i)
-        m_stages[i]->process(source, framesToProcess);
+        m_stages[i]->process(source);
 
     // Finally read from accumulation buffer
     m_accumulationBuffer.readAndClear(destination, framesToProcess);

--- a/Source/WebCore/platform/audio/ReverbConvolverStage.h
+++ b/Source/WebCore/platform/audio/ReverbConvolverStage.h
@@ -51,8 +51,8 @@ public:
     ReverbConvolverStage(const float* impulseResponse, size_t responseLength, size_t reverbTotalLatency, size_t stageOffset, size_t stageLength, size_t fftSize, size_t renderPhase, size_t renderSliceSize, ReverbAccumulationBuffer*, float scale, bool directMode = false);
     ~ReverbConvolverStage();
 
-    // WARNING: framesToProcess must be such that it evenly divides the delay buffer size (stage_offset).
-    void process(const float* source, size_t framesToProcess);
+    // WARNING: source.size() must be such that it evenly divides the delay buffer size (stage_offset).
+    void process(std::span<const float> source);
 
     void processInBackground(ReverbConvolver* convolver, size_t framesToProcess);
 

--- a/Source/WebCore/platform/audio/ReverbInputBuffer.cpp
+++ b/Source/WebCore/platform/audio/ReverbInputBuffer.cpp
@@ -31,6 +31,7 @@
 #if ENABLE(WEB_AUDIO)
 
 #include "ReverbInputBuffer.h"
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -44,24 +45,24 @@ ReverbInputBuffer::ReverbInputBuffer(size_t length)
 {
 }
 
-void ReverbInputBuffer::write(const float* sourceP, size_t numberOfFrames)
+void ReverbInputBuffer::write(std::span<const float> source)
 {
     size_t bufferLength = m_buffer.size();
-    bool isCopySafe = m_writeIndex + numberOfFrames <= bufferLength;
+    bool isCopySafe = m_writeIndex + source.size() <= bufferLength;
     ASSERT(isCopySafe);
     if (!isCopySafe)
         return;
         
-    memcpy(m_buffer.data() + m_writeIndex, sourceP, sizeof(float) * numberOfFrames);
+    memcpySpan(m_buffer.span().subspan(m_writeIndex), source);
 
-    m_writeIndex += numberOfFrames;
+    m_writeIndex += source.size();
     ASSERT(m_writeIndex <= bufferLength);
 
     if (m_writeIndex >= bufferLength)
         m_writeIndex = 0;
 }
 
-float* ReverbInputBuffer::directReadFrom(int* readIndex, size_t numberOfFrames)
+std::span<float> ReverbInputBuffer::directReadFrom(int* readIndex, size_t numberOfFrames)
 {
     size_t bufferLength = m_buffer.size();
     bool isPointerGood = readIndex && *readIndex >= 0 && *readIndex + numberOfFrames <= bufferLength;
@@ -70,11 +71,11 @@ float* ReverbInputBuffer::directReadFrom(int* readIndex, size_t numberOfFrames)
         // Should never happen in practice but return pointer to start of buffer (avoid crash)
         if (readIndex)
             *readIndex = 0;
-        return m_buffer.data();
+        return m_buffer.span().first(numberOfFrames);
     }
         
-    float* sourceP = m_buffer.data();
-    float* p = sourceP + *readIndex;
+    auto source = m_buffer.span();
+    auto p = source.subspan(*readIndex, numberOfFrames);
 
     // Update readIndex
     *readIndex = (*readIndex + numberOfFrames) % bufferLength;

--- a/Source/WebCore/platform/audio/ReverbInputBuffer.h
+++ b/Source/WebCore/platform/audio/ReverbInputBuffer.h
@@ -42,9 +42,9 @@ public:
     explicit ReverbInputBuffer(size_t length);
 
     // The realtime audio thread keeps writing samples here.
-    // The assumption is that the buffer's length is evenly divisible by numberOfFrames (for nearly all cases this will be fine).
-    // FIXME: remove numberOfFrames restriction...
-    void write(const float* sourceP, size_t numberOfFrames);
+    // The assumption is that the buffer's length is evenly divisible by source.size() (for nearly all cases this will be fine).
+    // FIXME: remove source.size() restriction...
+    void write(std::span<const float> source);
 
     // Background threads can call this to check if there's anything to read...
     size_t writeIndex() const { return m_writeIndex; }
@@ -53,7 +53,7 @@ public:
     // readIndex is updated with the next readIndex to read from...
     // The assumption is that the buffer's length is evenly divisible by numberOfFrames.
     // FIXME: remove numberOfFrames restriction...
-    float* directReadFrom(int* readIndex, size_t numberOfFrames);
+    std::span<float> directReadFrom(int* readIndex, size_t numberOfFrames);
 
     void reset();
 

--- a/Source/WebCore/platform/audio/UpSampler.cpp
+++ b/Source/WebCore/platform/audio/UpSampler.cpp
@@ -33,6 +33,7 @@
 #include "UpSampler.h"
 
 #include <wtf/MathExtras.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -77,14 +78,14 @@ void UpSampler::initializeKernel()
     }
 }
 
-void UpSampler::process(const float* sourceP, float* destP, size_t sourceFramesToProcess)
+void UpSampler::process(std::span<const float> source, std::span<float> destination)
 {
-    bool isInputBlockSizeGood = sourceFramesToProcess == m_inputBlockSize;
+    bool isInputBlockSizeGood = source.size() == m_inputBlockSize;
     ASSERT(isInputBlockSizeGood);
     if (!isInputBlockSizeGood)
         return;
 
-    bool isTempBufferGood = sourceFramesToProcess == m_tempBuffer.size();
+    bool isTempBufferGood = source.size() == m_tempBuffer.size();
     ASSERT(isTempBufferGood);
     if (!isTempBufferGood)
         return;
@@ -97,27 +98,27 @@ void UpSampler::process(const float* sourceP, float* destP, size_t sourceFramesT
     size_t halfSize = m_kernel.size() / 2;
 
     // Copy source samples to 2nd half of input buffer.
-    bool isInputBufferGood = m_inputBuffer.size() == sourceFramesToProcess * 2 && halfSize <= sourceFramesToProcess;
+    bool isInputBufferGood = m_inputBuffer.size() == source.size() * 2 && halfSize <= source.size();
     ASSERT(isInputBufferGood);
     if (!isInputBufferGood)
         return;
 
-    float* inputP = m_inputBuffer.data() + sourceFramesToProcess;
-    memcpy(inputP, sourceP, sizeof(float) * sourceFramesToProcess);
+    auto inputP = m_inputBuffer.span().subspan(source.size());
+    memcpySpan(inputP, source);
 
-    // Copy even sample-frames 0,2,4,6... (delayed by the linear phase delay) directly into destP.
-    for (unsigned i = 0; i < sourceFramesToProcess; ++i)
-        destP[i * 2] = *((inputP - halfSize) + i);
+    // Copy even sample-frames 0,2,4,6... (delayed by the linear phase delay) directly into destination.
+    for (size_t i = 0; i < source.size(); ++i)
+        destination[i * 2] = *((inputP.data() - halfSize) + i);
 
     // Compute odd sample-frames 1,3,5,7...
-    float* oddSamplesP = m_tempBuffer.data();
-    m_convolver.process(&m_kernel, sourceP, oddSamplesP, sourceFramesToProcess);
+    auto oddSamplesP = m_tempBuffer.span();
+    m_convolver.process(&m_kernel, source, oddSamplesP);
 
-    for (unsigned i = 0; i < sourceFramesToProcess; ++i)
-        destP[i * 2 + 1] = oddSamplesP[i];
+    for (size_t i = 0; i < source.size(); ++i)
+        destination[i * 2 + 1] = oddSamplesP[i];
 
     // Copy 2nd half of input buffer to 1st half.
-    memcpy(m_inputBuffer.data(), inputP, sizeof(float) * sourceFramesToProcess);
+    memcpySpan(m_inputBuffer.span(), inputP);
 }
 
 void UpSampler::reset()

--- a/Source/WebCore/platform/audio/UpSampler.h
+++ b/Source/WebCore/platform/audio/UpSampler.h
@@ -42,8 +42,8 @@ class UpSampler final {
 public:
     explicit UpSampler(size_t inputBlockSize);
 
-    // The destination buffer |destP| is of size sourceFramesToProcess * 2.
-    void process(const float* sourceP, float* destP, size_t sourceFramesToProcess);
+    // The destination buffer |destination| is of size source.size() * 2.
+    void process(std::span<const float> source, std::span<float> destination);
 
     void reset();
 

--- a/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.h
+++ b/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.h
@@ -44,15 +44,15 @@ public:
     SharedVideoFrameInfo() = default;
     SharedVideoFrameInfo(OSType, uint32_t width, uint32_t height, uint32_t bytesPerRow, uint32_t widthPlaneB = 0, uint32_t heightPlaneB = 0, uint32_t bytesPerRowPlaneB = 0, uint32_t bytesPerRowPlaneA = 0);
 
-    WEBCORE_EXPORT void encode(uint8_t*);
+    WEBCORE_EXPORT void encode(std::span<uint8_t>);
     WEBCORE_EXPORT static std::optional<SharedVideoFrameInfo> decode(std::span<const uint8_t>);
 
     WEBCORE_EXPORT static SharedVideoFrameInfo fromCVPixelBuffer(CVPixelBufferRef);
-    WEBCORE_EXPORT bool writePixelBuffer(CVPixelBufferRef, uint8_t* data);
+    WEBCORE_EXPORT bool writePixelBuffer(CVPixelBufferRef, std::span<uint8_t> data);
 
 #if USE(LIBWEBRTC)
     WEBCORE_EXPORT static SharedVideoFrameInfo fromVideoFrameBuffer(const webrtc::VideoFrameBuffer&);
-    WEBCORE_EXPORT bool writeVideoFrameBuffer(webrtc::VideoFrameBuffer&, uint8_t* data);
+    WEBCORE_EXPORT bool writeVideoFrameBuffer(webrtc::VideoFrameBuffer&, std::span<uint8_t> data);
 #endif
 
     WEBCORE_EXPORT size_t storageSize() const;

--- a/Source/WebCore/platform/graphics/cocoa/ANGLEUtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/ANGLEUtilitiesCocoa.mm
@@ -33,6 +33,7 @@
 #include <Metal/Metal.h>
 #include <pal/spi/cocoa/MetalSPI.h>
 #include <wtf/SoftLinking.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/darwin/WeakLinking.h>
 
 #if USE(APPLE_INTERNAL_SDK) && PLATFORM(VISION)
@@ -148,12 +149,12 @@ RetainPtr<id<MTLRasterizationRateMap>> newRasterizationRateMap(GCGLDisplay displ
     if (horizontalSamplesLeft.size() > maxSampleCount.width || horizontalSamplesRight.size() > maxSampleCount.width || verticalSamples.size() > maxSampleCount.height || !layerDescriptorLeft.get() || !layerDescriptorRight.get())
         return nullptr;
 
-    memcpy([layerDescriptorLeft horizontalSampleStorage], horizontalSamplesLeft.data(), horizontalSamplesLeft.size_bytes());
-    memcpy([layerDescriptorLeft verticalSampleStorage], verticalSamples.data(), verticalSamples.size_bytes());
+    memcpySpan(unsafeMakeSpan([layerDescriptorLeft horizontalSampleStorage], [layerDescriptorLeft sampleCount].width), horizontalSamplesLeft);
+    memcpySpan(unsafeMakeSpan([layerDescriptorLeft verticalSampleStorage], [layerDescriptorLeft sampleCount].height), verticalSamples);
     [layerDescriptorLeft setSampleCount:MTLSizeMake(horizontalSamplesLeft.size(), verticalSamples.size(), 0)];
 
-    memcpy([layerDescriptorRight horizontalSampleStorage], horizontalSamplesRight.data(), horizontalSamplesRight.size_bytes());
-    memcpy([layerDescriptorRight verticalSampleStorage], verticalSamples.data(), verticalSamples.size_bytes());
+    memcpySpan(unsafeMakeSpan([layerDescriptorRight horizontalSampleStorage], [layerDescriptorRight sampleCount].width), horizontalSamplesRight);
+    memcpySpan(unsafeMakeSpan([layerDescriptorRight verticalSampleStorage], [layerDescriptorRight sampleCount].height), verticalSamples);
     [layerDescriptorRight setSampleCount:MTLSizeMake(horizontalSamplesRight.size(), verticalSamples.size(), 0)];
 
     [descriptor setScreenSize:MTLSizeMake(screenSize.width(), screenSize.height(), 0)];

--- a/Source/WebCore/platform/xr/openxr/OpenXRInstance.cpp
+++ b/Source/WebCore/platform/xr/openxr/OpenXRInstance.cpp
@@ -25,6 +25,7 @@
 #include "PlatformXROpenXR.h"
 #include <wtf/NeverDestroyed.h>
 #include <wtf/Scope.h>
+#include <wtf/StdLibExtras.h>
 
 using namespace WebCore;
 
@@ -66,7 +67,7 @@ Instance::Impl::Impl()
 
         auto createInfo = createStructure<XrInstanceCreateInfo, XR_TYPE_INSTANCE_CREATE_INFO>();
         createInfo.createFlags = 0;
-        std::memcpy(createInfo.applicationInfo.applicationName, s_applicationName.characters(), XR_MAX_APPLICATION_NAME_SIZE);
+        memcpySpan(std::span { createInfo.applicationInfo.applicationName }, s_applicationName.spanIncludingNullTerminator());
         createInfo.applicationInfo.apiVersion = XR_CURRENT_API_VERSION;
         createInfo.applicationInfo.applicationVersion = s_applicationVersion;
         createInfo.enabledApiLayerCount = 0;

--- a/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp
@@ -144,7 +144,7 @@ std::optional<SharedVideoFrame::Buffer> SharedVideoFrameWriter::writeBuffer(CVPi
     if (!prepareWriting(info, newSemaphoreCallback, newMemoryCallback))
         return { };
 
-    if (!info.writePixelBuffer(pixelBuffer, m_storage->mutableSpan().data()))
+    if (!info.writePixelBuffer(pixelBuffer, m_storage->mutableSpan()))
         return { };
 
     scope.release();
@@ -171,7 +171,7 @@ std::optional<SharedVideoFrame::Buffer> SharedVideoFrameWriter::writeBuffer(webr
     if (!prepareWriting(info, newSemaphoreCallback, newMemoryCallback))
         return { };
 
-    if (!info.writeVideoFrameBuffer(frameBuffer, m_storage->mutableSpan().data()))
+    if (!info.writeVideoFrameBuffer(frameBuffer, m_storage->mutableSpan()))
         return { };
 
     scope.release();

--- a/Source/WebKitLegacy/mac/Plugins/WebBasePluginPackage.mm
+++ b/Source/WebKitLegacy/mac/Plugins/WebBasePluginPackage.mm
@@ -40,7 +40,9 @@
 #import <wtf/Assertions.h>
 #import <wtf/MainThread.h>
 #import <wtf/RunLoop.h>
+#import <wtf/StdLibExtras.h>
 #import <wtf/Vector.h>
+#import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/text/CString.h>
 
 static constexpr auto JavaCocoaPluginIdentifier ="com.apple.JavaPluginCocoa"_s;
@@ -263,7 +265,7 @@ static inline void swapIntsInHeader(uint32_t* rawData, size_t length)
 {
     NSUInteger sizeInBytes = [data length];
     Vector<uint32_t, 128> rawData((sizeInBytes + 3) / 4);
-    memcpy(rawData.data(), [data bytes], sizeInBytes);
+    memcpySpan(asMutableByteSpan(rawData.mutableSpan()), span(data));
     
     unsigned numArchs = 0;
     struct fat_arch singleArch = { 0, 0, 0, 0, 0 };

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
@@ -44,14 +44,14 @@ static NSData *literalAsData(const char* literal)
 
 static const char* dataAsString(NSData *data)
 {
-    static char buffer[1000];
-    if ([data length] > sizeof(buffer) - 1)
+    static std::array<char, 1000> buffer;
+    if ([data length] > buffer.size() - 1)
         return "ERROR";
     if (memchr([data bytes], 0, [data length]))
         return "ERROR";
-    memcpy(buffer, [data bytes], [data length]);
+    memcpySpan(std::span { buffer }, span(data));
     buffer[[data length]] = '\0';
-    return buffer;
+    return buffer.data();
 }
 
 static const char* originalDataAsString(NSURL *URL)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -57,6 +57,7 @@
 #import <mach/task.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/OSObjectPtr.h>
+#import <wtf/StdLibExtras.h>
 #import <wtf/UUID.h>
 #import <wtf/UniqueRef.h>
 #import <wtf/cocoa/SpanCocoa.h>
@@ -312,7 +313,7 @@ static WebKit::WebPushD::WebPushDaemonConnectionConfiguration defaultWebPushDaem
 {
     auto token = getSelfAuditToken();
     Vector<uint8_t> auditToken(sizeof(token));
-    memcpy(auditToken.data(), &token, sizeof(token));
+    memcpySpan(auditToken.mutableSpan(), asByteSpan(token));
 
     IGNORE_CLANG_WARNINGS_BEGIN("missing-designated-field-initializers")
     return { .hostAppAuditTokenData = WTFMove(auditToken) };


### PR DESCRIPTION
#### 970bbbc53b2d8dd3be98c96099298d221607f774
<pre>
Further reduce use of memcpy()
<a href="https://bugs.webkit.org/show_bug.cgi?id=284897">https://bugs.webkit.org/show_bug.cgi?id=284897</a>

Reviewed by Darin Adler.

* Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.cpp:
(WebCore::WaveShaperDSPKernel::process):
(WebCore::WaveShaperDSPKernel::processCurve):
(WebCore::WaveShaperDSPKernel::processCurve2x):
(WebCore::WaveShaperDSPKernel::processCurve4x):
* Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.h:
* Source/WebCore/Modules/webaudio/WaveShaperProcessor.cpp:
(WebCore::WaveShaperProcessor::process):
* Source/WebCore/platform/audio/DownSampler.cpp:
(WebCore::DownSampler::process):
* Source/WebCore/platform/audio/DownSampler.h:
* Source/WebCore/platform/audio/UpSampler.cpp:
(WebCore::UpSampler::process):
* Source/WebCore/platform/audio/UpSampler.h:
* Source/WebCore/platform/audio/cocoa/AudioSampleBufferList.cpp:
(WebCore::AudioSampleBufferList::copyFrom):
(WebCore::AudioSampleBufferList::copyTo):
* Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp:
(WebCore::FetchABL):
* Source/WebCore/platform/cocoa/SharedVideoFrameInfo.h:
* Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm:
(WebCore::SharedVideoFrameInfo::encode):
(WebCore::SharedVideoFrameInfo::writePixelBuffer):
(WebCore::SharedVideoFrameInfo::writeVideoFrameBuffer):
* Source/WebCore/platform/graphics/WidthCache.h:
(WebCore::WidthCache::SmallStringKey::SmallStringKey):
(WebCore::WidthCache::SmallStringKey::copySmallCharacters):
* Source/WebCore/platform/graphics/cocoa/ANGLEUtilitiesCocoa.mm:
(WebCore::newRasterizationRateMap):
* Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm:
(WebCore::MockAudioSharedInternalUnit::generateSampleBuffers):
(WebCore::MockAudioSharedInternalUnit::render):
* Source/WebCore/platform/video-codecs/cocoa/RTCVideoDecoderVTBAV1.mm:
(computeAV1InputFormat):
* Source/WebCore/platform/xr/openxr/OpenXRInstance.cpp:
(PlatformXR::Instance::Impl::Impl):
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::OffsetBuffer::readOutBytes):
(WebCore::readFunc):
(WebCore::XMLParserContext::createMemoryParser):
* Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp:
(WebKit::SharedVideoFrameWriter::writeBuffer):
* Source/WebKitLegacy/mac/History/BinaryPropertyList.cpp:
(BinaryPropertyListSerializer::BinaryPropertyListSerializer):
(BinaryPropertyListSerializer::writeArrayStart):
(BinaryPropertyListSerializer::writeArrayEnd):
(BinaryPropertyListSerializer::writeDictionaryStart):
(BinaryPropertyListSerializer::writeDictionaryEnd):
(BinaryPropertyListSerializer::startObject):
* Source/WebKitLegacy/mac/Plugins/WebBasePluginPackage.mm:
(-[WebBasePluginPackage isNativeLibraryData:]):
* Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm:
(TestWebKitAPI::dataAsString):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:
(TestWebKitAPI::defaultWebPushDaemonConfiguration):

Canonical link: <a href="https://commits.webkit.org/288121@main">https://commits.webkit.org/288121@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1aa1eadbd99ebb26d7c4b79fd7e536eaf8221f05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81889 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1416 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35845 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86446 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32891 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83995 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1450 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9239 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63872 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21599 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84959 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1072 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74524 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44156 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/972 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28701 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31340 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29310 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87877 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9131 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6509 "Found 1 new test failure: http/wpt/mediarecorder/record-96KHz-sources.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72231 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/content-with-transparent-background.html imported/w3c/web-platform-tests/css/css-view-transitions/sibling-frames-transition.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9316 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70343 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71454 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15548 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14473 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/512 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12697 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9082 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14618 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8922 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12447 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10730 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->