### PR TITLE
Use String.prototype.trim() instead of Regex to trim whitespaces in `XMLViewer.js`

### DIFF
--- a/Source/WebCore/xml/XMLViewer.js
+++ b/Source/WebCore/xml/XMLViewer.js
@@ -210,15 +210,9 @@ function processText(parentElement, node)
 }
 
 // Processing utils.
-
-function trim(value)
-{
-    return value.replace(/^\s\s*/, '').replace(/\s\s*$/, '');
-}
-
 function isShort(value)
 {
-    return trim(value).length <= 50;
+    return value.trim().length <= 50;
 }
 
 // Tree rendering.
@@ -290,7 +284,7 @@ function createComment(commentString)
 function createText(value)
 {
     var text = createHTMLElement('span');
-    text.textContent = trim(value);
+    text.textContent = value.trim();
     text.classList.add('text');
     return text;
 }


### PR DESCRIPTION
#### 4e9929ca2c25fb5ad9fd779cd88ab9481ae0b3c0
<pre>
Use String.prototype.trim() instead of Regex to trim whitespaces in `XMLViewer.js`

<a href="https://bugs.webkit.org/show_bug.cgi?id=284930">https://bugs.webkit.org/show_bug.cgi?id=284930</a>
<a href="https://rdar.apple.com/problem/141726975">rdar://problem/141726975</a>

Reviewed by Yusuke Suzuki and Tim Nguyen.

Merge: <a href="https://source.chromium.org/chromium/chromium/src/+/98f0c1af8d23027bc8f2dc0681255f649d73e374">https://source.chromium.org/chromium/chromium/src/+/98f0c1af8d23027bc8f2dc0681255f649d73e374</a>

This patch leverages standard API `String.prototype.trim()` to trim whitespaces
instead of leveraging RegEx.

* Source/WebCore/xml/XMLViewer.js:
(isShort):
(trim): Deleted.
(createText):

Canonical link: <a href="https://commits.webkit.org/288104@main">https://commits.webkit.org/288104@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b933026e24df71a04c09a604a3fea49ad5401bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81874 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1400 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35828 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86428 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32875 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83980 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1433 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9223 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63860 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21588 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84944 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1054 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74504 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44143 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/953 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28680 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31323 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29290 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87858 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9114 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6495 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72219 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9299 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70325 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71441 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17802 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15535 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14452 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9065 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14597 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8906 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12429 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10714 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->